### PR TITLE
Security Defenses realm settings lost when switching between Headers …

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/security-defences/BruteForceDetection.tsx
+++ b/js/apps/admin-ui/src/realm-settings/security-defences/BruteForceDetection.tsx
@@ -59,7 +59,7 @@ export const BruteForceDetection = ({
     convertToFormValues(realm, setValue);
     setIsBruteForceModeUpdated(false);
   };
-  useEffect(setupForm, []);
+  useEffect(setupForm, [realm]);
 
   const bruteForceMode = (() => {
     if (!form.getValues("bruteForceProtected")) {

--- a/js/apps/admin-ui/test/realm-settings/security-defenses.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/security-defenses.spec.ts
@@ -1,18 +1,21 @@
 import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
-import { selectItem } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
 import { goToRealm, goToRealmSettings } from "../utils/sidebar.ts";
 import {
   clickSaveBruteForce,
+  fillXFrameOptionsSecurityHeader,
+  assertXFrameOptionsSecurityHeaderValue,
   clickSaveSecurityDefenses,
+  selectBruteForceMode,
   fillMaxDeltaTimeSeconds,
   fillMaxFailureWaitSeconds,
   fillMinimumQuickLoginWaitSeconds,
   fillWaitIncrementSeconds,
   goToSecurityDefensesTab,
+  goToBruteForceTab,
 } from "./security-defenses.ts";
 
 test.describe.serial("Security defenses", () => {
@@ -29,19 +32,37 @@ test.describe.serial("Security defenses", () => {
   });
 
   test("Realm header settings", async ({ page }) => {
-    await page.getByTestId("browserSecurityHeaders.xFrameOptions").fill("DENY");
+    await fillXFrameOptionsSecurityHeader(page, "DENY");
     await clickSaveSecurityDefenses(page);
     await assertNotificationMessage(page, "Realm successfully updated");
+    await assertXFrameOptionsSecurityHeaderValue(page, "DENY");
   });
 
   test("Brute force detection", async ({ page }) => {
-    await page.getByTestId("security-defenses-brute-force-tab").click();
-    await selectItem(page, "#kc-brute-force-mode", "Lockout temporarily");
+    await goToBruteForceTab(page);
+    await selectBruteForceMode(page, "Lockout temporarily");
     await fillWaitIncrementSeconds(page, "1");
     await fillMaxFailureWaitSeconds(page, "1");
     await fillMaxDeltaTimeSeconds(page, "1");
     await fillMinimumQuickLoginWaitSeconds(page, "1");
     await clickSaveBruteForce(page);
     await assertNotificationMessage(page, "Realm successfully updated");
+  });
+
+  test("Realm header settings followed by Brute force detection", async ({
+    page,
+  }) => {
+    await fillXFrameOptionsSecurityHeader(page, "ALLOW-FROM foo");
+    await clickSaveSecurityDefenses(page);
+    await assertNotificationMessage(page, "Realm successfully updated");
+
+    await goToBruteForceTab(page);
+    await selectBruteForceMode(page, "Lockout temporarily");
+    await fillWaitIncrementSeconds(page, "2");
+    await clickSaveBruteForce(page);
+    await assertNotificationMessage(page, "Realm successfully updated");
+
+    await goToSecurityDefensesTab(page);
+    await assertXFrameOptionsSecurityHeaderValue(page, "ALLOW-FROM foo");
   });
 });

--- a/js/apps/admin-ui/test/realm-settings/security-defenses.ts
+++ b/js/apps/admin-ui/test/realm-settings/security-defenses.ts
@@ -1,11 +1,37 @@
 import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { selectItem } from "../utils/form.ts";
 
 export async function goToSecurityDefensesTab(page: Page) {
   await page.getByTestId("rs-security-defenses-tab").click();
 }
 
+export async function fillXFrameOptionsSecurityHeader(
+  page: Page,
+  value: string,
+) {
+  await page.getByTestId("browserSecurityHeaders.xFrameOptions").fill(value);
+}
+
+export async function assertXFrameOptionsSecurityHeaderValue(
+  page: Page,
+  expectedValue: string,
+) {
+  await expect(
+    page.getByTestId("browserSecurityHeaders.xFrameOptions"),
+  ).toHaveValue(expectedValue);
+}
+
 export async function clickSaveSecurityDefenses(page: Page) {
   await page.getByTestId("headers-form-tab-save").click();
+}
+
+export async function goToBruteForceTab(page: Page) {
+  await page.getByTestId("security-defenses-brute-force-tab").click();
+}
+
+export async function selectBruteForceMode(page: Page, mode: string) {
+  await selectItem(page, "#kc-brute-force-mode", mode);
 }
 
 export async function fillWaitIncrementSeconds(page: Page, value: string) {


### PR DESCRIPTION
…and Brute Force Detection tabs

closes #42676

### Analysis of the issue

Here is what it seems to happen (took me some time to figure that with my limited react knowledge...)

1) When the admin clicks on the "Security defenses" tab, it has 2 sub-tabs "Headers" and "Brute force detection" . At this point, method `setupForm` inside `BruteForceDetection.tsx` is already called (even if "Brute force detection" subtab is not rendered yet). The method converts `realm` to "form values" used by brute-force tab.

2) When user does some changes in the "Headers" tab and saves them, the "Brute force" tab still has the link to the realm with previously converted values. There is not new call to `setupForm` inside `BruteForceDetection.tsx` .

3) Now when the user switch to the sub-tab "Brute Force detection" (after he did some changes in the "Headers" tab), the `realm` converted for saving in the DB is still the instance, which was initially converted to the "Form values" in step 1. This instance does not contain the updates from step 2. So saving realm in "Brute force" tab effectively rewrite the updates done by step 2 and those are lost.

### Fix

It seems the easiest fix is to add `realm` as the variable being updated in `useEffects` . When the realm is updated in step 2, the `setupForm` of `BruteForceDetection.tsx` would be still called and it will convert to "Form values" the newly updated `realm` values (including the update from step 2).

Note that this issue does not happen when the opposite order of updated tabs is used (EG. First something is updated in the "Brute force" tab followed by the update in the "Headers" tab) . It seems to me this is due the fact that "Headers" uses the realm instance as it is without converting it to "Form values" and hence the update of the `realm` instance in brute-force tab directly updates the instance used by the "Headers" tab. Hence "Headers" tab has all the updates already done by the "Brute force" tab.