### PR TITLE
Only filter default organization related scopes based on dynamic scope format

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientScopeAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientScopeAdapter.java
@@ -25,7 +25,9 @@ import org.keycloak.models.cache.infinispan.entities.CachedClientScope;
 import org.keycloak.models.utils.RoleUtils;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 /**
@@ -39,16 +41,19 @@ public class ClientScopeAdapter implements ClientScopeModel {
     protected ClientScopeModel updated;
     protected CachedClientScope cached;
 
+    private final Supplier<ClientScopeModel> modelSupplier;
+
     public ClientScopeAdapter(RealmModel cachedRealm, CachedClientScope cached, RealmCacheSession cacheSession) {
         this.cachedRealm = cachedRealm;
         this.cacheSession = cacheSession;
         this.cached = cached;
+        this.modelSupplier = new LazyModel<>(this::getClientScope);
     }
 
     private void getDelegateForUpdate() {
         if (updated == null) {
             cacheSession.registerClientScopeInvalidation(cached.getId(), cachedRealm.getId());
-            updated = cacheSession.getClientScopeDelegate().getClientScopeById(cachedRealm, cached.getId());
+            updated = modelSupplier.get();
             if (updated == null) throw new IllegalStateException("Not found in database");
         }
     }
@@ -81,7 +86,7 @@ public class ClientScopeAdapter implements ClientScopeModel {
     @Override
     public Stream<ProtocolMapperModel> getProtocolMappersStream() {
         if (isUpdated()) return updated.getProtocolMappersStream();
-        return cached.getProtocolMappers().stream();
+        return cached.getProtocolMappers(cacheSession.session, modelSupplier);
     }
 
     @Override
@@ -106,18 +111,17 @@ public class ClientScopeAdapter implements ClientScopeModel {
 
     @Override
     public ProtocolMapperModel getProtocolMapperById(String id) {
-        for (ProtocolMapperModel mapping : cached.getProtocolMappers()) {
-            if (mapping.getId().equals(id)) return mapping;
-        }
-        return null;
+        return cached.getProtocolMapperById(cacheSession.session, modelSupplier, id);
+    }
+
+    @Override
+    public List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return cached.getProtocolMapperByType(cacheSession.session, modelSupplier, type);
     }
 
     @Override
     public ProtocolMapperModel getProtocolMapperByName(String protocol, String name) {
-        for (ProtocolMapperModel mapping : cached.getProtocolMappers()) {
-            if (mapping.getProtocol().equals(protocol) && mapping.getName().equals(name)) return mapping;
-        }
-        return null;
+        return cached.getProtocolMapperByName(cacheSession.session, modelSupplier, protocol, name);
     }
 
     @Override
@@ -224,6 +228,9 @@ public class ClientScopeAdapter implements ClientScopeModel {
         return copy;
     }
 
+    private ClientScopeModel getClientScope() {
+        return cacheSession.getClientScopeDelegate().getClientScopeById(cachedRealm, cached.getId());
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/AbstractCachedClientScope.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/AbstractCachedClientScope.java
@@ -1,0 +1,59 @@
+package org.keycloak.models.cache.infinispan.entities;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.cache.infinispan.DefaultLazyLoader;
+import org.keycloak.models.cache.infinispan.LazyLoader;
+
+abstract class AbstractCachedClientScope<D extends ClientScopeModel> extends AbstractRevisioned implements InRealm {
+
+    private final LazyLoader<D, Map<String, ProtocolMapperModel>> mappersById;
+    private final LazyLoader<D, Map<String, String>> mappersByName;
+    private final LazyLoader<D, Map<String, List<String>>> mappersByType;
+
+    public AbstractCachedClientScope(Long revision, ClientScopeModel model) {
+        super(revision, model.getId());
+        mappersById = new DefaultLazyLoader<>(scope -> scope.getProtocolMappersStream()
+                .collect(Collectors.toMap(ProtocolMapperModel::getId, ProtocolMapperModel::new)),
+                Collections::emptyMap);
+        mappersByName = new DefaultLazyLoader<>(scope -> scope.getProtocolMappersStream()
+                .collect(Collectors.toMap(mapper -> mapper.getProtocol() + "." + mapper.getName(),
+                        ProtocolMapperModel::getId)),
+                Collections::emptyMap);
+        mappersByType = new DefaultLazyLoader<>(scope ->
+                scope.getProtocolMappersStream()
+                        .collect(Collectors.groupingBy(ProtocolMapperModel::getProtocolMapper,
+                                Collectors.mapping(ProtocolMapperModel::getId, Collectors.toList()))),
+                Collections::emptyMap);
+    }
+
+    public Stream<ProtocolMapperModel> getProtocolMappers(KeycloakSession session, Supplier<D> model) {
+        return mappersById.get(session, model).values().stream();
+    }
+
+    public ProtocolMapperModel getProtocolMapperById(KeycloakSession session, Supplier<D> model, String id) {
+        if (id == null) {
+            return null;
+        }
+        return mappersById.get(session, model).get(id);
+    }
+
+    public List<ProtocolMapperModel> getProtocolMapperByType(KeycloakSession session, Supplier<D> model, String type) {
+        return mappersByType.get(session, model).getOrDefault(type, List.of()).stream()
+                .map(id -> getProtocolMapperById(session, model, id))
+                .collect(Collectors.toList());
+    }
+
+    public ProtocolMapperModel getProtocolMapperByName(KeycloakSession session, Supplier<D> model, String protocol, String name) {
+        String id = mappersByName.get(session, model).get(protocol + "." + name);
+        return getProtocolMapperById(session, model, id);
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedClient.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedClient.java
@@ -25,7 +25,6 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.keycloak.models.ClientModel;
-import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 
@@ -33,7 +32,7 @@ import org.keycloak.models.RoleModel;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class CachedClient extends AbstractRevisioned implements InRealm {
+public class CachedClient extends AbstractCachedClientScope<ClientModel> {
     protected String clientId;
     protected String name;
     protected String description;
@@ -53,7 +52,6 @@ public class CachedClient extends AbstractRevisioned implements InRealm {
     protected int notBefore;
     protected Set<String> scope = new HashSet<>();
     protected Set<String> webOrigins = new HashSet<>();
-    protected Set<ProtocolMapperModel> protocolMappers = new HashSet<>();
     protected boolean surrogateAuthRequired;
     protected String managementUrl;
     protected String rootUrl;
@@ -68,7 +66,7 @@ public class CachedClient extends AbstractRevisioned implements InRealm {
     protected Map<String, Integer> registeredNodes;
 
     public CachedClient(Long revision, RealmModel realm, ClientModel model) {
-        super(revision, model.getId());
+        super(revision, model);
         clientAuthenticatorType = model.getClientAuthenticatorType();
         secret = model.getSecret();
         registrationToken = model.getRegistrationToken();
@@ -88,7 +86,6 @@ public class CachedClient extends AbstractRevisioned implements InRealm {
         redirectUris.addAll(model.getRedirectUris());
         webOrigins.addAll(model.getWebOrigins());
         scope.addAll(model.getScopeMappingsStream().map(RoleModel::getId).collect(Collectors.toSet()));
-        protocolMappers.addAll(model.getProtocolMappersStream().collect(Collectors.toSet()));
         surrogateAuthRequired = model.isSurrogateAuthRequired();
         managementUrl = model.getManagementUrl();
         rootUrl = model.getRootUrl();
@@ -174,10 +171,6 @@ public class CachedClient extends AbstractRevisioned implements InRealm {
 
     public boolean isFrontchannelLogout() {
         return frontchannelLogout;
-    }
-
-    public Set<ProtocolMapperModel> getProtocolMappers() {
-        return protocolMappers;
     }
 
     public boolean isSurrogateAuthRequired() {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedClientScope.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedClientScope.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.cache.infinispan.entities;
 
 import org.keycloak.models.ClientScopeModel;
-import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 
@@ -32,23 +31,21 @@ import java.util.stream.Collectors;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
-public class CachedClientScope extends AbstractRevisioned implements InRealm {
+public class CachedClientScope extends AbstractCachedClientScope<ClientScopeModel> {
 
     private String name;
     private String description;
     private String realm;
     private String protocol;
     private Set<String> scope = new HashSet<>();
-    private Set<ProtocolMapperModel> protocolMappers = new HashSet<>();
     private Map<String, String> attributes = new HashMap<>();
 
     public CachedClientScope(Long revision, RealmModel realm, ClientScopeModel model) {
-        super(revision, model.getId());
+        super(revision, model);
         name = model.getName();
         description = model.getDescription();
         this.realm = realm.getId();
         protocol = model.getProtocol();
-        protocolMappers.addAll(model.getProtocolMappersStream().collect(Collectors.toSet()));
         scope.addAll(model.getScopeMappingsStream().map(RoleModel::getId).collect(Collectors.toSet()));
         attributes.putAll(model.getAttributes());
     }
@@ -63,9 +60,6 @@ public class CachedClientScope extends AbstractRevisioned implements InRealm {
 
     public String getRealm() {
         return realm;
-    }
-    public Set<ProtocolMapperModel> getProtocolMappers() {
-        return protocolMappers;
     }
 
     public String getProtocol() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientAdapter.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -467,6 +468,14 @@ public class ClientAdapter implements ClientModel, JpaModel<ClientEntity> {
         ProtocolMapperEntity entity = getProtocolMapperEntity(id);
         if (entity == null) return null;
         return entityToModel(entity);
+    }
+
+    @Override
+    public List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return this.entity.getProtocolMappers().stream()
+                .filter((mapper) -> mapper.getProtocolMapper().equals(type))
+                .map(this::entityToModel)
+                .toList();
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/ClientScopeAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/ClientScopeAdapter.java
@@ -31,8 +31,10 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 
 import jakarta.persistence.EntityManager;
+
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -190,6 +192,14 @@ public class ClientScopeAdapter implements ClientScopeModel, JpaModel<ClientScop
         ProtocolMapperEntity entity = getProtocolMapperEntity(id);
         if (entity == null) return null;
         return entityToModel(entity);
+    }
+
+    @Override
+    public List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return this.entity.getProtocolMappers().stream()
+                .filter((mapper) -> mapper.getProtocolMapper().equals(type))
+                .map(this::entityToModel)
+                .toList();
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/delegate/ClientModelLazyDelegate.java
@@ -24,6 +24,7 @@ import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicMarkableReference;
@@ -612,6 +613,11 @@ public class ClientModelLazyDelegate implements ClientModel {
     @Override
     public ProtocolMapperModel getProtocolMapperById(String id) {
         return getDelegate().getProtocolMapperById(id);
+    }
+
+    @Override
+    public List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return getDelegate().getProtocolMapperByType(type);
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -453,6 +453,11 @@ public class CredentialScopeModel implements ClientScopeModel {
     }
 
     @Override
+    public List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return clientScope.getProtocolMapperByType(type);
+    }
+
+    @Override
     public ProtocolMapperModel getProtocolMapperByName(String protocol, String name) {
         return clientScope.getProtocolMapperByName(protocol, name);
     }

--- a/server-spi/src/main/java/org/keycloak/models/ClientScopeDecorator.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientScopeDecorator.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -168,6 +169,11 @@ public class ClientScopeDecorator implements ClientScopeModel {
     @Override
     public ProtocolMapperModel getProtocolMapperById(String id) {
         return delegate.getProtocolMapperById(id);
+    }
+
+    @Override
+    public List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return delegate.getProtocolMapperByType(type);
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/ProtocolMapperContainerModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ProtocolMapperContainerModel.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.models;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,4 +42,8 @@ public interface ProtocolMapperContainerModel {
     ProtocolMapperModel getProtocolMapperById(String id);
 
     ProtocolMapperModel getProtocolMapperByName(String protocol, String name);
+
+    default List<ProtocolMapperModel> getProtocolMapperByType(String type) {
+        return List.of();
+    }
 }

--- a/server-spi/src/main/java/org/keycloak/models/ProtocolMapperModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/ProtocolMapperModel.java
@@ -18,6 +18,7 @@
 package org.keycloak.models;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -37,6 +38,21 @@ public class ProtocolMapperModel implements Serializable {
     protected String consentText;
     protected Map<String, String> config;
 
+    public ProtocolMapperModel() {
+
+    }
+
+    public ProtocolMapperModel(ProtocolMapperModel model) {
+        this.id = model.id;
+        this.name = model.name;
+        this.protocol = model.protocol;
+        this.protocolMapper = model.protocolMapper;
+        this.consentRequired = model.consentRequired;
+        this.consentText = model.consentText;
+        if (model.config != null) {
+            this.config = new HashMap<>(model.config);
+        }
+    }
 
     public String getId() {
         return id;

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -62,6 +62,7 @@ import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.SessionExpirationUtils;
 import org.keycloak.models.utils.RoleUtils;
+import org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper;
 import org.keycloak.organization.protocol.mappers.oidc.OrganizationScope;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.ProtocolMapperUtils;
@@ -638,10 +639,13 @@ public class TokenManager {
             return clientScopes;
         }
 
-        // skip scopes that were explicitly requested using the dynamic scope format
+        // skip organization-related scopes that were explicitly requested using the dynamic scope format
         // we don't want dynamic and default client scopes duplicated
-        // always include the dedicated client scope that maps to the client itself
-        clientScopes = clientScopes.filter(scope -> scope.equals(client) || !scopeParam.contains(scope.getName() + ClientScopeModel.VALUE_SEPARATOR));
+        clientScopes = clientScopes.filter(scope -> {
+            return scope.equals(client)
+                    || !scopeParam.contains(scope.getName() + ClientScopeModel.VALUE_SEPARATOR)
+                    || scope.getProtocolMapperByType(OrganizationMembershipMapper.PROVIDER_ID).isEmpty();
+        });
 
         Map<String, ClientScopeModel> allOptionalScopes = client.getClientScopes(false);
 


### PR DESCRIPTION
Closes #42877

* Only filter default scopes with the organization mapper when checking requested scopes using a dynamic format
* Added a new method to resolve mappers by type from `ClientScopeModel` to avoid iterating over mappers all the time. I'm not sure if we need to add a `protocol` parameter to the `getProtocolMappersByType` or if just the type is enough?
* Updated methods `getProtocolMapperById|Name` to avoid iterating over all mappers all the time

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
