### PR TITLE
Throw and catch UnsupportedOperationException to fix XPathAttributeMapperTest

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/mappers/XPathAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/saml/mappers/XPathAttributeMapper.java
@@ -65,10 +65,10 @@ public class XPathAttributeMapper extends AbstractIdentityProviderMapper impleme
     private static final ThreadLocal<XPathFactory> XPATH_FACTORY = ThreadLocal.withInitial(() -> {
         final XPathFactory xPathFactory = XPathFactory.newInstance();
         xPathFactory.setXPathVariableResolver(variableName -> {
-            throw new RuntimeException("resolveVariable for variable " + variableName + " not supported");
+            throw new UnsupportedOperationException("resolveVariable for variable " + variableName + " not supported");
         });
         xPathFactory.setXPathFunctionResolver((functionName, arity) -> {
-            throw new RuntimeException("resolveFunction for function " + functionName + " not supported");
+            throw new UnsupportedOperationException("resolveFunction for function " + functionName + " not supported");
         });
         return xPathFactory;
     });
@@ -212,7 +212,7 @@ public class XPathAttributeMapper extends AbstractIdentityProviderMapper impleme
                 });
                 Document document = DocumentUtil.getDocument(new StringReader(xml));
                 return xPath.compile(attributeXPath).evaluate(document, XPathConstants.STRING);
-            } catch (XPathExpressionException e) {
+            } catch (XPathExpressionException|UnsupportedOperationException e) {
                 LOGGER.warn("Unparsable element will be ignored", e);
                 return "";
             } catch (Exception e) {


### PR DESCRIPTION
Closes #43262

I think that this is a change in jdk between 17 and 21. In 25 it seems that the exception we are throwing in the `XPATH_FACTORY` is caught and re-thrown as `XPathExpressionException` (see [here](https://github.com/openjdk/jdk25u/blob/master/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathExpressionImpl.java#L95-L109)). But in 17 the `RuntimeException` is not caught and therefore there is an exception ([here](https://github.com/openjdk/jdk17/blob/master/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/jaxp/XPathExpressionImpl.java#L90-L104)). I'm just changing to throw a  `UnsupportedOperationException` for the XPATH_FACTORY variable and function resolver and catching that specific exception to continue. If you prefer that I add a custom private exception instead of  `UnsupportedOperationException` just let me know. But this is not very problematic as I suspect the change in 25 is because a bug, so the correct behavior is now in place in the jdk.