### PR TITLE
Convert the wizard to create client in progressive to validate every step

### DIFF
--- a/js/apps/admin-ui/src/clients/add/NewClientForm.tsx
+++ b/js/apps/admin-ui/src/clients/add/NewClientForm.tsx
@@ -107,6 +107,7 @@ export default function NewClientForm() {
             onClose={() => navigate(toClients({ realm }))}
             navAriaLabel={`${title} steps`}
             onSave={save}
+            isProgressive
             footer={<NewClientFooter {...form} />}
           >
             <WizardStep


### PR DESCRIPTION
Closes #42971

Just adding the `isProgressive` to the client wizard. This option does not show the future step links in the left side, only the already completed ones (you can go back but cannot go forward). This way, the administrator needs to pass through the three steps and ensures that all the required fields are filled. I don't see any test failing, so I suppose the links were never tested.