### PR TITLE
Ensure events are fully filled before success is called

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1069,8 +1069,9 @@ public class AuthenticationManager {
 
         event.event(EventType.LOGIN);
         event.session(userSession);
+        Response response = redirectAfterSuccessfulFlow(session, realm, userSession, clientSessionCtx, request, uriInfo, clientConnection, event, authSession);
         event.success();
-        return redirectAfterSuccessfulFlow(session, realm, userSession, clientSessionCtx, request, uriInfo, clientConnection, event, authSession);
+        return response;
     }
 
     // Return null if action is not required. Or the alias of the requiredAction in case it is required.

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -929,8 +929,6 @@ public class LoginActionsService {
                 .detail(Details.IDENTITY_PROVIDER_USERNAME, brokerContext.getUsername())
                 .detail(Details.IDENTITY_PROVIDER_BROKER_SESSION_ID, brokerContext.getBrokerSessionId());
 
-        event.success();
-
         AuthenticationProcessor processor = new AuthenticationProcessor() {
 
             @Override
@@ -967,7 +965,10 @@ public class LoginActionsService {
 
         configureOrganization(brokerContext);
 
-        return processFlow(checks.isActionRequest(), execution, authSession, flowPath, brokerLoginFlow, null, processor);
+        Response response = processFlow(checks.isActionRequest(), execution, authSession, flowPath, brokerLoginFlow, null, processor);
+        event.success();
+
+        return response;
     }
 
     private void configureOrganization(BrokeredIdentityContext brokerContext) {

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/events/TestEventsListenerProvider.java
@@ -41,12 +41,12 @@ public class TestEventsListenerProvider implements EventListenerProvider {
 
     @Override
     public void onEvent(Event event) {
-        tx.addEvent(event);
+        tx.addEvent(event.clone());
     }
 
     @Override
     public void onEvent(AdminEvent event, boolean includeRepresentation) {
-        tx.addAdminEvent(event, includeRepresentation);
+        tx.addAdminEvent(new AdminEvent(event), includeRepresentation);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractFirstBrokerLoginTest.java
@@ -1362,11 +1362,6 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
                 .detail(Details.IDENTITY_PROVIDER_USERNAME, "no-first-name")
                 .assertEvent(getFirstConsumerEvent());
 
-        events.expectAccount(EventType.UPDATE_PROFILE).client("broker-app")
-                .realm(consumerRealmRep).user((String)null)
-                .detail(Details.CONTEXT, UserProfileContext.IDP_REVIEW.name())
-                .assertEvent(getFirstConsumerEvent());
-
         events.expectAccount(EventType.UPDATE_EMAIL).client("broker-app")
                 .realm(consumerRealmRep).user((String)null).session((String) null)
             .detail(Details.CONTEXT, UserProfileContext.IDP_REVIEW.name())
@@ -1374,6 +1369,11 @@ public abstract class AbstractFirstBrokerLoginTest extends AbstractInitializedBa
             .detail(Details.PREVIOUS_EMAIL, "no-first-name@localhost.com")
             .detail(Details.UPDATED_EMAIL, "new-email@localhost.com")
             .assertEvent(getFirstConsumerEvent());
+
+        events.expectAccount(EventType.UPDATE_PROFILE).client("broker-app")
+                .realm(consumerRealmRep).user((String)null)
+                .detail(Details.CONTEXT, UserProfileContext.IDP_REVIEW.name())
+                .assertEvent(getFirstConsumerEvent());
 
         events.expectAccount(EventType.REGISTER).client("broker-app")
                 .realm(consumerRealmRep).user(Matchers.any(String.class)).session((String) null)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -707,7 +707,7 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         continueLoginWithInvalidTotp();
         events.clear();
         continueLoginWithInvalidTotp();
-        assertUserDisabledEvent(Errors.INVALID_AUTHENTICATION_SESSION);
+        assertUserDisabledEvent(Errors.USER_TEMPORARILY_DISABLED);
     }
 
     private void checkEmailPresent(String subject) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/MultipleTabsLoginTest.java
@@ -816,6 +816,11 @@ public class MultipleTabsLoginTest extends AbstractChangeImportedUserPasswordsTe
             //assert cookie not found
             events.expect(EventType.LOGIN_ERROR)
                     .user(new UserRepresentation())
+                    .error(Errors.INVALID_CODE)
+                    .assertEvent();
+
+            events.expect(EventType.LOGIN_ERROR)
+                    .user(new UserRepresentation())
                     .error(Errors.COOKIE_NOT_FOUND)
                     .assertEvent();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RPInitiatedLogoutTest.java
@@ -986,7 +986,7 @@ public class RPInitiatedLogoutTest extends AbstractTestRealmKeycloakTest {
         errorPage.assertCurrent();
         Assert.assertEquals("Logout failed", errorPage.getError());
 
-        events.expectLogoutError(Errors.LOGOUT_FAILED).assertEvent();
+        events.expectLogoutError(Errors.SESSION_EXPIRED).assertEvent();
     }
 
     @Test


### PR DESCRIPTION
Closes #42914

@mposolda I have done the exercise of cloning the events in the test provider in the `onEvent` method. There were not too many failures and mainly because of two code paths. It seems that some fields of the event were filled later when creating the response.

Regarding the changes in the tests, the main difference is that now sometimes the order is a bit different (because the `success` is executed later). It is more clear in the error messages, sometimes there are two errors and now moving the call later the order is the opposite. As you see it's just in three tests so I think it's OK. I checked that the same errors are reported but in different order (for example the `MultipleTabsLoginTest`, previously it was cookie_not_found and then code_invalid and now it is code_invalid and then cookie_not_found).

Check if it's OK or you want me to investigate more about this.