### PR TITLE
Mark the reading of admin and user events read-only

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaAdminEventQuery.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaAdminEventQuery.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.events.jpa;
 
+import org.hibernate.jpa.AvailableHints;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.OperationType;
@@ -181,6 +182,7 @@ public class JpaAdminEventQuery implements AdminEventQuery {
         }
 
         TypedQuery<AdminEventEntity> query = em.createQuery(cq);
+        query.setHint(AvailableHints.HINT_READ_ONLY, true);
 
         return closing(paginateQuery(query, firstResult, maxResults).getResultStream().map(JpaEventStoreProvider::convertAdminEvent));
     }

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventQuery.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventQuery.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.events.jpa;
 
+import org.hibernate.jpa.AvailableHints;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventQuery;
 import org.keycloak.events.EventType;
@@ -161,6 +162,7 @@ public class JpaEventQuery implements EventQuery {
         }
 
         TypedQuery<EventEntity> query = em.createQuery(cq);
+        query.setHint(AvailableHints.HINT_READ_ONLY, true);
 
         return closing(paginateQuery(query, firstResult, maxResults).getResultStream().map(JpaEventStoreProvider::convertEvent));
     }


### PR DESCRIPTION
This should decrease the memory usage and improve response times

Closes #43365

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
