### PR TITLE
Fix NPE in FederatedJWTClientAuthenticator (#43042) (#43043)

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
@@ -52,6 +52,10 @@ public class FederatedJWTClientAuthenticator extends AbstractClientAuthenticator
         try {
             ClientAssertionState clientAssertionState = context.getState(ClientAssertionState.class, ClientAssertionState.supplier());
 
+            if (clientAssertionState == null || clientAssertionState.getClientAssertionType() == null) {
+                return;
+            }
+
             if (!SUPPORTED_ASSERTION_TYPES.contains(clientAssertionState.getClientAssertionType())) {
                 return;
             }


### PR DESCRIPTION
Add additional null guard before the check for supported assertation types.

Fixes #43042

Signed-off-by: Thomas Darimont <thomas.darimont@googlemail.com>
(cherry picked from commit 8780bc22b47671c9d5a24ea6419ca937bc5f8ff9)
