### PR TITLE
Add a debug statement when the KeycloakFipsSecurityProvider is created

### DIFF
--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/KeycloakFipsSecurityProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/KeycloakFipsSecurityProvider.java
@@ -26,6 +26,7 @@ public class KeycloakFipsSecurityProvider extends Provider {
                 ", FIPS-JVM: " + isSystemFipsEnabled() +
                 ")", 1, "Keycloak pseudo provider");
         this.bcFipsProvider = bcFipsProvider;
+        logger.infof("KeycloakFipsSecurityProvider created: %s", this.toString());
     }
 
     @Override

--- a/docs/guides/server/fips.adoc
+++ b/docs/guides/server/fips.adoc
@@ -118,18 +118,11 @@ Using that option results in stricter security requirements on cryptography and 
 NOTE: In strict mode, the default keystore type (as well as default truststore type) is BCFKS. If you want to use a different keystore type
 it is required to use the option `--https-key-store-type` with appropriate type. A similar command might be needed for the truststore as well if you want to use it.
 
-When starting the server, you can include TRACE level in the startup command. For example:
-
-[source,bash,subs=+attributes]
-----
---log-level=INFO,org.keycloak.common.crypto.CryptoIntegration:TRACE
-----
-
-By using TRACE level, you can check that the startup log contains `KC` provider with the note about `Approved Mode` such as the following:
+When starting the server, you can check that the startup log contains `KC` provider with the note about `Approved Mode` such as the following:
 
 [source]
 ----
-KC(BCFIPS version 2.0102 Approved Mode, FIPS-JVM: enabled) version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider,
+KeycloakFipsSecurityProvider created: KC(BCFIPS version 2.0102 Approved Mode, FIPS-JVM: enabled) version 1.0
 ----
 
 === Cryptography restrictions in strict mode

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/FipsDistTest.java
@@ -30,7 +30,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
 
-@DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--features=fips", "--http-enabled=true", "--hostname-strict=false", "--log-level=org.keycloak.common.crypto.CryptoIntegration:trace" })
+@DistributionTest(keepAlive = true, defaultOptions = { "--db=dev-file", "--features=fips", "--http-enabled=true", "--hostname-strict=false" })
 @RawDistOnly(reason = "Containers are immutable")
 @Tag(DistributionTest.SLOW)
 public class FipsDistTest {
@@ -44,8 +44,7 @@ public class FipsDistTest {
             cliResult.assertStarted();
             // Not shown as FIPS is not a preview anymore
             cliResult.assertMessageWasShownExactlyNumberOfTimes("Preview features enabled: fips:v1", 0);
-            cliResult.assertMessage("Java security providers: [ \n"
-                    + " KC(" + BCFIPS_VERSION + ", FIPS-JVM: " + KeycloakFipsSecurityProvider.isSystemFipsEnabled() + ") version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider");
+            cliResult.assertMessage("KeycloakFipsSecurityProvider created: KC(" + BCFIPS_VERSION + ", FIPS-JVM: " + KeycloakFipsSecurityProvider.isSystemFipsEnabled() + ") version 1.0");
         });
     }
 
@@ -57,8 +56,7 @@ public class FipsDistTest {
 
             CLIResult cliResult = dist.run("start", "--fips-mode=strict");
             cliResult.assertMessage("password must be at least 112 bits");
-            cliResult.assertMessage("Java security providers: [ \n"
-                    + " KC(" + BCFIPS_VERSION + " Approved Mode, FIPS-JVM: " + KeycloakFipsSecurityProvider.isSystemFipsEnabled() + ") version 1.0 - class org.keycloak.crypto.fips.KeycloakFipsSecurityProvider");
+            cliResult.assertMessage("KeycloakFipsSecurityProvider created: KC(" + BCFIPS_VERSION + " Approved Mode, FIPS-JVM: " + KeycloakFipsSecurityProvider.isSystemFipsEnabled() + ") version 1.0");
 
             dist.setEnvVar("KC_BOOTSTRAP_ADMIN_PASSWORD", "adminadminadmin");
             cliResult = dist.run("start", "--fips-mode=strict");

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/cli/KcAdmExec.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/cli/KcAdmExec.java
@@ -1,9 +1,12 @@
 package org.keycloak.testsuite.cli;
 
+import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.testsuite.arquillian.AuthServerTestEnricher;
 import org.keycloak.testsuite.cli.exec.AbstractExec;
 import org.keycloak.testsuite.cli.exec.AbstractExecBuilder;
 
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -35,6 +38,15 @@ public class KcAdmExec extends AbstractExec {
         return newBuilder()
                 .argsLine(args)
                 .execute();
+    }
+
+    @Override
+    public List<String> stderrLines() {
+        List<String> lines = super.stderrLines();
+        // remove the two lines with the BC provider info if FIPS
+        return AuthServerTestEnricher.AUTH_SERVER_FIPS_MODE == FipsMode.DISABLED || lines.size() < 2
+            ? lines
+            : lines.subList(2, lines.size());
     }
 
     public static class Builder extends AbstractExecBuilder<KcAdmExec> {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/cli/KcRegExec.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/cli/KcRegExec.java
@@ -1,9 +1,12 @@
 package org.keycloak.testsuite.cli;
 
+import org.keycloak.common.crypto.FipsMode;
+import org.keycloak.testsuite.arquillian.AuthServerTestEnricher;
 import org.keycloak.testsuite.cli.exec.AbstractExec;
 import org.keycloak.testsuite.cli.exec.AbstractExecBuilder;
 
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -35,6 +38,15 @@ public class KcRegExec extends AbstractExec {
         return newBuilder()
                 .argsLine(args)
                 .execute();
+    }
+
+    @Override
+    public List<String> stderrLines() {
+        List<String> lines = super.stderrLines();
+        // remove the two lines with the BC provider info if FIPS
+        return AuthServerTestEnricher.AUTH_SERVER_FIPS_MODE == FipsMode.DISABLED || lines.size() < 2
+            ? lines
+            : lines.subList(2, lines.size());
     }
 
     public static class Builder extends AbstractExecBuilder<KcRegExec> {


### PR DESCRIPTION
Closes #43015

@mposolda @ahus1 Draft PR for the debug info for the FIPS provider. This was my idea. The info line is executed in the `KeycloakFipsSecurityProvider` and this way it's only displayed when FIPS is configured. Tests modified do not require the extra debug parameters. The only snag that this line is also present for commands like `kcadm`or `kcreg` (but I think we cannot do anything for that), so I needed to also change the related tests when executed in FIPS. Let me know if you prefer the line in another class or you prefer another text. There will be issues in the docs because we need to adjust some links after the 26.4 release (I'll rebase when they are fixed).
