### PR TITLE
openid-connect flow is missing response type on language change

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -523,6 +523,9 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                         case LOGOUT_CONFIRM:
                             b = UriBuilder.fromUri(Urls.logoutConfirm(baseUri, realm.getName()));
                             break;
+                        case LOGIN_PAGE_EXPIRED:
+                            b = UriBuilder.fromUri(baseUri).path(uriInfo.getPath());
+                            break;
                         case INFO:
                         case ERROR:
                             if (isDetachedAuthenticationSession()) {
@@ -540,12 +543,11 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                                 break;
                             }
                         default:
-                            b = UriBuilder.fromUri(baseUri).path(uriInfo.getPath());
+                            b = getDefaultPageUriForLocale(baseUri);
                             break;
                     }
                 } else {
-                    b = UriBuilder.fromUri(baseUri)
-                            .path(uriInfo.getPath());
+                    b = getDefaultPageUriForLocale(baseUri);
                 }
 
                 if (execution != null) {
@@ -589,6 +591,12 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
         }
 
         attributes.put("lang", lang);
+    }
+
+    private UriBuilder getDefaultPageUriForLocale(URI baseUri) {
+        // Using "actionUri" by default in the language combobox when available
+        return actionUri != null ? UriBuilder.fromUri(actionUri.getPath()).replaceQuery(baseUri.getQuery()) :
+                UriBuilder.fromUri(baseUri).path(uriInfo.getPath());
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/TermsAndConditionsPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/TermsAndConditionsPage.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.support.FindBy;
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class TermsAndConditionsPage extends AbstractPage {
+public class TermsAndConditionsPage extends LanguageComboboxAwarePage {
 
     @FindBy(id = "kc-accept")
     private WebElement submitButton;


### PR DESCRIPTION
closes #41292

When the authentication flow is configured in a way that OIDC login request does not display the default username/password page, but some custom authenticator page, then the request might not be handled by the `loginFormsProvider.createResponse` method, but rather by `loginFormsProvider.createForm` method. In this case, the URL used for switching the language in the locale combobox is based on the current browser URL ( `UriBuilder.fromUri(baseUri).path(uriInfo.getPath())` ). But in the case when the page with custom authenticator was just displayed, this URL is OIDC login URL (something like `/auth/realms/test/protocol/openid-connect/auth` ), which is incorrect. The correct URL should be something like `/auth/realms/test/login-actions/authenticate` .

The PR does small update to make sure that default URL for the language combobox is based on the `actionUrl` . This seems to be correct behaviour for most of the pages. The corner-case where it is not accurate is `Language expired page` where the URL should be still based on the current browser URL.
