### PR TITLE
Resolve scope

### DIFF
--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -27,7 +27,6 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.OAuth2Constants;
 import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -161,8 +160,6 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         // make sure the organization is set to the session to make it available to templates
         session.getContext().setOrganization(organization);
 
-        updateUserSelectOrganizationScope(authSession, organization.getAlias());
-
         if (isMembershipRequired(context, organization, user)) {
             return;
         }
@@ -187,20 +184,6 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             context.success();
         } else {
             attempted(context, username);
-        }
-    }
-
-    private void updateUserSelectOrganizationScope(AuthenticationSessionModel authSession, String orgId) {
-        if (!OrganizationScope.ANY.equals(OrganizationScope.valueOfScope(session))) {
-            // there was no user selection, nothing to do
-            return;
-        }
-
-        String scopeParam = authSession.getClientNote(OAuth2Constants.SCOPE);
-        if (scopeParam != null && scopeParam.contains("organization")) {
-            // Transform generic "organization" to specific "organization:orgId"
-            String transformedScope = scopeParam.replaceAll("\\borganization(?!:)\\b", "organization:" + orgId);
-            authSession.setClientNote(OAuth2Constants.SCOPE, transformedScope);
         }
     }
 

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.WebAuthnConstants;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
@@ -160,6 +161,8 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         // make sure the organization is set to the session to make it available to templates
         session.getContext().setOrganization(organization);
 
+        updateUserSelectOrganizationScope(authSession, organization.getAlias());
+
         if (isMembershipRequired(context, organization, user)) {
             return;
         }
@@ -184,6 +187,20 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             context.success();
         } else {
             attempted(context, username);
+        }
+    }
+
+    private void updateUserSelectOrganizationScope(AuthenticationSessionModel authSession, String orgId) {
+        if (!OrganizationScope.ANY.equals(OrganizationScope.valueOfScope(session))) {
+            // there was no user selection, nothing to do
+            return;
+        }
+
+        String scopeParam = authSession.getClientNote(OAuth2Constants.SCOPE);
+        if (scopeParam != null && scopeParam.contains("organization")) {
+            // Transform generic "organization" to specific "organization:orgId"
+            String transformedScope = scopeParam.replaceAll("\\borganization(?!:)\\b", "organization:" + orgId);
+            authSession.setClientNote(OAuth2Constants.SCOPE, transformedScope);
         }
     }
 

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
@@ -111,24 +111,32 @@ public class OrganizationMembershipMapper extends AbstractOIDCProtocolMapper imp
 
     @Override
     protected void setClaim(IDToken token, ProtocolMapperModel model, UserSessionModel userSession, KeycloakSession session, ClientSessionContext clientSessionCtx) {
-        // First, try to resolve from requested scopes (respects token refresh)
-        List<OrganizationModel> organizations = resolveFromRequestedScopes(session, userSession, clientSessionCtx).toList();
+        String orgId;
+        KeycloakContext context = session.getContext();
+        OrganizationModel organization = context.getOrganization();
 
-        // If no organizations found from scopes, fall back to stored session note
-        if (organizations.isEmpty()) {
-            String orgId = clientSessionCtx.getClientSession().getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);
-            if (orgId != null) {
-                OrganizationModel org = session.getProvider(OrganizationProvider.class).getById(orgId);
-                if (org != null) {
-                    organizations = List.of(org);
-                }
-            }
+        if (organization != null) {
+            orgId = organization.getId();
+        } else {
+            orgId = clientSessionCtx.getClientSession().getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);
         }
 
-        KeycloakContext context = session.getContext();
+        List<OrganizationModel> organizations;
+
+        if (orgId == null) {
+            organizations = resolveFromRequestedScopes(session, userSession, clientSessionCtx).toList();
+        } else {
+            organizations = List.of(session.getProvider(OrganizationProvider.class).getById(orgId));
+        }
+
         RealmModel realm = context.getRealm();
         ProtocolMapperModel effectiveModel = getEffectiveModel(session, realm, model);
         UserModel user = userSession.getUser();
+
+        if (organizations.size() == 1) {
+            context.setOrganization(organizations.get(0));
+        }
+
         Object claim = resolveValue(effectiveModel, user, organizations);
 
         if (claim == null) {

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
@@ -37,7 +37,6 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
-import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
@@ -111,22 +110,14 @@ public class OrganizationMembershipMapper extends AbstractOIDCProtocolMapper imp
 
     @Override
     protected void setClaim(IDToken token, ProtocolMapperModel model, UserSessionModel userSession, KeycloakSession session, ClientSessionContext clientSessionCtx) {
-        String orgId;
         KeycloakContext context = session.getContext();
         OrganizationModel organization = context.getOrganization();
-
-        if (organization != null) {
-            orgId = organization.getId();
-        } else {
-            orgId = clientSessionCtx.getClientSession().getNote(OrganizationModel.ORGANIZATION_ATTRIBUTE);
-        }
-
         List<OrganizationModel> organizations;
 
-        if (orgId == null) {
-            organizations = resolveFromRequestedScopes(session, userSession, clientSessionCtx).toList();
+        if (organization != null) {
+            organizations = List.of(organization);
         } else {
-            organizations = List.of(session.getProvider(OrganizationProvider.class).getById(orgId));
+            organizations = resolveFromRequestedScopes(session, userSession, clientSessionCtx).toList();
         }
 
         RealmModel realm = context.getRealm();

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationScope.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationScope.java
@@ -76,7 +76,7 @@ public enum OrganizationScope {
                 }
                 
                 // Reject ANY scope requests - they require user selection which isn't available during refresh
-                if (currentScope != null && currentScope.name().equals("ANY")) {
+                if (isAnyScope(currentScope)) {
                     return null;
                 }
                 
@@ -122,7 +122,7 @@ public enum OrganizationScope {
                 // Handle the case where current is ANY scope ("organization") and previous is a SINGLE scope ("organization:foo")
                 // When the current scope is just "organization" and the previous scope has a specific org like "organization:foo",
                 // we should preserve the specific organization from the previous scope
-                if (currentScope != null && currentScope.valueMatcher.test("")) {
+                if (isAnyScope(currentScope)) {
                     return previous;
                 }
 
@@ -180,6 +180,19 @@ public enum OrganizationScope {
     private static final String UNSUPPORTED_ORGANIZATION_SCOPES_ATTRIBUTE = "kc.org.client.scope.unsupported";
     private static final Pattern SCOPE_PATTERN = Pattern.compile("(.*)" + VALUE_SEPARATOR + "(.*)");
     private static final String EMPTY_SCOPE = "";
+
+    /**
+     * Checks if the given scope is {@link OrganizationScope#ANY}.
+     *
+     * <p>This method exists because {@code ALL} and {@code SINGLE} are declared before {@code ANY} in this enum.
+     * Referencing {@code OrganizationScope.ANY} directly inside their initializer lambdas causes a
+     * "Cannot refer to enum constant before its definition" compile error. Routing through this static method
+     * (defined after all constants) avoids the forward-reference restriction.
+     */
+    private static boolean isAnyScope(OrganizationScope scope) {
+        return OrganizationScope.ANY.equals(scope);
+    }
+
 
     /**
      * <p>Resolves the value of the scope from its raw format. For instance, {@code organization:<value>} will resolve to {@code <value>}.

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationScope.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationScope.java
@@ -27,6 +27,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.BadRequestException;
+
 import org.keycloak.common.util.TriFunction;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
@@ -77,7 +79,7 @@ public enum OrganizationScope {
                 
                 // Reject ANY scope requests - they require user selection which isn't available during refresh
                 if (isAnyScope(currentScope)) {
-                    return null;
+                    throw new BadRequestException("ANY organization scope is not allowed in this context");
                 }
                 
                 // Allow SINGLE (narrowing) or ALL (maintaining) scopes

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationTokenPostProcessor.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationTokenPostProcessor.java
@@ -1,0 +1,76 @@
+package org.keycloak.organization.protocol.mappers.oidc;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.organization.utils.Organizations;
+import org.keycloak.protocol.oidc.token.TokenInterceptorException;
+import org.keycloak.protocol.oidc.token.TokenPostProcessor;
+import org.keycloak.protocol.oidc.token.TokenPostProcessorContext;
+import org.keycloak.representations.RefreshToken;
+
+public class OrganizationTokenPostProcessor implements TokenPostProcessor{
+
+    private final KeycloakSession session;
+
+    public OrganizationTokenPostProcessor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void process(TokenPostProcessorContext context) {
+        String grantType = context.clientSessionCtx().getAttribute(Constants.GRANT_TYPE, String.class);
+
+        if (OAuth2Constants.REFRESH_TOKEN.equals(grantType)) {
+            RefreshToken refreshToken = context.requestRefreshToken();
+
+            if (refreshToken != null) {
+                Object orgAlias = refreshToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+                if (orgAlias != null) {
+                    addOrganizationRefreshTokenClaim(context, orgAlias.toString());
+                }
+            }
+        } else {
+            OrganizationModel organization = session.getContext().getOrganization();
+
+            if (organization != null) {
+                addOrganizationRefreshTokenClaim(context, organization.getAlias());
+            }
+        }
+    }
+
+    private void addOrganizationRefreshTokenClaim(TokenPostProcessorContext context, String orgAlias) {
+        if (orgAlias == null) {
+            return;
+        }
+
+        OrganizationProvider provider = Organizations.getProvider(session);
+        ClientSessionContext clientSessionContext = context.clientSessionCtx();
+        AuthenticatedClientSessionModel clientSession = clientSessionContext.getClientSession();
+        UserSessionModel userSession = clientSession.getUserSession();
+        OrganizationModel organization = provider.getByAlias(orgAlias);
+
+        if (organization == null) {
+            throw new TokenInterceptorException(OAuthErrorException.INVALID_REQUEST, OAuthErrorException.INVALID_TOKEN);
+        }
+
+        UserModel user = userSession.getUser();
+
+        if (user != null && !organization.isMember(user)) {
+            throw new TokenInterceptorException(OAuthErrorException.INVALID_REQUEST, OAuthErrorException.INVALID_TOKEN);
+        }
+
+        RefreshToken newRefreshToken = context.refreshToken();
+
+        if (newRefreshToken != null) {
+            newRefreshToken.getOtherClaims().put(OAuth2Constants.ORGANIZATION, orgAlias);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationTokenPostProcessor.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationTokenPostProcessor.java
@@ -57,7 +57,7 @@ public class OrganizationTokenPostProcessor implements TokenPostProcessor{
         UserSessionModel userSession = clientSession.getUserSession();
         OrganizationModel organization = provider.getByAlias(orgAlias);
 
-        if (organization == null) {
+        if (organization == null || !organization.isEnabled()) {
             throw new TokenInterceptorException(OAuthErrorException.INVALID_REQUEST, OAuthErrorException.INVALID_TOKEN);
         }
 

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationTokenPostProcessorFactory.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationTokenPostProcessorFactory.java
@@ -1,0 +1,27 @@
+package org.keycloak.organization.protocol.mappers.oidc;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.common.Profile.Feature;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.token.TokenPostProcessor;
+import org.keycloak.protocol.oidc.token.TokenPostProcessorFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+
+public class OrganizationTokenPostProcessorFactory implements TokenPostProcessorFactory, EnvironmentDependentProviderFactory {
+
+    @Override
+    public TokenPostProcessor create(KeycloakSession session) {
+        return new OrganizationTokenPostProcessor(session);
+    }
+
+    @Override
+    public String getId() {
+        return "organizations";
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Feature.ORGANIZATION);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -147,7 +147,7 @@ public class AccessTokenIntrospectionProvider<T extends AccessToken> implements 
 
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, token.getScope(), session);
         AccessToken smallToken = getAccessTokenFromStoredData(token);
-        return tokenManager.transformIntrospectionAccessToken(session, smallToken, userSession, clientSessionCtx);
+        return tokenManager.transformIntrospectionAccessToken(session, token, smallToken, userSession, clientSessionCtx);
     }
 
     private AccessToken getAccessTokenFromStoredData(AccessToken token) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.OAuth2Constants;
@@ -233,7 +234,7 @@ public class TokenManager {
             throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Unmatching clients", "Unmatching clients");
         }
 
-        validateOrganization(session, oldToken, user);
+        validateSelectedOrganization(session, oldToken, user);
 
         try {
             TokenVerifier.createWithoutSignature(oldToken)
@@ -894,10 +895,16 @@ public class TokenManager {
                 });
     }
 
-    public AccessToken transformUserInfoAccessToken(KeycloakSession session, AccessToken token,
+    public AccessToken transformUserInfoAccessToken(KeycloakSession session, AccessToken userInfo,
                                                     UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        return transformUserInfoAccessToken(session, null, userInfo, userSession, clientSessionCtx);
+    }
+
+    public AccessToken transformUserInfoAccessToken(KeycloakSession session, AccessToken bearerToken, AccessToken userInfo,
+                                                    UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        validateSelectedOrganization(session, bearerToken, userSession == null ? null : userSession.getUser());
         return ProtocolMapperUtils.getSortedProtocolMappers(session, clientSessionCtx, mapper -> mapper.getValue() instanceof UserInfoTokenMapper)
-                .collect(new TokenCollector<AccessToken>(token) {
+                .collect(new TokenCollector<AccessToken>(userInfo) {
                     @Override
                     protected AccessToken applyMapper(AccessToken token, Map.Entry<ProtocolMapperModel, ProtocolMapper> mapper) {
                         return ((UserInfoTokenMapper) mapper.getValue()).transformUserInfoToken(token, mapper.getKey(), session, userSession, clientSessionCtx);
@@ -905,8 +912,9 @@ public class TokenManager {
                 });
     }
 
-    public AccessToken transformIntrospectionAccessToken(KeycloakSession session, AccessToken token,
+    public AccessToken transformIntrospectionAccessToken(KeycloakSession session, AccessToken bearer, AccessToken token,
                                                          UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+        validateSelectedOrganization(session, bearer, userSession == null ? null : userSession.getUser());
         return ProtocolMapperUtils.getSortedProtocolMappers(session, clientSessionCtx, mapper -> mapper.getValue() instanceof TokenIntrospectionTokenMapper)
                 .collect(new TokenCollector<AccessToken>(token) {
                     @Override
@@ -1672,15 +1680,28 @@ public class TokenManager {
         return Optional.ofNullable(refreshToken.getOtherClaims().get(Constants.REUSE_ID)).map(String::valueOf).orElse("");
     }
 
-    private void validateOrganization(KeycloakSession session, RefreshToken refreshToken, UserModel user) throws OAuthErrorException {
-        Object orgAlias = refreshToken.getOtherClaims().get(ORGANIZATION);
+    private void validateSelectedOrganization(KeycloakSession session, JsonWebToken token, UserModel user) {
+        if (token == null) {
+            return;
+        }
 
-        if (orgAlias != null) {
+        List<String> orgAlias = List.of();
+        Object organizations = token.getOtherClaims().get(ORGANIZATION);
+
+        if (organizations instanceof String) {
+            orgAlias = List.of((String) organizations);
+        } else if (organizations instanceof Collection<?> orgList) {
+            orgAlias = orgList.stream().map(String::valueOf).collect(Collectors.toList());
+        } else if (organizations instanceof Map<?,?> orgMap) {
+            orgAlias = orgMap.keySet().stream().map(String::valueOf).collect(Collectors.toList());
+        }
+
+        if (orgAlias.size() == 1) {
             OrganizationProvider provider = Organizations.getProvider(session);
-            OrganizationModel organization = provider.getByAlias(orgAlias.toString());
+            OrganizationModel organization = provider.getByAlias(orgAlias.get(0));
 
             if (organization == null || !organization.isEnabled() || !organization.isMember(user)) {
-                throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Invalid organization", "Invalid organization");
+                throw new ErrorResponseException(OAuthErrorException.INVALID_GRANT, "Invalid organization", Status.BAD_REQUEST);
             }
 
             session.getContext().setOrganization(organization);

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -78,6 +78,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.IdentityProviderQuery;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
@@ -90,8 +91,10 @@ import org.keycloak.models.light.LightweightUserAdapter;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.models.utils.SessionExpirationUtils;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.protocol.mappers.oidc.OrganizationMembershipMapper;
 import org.keycloak.organization.protocol.mappers.oidc.OrganizationScope;
+import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocolFactory;
 import org.keycloak.protocol.ProtocolMapper;
@@ -230,6 +233,8 @@ public class TokenManager {
             throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Unmatching clients", "Unmatching clients");
         }
 
+        validateOrganization(session, oldToken, user);
+
         try {
             TokenVerifier.createWithoutSignature(oldToken)
                     .withChecks(NotBeforeCheck.forModel(client), NotBeforeCheck.forModel(session, realm, user))
@@ -335,7 +340,6 @@ public class TokenManager {
                     .filter(Objects::nonNull)
                     .collect(Collectors.joining(" "));
         }
-
 
         TokenValidation validation = validateToken(session, uriInfo, connection, realm, refreshToken, headers, oldTokenScope);
         session.getContext().setUserSession(validation.userSession);
@@ -1668,4 +1672,18 @@ public class TokenManager {
         return Optional.ofNullable(refreshToken.getOtherClaims().get(Constants.REUSE_ID)).map(String::valueOf).orElse("");
     }
 
+    private void validateOrganization(KeycloakSession session, RefreshToken refreshToken, UserModel user) throws OAuthErrorException {
+        Object orgAlias = refreshToken.getOtherClaims().get(ORGANIZATION);
+
+        if (orgAlias != null) {
+            OrganizationProvider provider = Organizations.getProvider(session);
+            OrganizationModel organization = provider.getByAlias(orgAlias.toString());
+
+            if (organization == null || !organization.isEnabled() || !organization.isMember(user)) {
+                throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Invalid organization", "Invalid organization");
+            }
+
+            session.getContext().setOrganization(organization);
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -281,7 +281,7 @@ public class UserInfoEndpoint {
 
         AccessToken userInfo = new AccessToken();
 
-        userInfo = tokenManager.transformUserInfoAccessToken(session, userInfo, userSession, clientSessionCtx);
+        userInfo = tokenManager.transformUserInfoAccessToken(session, token, userInfo, userSession, clientSessionCtx);
         Map<String, Object> claims = tokenManager.generateUserInfoClaims(userInfo, userModel);
 
         Response.ResponseBuilder responseBuilder;

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.token.TokenPostProcessorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oidc.token.TokenPostProcessorFactory
@@ -1,1 +1,2 @@
 org.keycloak.protocol.oidc.resourceindicators.ResourceIndicatorsPostProcessorFactory
+org.keycloak.organization.protocol.mappers.oidc.OrganizationTokenPostProcessorFactory

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -193,7 +193,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         }
 
         if (System.getProperty("auth.server.host") != null) {
-            commands.add("-Dauth.server.host=" + System.getProperty("auth.server.host"));
+//            commands.add("-Dauth.server.host=" + System.getProperty("auth.server.host"));
         }
 
         commands.addAll(getAdditionalBuildArgs());
@@ -206,7 +206,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         if ("local".equals(cacheMode)) {
             commands.add("--cache=local");
             // Save ~2s for each Quarkus startup, when we know ISPN cluster is empty. See https://github.com/keycloak/keycloak/issues/21033
-            commands.add("-Djgroups.join_timeout=10");
+//            commands.add("-Djgroups.join_timeout=10");
         } else {
             commands.add("--cache=ispn");
             commands.add("--cache-config-file=cluster-" + cacheMode + ".xml");

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -193,7 +193,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         }
 
         if (System.getProperty("auth.server.host") != null) {
-//            commands.add("-Dauth.server.host=" + System.getProperty("auth.server.host"));
+            commands.add("-Dauth.server.host=" + System.getProperty("auth.server.host"));
         }
 
         commands.addAll(getAdditionalBuildArgs());
@@ -206,7 +206,7 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         if ("local".equals(cacheMode)) {
             commands.add("--cache=local");
             // Save ~2s for each Quarkus startup, when we know ISPN cluster is empty. See https://github.com/keycloak/keycloak/issues/21033
-//            commands.add("-Djgroups.join_timeout=10");
+            commands.add("-Djgroups.join_timeout=10");
         } else {
             commands.add("--cache=ispn");
             commands.add("--cache-config-file=cluster-" + cacheMode + ".xml");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -794,6 +794,42 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(organizations.contains(orgB.getAlias()), is(true));
     }
 
+    @Test
+    public void testRefreshTokenScopeWithSingleOrganizationAskingForAll() {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        oauth.client("broker-app", "broker-app-secret");
+        String originalScope = "organization:" + orgA.getAlias();
+        oauth.scope(originalScope);
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(member.getEmail());
+        loginPage.login(memberPassword);
+        AccessTokenResponse response = assertSuccessfulCodeGrant();
+        assertThat(response.getScope(), containsString(originalScope));
+        AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString(originalScope));
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
+        assertThat(organizations.contains(orgA.getAlias()), is(true));
+        RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        assertThat(refreshToken.getScope(), containsString(originalScope));
+
+        //previous:(SINGLE:orga) -> current:(ALL) == SINGLE:orga
+        String allOrgsScope = "organization:*";
+        oauth.scope(allOrgsScope);
+        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertThat(response.getScope(), not(containsString(allOrgsScope)));
+        accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString(originalScope));
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
+        assertThat(organizations.contains(orgA.getAlias()), is(true));
+    }
+
     @SuppressWarnings("unchecked")
     @Test
     public void testPasswordGrantWithAllOrganizationsAndRefresh() throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -606,7 +606,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         orgScope = "organization";
         oauth.scope(orgScope).openid(false);
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
-        assertResponseMissingOrganizationScopeAndClaims(response);
+        assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+        assertEquals("ANY organization scope is not allowed in this context", response.getError());
     }
 
     @Test
@@ -946,10 +947,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
             tabUtil.switchToTab(0);
             oauth.scope("organization");
             response = oauth.doRefreshTokenRequest(tab1RefreshToken);
-            assertThat(response.getScope(), not(containsString("organization")));
-            accessToken = oauth.verifyToken(response.getAccessToken());
-            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
-            assertThat(organizations, is(nullValue()));
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals("ANY organization scope is not allowed in this context", response.getError());
 
             // try to refresh first tab changing scopes SINGLE -> ALL
             tabUtil.switchToTab(0);
@@ -975,10 +974,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
             tabUtil.switchToTab(1);
             oauth.scope("organization");
             response = oauth.doRefreshTokenRequest(tab1RefreshToken);
-            assertThat(response.getScope(), not(containsString("organization")));
-            accessToken = oauth.verifyToken(response.getAccessToken());
-            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
-            assertThat(organizations, is(nullValue()));
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), response.getStatusCode());
+            assertEquals("ANY organization scope is not allowed in this context", response.getError());
 
             // refresh second tab resetting scopes so that the scopes from the last successful refresh are respected
             tabUtil.switchToTab(1);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -794,6 +794,168 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(organizations.contains(orgB.getAlias()), is(true));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testPasswordGrantWithAllOrganizationsAndRefresh() throws Exception {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+
+        oauth.client("direct-grant", "password");
+        oauth.scope("openid organization:*");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(member.getEmail(), memberPassword);
+        assertThat(response.getScope(), containsString("organization"));
+
+        AccessToken accessToken = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertThat(organizations, containsInAnyOrder("orga", "orgb"));
+
+        // refresh token and verify same organizations are resolved
+        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertThat(response.getScope(), containsString("organization"));
+        accessToken = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertThat(organizations, containsInAnyOrder("orga", "orgb"));
+
+        // refresh again to verify subsequent refreshes also work
+        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertThat(response.getScope(), containsString("organization"));
+        accessToken = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertThat(organizations, containsInAnyOrder("orga", "orgb"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testMultipleTabsWithMixedScopeFormats() {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        oauth.client("broker-app", KcOidcBrokerConfiguration.CONSUMER_BROKER_APP_SECRET);
+
+        try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
+            // first tab - organization:* (all orgs)
+            oauth.scope("organization:*");
+            loginPage.open(bc.consumerRealmName());
+            loginPage.loginUsername(member.getEmail());
+            loginPage.login(memberPassword);
+            AccessTokenResponse response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString("organization:*"));
+            String tab1RefreshToken = response.getRefreshToken();
+            AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+            List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(2));
+            assertThat(organizations, containsInAnyOrder(orgA.getAlias(), orgB.getAlias()));
+
+            // second tab - organization (ANY, select orgB)
+            oauth.scope("organization");
+            tabUtil.newTab(oauth.loginForm().build());
+            assertThat(tabUtil.getCountOfTabs(), is(2));
+            selectOrganizationPage.isCurrent();
+            selectOrganizationPage.selectOrganization(orgB.getAlias());
+            response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString("organization"));
+            String tab2RefreshToken = response.getRefreshToken();
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgB.getAlias()), is(true));
+
+            // refresh first tab - should still have all organizations (not contaminated by tab 2's org selection)
+            tabUtil.switchToTab(0);
+            oauth.scope(null);
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), containsString("organization:*"));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(2));
+            assertThat(organizations, containsInAnyOrder(orgA.getAlias(), orgB.getAlias()));
+
+            // refresh second tab - should still have only orgB
+            tabUtil.switchToTab(1);
+            oauth.scope(null);
+            response = oauth.doRefreshTokenRequest(tab2RefreshToken);
+            assertThat(response.getScope(), containsString("organization"));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgB.getAlias()), is(true));
+
+            // refresh second tab changing scopes to ask for orgA, should not be allowed since the user selection in
+            // that tab was orgB
+            tabUtil.switchToTab(1);
+            oauth.scope("organization:" + orgA.getAlias());
+            response = oauth.doRefreshTokenRequest(tab2RefreshToken);
+            assertThat(response.getScope(), not(containsString("organization")));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations, is(nullValue()));
+
+            // refresh first tab changing scopes ALL -> SINGLE
+            tabUtil.switchToTab(0);
+            oauth.scope("organization:" + orgA.getAlias());
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), containsString("organization:" + orgA.getAlias()));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations, containsInAnyOrder(orgA.getAlias()));
+
+            // try to refresh first tab changing scopes SINGLE -> ANY, not allowed
+            tabUtil.switchToTab(0);
+            oauth.scope("organization");
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), not(containsString("organization")));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations, is(nullValue()));
+
+            // try to refresh first tab changing scopes SINGLE -> ALL
+            tabUtil.switchToTab(0);
+            oauth.scope("organization:*");
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), containsString("organization:*"));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(2));
+            assertThat(organizations, containsInAnyOrder(orgA.getAlias(), orgB.getAlias()));
+
+            // try to refresh second tab changing scopes ANY -> ALL
+            tabUtil.switchToTab(1);
+            oauth.scope("organization:*");
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), containsString("organization:*"));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(2));
+            assertThat(organizations, containsInAnyOrder(orgA.getAlias(), orgB.getAlias()));
+
+            // try to refresh second tab changing scopes ALL -> ANY
+            tabUtil.switchToTab(1);
+            oauth.scope("organization");
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), not(containsString("organization")));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations, is(nullValue()));
+
+            // refresh second tab resetting scopes so that the scopes from the last successful refresh are respected
+            tabUtil.switchToTab(1);
+            oauth.scope(null);
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), containsString("organization:*"));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(2));
+            assertThat(organizations, containsInAnyOrder(orgA.getAlias(), orgB.getAlias()));
+        }
+    }
+
     @Test
     public void testIncludeOrganizationAttributes() throws Exception {
         OrganizationRepresentation orgRep = createOrganization();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -54,11 +54,14 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.broker.KcOidcBrokerConfiguration;
 import org.keycloak.testsuite.organization.admin.AbstractOrganizationTest;
+import org.keycloak.testsuite.util.BrowserTabUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import org.keycloak.testsuite.util.oauth.OAuthClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -252,7 +255,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         loginPage.loginUsername(member.getEmail());
         loginPage.login(memberPassword);
 
-        assertScopeAndClaims(orgScope, orgA);
+        String transformedScope = "organization:orga";
+        assertScopeAndClaims(transformedScope, orgA);
     }
 
     @Test
@@ -270,6 +274,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
+        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
         assertThat(response.getScope(), containsString("organization"));
@@ -409,6 +414,56 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
     }
 
     @Test
+    public void testMultipleTabsTrackingDifferentOrganizationSelectionHoldAcrossTokenRefresh() {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        oauth.client("broker-app", KcOidcBrokerConfiguration.CONSUMER_BROKER_APP_SECRET);
+        oauth.scope("organization");
+
+        try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
+            //first tab - select orgA
+            loginPage.open(bc.consumerRealmName());
+            loginPage.loginUsername(member.getEmail());
+            selectOrganizationPage.selectOrganization(orgA.getAlias());
+            String tab1TransformedScope = "organization:orga";
+            loginPage.login(memberPassword);
+            AccessTokenResponse response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString(tab1TransformedScope));
+            String tab1RefreshToken = response.getRefreshToken();
+
+            //second tab - select orgB
+            tabUtil.newTab(oauth.loginForm().build());
+            assertThat(tabUtil.getCountOfTabs(), is(2));
+            selectOrganizationPage.isCurrent();
+            selectOrganizationPage.selectOrganization(orgB.getAlias());
+            String tab2TransformedScope = "organization:orgb";
+            response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString(tab2TransformedScope));
+            String tab2RefreshToken = response.getRefreshToken();
+
+            //refresh first tab - ensure still orgA
+            tabUtil.switchToTab(0);
+            response = oauth.doRefreshTokenRequest(tab1RefreshToken);
+            assertThat(response.getScope(), containsString(tab1TransformedScope));
+            AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+            List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgA.getAlias()), is(true));
+
+            //refresh second tab - ensure still orgB
+            tabUtil.switchToTab(1);
+            response = oauth.doRefreshTokenRequest(tab2RefreshToken);
+            assertThat(response.getScope(), containsString(tab2TransformedScope));
+            accessToken = oauth.verifyToken(response.getAccessToken());
+            organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgB.getAlias()), is(true));
+        }
+    }
+
+    @Test
     public void testRefreshTokenWithAllOrganizationsAskingForSpecificOrganization() {
         OrganizationRepresentation orgA = createOrganization("orga", true);
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
@@ -428,6 +483,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(organizations.size(), is(2));
+
+        //previous:(ALL) -> current:(SINGLE:orga) == SINGLE:orga
         orgScope = "organization:orga";
         oauth.scope(orgScope).openid(false);
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
@@ -438,6 +495,34 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(organizations.size(), is(1));
         assertThat(organizations.contains(orgA.getAlias()), is(true));
+    }
+
+    @Test
+    public void testRefreshTokenWithAllOrganizationsAskingForAny() {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        // identity-first login will respect the organization provided in the scope even though the user email maps to a different organization
+        oauth.client("broker-app", KcOidcBrokerConfiguration.CONSUMER_BROKER_APP_SECRET);
+        String orgScope = "organization:*";
+        oauth.scope(orgScope);
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(member.getEmail());
+        loginPage.login(memberPassword);
+        AccessTokenResponse response = assertSuccessfulCodeGrant();
+        assertThat(response.getScope(), containsString(orgScope));
+        AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString(orgScope));
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertThat(organizations.size(), is(2));
+
+        //previous:(ALL) -> current:(ANY) == not allowed
+        orgScope = "organization";
+        oauth.scope(orgScope).openid(false);
+        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertResponseMissingOrganizationScopeAndClaims(response);
     }
 
     @Test
@@ -462,6 +547,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(organizations.size(), is(1));
         assertThat(organizations.contains(orgA.getAlias()), is(true));
+
+        //previous:(SINGLE:orga) -> current:(ALL) == SINGLE:orga
         orgScope = "organization:*";
         oauth.scope(orgScope);
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
@@ -496,18 +583,16 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(organizations.size(), is(1));
         assertThat(organizations.contains(orgA.getAlias()), is(true));
+
+        //previous:(SINGLE:orga) -> current:(SINGLE:orgb) == not allowed
         orgScope = "organization:orgb";
         oauth.scope(orgScope);
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
-        assertThat(response.getScope(), not(containsString(originalScope)));
-        accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), not(containsString(orgScope)));
-        assertThat(accessToken.getScope(), not(containsString(originalScope)));
-        assertThat(accessToken.getOtherClaims().keySet(), not(hasItem(OAuth2Constants.ORGANIZATION)));
+        assertResponseMissingOrganizationScopeAndClaims(response);
     }
 
     @Test
-    public void testRefreshTokenScopeAnyAskingAllOrganizations() {
+    public void testRefreshTokenScopeWithOrganizationSelectionAskingForSameOrganization() {
         OrganizationRepresentation orgA = createOrganization("orga", true);
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
         OrganizationRepresentation orgB = createOrganization("orgb", true);
@@ -521,28 +606,34 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
+        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
-        // for now, return the organization scope in the response and access token even though no organization is mapped into the token
-        // once we support the user to select an organization, the selected organization will be mapped
         assertThat(response.getScope(), containsString("organization"));
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString(transformedScope));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
         assertThat(organizations.contains(orgB.getAlias()), is(true));
-        String orgScope = "organization:*";
+        RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        assertThat(refreshToken.getScope(), containsString(transformedScope));
+
+        //previous:(ANY -> SINGLE:orgb) -> current:(SINGLE:orgb) == SINGLE:orgb
+        String orgScope = "organization:orgb";
         oauth.scope(orgScope);
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
-        assertThat(response.getScope(), containsString(originalScope));
+        assertThat(response.getScope(), containsString(orgScope));
         accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), containsString(originalScope));
+        assertThat(accessToken.getScope(), containsString(orgScope));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
         assertThat(organizations.contains(orgB.getAlias()), is(true));
     }
 
     @Test
-    public void testRefreshTokenScopeAnyAskingSingleOrganization() {
+    public void testRefreshTokenScopeWithOrganizationSelectionAskingForDifferentOrganization() {
         OrganizationRepresentation orgA = createOrganization("orga", true);
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
         OrganizationRepresentation orgB = createOrganization("orgb", true);
@@ -556,20 +647,65 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
+        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
         assertThat(response.getScope(), containsString("organization"));
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString(transformedScope));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
         assertThat(organizations.contains(orgB.getAlias()), is(true));
-        String orgScope = "organization:orgb";
+        RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        assertThat(refreshToken.getScope(), containsString(transformedScope));
+
+        //previous:(ANY -> SINGLE:orgb) -> current:(SINGLE:orga) == not allowed
+        String orgScope = "organization:orga";
         oauth.scope(orgScope);
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
-        assertThat(response.getScope(), not(containsString(orgScope)));
+        assertResponseMissingOrganizationScopeAndClaims(response);
+    }
+
+    @Test
+    public void testRefreshTokenScopeWithOrganizationSelectionAskingForAll() {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        oauth.client("broker-app", "broker-app-secret");
+        String originalScope = "organization";
+        oauth.scope(originalScope);
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(member.getEmail());
+        assertTrue(selectOrganizationPage.isCurrent());
+        assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
+        assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
+        selectOrganizationPage.selectOrganization(orgB.getAlias());
+        String transformedScope = "organization:orgb";
+        loginPage.login(memberPassword);
+        AccessTokenResponse response = assertSuccessfulCodeGrant();
+        assertThat(response.getScope(), containsString("organization"));
+        AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString(transformedScope));
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
+        assertThat(organizations.contains(orgB.getAlias()), is(true));
+        RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        assertThat(refreshToken.getScope(), containsString(transformedScope));
+
+        //previous:(ANY -> SINGLE:orgb) -> current:(ALL) == SINGLE:orgb
+        String allOrgsScope = "organization:*";
+        oauth.scope(allOrgsScope);
+        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertThat(response.getScope(), not(containsString(allOrgsScope)));
         accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), not(containsString(orgScope)));
-        assertThat(accessToken.getOtherClaims().keySet(), not(hasItem(OAuth2Constants.ORGANIZATION)));
+        assertThat(accessToken.getScope(), containsString(transformedScope));
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
+        assertThat(organizations.contains(orgB.getAlias()), is(true));
     }
 
     @Test
@@ -910,10 +1046,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         oauth.scope("openid");
         oauth.openLoginForm();
         response = assertSuccessfulCodeGrant();
-        assertThat(response.getScope(), not(containsString(orgScope)));
-        accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), not(containsString(orgScope)));
-        assertThat(accessToken.getOtherClaims().keySet(), not(hasItem(OAuth2Constants.ORGANIZATION)));
+        assertResponseMissingOrganizationScopeAndClaims(response);
     }
 
     @Test
@@ -1117,14 +1250,14 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         OrganizationRepresentation orgRep = createOrganization();
         OrganizationResource organization = testRealm().organizations().get(orgRep.getId());
         addMember(organization);
-        
+
         // Add a custom attribute named "id" to the organization
         orgRep.singleAttribute("id", "custom-id-value");
-        
+
         try (Response response = organization.update(orgRep)) {
             assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
         }
-        
+
         // Verify that organization ID overrides custom "id" attribute in tokens
         setMapperConfig(OrganizationMembershipMapper.ADD_ORGANIZATION_ID, Boolean.TRUE.toString());
         setMapperConfig(OrganizationMembershipMapper.ADD_ORGANIZATION_ATTRIBUTES, Boolean.TRUE.toString());
@@ -1135,17 +1268,21 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(response.getScope(), containsString("organization"));
         AccessToken accessToken = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
-        
+
         Map<String, Map<String, String>> organizations = (Map<String, Map<String, String>>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(organizations.keySet(), hasItem(organizationName));
         Map<String, String> orgClaims = organizations.get(organizationName);
-        
+
         // The "id" attribute should contain the organization ID, not the custom value
         assertThat(orgClaims.get("id"), equalTo(orgRep.getId()));
         assertThat(orgClaims.get("id"), not(equalTo("custom-id-value")));
     }
 
     private AccessTokenResponse assertSuccessfulCodeGrant() {
+       return assertSuccessfulCodeGrant(oauth);
+    }
+
+    private AccessTokenResponse assertSuccessfulCodeGrant(OAuthClient oauth) {
         String code = oauth.parseLoginResponse().getCode();
         AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertThat(Status.OK, is(Status.fromStatusCode(response.getStatusCode())));
@@ -1187,6 +1324,13 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(organizations.contains(org.getAlias()), is(true));
         refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
         assertThat(refreshToken.getScope(), containsString(orgScope));
+    }
+
+    private void assertResponseMissingOrganizationScopeAndClaims(AccessTokenResponse response) {
+        assertThat(response.getScope(), not(containsString("organization")));
+        AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), not(containsString("organization")));
+        assertThat(accessToken.getOtherClaims().keySet(), not(hasItem(OAuth2Constants.ORGANIZATION)));
     }
 
     private void assertClaimNotMapped(String orgScope, OrganizationRepresentation orgARep, boolean grantScope) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -56,12 +56,11 @@ import org.keycloak.testsuite.broker.KcOidcBrokerConfiguration;
 import org.keycloak.testsuite.organization.admin.AbstractOrganizationTest;
 import org.keycloak.testsuite.util.BrowserTabUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.OAuthClient;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.keycloak.testsuite.util.oauth.OAuthClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -255,8 +254,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         loginPage.loginUsername(member.getEmail());
         loginPage.login(memberPassword);
 
-        String transformedScope = "organization:orga";
-        assertScopeAndClaims(transformedScope, orgA);
+        assertScopeAndClaims(orgScope, orgA);
     }
 
     @Test
@@ -274,7 +272,6 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
-        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
         assertThat(response.getScope(), containsString("organization"));
@@ -427,10 +424,9 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
             loginPage.open(bc.consumerRealmName());
             loginPage.loginUsername(member.getEmail());
             selectOrganizationPage.selectOrganization(orgA.getAlias());
-            String tab1TransformedScope = "organization:orga";
             loginPage.login(memberPassword);
             AccessTokenResponse response = assertSuccessfulCodeGrant(oauth);
-            assertThat(response.getScope(), containsString(tab1TransformedScope));
+            assertThat(response.getScope(), containsString("organization"));
             String tab1RefreshToken = response.getRefreshToken();
 
             //second tab - select orgB
@@ -438,15 +434,14 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
             assertThat(tabUtil.getCountOfTabs(), is(2));
             selectOrganizationPage.isCurrent();
             selectOrganizationPage.selectOrganization(orgB.getAlias());
-            String tab2TransformedScope = "organization:orgb";
             response = assertSuccessfulCodeGrant(oauth);
-            assertThat(response.getScope(), containsString(tab2TransformedScope));
+            assertThat(response.getScope(), containsString("organization"));
             String tab2RefreshToken = response.getRefreshToken();
 
             //refresh first tab - ensure still orgA
             tabUtil.switchToTab(0);
             response = oauth.doRefreshTokenRequest(tab1RefreshToken);
-            assertThat(response.getScope(), containsString(tab1TransformedScope));
+            assertThat(response.getScope(), containsString("organization"));
             AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
             List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
             assertThat(organizations.size(), is(1));
@@ -455,7 +450,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
             //refresh second tab - ensure still orgB
             tabUtil.switchToTab(1);
             response = oauth.doRefreshTokenRequest(tab2RefreshToken);
-            assertThat(response.getScope(), containsString(tab2TransformedScope));
+            assertThat(response.getScope(), containsString("organization"));
             accessToken = oauth.verifyToken(response.getAccessToken());
             organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
             assertThat(organizations.size(), is(1));
@@ -606,30 +601,22 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
-        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
         assertThat(response.getScope(), containsString("organization"));
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), containsString(transformedScope));
+        assertThat(accessToken.getScope(), containsString("organization"));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertEquals( 1, organizations.toArray().length);
         assertThat(organizations.contains(orgB.getAlias()), is(true));
         RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
-        assertThat(refreshToken.getScope(), containsString(transformedScope));
+        assertThat(refreshToken.getScope(), containsString("organization"));
 
-        //previous:(ANY -> SINGLE:orgb) -> current:(SINGLE:orgb) == SINGLE:orgb
-        String orgScope = "organization:orgb";
-        oauth.scope(orgScope);
+        //previous:(ANY -> SINGLE:orgb) -> current:(SINGLE:orgb) == SINGLE:orgb -> cannot change user selection
+        oauth.scope("organization:orgb");
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
-        assertThat(response.getScope(), containsString(orgScope));
-        accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), containsString(orgScope));
-        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
-        organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
-        assertEquals( 1, organizations.toArray().length);
-        assertThat(organizations.contains(orgB.getAlias()), is(true));
+        assertThat(response.getScope(), not(containsString("organization")));
     }
 
     @Test
@@ -647,18 +634,17 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
-        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
         assertThat(response.getScope(), containsString("organization"));
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), containsString(transformedScope));
+        assertThat(accessToken.getScope(), containsString("organization"));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertEquals( 1, organizations.toArray().length);
         assertThat(organizations.contains(orgB.getAlias()), is(true));
         RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
-        assertThat(refreshToken.getScope(), containsString(transformedScope));
+        assertThat(refreshToken.getScope(), containsString("organization"));
 
         //previous:(ANY -> SINGLE:orgb) -> current:(SINGLE:orga) == not allowed
         String orgScope = "organization:orga";
@@ -682,18 +668,17 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
         assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
         selectOrganizationPage.selectOrganization(orgB.getAlias());
-        String transformedScope = "organization:orgb";
         loginPage.login(memberPassword);
         AccessTokenResponse response = assertSuccessfulCodeGrant();
         assertThat(response.getScope(), containsString("organization"));
         AccessToken accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), containsString(transformedScope));
+        assertThat(accessToken.getScope(), containsString("organization"));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         List<String> organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertEquals( 1, organizations.toArray().length);
         assertThat(organizations.contains(orgB.getAlias()), is(true));
         RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
-        assertThat(refreshToken.getScope(), containsString(transformedScope));
+        assertThat(refreshToken.getScope(), containsString("organization"));
 
         //previous:(ANY -> SINGLE:orgb) -> current:(ALL) == SINGLE:orgb
         String allOrgsScope = "organization:*";
@@ -701,7 +686,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
         assertThat(response.getScope(), not(containsString(allOrgsScope)));
         accessToken = oauth.verifyToken(response.getAccessToken());
-        assertThat(accessToken.getScope(), containsString(transformedScope));
+        assertThat(accessToken.getScope(), containsString("organization"));
         assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
         organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertEquals( 1, organizations.toArray().length);
@@ -710,7 +695,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
 
     @Test
     public void testIncludeOrganizationAttributes() throws Exception {
-        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        OrganizationRepresentation orgRep = createOrganization();
+        OrganizationResource organization = testRealm().organizations().get(orgRep.getId());
         addMember(organization);
         setMapperConfig(OrganizationMembershipMapper.ADD_ORGANIZATION_ATTRIBUTES, Boolean.TRUE.toString());
 
@@ -735,6 +721,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(organizations.keySet(), hasItem(organizationName));
         assertThat(organizations.get(organizationName).keySet(), hasItem("key"));
         assertThat(organizations.get(organizationName).get("key"), containsInAnyOrder("value1", "value2"));
+        RefreshToken refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        assertThat(refreshToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION), is(orgRep.getAlias()));
 
         setMapperConfig(OrganizationMembershipMapper.ADD_ORGANIZATION_ATTRIBUTES, Boolean.FALSE.toString());
         setMapperConfig(OIDCAttributeMapperHelper.JSON_TYPE, "JSON");
@@ -744,6 +732,8 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         organizations = (Map<String, Map<String, List<String>>>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
         assertThat(organizations.keySet(), hasItem(organizationName));
         assertThat(organizations.get(organizationName).keySet().isEmpty(), is(true));
+        refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
+        assertThat(refreshToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION), is(orgRep.getAlias()));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.testsuite.organization.mapper;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -43,6 +44,7 @@ import org.keycloak.protocol.oidc.mappers.GroupMembershipMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
+import org.keycloak.representations.UserInfo;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.FederatedIdentityRepresentation;
@@ -51,12 +53,15 @@ import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.oidc.TokenMetadataRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.broker.KcOidcBrokerConfiguration;
 import org.keycloak.testsuite.organization.admin.AbstractOrganizationTest;
 import org.keycloak.testsuite.util.BrowserTabUtil;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
+import org.keycloak.testsuite.util.oauth.UserInfoResponse;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -459,6 +464,90 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
     }
 
     @Test
+    public void testUserInfoEndpoint() {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        oauth.client("broker-app", KcOidcBrokerConfiguration.CONSUMER_BROKER_APP_SECRET);
+        oauth.scope("organization");
+
+        try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
+            //first tab - select orgA
+            loginPage.open(bc.consumerRealmName());
+            loginPage.loginUsername(member.getEmail());
+            selectOrganizationPage.selectOrganization(orgA.getAlias());
+            loginPage.login(memberPassword);
+            AccessTokenResponse response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString("organization"));
+            String tab1AccessToken = response.getAccessToken();
+
+            //second tab - select orgB
+            tabUtil.newTab(oauth.loginForm().build());
+            assertThat(tabUtil.getCountOfTabs(), is(2));
+            selectOrganizationPage.isCurrent();
+            selectOrganizationPage.selectOrganization(orgB.getAlias());
+            response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString("organization"));
+            String tab2AccessToken = response.getAccessToken();
+
+            UserInfoResponse userInfoResponse = oauth.userInfoRequest(tab1AccessToken).send();
+            UserInfo userInfo = userInfoResponse.getUserInfo();
+            List<String> organizations = (List<String>) userInfo.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgA.getAlias()), is(true));
+
+            userInfoResponse = oauth.userInfoRequest(tab2AccessToken).send();
+            userInfo = userInfoResponse.getUserInfo();
+            organizations = (List<String>) userInfo.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgB.getAlias()), is(true));
+        }
+    }
+
+    @Test
+    public void testIntrospectionEndpoint() throws IOException {
+        OrganizationRepresentation orgA = createOrganization("orga", true);
+        MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
+        OrganizationRepresentation orgB = createOrganization("orgb", true);
+        testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
+        oauth.client("broker-app", KcOidcBrokerConfiguration.CONSUMER_BROKER_APP_SECRET);
+        oauth.scope("organization");
+
+        try (BrowserTabUtil tabUtil = BrowserTabUtil.getInstanceAndSetEnv(driver)) {
+            //first tab - select orgA
+            loginPage.open(bc.consumerRealmName());
+            loginPage.loginUsername(member.getEmail());
+            selectOrganizationPage.selectOrganization(orgA.getAlias());
+            loginPage.login(memberPassword);
+            AccessTokenResponse response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString("organization"));
+            String tab1AccessToken = response.getAccessToken();
+
+            //second tab - select orgB
+            tabUtil.newTab(oauth.loginForm().build());
+            assertThat(tabUtil.getCountOfTabs(), is(2));
+            selectOrganizationPage.isCurrent();
+            selectOrganizationPage.selectOrganization(orgB.getAlias());
+            response = assertSuccessfulCodeGrant(oauth);
+            assertThat(response.getScope(), containsString("organization"));
+            String tab2AccessToken = response.getAccessToken();
+
+            IntrospectionResponse userInfoResponse = oauth.introspectionRequest(tab1AccessToken).send();
+            TokenMetadataRepresentation metadata = userInfoResponse.asTokenMetadata();
+            List<String> organizations = (List<String>) metadata.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgA.getAlias()), is(true));
+
+            userInfoResponse = oauth.introspectionRequest(tab2AccessToken).send();
+            metadata = userInfoResponse.asTokenMetadata();
+            organizations = (List<String>) metadata.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+            assertThat(organizations.size(), is(1));
+            assertThat(organizations.contains(orgB.getAlias()), is(true));
+        }
+    }
+
+    @Test
     public void testRefreshTokenWithAllOrganizationsAskingForSpecificOrganization() {
         OrganizationRepresentation orgA = createOrganization("orga", true);
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
@@ -617,6 +706,18 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         oauth.scope("organization:orgb");
         response = oauth.doRefreshTokenRequest(response.getRefreshToken());
         assertThat(response.getScope(), not(containsString("organization")));
+
+        //previous:(ANY -> ALL) -> return the selected org
+        oauth.scope("organization:*");
+        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertThat(response.getScope(), containsString("organization"));
+        accessToken = oauth.verifyToken(response.getAccessToken());
+        assertThat(accessToken.getScope(), containsString("organization"));
+        assertThat(accessToken.getOtherClaims().keySet(), hasItem(OAuth2Constants.ORGANIZATION));
+        organizations = (List<String>) accessToken.getOtherClaims().get(OAuth2Constants.ORGANIZATION);
+        assertEquals( 1, organizations.toArray().length);
+        assertThat(organizations.contains(orgB.getAlias()), is(true));
+        assertThat(organizations.contains(orgA.getAlias()), is(false));
     }
 
     @Test


### PR DESCRIPTION
Resolves #42836
Resolves #42839

- OrganizationAuthenticator.java -> ANY scope organization selection will be transformed to SINGLE
- OrganizationMembershipMapper.java -> resolve organization from the scope instead of client session note
- OrganizationScopes.java -> update name resolves to account for all possible token refresh scenarios

SINGLE Scope Tests (Previous: organization:foo)
- SINGLE → ANY: organization:foo + request organization → Result: organization:foo
- SINGLE → ALL: organization:foo + request organization:* → Result: organization:foo
- SINGLE → Different SINGLE: organization:foo + request organization:bar → Result: null
- SINGLE → Same SINGLE: Not explicitly shown, but would work via equality check

ALL Scope Tests (Previous: organization:*)
- ALL → SINGLE: organization:* + request organization:foo → Result: organization:foo
- ALL → Different SINGLE: organization:* + request organization:bar → Result: organization:bar
- ALL → ANY: organization:* + request organization → Result: null

Additional SINGLE Tests (Previous: organization:bar)
- SINGLE → ANY: organization:bar + request organization → Result: organization:bar
- SINGLE → ALL: organization:bar + request organization:* → Result: organization:bar
- SINGLE → Different SINGLE: organization:bar + request organization:foo → Result: null

ANY Scope tests
- N/A - the browser flow transforms the scope to SINGLE (see single cases above)