### PR TITLE
CI pipeline breaks when there are no tags for a release branch yet

### DIFF
--- a/.github/scripts/version-compatibility.sh
+++ b/.github/scripts/version-compatibility.sh
@@ -9,6 +9,7 @@ REPO="${2:-keycloak}"
 ORG="${3:-keycloak}"
 
 if [[ "${TARGET_BRANCH}" != "release/"* ]]; then
+  echo "skip"
   exit 0
 fi
 
@@ -20,6 +21,10 @@ ALL_RELEASES=$(gh release list \
   --template '{{range .}}{{.name}}{{"\n"}}{{end}}'
 )
 MAJOR_MINOR=${TARGET_BRANCH#"release/"}
-MAJOR_MINOR_RELEASES=$(echo "${ALL_RELEASES}" | grep "${MAJOR_MINOR}")
+MAJOR_MINOR_RELEASES=$(echo "${ALL_RELEASES}" | (grep "${MAJOR_MINOR}" || true))
 
-echo "${MAJOR_MINOR_RELEASES}" | jq -cnR '[inputs] | map({version: .})'
+if [[ -z "${MAJOR_MINOR_RELEASES}" ]]; then
+  echo "skip"
+else
+  echo -n "${MAJOR_MINOR_RELEASES}" | jq -cnR '[inputs] | map({version: .})'
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -889,7 +889,7 @@ jobs:
 
   mixed-cluster-compatibility-tests:
     name: Cluster Compatibility Tests
-    if: needs.conditional.outputs.ci-compatibility-matrix != ''
+    if: needs.conditional.outputs.ci-compatibility-matrix != 'skip'
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
Closes #43057

Run on my fork with a `release/26.5` branch i.e. no existing releases for MAJOR_MINOR exist. Status check fails due to cancelled `store-integration-tests`, but the skipped `mixed-cluster-compatibility-tests` job check is now working as expected: https://github.com/ryanemerson/keycloak/actions/runs/18159833624

