### PR TITLE
Security Defenses realm settings lost when switching between Headers and Brute Force Detection tabs

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/security-defences/BruteForceDetection.tsx
+++ b/js/apps/admin-ui/src/realm-settings/security-defences/BruteForceDetection.tsx
@@ -59,7 +59,7 @@ export const BruteForceDetection = ({
     convertToFormValues(realm, setValue);
     setIsBruteForceModeUpdated(false);
   };
-  useEffect(setupForm, []);
+  useEffect(setupForm, [realm]);
 
   const bruteForceMode = (() => {
     if (!form.getValues("bruteForceProtected")) {

--- a/js/apps/admin-ui/test/realm-settings/security-defenses.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/security-defenses.spec.ts
@@ -1,18 +1,21 @@
 import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
-import { selectItem } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
 import { goToRealm, goToRealmSettings } from "../utils/sidebar.ts";
 import {
   clickSaveBruteForce,
+  fillXFrameOptionsSecurityHeader,
+  assertXFrameOptionsSecurityHeaderValue,
   clickSaveSecurityDefenses,
+  selectBruteForceMode,
   fillMaxDeltaTimeSeconds,
   fillMaxFailureWaitSeconds,
   fillMinimumQuickLoginWaitSeconds,
   fillWaitIncrementSeconds,
   goToSecurityDefensesTab,
+  goToBruteForceTab,
 } from "./security-defenses.ts";
 
 test.describe.serial("Security defenses", () => {
@@ -29,19 +32,37 @@ test.describe.serial("Security defenses", () => {
   });
 
   test("Realm header settings", async ({ page }) => {
-    await page.getByTestId("browserSecurityHeaders.xFrameOptions").fill("DENY");
+    await fillXFrameOptionsSecurityHeader(page, "DENY");
     await clickSaveSecurityDefenses(page);
     await assertNotificationMessage(page, "Realm successfully updated");
+    await assertXFrameOptionsSecurityHeaderValue(page, "DENY");
   });
 
   test("Brute force detection", async ({ page }) => {
-    await page.getByTestId("security-defenses-brute-force-tab").click();
-    await selectItem(page, "#kc-brute-force-mode", "Lockout temporarily");
+    await goToBruteForceTab(page);
+    await selectBruteForceMode(page, "Lockout temporarily");
     await fillWaitIncrementSeconds(page, "1");
     await fillMaxFailureWaitSeconds(page, "1");
     await fillMaxDeltaTimeSeconds(page, "1");
     await fillMinimumQuickLoginWaitSeconds(page, "1");
     await clickSaveBruteForce(page);
     await assertNotificationMessage(page, "Realm successfully updated");
+  });
+
+  test("Realm header settings followed by Brute force detection", async ({
+    page,
+  }) => {
+    await fillXFrameOptionsSecurityHeader(page, "ALLOW-FROM foo");
+    await clickSaveSecurityDefenses(page);
+    await assertNotificationMessage(page, "Realm successfully updated");
+
+    await goToBruteForceTab(page);
+    await selectBruteForceMode(page, "Lockout temporarily");
+    await fillWaitIncrementSeconds(page, "2");
+    await clickSaveBruteForce(page);
+    await assertNotificationMessage(page, "Realm successfully updated");
+
+    await goToSecurityDefensesTab(page);
+    await assertXFrameOptionsSecurityHeaderValue(page, "ALLOW-FROM foo");
   });
 });

--- a/js/apps/admin-ui/test/realm-settings/security-defenses.ts
+++ b/js/apps/admin-ui/test/realm-settings/security-defenses.ts
@@ -1,11 +1,37 @@
 import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { selectItem } from "../utils/form.ts";
 
 export async function goToSecurityDefensesTab(page: Page) {
   await page.getByTestId("rs-security-defenses-tab").click();
 }
 
+export async function fillXFrameOptionsSecurityHeader(
+  page: Page,
+  value: string,
+) {
+  await page.getByTestId("browserSecurityHeaders.xFrameOptions").fill(value);
+}
+
+export async function assertXFrameOptionsSecurityHeaderValue(
+  page: Page,
+  expectedValue: string,
+) {
+  await expect(
+    page.getByTestId("browserSecurityHeaders.xFrameOptions"),
+  ).toHaveValue(expectedValue);
+}
+
 export async function clickSaveSecurityDefenses(page: Page) {
   await page.getByTestId("headers-form-tab-save").click();
+}
+
+export async function goToBruteForceTab(page: Page) {
+  await page.getByTestId("security-defenses-brute-force-tab").click();
+}
+
+export async function selectBruteForceMode(page: Page, mode: string) {
+  await selectItem(page, "#kc-brute-force-mode", mode);
 }
 
 export async function fillWaitIncrementSeconds(page: Page, value: string) {


### PR DESCRIPTION
closes #42676

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 0100ac6d6eec6ca4c6b45e11d54d5de9cb0660b6)
