### PR TITLE
Automatically dispose of realms created by `createTestBed()`

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: Node.js version
     required: false
-    default: "22"
+    default: "24"
 
 runs:
   using: composite

--- a/js/apps/account-ui/test/account-security/device-activity.spec.ts
+++ b/js/apps/account-ui/test/account-security/device-activity.spec.ts
@@ -4,7 +4,7 @@ import { createTestBed } from "../support/testbed.ts";
 
 test.describe("Device activity", () => {
   test("signs out of a single device session", async ({ browser }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
     const context1 = await browser.newContext();
     const context2 = await browser.newContext();
 
@@ -13,13 +13,13 @@ test.describe("Device activity", () => {
       const page2 = await context2.newPage();
 
       // Log in the first session, and verify it is active.
-      await login(page1, realm);
+      await login(page1, testBed.realm);
       await page1.getByTestId("accountSecurity").click();
       await page1.getByTestId("account-security/device-activity").click();
       await expect(page1.getByTestId("row-0")).toContainText("Current session");
 
       // Log in the second session, and verify it is active.
-      await login(page2, realm);
+      await login(page2, testBed.realm);
       await page2.getByTestId("accountSecurity").click();
       await page2.getByTestId("account-security/device-activity").click();
       await expect(page2.getByTestId("row-0")).toContainText("Current session");
@@ -48,7 +48,7 @@ test.describe("Device activity", () => {
   });
 
   test("signs out of all device sessions", async ({ browser }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
     const context1 = await browser.newContext();
     const context2 = await browser.newContext();
 
@@ -57,8 +57,8 @@ test.describe("Device activity", () => {
       const page2 = await context2.newPage();
 
       // Log in both sessions, then sign out of all devices from the second session.
-      await login(page1, realm);
-      await login(page2, realm);
+      await login(page1, testBed.realm);
+      await login(page2, testBed.realm);
       await page2.getByTestId("accountSecurity").click();
       await page2.getByTestId("account-security/device-activity").click();
       await page2

--- a/js/apps/account-ui/test/account-security/signing-in.spec.ts
+++ b/js/apps/account-ui/test/account-security/signing-in.spec.ts
@@ -6,10 +6,10 @@ import { createTestBed } from "../support/testbed.ts";
 
 test.describe("Signing in", () => {
   test("shows password and OTP credentials", async ({ page }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
 
     // Log in and navigate to the signing in section.
-    await login(page, realm);
+    await login(page, testBed.realm);
     await page.getByTestId("accountSecurity").click();
     await page.getByTestId("account-security/signing-in").click();
 
@@ -38,17 +38,17 @@ test.describe("Signing in", () => {
   test("allows setting a password credential if none exists", async ({
     page,
   }) => {
-    const realm = await createTestBed();
-    const user = await findUserByUsername(realm, DEFAULT_USER.username);
+    await using testBed = await createTestBed();
+    const user = await findUserByUsername(testBed.realm, DEFAULT_USER.username);
 
     // Log in and delete the password credential of the user.
-    await login(page, realm);
+    await login(page, testBed.realm);
     const credentials = await adminClient.users.getCredentials({
-      realm,
+      realm: testBed.realm,
       id: user.id as string,
     });
     await adminClient.users.deleteCredential({
-      realm,
+      realm: testBed.realm,
       id: user.id as string,
       credentialId: credentials[0].id as string,
     });

--- a/js/apps/account-ui/test/applications.spec.ts
+++ b/js/apps/account-ui/test/applications.spec.ts
@@ -6,10 +6,10 @@ test.describe("Applications", () => {
   test("shows a list of applications the user has access to", async ({
     page,
   }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
 
     // Log in and navigate to the applications page.
-    await login(page, realm);
+    await login(page, testBed.realm);
     await page.getByTestId("applications").click();
 
     // Assert that the applications list is displayed and contains the expected application.

--- a/js/apps/account-ui/test/groups.spec.ts
+++ b/js/apps/account-ui/test/groups.spec.ts
@@ -5,17 +5,17 @@ import { createTestBed } from "./support/testbed.ts";
 
 test.describe("Groups", () => {
   test("lists groups", async ({ page }) => {
-    const realm = await createTestBed(groupsRealm);
+    await using testBed = await createTestBed(groupsRealm);
 
-    await login(page, realm);
+    await login(page, testBed.realm);
     await page.getByTestId("groups").click();
     await expect(page.getByTestId("group[1].name")).toHaveText("three");
   });
 
   test("lists direct and indirect groups", async ({ page }) => {
-    const realm = await createTestBed(groupsRealm);
+    await using testBed = await createTestBed(groupsRealm);
 
-    await login(page, realm, "alice", "alice");
+    await login(page, testBed.realm, "alice", "alice");
     await page.getByTestId("groups").click();
 
     await expect(

--- a/js/apps/account-ui/test/personal-info/personal-info.spec.ts
+++ b/js/apps/account-ui/test/personal-info/personal-info.spec.ts
@@ -7,9 +7,9 @@ import userProfileRealm from "../realms/user-profile-realm.json" with { type: "j
 
 test.describe("Personal info", () => {
   test("sets basic information", async ({ page }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
 
-    await login(page, realm);
+    await login(page, testBed.realm);
 
     await page.getByTestId("email").fill("edewit@somewhere.com");
     await page.getByTestId("firstName").fill("Erik");
@@ -22,10 +22,13 @@ test.describe("Personal info", () => {
 
 test.describe("Personal info (user profile enabled)", () => {
   test("renders user profile fields", async ({ page }) => {
-    const realm = await createTestBed(userProfileRealm);
+    await using testBed = await createTestBed(userProfileRealm);
 
-    await adminClient.users.updateProfile({ ...userProfile, realm });
-    await login(page, realm);
+    await adminClient.users.updateProfile({
+      ...userProfile,
+      realm: testBed.realm,
+    });
+    await login(page, testBed.realm);
 
     await expect(page.locator("#select")).toBeVisible();
     await expect(page.getByTestId("help-label-select")).toBeVisible();
@@ -36,10 +39,13 @@ test.describe("Personal info (user profile enabled)", () => {
   });
 
   test("renders long select options as typeahead", async ({ page }) => {
-    const realm = await createTestBed(userProfileRealm);
+    await using testBed = await createTestBed(userProfileRealm);
 
-    await adminClient.users.updateProfile({ ...userProfile, realm });
-    await login(page, realm);
+    await adminClient.users.updateProfile({
+      ...userProfile,
+      realm: testBed.realm,
+    });
+    await login(page, testBed.realm);
 
     await page.locator("#alternatelang").click();
     await page.waitForSelector("text=Italiano");
@@ -53,10 +59,13 @@ test.describe("Personal info (user profile enabled)", () => {
   });
 
   test("renders long list of locales as typeahead", async ({ page }) => {
-    const realm = await createTestBed(userProfileRealm);
+    await using testBed = await createTestBed(userProfileRealm);
 
-    await adminClient.users.updateProfile({ ...userProfile, realm });
-    await login(page, realm);
+    await adminClient.users.updateProfile({
+      ...userProfile,
+      realm: testBed.realm,
+    });
+    await login(page, testBed.realm);
 
     await page.locator("#attributes\\.locale").click();
     await page.waitForSelector("text=Italiano");
@@ -70,10 +79,13 @@ test.describe("Personal info (user profile enabled)", () => {
   });
 
   test("saves user profile", async ({ page }) => {
-    const realm = await createTestBed(userProfileRealm);
+    await using testBed = await createTestBed(userProfileRealm);
 
-    await adminClient.users.updateProfile({ ...userProfile, realm });
-    await login(page, realm);
+    await adminClient.users.updateProfile({
+      ...userProfile,
+      realm: testBed.realm,
+    });
+    await login(page, testBed.realm);
 
     await page.locator("#select").click();
     await page.getByRole("option", { name: "two" }).click();
@@ -101,12 +113,12 @@ test.describe("Personal info (user profile enabled)", () => {
 
 test.describe("Realm localization", () => {
   test("changes locale", async ({ page }) => {
-    const realm = await createTestBed({
+    await using testBed = await createTestBed({
       internationalizationEnabled: true,
       supportedLocales: ["en", "nl", "de"],
     });
 
-    await login(page, realm);
+    await login(page, testBed.realm);
     await page.locator("#attributes\\.locale").click();
     page.getByRole("option").filter({ hasText: "Deutsch" });
     await page.getByRole("option", { name: "English" }).click();

--- a/js/apps/account-ui/test/resources.spec.ts
+++ b/js/apps/account-ui/test/resources.spec.ts
@@ -2,26 +2,33 @@ import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/r
 import { expect, test } from "@playwright/test";
 import resourcesRealm from "./realms/resources-realm.json" with { type: "json" };
 import { login } from "./support/actions.ts";
-import { createTestBed } from "./support/testbed.ts";
+import { createTestBed, type TestBed } from "./support/testbed.ts";
 
 test.describe("Resources", () => {
+  // The test cases in this suite depend on state created in previous tests.
+  // Therefore, we run them in serial mode.
+  // TODO: Refactor tests to be independent and run in parallel.
   test.describe.configure({ mode: "serial" });
 
-  let realm: string;
+  let testBed: TestBed;
 
   test.beforeAll(async () => {
-    realm = await createTestBed(resourcesRealm as RealmRepresentation);
+    testBed = await createTestBed(resourcesRealm as RealmRepresentation);
+  });
+
+  test.afterAll(async () => {
+    await testBed[Symbol.asyncDispose]();
   });
 
   test("shows the resources owned by the user", async ({ page }) => {
-    await login(page, realm);
+    await login(page, testBed.realm);
     await page.getByTestId("resources").click();
 
     await expect(page.getByRole("gridcell", { name: "one" })).toBeVisible();
   });
 
   test("shows no resources are shared with another user", async ({ page }) => {
-    await login(page, realm, "alice", "alice");
+    await login(page, testBed.realm, "alice", "alice");
     await page.getByTestId("resources").click();
 
     await page.getByTestId("sharedWithMe").click();
@@ -30,7 +37,7 @@ test.describe("Resources", () => {
   });
 
   test("shares a recourse with another user", async ({ page }) => {
-    await login(page, realm);
+    await login(page, testBed.realm);
     await page.getByTestId("resources").click();
 
     await page.getByTestId("expand-one").click();
@@ -62,7 +69,7 @@ test.describe("Resources", () => {
   });
 
   test("shows the resources shared with another user", async ({ page }) => {
-    await login(page, realm, "alice", "alice");
+    await login(page, testBed.realm, "alice", "alice");
     await page.getByTestId("resources").click();
 
     await page.getByTestId("sharedWithMe").click();

--- a/js/apps/account-ui/test/support/testbed.ts
+++ b/js/apps/account-ui/test/support/testbed.ts
@@ -2,15 +2,24 @@ import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/r
 import { adminClient } from "./admin-client.ts";
 import { DEFAULT_USER } from "./common.ts";
 
+export interface TestBed extends AsyncDisposable {
+  realm: string;
+}
+
 export async function createTestBed(
   overrides?: RealmRepresentation,
-): Promise<string> {
-  const { realmName } = await adminClient.realms.create({
+): Promise<TestBed> {
+  const { realmName: realm } = await adminClient.realms.create({
     enabled: true,
     users: [DEFAULT_USER],
     ...overrides,
     realm: crypto.randomUUID(),
   });
 
-  return realmName;
+  const deleteRealm = () => adminClient.realms.del({ realm });
+
+  return {
+    realm,
+    [Symbol.asyncDispose]: deleteRealm,
+  };
 }

--- a/js/apps/admin-ui/CONTRIBUTING.md
+++ b/js/apps/admin-ui/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This project is the next generation of the Keycloak Administration UI. It is wri
 
 ### Prerequisites
 
-Make sure that you have Node.js version 18 (or later) installed on your system. If you do not have Node.js installed we recommend using [Node Version Manager](https://github.com/nvm-sh/nvm) to install it.
+Make sure that you have Node.js version 24 (or later) [installed on your system](https://nodejs.org/en/download).
 
 You can find out which version of Node.js you are using by running the following command:
 

--- a/js/apps/admin-ui/test/realm-settings/oid4vci-attributes.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/oid4vci-attributes.spec.ts
@@ -9,8 +9,8 @@ import { login } from "../utils/login.js";
 test("OID4VCI section visibility and jump link in Tokens tab", async ({
   page,
 }) => {
-  const realm = await createTestBed();
-  await login(page, { to: toRealmSettings({ realm }) });
+  await using testBed = await createTestBed();
+  await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
   const tokensTab = page.getByTestId("rs-tokens-tab");
   await tokensTab.click();
@@ -28,8 +28,8 @@ test("OID4VCI section visibility and jump link in Tokens tab", async ({
 test("should render fields and save values with correct attribute keys", async ({
   page,
 }) => {
-  const realm = await createTestBed();
-  await login(page, { to: toRealmSettings({ realm }) });
+  await using testBed = await createTestBed();
+  await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
   const tokensTab = page.getByTestId("rs-tokens-tab");
   await tokensTab.click();
@@ -54,7 +54,7 @@ test("should render fields and save values with correct attribute keys", async (
     page.getByText("Realm successfully updated").first(),
   ).toBeVisible();
 
-  const realmData = await adminClient.getRealm(realm);
+  const realmData = await adminClient.getRealm(testBed.realm);
   expect(realmData).toBeDefined();
   // TimeSelector converts values based on selected unit (60 minutes = 3600 seconds, 120 seconds = 120 seconds)
   expect(realmData?.attributes?.["vc.c-nonce-lifetime-seconds"]).toBe("3600");
@@ -62,8 +62,8 @@ test("should render fields and save values with correct attribute keys", async (
 });
 
 test("should persist values after page refresh", async ({ page }) => {
-  const realm = await createTestBed();
-  await login(page, { to: toRealmSettings({ realm }) });
+  await using testBed = await createTestBed();
+  await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
   const tokensTab = page.getByTestId("rs-tokens-tab");
   await tokensTab.click();
@@ -89,12 +89,15 @@ test("should persist values after page refresh", async ({ page }) => {
   await page.reload();
 
   // Navigate back to realm settings using the same pattern as login
-  const url = new URL(generatePath(ROOT_PATH, { realm }), SERVER_URL);
-  url.hash = toRealmSettings({ realm }).pathname!;
+  const url = new URL(
+    generatePath(ROOT_PATH, { realm: testBed.realm }),
+    SERVER_URL,
+  );
+  url.hash = toRealmSettings({ realm: testBed.realm }).pathname!;
   await page.goto(url.toString());
 
   // The TimeSelector component converts values based on units, so we need to check the actual saved values
-  const realmData = await adminClient.getRealm(realm);
+  const realmData = await adminClient.getRealm(testBed.realm);
   expect(realmData?.attributes?.["vc.c-nonce-lifetime-seconds"]).toBeDefined();
   expect(realmData?.attributes?.["preAuthorizedCodeLifespanS"]).toBeDefined();
 
@@ -111,8 +114,8 @@ test("should persist values after page refresh", async ({ page }) => {
 });
 
 test("should validate form fields and save valid values", async ({ page }) => {
-  const realm = await createTestBed();
-  await login(page, { to: toRealmSettings({ realm }) });
+  await using testBed = await createTestBed();
+  await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
   const tokensTab = page.getByTestId("rs-tokens-tab");
   await tokensTab.click();
@@ -150,7 +153,7 @@ test("should validate form fields and save valid values", async ({ page }) => {
   ).toBeVisible();
 
   // Verify the values were saved correctly
-  const realmData = await adminClient.getRealm(realm);
+  const realmData = await adminClient.getRealm(testBed.realm);
   expect(realmData?.attributes?.["vc.c-nonce-lifetime-seconds"]).toBeDefined();
   expect(realmData?.attributes?.["preAuthorizedCodeLifespanS"]).toBeDefined();
 
@@ -169,8 +172,8 @@ test("should validate form fields and save valid values", async ({ page }) => {
 test("should show validation error for values below minimum threshold", async ({
   page,
 }) => {
-  const realm = await createTestBed();
-  await login(page, { to: toRealmSettings({ realm }) });
+  await using testBed = await createTestBed();
+  await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
   const tokensTab = page.getByTestId("rs-tokens-tab");
   await tokensTab.click();

--- a/js/apps/admin-ui/test/support/testbed.ts
+++ b/js/apps/admin-ui/test/support/testbed.ts
@@ -1,12 +1,22 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation.js";
 import adminClient from "../utils/AdminClient.ts";
 
+export interface TestBed extends AsyncDisposable {
+  realm: string;
+}
+
 export async function createTestBed(
   overrides?: RealmRepresentation,
-): Promise<string> {
-  const { realmName } = await adminClient.createRealm(
+): Promise<TestBed> {
+  const { realmName: realm } = await adminClient.createRealm(
     crypto.randomUUID(),
     overrides,
   );
-  return realmName;
+
+  const deleteRealm = () => adminClient.deleteRealm(realm);
+
+  return {
+    realm,
+    [Symbol.asyncDispose]: deleteRealm,
+  };
 }

--- a/js/apps/admin-ui/test/users/main.spec.ts
+++ b/js/apps/admin-ui/test/users/main.spec.ts
@@ -34,9 +34,9 @@ import {
 
 test.describe("User creation", () => {
   test("navigates to the create user page", async ({ page }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
 
-    await login(page, { to: toUsers({ realm }) });
+    await login(page, { to: toUsers({ realm: testBed.realm }) });
 
     await clickAddUserButton(page);
     await expect(page).toHaveURL(/.*users\/add-user/);
@@ -46,9 +46,9 @@ test.describe("User creation", () => {
   });
 
   test("creates a new user", async ({ page }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
 
-    await login(page, { to: toAddUser({ realm }) });
+    await login(page, { to: toAddUser({ realm: testBed.realm }) });
 
     await fillUserForm(page, {
       username: "test-user",
@@ -72,11 +72,11 @@ test.describe("User creation", () => {
   });
 
   test("creates a user that joins a group", async ({ page }) => {
-    const realm = await createTestBed({
+    await using testBed = await createTestBed({
       groups: [{ name: "test-group" }],
     });
 
-    await login(page, { to: toAddUser({ realm }) });
+    await login(page, { to: toAddUser({ realm: testBed.realm }) });
 
     await fillUserForm(page, { username: "test-user" });
     await joinGroup(page, ["test-group"]);
@@ -85,9 +85,9 @@ test.describe("User creation", () => {
   });
 
   test("creates a user with a password credential", async ({ page }) => {
-    const realm = await createTestBed();
+    await using testBed = await createTestBed();
 
-    await login(page, { to: toAddUser({ realm }) });
+    await login(page, { to: toAddUser({ realm: testBed.realm }) });
 
     await fillUserForm(page, {
       username: "test-user",
@@ -116,28 +116,33 @@ test.describe("Existing users", () => {
   };
 
   test("searches for an existing user", async ({ page }) => {
-    const realm = await createTestBed(overrides);
+    await using testBed = await createTestBed(overrides);
 
-    await login(page, { to: toUsers({ realm }) });
+    await login(page, { to: toUsers({ realm: testBed.realm }) });
 
     await searchItem(page, placeHolder, existingUserName);
     await assertRowExists(page, existingUserName);
   });
 
   test("searches for a non-existing user", async ({ page }) => {
-    const realm = await createTestBed(overrides);
+    await using testBed = await createTestBed(overrides);
 
-    await login(page, { to: toUsers({ realm }) });
+    await login(page, { to: toUsers({ realm: testBed.realm }) });
 
     await searchItem(page, "Search", "non-existing-user");
     await assertNoResults(page);
   });
 
   test("edits a user", async ({ page }) => {
-    const realm = await createTestBed(overrides);
-    const user = await adminClient.findUserByUsername(realm, existingUserName);
+    await using testBed = await createTestBed(overrides);
+    const user = await adminClient.findUserByUsername(
+      testBed.realm,
+      existingUserName,
+    );
 
-    await login(page, { to: toUser({ realm, id: user.id!, tab: "settings" }) });
+    await login(page, {
+      to: toUser({ realm: testBed.realm, id: user.id!, tab: "settings" }),
+    });
 
     await fillUserForm(page, {
       email: "test-user@example.com",
@@ -151,9 +156,9 @@ test.describe("Existing users", () => {
   const attributesName = "unmanagedAttributes";
 
   test("adds unmanaged attributes to a user", async ({ page }) => {
-    const realm = await createTestBed(overrides);
+    await using testBed = await createTestBed(overrides);
 
-    await login(page, { to: toRealmSettings({ realm }) });
+    await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
     await selectItem(page, "#unmanagedAttributePolicy", "Enabled");
     await page.getByTestId("realmSettingsGeneralTab-save").click();
@@ -185,9 +190,9 @@ test.describe("Existing users", () => {
   test("adds unmanaged attributes with multiple values to a user", async ({
     page,
   }) => {
-    const realm = await createTestBed(overrides);
+    await using testBed = await createTestBed(overrides);
 
-    await login(page, { to: toRealmSettings({ realm }) });
+    await login(page, { to: toRealmSettings({ realm: testBed.realm }) });
 
     await selectItem(page, "#unmanagedAttributePolicy", "Enabled");
     await page.getByTestId("realmSettingsGeneralTab-save").click();
@@ -204,13 +209,18 @@ test.describe("Existing users", () => {
   });
 
   test("adds a user to a group", async ({ page }) => {
-    const realm = await createTestBed({
+    await using testBed = await createTestBed({
       ...overrides,
       groups: [{ name: "test-group" }],
     });
-    const user = await adminClient.findUserByUsername(realm, existingUserName);
+    const user = await adminClient.findUserByUsername(
+      testBed.realm,
+      existingUserName,
+    );
 
-    await login(page, { to: toUser({ realm, id: user.id!, tab: "groups" }) });
+    await login(page, {
+      to: toUser({ realm: testBed.realm, id: user.id!, tab: "groups" }),
+    });
 
     await joinGroup(page, ["test-group"], true);
     await assertNotificationMessage(page, "Added group membership");

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -24,7 +24,7 @@
     </modules>
 
     <properties>
-        <node.version>v22.18.0</node.version>
+        <node.version>v24.9.0</node.version>
         <pnpm.version>10.14.0</pnpm.version>
         <!-- The JavaScript projects use non-standard folders for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>


### PR DESCRIPTION
Automatically disposes of any realms that are created by `createTestBed()` once a test has completed. This uses [explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) to automatically delete the realm created by the test bed once it is no longer in scope. Since this feature is only available in Node.js 24, I have raised the version on CI, and updated the documentation.


Closes #43298

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
