### PR TITLE
feat: add hCaptcha registration form action

### DIFF
--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -1,0 +1,48 @@
+// Release notes should contain only headline-worthy new features,
+// assuming that people who migrate will read the upgrading guide anyway.
+
+= hCaptcha support for registration
+
+{project_name} now includes support for hCaptcha as an alternative to reCAPTCHA for protecting the registration form against bots.
+Similar to reCAPTCHA, hCaptcha can be configured as a registration form action, allowing you to choose your preferred CAPTCHA provider.
+
+For more details, see the https://www.keycloak.org/server/authentication[User authentication] guide.
+
+= Preview of enhanced HTTP performance
+
+You can now enable a more efficient way to handle JSON data in the HTTP layer.
+This change increases throughput by ~5%, stabilizes response times, and reduces system resource usage.
+
+In order to apply it, you need to explicitly enable the feature `http-optimized-serializers`.
+
+NOTE: This feature is *preview*.
+ifeval::[{project_community}==true]
+We gather more feedback about potential issues in https://github.com/keycloak/keycloak/discussions/43484[this discussion]. We appreciate any feedback.
+endif::[]
+
+For more details, see the https://www.keycloak.org/server/configuration-production[Configuring Keycloak for production] guide.
+
+= Breaking Fix for Windows in Loopback Hostname Verification
+
+This release introduces a breaking change for Windows users: setups that previously relied on custom machine names or non-standard hostnames for loopback (e.g., `127.0.0.1` resolving to a custom name) may require updates to their trusted domain configuration. Only `localhost` and `*.localhost` are now recognized for loopback verification.
+
+Keycloak now consistently normalizes loopback addresses to `localhost` for domain verification across all platforms. This change ensures predictable behavior for trusted domain checks, regardless of the underlying OS.
+
+= Export traces with custom request headers
+
+It is now possible to set request headers for exporting traces via Open Telemetry Protocol (OTLP).
+It is mainly useful for providing tokens in the request.
+
+You can specify these headers via the `tracing-header-<header>` wildcard option, accepting any custom header name.
+
+For more details, see the  link:{tracingguide_link}[{tracingguide_name}] guide.
+
+= Enable/disable features via a single option
+
+You can now enable or disable individual features using the `feature-<name>` option (like `feature-spiffe=enabled`).
+
+This provides a more fine-grained way to manage features and eliminates the need to maintain long lists of enabled or disabled features.
+
+The `feature-<name>` option takes precedence over both `features` and `features-disabled`.
+
+For more details, see the https://www.keycloak.org/server/features[Enabling and disabling features] guide.

--- a/docs/documentation/server_admin/topics/users/proc-enabling-recaptcha.adoc
+++ b/docs/documentation/server_admin/topics/users/proc-enabling-recaptcha.adoc
@@ -3,11 +3,11 @@
 // server_admin/topics/users.adoc
 
 [id="proc-enabling-recaptcha_{context}"]
-= Enabling reCAPTCHA
+= Enabling CAPTCHA
 
 [role="_abstract"]
-To safeguard registration against bots, {project_name} has integration with Google reCAPTCHA (see <<procedure_recaptcha>>) and reCAPTCHA Enterprise (see <<procedure_recaptcha_enterprise>>).
-The default theme (`register.ftl`) supports both v2 (visible, checkbox-based) and v3 (score-based, invisible) reCAPTCHA (see https://cloud.google.com/recaptcha/docs/choose-key-type[Choose the appropriate reCAPTCHA key type]).
+To safeguard registration against bots, {project_name} has integration with Google reCAPTCHA (see <<procedure_recaptcha>>), hCaptcha (see <<procedure_hcaptcha>>), and reCAPTCHA Enterprise (see <<procedure_recaptcha_enterprise>>).
+The default theme (`register.ftl`) supports both v2 (visible, checkbox-based) and v3 (score-based, invisible) reCAPTCHA (see https://docs.google.com/recaptcha/docs/choose-key-type[Choose the appropriate reCAPTCHA key type]).
 
 [[procedure_recaptcha]]
 == Setting up Google reCAPTCHA
@@ -48,6 +48,29 @@ NOTE: In {project_name}, websites cannot include a login page dialog in an ifram
 .. Enter `https://www.google.com` in the field for the *X-Frame-Options* header (or `https//www.recaptcha.net` if you enabled *Use recaptcha.net*).
 .. Enter `https://www.google.com` in the field for the *Content-Security-Policy* header (or `https//www.recaptcha.net` if you enabled *Use recaptcha.net*).
 
+
+[[procedure_hcaptcha]]
+== Setting up hCaptcha
+
+. Enter the following URL in a browser:
++
+[source,bash,subs=+attributes]
+----
+https://www.hcaptcha.com/
+----
+
+. Sign in and create a site in the hCaptcha dashboard to obtain your *Site Key* and *Secret*. Note them down for future use in this procedure.
+. Navigate to the {project_name} admin console.
+. Click *Authentication* in the menu.
+. Click the *Flows* tab.
+. Select *Registration* from the list.
+. Add the *hCaptcha* execution as a sub-step of *Registration Form* and set its requirement to *Required*.
+. Click the *gear icon* ⚙️ on the *hCaptcha* row.
+
++
+. Enter the *hCaptcha Site Key* generated from the hCaptcha dashboard.
+. Enter the *hCaptcha Secret* generated from the hCaptcha dashboard.
+. Save the configuration.
 
 [[procedure_recaptcha_enterprise]]
 == Setting up Google reCAPTCHA Enterprise

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationHCaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationHCaptcha.java
@@ -1,0 +1,127 @@
+package org.keycloak.authentication.forms;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.jboss.logging.Logger;
+import org.keycloak.authentication.ValidationContext;
+import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.services.ServicesLogger;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
+
+public class RegistrationHCaptcha extends AbstractRegistrationRecaptcha {
+
+    private static final Logger LOGGER = Logger.getLogger(RegistrationHCaptcha.class);
+
+    public static final String PROVIDER_ID = "registration-hcaptcha-action";
+    public static final String SECRET_KEY = "secret.key";
+
+    @Override
+    public String getDisplayType() {
+        return "hCaptcha";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Adds hCaptcha to the form.";
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    protected boolean validateConfig(Map<String, String> config) {
+        return !StringUtil.isNullOrEmpty(config.get(SITE_KEY))
+                && !StringUtil.isNullOrEmpty(config.get(SECRET_KEY));
+    }
+
+    @Override
+    protected boolean validate(ValidationContext context, String captcha, Map<String, String> config) {
+        LOGGER.trace("Verifying hCaptcha token");
+        CloseableHttpClient httpClient = context.getSession().getProvider(HttpClientProvider.class).getHttpClient();
+
+        HttpPost post = new HttpPost("https://hcaptcha.com/siteverify");
+        List<NameValuePair> formparams = new LinkedList<>();
+        formparams.add(new BasicNameValuePair("secret", config.get(SECRET_KEY)));
+        formparams.add(new BasicNameValuePair("response", captcha));
+        if (context.getConnection().getRemoteAddr() != null) {
+            formparams.add(new BasicNameValuePair("remoteip", context.getConnection().getRemoteAddr()));
+        }
+
+        try {
+            UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8);
+            post.setEntity(form);
+            try (CloseableHttpResponse response = httpClient.execute(post)) {
+                InputStream content = response.getEntity().getContent();
+                try {
+                    Map json = JsonSerialization.readValue(content, Map.class);
+                    return Boolean.TRUE.equals(json.get("success"));
+                } finally {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            }
+        } catch (Exception e) {
+            ServicesLogger.LOGGER.recaptchaFailed(e);
+        }
+        return false;
+    }
+
+    @Override
+    protected String getScriptUrl(Map<String, String> config, String userLanguageTag) {
+        return "https://hcaptcha.com/1/api.js?hl=" + userLanguageTag;
+    }
+
+    @Override
+    protected String resolveAction(Map<String, String> config) {
+        return null;
+    }
+
+    @Override
+    protected boolean isInvisible(Map<String, String> config) {
+        return false;
+    }
+
+    @Override
+    protected String getResponseFieldName() {
+        return H_CAPTCHA_RESPONSE;
+    }
+
+    @Override
+    protected String getCaptchaCssClass() {
+        return "h-captcha";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(SITE_KEY)
+                .label("hCaptcha Site Key")
+                .helpText("The site key.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+                .property()
+                .name(SECRET_KEY)
+                .label("hCaptcha Secret")
+                .helpText("The secret key.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .secret(true)
+                .add()
+                .build();
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPage.java
@@ -52,7 +52,7 @@ public class RegistrationPage implements FormAuthenticator, FormAuthenticatorFac
     public static final String FIELD_USERNAME = "username";
     public static final String FIELD_LAST_NAME = "lastName";
     public static final String FIELD_FIRST_NAME = "firstName";
-    public static final String FIELD_RECAPTCHA_RESPONSE = "g-recaptcha-response";
+    public static final String FIELD_RECAPTCHA_RESPONSE = AbstractRegistrationRecaptcha.G_RECAPTCHA_RESPONSE;
     public static final String PROVIDER_ID = "registration-page-form";
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptcha.java
@@ -74,6 +74,11 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
     }
 
     @Override
+    protected String getResponseFieldName() {
+        return G_RECAPTCHA_RESPONSE;
+    }
+
+    @Override
     protected boolean validate(ValidationContext context, String captcha, Map<String, String> config) {
         LOGGER.trace("Verifying reCAPTCHA using non-enterprise API");
         CloseableHttpClient httpClient = context.getSession().getProvider(HttpClientProvider.class).getHttpClient();
@@ -119,8 +124,32 @@ public class RegistrationRecaptcha extends AbstractRegistrationRecaptcha {
     }
 
     @Override
+    protected String getCaptchaCssClass() {
+        return "g-recaptcha";
+    }
+
+    @Override
+    protected boolean usesCaptchaCallback() {
+        return true;
+    }
+
+    @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+
+    @Override
+    protected void setRecaptchaLegacyAttributes(LoginFormsProvider form, Map<String, String> config) {
+        // Set legacy reCAPTCHA attributes for backwards compatibility with custom themes
+        // TODO: Remove these attributes in a future version
+        boolean invisible = isInvisible(config);
+        String action = resolveAction(config);
+
+        form.setAttribute("recaptchaRequired", true);
+        form.setAttribute("recaptchaSiteKey", config.get(SITE_KEY));
+        form.setAttribute("recaptchaAction", action);
+        form.setAttribute("recaptchaVisible", !invisible);
+        form.setAttribute("recaptchaProviderId", getId());
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptchaEnterprise.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationRecaptchaEnterprise.java
@@ -72,9 +72,38 @@ public class RegistrationRecaptchaEnterprise extends AbstractRegistrationRecaptc
     }
 
     @Override
+    protected String getResponseFieldName() {
+        return G_RECAPTCHA_RESPONSE;
+    }
+
+    @Override
     protected String getScriptUrl(Map<String, String> config, String userLanguageTag) {
         return "https://www." + getRecaptchaDomain(config) + "/recaptcha/enterprise.js?hl=" + userLanguageTag;
 
+    }
+
+    @Override
+    protected String getCaptchaCssClass() {
+        return "g-recaptcha";
+    }
+
+    @Override
+    protected boolean usesCaptchaCallback() {
+        return true;
+    }
+
+    @Override
+    protected void setRecaptchaLegacyAttributes(LoginFormsProvider form, Map<String, String> config) {
+        // Set legacy reCAPTCHA attributes for backwards compatibility with custom themes
+        // TODO: Remove these attributes in a future version
+        boolean invisible = isInvisible(config);
+        String action = resolveAction(config);
+
+        form.setAttribute("recaptchaRequired", true);
+        form.setAttribute("recaptchaSiteKey", config.get(SITE_KEY));
+        form.setAttribute("recaptchaAction", action);
+        form.setAttribute("recaptchaVisible", !invisible);
+        form.setAttribute("recaptchaProviderId", getId());
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -262,8 +262,8 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
     private MultivaluedMap<String, String> normalizeFormParameters(MultivaluedMap<String, String> formParams) {
         MultivaluedHashMap<String, String> copy = new MultivaluedHashMap<>(formParams);
 
-        // Remove google recaptcha form property to avoid length errors
-        copy.remove(RegistrationPage.FIELD_RECAPTCHA_RESPONSE);
+        // Remove captcha form properties to avoid length errors
+        AbstractRegistrationRecaptcha.CAPTCHA_RESPONSE_FIELDS.forEach(copy::remove);
         // Remove "password" and "password-confirm" to avoid leaking them in the user-profile data
         copy.remove(RegistrationPage.FIELD_PASSWORD);
         copy.remove(RegistrationPage.FIELD_PASSWORD_CONFIRM);

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
@@ -18,5 +18,6 @@
 org.keycloak.authentication.forms.RegistrationPassword
 org.keycloak.authentication.forms.RegistrationUserCreation
 org.keycloak.authentication.forms.RegistrationRecaptcha
+org.keycloak.authentication.forms.RegistrationHCaptcha
 org.keycloak.authentication.forms.RegistrationRecaptchaEnterprise
 org.keycloak.authentication.forms.RegistrationTermsAndConditions

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.keycloak.authentication.authenticators.broker.IdpCreateUserIfUniqueAuthenticatorFactory;
+import org.keycloak.authentication.forms.RegistrationHCaptcha;
 import org.keycloak.authentication.forms.RegistrationRecaptcha;
 import org.keycloak.authentication.forms.RegistrationRecaptchaEnterprise;
 import org.keycloak.representations.idm.AuthenticatorConfigInfoRepresentation;
@@ -65,6 +66,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
 
         List<Map<String, Object>> expected = new LinkedList<>();
         addProviderInfo(expected, RegistrationRecaptcha.PROVIDER_ID, "reCAPTCHA", "Adds Google reCAPTCHA to the form.");
+        addProviderInfo(expected, RegistrationHCaptcha.PROVIDER_ID, "hCaptcha", "Adds hCaptcha to the form.");
         addProviderInfo(expected, RegistrationRecaptchaEnterprise.PROVIDER_ID, "reCAPTCHA Enterprise", "Adds Google reCAPTCHA Enterprise to the form.");
         addProviderInfo(expected, "registration-password-action", "Password Validation",
                 "Validates that password matches password confirmation field.  It also will store password in user's credential store.");

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/address/login/register.ftl
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/theme/address/login/register.ftl
@@ -107,12 +107,14 @@
                     <input type="text" class="${properties.kcInputClass!}"  id="user.attributes.country" name="user.attributes.country" value="${(register.formData['user.attributes.country']!'')}"/>
                 </div>
             </div>
-            <#if recaptchaRequired??>
+            <#if captchaRequired!false>
+                <#if captchaVisible!false>
             <div class="form-group">
                 <div class="${properties.kcInputWrapperClass!}">
-                    <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}"></div>
+                    <div class="${captchaCssClass!}" data-size="compact" data-sitekey="${captchaSiteKey}"></div>
                 </div>
             </div>
+                </#if>
             </#if>
 
             <div class="${properties.kcFormGroupClass!}">

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -73,12 +73,14 @@
 
             <@registerCommons.termsAcceptance/>
 
-            <#if recaptchaRequired?? && (recaptchaVisible!false)>
+            <#if captchaRequired!false>
+                <#if captchaVisible!false>
                 <div class="form-group">
                     <div class="${properties.kcInputWrapperClass!}">
-                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}" data-action="${recaptchaAction}"></div>
+                        <div class="${captchaCssClass!}" data-size="compact" data-sitekey="${captchaSiteKey}"<#if captchaUseCallback!false && captchaAction?has_content> data-action="${captchaAction}"</#if>></div>
                     </div>
                 </div>
+                </#if>
             </#if>
 
             <div class="${properties.kcFormGroupClass!}">
@@ -88,18 +90,24 @@
                     </div>
                 </div>
 
-                <#if recaptchaRequired?? && !(recaptchaVisible!false)>
+                <#if captchaRequired!false && !(captchaVisible!false)>
+                    <#if captchaUseCallback!false>
                     <script>
                         function onSubmitRecaptcha(token) {
                             document.getElementById("kc-register-form").requestSubmit();
                         }
                     </script>
                     <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-                        <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha" 
-                            data-sitekey="${recaptchaSiteKey}" data-callback='onSubmitRecaptcha' data-action='${recaptchaAction}' type="submit">
+                        <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} ${captchaCssClass!}"
+                            data-sitekey="${captchaSiteKey}" data-callback='onSubmitRecaptcha'<#if captchaAction?has_content> data-action='${captchaAction}'</#if> type="submit">
                             ${msg("doRegister")}
                         </button>
                     </div>
+                    <#else>
+                    <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>
+                    </div>
+                    </#if>
                 <#else>
                     <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                         <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>

--- a/themes/src/main/resources/theme/keycloak.v2/login/register.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/register.ftl
@@ -26,26 +26,34 @@
 
             <@registerCommons.termsAcceptance/>
 
-            <#if recaptchaRequired?? && (recaptchaVisible!false)>
+            <#if captchaRequired!false>
+                <#if captchaVisible!false>
                 <div class="form-group">
                     <div class="${properties.kcInputWrapperClass!}">
-                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}" data-action="${recaptchaAction}"></div>
+                        <div class="${captchaCssClass!}" data-size="compact" data-sitekey="${captchaSiteKey}"<#if captchaUseCallback!false && captchaAction?has_content> data-action="${captchaAction}"</#if>></div>
                     </div>
                 </div>
+                </#if>
             </#if>
 
-            <#if recaptchaRequired?? && !(recaptchaVisible!false)>
+            <#if captchaRequired!false && !(captchaVisible!false)>
+                <#if captchaUseCallback!false>
                 <script>
                     function onSubmitRecaptcha(token) {
                         document.getElementById("kc-register-form").requestSubmit();
                     }
                 </script>
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
-                    <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha"
-                            data-sitekey="${recaptchaSiteKey}" data-callback="onSubmitRecaptcha" data-action="${recaptchaAction}" type="submit" id="kc-submit">
+                    <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} ${captchaCssClass!}"
+                            data-sitekey="${captchaSiteKey}" data-callback="onSubmitRecaptcha"<#if captchaAction?has_content> data-action="${captchaAction}"</#if> type="submit" id="kc-submit">
                         ${msg("doRegister")}
                     </button>
                 </div>
+                <#else>
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}" id="kc-submit"/>
+                </div>
+                </#if>
             <#else>
                 <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
                     <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>


### PR DESCRIPTION
adds hcaptcha as requested in https://github.com/keycloak/keycloak/issues/41057

- generalize the registration captcha base so providers can supply their response field names, template metadata, and scripts
- add an hCaptcha form action with service registration, theme updates, and documentation for configuring the provider
- extend admin provider tests to expect the hCaptcha action in addition to the existing reCAPTCHA entries
