### PR TITLE
Run account console resource tests in parallel

### DIFF
--- a/js/apps/account-ui/test/account-security/device-activity.spec.ts
+++ b/js/apps/account-ui/test/account-security/device-activity.spec.ts
@@ -5,84 +5,72 @@ import { createTestBed } from "../support/testbed.ts";
 test.describe("Device activity", () => {
   test("signs out of a single device session", async ({ browser }) => {
     await using testBed = await createTestBed();
-    const context1 = await browser.newContext();
-    const context2 = await browser.newContext();
+    await using context1 = await browser.newContext();
+    await using context2 = await browser.newContext();
 
-    try {
-      const page1 = await context1.newPage();
-      const page2 = await context2.newPage();
+    const page1 = await context1.newPage();
+    const page2 = await context2.newPage();
 
-      // Log in the first session, and verify it is active.
-      await login(page1, testBed.realm);
-      await page1.getByTestId("accountSecurity").click();
-      await page1.getByTestId("account-security/device-activity").click();
-      await expect(page1.getByTestId("row-0")).toContainText("Current session");
+    // Log in the first session, and verify it is active.
+    await login(page1, testBed.realm);
+    await page1.getByTestId("accountSecurity").click();
+    await page1.getByTestId("account-security/device-activity").click();
+    await expect(page1.getByTestId("row-0")).toContainText("Current session");
 
-      // Log in the second session, and verify it is active.
-      await login(page2, testBed.realm);
-      await page2.getByTestId("accountSecurity").click();
-      await page2.getByTestId("account-security/device-activity").click();
-      await expect(page2.getByTestId("row-0")).toContainText("Current session");
+    // Log in the second session, and verify it is active.
+    await login(page2, testBed.realm);
+    await page2.getByTestId("accountSecurity").click();
+    await page2.getByTestId("account-security/device-activity").click();
+    await expect(page2.getByTestId("row-0")).toContainText("Current session");
 
-      // Sign out the first session from the second session.
-      await page2
-        .getByRole("button", { name: "Sign out", exact: true })
-        .click();
-      await page2.getByRole("button", { name: "Confirm", exact: true }).click();
-      await expect(page2.getByTestId("last-alert")).toContainText("Signed out");
+    // Sign out the first session from the second session.
+    await page2.getByRole("button", { name: "Sign out", exact: true }).click();
+    await page2.getByRole("button", { name: "Confirm", exact: true }).click();
+    await expect(page2.getByTestId("last-alert")).toContainText("Signed out");
 
-      // Reload pages and verify the first session is logged out, while the second session remains active.
-      await page1.reload();
-      await page2.reload();
-      await expect(
-        page1.getByRole("heading", {
-          name: "Sign in to your account",
-          exact: true,
-        }),
-      ).toBeVisible();
-      await expect(page2.getByTestId("accountSecurity")).toBeVisible();
-    } finally {
-      await context1.close();
-      await context2.close();
-    }
+    // Reload pages and verify the first session is logged out, while the second session remains active.
+    await page1.reload();
+    await page2.reload();
+    await expect(
+      page1.getByRole("heading", {
+        name: "Sign in to your account",
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(page2.getByTestId("accountSecurity")).toBeVisible();
   });
 
   test("signs out of all device sessions", async ({ browser }) => {
     await using testBed = await createTestBed();
-    const context1 = await browser.newContext();
-    const context2 = await browser.newContext();
+    await using context1 = await browser.newContext();
+    await using context2 = await browser.newContext();
 
-    try {
-      const page1 = await context1.newPage();
-      const page2 = await context2.newPage();
+    const page1 = await context1.newPage();
+    const page2 = await context2.newPage();
 
-      // Log in both sessions, then sign out of all devices from the second session.
-      await login(page1, testBed.realm);
-      await login(page2, testBed.realm);
-      await page2.getByTestId("accountSecurity").click();
-      await page2.getByTestId("account-security/device-activity").click();
-      await page2
-        .getByRole("button", { name: "Sign out all devices", exact: true })
-        .click();
-      await page2.getByRole("button", { name: "Confirm", exact: true }).click();
-      await expect(
-        page2.getByRole("heading", {
-          name: "Sign in to your account",
-          exact: true,
-        }),
-      ).toBeVisible();
+    // Log in both sessions, then sign out of all devices from the second session.
+    await login(page1, testBed.realm);
+    await login(page2, testBed.realm);
+    await page2.getByTestId("accountSecurity").click();
+    await page2.getByTestId("account-security/device-activity").click();
+    await page2
+      .getByRole("button", { name: "Sign out all devices", exact: true })
+      .click();
+    await page2.getByRole("button", { name: "Confirm", exact: true }).click();
+    await expect(
+      page2.getByRole("heading", {
+        name: "Sign in to your account",
+        exact: true,
+      }),
+    ).toBeVisible();
 
-      // Reload only the first page (second page is already logged out), and verify both sessions are logged out.
-      await page1.reload();
-      await expect(
-        page1.getByRole("heading", {
-          name: "Sign in to your account",
-          exact: true,
-        }),
-      ).toBeVisible();
-    } finally {
-      await context1.close();
-      await context2.close();
-    }
+    // Reload only the first page (second page is already logged out), and verify both sessions are logged out.
+    await page1.reload();
+    await expect(
+      page1.getByRole("heading", {
+        name: "Sign in to your account",
+        exact: true,
+      }),
+    ).toBeVisible();
   });
 });

--- a/js/apps/account-ui/test/resources.spec.ts
+++ b/js/apps/account-ui/test/resources.spec.ts
@@ -2,25 +2,14 @@ import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/r
 import { expect, test } from "@playwright/test";
 import resourcesRealm from "./realms/resources-realm.json" with { type: "json" };
 import { login } from "./support/actions.ts";
-import { createTestBed, type TestBed } from "./support/testbed.ts";
+import { createTestBed } from "./support/testbed.ts";
 
 test.describe("Resources", () => {
-  // The test cases in this suite depend on state created in previous tests.
-  // Therefore, we run them in serial mode.
-  // TODO: Refactor tests to be independent and run in parallel.
-  test.describe.configure({ mode: "serial" });
-
-  let testBed: TestBed;
-
-  test.beforeAll(async () => {
-    testBed = await createTestBed(resourcesRealm as RealmRepresentation);
-  });
-
-  test.afterAll(async () => {
-    await testBed[Symbol.asyncDispose]();
-  });
-
   test("shows the resources owned by the user", async ({ page }) => {
+    await using testBed = await createTestBed(
+      resourcesRealm as RealmRepresentation,
+    );
+
     await login(page, testBed.realm);
     await page.getByTestId("resources").click();
 
@@ -28,6 +17,10 @@ test.describe("Resources", () => {
   });
 
   test("shows no resources are shared with another user", async ({ page }) => {
+    await using testBed = await createTestBed(
+      resourcesRealm as RealmRepresentation,
+    );
+
     await login(page, testBed.realm, "alice", "alice");
     await page.getByTestId("resources").click();
 
@@ -36,44 +29,54 @@ test.describe("Resources", () => {
     expect(tableData).toBe(0);
   });
 
-  test("shares a recourse with another user", async ({ page }) => {
-    await login(page, testBed.realm);
-    await page.getByTestId("resources").click();
+  test("shares a resource with another user", async ({ browser }) => {
+    await using testBed = await createTestBed(
+      resourcesRealm as RealmRepresentation,
+    );
 
-    await page.getByTestId("expand-one").click();
-    await expect(page.getByText("This resource is not shared.")).toBeVisible();
+    await using context1 = await browser.newContext();
+    await using context2 = await browser.newContext();
 
-    await page.getByTestId("share-one").click();
-    await page.getByTestId("users").click();
-    await page.getByTestId("users").fill("alice");
-    await page.getByTestId("add").click();
+    const page1 = await context1.newPage();
+    const page2 = await context2.newPage();
 
-    await expect(page.getByRole("group", { name: "Share with" })).toHaveText(
+    // Share a resource as the main user
+    await login(page1, testBed.realm);
+    await page1.getByTestId("resources").click();
+
+    await page1.getByTestId("expand-one").click();
+    await expect(page1.getByText("This resource is not shared.")).toBeVisible();
+
+    await page1.getByTestId("share-one").click();
+    await page1.getByTestId("users").click();
+    await page1.getByTestId("users").fill("alice");
+    await page1.getByTestId("add").click();
+
+    await expect(page1.getByRole("group", { name: "Share with" })).toHaveText(
       "Share with alice",
     );
 
-    await page
+    await page1
       .getByTestId("permissions")
       .getByRole("button", { expanded: false })
       .click();
-    await page.getByRole("option", { name: "album:view" }).click();
-    await page
+    await page1.getByRole("option", { name: "album:view" }).click();
+    await page1
       .getByTestId("permissions")
       .getByRole("button", { expanded: true })
       .click();
 
-    await page.getByTestId("done").click();
+    await page1.getByTestId("done").click();
 
-    await page.getByTestId("expand-one").click();
-    await expect(page.getByTestId("shared-with-alice")).toBeVisible();
-  });
+    await page1.getByTestId("expand-one").click();
+    await expect(page1.getByTestId("shared-with-alice")).toBeVisible();
 
-  test("shows the resources shared with another user", async ({ page }) => {
-    await login(page, testBed.realm, "alice", "alice");
-    await page.getByTestId("resources").click();
+    // Verify that alice can see the shared resource
+    await login(page2, testBed.realm, "alice", "alice");
+    await page2.getByTestId("resources").click();
 
-    await page.getByTestId("sharedWithMe").click();
-    const rowData = page.getByTestId("row[0].name");
+    await page2.getByTestId("sharedWithMe").click();
+    const rowData = page2.getByTestId("row[0].name");
     await expect(rowData).toHaveText("one");
   });
 });


### PR DESCRIPTION
Refactors the account console resource tests (`resources.spec.ts`) to execute in parallel, speeding up test execution. Additionally, two tests with repeated logic have been merged into one. This PR also refactors some other code to make use of explicit resource management to automatically close browsers. 

Closes #43315