### PR TITLE
[PERF] Jackson reflection-free serialization/deserialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,10 +140,11 @@ jobs:
         uses: ./.github/actions/integration-test-setup
 
       - name: Run base tests
+        # enable the http-optimized-serializers feature for the old testsuite to verify it works as expected
         run: |
           TESTS=`testsuite/integration-arquillian/tests/base/testsuites/base-suite.sh ${{ matrix.group }}`
           echo "Tests: $TESTS"
-          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+          ./mvnw test ${{ env.SUREFIRE_RETRY }} -Pauth-server-quarkus -Dauth.server.feature=http-optimized-serializers -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 
       - uses: ./.github/actions/upload-flaky-tests
         name: Upload flaky tests

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -148,7 +148,7 @@ public class Profile {
 
         DB_TIDB("TiDB database type", Type.EXPERIMENTAL),
 
-        HTTP_OPTIMIZED_SERIALIZERS("Use reflection-free Jackson JSON serializers for better performance of the HTTP layer", Type.PREVIEW),
+        HTTP_OPTIMIZED_SERIALIZERS("Optimized JSON serializers for better performance of the HTTP layer", Type.PREVIEW),
 
         /**
          * @see <a href="https://github.com/keycloak/keycloak/issues/37967">Deprecate for removal the Instagram social broker</a>.

--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -148,6 +148,8 @@ public class Profile {
 
         DB_TIDB("TiDB database type", Type.EXPERIMENTAL),
 
+        HTTP_OPTIMIZED_SERIALIZERS("Use reflection-free Jackson JSON serializers for better performance of the HTTP layer", Type.PREVIEW),
+
         /**
          * @see <a href="https://github.com/keycloak/keycloak/issues/37967">Deprecate for removal the Instagram social broker</a>.
          */

--- a/docs/documentation/release_notes/index.adoc
+++ b/docs/documentation/release_notes/index.adoc
@@ -13,6 +13,9 @@ include::topics/templates/document-attributes.adoc[]
 :release_header_latest_link: {releasenotes_link_latest}
 include::topics/templates/release-header.adoc[]
 
+== {project_name_full} 26.5.0
+include::topics/26_5_0.adoc[leveloffset=2]
+
 == {project_name_full} 26.4.0
 include::topics/26_4_0.adoc[leveloffset=2]
 

--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -3,11 +3,14 @@
 
 = Better HTTP performance
 
-For the HTTP layer, you can now use Jackson JSON reflection-free serializers, improving request handling efficiency.
+You can now enable a more efficient way to handle JSON data in the HTTP layer.
 This change increases throughput by ~5%, stabilizes response times, and reduces system resource usage.
 
 In order to apply it, you need to explicitly enable the feature `http-optimized-serializers`.
 
-NOTE: This feature is *preview* as we gather more feedback about potential issues. We appreciate any feedback.
+NOTE: This feature is *preview*.
+ifeval::[{project_community}==true]
+We gather more feedback about potential issues in https://github.com/keycloak/keycloak/discussions/43484[this discussion]. We appreciate any feedback.
+endif::[]
 
 For more details, see the https://www.keycloak.org/server/configuration-production[Configuring Keycloak for production] guide.

--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -1,0 +1,13 @@
+// Release notes should contain only headline-worthy new features,
+// assuming that people who migrate will read the upgrading guide anyway.
+
+= Better HTTP performance
+
+For the HTTP layer, you can now use Jackson JSON reflection-free serializers, improving request handling efficiency.
+This change increases throughput by ~5%, stabilizes response times, and reduces system resource usage.
+
+In order to apply it, you need to explicitly enable the feature `http-optimized-serializers`.
+
+NOTE: This feature is *preview* as we gather more feedback about potential issues. We appreciate any feedback.
+
+For more details, see the https://www.keycloak.org/server/configuration-production[Configuring Keycloak for production] guide.

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -1,5 +1,6 @@
 <#import "/templates/guide.adoc" as tmpl>
 <#import "/templates/links.adoc" as links>
+<#import "/templates/features.adoc" as features>
 
 <@tmpl.guide
 title="Configuring and using token exchange"
@@ -327,22 +328,7 @@ s|Subject impersonation (including direct naked impersonation)   | Not implement
 [[_legacy-token-exchange]]
 == Legacy token exchange
 
-:tech_feature_name: Token Exchange
-:tech_feature_id: token-exchange
-
-[NOTE]
-====
-{tech_feature_name} is
-*Preview*
-and is not fully supported. This feature is disabled by default.
-
-To enable start the server with `--features=preview`
-ifdef::tech_feature_id[]
-or `--features={tech_feature_id}`
-endif::[]
-
-{tech_feature_name} is *Technology Preview* and is not fully supported.
-====
+<@features.techpreview feature="token-exchange"/>
 
 [NOTE]
 ====

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -88,7 +88,7 @@ export JAVA_OPTS_APPEND="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6A
 
 See <@links.server id="caching" anchor="network-bind-address"/> for more details.
 
-== Better HTTP performance
+== Preview of enhanced HTTP performance
 <@features.techpreview feature="http-optimized-serializers" additionalCommunityText="We gather more feedback on this feature to promote it to supported. Please, share your feedback about any issue in https://github.com/keycloak/keycloak/discussions/43484[this discussion]."/>
 
 In production environments, the performance of the HTTP layer is critical.

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -102,7 +102,7 @@ By removing the overhead of reflection during serialization/deserialization, it 
 
 These improvements help ensure smoother, more predictable performance at scale while also lowering the operational cost of running production systems.
 
-The only known tradeoff is that build(augmentation) time increased by ~6% as certain actions were moved to the build time instead of runtime.
+The only known tradeoff is that build time increases by ~6% as certain actions were moved to the build time instead of runtime.
 
 You can enable this feature as follows:
 

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -1,6 +1,7 @@
 <#import "/templates/guide.adoc" as tmpl>
 <#import "/templates/kc.adoc" as kc>
 <#import "/templates/links.adoc" as links>
+<#import "/templates/features.adoc" as features>
 
 <@tmpl.guide
 title="Configuring {project_name} for production"
@@ -88,13 +89,13 @@ export JAVA_OPTS_APPEND="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6A
 See <@links.server id="caching" anchor="network-bind-address"/> for more details.
 
 == Better HTTP performance
-NOTE: This section is describing a feature which is currently in *preview* as we gather more feedback about potential issues. We appreciate any feedback.
+<@features.techpreview feature="http-optimized-serializers" additionalCommunityText="We gather more feedback on this feature to promote it to supported. Please, share your feedback about any issue in https://github.com/keycloak/keycloak/discussions/43484[this discussion]."/>
 
 In production environments, the performance of the HTTP layer is critical.
 Every request passes through it, making it a key factor in overall system responsiveness, scalability, and user experience.
 
-This feature introduces Jackson JSON reflection-free serializers to optimize HTTP processing.
-By removing the overhead of reflection during serialization/deserialization, it delivers measurable benefits:
+This feature improves how {project_name} handles JSON data in HTTP requests and responses.
+The result is a more efficient runtime with measurable benefits:
 
 - ~5% increase in throughput
 - More stable response times
@@ -107,7 +108,5 @@ The only known tradeoff is that build time increases by ~6% as certain actions w
 You can enable this feature as follows:
 
 <@kc.start parameters="--features=http-optimized-serializers"/>
-
-The feature is *disabled by default*, as we gather more feedback.
 
 </@tmpl.guide>

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -87,4 +87,27 @@ export JAVA_OPTS_APPEND="-Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6A
 
 See <@links.server id="caching" anchor="network-bind-address"/> for more details.
 
+== Better HTTP performance
+NOTE: This section is describing a feature which is currently in *preview* as we gather more feedback about potential issues. We appreciate any feedback.
+
+In production environments, the performance of the HTTP layer is critical.
+Every request passes through it, making it a key factor in overall system responsiveness, scalability, and user experience.
+
+This feature introduces Jackson JSON reflection-free serializers to optimize HTTP processing.
+By removing the overhead of reflection during serialization/deserialization, it delivers measurable benefits:
+
+- ~5% increase in throughput
+- More stable response times
+- Reduced system resource usage
+
+These improvements help ensure smoother, more predictable performance at scale while also lowering the operational cost of running production systems.
+
+The only known tradeoff is that build(augmentation) time increased by ~6% as certain actions were moved to the build time instead of runtime.
+
+You can enable this feature as follows:
+
+<@kc.start parameters="--features=http-optimized-serializers"/>
+
+The feature is *disabled by default*, as we gather more feedback.
+
 </@tmpl.guide>

--- a/docs/guides/templates/features.adoc
+++ b/docs/guides/templates/features.adoc
@@ -12,7 +12,6 @@
 <#macro techpreview feature additionalCommunityText="">
 <#assign profileFeature = ctx.features.getFeature(feature)>
 
-<#if !profileFeature.enabled>
 [NOTE]
 ====
 ${profileFeature.description} is
@@ -28,13 +27,7 @@ ifeval::[{project_community}==true]
 ${additionalCommunityText!""}
 endif::[]
 
-To enable start the server with `--features=preview` or `--features=${profileFeature.name}`
+To enable start the server with <#if profileFeature.type != "PREVIEW_DISABLED_BY_DEFAULT">`--features=preview` or </#if>`--features=${profileFeature.name}`
 
 ====
-<#else>
-[NOTE]
-====
-${profileFeature.description} is *Technology Preview* and is not fully supported.
-====
-</#if>
 </#macro>

--- a/docs/guides/templates/features.adoc
+++ b/docs/guides/templates/features.adoc
@@ -8,3 +8,33 @@
 </#list>
 |===
 </#macro>
+
+<#macro techpreview feature additionalCommunityText="">
+<#assign profileFeature = ctx.features.getFeature(feature)>
+
+<#if !profileFeature.enabled>
+[NOTE]
+====
+${profileFeature.description} is
+ifeval::[{project_product}==true]
+*Technology Preview*
+endif::[]
+ifeval::[{project_community}==true]
+*Preview*
+endif::[]
+and is not fully supported. This feature is disabled by default.
+
+ifeval::[{project_community}==true]
+${additionalCommunityText!""}
+endif::[]
+
+To enable start the server with `--features=preview` or `--features=${profileFeature.name}`
+
+====
+<#else>
+[NOTE]
+====
+${profileFeature.description} is *Technology Preview* and is not fully supported.
+====
+</#if>
+</#macro>

--- a/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/Features.java
+++ b/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/Features.java
@@ -51,11 +51,9 @@ public class Features {
     public static class Feature {
 
         private final Profile.Feature profileFeature;
-        private final boolean isEnabled;
 
         public Feature(Profile.Feature profileFeature) {
             this.profileFeature = profileFeature;
-            this.isEnabled = Profile.defaults().isFeatureEnabled(profileFeature);
         }
 
         public String getName() {
@@ -74,11 +72,7 @@ public class Features {
             return profileFeature.getUpdatePolicy().toString();
         }
 
-        public boolean isEnabled() {
-            return isEnabled;
-        }
-
-        private Profile.Feature.Type getType() {
+        public Profile.Feature.Type getType() {
             return profileFeature.getType();
         }
     }

--- a/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/Features.java
+++ b/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/Features.java
@@ -43,12 +43,19 @@ public class Features {
         return features.stream().filter(f -> f.profileFeature.getUpdatePolicy() == Profile.FeatureUpdatePolicy.ROLLING_NO_UPGRADE).collect(Collectors.toList());
     }
 
+    public Feature getFeature(String featureId) {
+        return features.stream().filter(f -> f.getName().equals(featureId)).findAny()
+                .orElseThrow(() -> new IllegalArgumentException("Cannot find the '%s' feature for guides".formatted(featureId)));
+    }
+
     public static class Feature {
 
         private final Profile.Feature profileFeature;
+        private final boolean isEnabled;
 
         public Feature(Profile.Feature profileFeature) {
             this.profileFeature = profileFeature;
+            this.isEnabled = Profile.defaults().isFeatureEnabled(profileFeature);
         }
 
         public String getName() {
@@ -65,6 +72,10 @@ public class Features {
 
         public String getUpdatePolicy() {
             return profileFeature.getUpdatePolicy().toString();
+        }
+
+        public boolean isEnabled() {
+            return isEnabled;
         }
 
         private Profile.Feature.Type getType() {

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -150,5 +150,4 @@ public class HttpOptions {
             .description("Service level objectives for HTTP server requests. Use this instead of the default histogram, or use it in combination to add additional buckets. " +
                     "Specify a list of comma-separated values defined in milliseconds. Example with buckets from 5ms to 10s: 5,10,25,50,250,500,1000,2500,5000,10000")
             .build();
-
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -4,6 +4,7 @@ import io.quarkus.runtime.util.ClassPathUtils;
 import io.quarkus.vertx.http.runtime.options.TlsUtils;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 
+import org.keycloak.common.Profile;
 import org.keycloak.common.crypto.FipsMode;
 import org.keycloak.config.HttpOptions;
 import org.keycloak.config.SecurityOptions;
@@ -23,6 +24,7 @@ import java.util.Optional;
 
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalValue;
+import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromFeature;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 public final class HttpPropertyMappers implements PropertyMapperGrouping {
@@ -154,6 +156,9 @@ public final class HttpPropertyMappers implements PropertyMapperGrouping {
                 fromOption(HttpOptions.HTTP_METRICS_SLOS)
                         .isEnabled(MetricsPropertyMappers::metricsEnabled, MetricsPropertyMappers.METRICS_ENABLED_MSG)
                         .paramLabel("list of buckets")
+                        .build(),
+                fromFeature(Profile.Feature.HTTP_OPTIMIZED_SERIALIZERS)
+                        .to("quarkus.rest.jackson.optimization.enable-reflection-free-serializers")
                         .build()
         );
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -33,8 +33,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.keycloak.common.Profile;
 import org.keycloak.config.DeprecatedMetadata;
 import org.keycloak.config.Option;
+import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.ShortErrorMessageHandler;
@@ -545,6 +547,22 @@ public class PropertyMapper<T> {
 
     public static <T> PropertyMapper.Builder<T> fromOption(Option<T> opt) {
         return new PropertyMapper.Builder<>(opt);
+    }
+
+    /**
+     * Create a property mapper from a feature.
+     * The mapper maps to external properties the state of the feature.
+     * <p>
+     * If the feature is enabled, it returns {@code true}. Otherwise {@code null}.
+     */
+    public static PropertyMapper.Builder<Boolean> fromFeature(Profile.Feature feature) {
+        final var option = new OptionBuilder<>(feature.getKey() + "-hidden-mapper", Boolean.class)
+                .buildTime(true)
+                .hidden()
+                .build();
+        return new Builder<>(option)
+                .isEnabled(() -> Profile.isFeatureEnabled(feature))
+                .transformer((v, ctx) -> Boolean.TRUE.toString()); // we know the feature is enabled due to .isEnabled()
     }
 
     public void validate(ConfigValue value) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -966,4 +966,16 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
         assertThat(nonRunningPicocli.getErrString(), containsString("Available only when health is enabled"));
     }
+
+    @Test
+    public void httpOptimizedSerializers() {
+        var nonRunningPicocli = pseudoLaunch("start-dev");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfigNull("quarkus.rest.jackson.optimization.enable-reflection-free-serializers");
+        onAfter();
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "--features=http-optimized-serializers");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfig("quarkus.rest.jackson.optimization.enable-reflection-free-serializers", "true");
+    }
 }


### PR DESCRIPTION
- Closes #42945

I've followed up on the [guide](https://quarkus.io/blog/quarkus-metaprogramming/) provided by the Quarkus team. The Jackson-free serdes was mentioned during the presentation about Observability performance in Quarkus, so they're including that even in their benchmarks.

In the guide, there's mentioned ~12% improvement in the throughput for HTTP calls. I made a brief performance analysis, and these are my findings:

## Performance analysis

- Run official KC distribution (OLD) and official KC distribution with the optimization (NEW)
- Used `wrk` from the [Hyperfoil](https://github.com/Hyperfoil/Hyperfoil)

### Test characteristic
- Benchmarking how many req/s can KC server handle on one node
- Only the `host:8080/admin/realms/master/clients` endpoint was called (multiple clients that are deserialized) with the access token 
- On a client, changed how many threads and connections are used when introducing the load on the server
-- Matrix 1: 3 threads, 3 connections
-- Matrix 2: 10 threads, 10 connections
-- Matrix 3: 15 threads, 15 connections
- Every matrix run for 15s
- Every matrix is executed 5x

### Matrix 1 (3 threads, 3 connections)
**Requests per second**
| Run | Old  | New  | Diff % |
|-----|-----------|-----------|-------------|
| 1   | 1224      | 1385      | ⬆️ **13.15** ✅ |
| 2   | 1494      | 1486      | ⬇️ *-0.54* ❌ |
| 3   | 1483      | 1550      | ⬆️ **4.52** ✅ |
| 4   | 1501      | 1491      | ⬇️ *-0.67* ❌ |
| 5   | 1492      | 1634      | ⬆️ **9.52** ✅ |

Average: **5.196% improvement** ✅

### Matrix 2 (10 threads, 10 connections)
**Requests per second**
| Run | Old  | New  | Diff % |
|-----|-----------|-----------|-------------|
| 1   | 3455      | 3636      | ⬆️ **5.24** ✅ |
| 2   | 3416      | 3504      | ⬆️ **2.58** ✅ |
| 3   | 3395      | 3496      | ⬆️ **2.97** ✅ |
| 4   | 3341      | 3419      | ⬆️ **2.33** ✅ |
| 5   | 3347      | 3738      | ⬆️ **11.68** ✅ |

Average: **4.96% improvement** ✅

### Matrix 3 (15 threads, 15 connections)
**Requests per second**
| Run | Old  | New  | Diff % |
|-----|-----------|-----------|-------------|
| 1   | 3268      | 3100      | ⬇️ *-5.14* ❌ |
| 2   | 4034      | 4278      | ⬆️ **6.05** ✅ |
| 3   | 3976      | 4586      | ⬆️ **15.34** ✅ |
| 4   | 4000      | 4272      | ⬆️ **6.80** ✅ |
| 5   | 3993      | 4281      | ⬆️ **7.21** ✅ |

Average: **6.052% improvement** ✅

### Augmentation time
As some work is moved to the build phase, we experience a small increase in the augmentation time (which should be ok):

| Run | Old  | New  | Diff | Diff % |
|-----|------|------|------|--------|
| 1   | 4341ms | 4501ms | ⬆️ *160ms* ❌ | ⬆️ *3.69%* ❌ |
| 2   | 4482ms | 5131ms | ⬆️ *649ms* ❌ | ⬆️ *14.48%* ❌ |
| 3   | 8233ms | 8630ms | ⬆️ *397ms* ❌ | ⬆️ *4.82%* ❌ |
| 4   | 7552ms | 7691ms | ⬆️ *139ms* ❌ | ⬆️ *1.84%* ❌ |

Average Old: **6152ms**
Average New: **6488ms**
Difference: **+336ms** ❌
Difference in %: **+6.20%** ❌

### Node characteristics
```
Architecture:                x86_64
  CPU op-mode(s):            32-bit, 64-bit
  Address sizes:             46 bits physical, 48 bits virtual
  Byte Order:                Little Endian
CPU(s):                      20
  On-line CPU(s) list:       0-19
Vendor ID:                   GenuineIntel
  Model name:                12th Gen Intel(R) Core(TM) i7-1280P
    CPU family:              6
    Model:                   154
    Thread(s) per core:      2
    Core(s) per socket:      14
Memory:                      32GB
```

## Conclusion

In total, in this brief performance analysis, we experience **5.40%** ✅ improvement in the throughput in our API. Note that values for some runs differ as it might be influenced by other tasks done on the CPU and not related to this benchmark. This test only gets clients from the realm, so for some endpoints, where the serdes is not used much does not have a big effect. On the other hand, the effect should be higher when serdes is used frequently. 

I think it's a nice improvement, and there should not be any issues I'm not aware of. 

cc: @keycloak/cloud-native @keycloak/sre
cc: @franz1981 @brunobat

  




