### PR TITLE
Chore(i18n): Add missing Korean translations

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_ko.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_ko.properties
@@ -76,6 +76,9 @@ acceptTerms=이용 약관에 동의합니다
 deleteCredentialTitle={0} 삭제
 deleteCredentialMessage={0}을 삭제하시겠습니까?
 
+linkIdpActionTitle={0} 로 연결
+linkIdpActionMessage=당신의 계정을 {0}와(과) 연결하시겠습니까?
+
 recaptchaFailed=잘못된 Recaptcha
 recaptchaNotConfigured=Recaptcha가 필요하지만 구성되지 않았습니다
 consentDenied=동의 거부됨.
@@ -168,6 +171,10 @@ oauth2DeviceAuthorizationGrantDisabledMessage=클라이언트는 OAuth 2.0 장�
 emailVerifyInstruction1=이메일 주소 {0}로 이메일 확인 지침이 포함된 이메일이 전송되었습니다.
 emailVerifyInstruction2=이메일로 확인 코드를 받지 못하셨나요?
 emailVerifyInstruction3=이메일을 다시 전송하세요.
+emailVerifyInstruction4=이메일 주소를 확인하기 위해 {0} 주소로 지침이 담긴 이메일을 보낼 예정입니다.
+emailVerifyResend=확인 이메일 다시 보내기
+emailVerifySend=확인 이메일 보내기
+emailVerifySendCooldown=확인 이메일을 다시 보내려면 {0}초를 기다려야 합니다.
 
 emailLinkIdpTitle={0} 연결
 emailLinkIdp1={0} 계정 {1}을(를) {2} 계정과 연결하는 방법이 포함된 이메일이 발송되었습니다.
@@ -224,8 +231,10 @@ invalidUsernameOrEmailMessage=잘못된 사용자 이름 또는 이메일입니�
 invalidPasswordMessage=잘못된 비밀번호입니다.
 invalidEmailMessage=잘못된 이메일 주소입니다.
 accountDisabledMessage=계정이 비활성화되었습니다. 관리자에게 문의하세요.
+# 이 속성은 의도적으로 "invalidUsernameMessage"와 동일하므로 기본적으로 인증 실패 이유가 일시적으로 비활성화된 계정인지 인식할 수 없습니다.
 accountTemporarilyDisabledMessage=잘못된 사용자 이름 또는 비밀번호입니다.
 accountPermanentlyDisabledMessage=잘못된 사용자 이름 또는 비밀번호입니다.
+# 이 속성은 의도적으로 "invalidTotpMessage"와 동일하므로 기본적으로 인증 실패 이유가 일시적으로 비활성화된 계정인지 인식할 수 없습니다.
 accountTemporarilyDisabledMessageTotp=잘못된 인증기 코드입니다.
 accountPermanentlyDisabledMessageTotp=잘못된 인증기 코드입니다.
 expiredCodeMessage=로그인 시간 초과. 다시 로그인하세요.
@@ -265,6 +274,7 @@ error-user-attribute-read-only=이 필드는 읽기 전용입니다.
 error-username-invalid-character=값에 잘못된 문자가 포함되어 있습니다.
 error-person-name-invalid-character=값에 잘못된 문자가 포함되어 있습니다.
 error-reset-otp-missing-id=OTP 구성을 선택하세요.
+error-non-ascii-local-part-email=주소의 로컬 부분은 ASCII 문자만 포함해야 합니다.
 
 invalidPasswordExistingMessage=기존 비밀번호가 잘못되었습니다.
 invalidPasswordBlacklistedMessage=잘못된 비밀번호: 비밀번호가 블랙리스트에 포함되어 있습니다.
@@ -366,11 +376,15 @@ staleCodeMessage=이 페이지는 더 이상 유효하지 않습니다. 애플�
 realmSupportsNoCredentialsMessage=영역이 자격 증명 유형을 지원하지 않습니다.
 credentialSetupRequired=로그인할 수 없습니다. 자격 증명 설정이 필요합니다.
 identityProviderNotUniqueMessage=영역이 여러 ID 공급자를 지원합니다. 어떤 ID 공급자로 인증해야 할지 결정할 수 없습니다.
+emailVerifiedMessageHeader=이메일 주소 확인됨
 emailVerifiedMessage=이메일 주소가 확인되었습니다.
+emailVerifiedAlreadyMessageHeader=이메일 주소 이미 확인됨
 emailVerifiedAlreadyMessage=이메일 주소가 이미 확인되었습니다.
 staleEmailVerificationLink=클릭한 링크는 오래된 링크로 더 이상 유효하지 않습니다. 이미 이메일을 확인했을 수도 있습니다.
 identityProviderAlreadyLinkedMessage={0}에서 반환된 연합 ID가 다른 사용자와 이미 연결되어 있습니다.
 confirmAccountLinking=ID 공급자 {1}의 계정 {0}을 계정에 연결하는 것을 확인하세요.
+confirmAccountLinkingBody=계정을 연결하면 ID 공급자 {1}의 계정 {0}을 사용하여 로그인할 수도 있습니다. 이 프로세스를 시작하지 않았거나 계정을 연결하고 싶지 않은 경우 계속하지 마십시오.
+confirmEmailAddressVerificationHeader=Email address validation
 confirmEmailAddressVerification=이메일 주소 {0}의 유효성을 확인하세요.
 confirmExecutionOfActions=다음 작업 수행
 
@@ -390,8 +404,15 @@ requiredAction.TERMS_AND_CONDITIONS=이용 약관
 requiredAction.UPDATE_PASSWORD=비밀번호 업데이트
 requiredAction.UPDATE_PROFILE=프로필 업데이트
 requiredAction.VERIFY_EMAIL=이메일 확인
+requiredAction.delete_account=계정 삭제
+requiredAction.UPDATE_EMAIL=이메일 업데이트
+requiredAction.webauthn-register=WebAuthn 등록
+requiredAction.webauthn-register-passwordless=WebAuthn 비밀번호 없는 등록
+requiredAction.VERIFY_PROFILE=프로필 확인
+requiredAction.delete_credential=자격 증명 삭제
+requiredAction.idp_link=ID 공급자 연결
 requiredAction.CONFIGURE_RECOVERY_AUTHN_CODES=복구 코드 생성
-requiredAction.webauthn-register-passwordless=Webauthn 비밀번호 없는 등록
+requiredAction.update_user_locale=사용자 로캘 업데이트
 
 invalidTokenRequiredActions=링크에 포함된 필수 작업이 유효하지 않습니다
 
@@ -500,6 +521,12 @@ idp-email-verification-help-text=이메일을 검증하여 계정을 연결하�
 idp-username-password-form-display-name=사용자 이름과 비밀번호
 idp-username-password-form-help-text=로그인하여 계정을 연결하세요.
 
+# Code
+code-clipboard-label=내용 보기
+code-copy-label=클립보드에 복사
+code-copy-success=코드가 클립보드에 복사되었습니다.
+code-copy-failure=코드를 클립보드에 복사하지 못했습니다.
+
 finalDeletionConfirmation=계정을 삭제하면 복구할 수 없습니다. 계정을 유지하려면 취소를 클릭하세요.
 irreversibleAction=이 작업은 되돌릴 수 없습니다
 deleteAccountConfirm=계정 삭제 확인
@@ -525,3 +552,6 @@ error-invalid-multivalued-size=속성 {0}은(는) 최소 {1}개 및 최대 {2}�
 organization.confirm-membership.title=${kc.org.name} 조직에 가입하려고 합니다
 organization.confirm-membership=아래 링크를 클릭하면 {0} 조직의 멤버가 됩니다:
 organization.member.register.title=${kc.org.name} 조직에 가입하려면 계정을 생성하세요
+organization.select=진행할 조직을 선택하세요:
+notMemberOfOrganization=사용자가 {0} 조직의 구성원이 아닙니다.
+notMemberOfAnyOrganization=사용자가 어떠한 조직의 구성원도 아닙니다.


### PR DESCRIPTION
Adds missing properties to the messages_ko.properties file to ensure full localization for Korean-speaking users.

closes #42917

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->


