### PR TITLE
Prevent root attributes from being configured as multivalued  Closes #42749

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/config/UPConfigUtils.java
+++ b/services/src/main/java/org/keycloak/userprofile/config/UPConfigUtils.java
@@ -213,6 +213,10 @@ public class UPConfigUtils {
         if (attributeConfig.getAnnotations()!=null) {
             validateAnnotations(attributeConfig.getAnnotations(), errors, attributeName);
         }
+
+        if (attributeConfig.isMultivalued() && isRootAttribute(attributeName)) {
+            errors.add("Attribute '" + attributeName + "' is a root attribute and cannot be multivalued");
+        }
     }
 
     private static void validateDefaultValue(KeycloakSession session, UPAttribute attributeConfig, List<String> errors) {


### PR DESCRIPTION
Prevent root attributes from being configured as multivalued  Closes #42749

### Summary
Fixes issue #42749 where enabling "multivalued" for root attributes such as `email`
or `username` results in 400 errors due to deserialization mismatches.

### Changes
- Added validation in `UPConfigUtils.validateAttribute()` to disallow
  multivalued configuration for root attributes.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
