### PR TITLE
Expose scheduled tasks and start time

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/timer/TimerProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/timer/TimerProvider.java
@@ -19,6 +19,10 @@ package org.keycloak.timer;
 
 import org.keycloak.provider.Provider;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -44,10 +48,13 @@ public interface TimerProvider extends Provider {
      */
     public TimerTaskContext cancelTask(String taskName);
 
+    public Map<String, TimerTaskContext> getTasks();
 
     interface TimerTaskContext {
 
         Runnable getRunnable();
+
+        long getStartTimeMillis();
 
         long getIntervalMillis();
     }

--- a/services/src/main/java/org/keycloak/timer/basic/BasicTimerProvider.java
+++ b/services/src/main/java/org/keycloak/timer/basic/BasicTimerProvider.java
@@ -18,13 +18,21 @@
 package org.keycloak.timer.basic;
 
 import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.scheduled.ScheduledTaskRunner;
 import org.keycloak.timer.ScheduledTask;
 import org.keycloak.timer.TimerProvider;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.stream.Collectors;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -54,7 +62,7 @@ public class BasicTimerProvider implements TimerProvider {
             }
         };
 
-        TimerTaskContextImpl taskContext = new TimerTaskContextImpl(runnable, task, intervalMillis);
+        TimerTaskContextImpl taskContext = new TimerTaskContextImpl(runnable, task, Time.currentTimeMillis(), intervalMillis);
         TimerTaskContextImpl existingTask = factory.putTask(taskName, taskContext);
         if (existingTask != null) {
             logger.debugf("Existing timer task '%s' found. Cancelling it", taskName);
@@ -87,4 +95,8 @@ public class BasicTimerProvider implements TimerProvider {
         // do nothing
     }
 
+    @Override
+    public Map<String, TimerTaskContext> getTasks() {
+        return Collections.unmodifiableMap(new HashMap<>(factory.getTasks()));
+    }
 }

--- a/services/src/main/java/org/keycloak/timer/basic/BasicTimerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/timer/basic/BasicTimerProviderFactory.java
@@ -23,6 +23,9 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.timer.TimerProvider;
 import org.keycloak.timer.TimerProviderFactory;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -75,4 +78,7 @@ public class BasicTimerProviderFactory implements TimerProviderFactory {
         return scheduledTasks.remove(taskName);
     }
 
+    protected Map<String, TimerTaskContextImpl> getTasks(){
+        return scheduledTasks;
+    }
 }

--- a/services/src/main/java/org/keycloak/timer/basic/TimerTaskContextImpl.java
+++ b/services/src/main/java/org/keycloak/timer/basic/TimerTaskContextImpl.java
@@ -28,17 +28,23 @@ public class TimerTaskContextImpl implements TimerProvider.TimerTaskContext {
 
     private final Runnable runnable;
     final TimerTask timerTask;
+    private final long startTimeMillis;
     private final long intervalMillis;
 
-    public TimerTaskContextImpl(Runnable runnable, TimerTask timerTask, long intervalMillis) {
+    public TimerTaskContextImpl(Runnable runnable, TimerTask timerTask, long startTimeMillis, long intervalMillis) {
         this.runnable = runnable;
         this.timerTask = timerTask;
+        this.startTimeMillis = startTimeMillis;
         this.intervalMillis = intervalMillis;
     }
 
     @Override
     public Runnable getRunnable() {
         return runnable;
+    }
+
+    public long getStartTimeMillis() {
+        return startTimeMillis;
     }
 
     @Override


### PR DESCRIPTION
Expose scheduled timer tasks (runnable, start time, interval) via the Timer SPI to improve operational visibility and debugging.

Closes #43106 

## Changes
- Add `List<TimerTaskContext> getTasks()` to `TimerProvider`.
- Extend `TimerTaskContext` with:
  ```java
  Runnable getRunnable();
  long getStartDateMillis();
  long getIntervalMillis();
