### PR TITLE
Fix sdjwt tests: make all string-byte conversions explicit (UTF-8)

### DIFF
--- a/core/src/main/java/org/keycloak/sdjwt/Disclosable.java
+++ b/core/src/main/java/org/keycloak/sdjwt/Disclosable.java
@@ -18,8 +18,6 @@ package org.keycloak.sdjwt;
 
 import java.util.Objects;
 
-import org.keycloak.jose.jws.crypto.HashUtils;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
@@ -63,11 +61,11 @@ public abstract class Disclosable {
 
     public String getDisclosureString() {
         String json = toJson();
-        return SdJwtUtils.encodeNoPad(json.getBytes());
+        return SdJwtUtils.encodeNoPad(json);
     }
 
     public String getDisclosureDigest(String hashAlg) {
-        return SdJwtUtils.encodeNoPad(HashUtils.hash(hashAlg, getDisclosureString().getBytes()));
+        return SdJwtUtils.hashAndBase64EncodeNoPad(getDisclosureString(), hashAlg);
     }
 
     @Override

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwtUtils.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwtUtils.java
@@ -17,6 +17,7 @@
 package org.keycloak.sdjwt;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Optional;
 
@@ -45,12 +46,24 @@ public class SdJwtUtils {
         return Base64Url.encode(bytes);
     }
 
+    public static String encodeNoPad(String input) {
+        return encodeNoPad(utf8Bytes(input));
+    }
+
     public static byte[] decodeNoPad(String encoded) {
         return Base64Url.decode(encoded);
     }
 
     public static String hashAndBase64EncodeNoPad(byte[] disclosureBytes, String hashAlg) {
         return encodeNoPad(HashUtils.hash(hashAlg, disclosureBytes));
+    }
+
+    public static String hashAndBase64EncodeNoPad(String disclosure, String hashAlg) {
+        return hashAndBase64EncodeNoPad(utf8Bytes(disclosure), hashAlg);
+    }
+
+    public static byte[] utf8Bytes(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
     }
 
     public static String requireNonEmpty(String str, String message) {
@@ -82,8 +95,8 @@ public class SdJwtUtils {
     public static ArrayNode decodeDisclosureString(String disclosure) throws VerificationException {
         JsonNode jsonNode;
 
-        // Decode Base64URL-encoded disclosure
-        String decoded = new String(decodeNoPad(disclosure));
+    // Decode Base64URL-encoded disclosure using UTF-8
+    String decoded = new String(decodeNoPad(disclosure), StandardCharsets.UTF_8);
 
         // Parse the disclosure string into a JSON array
         try {

--- a/core/src/test/java/org/keycloak/sdjwt/SdJwtUtilsTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/SdJwtUtilsTest.java
@@ -34,8 +34,8 @@ public class SdJwtUtilsTest {
     @Test
     public void testHashDisclosure() {
         String expected = "uutlBuYeMDyjLLTpf6Jxi7yNkEF35jdyWMn9U7b_RYY";
-        byte[] hash = HashUtils.hash("SHA-256", "WyI2cU1RdlJMNWhhaiIsICJmYW1pbHlfbmFtZSIsICJNw7ZiaXVzIl0".getBytes());
-        assertEquals(expected, SdJwtUtils.encodeNoPad(hash));
+    byte[] hash = HashUtils.hash("SHA-256", SdJwtUtils.utf8Bytes("WyI2cU1RdlJMNWhhaiIsICJmYW1pbHlfbmFtZSIsICJNw7ZiaXVzIl0"));
+    assertEquals(expected, SdJwtUtils.encodeNoPad(hash));
     }
 
     /**
@@ -45,8 +45,8 @@ public class SdJwtUtilsTest {
     @Test
     public void testHashDisclosure2() {
         String expected = "w0I8EKcdCtUPkGCNUrfwVp2xEgNjtoIDlOxc9-PlOhs";
-        byte[] hash = HashUtils.hash("SHA-256", "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0".getBytes());
-        assertEquals(expected, SdJwtUtils.encodeNoPad(hash));
+    byte[] hash = HashUtils.hash("SHA-256", SdJwtUtils.utf8Bytes("WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0"));
+    assertEquals(expected, SdJwtUtils.encodeNoPad(hash));
     }
 
     /**
@@ -74,7 +74,7 @@ public class SdJwtUtilsTest {
 
         // Assert that the base64 URL encoded string from the object matches the
         // expected string
-        assertEquals(expected, SdJwtUtils.encodeNoPad(input.getBytes()));
+    assertEquals(expected, SdJwtUtils.encodeNoPad(input));
     }
 
     /**
@@ -95,7 +95,7 @@ public class SdJwtUtilsTest {
 
         // Assert that the base64 URL encoded string from the object matches the
         // expected string
-        assertEquals(expected, SdJwtUtils.encodeNoPad(input.getBytes()));
+    assertEquals(expected, SdJwtUtils.encodeNoPad(input));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class SdJwtUtilsTest {
 
         // Assert that the base64 URL encoded string from the object matches the
         // expected string
-        assertEquals(expected, SdJwtUtils.encodeNoPad(input.getBytes()));
+    assertEquals(expected, SdJwtUtils.encodeNoPad(input));
     }
 
     @Test
@@ -119,6 +119,6 @@ public class SdJwtUtilsTest {
 
         // Assert that the base64 URL encoded string from the object matches the
         // expected string
-        assertEquals(expected, SdJwtUtils.encodeNoPad(input.getBytes()));
+    assertEquals(expected, SdJwtUtils.encodeNoPad(input));
     }
 }


### PR DESCRIPTION
* this unifies behaviour prior to JDK18 on Windows platform

Closes #43264

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
