### PR TITLE
SAML WildFly adapter, impact of the WildFly catalog and Galleon dual mode

### DIFF
--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/layers/metadata/layers/standalone/keycloak-client-saml-ejb/layer-spec.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/layers/metadata/layers/standalone/keycloak-client-saml-ejb/layer-spec.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="keycloak-client-saml-ejb">
     <props>
+        <prop name="org.wildfly.category" value="Security"/>
+        <prop name="org.wildfly.description" value="Support for securing your EJB with the keyloack SAML protocol."/>
+        <prop name="org.wildfly.note" value="Not to be used when provisioning for the cloud if you are using the env variables to automatically configure SAML (SSO_URL, SSO_REALM)."/>
         <prop name="org.wildfly.rule.inclusion-mode" value="all-dependencies"/>
     </props>
     <dependencies>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/layers/metadata/layers/standalone/keycloak-client-saml/layer-spec.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/layers/metadata/layers/standalone/keycloak-client-saml/layer-spec.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="keycloak-client-saml">
     <props>
+        <prop name="org.wildfly.category" value="Security"/>
+        <prop name="org.wildfly.description" value="Support for securing your Web deployments with the keyloack SAML protocol."/>
+        <prop name="org.wildfly.note" value="Not to be used when provisioning for the cloud if you are using the env variables to automatically configure SAML (SSO_URL, SSO_REALM)."/>
         <prop name="org.wildfly.rule.inclusion-mode" value="all-dependencies"/>
     </props>
     <dependencies>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/layers/metadata/layers/standalone/keycloak-saml/layer-spec.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/src/main/layers/metadata/layers/standalone/keycloak-saml/layer-spec.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="keycloak-saml">
     <props>
+        <prop name="org.wildfly.category" value="Security"/>
+        <prop name="org.wildfly.description" value="Add the keyloack SAML subsystem to the server configuration."/>
         <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/login-config/auth-method,KEYCLOAK-SAML"/>
     </props>
     <dependencies>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/wildfly-feature-pack-build.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/wildfly-feature-pack-build.xml
@@ -14,9 +14,9 @@
   ~ limitations under the License.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.keycloak:keycloak-saml-adapter-galleon-pack">
+<build xmlns="urn:wildfly:feature-pack-build:3.5" producer="org.keycloak:keycloak-saml-adapter-galleon-pack">
     <dependencies>
-        <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack">
+        <dependency group-id="org.wildfly" artifact-id="wildfly-ee-galleon-pack" allowedFamily="wildfly:jakarta-ee-10+">
             <name>org.wildfly:wildfly-ee-galleon-pack</name>
             <packages inherit="false">
                 <exclude name="product.conf"/>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <webauthn4j.version>0.30.3.RELEASE</webauthn4j.version>
 
         <!-- Used to test SAML Galleon feature-pack layers discovery -->
-        <version.org.wildfly.glow>1.0.0.Alpha8</version.org.wildfly.glow>
+        <version.org.wildfly.glow>1.5.2.Final</version.org.wildfly.glow>
 
         <!-- Galleon -->
         <galleon.fork.embedded>true</galleon.fork.embedded>
@@ -1662,8 +1662,8 @@
                 <!-- relative directory for galleon pack with layer spec files -->
                 <saml.adapter.galleon.pack.metadata.dir>metadata</saml.adapter.galleon.pack.metadata.dir>
                 <!-- WildFly Galleon Build related properties -->
-                <org.wildfly.galleon-plugins.version>7.3.1.Final</org.wildfly.galleon-plugins.version>
-                <org.jboss.galleon.version>6.0.4.Final</org.jboss.galleon.version>
+                <org.wildfly.galleon-plugins.version>8.1.2.Final</org.wildfly.galleon-plugins.version>
+                <org.jboss.galleon.version>7.0.5.Final</org.jboss.galleon.version>
                 <org.wildfly.maven.plugins.licenses-plugin.version>2.3.1.Final</org.wildfly.maven.plugins.licenses-plugin.version>
             </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <dist.archive.dir>${dist.archive.dir.prefix}-${dist.archive.dir.version}</dist.archive.dir>
 
         <!-- Upstream WildFly Versions -->
-        <upstream.wildfly.version>35.0.1.Final</upstream.wildfly.version>
-        <upstream.wildfly.core.version>27.0.1.Final</upstream.wildfly.core.version>
+        <upstream.wildfly.version>39.0.1.Final</upstream.wildfly.version>
+        <upstream.wildfly.core.version>31.0.3.Final</upstream.wildfly.core.version>
 
         <!-- Downstream Builds WildFly Versions Override -->
         <eap8.version>8.1.0.GA-redhat-00015</eap8.version>  <!-- G:A = org.jboss.eap:jboss-eap-parent -->


### PR DESCRIPTION
* Integration with the WildFly catalog: https://docs.wildfly.org/wildfly-catalog/

Those changes are required for the WildFly catalog that document all our feature-packs.
You will find in the section WildFly feature-pack a section "Keycloak Galleon Feature Pack: SAML Adapter".

Then the keycloak saml Galleon layers are put in the category "Security". You can check if that is fine for you.

The bump to galleon-plugins 8.0.0.Final implies a minimum JDK version of JDK17 (that is the minimum version mandated by WildFly). That should be just fine for keycloak.

A new artifact (classifier doc) will be deployed when you release the SAML feature-pack. This artifact contains some documentation that the catalog requires.

* Allow for Dual mode, prepare WildFly 40 EE-10 feature-pack.

WildFly 39.0.1 introduces a new mechanism allowing to provision Galleon feature-packs with variant of the main distribution (In WIldFly 40, a new EE10 feature-pack).
This PR upgrades the dependency to WildFly 39.0.1.FInal and make the SAML feature-pack to depend on feature-pack that are part of the `wildfly:jakarta-ee-10+` family.