### PR TITLE
Remove a link to Docker web from the docs [26.4]

### DIFF
--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -88,7 +88,7 @@ NOTE: If you configure mTLS with `https-client-auth` set to `required`, this con
 
 === HEALTHCHECK
 
-The Containerfile https://docs.docker.com/reference/dockerfile/#healthcheck[`+HEALTHCHECK+`] instruction defines a command that will be periodically executed inside the container as it runs. While the {project_name} container does not have any CLI HTTP clients installed, it is possible to leverage BASH support for redirects to TCP sockets and craft a simple HTTP request to the healthcheck endpoint:
+The Containerfile `+HEALTHCHECK+` instruction defines a command that will be periodically executed inside the container as it runs. While the {project_name} container does not have any CLI HTTP clients installed, it is possible to leverage BASH support for redirects to TCP sockets and craft a simple HTTP request to the healthcheck endpoint:
 
 [source, bash]
 ----


### PR DESCRIPTION
Closes #43072

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
