### PR TITLE
Update reverseproxy documentation to point configuration of provider Closes (#43284)

### DIFF
--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -233,6 +233,7 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 | Whether the forwarded certificate is url-encoded or not. In NGINX, this corresponds to the `$ssl_client_cert` and `$ssl_client_escaped_cert` variables. This can also be used for the Traefik PassTlsClientCert middleware, as it sends the client certficate unencoded.
 |===
 
+NOTE: look into <@links.server id="configuration-provider"/>. For example tes parameter like --spi-x509cert-lookup-ngnix-ssl-client-cert=SSL_CLIENT_CERT
 === Configuring the NGINX provider
 
 The NGINX SSL/TLS module does not expose the client certificate chain. {project_name}'s NGINX certificate lookup provider rebuilds it by using the {project_name} truststore.

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -233,7 +233,7 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 | Whether the forwarded certificate is url-encoded or not. In NGINX, this corresponds to the `$ssl_client_cert` and `$ssl_client_escaped_cert` variables. This can also be used for the Traefik PassTlsClientCert middleware, as it sends the client certficate unencoded.
 |===
 
-NOTE: look into <@links.server id="configuration-provider"/>. For example tes parameter like --spi-x509cert-lookup-ngnix-ssl-client-cert=SSL_CLIENT_CERT
+NOTE: look into <@links.server id="configuration-provider"/>. For example you can use this parameter <@kc.start parameters="--spi-x509cert-lookup-nginx-ssl-client-cert=SSL_CLIENT_CERT"/>
 === Configuring the NGINX provider
 
 The NGINX SSL/TLS module does not expose the client certificate chain. {project_name}'s NGINX certificate lookup provider rebuilds it by using the {project_name} truststore.

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -237,7 +237,7 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 ====
 Consult the <@links.server id="configuration-provider"/> guide for details on the format of the options. For example you can use:
 
-<@kc.start parameters="--spi-x509cert-lookup-nginx-ssl-client-cert=SSL_CLIENT_CERT"/>
+<@kc.start parameters="--spi-x509cert-lookup--nginx--ssl-client-cert=SSL_CLIENT_CERT"/>
 ====
 
 === Configuring the NGINX provider

--- a/docs/guides/server/reverseproxy.adoc
+++ b/docs/guides/server/reverseproxy.adoc
@@ -233,7 +233,13 @@ to load additional certificates from headers `CERT_CHAIN_0` to `CERT_CHAIN_9` if
 | Whether the forwarded certificate is url-encoded or not. In NGINX, this corresponds to the `$ssl_client_cert` and `$ssl_client_escaped_cert` variables. This can also be used for the Traefik PassTlsClientCert middleware, as it sends the client certficate unencoded.
 |===
 
-NOTE: look into <@links.server id="configuration-provider"/>. For example you can use this parameter <@kc.start parameters="--spi-x509cert-lookup-nginx-ssl-client-cert=SSL_CLIENT_CERT"/>
+[NOTE]
+====
+Consult the <@links.server id="configuration-provider"/> guide for details on the format of the options. For example you can use:
+
+<@kc.start parameters="--spi-x509cert-lookup-nginx-ssl-client-cert=SSL_CLIENT_CERT"/>
+====
+
 === Configuring the NGINX provider
 
 The NGINX SSL/TLS module does not expose the client certificate chain. {project_name}'s NGINX certificate lookup provider rebuilds it by using the {project_name} truststore.


### PR DESCRIPTION
Add link to configuration_provider with example how to start spi with simplified spi parameter launch.

Fixes: #43284 