### PR TITLE
Upgrade bc-fips testing and documentation to 2.1.2

### DIFF
--- a/docs/guides/server/fips.adoc
+++ b/docs/guides/server/fips.adoc
@@ -129,7 +129,7 @@ By using TRACE level, you can check that the startup log contains `KC` provider 
 
 [source]
 ----
-KC(BCFIPS version 2.0 Approved Mode, FIPS-JVM: enabled) version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider,
+KC(BCFIPS version 2.0102 Approved Mode, FIPS-JVM: enabled) version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider,
 ----
 
 === Cryptography restrictions in strict mode
@@ -194,8 +194,6 @@ property above for adding XMLDSig provider into that file. Then start your {proj
 For Kerberos/SPNEGO, the security provider `SunJGSS` is not yet fully FIPS compliant. Hence it is not recommended to add it to your list of security providers
 if you want to be FIPS compliant. The `KERBEROS` feature is disabled by default in {project_name} when it is executed on FIPS platform and when security provider is not
 available. Details are in the https://bugzilla.redhat.com/show_bug.cgi?id=2051628[bugzilla].
-
-The algorithm `EdDSA` cannot be used in FIPS mode. Although the current `BCFIPS` provider supports `Ed25519` and `Ed448` curves, the resulting keys do not implement the standard JDK interfaces to manage them (`EdECKey`, `EdECPublicKey`, `EdECPrivateKey`,...), and {project_name} cannot use them for signatures.
 
 == Run the CLI on the FIPS host
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,10 @@
         <!-- Versions used mostly for Undertow server, aligned with WildFly -->
         <jboss.dmr.version>1.5.1.Final</jboss.dmr.version>
 
-        <bouncycastle.pkixfips.version>2.0.7</bouncycastle.pkixfips.version>
-        <bouncycastle.bcfips.version>2.0.0</bouncycastle.bcfips.version>
-        <bouncycastle.bctls-fips.version>2.0.19</bouncycastle.bctls-fips.version>
-        <bouncycastle.bcutilfips.version>2.0.3</bouncycastle.bcutilfips.version>
+        <bouncycastle.pkixfips.version>2.1.10</bouncycastle.pkixfips.version>
+        <bouncycastle.bcfips.version>2.1.2</bouncycastle.bcfips.version>
+        <bouncycastle.bctls-fips.version>2.1.22</bouncycastle.bctls-fips.version>
+        <bouncycastle.bcutilfips.version>2.1.5</bouncycastle.bcutilfips.version>
 
         <dom4j.version>2.1.3</dom4j.version>
         <h2.version>2.3.230</h2.version>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -35,7 +35,7 @@ import io.quarkus.test.junit.main.Launch;
 @Tag(DistributionTest.SLOW)
 public class FipsDistTest {
 
-    private static final String BCFIPS_VERSION = "BCFIPS version 2.0";
+    private static final String BCFIPS_VERSION = "BCFIPS version 2.0102";
 
     @Test
     void testFipsNonApprovedMode(KeycloakDistribution dist) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/keys/JavaKeystoreKeyProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/keys/JavaKeystoreKeyProviderTest.java
@@ -151,8 +151,17 @@ public class JavaKeystoreKeyProviderTest extends AbstractKeycloakTest {
 
     @Test
     public void createJksEdDSA() throws Exception {
-        // BCFIPS does not support EdEC keys as it does not implement JDK interfaces
         createSuccess(KeystoreUtil.KeystoreFormat.JKS, AlgorithmType.EDDSA, Algorithm.EdDSA, true);
+    }
+
+    @Test
+    public void createPkcs12EdDSA() throws Exception {
+        createSuccess(KeystoreUtil.KeystoreFormat.PKCS12, AlgorithmType.EDDSA, Algorithm.EdDSA, true);
+    }
+
+    @Test
+    public void createBcfksEdDSA() throws Exception {
+        createSuccess(KeystoreUtil.KeystoreFormat.BCFKS, AlgorithmType.EDDSA, Algorithm.EdDSA, true);
     }
 
     private void createSuccess(KeystoreUtil.KeystoreFormat keystoreType, AlgorithmType algorithmType, String keyAlgorithm, boolean vault) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/testsuites/fips-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/fips-suite
@@ -2,6 +2,7 @@ LoginTest
 LoginTotpTest
 PasswordHashingTest
 ClientAuthSignedJWTTest
+ClientAuthEdDSASignedJWTTest
 CredentialsTest
 JavaKeystoreKeyProviderTest
 ServerInfoTest


### PR DESCRIPTION
Closes #42958

Just upgrading the BC jars to the last version for testing and documentation. As version 2.1 supports EdDSA the PR adds `ClientAuthEdDSASignedJWTTest` to the CI and adds this key in the `JavaKeystoreKeyProviderTest`. If you think that is better to continue using 2.0 versions just let me know.