### PR TITLE
Check sites names on startup

### DIFF
--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-cachestore-remote</artifactId>
         </dependency>
         <!-- required for query/search in the external Infinispan server -->

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -622,6 +622,10 @@
             <artifactId>infinispan-cachestore-remote</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-rest</artifactId>
+        </dependency>
+        <dependency>
             <!-- adding to avoid warning during compilation about "unknown enum constant org.infinispan.jmx.annotations.DataType.TRAIT" and others -->
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-component-annotations</artifactId>


### PR DESCRIPTION
Closes #42956

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

The following warnings are shown if there is a mismatch

```
[kc-server] 2025-09-25 13:36:58,586 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-7) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'actionTokens'
[kc-server] 2025-09-25 13:36:58,586 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-8) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'work'
[kc-server] 2025-09-25 13:36:58,586 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-4) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'offlineSessions'
[kc-server] 2025-09-25 13:36:58,586 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-5) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'offlineClientSessions'
[kc-server] 2025-09-25 13:36:58,586 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-6) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'authenticationSessions'
[kc-server] 2025-09-25 13:36:58,588 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-1) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'sessions'
[kc-server] 2025-09-25 13:36:58,588 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-2) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'loginFailures'
[kc-server] 2025-09-25 13:36:58,588 WARN  [org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory] (ForkJoinPool.commonPool-worker-3) Incorrect 'cache-remote-backup-sites' option configured. Expected sites are '[site2]', but the Infinispan cluster reports '[site1]' for cache 'clientSessions'
```