### PR TITLE
fix: adding checks around the hostname path

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ProxyHostnameV2DistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ProxyHostnameV2DistTest.java
@@ -104,6 +104,16 @@ public class ProxyHostnameV2DistTest {
     }
 
     @Test
+    @Launch({ "start-dev", "--hostname=https://mykeycloak.org:8443/path", "--proxy-headers=forwarded", "--hostname-backchannel-dynamic=true" })
+    public void testForwardedProxyHeadersWithPathAndDynamicBackchannel(LaunchResult result) {
+        assertFrontEndUrl("https://mykeycloak.org:8443", "https://mykeycloak.org:8443/path/");
+        // a backend url generated via the frontend protocol/host/port should be a front-end url
+        assertBackEndUrl("https://mykeycloak.org:8443", "https://mykeycloak.org:8443/path/");
+        // any other protocol/host/port will be the backend
+        assertBackEndUrl("http://localhost:8080", "http://localhost:8080/");
+    }
+
+    @Test
     @Launch({ "start-dev", "--hostname-strict=false", "--proxy-headers=xforwarded" })
     public void testXForwardedProxyHeaders() {
         assertForwardedHeaderIsIgnored();
@@ -151,4 +161,10 @@ public class ProxyHostnameV2DistTest {
         Assert.assertEquals(expectedBaseUrl + "realms/master/protocol/openid-connect/auth", getServerMetadata(requestBaseUrl)
                 .getAuthorizationEndpoint());
     }
+
+    private void assertBackEndUrl(String requestBaseUrl, String expectedBaseUrl) {
+        Assert.assertEquals(expectedBaseUrl + "realms/master/protocol/openid-connect/token", getServerMetadata(requestBaseUrl)
+                .getTokenEndpoint());
+    }
+
 }


### PR DESCRIPTION
closes: #43166

@vmuzikar absent support for X-Forwarded-Prefix (which won't work for the Forwarded header regardless) here's a possible way to handle the validation and detection of this case.

There would of course need to be some doc updates here as well. I can understand that you may not want to account for this case in code. The alternative there is to document why it doesn't work and suggest using http-relative-path.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
