### PR TITLE
Make the script work when there are no tags for the release yet

### DIFF
--- a/.github/scripts/version-compatibility.sh
+++ b/.github/scripts/version-compatibility.sh
@@ -20,6 +20,6 @@ ALL_RELEASES=$(gh release list \
   --template '{{range .}}{{.name}}{{"\n"}}{{end}}'
 )
 MAJOR_MINOR=${TARGET_BRANCH#"release/"}
-MAJOR_MINOR_RELEASES=$(echo "${ALL_RELEASES}" | grep "${MAJOR_MINOR}")
+MAJOR_MINOR_RELEASES=$(echo "${ALL_RELEASES}" | (grep "${MAJOR_MINOR}" || true))
 
-echo "${MAJOR_MINOR_RELEASES}" | jq -cnR '[inputs] | map({version: .})'
+echo -n "${MAJOR_MINOR_RELEASES}" | jq -cnR '[inputs] | map({version: .})'


### PR DESCRIPTION
Closes #43057

New output: 

```
$ ./.github/scripts/version-compatibility.sh "release/26.3"
[{"version":"26.3.5"},{"version":"26.3.4"},{"version":"26.3.3"},{"version":"26.3.2"},{"version":"26.3.1"},{"version":"26.3.0"}]
$ ./.github/scripts/version-compatibility.sh "release/26.4"
[]
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
