### PR TITLE
Client Resource must return a single item (#39851)

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
@@ -18,10 +18,12 @@
 package org.keycloak.admin.client.resource;
 
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -60,9 +62,24 @@ public interface ClientsResource {
                                                  @QueryParam("first") Integer firstResult,
                                                  @QueryParam("max") Integer maxResults);
 
+    /** @deprecated use {@link #findClientByClientId(String)} */
+    @Deprecated
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<ClientRepresentation> findByClientId(@QueryParam("clientId") String clientId);
+
+    default Optional<ClientRepresentation> findClientByClientId(String clientId) {
+        List<ClientRepresentation> list = findByClientId(clientId);
+        if (list.isEmpty()) {
+            return Optional.<ClientRepresentation>empty();
+        }
+        return Optional.of(list.get(0));
+    }
+
+    default ClientResource getByClientId(String id) {
+        return get(findClientByClientId(id).map(ClientRepresentation::getId)
+                .orElseThrow(() -> new NotFoundException("client not found " + id)));
+    }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/ClientSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/ClientSupplier.java
@@ -1,7 +1,5 @@
 package org.keycloak.testframework.realm;
 
-import java.util.List;
-
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
@@ -40,11 +38,7 @@ public class ClientSupplier implements Supplier<ManagedClient, InjectClient> {
             }
             clientRepresentation.setId(ApiUtil.getCreatedId(response));
         } else {
-            List<ClientRepresentation> clients = realm.admin().clients().findByClientId(attachTo);
-            if (clients.isEmpty()) {
-                throw new IllegalStateException("No client found with client id: " + attachTo);
-            }
-            clientRepresentation = clients.get(0);
+            clientRepresentation = realm.admin().clients().findClientByClientId(attachTo).orElseThrow();
         }
 
         instanceContext.addNote("managed", managed);

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/ManagedResources2Test.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/ManagedResources2Test.java
@@ -1,7 +1,5 @@
 package org.keycloak.test.examples;
 
-import java.util.List;
-
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -33,8 +31,8 @@ public class ManagedResources2Test {
     public void testCreatedClient() {
         Assertions.assertEquals("default", client.getClientId());
 
-        List<ClientRepresentation> clients = realm.admin().clients().findByClientId("default");
-        Assertions.assertEquals(1, clients.size());
+        ClientRepresentation client = realm.admin().clients().findClientByClientId("default").orElse(null);
+        Assertions.assertNotNull(client);
     }
 
 }

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/RealmSpecificAdminClientTest.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/RealmSpecificAdminClientTest.java
@@ -47,10 +47,7 @@ public class RealmSpecificAdminClientTest {
     public void testRealmWithClientAndUser() {
         RealmResource realmResource = realmAdminClient.realms().realm(realm.getName());
 
-        List<ClientRepresentation> clients = realmResource.clients().findByClientId("myclient");
-        Assertions.assertEquals(1, clients.size());
-
-        ClientRepresentation client = clients.get(0);
+        ClientRepresentation client = realmResource.clients().findClientByClientId("myclient").orElseThrow();
         Assertions.assertTrue(client.isEnabled());
         Assertions.assertTrue(client.isDirectAccessGrantsEnabled());
         Assertions.assertEquals("mysecret", client.getSecret());

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/TestAppTest.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/TestAppTest.java
@@ -26,8 +26,7 @@ public class TestAppTest {
 
     @Test
     public void testPushNotBefore() throws InterruptedException {
-        String clientUuid = managedRealm.admin().clients().findByClientId("test-app").stream().findFirst().get().getId();
-        managedRealm.admin().clients().get(clientUuid).pushRevocation();
+        managedRealm.admin().clients().getByClientId("test-app").pushRevocation();
 
         PushNotBeforeAction adminPushNotBefore = testApp.kcAdmin().getAdminPushNotBefore();
         Assertions.assertNotNull(adminPushNotBefore);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AbstractPermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AbstractPermissionsTest.java
@@ -68,7 +68,7 @@ public class AbstractPermissionsTest {
             String roleUserUuid = ApiUtil.getCreatedId(response);
             managedMasterRealm.cleanup().add(r -> r.users().delete(roleUserUuid));
 
-            String clientUuid = managedMasterRealm.admin().clients().findByClientId(REALM_NAME + "-realm").get(0).getId();
+            String clientUuid = managedMasterRealm.admin().clients().findClientByClientId(REALM_NAME + "-realm").orElseThrow().getId();
             RoleRepresentation roleRep = managedMasterRealm.admin().clients().get(clientUuid).roles().get(role).toRepresentation();
             managedMasterRealm.admin().users().get(roleUserUuid).roles().clientLevel(clientUuid).add(Collections.singletonList(roleRep));
         }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AuthzCleanupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AuthzCleanupTest.java
@@ -62,7 +62,7 @@ public class AuthzCleanupTest {
     @Test
     public void testCreate() throws Exception {
         ClientsResource clients = managedRealm.admin().clients();
-        ClientRepresentation client = clients.findByClientId(clientId).get(0);
+        ClientRepresentation client = clients.findClientByClientId(clientId).orElseThrow();
         ResourceServerRepresentation settings = JsonSerialization.readValue(AuthzCleanupTest.class.getResourceAsStream("authz/acme-resource-server-cleanup-test.json"), ResourceServerRepresentation.class);
 
         clients.get(client.getId()).authorization().importSettings(settings);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -730,7 +730,7 @@ public class ClientTest {
 
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.roleResourceCompositesPath("realm-composite"), List.of(roleRep2), ResourceType.REALM_ROLE);
 
-        String accountMgmtId = managedRealm.admin().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).getId();
+        String accountMgmtId = managedRealm.admin().clients().findClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).orElseThrow().getId();
         RoleRepresentation viewAccountRoleRep = managedRealm.admin().clients().get(accountMgmtId).roles().get(AccountRoles.VIEW_PROFILE).toRepresentation();
 
         scopesResource.realmLevel().add(List.of(roleRep1));
@@ -969,6 +969,12 @@ public class ClientTest {
 
         ClientRepresentation storedClient = managedRealm.admin().clients().get(client.getId()).toRepresentation();
         assertClient(client, storedClient);
+    }
+    @Test
+    @SuppressWarnings("deprecation")
+    void findByClientListResult() {
+        assertTrue( managedRealm.admin().clients().findByClientId("client-0").isEmpty());
+        assertEquals(1,  managedRealm.admin().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).size());
     }
 
     public static void assertClient(ClientRepresentation client, ClientRepresentation storedClient) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ConsentsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ConsentsTest.java
@@ -214,7 +214,7 @@ public class ConsentsTest {
         providerRealm.admin().update(providerRealmRep);
         providerRealm.admin().clients().create(ClientConfigBuilder.create().clientId("test-app").redirectUris("*").publicClient(true).webOrigins("*").build());
 
-        ClientRepresentation providerAccountRep = providerRealm.admin().clients().findByClientId("test-app").get(0);
+        ClientRepresentation providerAccountRep = providerRealm.admin().clients().findClientByClientId("test-app").orElseThrow();
 
         // add offline_scope to default account-console client scope
         ClientScopeRepresentation offlineAccessScope = providerRealm.admin().getDefaultOptionalClientScopes().stream()
@@ -314,7 +314,7 @@ public class ConsentsTest {
         userRealm.updateWithCleanup(r -> r.enabledEventTypes("REFRESH_TOKEN_ERROR"));
         String sessionId = loginEvent.getSessionId();
 
-        ClientRepresentation clientRepresentation = userRealm.admin().clients().findByClientId("test-app").get(0);
+        ClientRepresentation clientRepresentation = userRealm.admin().clients().findClientByClientId("test-app").orElseThrow();
         try {
             clientRepresentation.setConsentRequired(true);
             userRealm.admin().clients().get(clientRepresentation.getId()).update(clientRepresentation);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/IllegalAdminUpgradeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/IllegalAdminUpgradeTest.java
@@ -23,6 +23,7 @@ import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.RolesResource;
 import org.keycloak.common.Profile;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
@@ -132,42 +133,44 @@ public class IllegalAdminUpgradeTest {
         UserRepresentation realmUser = managedRealm.admin().users().search("user").get(0);
         UserRepresentation masterUser = masterRealm.admin().users().search("user").get(0);
 
-        ClientRepresentation realmAdminClient = managedRealm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
-        RoleRepresentation realmManageAuthorization = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.MANAGE_AUTHORIZATION).toRepresentation();
-        RoleRepresentation realmViewAuthorization = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.VIEW_AUTHORIZATION).toRepresentation();
-        RoleRepresentation realmManageClients = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.MANAGE_CLIENTS).toRepresentation();
-        RoleRepresentation realmViewClients = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.VIEW_CLIENTS).toRepresentation();
-        RoleRepresentation realmManageEvents = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.MANAGE_EVENTS).toRepresentation();
-        RoleRepresentation realmViewEvents = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.VIEW_EVENTS).toRepresentation();
-        RoleRepresentation realmManageIdentityProviders = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.MANAGE_IDENTITY_PROVIDERS).toRepresentation();
-        RoleRepresentation realmViewIdentityProviders = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.VIEW_IDENTITY_PROVIDERS).toRepresentation();
-        RoleRepresentation realmManageRealm = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.MANAGE_REALM).toRepresentation();
-        RoleRepresentation realmViewRealm = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.VIEW_REALM).toRepresentation();
-        RoleRepresentation realmImpersonate = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        RoleRepresentation realmManageUsers = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.MANAGE_USERS).toRepresentation();
-        RoleRepresentation realmViewUsers = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.VIEW_USERS).toRepresentation();
-        RoleRepresentation realmQueryUsers = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.QUERY_USERS).toRepresentation();
-        RoleRepresentation realmQueryClients = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.QUERY_CLIENTS).toRepresentation();
-        RoleRepresentation realmQueryGroups = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.QUERY_GROUPS).toRepresentation();
-        RoleRepresentation realmAdmin = managedRealm.admin().clients().get(realmAdminClient.getId()).roles().get(AdminRoles.REALM_ADMIN).toRepresentation();
+        ClientRepresentation realmAdminClient = managedRealm.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
+        RolesResource realmManagementRoles = managedRealm.admin().clients().get(realmAdminClient.getId()).roles();
+        RoleRepresentation realmManageAuthorization = realmManagementRoles.get(AdminRoles.MANAGE_AUTHORIZATION).toRepresentation();
+        RoleRepresentation realmViewAuthorization = realmManagementRoles.get(AdminRoles.VIEW_AUTHORIZATION).toRepresentation();
+        RoleRepresentation realmManageClients = realmManagementRoles.get(AdminRoles.MANAGE_CLIENTS).toRepresentation();
+        RoleRepresentation realmViewClients = realmManagementRoles.get(AdminRoles.VIEW_CLIENTS).toRepresentation();
+        RoleRepresentation realmManageEvents = realmManagementRoles.get(AdminRoles.MANAGE_EVENTS).toRepresentation();
+        RoleRepresentation realmViewEvents = realmManagementRoles.get(AdminRoles.VIEW_EVENTS).toRepresentation();
+        RoleRepresentation realmManageIdentityProviders = realmManagementRoles.get(AdminRoles.MANAGE_IDENTITY_PROVIDERS).toRepresentation();
+        RoleRepresentation realmViewIdentityProviders = realmManagementRoles.get(AdminRoles.VIEW_IDENTITY_PROVIDERS).toRepresentation();
+        RoleRepresentation realmManageRealm = realmManagementRoles.get(AdminRoles.MANAGE_REALM).toRepresentation();
+        RoleRepresentation realmViewRealm = realmManagementRoles.get(AdminRoles.VIEW_REALM).toRepresentation();
+        RoleRepresentation realmImpersonate = realmManagementRoles.get(AdminRoles.IMPERSONATION).toRepresentation();
+        RoleRepresentation realmManageUsers = realmManagementRoles.get(AdminRoles.MANAGE_USERS).toRepresentation();
+        RoleRepresentation realmViewUsers = realmManagementRoles.get(AdminRoles.VIEW_USERS).toRepresentation();
+        RoleRepresentation realmQueryUsers = realmManagementRoles.get(AdminRoles.QUERY_USERS).toRepresentation();
+        RoleRepresentation realmQueryClients = realmManagementRoles.get(AdminRoles.QUERY_CLIENTS).toRepresentation();
+        RoleRepresentation realmQueryGroups = realmManagementRoles.get(AdminRoles.QUERY_GROUPS).toRepresentation();
+        RoleRepresentation realmAdmin = realmManagementRoles.get(AdminRoles.REALM_ADMIN).toRepresentation();
 
-        ClientRepresentation masterClient = masterRealm.admin().clients().findByClientId(REALM_NAME + "-realm").get(0);
-        RoleRepresentation masterManageAuthorization = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.MANAGE_AUTHORIZATION).toRepresentation();
-        RoleRepresentation masterViewAuthorization = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.VIEW_AUTHORIZATION).toRepresentation();
-        RoleRepresentation masterManageClients = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.MANAGE_CLIENTS).toRepresentation();
-        RoleRepresentation masterViewClients = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.VIEW_CLIENTS).toRepresentation();
-        RoleRepresentation masterManageEvents = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.MANAGE_EVENTS).toRepresentation();
-        RoleRepresentation masterViewEvents = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.VIEW_EVENTS).toRepresentation();
-        RoleRepresentation masterManageIdentityProviders = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.MANAGE_IDENTITY_PROVIDERS).toRepresentation();
-        RoleRepresentation masterViewIdentityProviders = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.VIEW_IDENTITY_PROVIDERS).toRepresentation();
-        RoleRepresentation masterManageRealm = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.MANAGE_REALM).toRepresentation();
-        RoleRepresentation masterViewRealm = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.VIEW_REALM).toRepresentation();
-        RoleRepresentation masterImpersonate = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.IMPERSONATION).toRepresentation();
-        RoleRepresentation masterManageUsers = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.MANAGE_USERS).toRepresentation();
-        RoleRepresentation masterViewUsers = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.VIEW_USERS).toRepresentation();
-        RoleRepresentation masterQueryUsers = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.QUERY_USERS).toRepresentation();
-        RoleRepresentation masterQueryClients = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.QUERY_CLIENTS).toRepresentation();
-        RoleRepresentation masterQueryGroups = masterRealm.admin().clients().get(masterClient.getId()).roles().get(AdminRoles.QUERY_GROUPS).toRepresentation();
+        ClientRepresentation masterClient = masterRealm.admin().clients().findClientByClientId(REALM_NAME + "-realm").orElseThrow();
+        RolesResource masterClientRoles = masterRealm.admin().clients().get(masterClient.getId()).roles();
+        RoleRepresentation masterManageAuthorization = masterClientRoles.get(AdminRoles.MANAGE_AUTHORIZATION).toRepresentation();
+        RoleRepresentation masterViewAuthorization = masterClientRoles.get(AdminRoles.VIEW_AUTHORIZATION).toRepresentation();
+        RoleRepresentation masterManageClients = masterClientRoles.get(AdminRoles.MANAGE_CLIENTS).toRepresentation();
+        RoleRepresentation masterViewClients = masterClientRoles.get(AdminRoles.VIEW_CLIENTS).toRepresentation();
+        RoleRepresentation masterManageEvents = masterClientRoles.get(AdminRoles.MANAGE_EVENTS).toRepresentation();
+        RoleRepresentation masterViewEvents = masterClientRoles.get(AdminRoles.VIEW_EVENTS).toRepresentation();
+        RoleRepresentation masterManageIdentityProviders = masterClientRoles.get(AdminRoles.MANAGE_IDENTITY_PROVIDERS).toRepresentation();
+        RoleRepresentation masterViewIdentityProviders = masterClientRoles.get(AdminRoles.VIEW_IDENTITY_PROVIDERS).toRepresentation();
+        RoleRepresentation masterManageRealm = masterClientRoles.get(AdminRoles.MANAGE_REALM).toRepresentation();
+        RoleRepresentation masterViewRealm = masterClientRoles.get(AdminRoles.VIEW_REALM).toRepresentation();
+        RoleRepresentation masterImpersonate = masterClientRoles.get(AdminRoles.IMPERSONATION).toRepresentation();
+        RoleRepresentation masterManageUsers = masterClientRoles.get(AdminRoles.MANAGE_USERS).toRepresentation();
+        RoleRepresentation masterViewUsers = masterClientRoles.get(AdminRoles.VIEW_USERS).toRepresentation();
+        RoleRepresentation masterQueryUsers = masterClientRoles.get(AdminRoles.QUERY_USERS).toRepresentation();
+        RoleRepresentation masterQueryClients = masterClientRoles.get(AdminRoles.QUERY_CLIENTS).toRepresentation();
+        RoleRepresentation masterQueryGroups = masterClientRoles.get(AdminRoles.QUERY_GROUPS).toRepresentation();
 
         List<RoleRepresentation> roles = new LinkedList<>();
 
@@ -184,7 +187,7 @@ public class IllegalAdminUpgradeTest {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
                             is(equalTo(Response.Status.FORBIDDEN)));
                 }
-            
+
                 roles.clear();
                 roles.add(realmViewAuthorization);
                 try {
@@ -484,7 +487,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterViewAuthorization);
@@ -493,7 +496,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterManageClients);
@@ -502,7 +505,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterViewClients);
@@ -511,7 +514,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterManageEvents);
@@ -520,7 +523,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterViewEvents);
@@ -529,7 +532,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterManageIdentityProviders);
@@ -538,7 +541,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterViewIdentityProviders);
@@ -547,7 +550,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterManageRealm);
@@ -556,7 +559,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterViewRealm);
@@ -565,7 +568,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterImpersonate);
@@ -574,7 +577,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterManageUsers);
@@ -583,7 +586,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterViewUsers);
@@ -592,7 +595,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterQueryUsers);
@@ -601,7 +604,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterQueryGroups);
@@ -610,7 +613,7 @@ public class IllegalAdminUpgradeTest {
                     Assertions.fail("should fail with forbidden exception");
                 } catch (ClientErrorException e) {
                     assertThat(Response.Status.fromStatusCode(e.getResponse().getStatus()),
-                            is(equalTo(Response.Status.FORBIDDEN)));                    
+                            is(equalTo(Response.Status.FORBIDDEN)));
                 }
                 roles.clear();
                 roles.add(masterQueryClients);
@@ -632,80 +635,80 @@ public class IllegalAdminUpgradeTest {
                 roles.add(realmManageAuthorization);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmViewAuthorization);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmManageClients);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmViewClients);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmManageEvents);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmViewEvents);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmManageIdentityProviders);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmViewIdentityProviders);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmManageRealm);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmViewRealm);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmImpersonate);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmManageUsers);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
-                
+
+
                 roles.clear();
                 roles.add(realmViewUsers);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
-                
+
+
                 roles.clear();
                 roles.add(realmQueryUsers);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
-                
+
+
                 roles.clear();
                 roles.add(realmQueryGroups);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(realmQueryClients);
                 realmClient.realm(REALM_NAME).users().get(realmUser.getId()).roles().clientLevel(client.getId()).add(roles);
@@ -721,80 +724,80 @@ public class IllegalAdminUpgradeTest {
                 roles.add(masterManageAuthorization);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterViewAuthorization);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterManageClients);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterViewClients);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterManageEvents);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterViewEvents);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterManageIdentityProviders);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterViewIdentityProviders);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterManageRealm);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterViewRealm);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterImpersonate);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterManageUsers);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
-                
+
+
                 roles.clear();
                 roles.add(masterViewUsers);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
-                
+
+
                 roles.clear();
                 roles.add(masterQueryUsers);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
-                
+
+
                 roles.clear();
                 roles.add(masterQueryGroups);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).remove(roles);
-                
+
                 roles.clear();
                 roles.add(masterQueryClients);
                 realmClient.realm(MASTER_REALM_NAME).users().get(masterUser.getId()).roles().clientLevel(client.getId()).add(roles);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
@@ -147,7 +147,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
                         response.set(realm.clients().create(ClientConfigBuilder.create().clientId("foo").build())),
                 Resource.CLIENT, true);
 
-        ClientRepresentation foo = managedRealm1.admin().clients().findByClientId("foo").get(0);
+        ClientRepresentation foo = managedRealm1.admin().clients().findClientByClientId("foo").orElseThrow();
 
         invoke(realm -> realm.clients().get(foo.getId()).toRepresentation(), Resource.CLIENT, false);
         invoke(realm -> realm.clients().get(foo.getId()).getInstallationProvider("nosuch"), Resource.CLIENT, false);
@@ -155,7 +155,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
         invoke(realm -> {
             realm.clients().get(foo.getId()).remove();
             realm.clients().create(foo);
-            ClientRepresentation temp = realm.clients().findByClientId("foo").get(0);
+            ClientRepresentation temp = realm.clients().findClientByClientId("foo").orElseThrow();
             foo.setId(temp.getId());
         }, Resource.CLIENT, true);
         invoke(realm -> realm.clients().get(foo.getId()).generateNewSecret(), Resource.CLIENT, true);
@@ -269,7 +269,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
                 Resource.CLIENT, true);
         invoke((RealmResource realm) -> realm.clientScopes().get(scope.getId()).getScopeMappings().realmLevel().remove(List.of()),
                 Resource.CLIENT, true);
-        ClientRepresentation realmAccessClient = adminClient.realms().realm(REALM_NAME) .clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation realmAccessClient = adminClient.realms().realm(REALM_NAME) .clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
         invoke((RealmResource realm) -> realm.clientScopes().get(scope.getId()).getScopeMappings().clientLevel(realmAccessClient.getId()).listAll(),
                 Resource.CLIENT, false);
         invoke((RealmResource realm) ->
@@ -362,7 +362,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
         }, Resource.USER, true);
 
         GroupRepresentation group = managedRealm1.admin().getGroupByPath("mygroup");
-        ClientRepresentation realmAccessClient = managedRealm1.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation realmAccessClient = managedRealm1.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
 
         // this should throw forbidden as "create-client" role isn't enough
         invoke(realm -> clients.get(AdminRoles.CREATE_CLIENT).realm(REALM_NAME).groups().groups(),
@@ -451,7 +451,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
         invoke(realm -> realm.users().get(user.getId()).roles().realmLevel().add(List.of()), Resource.USER, true);
         invoke(realm -> realm.users().get(user.getId()).roles().realmLevel().remove(List.of()), Resource.USER, true);
 
-        ClientRepresentation realmAccessClient = managedRealm1.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation realmAccessClient = managedRealm1.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
         invoke(realm -> realm.users().get(user.getId()).roles().clientLevel(realmAccessClient.getId()).listAll(),
                 Resource.USER, false);
         invoke(realm -> realm.users().get(user.getId()).roles().clientLevel(realmAccessClient.getId()).listAvailable(),
@@ -579,7 +579,7 @@ public class PermissionsTest extends AbstractPermissionsTest {
         Assert.assertNull(serverInfo.getMemoryInfo());
 
         // assign the view-system permission to a test realm user and check the fallback works
-        ClientRepresentation realmMgtRep = adminClient.realm(REALM_NAME).clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation realmMgtRep = adminClient.realm(REALM_NAME).clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
         ClientResource realmMgtRes = adminClient.realm(REALM_NAME).clients().get(realmMgtRep.getId());
         RoleRepresentation viewSystem = new RoleRepresentation();
         viewSystem.setName(AdminRoles.VIEW_SYSTEM);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/FlowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/FlowTest.java
@@ -326,7 +326,7 @@ public class FlowTest extends AbstractAuthenticationTest {
 
         {
             // used by client override
-            ClientRepresentation client = realmResource.clients().findByClientId("account").get(0);
+            ClientRepresentation client = realmResource.clients().findClientByClientId("account").orElseThrow();
             ClientResource clientResource = realmResource.clients().get(client.getId());
 
             try {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeEvaluationTest.java
@@ -125,7 +125,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
 
     @Test
     public void testManageOnlyOneClient() {
-        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        ClientRepresentation myclient = realm.admin().clients().findClientByClientId("myclient").orElseThrow();
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
 
         ClientResource clientResource = realmAdminClient.realm(realm.getName()).clients().get(myclient.getId());
@@ -224,7 +224,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
 
     @Test
     public void testViewAllClients() {
-        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        ClientRepresentation myclient = realm.admin().clients().findClientByClientId("myclient").orElseThrow();
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
 
         // the following operations should fail as the permission wasn't granted yet
@@ -306,7 +306,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
     @Test
     public void testMapRolesOnlyOneClient() {
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
-        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        ClientRepresentation myclient = realm.admin().clients().findClientByClientId("myclient").orElseThrow();
 
         // create a role
         RoleRepresentation role = new RoleRepresentation();
@@ -336,7 +336,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
         // to add a client role ('myclient') 'roleA' as a composite role of 'roleB' (client role of 'realmClient' client)
         // it is required to have permission to manage the `realmClient` and to map-roles-composite of the `myclient`
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
-        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        ClientRepresentation myclient = realm.admin().clients().findClientByClientId("myclient").orElseThrow();
 
         // create two roles, each for seprate client
         RoleRepresentation roleA = new RoleRepresentation();
@@ -378,7 +378,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
 
     @Test
     public void testEvaluateAllResourcePermissionsForSpecificResourcePermission() {
-        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        ClientRepresentation myclient = realm.admin().clients().findClientByClientId("myclient").orElseThrow();
         UserRepresentation adminUser = realm.admin().users().search("myadmin").get(0);
         UserPolicyRepresentation allowPolicy = createUserPolicy(realm, client, "Only My Admin", adminUser.getId());
         ScopePermissionRepresentation allResourcesPermission = createAllPermission(client, clientsType, allowPolicy, Set.of(MANAGE, MAP_ROLES));
@@ -431,7 +431,7 @@ public class ClientResourceTypeEvaluationTest extends AbstractPermissionTest {
 
     @Test
     public void testManageClientWithAuthorizationSettings() {
-        ClientRepresentation myResourceServer = realm.admin().clients().findByClientId("myresourceserver").get(0);
+        ClientRepresentation myResourceServer = realm.admin().clients().findClientByClientId("myresourceserver").orElseThrow();
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
         ClientResource clientResource = realmAdminClient.realm(realm.getName()).clients().get(myResourceServer.getId());
         UserPolicyRepresentation onlyMyAdminUserPolicy = createUserPolicy(realm, client, "Only My Admin User Policy", myadmin.getId());

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/ClientResourceTypeFilteringTest.java
@@ -38,6 +38,7 @@ import static org.keycloak.authorization.fgap.AdminPermissionsSchema.VIEW;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest
@@ -126,14 +127,12 @@ public class ClientResourceTypeFilteringTest extends AbstractPermissionTest {
     @Test
     public void testSearchByClientId() {
         String expectedClientId = "client-0";
-        List<ClientRepresentation> search = realmAdminClient.realm(realm.getName()).clients().findByClientId(expectedClientId);
-        assertTrue(search.isEmpty());
+        ClientRepresentation search = realmAdminClient.realm(realm.getName()).clients().findClientByClientId(expectedClientId).orElse(null);
+        assertNull(search);
 
         UserPolicyRepresentation allowPolicy = createUserPolicy(realm, client,"Only My Admin User Policy", realm.admin().users().search("myadmin").get(0).getId());
         createPermission(client, expectedClientId, CLIENTS_RESOURCE_TYPE, Set.of(VIEW), allowPolicy);
-        search = realmAdminClient.realm(realm.getName()).clients().findByClientId(expectedClientId);
-        assertFalse(search.isEmpty());
-        assertEquals(1, search.size());
-        assertEquals(search.get(0).getClientId(), expectedClientId);
+        search = realmAdminClient.realm(realm.getName()).clients().findClientByClientId(expectedClientId).orElseThrow();
+        assertEquals(search.getClientId(), expectedClientId);
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/FeatureV2EnabledTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/FeatureV2EnabledTest.java
@@ -16,8 +16,6 @@
  */
 package org.keycloak.tests.admin.authz.fgap;
 
-import java.util.List;
-
 import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -31,9 +29,6 @@ import org.keycloak.testframework.realm.ManagedRealm;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -56,16 +51,15 @@ public class FeatureV2EnabledTest {
     @Test
     public void schemaAvailableAfterFGAPEnabledForRealm() {
         // admin permissions client should not exist when the switch in not enabled for the realm
-        assertThat(realm.admin().clients().findByClientId(Constants.ADMIN_PERMISSIONS_CLIENT_ID), is(empty()));
+        assertThat(realm.admin().clients().findClientByClientId(Constants.ADMIN_PERMISSIONS_CLIENT_ID).orElse(null), nullValue());
 
         // enable admin permissions for the realm
         RealmRepresentation realmRep = realm.admin().toRepresentation();
         realmRep.setAdminPermissionsEnabled(Boolean.TRUE);
         realm.admin().update(realmRep);
 
-        List<ClientRepresentation> clients = realm.admin().clients().findByClientId(Constants.ADMIN_PERMISSIONS_CLIENT_ID);
-        assertThat(clients, hasSize(1));
-        ResourceServerRepresentation authorizationSettings = realm.admin().clients().get(clients.get(0).getId()).authorization().getSettings();
+        ClientRepresentation clients = realm.admin().clients().findClientByClientId(Constants.ADMIN_PERMISSIONS_CLIENT_ID).orElseThrow();
+        ResourceServerRepresentation authorizationSettings = realm.admin().clients().get(clients.getId()).authorization().getSettings();
         assertThat(authorizationSettings, notNullValue());
         assertThat(authorizationSettings.getAuthorizationSchema(), notNullValue());
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/FineGrainedPermissionsUsersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/FineGrainedPermissionsUsersTest.java
@@ -178,7 +178,7 @@ public class FineGrainedPermissionsUsersTest extends AbstractPermissionTest {
                 .build();
         String testUserId = ApiUtil.getCreatedId(realm.admin().users().create(user));
         //assign 'query-users' role to test user
-        ClientRepresentation clientRepresentation = realm.admin().clients().findByClientId("realm-management").get(0);
+        ClientRepresentation clientRepresentation = realm.admin().clients().findClientByClientId("realm-management").orElseThrow();
         String realmManagementId = clientRepresentation.getId();
         RoleRepresentation roleRepresentation = realm.admin().clients().get(realmManagementId).roles().get("query-users").toRepresentation();
         realm.admin().users().get(testUserId).roles().clientLevel(realmManagementId).add(Collections.singletonList(roleRepresentation));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/RoleResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/RoleResourceTypeEvaluationTest.java
@@ -112,7 +112,7 @@ public class RoleResourceTypeEvaluationTest extends AbstractPermissionTest {
             assertThat(ex, instanceOf(ForbiddenException.class));
         }
 
-        String clientId = realm.admin().clients().findByClientId("realm-management").get(0).getId();
+        String clientId = realm.admin().clients().findClientByClientId("realm-management").orElseThrow().getId();
         RoleRepresentation manageRealmRole = realm.admin().clients().get(clientId).roles().get("manage-realm").toRepresentation();
         realm.admin().users().get(myadmin.getId()).roles().clientLevel(clientId).add(List.of(manageRealmRole));
         realmAdminClient.tokenManager().grantToken();
@@ -168,7 +168,7 @@ public class RoleResourceTypeEvaluationTest extends AbstractPermissionTest {
     @Test
     public void testMappingAdminRoles() {
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
-        ClientRepresentation realmManagement = realm.admin().clients().findByClientId("realm-management").get(0);
+        ClientRepresentation realmManagement = realm.admin().clients().findClientByClientId("realm-management").orElseThrow();
         RoleRepresentation createClientRole = realm.admin().clients().get(realmManagement.getId()).roles().get(AdminRoles.CREATE_CLIENT).toRepresentation();
 
         // create permission to map roles from all clients and to all users
@@ -179,7 +179,7 @@ public class RoleResourceTypeEvaluationTest extends AbstractPermissionTest {
         // create a role
         RoleRepresentation role = new RoleRepresentation();
         role.setName("myRole");
-        ClientRepresentation myclient = realm.admin().clients().findByClientId("myclient").get(0);
+        ClientRepresentation myclient = realm.admin().clients().findClientByClientId("myclient").orElseThrow();
         realm.admin().clients().get(myclient.getId()).roles().create(role);
         role = realm.admin().clients().get(myclient.getId()).roles().get("myRole").toRepresentation();
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeEvaluationTest.java
@@ -525,7 +525,7 @@ public class UserResourceTypeEvaluationTest extends AbstractPermissionTest {
         realm.admin().update(realmRep);
 
         //assign view-users role to myadmin
-        String realmManagementClientId = realm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+        String realmManagementClientId = realm.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow().getId();
         RoleRepresentation viewUsersRole = realm.admin().clients().get(realmManagementClientId).roles().get(AdminRoles.VIEW_USERS).toRepresentation();
         realm.admin().users().get(myadmin.getId()).roles().clientLevel(realmManagementClientId).add(List.of(viewUsersRole));
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeFilteringTest.java
@@ -343,7 +343,7 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
         assertThat(search, Matchers.hasSize(1));
 
         String userId = search.get(0).getId();
-        String clientUuid = realm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+        String clientUuid = realm.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow().getId();
         RoleRepresentation viewUsers = realm.admin().clients().get(clientUuid).roles().get(AdminRoles.VIEW_USERS).toRepresentation();
         realm.admin().users().get(userId).roles().clientLevel(clientUuid).add(List.of(viewUsers));
         realm.cleanup().add(r -> r.users().get(userId).roles().clientLevel(clientUuid).remove(List.of(viewUsers)));
@@ -429,7 +429,7 @@ public class UserResourceTypeFilteringTest extends AbstractPermissionTest {
     @Test
     public void testSessionEndpointRespectsUserViewPermission() {
         UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
-        String clientUuid = realm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+        String clientUuid = realm.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow().getId();
         RoleRepresentation viewRealmRole = realm.admin().clients().get(clientUuid).roles().get(AdminRoles.VIEW_REALM).toRepresentation();
 
         // create users

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTest.java
@@ -267,7 +267,7 @@ public class ClientScopeTest extends AbstractClientScopeTest {
 
         // update with some scopes
         String accountMgmtId =
-                managedRealm.admin().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).getId();
+                managedRealm.admin().clients().findClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).orElseThrow().getId();
         RoleRepresentation viewAccountRoleRep = managedRealm.admin().clients().get(accountMgmtId).roles()
                 .get(AccountRoles.VIEW_PROFILE).toRepresentation();
         RoleMappingResource scopesResource = clientScopes().get(scopeId).getScopeMappings();
@@ -346,7 +346,7 @@ public class ClientScopeTest extends AbstractClientScopeTest {
         ClientRepresentation clientRep = new ClientRepresentation();
         clientRep.setClientId("role-container-client");
         createClientWithCleanup(clientRep);
-        String roleContainerClientUuid = realm.clients().findByClientId("role-container-client").stream().findFirst().orElseThrow().getId();
+        String roleContainerClientUuid = realm.clients().findClientByClientId("role-container-client").orElseThrow().getId();
         ClientResource roleContainerClient = realm.clients().get(roleContainerClientUuid);
 
         RoleRepresentation clientCompositeRole = RoleConfigBuilder.create().name("client-composite").build();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/event/AdminEventAuthDetailsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/event/AdminEventAuthDetailsTest.java
@@ -42,7 +42,7 @@ import org.opentest4j.AssertionFailedError;
 
 /**
  * Test authDetails in admin events
- * 
+ *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  */
 @KeycloakIntegrationTest
@@ -64,7 +64,7 @@ public class AdminEventAuthDetailsTest {
 
     @BeforeEach
     public void initConfig() {
-        clientUuid = adminClient.realm(managedRealm.getName()).clients().findByClientId("client").get(0).getId();
+        clientUuid = adminClient.realm(managedRealm.getName()).clients().findClientByClientId("client").orElseThrow().getId();
         adminId = adminClient.realm(managedRealm.getName()).users().search("admin", true).get(0).getId();
         appUserId = adminClient.realm(managedRealm.getName()).users().search("app-user", true).get(0).getId();
         adminCliUuid = AdminApiUtil.findClientByClientId(managedRealm.admin(), Constants.ADMIN_CLI_CLIENT_ID).toRepresentation().getId();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminDefaultRealmTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminDefaultRealmTest.java
@@ -40,7 +40,7 @@ public class FineGrainedAdminDefaultRealmTest extends AbstractFineGrainedAdminTe
             realmClient.realm(REALM_NAME).roles().create(composite);
             composite = managedRealm.admin().roles().get("composite").toRepresentation();
 
-            ClientRepresentation client = managedRealm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+            ClientRepresentation client = managedRealm.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
             RoleRepresentation viewUsers = managedRealm.admin().clients().get(client.getId()).roles().get(AdminRoles.CREATE_CLIENT).toRepresentation();
 
             List<RoleRepresentation> composites = new LinkedList<>();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminMasterRealmTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminMasterRealmTest.java
@@ -38,7 +38,7 @@ public class FineGrainedAdminMasterRealmTest extends AbstractFineGrainedAdminTes
         RoleRepresentation realmRole2 = managedRealm.admin().roles().get("realm-role2").toRepresentation();
         List<RoleRepresentation> realmRole2Set = new LinkedList<>();
         realmRole2Set.add(realmRole);
-        ClientRepresentation client = managedRealm.admin().clients().findByClientId(CLIENT_NAME).get(0);
+        ClientRepresentation client = managedRealm.admin().clients().findClientByClientId(CLIENT_NAME).orElseThrow();
         RoleRepresentation clientRole = managedRealm.admin().clients().get(client.getId()).roles().get("client-role").toRepresentation();
         List<RoleRepresentation> clientRoleSet = new LinkedList<>();
         clientRoleSet.add(clientRole);
@@ -75,7 +75,7 @@ public class FineGrainedAdminMasterRealmTest extends AbstractFineGrainedAdminTes
         managedRealm.admin().roles().create(composite);
         composite = managedRealm.admin().roles().get("composite").toRepresentation();
 
-        ClientRepresentation client = managedRealm.admin().clients().findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation client = managedRealm.admin().clients().findClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).orElseThrow();
         RoleRepresentation createClient = managedRealm.admin().clients().get(client.getId()).roles().get(AdminRoles.CREATE_CLIENT).toRepresentation();
         RoleRepresentation queryRealms = managedRealm.admin().clients().get(client.getId()).roles().get(AdminRoles.QUERY_REALMS).toRepresentation();
         List<RoleRepresentation> composites = new LinkedList<>();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminRestTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminRestTest.java
@@ -63,7 +63,7 @@ public class FineGrainedAdminRestTest extends AbstractFineGrainedAdminTest {
         RoleRepresentation realmRole2 = managedRealm.admin().roles().get("realm-role2").toRepresentation();
         List<RoleRepresentation> realmRole2Set = new LinkedList<>();
         realmRole2Set.add(realmRole2);
-        ClientRepresentation client = managedRealm.admin().clients().findByClientId(CLIENT_NAME).get(0);
+        ClientRepresentation client = managedRealm.admin().clients().findClientByClientId(CLIENT_NAME).orElseThrow();
         ClientScopeRepresentation scope = managedRealm.admin().clientScopes().findAll().get(0);
         RoleRepresentation clientRole = managedRealm.admin().clients().get(client.getId()).roles().get("client-role").toRepresentation();
         List<RoleRepresentation> clientRoleSet = new LinkedList<>();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedPermissionsV1UsersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedPermissionsV1UsersTest.java
@@ -192,7 +192,7 @@ public class FineGrainedPermissionsV1UsersTest extends AbstractFineGrainedAdminT
                 .build();
         String testUserId = ApiUtil.getCreatedId(realm.admin().users().create(user));
         //assign 'query-users' role to test user
-        ClientRepresentation clientRepresentation = realm.admin().clients().findByClientId("realm-management").get(0);
+        ClientRepresentation clientRepresentation = realm.admin().clients().findClientByClientId("realm-management").orElseThrow();
         String realmManagementId = clientRepresentation.getId();
         RoleRepresentation roleRepresentation = realm.admin().clients().get(realmManagementId).roles().get("query-users").toRepresentation();
         realm.admin().users().get(testUserId).roles().clientLevel(realmManagementId).add(Collections.singletonList(roleRepresentation));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
@@ -117,7 +117,7 @@ public class GroupTest extends AbstractGroupTest {
     @InjectHttpClient
     CloseableHttpClient httpClient;
 
-    
+
     @Test
     @DisabledForDatabases("mssql")
     public void createMultiDeleteMultiReadMulti() {
@@ -177,7 +177,7 @@ public class GroupTest extends AbstractGroupTest {
                 .resourcePath(AdminEventPaths.clientResourcePath(clientUuid))
                 .representation(client)
                 .resourceType(ResourceType.CLIENT);
-        client = realm.clients().findByClientId("foo").get(0);
+        client = realm.clients().findClientByClientId("foo").orElseThrow();
 
         RoleRepresentation role = RoleConfigBuilder.create().name("foo-role").build();
         realm.clients().get(client.getId()).roles().create(role);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
@@ -145,7 +145,7 @@ public class PartialImportClientTest extends AbstractPartialImportTest {
     public void testOverwriteExistingClientWithRoles() {
         setOverwrite();
 
-        ClientRepresentation client = masterRealm.admin().clients().findByClientId("broker").get(0);
+        ClientRepresentation client = masterRealm.admin().clients().findClientByClientId("broker").orElseThrow();
         List<RoleRepresentation> clientRoles = masterRealm.admin().clients().get(client.getId()).roles().list();
 
         Map<String, List<RoleRepresentation>> clients = new HashMap<>();
@@ -164,8 +164,8 @@ public class PartialImportClientTest extends AbstractPartialImportTest {
     @Test
     public void testOverwriteExistingInternalClient() {
         setOverwrite();
-        ClientRepresentation client = masterRealm.admin().clients().findByClientId("security-admin-console").get(0);
-        ClientRepresentation client2 = masterRealm.admin().clients().findByClientId("master-realm").get(0);
+        ClientRepresentation client = masterRealm.admin().clients().findClientByClientId("security-admin-console").orElseThrow();
+        ClientRepresentation client2 = masterRealm.admin().clients().findClientByClientId("master-realm").orElseThrow();
         piRep.setClients(Arrays.asList(client, client2));
 
         PartialImportResults result = doImport();
@@ -179,7 +179,7 @@ public class PartialImportClientTest extends AbstractPartialImportTest {
 
         Assertions.assertEquals(1, doImport().getOverwritten());
 
-        ClientRepresentation client = managedRealm.admin().clients().findByClientId(CLIENT_SERVICE_ACCOUNT).get(0);
+        ClientRepresentation client = managedRealm.admin().clients().findClientByClientId(CLIENT_SERVICE_ACCOUNT).orElseThrow();
         Assertions.assertDoesNotThrow(() -> managedRealm.admin().clients().get(client.getId()).getServiceAccountUser());
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmUpdateTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmUpdateTest.java
@@ -95,23 +95,23 @@ public class RealmUpdateTest extends AbstractRealmTest {
         adminClient.realm(OLD).update(rep);
 
         // Check client in master realm renamed
-        Assertions.assertEquals(0, adminClient.realm("master").clients().findByClientId("old-realm").size());
-        Assertions.assertEquals(1, adminClient.realm("master").clients().findByClientId("new-realm").size());
+        Assertions.assertFalse( adminClient.realm("master").clients().findClientByClientId("old-realm").isPresent());
+        Assertions.assertTrue( adminClient.realm("master").clients().findClientByClientId("new-realm").isPresent());
 
-        ClientRepresentation adminConsoleClient = adminClient.realm(NEW).clients().findByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID).get(0);
+        ClientRepresentation adminConsoleClient = adminClient.realm(NEW).clients().findClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID).orElseThrow();
         assertEquals(Constants.AUTH_ADMIN_URL_PROP, adminConsoleClient.getRootUrl());
 
-        ClientRepresentation accountClient = adminClient.realm(NEW).clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation accountClient = adminClient.realm(NEW).clients().findClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).orElseThrow();
         assertEquals(Constants.AUTH_BASE_URL_PROP, accountClient.getRootUrl());
 
-        ClientRepresentation accountConsoleClient = adminClient.realm(NEW).clients().findByClientId(Constants.ACCOUNT_CONSOLE_CLIENT_ID).get(0);
+        ClientRepresentation accountConsoleClient = adminClient.realm(NEW).clients().findClientByClientId(Constants.ACCOUNT_CONSOLE_CLIENT_ID).orElseThrow();
         assertEquals(Constants.AUTH_BASE_URL_PROP, accountConsoleClient.getRootUrl());
 
         newBaseUrls.forEach((clientId, baseUrl) -> {
-            assertEquals(baseUrl, adminClient.realm(NEW).clients().findByClientId(clientId).get(0).getBaseUrl());
+            assertEquals(baseUrl, adminClient.realm(NEW).clients().findClientByClientId(clientId).orElseThrow().getBaseUrl());
         });
         newRedirectUris.forEach((clientId, redirectUris) -> {
-            assertEquals(redirectUris, adminClient.realm(NEW).clients().findByClientId(clientId).get(0).getRedirectUris());
+            assertEquals(redirectUris, adminClient.realm(NEW).clients().findClientByClientId(clientId).orElseThrow().getRedirectUris());
         });
 
         adminClient.realms().realm(NEW).remove();

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserEmailTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserEmailTest.java
@@ -209,7 +209,7 @@ public class UserEmailTest extends AbstractUserTest {
 
     @Test
     public void sendResetPasswordEmailSuccessWithAccountClientDisabled() throws IOException {
-        ClientRepresentation clientRepresentation = managedRealm.admin().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0);
+        ClientRepresentation clientRepresentation = managedRealm.admin().clients().findClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).orElseThrow();
         clientRepresentation.setEnabled(false);
         managedRealm.admin().clients().get(clientRepresentation.getId()).update(clientRepresentation);
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientResourcePath(clientRepresentation.getId()), clientRepresentation, ResourceType.CLIENT);
@@ -890,6 +890,7 @@ public class UserEmailTest extends AbstractUserTest {
 
     private static class UserEmailTestAppClientConf implements ClientConfig {
 
+        @Override
         public ClientConfigBuilder configure(ClientConfigBuilder builder) {
             builder.clientId("test-app-email");
             builder.secret("password");

--- a/tests/base/src/test/java/org/keycloak/tests/welcomepage/WelcomePageTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/welcomepage/WelcomePageTest.java
@@ -78,7 +78,7 @@ public class WelcomePageTest {
         var users = adminClient.realms().realm("master").users();
         users.searchByUsername(Config.getAdminUsername(), true).stream().findFirst().ifPresent(admin -> users.delete(admin.getId()));
         var clients = adminClient.realms().realm("master").clients();
-        clients.findByClientId(Config.getAdminClientId()).stream().findFirst().ifPresent(client -> clients.delete(client.getId()));
+        clients.findClientByClientId(Config.getAdminClientId()).ifPresent(c -> clients.delete(c.getId()));
 
         driver.open(keycloakUrls.getBaseUrl());
 

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/RoleWorkflowConditionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/RoleWorkflowConditionTest.java
@@ -190,20 +190,16 @@ public class RoleWorkflowConditionTest extends AbstractWorkflowTest {
             String[] parts = roleName.split("/");
             String clientId = parts[0];
             String clientRoleName = parts[1];
-            List<ClientRepresentation> clients = managedRealm.admin().clients().findByClientId(clientId);
+            ClientRepresentation client = managedRealm.admin().clients().findClientByClientId(clientId).orElseGet(() -> {
+                ClientRepresentation newClient = new ClientRepresentation();
+                newClient.setClientId(clientId);
+                newClient.setName(clientId);
+                newClient.setProtocol("openid-connect");
+                managedRealm.admin().clients().create(newClient).close();
+                return managedRealm.admin().clients().findClientByClientId(clientId).orElseThrow();
+            });
 
-            if (clients.isEmpty()) {
-                ClientRepresentation client = new ClientRepresentation();
-                client.setClientId(clientId);
-                client.setName(clientId);
-                client.setProtocol("openid-connect");
-                managedRealm.admin().clients().create(client).close();
-                clients = managedRealm.admin().clients().findByClientId(clientId);
-            }
-
-            assertThat(clients.isEmpty(), is(false));
-
-            RolesResource roles = managedRealm.admin().clients().get(clients.get(0).getId()).roles();
+            RolesResource roles = managedRealm.admin().clients().get(client.getId()).roles();
 
             if (roles.list(clientRoleName, -1, -1).isEmpty()) {
                 roles.create(RoleConfigBuilder.create()

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -14,9 +14,6 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-
 /**
  * Updater for client attributes. See {@link ServerResourceUpdater} for further details.
  * @author hmlnarik
@@ -35,10 +32,8 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
     public static ClientAttributeUpdater forClient(Keycloak adminClient, String realm, String clientId) {
         RealmResource realmRes = adminClient.realm(realm);
         ClientsResource clients = realmRes.clients();
-        List<ClientRepresentation> foundClients = clients.findByClientId(clientId);
-        assertThat(foundClients, hasSize(1));
-        ClientResource clientRes = clients.get(foundClients.get(0).getId());
-        
+        ClientResource clientRes = clients.getByClientId(clientId);
+
         return new ClientAttributeUpdater(clientRes, realmRes);
     }
 
@@ -86,7 +81,7 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
         this.rep.setRedirectUris(values);
         return this;
     }
-    
+
     public ClientAttributeUpdater filterRedirectUris(Predicate<String> filter) {
         this.rep.setRedirectUris(this.rep.getRedirectUris().stream().filter(filter).collect(Collectors.toList()));
         return this;

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlUtils.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/SamlUtils.java
@@ -9,7 +9,6 @@ import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.dom.saml.v2.metadata.EntityDescriptorType;
 import org.keycloak.dom.saml.v2.metadata.SPSSODescriptorType;
 import org.keycloak.protocol.saml.installation.SamlSPDescriptorClientInstallation;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.saml.common.exceptions.ParsingException;
 import org.keycloak.saml.processing.core.parsers.saml.SAMLParser;
 import org.keycloak.testsuite.utils.arquillian.DeploymentArchiveProcessorUtils;
@@ -42,11 +41,7 @@ public class SamlUtils {
     }
 
     public static SPSSODescriptorType getSPInstallationDescriptor(ClientsResource res, String clientId) throws ParsingException {
-        String spDescriptorString = res.findByClientId(clientId).stream().findFirst()
-                .map(ClientRepresentation::getId)
-                .map(res::get)
-                .map(clientResource -> clientResource.getInstallationProvider(SamlSPDescriptorClientInstallation.SAML_CLIENT_INSTALATION_SP_DESCRIPTOR))
-                .orElseThrow(() -> new RuntimeException("Missing descriptor"));
+        String spDescriptorString = res.getByClientId(clientId).getInstallationProvider(SamlSPDescriptorClientInstallation.SAML_CLIENT_INSTALATION_SP_DESCRIPTOR);
 
         SAMLParser parser = SAMLParser.getInstance();
         EntityDescriptorType o = (EntityDescriptorType) parser.parse(new StringInputStream(spDescriptorString));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AccountRestServiceTest.java
@@ -234,8 +234,9 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
     }
 
     protected static UserProfileAttributeMetadata getUserProfileAttributeMetadata(UserRepresentation user, String attName) {
-        if(user.getUserProfileMetadata() == null)
+        if(user.getUserProfileMetadata() == null) {
             return null;
+        }
         for(UserProfileAttributeMetadata uam : user.getUserProfileMetadata().getAttributes()) {
             if(attName.equals(uam.getName())) {
                 return uam;
@@ -1788,7 +1789,7 @@ public class AccountRestServiceTest extends AbstractRestServiceTest {
         }
 
         // update to correct audience
-        org.keycloak.representations.idm.ClientRepresentation clientRep = testRealm().clients().findByClientId("custom-audience").get(0);
+        org.keycloak.representations.idm.ClientRepresentation clientRep = testRealm().clients().findClientByClientId("custom-audience").orElseThrow();
         ProtocolMapperRepresentation mapperRep = clientRep.getProtocolMappers().stream().filter(m -> m.getName().equals("aud")).findFirst().orElse(null);
         assertNotNull("Audience mapper not found", mapperRep);
         mapperRep.getConfig().put("included.custom.audience", "account");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
@@ -32,7 +32,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.Configuration;
 import org.keycloak.common.Profile;
@@ -155,8 +154,7 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
     }
 
     private ClientResource getResourceServer() {
-        ClientsResource clients = testRealm().clients();
-        return clients.get(clients.findByClientId("my-resource-server").get(0).getId());
+        return testRealm().clients().getByClientId("my-resource-server");
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/DeleteAccountActionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/DeleteAccountActionTest.java
@@ -139,7 +139,7 @@ public class DeleteAccountActionTest extends AbstractTestRealmKeycloakTest {
   private void removeDeleteAccountRoleFromUserClientRoles() {
     UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, "test-user@localhost");
     UserResource userResource = testRealm().users().get(user.getId());
-    ClientRepresentation clientRepresentation = testRealm().clients().findByClientId("account").get(0);
+    ClientRepresentation clientRepresentation = testRealm().clients().findClientByClientId("account").orElseThrow();;
     String deleteRoleId = userResource.roles().clientLevel(clientRepresentation.getId()).listAll().stream().filter(role -> Objects
         .equals(role.getName(), "delete-account")).findFirst().get().getId();
     RoleRepresentation deleteRole = new RoleRepresentation();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionResetPasswordTest.java
@@ -156,7 +156,7 @@ public class RequiredActionResetPasswordTest extends AbstractTestRealmKeycloakTe
         AuthorizationEndpointResponse os = oauth2.doLogin("test-user@localhost", "password");
         EventRepresentation offlineSession = events.expectLogin().assertEvent();
         AccessTokenResponse at = oauth2.doAccessTokenRequest(os.getCode());
-        String clientUuid = testRealm().clients().findByClientId(oauth2.getClientId()).get(0).getId();
+        String clientUuid = testRealm().clients().findClientByClientId(oauth2.getClientId()).orElseThrow().getId();
         assertEquals(1, testUser.getOfflineSessions(clientUuid).size());
 
         requireUpdatePassword();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
@@ -1199,7 +1199,9 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         waitUntilElement(By.xpath("//body")).text().contains("Insecure Page");
         Assert.assertNotEquals("SessionID has not been changed at login", sessionId, driver.manage().getCookieNamed("JSESSIONID").getValue());
 
-        if (System.getProperty("insecure.user.principal.unsupported") == null) waitUntilElement(By.xpath("//body")).text().contains("UserPrincipal");
+        if (System.getProperty("insecure.user.principal.unsupported") == null) {
+            waitUntilElement(By.xpath("//body")).text().contains("UserPrincipal");
+        }
 
         // test logout
 
@@ -1871,7 +1873,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         // assign the supervisor role to user bburke - it should be mapped to coordinator next time he logs in.
         UserRepresentation bburke = adminClient.realm(DEMO).users().search("bburke", 0, 1).get(0);
         ClientRepresentation clientRepresentation = adminClient.realm(DEMO)
-                .clients().findByClientId("http://localhost:8280/employee-role-mapping/").get(0);
+                .clients().findClientByClientId("http://localhost:8280/employee-role-mapping/").orElseThrow();
         RoleRepresentation role = adminClient.realm(DEMO).clients().get(clientRepresentation.getId())
                 .roles().get("supervisor").toRepresentation();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/admin/AdminClientTest.java
@@ -142,8 +142,8 @@ public class AdminClientTest extends AbstractKeycloakTest {
     public void importRealm(RealmRepresentation realm) {
         super.importRealm(realm);
         if (Objects.equals(realm.getRealm(), realmName)) {
-            x509ClientUUID = adminClient.realm(realmName).clients().findByClientId(x509ClientId).get(0).getId();
-            clientUUID = adminClient.realm(realmName).clients().findByClientId(clientId).get(0).getId();
+            x509ClientUUID = adminClient.realm(realmName).clients().findClientByClientId(x509ClientId).orElseThrow().getId();
+            clientUUID = adminClient.realm(realmName).clients().findClientByClientId(clientId).orElseThrow().getId();
             userId = adminClient.realm(realmName).users().searchByUsername(userName, true).get(0).getId();
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AbstractResourceServerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AbstractResourceServerTest.java
@@ -28,7 +28,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.resource.ProtectionResource;
@@ -178,14 +177,16 @@ public abstract class AbstractResourceServerTest extends AbstractAuthzTest {
             authorization = getAuthzClient().authorization();
         }
 
-        for (PermissionRequest permission : permissions)
+        for (PermissionRequest permission : permissions) {
             authorizationRequest.addPermission(permission.getResourceId(), new ArrayList<String>(permission.getScopes()));
+        }
 
         Metadata metadata = new Metadata();
         metadata.setResponseMode("decision");
         metadata.setPermissionResourceFormat("uri");
-        if (matchingUri != null)
+        if (matchingUri != null) {
             metadata.setPermissionResourceMatchingUri(matchingUri);
+        }
 
         authorizationRequest.setMetadata(metadata);
 
@@ -197,8 +198,7 @@ public abstract class AbstractResourceServerTest extends AbstractAuthzTest {
     }
 
     protected ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     protected AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationAPITest.java
@@ -24,7 +24,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.jose.jws.JWSInput;
@@ -233,8 +232,7 @@ public class AuthorizationAPITest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm, String clientId) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId(clientId).stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId(clientId);
     }
 
     private AuthzClient getAuthzClient(String configFile) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthorizationTest.java
@@ -25,7 +25,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.ResourcesResource;
 import org.keycloak.authorization.client.AuthzClient;
@@ -210,8 +209,7 @@ public class AuthorizationTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient() {
-        ClientsResource clients = getRealm().clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return getRealm().clients().getByClientId("resource-server-test");
     }
 
     private AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientCredentialsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/AuthzClientCredentialsTest.java
@@ -114,7 +114,7 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
         testContext.getTestRealmReps().forEach(realmRepresentation -> {
             Keycloak adminClient = getAdminClient();
             ClientsResource clients = adminClient.realm(realmRepresentation.getRealm()).clients();
-            ClientRepresentation client = clients.findByClientId("resource-server-test").get(0);
+            ClientRepresentation client = clients.findClientByClientId("resource-server-test").orElseThrow();
 
             client.setAuthorizationServicesEnabled(false);
 
@@ -260,7 +260,7 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
 
     private void testReusingAccessAndRefreshTokens(int expectedUserSessionsCount) throws Exception {
         ClientsResource clients = getAdminClient().realm("authz-test-session").clients();
-        ClientRepresentation clientRepresentation = clients.findByClientId("resource-server-test").get(0);
+        ClientRepresentation clientRepresentation = clients.findClientByClientId("resource-server-test").orElseThrow();
         List<UserSessionRepresentation> userSessions = clients.get(clientRepresentation.getId()).getUserSessions(-1, -1);
 
         assertEquals(0, userSessions.size());
@@ -284,8 +284,7 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
     @Test
     public void testPermissionWhenResourceServerIsCurrentUser() throws Exception {
         ClientsResource clients = getAdminClient().realm("authz-test-session").clients();
-        ClientRepresentation clientRepresentation = clients.findByClientId("resource-server-test").get(0);
-        List<UserSessionRepresentation> userSessions = clients.get(clientRepresentation.getId()).getUserSessions(-1, -1);
+        List<UserSessionRepresentation> userSessions = clients.getByClientId("resource-server-test").getUserSessions(-1, -1);
 
         assertEquals(0, userSessions.size());
 
@@ -301,7 +300,7 @@ public class AuthzClientCredentialsTest extends AbstractAuthzTest {
     @Test
     public void testSingleSessionPerUser() throws Exception {
         ClientsResource clients = getAdminClient().realm("authz-test-session").clients();
-        ClientRepresentation clientRepresentation = clients.findByClientId("resource-server-test").get(0);
+        ClientRepresentation clientRepresentation = clients.findClientByClientId("resource-server-test").orElseThrow();
         List<UserSessionRepresentation> userSessions = clients.get(clientRepresentation.getId()).getUserSessions(-1, -1);
 
         assertEquals(0, userSessions.size());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ClientScopePolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ClientScopePolicyTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientScopesResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
@@ -126,10 +125,7 @@ public class ClientScopePolicyTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream()
-            .map(representation -> clients.get(representation.getId())).findFirst()
-            .orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     private RealmResource getRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ConflictingScopePermissionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/ConflictingScopePermissionTest.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.jose.jws.JWSInput;
@@ -273,8 +272,7 @@ public class ConflictingScopePermissionTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     private void createPermissions(ClientResource client) throws IOException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/EntitlementAPITest.java
@@ -36,7 +36,6 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.ResourceResource;
 import org.keycloak.admin.client.resource.ScopePermissionsResource;
@@ -1118,7 +1117,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         String accessToken = oauth.newConfig().realm("authz-test").client(RESOURCE_SERVER_TEST, "secret").doPasswordGrantRequest("kolo", "password").getAccessToken();
         AuthzClient authzClient = getAuthzClient(AUTHZ_CLIENT_CONFIG);
         AuthorizationRequest request = new AuthorizationRequest();
-        
+
         request.addPermission(resource.getName());
 
         try {
@@ -1130,17 +1129,17 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         }
 
         ResourceServerRepresentation settings = authorization.getSettings();
-        
+
         settings.setDecisionStrategy(DecisionStrategy.AFFIRMATIVE);
-        
+
         authorization.update(settings);
 
         assertPermissions(authzClient, accessToken, request, resource, "read");
 
         scopePermission1 = scopePermissions.findByName(scopePermission1.getName());
-        
+
         scopePermission1.addScope("read", "delete");
-        
+
         scopePermissions.findById(scopePermission1.getId()).update(scopePermission1);
 
         assertPermissions(authzClient, accessToken, request, resource, "read", "delete");
@@ -1177,12 +1176,12 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         assertPermissions(authzClient, accessToken, request, resource, "read", "delete", "write");
 
         scopePermission3 = scopePermissions.findByName(scopePermission3.getName());
-        
+
         scopePermission3.addScope("write", "delete");
         scopePermissions.findById(scopePermission3.getId()).update(scopePermission3);
 
         assertPermissions(authzClient, accessToken, request, resource, "delete", "write");
-        
+
         scopePermissions.findById(scopePermission3.getId()).remove();
 
         try {
@@ -1202,7 +1201,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         authorization.permissions().resource().create(grantResourcePermission).close();
 
         assertPermissions(authzClient, accessToken, request, resource, "read", "delete", "write");
-        
+
         settings.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
         authorization.update(settings);
 
@@ -2279,7 +2278,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
         AuthzClient authzClient = getAuthzClient(AUTHZ_CLIENT_CONFIG);
         AccessTokenResponse response = authzClient.authorization(accessToken).authorize();
         assertNotNull(response.getToken());
-        
+
         getRealm().logoutAll();
 
         AuthorizationRequest request = new AuthorizationRequest();
@@ -2300,12 +2299,12 @@ public class EntitlementAPITest extends AbstractAuthzTest {
     @Test
     public void testInvalidTokenSignature() throws Exception {
         RealmEventsConfigRepresentation eventConfig = getRealm().getRealmEventsConfig();
-        
+
         eventConfig.setEventsEnabled(true);
         eventConfig.setEnabledEventTypes(Arrays.asList(EventType.PERMISSION_TOKEN_ERROR.name()));
-        
+
         getRealm().updateRealmEventsConfig(eventConfig);
-        
+
         ClientResource client = getClient(getRealm(), RESOURCE_SERVER_TEST);
         AuthorizationResource authorization = client.authorization();
 
@@ -2774,8 +2773,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm, String clientId) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId(clientId).stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId(clientId);
     }
 
     private AuthzClient getAuthzClient(String configFile) {
@@ -2836,7 +2834,7 @@ public class EntitlementAPITest extends AbstractAuthzTest {
 
         client.update(representation);
     }
-    
+
     private void assertPermissions(AuthzClient authzClient, String accessToken, AuthorizationRequest request, ResourceRepresentation resource, String... expectedScopes) {
         AuthorizationResponse response = authzClient.authorization(accessToken).authorize(request);
         assertNotNull(response.getToken());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupNamePolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupNamePolicyTest.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
@@ -229,8 +228,8 @@ public class GroupNamePolicyTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
+
     }
 
     private AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupPathPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/GroupPathPolicyTest.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
@@ -205,8 +204,7 @@ public class GroupPathPolicyTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     private AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionClaimTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PermissionClaimTest.java
@@ -28,7 +28,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.util.HttpResponseException;
@@ -448,8 +447,7 @@ public class PermissionClaimTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     private AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
@@ -124,7 +124,7 @@ public class PolicyEvaluationCompositeRoleTest extends AbstractAuthzTest {
         testingClient.server().run(PolicyEvaluationCompositeRoleTest::setup);
 
         RealmResource realm = adminClient.realm(TEST);
-        String resourceServerId = realm.clients().findByClientId("myclient").get(0).getId();
+        String resourceServerId = realm.clients().findClientByClientId("myclient").orElseThrow().getId();
         UserRepresentation user = realm.users().search("user").get(0);
 
         PolicyEvaluationRequest request = new PolicyEvaluationRequest();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RegexPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RegexPolicyTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
@@ -232,10 +231,7 @@ private void createRegexPolicyExtended(String name, String targetClaim, String p
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream()
-            .map(representation -> clients.get(representation.getId())).findFirst()
-            .orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     private RealmResource getRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RolePolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/RolePolicyTest.java
@@ -26,7 +26,6 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -174,9 +173,8 @@ public class RolePolicyTest extends AbstractAuthzTest {
         AuthzClient authzClient = getAuthzClient();
         RealmResource realm = getRealm();
         ClientsResource clients = realm.clients();
-        ClientRepresentation client = clients.findByClientId(authzClient.getConfiguration().getResource()).get(0);
         ClientScopeRepresentation rolesScope = ApiUtil.findClientScopeByName(realm, OIDCLoginProtocolFactory.ROLES_SCOPE).toRepresentation();
-        ClientResource clientResource = clients.get(client.getId());
+        ClientResource clientResource = clients.getByClientId(authzClient.getConfiguration().getResource());
         clientResource.removeDefaultClientScope(rolesScope.getId());
         getCleanup().addCleanup(() -> clientResource.addDefaultClientScope(rolesScope.getId()));
         PermissionRequest request = new PermissionRequest("Resource B");
@@ -198,9 +196,8 @@ public class RolePolicyTest extends AbstractAuthzTest {
         AuthzClient authzClient = getAuthzClient();
         RealmResource realm = getRealm();
         ClientsResource clients = realm.clients();
-        ClientRepresentation client = clients.findByClientId(authzClient.getConfiguration().getResource()).get(0);
         ClientScopeRepresentation rolesScope = ApiUtil.findClientScopeByName(realm, OIDCLoginProtocolFactory.ROLES_SCOPE).toRepresentation();
-        ClientResource clientResource = clients.get(client.getId());
+        ClientResource clientResource = clients.getByClientId(authzClient.getConfiguration().getResource());
         clientResource.removeDefaultClientScope(rolesScope.getId());
         UserRepresentation serviceAccountUser = clientResource.getServiceAccountUser();
         RoleRepresentation roleB = realm.roles().get("Role B").toRepresentation();
@@ -254,8 +251,7 @@ public class RolePolicyTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     private AuthzClient getAuthzClient() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/AbstractPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/AbstractPolicyManagementTest.java
@@ -26,7 +26,6 @@ import java.util.function.Supplier;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentation;
@@ -170,8 +169,7 @@ public abstract class AbstractPolicyManagementTest extends AbstractKeycloakTest 
     }
 
     protected ClientResource getClient(RealmResource realm) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId("resource-server-test").stream().map(representation -> clients.get(representation.getId())).findFirst().orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId("resource-server-test");
     }
 
     protected RealmResource getRealm() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ClientPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ClientPolicyManagementTest.java
@@ -150,7 +150,7 @@ public class ClientPolicyManagementTest extends AbstractPolicyManagementTest {
         assertCreated(authorization, representation);
 
         ClientsResource clients = getRealm().clients();
-        ClientRepresentation client = clients.findByClientId("Client D").get(0);
+        ClientRepresentation client = clients.findClientByClientId("Client D").orElseThrow();
 
         clients.get(client.getId()).remove();
 
@@ -159,7 +159,7 @@ public class ClientPolicyManagementTest extends AbstractPolicyManagementTest {
         Assert.assertEquals(2, representation.getClients().size());
         Assert.assertFalse(representation.getClients().contains(client.getId()));
 
-        client = clients.findByClientId("Client E").get(0);
+        client = clients.findClientByClientId("Client E").orElseThrow();
         clients.get(client.getId()).remove();
 
         representation = authorization.policies().client().findById(representation.getId()).toRepresentation();
@@ -167,7 +167,7 @@ public class ClientPolicyManagementTest extends AbstractPolicyManagementTest {
         Assert.assertEquals(1, representation.getClients().size());
         Assert.assertFalse(representation.getClients().contains(client.getId()));
 
-        client = clients.findByClientId("Client F").get(0);
+        client = clients.findClientByClientId("Client F").orElseThrow();
         clients.get(client.getId()).remove();
 
         representation = authorization.policies().client().findById(representation.getId()).toRepresentation();
@@ -195,7 +195,7 @@ public class ClientPolicyManagementTest extends AbstractPolicyManagementTest {
             assertNotNull(genericConfig.getConfig());
             assertNotNull(genericConfig.getConfig().get("clients"));
 
-            ClientRepresentation user = getRealm().clients().findByClientId("Client A").get(0);
+            ClientRepresentation user = getRealm().clients().findClientByClientId("Client A").orElseThrow();
 
             assertTrue(genericConfig.getConfig().get("clients").contains(user.getId()));
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ExportAuthorizationSettingsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ExportAuthorizationSettingsTest.java
@@ -52,7 +52,7 @@ public class ExportAuthorizationSettingsTest extends AbstractAuthorizationTest {
     @Test
     public void testResourceBasedPermission() throws Exception {
         String permissionName = "resource-based-permission";
-        
+
         ClientResource clientResource = getClientResource();
         AuthorizationResource authorizationResource = clientResource.authorization();
 
@@ -98,16 +98,15 @@ public class ExportAuthorizationSettingsTest extends AbstractAuthorizationTest {
         }
         Assert.assertTrue("Permission \"role-based-permission\" was not found.", found);
     }
-    
+
     //KEYCLOAK-4340
     @Test
     public void testRoleBasedPolicy() {
         ClientResource clientResource = getClientResource();
         AuthorizationResource authorizationResource = clientResource.authorization();
-        
-        ClientRepresentation account = testRealmResource().clients().findByClientId("account").get(0);
-        RoleRepresentation role = testRealmResource().clients().get(account.getId()).roles().get("view-profile").toRepresentation();
-        
+
+        RoleRepresentation role = testRealmResource().clients().getByClientId("account").roles().get("view-profile").toRepresentation();
+
         PolicyRepresentation policy = new PolicyRepresentation();
         policy.setName("role-based-policy");
         policy.setType("role");
@@ -120,15 +119,15 @@ public class ExportAuthorizationSettingsTest extends AbstractAuthorizationTest {
         } finally {
             create.close();
         }
-        
+
         //this call was messing up with DB, see KEYCLOAK-4340
         authorizationResource.exportSettings();
-        
+
         //this call failed with NPE
         authorizationResource.exportSettings();
     }
-    
-    
+
+
     //KEYCLOAK-4983
     @Test
     public void testRoleBasedPolicyWithMultipleRoles() {
@@ -146,7 +145,7 @@ public class ExportAuthorizationSettingsTest extends AbstractAuthorizationTest {
 
         RoleRepresentation role1 = testRealmResource().clients().get(client1.getId()).roles().get("client-role").toRepresentation();
         RoleRepresentation role2 = testRealmResource().clients().get(client2.getId()).roles().get("client-role").toRepresentation();
-        
+
         PolicyRepresentation policy = new PolicyRepresentation();
         policy.setName("role-based-policy");
         policy.setType("role");
@@ -156,15 +155,15 @@ public class ExportAuthorizationSettingsTest extends AbstractAuthorizationTest {
         try (Response create = authorizationResource.policies().create(policy)) {
             Assert.assertEquals(Status.CREATED, create.getStatusInfo());
         }
-        
+
         //export authorization settings
         ResourceServerRepresentation exportSettings = authorizationResource.exportSettings();
-        
+
         boolean found = false;
         for (PolicyRepresentation p : exportSettings.getPolicies()) {
             if (p.getName().equals("role-based-policy")) {
                 found = true;
-                Assert.assertTrue(p.getConfig().get("roles").contains("test-client-1/client-role") && 
+                Assert.assertTrue(p.getConfig().get("roles").contains("test-client-1/client-role") &&
                         p.getConfig().get("roles").contains("test-client-2/client-role"));
             }
         }
@@ -172,10 +171,8 @@ public class ExportAuthorizationSettingsTest extends AbstractAuthorizationTest {
             Assert.fail("Policy \"role-based-policy\" was not found in exported settings.");
         }
     }
-    
+
     private ClientRepresentation getClientByClientId(String clientId) {
-        List<ClientRepresentation> findByClientId = testRealmResource().clients().findByClientId(clientId);
-        Assert.assertTrue(findByClientId.size() == 1);
-        return findByClientId.get(0);
+        return testRealmResource().clients().findClientByClientId(clientId).orElseThrow();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceServerManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceServerManagementTest.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.testsuite.authz.admin;
 
-import java.util.List;
 import java.util.Objects;
 
 import jakarta.ws.rs.NotFoundException;
@@ -40,7 +39,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 /**
@@ -55,11 +54,9 @@ public class ResourceServerManagementTest extends AbstractAuthorizationTest {
 
         clientsResource.create(JsonSerialization.readValue(getClass().getResourceAsStream("/authorization-test/client-with-authz-settings.json"), ClientRepresentation.class)).close();
 
-        List<ClientRepresentation> clients = clientsResource.findByClientId("authz-client");
+        ClientRepresentation client = clientsResource.findClientByClientId("authz-client").orElseThrow();
 
-        assertFalse(clients.isEmpty());
-
-        String clientId = clients.get(0).getId();
+        String clientId = client.getId();
         AuthorizationResource settings = clientsResource.get(clientId).authorization();
 
         assertEquals(PolicyEnforcementMode.PERMISSIVE, settings.exportSettings().getPolicyEnforcementMode());
@@ -74,9 +71,9 @@ public class ResourceServerManagementTest extends AbstractAuthorizationTest {
 
         clientsResource.get(clientId).remove();
 
-        clients = clientsResource.findByClientId("authz-client");
+        client = clientsResource.findClientByClientId("authz-client").orElse(null);
 
-        assertTrue(clients.isEmpty());
+        assertNull(client);
     }
 
     @Test
@@ -91,11 +88,9 @@ public class ResourceServerManagementTest extends AbstractAuthorizationTest {
 
         clientsResource.create(clientRepresentation).close();
 
-        List<ClientRepresentation> clients = clientsResource.findByClientId("authz-client");
+        ClientRepresentation client = clientsResource.findClientByClientId("authz-client").orElseThrow();
 
-        assertFalse(clients.isEmpty());
-
-        String clientId = clients.get(0).getId();
+        String clientId = client.getId();
 
         try {
             clientsResource.get(clientId).authorization().getSettings();
@@ -111,9 +106,8 @@ public class ResourceServerManagementTest extends AbstractAuthorizationTest {
         ClientRepresentation clientRep = JsonSerialization.readValue(getClass().getResourceAsStream("/authorization-test/client-with-authz-settings.json"), ClientRepresentation.class);
         clientRep.setClientId(KeycloakModelUtils.generateId());
         clientsResource.create(clientRep).close();
-        List<ClientRepresentation> clients = clientsResource.findByClientId(clientRep.getClientId());
-        assertFalse(clients.isEmpty());
-        String clientId = clients.get(0).getId();
+        ClientRepresentation client = clientsResource.findClientByClientId(clientRep.getClientId()).orElseThrow();
+        String clientId = client.getId();
         AuthorizationResource authorization = clientsResource.get(clientId).authorization();
         ResourceServerRepresentation settings = authorization.exportSettings();
         assertEquals(PolicyEnforcementMode.PERMISSIVE, settings.getPolicyEnforcementMode());
@@ -127,10 +121,8 @@ public class ResourceServerManagementTest extends AbstractAuthorizationTest {
 
         ClientRepresentation anotherClientRep = ClientBuilder.create().clientId(KeycloakModelUtils.generateId()).secret("secret").authorizationServicesEnabled(true).serviceAccount().enabled(true).build();
         clientsResource.create(anotherClientRep).close();
-        clients = clientsResource.findByClientId(anotherClientRep.getClientId());
-        assertFalse(clients.isEmpty());
-        ClientRepresentation anotherClient = clients.get(0);
-        authorization = clientsResource.get(anotherClient.getId()).authorization();
+        client = clientsResource.findClientByClientId(anotherClientRep.getClientId()).orElseThrow();
+        authorization = clientsResource.get(client.getId()).authorization();
         authorization.importSettings(settings);
         ResourceServerRepresentation anotherSettings = authorization.exportSettings();
         assertEquals(PolicyEnforcementMode.PERMISSIVE, anotherSettings.getPolicyEnforcementMode());
@@ -148,9 +140,8 @@ public class ResourceServerManagementTest extends AbstractAuthorizationTest {
         ClientRepresentation clientRep = JsonSerialization.readValue(getClass().getResourceAsStream("/authorization-test/client-with-authz-settings.json"), ClientRepresentation.class);
         clientRep.setClientId(KeycloakModelUtils.generateId());
         clientsResource.create(clientRep).close();
-        List<ClientRepresentation> clients = clientsResource.findByClientId(clientRep.getClientId());
-        assertFalse(clients.isEmpty());
-        String clientId = clients.get(0).getId();
+        ClientRepresentation client = clientsResource.findClientByClientId(clientRep.getClientId()).orElseThrow();
+        String clientId = client.getId();
         AuthorizationResource authorization = clientsResource.get(clientId).authorization();
         ResourceServerRepresentation settings = authorization.exportSettings();
         assertFalse(settings.getResources().stream().map(ResourceRepresentation::getId).anyMatch(Objects::nonNull));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
@@ -202,7 +202,7 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
         testingClient.server(bc.consumerRealmName()).run(grantReadTokenRole(username));
 
         AccessTokenResponse accessTokenResponse = oauth.realm(bc.consumerRealmName()).client("broker-app", "broker-app-secret").doPasswordGrantRequest(bc.getUserLogin(), bc.getUserPassword());
-        AtomicReference<String> accessToken = (AtomicReference<String>) new AtomicReference<>(accessTokenResponse.getAccessToken());
+        AtomicReference<String> accessToken = new AtomicReference<>(accessTokenResponse.getAccessToken());
         Client client = KeycloakTestingClient.getRestEasyClientBuilder().register((ClientRequestFilter) request -> request.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken.get())).build();
 
         try {
@@ -287,8 +287,7 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
     public void loginWithExistingUserWithErrorFromProviderIdP() {
         ClientRepresentation client = adminClient.realm(bc.providerRealmName())
                 .clients()
-                .findByClientId(bc.getIDPClientIdInProviderRealm())
-                .get(0);
+                .findClientByClientId(bc.getIDPClientIdInProviderRealm()).orElseThrow();
 
         adminClient.realm(bc.providerRealmName())
                 .clients()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -60,7 +60,6 @@ import org.keycloak.testsuite.util.oauth.LogoutUrlBuilder;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.userprofile.UserProfileUtil;
 
-import org.hamcrest.Matchers;
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.After;
 import org.junit.Before;
@@ -77,7 +76,6 @@ import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 import static org.keycloak.testsuite.util.ServerURLs.getAuthServerContextRoot;
 import static org.keycloak.testsuite.util.ServerURLs.removeDefaultPorts;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -317,11 +315,9 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
      * @return Login URL
      */
     protected String getLoginUrl(String contextRoot, String realmName, String clientId) {
-        List<ClientRepresentation> clients = adminClient.realm(realmName).clients().findByClientId(clientId);
+        ClientRepresentation client = adminClient.realm(realmName).clients().findClientByClientId(clientId).orElseThrow();
 
-        assertThat(clients, Matchers.is(Matchers.not(Matchers.empty())));
-
-        String redirectURI = clients.get(0).getBaseUrl();
+        String redirectURI = client.getBaseUrl();
         if (redirectURI.startsWith("/")) {
             redirectURI = contextRoot + "/auth" + redirectURI;
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBrokerTest.java
@@ -128,7 +128,7 @@ public abstract class AbstractBrokerTest extends AbstractInitializedBaseBrokerTe
     }
 
     protected Stream<UserRepresentation> getConsumerUserRepresentations() {
-        String consumerClientBrokerAppId = adminClient.realm(bc.consumerRealmName()).clients().findByClientId("broker-app").get(0).getId();
+        String consumerClientBrokerAppId = adminClient.realm(bc.consumerRealmName()).clients().findClientByClientId("broker-app").orElseThrow().getId();
         List<UserSessionRepresentation> brokeredSessions = adminClient.realm(bc.consumerRealmName()).clients().get(consumerClientBrokerAppId).getUserSessions(0, 10);
 
         final List<UserRepresentation> persistentUsers = adminClient.realm(bc.consumerRealmName()).users().list();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractDefaultIdpTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractDefaultIdpTest.java
@@ -54,11 +54,9 @@ public abstract class AbstractDefaultIdpTest extends AbstractInitializedBaseBrok
         super.beforeBrokerTest();
         // Require broker to show consent screen
         RealmResource brokeredRealm = adminClient.realm(bc.providerRealmName());
-        List<ClientRepresentation> clients = brokeredRealm.clients().findByClientId(bc.getIDPClientIdInProviderRealm());
-        org.junit.Assert.assertEquals(1, clients.size());
-        ClientRepresentation brokerApp = clients.get(0);
-        brokerApp.setConsentRequired(true);
-        brokeredRealm.clients().get(brokerApp.getId()).update(brokerApp);
+        ClientRepresentation client = brokeredRealm.clients().findClientByClientId(bc.getIDPClientIdInProviderRealm()).orElseThrow();
+        client.setConsentRequired(true);
+        brokeredRealm.clients().get(client.getId()).update(client);
     }
 
     @Test
@@ -163,9 +161,9 @@ public abstract class AbstractDefaultIdpTest extends AbstractInitializedBaseBrok
         if (defaultIdpValue != null && !defaultIdpValue.isEmpty()) {
             defaultIdpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, defaultIdpValue);
             newFlowAlias = "Browser - Default IdP " + defaultIdpValue;
-        }
-        else
+        } else {
             newFlowAlias = "Browser - Default IdP OFF";
+        }
 
         testingClient.server("consumer").run(session -> FlowUtil.inCurrentRealm(session).copyBrowserFlow(newFlowAlias));
         testingClient.server("consumer").run(session ->

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/JsonUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/JsonUserAttributeMapperTest.java
@@ -129,7 +129,7 @@ public class JsonUserAttributeMapperTest extends AbstractIdentityProviderMapperT
 
     private void updateClaimSentToIDP(String claim, String updatedValue) {
         ProtocolMapperRepresentation claimMapper = null;
-        final ClientRepresentation brokerClient = adminClient.realm(bc.providerRealmName()).clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
+        final ClientRepresentation brokerClient = adminClient.realm(bc.providerRealmName()).clients().findClientByClientId(BrokerTestConstants.CLIENT_ID).orElseThrow();
         ProtocolMappersResource protocolMappers = adminClient.realm(bc.providerRealmName()).clients().get(brokerClient.getId()).getProtocolMappers();
         for (ProtocolMapperRepresentation representation : protocolMappers.getMappers()) {
             if (representation.getProtocolMapper().equals(HardcodedClaim.PROVIDER_ID)) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerJWETest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerJWETest.java
@@ -149,7 +149,7 @@ public class KcOidcBrokerJWETest extends AbstractBrokerTest {
 
                 return realm;
             }
-            
+
             @Override
             public RealmRepresentation createProviderRealm() {
                 RealmRepresentation realm = super.createProviderRealm();
@@ -186,7 +186,7 @@ public class KcOidcBrokerJWETest extends AbstractBrokerTest {
 
     private void configureUserInfoEndpointMappers() {
         RealmResource providerRealm = realmsResouce().realm(bc.providerRealmName());
-        ClientRepresentation client = providerRealm.clients().findByClientId(bc.getIDPClientIdInProviderRealm()).get(0);
+        ClientRepresentation client = providerRealm.clients().findClientByClientId(bc.getIDPClientIdInProviderRealm()).orElseThrow();
 
         ProtocolMapperRepresentation claimMapper = new ProtocolMapperRepresentation();
         claimMapper.setName("custom-claim-hardcoded-mapper");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptNoneRedirectTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptNoneRedirectTest.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.testsuite.broker;
 
-import java.util.List;
 import java.util.Map;
 
 import org.keycloak.admin.client.resource.RealmResource;
@@ -37,8 +36,6 @@ import static org.keycloak.testsuite.broker.BrokerTestConstants.CLIENT_ID;
 import static org.keycloak.testsuite.broker.BrokerTestConstants.USER_EMAIL;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getProviderRoot;
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * This class tests the propagation of the {@code prompt=none} request parameter to a default IDP (if one has been specified)
@@ -191,11 +188,9 @@ public class KcOidcBrokerPromptNoneRedirectTest extends AbstractInitializedBaseB
     @Test
     public void testRequireConsentReturnsInteractionRequired() throws Exception {
         RealmResource brokeredRealm = adminClient.realm(bc.providerRealmName());
-        List<ClientRepresentation> clients = brokeredRealm.clients().findByClientId(CLIENT_ID);
-        assertEquals(1, clients.size());
-        ClientRepresentation brokerApp = clients.get(0);
-        brokerApp.setConsentRequired(true);
-        brokeredRealm.clients().get(brokerApp.getId()).update(brokerApp);
+        ClientRepresentation client = brokeredRealm.clients().findClientByClientId(CLIENT_ID).orElseThrow();
+        client.setConsentRequired(true);
+        brokeredRealm.clients().get(client.getId()).update(client);
         /* verify that the interaction_required error is returned with sending auth request to the consumer realm with prompt=none. */
         checkAuthWithPromptNoneReturnsInteractionRequired();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTest.java
@@ -188,7 +188,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
     private void loginFetchingUserFromUserEndpoint(boolean loginIsDenied) {
         RealmResource realm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = realm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
 
         try {
             IdentityProviderResource identityProviderResource = realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias());
@@ -249,7 +249,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
     public void loginFetchingUserFromUserEndpointWithClaimMapper() {
         RealmResource realm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = realm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
         IdentityProviderResource identityProviderResource = getIdentityProviderResource();
 
         clients.get(brokerApp.getId()).getProtocolMappers().createMapper(createHardcodedClaim("hard-coded", "hard-coded", "hard-coded", "String", true, true, true)).close();
@@ -293,8 +293,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
         waitForPage(driver, "sign in to", true);
 
         RealmResource realm = adminClient.realm(bc.providerRealmName());
-        ClientRepresentation rep = realm.clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
-        ClientResource clientResource = realm.clients().get(rep.getId());
+        ClientResource clientResource = realm.clients().getByClientId(BrokerTestConstants.CLIENT_ID);
         ProtocolMapperRepresentation hardCodedAzp = createHardcodedClaim("hard", "azp", "invalid-azp", ProviderConfigProperty.STRING_TYPE, true, true, true);
         clientResource.getProtocolMappers().createMapper(hardCodedAzp);
 
@@ -356,8 +355,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
         waitForPage(driver, "sign in to", true);
 
         RealmResource realm = adminClient.realm(bc.providerRealmName());
-        ClientRepresentation rep = realm.clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
-        ClientResource clientResource = realm.clients().get(rep.getId());
+        ClientResource clientResource = realm.clients().getByClientId(BrokerTestConstants.CLIENT_ID);
         ProtocolMapperRepresentation hardCodedAzp = createHardcodedClaim("hard", "aud", "invalid-aud", ProviderConfigProperty.LIST_TYPE, true, true, true);
         clientResource.getProtocolMappers().createMapper(hardCodedAzp);
 
@@ -613,6 +611,7 @@ public final class KcOidcBrokerTest extends AbstractAdvancedBrokerTest {
         assertThat(users, Matchers.empty());
     }
 
+    @Override
     protected void postInitializeUser(UserRepresentation user) {
         user.setAttributes(ImmutableMap.<String, List<String>>builder()
                 .put(USER_ATTRIBUTE_NAME, ImmutableList.<String>builder().add(USER_ATTRIBUTE_VALUE).build())

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTokenExchangeTest.java
@@ -106,7 +106,7 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
 
         ClientRepresentation brokerApp = realmsResouce().realm(bc.providerRealmName())
                 .clients()
-                .findByClientId("brokerapp").get(0);
+                .findClientByClientId("brokerapp").orElseThrow();
         org.keycloak.testsuite.util.oauth.AccessTokenResponse tokenResponse = oauth.realm(bc.providerRealmName()).client(brokerApp.getClientId(), brokerApp.getSecret()).doPasswordGrantRequest(bc.getUserLogin(), bc.getUserPassword());
         assertThat(tokenResponse.getIdToken(), notNullValue());
 
@@ -133,7 +133,7 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
     private void assertExternalToInternalExchange(String subjectIssuer, boolean idToken, boolean userInfo) throws Exception {
         RealmResource providerRealm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = providerRealm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
         brokerApp.setDirectAccessGrantsEnabled(true);
         ClientResource brokerAppResource = providerRealm.clients().get(brokerApp.getId());
         brokerAppResource.update(brokerApp);
@@ -170,7 +170,7 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
 
         testingClient.server(BrokerTestConstants.REALM_CONS_NAME).run(KcOidcBrokerTokenExchangeTest::setupRealm);
 
-        ClientRepresentation client = consumerRealm.clients().findByClientId("test-app").get(0);
+        ClientRepresentation client = consumerRealm.clients().findClientByClientId("test-app").orElseThrow();
 
         try (Client httpClient = AdminClientUtil.createResteasyClient()) {
             WebTarget exchangeUrl = getConsumerTokenEndpoint(httpClient);
@@ -276,7 +276,7 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
         testingClient.server(BrokerTestConstants.REALM_CONS_NAME).run(KcOidcBrokerTokenExchangeTest::setupRealm);
         RealmResource providerRealm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = providerRealm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
         brokerApp.setDirectAccessGrantsEnabled(true);
         ClientResource brokerAppResource = providerRealm.clients().get(brokerApp.getId());
         brokerAppResource.update(brokerApp);
@@ -316,7 +316,7 @@ public class KcOidcBrokerTokenExchangeTest extends AbstractInitializedBaseBroker
         testingClient.server(BrokerTestConstants.REALM_CONS_NAME).run(KcOidcBrokerTokenExchangeTest::setupRealm);
         RealmResource providerRealm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = providerRealm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
         brokerApp.setDirectAccessGrantsEnabled(true);
         ClientResource brokerAppResource = providerRealm.clients().get(brokerApp.getId());
         brokerAppResource.update(brokerApp);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTransientSessionsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerTransientSessionsTest.java
@@ -181,7 +181,7 @@ public final class KcOidcBrokerTransientSessionsTest extends AbstractAdvancedBro
         loginPage.open(bc.consumerRealmName());
         logInAsUserInIDPForFirstTime();
 
-        String consumerClientBrokerAppId = adminClient.realm(bc.consumerRealmName()).clients().findByClientId("broker-app").get(0).getId();
+        String consumerClientBrokerAppId = adminClient.realm(bc.consumerRealmName()).clients().findClientByClientId("broker-app").orElseThrow().getId();
         String transientUserId = adminClient.realm(bc.consumerRealmName()).clients().get(consumerClientBrokerAppId).getUserSessions(0, 10).get(0).getUserId();
         assertThat(adminClient.realm(bc.consumerRealmName()).users().list(), empty());
 
@@ -223,7 +223,7 @@ public final class KcOidcBrokerTransientSessionsTest extends AbstractAdvancedBro
     private void loginFetchingUserFromUserEndpoint(boolean loginIsDenied) {
         RealmResource realm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = realm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
 
         try {
             IdentityProviderResource identityProviderResource = realmsResouce().realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias());
@@ -282,7 +282,7 @@ public final class KcOidcBrokerTransientSessionsTest extends AbstractAdvancedBro
     public void loginFetchingUserFromUserEndpointWithClaimMapper() {
         RealmResource realm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = realm.clients();
-        ClientRepresentation brokerApp = clients.findByClientId("brokerapp").get(0);
+        ClientRepresentation brokerApp = clients.findClientByClientId("brokerapp").orElseThrow();
         IdentityProviderResource identityProviderResource = getIdentityProviderResource();
 
         clients.get(brokerApp.getId()).getProtocolMappers().createMapper(createHardcodedClaim("hard-coded", "hard-coded", "hard-coded", "String", true, true, true)).close();
@@ -325,8 +325,7 @@ public final class KcOidcBrokerTransientSessionsTest extends AbstractAdvancedBro
         waitForPage(driver, "sign in to", true);
 
         RealmResource realm = adminClient.realm(bc.providerRealmName());
-        ClientRepresentation rep = realm.clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
-        ClientResource clientResource = realm.clients().get(rep.getId());
+        ClientResource clientResource = realm.clients().getByClientId(BrokerTestConstants.CLIENT_ID);
         ProtocolMapperRepresentation hardCodedAzp = createHardcodedClaim("hard", "azp", "invalid-azp", ProviderConfigProperty.STRING_TYPE, true, true, true);
         clientResource.getProtocolMappers().createMapper(hardCodedAzp);
 
@@ -349,8 +348,7 @@ public final class KcOidcBrokerTransientSessionsTest extends AbstractAdvancedBro
         waitForPage(driver, "sign in to", true);
 
         RealmResource realm = adminClient.realm(bc.providerRealmName());
-        ClientRepresentation rep = realm.clients().findByClientId(BrokerTestConstants.CLIENT_ID).get(0);
-        ClientResource clientResource = realm.clients().get(rep.getId());
+        ClientResource clientResource = realm.clients().getByClientId(BrokerTestConstants.CLIENT_ID);
         ProtocolMapperRepresentation hardCodedAzp = createHardcodedClaim("hard", "aud", "invalid-aud", ProviderConfigProperty.LIST_TYPE, true, true, true);
         clientResource.getProtocolMappers().createMapper(hardCodedAzp);
 
@@ -433,6 +431,7 @@ public final class KcOidcBrokerTransientSessionsTest extends AbstractAdvancedBro
         assertThat(users, Matchers.empty());
     }
 
+    @Override
     protected void postInitializeUser(UserRepresentation user) {
         user.setAttributes(ImmutableMap.<String, List<String>> builder()
                 .put(USER_ATTRIBUTE_NAME, ImmutableList.<String> builder().add(USER_ATTRIBUTE_VALUE).build())

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerWithConsentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerWithConsentTest.java
@@ -1,7 +1,5 @@
 package org.keycloak.testsuite.broker;
 
-import java.util.List;
-
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -31,9 +29,7 @@ public class KcOidcBrokerWithConsentTest extends AbstractInitializedBaseBrokerTe
         super.beforeBrokerTest();
         // Require broker to show consent screen
         RealmResource brokeredRealm = adminClient.realm(bc.providerRealmName());
-        List<ClientRepresentation> clients = brokeredRealm.clients().findByClientId("brokerapp");
-        org.junit.Assert.assertEquals(1, clients.size());
-        ClientRepresentation brokerApp = clients.get(0);
+        ClientRepresentation brokerApp = brokeredRealm.clients().findClientByClientId("brokerapp").orElseThrow();
         brokerApp.setConsentRequired(true);
         brokeredRealm.clients().get(brokerApp.getId()).update(brokerApp);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlIdPInitiatedSsoTest.java
@@ -520,7 +520,7 @@ public class KcSamlIdPInitiatedSsoTest extends AbstractKeycloakTest {
         Map<String, String> clientSessions = userSessions.get(0).getClients();
 
         Set<String> clientIds = clientSessions.values().stream()
-          .flatMap(c -> clients.findByClientId(c).stream())
+          .map(c -> clients.findClientByClientId(c).orElseThrow())
           .map(ClientRepresentation::getClientId)
           .collect(Collectors.toSet());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlXPathAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcSamlXPathAttributeMapperTest.java
@@ -8,7 +8,6 @@ import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
 import org.keycloak.models.IdentityProviderMapperModel;
 import org.keycloak.protocol.saml.mappers.AttributeStatementHelper;
 import org.keycloak.protocol.saml.mappers.HardcodedAttributeMapper;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -55,9 +54,7 @@ public class KcSamlXPathAttributeMapperTest extends AbstractInitializedBaseBroke
         protocolMapper.getConfig().put(AttributeStatementHelper.SAML_ATTRIBUTE_NAME, "xml-name");
         protocolMapper.getConfig().put(AttributeStatementHelper.SAML_ATTRIBUTE_NAMEFORMAT, AttributeStatementHelper.BASIC);
 
-        ClientRepresentation clientRepresentation = realm.clients().findByClientId(bc.getIDPClientIdInProviderRealm())
-                .get(0);
-        realm.clients().get(clientRepresentation.getId()).getProtocolMappers().createMapper(protocolMapper).close();
+        realm.clients().getByClientId(bc.getIDPClientIdInProviderRealm()).getProtocolMappers().createMapper(protocolMapper).close();
 
         addXpathMapper("firstName");
         addXpathMapper("lastName");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcClaimToUserSessionNoteMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcClaimToUserSessionNoteMapperTest.java
@@ -54,7 +54,7 @@ public class OidcClaimToUserSessionNoteMapperTest extends AbstractIdentityProvid
     public void setup() {
         RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
 
-        consumerClientRep = consumerRealm.clients().findByClientId("broker-app").get(0);
+        consumerClientRep = consumerRealm.clients().findClientByClientId("broker-app").orElseThrow();
 
         setupIdentityProvider();
         // initialize the user with firstName and lastName, to avoid having to complete account data after login
@@ -72,7 +72,7 @@ public class OidcClaimToUserSessionNoteMapperTest extends AbstractIdentityProvid
                 .createMapper(consumerSessionNoteToClaimMapper));
 
         RealmResource providerRealm = adminClient.realm(bc.providerRealmName());
-        ClientRepresentation providerClientRep = providerRealm.clients().findByClientId("brokerapp").get(0);
+        ClientRepresentation providerClientRep = providerRealm.clients().findClientByClientId("brokerapp").orElseThrow();
         providerClientUuid = providerClientRep.getId();
 
         ProtocolMapperRepresentation providerHardcodedClaimMapper = new ProtocolMapperRepresentation();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/registration/KcRegCreateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cli/registration/KcRegCreateTest.java
@@ -262,7 +262,7 @@ public class KcRegCreateTest extends AbstractRegCliTest {
 
             RealmResource realm = adminClient.realm("test");
             ClientsResource clients = realm.clients();
-            ClientRepresentation clientRep = clients.findByClientId("authz-client").get(0);
+            ClientRepresentation clientRep = clients.findClientByClientId("authz-client").orElseThrow();
 
             ClientResource client = clients.get(clientRep.getId());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/MutualTLSClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/MutualTLSClientTest.java
@@ -287,7 +287,7 @@ public class MutualTLSClientTest extends AbstractTestRealmKeycloakTest {
    }
 
    private void disableClient(String clientId) {
-      ClientRepresentation disabledClientRepresentation = adminClient.realm(REALM).clients().findByClientId(clientId).get(0);
+      ClientRepresentation disabledClientRepresentation = adminClient.realm(REALM).clients().findClientByClientId(clientId).orElseThrow();
       ClientResource disabledClientResource = adminClient.realms().realm(REALM).clients().get(disabledClientRepresentation.getId());
       disabledClientRepresentation.setEnabled(false);
       disabledClientResource.update(disabledClientRepresentation);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -85,6 +85,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         samlApp.setDirectAccessGrantsEnabled(true);
     }
 
+    @Override
     @Before
     public void before() throws Exception {
         super.before();
@@ -704,7 +705,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         reg.auth(Auth.token(response));
         assertNotNull(reg.oidc().get(response.getClientId()));
         ClientsResource clientsResource = adminClient.realm(TEST).clients();
-        ClientRepresentation client = clientsResource.findByClientId(response.getClientId()).get(0);
+        ClientRepresentation client = clientsResource.findClientByClientId(response.getClientId()).orElseThrow();
 
         // change client to saml
         client.setProtocol("saml");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/SAMLClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/SAMLClientRegistrationTest.java
@@ -65,6 +65,7 @@ public class SAMLClientRegistrationTest extends AbstractClientRegistrationTest {
         samlApp.setDirectAccessGrantsEnabled(true);
     }
 
+    @Override
     @Before
     public void before() throws Exception {
         super.before();
@@ -82,10 +83,10 @@ public class SAMLClientRegistrationTest extends AbstractClientRegistrationTest {
     @Test
     public void testSAMLEndpointCreateWithOIDCClient() throws Exception {
         ClientsResource clientsResource = adminClient.realm(TEST).clients();
-        ClientRepresentation oidcClient = clientsResource.findByClientId("oidc-client").get(0);
+        ClientRepresentation oidcClient = clientsResource.findClientByClientId("oidc-client").orElseThrow();
         String oidcClientServiceId = clientsResource.get(oidcClient.getId()).getServiceAccountUser().getId();
 
-        String realmManagementId = clientsResource.findByClientId("realm-management").get(0).getId();
+        String realmManagementId = clientsResource.findClientByClientId("realm-management").orElseThrow().getId();
         RoleRepresentation role = clientsResource.get(realmManagementId).roles().get("create-client").toRepresentation();
 
         adminClient.realm(TEST).users().get(oidcClientServiceId).roles().clientLevel(realmManagementId).add(Arrays.asList(role));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExtendedEventTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExtendedEventTest.java
@@ -76,8 +76,6 @@ import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientRolesCo
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientScopesConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionExecutorConfig;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -196,7 +194,7 @@ public class ClientPoliciesExtendedEventTest extends AbstractClientPoliciesTest 
             assertEquals(ClientPolicyEvent.REGISTERED.toString(), cpe.getError());
         }
 
-        assertThat(adminClient.realm(REALM_NAME).clients().findByClientId(clientName), empty());
+        assertNull(adminClient.realm(REALM_NAME).clients().findClientByClientId(clientName).orElse(null));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SamlClientPoliciesExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SamlClientPoliciesExecutorTest.java
@@ -127,7 +127,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
             testSamlSecureClient(client, c -> realm.clients().create(c));
             // create it
             testClientOperation(client, null, c -> realm.clients().create(c));
-            clientId = realm.clients().findByClientId(client.getClientId()).iterator().next().getId();
+            clientId = realm.clients().findClientByClientId(client.getClientId()).orElseThrow().getId();
             client.setId(clientId);
             // test update fails for non-https urls
             testSamlSecureClient(client, c -> updateClient(realm, c));
@@ -155,7 +155,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
 
             // create a client without the executor enabled
             testClientOperation(client, null, c -> realm.clients().create(c));
-            clientId = realm.clients().findByClientId(client.getClientId()).iterator().next().getId();
+            clientId = realm.clients().findClientByClientId(client.getClientId()).orElseThrow().getId();
 
             // enable the policy and check redirect is not allowed
             createClientProfileAndPolicyToTest(SamlAvoidRedirectBindingExecutorFactory.PROVIDER_ID, null);
@@ -168,7 +168,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
             client.getAttributes().put(SamlConfigAttributes.SAML_FORCE_POST_BINDING, Boolean.TRUE.toString());
             testClientOperation(client, null, c -> realm.clients().create(c));
             // update without post binding fails
-            clientId = realm.clients().findByClientId(client.getClientId()).iterator().next().getId();
+            clientId = realm.clients().findClientByClientId(client.getClientId()).orElseThrow().getId();
             client.setId(clientId);
             client.getAttributes().put(SamlConfigAttributes.SAML_FORCE_POST_BINDING, Boolean.FALSE.toString());
             testClientOperation(client, "Force POST binding is not enabled", c -> updateClient(realm, client));
@@ -195,7 +195,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
 
             // create a client without client signature
             testClientOperation(client, null, c -> realm.clients().create(c));
-            clientId = realm.clients().findByClientId(client.getClientId()).iterator().next().getId();
+            clientId = realm.clients().findClientByClientId(client.getClientId()).orElseThrow().getId();
 
             // enable the policy and check login without signature is not allowed
             createClientProfileAndPolicyToTest(SamlSignatureEnforcerExecutorFactory.PROVIDER_ID, null);
@@ -215,7 +215,7 @@ public class SamlClientPoliciesExecutorTest extends AbstractTestRealmKeycloakTes
             testSamlAttributeOperation(client, null,
                     SamlConfigAttributes.SAML_SERVER_SIGNATURE,
                     Boolean.TRUE.toString(), Boolean.TRUE.toString(), c -> realm.clients().create(c));
-            clientId = realm.clients().findByClientId(client.getClientId()).iterator().next().getId();
+            clientId = realm.clients().findClientByClientId(client.getClientId()).orElseThrow().getId();
             client.setId(clientId);
 
             // test update

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/cookies/CookieTest.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -99,7 +99,7 @@ public class CookieTest extends AbstractKeycloakTest {
     }
 
     private void testCookieValue(String cookieName) throws Exception {
-        final String accountClientId = realmsResouce().realm("test").clients().findByClientId("test-app").get(0).getId();
+        final String accountClientId = realmsResouce().realm("test").clients().findClientByClientId("test-app").orElseThrow().getId();
         final String clientSecret = realmsResouce().realm("test").clients().get(accountClientId).getSecret().getValue();
 
         AuthorizationEndpointResponse codeResponse = oauth.client("test-app", clientSecret).redirectUri(oauth.APP_AUTH_ROOT).doLogin("test-user@localhost", "password");
@@ -136,7 +136,7 @@ public class CookieTest extends AbstractKeycloakTest {
 
     @Test
     public void testCookieValueLoggedOut() throws Exception {
-        final String accountClientId = realmsResouce().realm("test").clients().findByClientId("test-app").get(0).getId();
+        final String accountClientId = realmsResouce().realm("test").clients().findClientByClientId("test-app").orElseThrow().getId();
         final String clientSecret = realmsResouce().realm("test").clients().get(accountClientId).getSecret().getValue();
 
         AuthorizationEndpointResponse codeResponse = oauth.client("test-app", clientSecret).redirectUri(oauth.APP_AUTH_ROOT).doLogin("test-user@localhost", "password");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -492,7 +492,7 @@ public class ExportImportTest extends AbstractKeycloakTest {
         KeysMetadataRepresentation keyMetadata = adminClient.realm("test").keys().getKeyMetadata();
         String sampleRealmRoleId = adminClient.realm("test").roles().get("sample-realm-role").toRepresentation().getId();
         Map<String, List<String>> roleAttributes = adminClient.realm("test").roles().get("attribute-role").toRepresentation().getAttributes();
-        String testAppId = adminClient.realm("test").clients().findByClientId("test-app").get(0).getId();
+        String testAppId = adminClient.realm("test").clients().findClientByClientId("test-app").orElseThrow().getId();
         String sampleClientRoleId = adminClient.realm("test").clients().get(testAppId).roles().get("sample-client-role").toRepresentation().getId();
         String sampleClientRoleAttribute = adminClient.realm("test").clients().get(testAppId).roles().get("sample-client-role").toRepresentation().getAttributes().get("sample-client-role-attribute").get(0);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BrowserFlowTest.java
@@ -435,7 +435,7 @@ public class BrowserFlowTest extends AbstractChangeImportedUserPasswordsTest {
     public void testConditionalRoleAuthenticatorWithClientRoleIncludedInCompositeClientRole() {
 
         String clientName = "test-app";
-        ClientRepresentation testClient = testRealm().clients().findByClientId(clientName).get(0);
+        ClientRepresentation testClient = testRealm().clients().findClientByClientId(clientName).orElseThrow();
 
         // Create composite-client-role-1
         String compositeClientRoleName = "composite-client-role-1";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/FlowOverrideTest.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.testsuite.forms;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -335,8 +334,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
     @Test
     public void testRestInterface() throws Exception {
         ClientsResource clients = adminClient.realm("test").clients();
-        List<ClientRepresentation> query = clients.findByClientId(TEST_APP_DIRECT_OVERRIDE);
-        ClientRepresentation clientRep = query.get(0);
+        ClientRepresentation clientRep = clients.findClientByClientId(TEST_APP_DIRECT_OVERRIDE).orElseThrow();
         String directGrantFlowId = clientRep.getAuthenticationFlowBindingOverrides().get(AuthenticationFlowBindings.DIRECT_GRANT_BINDING);
         Assert.assertNotNull(directGrantFlowId);
         clientRep.getAuthenticationFlowBindingOverrides().put(AuthenticationFlowBindings.DIRECT_GRANT_BINDING, "");
@@ -346,8 +344,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
         clients.get(clientRep.getId()).update(clientRep);
         testGrantAccessTokenWithClientOverride();
 
-        query = clients.findByClientId(TEST_APP_FLOW);
-        clientRep = query.get(0);
+        clientRep = clients.findClientByClientId(TEST_APP_FLOW).orElseThrow();
         String browserFlowId = clientRep.getAuthenticationFlowBindingOverrides().get(AuthenticationFlowBindings.BROWSER_BINDING);
         Assert.assertNotNull(browserFlowId);
         clientRep.getAuthenticationFlowBindingOverrides().put(AuthenticationFlowBindings.BROWSER_BINDING, "");
@@ -362,8 +359,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
     @UncaughtServerErrorExpected
     public void testRestInterfaceWithBadId() throws Exception {
         ClientsResource clients = adminClient.realm("test").clients();
-        List<ClientRepresentation> query = clients.findByClientId(TEST_APP_FLOW);
-        ClientRepresentation clientRep = query.get(0);
+        ClientRepresentation clientRep = clients.findClientByClientId(TEST_APP_FLOW).orElseThrow();
         String browserFlowId = clientRep.getAuthenticationFlowBindingOverrides().get(AuthenticationFlowBindings.BROWSER_BINDING);
 
         clientRep.getAuthenticationFlowBindingOverrides().put(AuthenticationFlowBindings.BROWSER_BINDING, "bad-id");
@@ -373,8 +369,7 @@ public class FlowOverrideTest extends AbstractFlowTest {
         } catch (Exception e) {
 
         }
-        query = clients.findByClientId(TEST_APP_FLOW);
-        clientRep = query.get(0);
+        clientRep = clients.findClientByClientId(TEST_APP_FLOW).orElseThrow();
         Assert.assertEquals(browserFlowId, clientRep.getAuthenticationFlowBindingOverrides().get(AuthenticationFlowBindings.BROWSER_BINDING));
 
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RPInitiatedFrontChannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RPInitiatedFrontChannelLogoutTest.java
@@ -41,7 +41,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractChangeImportedUse
     @Test
     public void testFrontChannelLogoutWithPostLogoutRedirectUri() throws Exception {
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
         rep.setFrontchannelLogout(true);
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout");
         clients.get(rep.getId()).update(rep);
@@ -69,7 +69,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractChangeImportedUse
     @Test
     public void testFrontChannelLogoutWithoutSessionRequired() throws Exception {
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
         rep.setFrontchannelLogout(true);
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout");
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_SESSION_REQUIRED, "false");
@@ -97,7 +97,7 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractChangeImportedUse
     @Test
     public void testFrontChannelLogout() throws Exception {
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
         rep.setName("My Testing App");
         rep.setFrontchannelLogout(true);
         rep.getAttributes().put(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ThemeSelectorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ThemeSelectorTest.java
@@ -27,7 +27,7 @@ public class ThemeSelectorTest extends AbstractTestRealmKeycloakTest {
         loginPage.open();
         assertEquals(System.getProperty(PROPERTY_LOGIN_THEME_DEFAULT, SYSTEM_DEFAULT_LOGIN_THEME), detectTheme());
 
-        ClientRepresentation rep = testRealm().clients().findByClientId("test-app").get(0);
+        ClientRepresentation rep = testRealm().clients().findClientByClientId("test-app").orElseThrow();
 
         try {
             rep.getAttributes().put("login_theme", "base");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -272,7 +272,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
     @Test
     public void testTokenResponseUsingLowerCaseType() throws Exception {
         ClientsResource clients = realmsResouce().realm("test").clients();
-        ClientRepresentation client = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation client = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
 
         OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setUseLowerCaseInTokenResponse(true);
 
@@ -294,7 +294,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
     @Test
     public void testTokenResponseUsingRfc9068HeaderType() throws Exception {
         ClientsResource clients = realmsResouce().realm("test").clients();
-        ClientRepresentation client = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation client = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
 
         OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setUseRfc9068AccessTokenHeaderType(true);
         clients.get(client.getId()).update(client);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutTest.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.IdentityProviderResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.common.util.Base64Url;
@@ -124,12 +123,11 @@ public class BackchannelLogoutTest extends AbstractNestedBrokerTest {
         RealmResource realmResourceConsumerRealm = adminClient.realm(nbc.consumerRealmName());
         realmIdConsumerRealm = realmResourceConsumerRealm.toRepresentation().getId();
         accountClientIdConsumerRealm =
-                adminClient.realm(nbc.consumerRealmName()).clients().findByClientId(OidcBackchannelLogoutBrokerConfiguration.CONSUMER_CLIENT_ID).get(0).getId();
+                adminClient.realm(nbc.consumerRealmName()).clients().findClientByClientId(OidcBackchannelLogoutBrokerConfiguration.CONSUMER_CLIENT_ID).orElseThrow().getId();
 
         RealmResource realmResourceSubConsumerRealm = adminClient.realm(nbc.subConsumerRealmName());
         accountClientIdSubConsumerRealm =
-                adminClient.realm(nbc.subConsumerRealmName()).clients().findByClientId(ACCOUNT_CLIENT_NAME).get(0)
-                        .getId();
+                adminClient.realm(nbc.subConsumerRealmName()).clients().findClientByClientId(ACCOUNT_CLIENT_NAME).orElseThrow().getId();
     }
 
     @Before
@@ -804,12 +802,7 @@ public class BackchannelLogoutTest extends AbstractNestedBrokerTest {
     }
 
     private ClientResource getByClientId(String realmName, String clientId) {
-        final ClientsResource c = adminClient.realm(realmName).clients();
-        ClientResource ipdClientResource = c.findByClientId(clientId).stream()
-          .findAny()
-          .map(rep -> c.get(rep.getId()))
-          .orElseThrow(IllegalArgumentException::new);
-        return ipdClientResource;
+        return adminClient.realm(realmName).clients().getByClientId(clientId);
     }
 
     private void disableClient(String realmName, String clientUuid) {
@@ -841,9 +834,6 @@ public class BackchannelLogoutTest extends AbstractNestedBrokerTest {
     }
 
     private String getClientId(String realm, String clientId) {
-        return adminClient.realm(realm).clients().findByClientId(clientId).stream()
-         .findAny()
-         .map(ClientRepresentation::getId)
-         .orElse(null);
+        return adminClient.realm(realm).clients().findClientByClientId(clientId).orElseThrow().getId();
    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LoginStatusIframeEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LoginStatusIframeEndpointTest.java
@@ -171,7 +171,7 @@ public class LoginStatusIframeEndpointTest extends AbstractKeycloakTest {
 
     @Test
     public void checkIframeWildcardOrigin() throws IOException {
-        String id = adminClient.realm("master").clients().findByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID).get(0).getId();
+        String id = adminClient.realm("master").clients().findClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID).orElseThrow().getId();
         ClientResource master = adminClient.realm("master").clients().get(id);
         ClientRepresentation rep = master.toRepresentation();
         List<String> org = rep.getWebOrigins();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -350,7 +350,7 @@ public class LogoutTest extends AbstractKeycloakTest {
     @Test
     public void successfulKLogoutAfterEmptyBackChannelUrl() throws Exception {
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
 
         rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "");
 
@@ -387,7 +387,7 @@ public class LogoutTest extends AbstractKeycloakTest {
     @Test
     public void backChannelPreferenceOverKLogout() throws Exception {
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
 
         rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, oauth.APP_ROOT + "/admin/backchannelLogout");
 
@@ -427,7 +427,7 @@ public class LogoutTest extends AbstractKeycloakTest {
     @Test
     public void backChannelWithPairwiseLogout() throws Exception {
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
 
         rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, oauth.APP_ROOT + "/admin/backchannelLogout");
         List<ProtocolMapperRepresentation> mappers = new LinkedList<>();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuth2DeviceAuthorizationGrantTest.java
@@ -492,8 +492,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
     public void testPublicClientConsentWithoutScopes() throws Exception {
 
         ClientsResource clients = realmsResouce().realm(REALM_NAME).clients();
-        ClientRepresentation clientRep = clients.findByClientId(DEVICE_APP_WITHOUT_SCOPES).get(0);
-        ClientResource client =  clients.get(clientRep.getId());
+        ClientResource client =  clients.getByClientId(DEVICE_APP_WITHOUT_SCOPES);
 
         List<ClientScopeRepresentation> defaultClientScopes =  client.getDefaultClientScopes();
         defaultClientScopes.forEach(scope -> client.removeDefaultClientScope(scope.getId()));
@@ -577,7 +576,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
         grantPage.cancel();
 
         verificationPage.assertDeniedPage();
- 
+
         AccessTokenResponse tokenResponse = oauth.device().doDeviceTokenRequest(response.getDeviceCode());
 
         Assert.assertEquals(400, tokenResponse.getStatusCode());
@@ -734,7 +733,7 @@ public class OAuth2DeviceAuthorizationGrantTest extends AbstractKeycloakTest {
         oauth.realm(REALM_NAME);
         oauth.client(DEVICE_APP_PUBLIC);
         DeviceAuthorizationResponse response = doDeviceAuthorizationWithDuplicatedParams(DEVICE_APP_PUBLIC, null);
-        
+
         Assert.assertEquals(400, response.getStatusCode());
         Assert.assertEquals("invalid_grant", response.getError());
         Assert.assertEquals("duplicated parameter", response.getErrorDescription());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthScopeInTokenResponseTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthScopeInTokenResponseTest.java
@@ -50,28 +50,28 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
         String clientSecret = "password";
 
     	String expectedScope = "openid profile email";
-    	
+
         oauth.doLogin(loginUser, loginPassword);
 
         String code = oauth.parseLoginResponse().getCode();
-        
+
         expectSuccessfulResponseFromTokenEndpoint(code, expectedScope);
     }
-    
+
     @Test
     public void specifyEmptyScopeTest() throws Exception {
         String loginUser = "john-doh@localhost";
         String loginPassword = "password";
         String clientSecret = "password";
-        
+
     	String requestedScope = "";
     	String expectedScope = "openid profile email";
-    	
+
     	oauth.scope(requestedScope);
         oauth.doLogin(loginUser, loginPassword);
 
         String code = oauth.parseLoginResponse().getCode();
-        
+
         expectSuccessfulResponseFromTokenEndpoint(code, expectedScope);
     }
 
@@ -82,16 +82,15 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
         String clientSecret = "password";
 
         ClientsResource clients = realmsResouce().realm("test").clients();
-        ClientRepresentation clientRep = clients.findByClientId(oauth.getClientId()).get(0);
-        ClientResource client = clients.get(clientRep.getId());
+        ClientResource client = clients.getByClientId(oauth.getClientId());
         List<ClientScopeRepresentation> scopes = client.getDefaultClientScopes();
 
         for (ClientScopeRepresentation scope : scopes) {
-            client.removeDefaultClientScope(scope.getId());                        
+            client.removeDefaultClientScope(scope.getId());
         }
 
         oauth.openid(false);
-        
+
         oauth.scope("user openid phone");
         oauth.openLoginForm();
         MultivaluedHashMap<String, String> queryParams = UriUtils.decodeQueryString(new URL(driver.getCurrentUrl()).getQuery());
@@ -126,7 +125,7 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
         String loginPassword = "password";
 
         ClientsResource clients = realmsResouce().realm("test").clients();
-        ClientRepresentation clientRep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation clientRep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
         clientRep.setDirectAccessGrantsEnabled(true);
         ClientResource client = clients.get(clientRep.getId());
         client.update(clientRep);
@@ -140,7 +139,7 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
         oauth.openid(false);
         oauth.scope("user phone");
         AccessTokenResponse response = oauth.doPasswordGrantRequest(loginUser, loginPassword);
-        
+
         assertNotNull(response.getError());
         assertEquals(OAuthErrorException.INVALID_SCOPE, response.getError());
 
@@ -159,21 +158,21 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
             client.addDefaultClientScope(scope.getId());
         }
     }
-    
+
     @Test
     public void specifyMultipleScopeTest() throws Exception {
         String loginUser = "rich.roles@redhat.com";
         String loginPassword = "password";
         String clientSecret = "password";
-        
+
     	String requestedScope = "address";
     	String expectedScope = "openid profile email address";
-    	
+
     	oauth.scope(requestedScope);
         oauth.doLogin(loginUser, loginPassword);
 
         String code = oauth.parseLoginResponse().getCode();
-        
+
         expectSuccessfulResponseFromTokenEndpoint(code, expectedScope);
     }
 
@@ -197,12 +196,12 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
         // Login without 'user' scope
     	String requestedScope = "address phone";
     	String expectedScope = "openid profile email address phone";
-    	
+
     	oauth.scope(requestedScope);
         oauth.doLogin(loginUser, loginPassword);
 
         String code = oauth.parseLoginResponse().getCode();
-        
+
         expectSuccessfulResponseFromTokenEndpoint(code, expectedScope);
 
         // Login with 'user' scope
@@ -219,7 +218,7 @@ public class OAuthScopeInTokenResponseTest extends AbstractKeycloakTest {
         // Cleanup
         ApiUtil.findClientResourceByClientId(realmsResouce().realm("test"), "test-app").removeOptionalClientScope(userScopeId);
     }
-    
+
     private void expectSuccessfulResponseFromTokenEndpoint(String code, String expectedScope) throws Exception {
     	AccessTokenResponse response = oauth.doAccessTokenRequest(code);
         assertEquals(200, response.getStatusCode());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationTest.java
@@ -136,8 +136,8 @@ public class TokenRevocationTest extends AbstractKeycloakTest {
         List<UserSessionRepresentation> userSessions = testUser.getUserSessions();
         assertEquals(1, userSessions.size());
         Map<String, String> clients = userSessions.get(0).getClients();
-        assertEquals("test-app", clients.get(realm.clients().findByClientId("test-app").get(0).getId()));
-        assertEquals("test-app-scope", clients.get(realm.clients().findByClientId("test-app-scope").get(0).getId()));
+        assertEquals("test-app", clients.get(realm.clients().findClientByClientId("test-app").orElseThrow().getId()));
+        assertEquals("test-app-scope", clients.get(realm.clients().findClientByClientId("test-app-scope").orElseThrow().getId()));
 
         isTokenEnabled(tokenResponse1, "test-app");
         isTokenEnabled(tokenResponse2, "test-app-scope");
@@ -148,8 +148,8 @@ public class TokenRevocationTest extends AbstractKeycloakTest {
         userSessions = testUser.getUserSessions();
         assertEquals(1, userSessions.size());
         clients = userSessions.get(0).getClients();
-        assertNull(clients.get(realm.clients().findByClientId("test-app").get(0).getId()));
-        assertEquals("test-app-scope", clients.get(realm.clients().findByClientId("test-app-scope").get(0).getId()));
+        assertNull(clients.get(realm.clients().findClientByClientId("test-app").orElseThrow().getId()));
+        assertEquals("test-app-scope", clients.get(realm.clients().findClientByClientId("test-app-scope").orElseThrow().getId()));
 
         isTokenDisabled(tokenResponse1, "test-app");
         isTokenEnabled(tokenResponse2, "test-app-scope");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ExternalInternalTokenExchangeV2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/ExternalInternalTokenExchangeV2Test.java
@@ -307,6 +307,6 @@ public class ExternalInternalTokenExchangeV2Test extends AbstractInitializedBase
     private ClientRepresentation getBrokerAppClient() {
         RealmResource providerRealm = realmsResouce().realm(bc.providerRealmName());
         ClientsResource clients = providerRealm.clients();
-        return clients.findByClientId("brokerapp").get(0);
+        return clients.findClientByClientId("brokerapp").orElseThrow();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV1Test.java
@@ -486,7 +486,7 @@ public class StandardTokenExchangeV1Test extends AbstractKeycloakTest {
         oauth.client("direct-legal", "secret");
         oauth.scope(OAuth2Constants.SCOPE_OPENID);
         ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientRepresentation rep = clients.findClientByClientId(oauth.getClientId()).orElseThrow();
         rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, oauth.APP_ROOT + "/admin/backchannelLogout");
         getCleanup().addCleanup(() -> {
             rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -206,8 +206,8 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
     public void setup() {
         CryptoIntegration.init(this.getClass().getClassLoader());
         httpClient = HttpClientBuilder.create().build();
-        client = testRealm().clients().findByClientId(clientId).get(0);
-        namedClient = testRealm().clients().findByClientId(namedClientId).get(0);
+        client = testRealm().clients().findClientByClientId(clientId).orElseThrow();
+        namedClient = testRealm().clients().findClientByClientId(namedClientId).orElseThrow();
 
         // Lookup the pre-installed oid4vc_natural_person client scope
         sdJwtTypeNaturalPersonClientScope = requireExistingClientScope(sdJwtTypeNaturalPersonScopeName);
@@ -476,7 +476,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
     }
 
     void setClientOid4vciEnabled(String clientId, boolean enabled) {
-        ClientRepresentation clientRepresentation = adminClient.realm(TEST_REALM_NAME).clients().findByClientId(clientId).get(0);
+        ClientRepresentation clientRepresentation = adminClient.realm(TEST_REALM_NAME).clients().findClientByClientId(clientId).orElseThrow();
         ClientResource clientResource = adminClient.realm(TEST_REALM_NAME).clients().get(clientRepresentation.getId());
 
         Map<String, String> attributes = new HashMap<>(clientRepresentation.getAttributes() != null ? clientRepresentation.getAttributes() : Map.of());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
@@ -143,7 +143,9 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
 
     private UserRepresentation findUser(RealmRepresentation testRealm, String userName) {
         for (UserRepresentation user : testRealm.getUsers()) {
-            if (user.getUsername().equals(userName)) return user;
+            if (user.getUsername().equals(userName)) {
+                return user;
+            }
         }
         return null;
     }
@@ -550,7 +552,7 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
         transientClient.setAttributes(new HashMap<>());
         transientClient.getAttributes().put(Constants.USE_LIGHTWEIGHT_ACCESS_TOKEN_ENABLED, String.valueOf(true));
         masterRealm.clients().create(transientClient);
-        transientClient = masterRealm.clients().findByClientId(transientClient.getClientId()).get(0);
+        transientClient = masterRealm.clients().findClientByClientId(transientClient.getClientId()).orElseThrow();
 
         UserRepresentation userRep = masterRealm.clients().get(transientClient.getId()).getServiceAccountUser();
         masterRealm.users().get(userRep.getId()).roles().realmLevel().add(Collections.singletonList(masterRealm.roles().get(AdminRoles.ADMIN).toRepresentation()));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -709,7 +709,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
             realm.update(rep);
 
             // do the same with client's notBefore
-            ClientResource clientResource = realm.clients().get(realm.clients().findByClientId("test-app").get(0).getId());
+            ClientResource clientResource = realm.clients().get(realm.clients().findClientByClientId("test-app").orElseThrow().getId());
             ClientRepresentation clientRep = clientResource.toRepresentation();
             clientRep.setNotBefore(time);
             clientResource.update(clientRep);
@@ -909,7 +909,7 @@ public class UserInfoTest extends AbstractKeycloakTest {
         String accessToken = oauth.client("saml-client", "secret").doPasswordGrantRequest( "test-user@localhost", "password").getAccessToken();
 
         // change client's protocol
-        ClientRepresentation samlClient = adminClient.realm("test").clients().findByClientId("saml-client").get(0);
+        ClientRepresentation samlClient = adminClient.realm("test").clients().findClientByClientId("saml-client").orElseThrow();
         samlClient.setProtocol("saml");
         adminClient.realm("test").clients().get(samlClient.getId()).update(samlClient);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -146,8 +146,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
     public void testOrganizationNotAddedByGroupMapper() throws Exception {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         addMember(organization);
-        ClientRepresentation client = testRealm().clients().findByClientId("direct-grant").get(0);
-        ClientResource clientResource = testRealm().clients().get(client.getId());
+        ClientResource clientResource = testRealm().clients().getByClientId("direct-grant");
         clientResource.getProtocolMappers().createMapper(createGroupMapper()).close();
 
         oauth.client("direct-grant", "password");
@@ -669,7 +668,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
         OrganizationRepresentation orgB = createOrganization("orgb", true);
         testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
-        ClientRepresentation client = testRealm().clients().findByClientId("broker-app").get(0);
+        ClientRepresentation client = testRealm().clients().findClientByClientId("broker-app").orElseThrow();
         client.setId(null);
         client.setClientId("broker-app2");
         testRealm().clients().create(client).close();
@@ -709,7 +708,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
     public void testReAuthenticationUserMemberOfSingleOrganizationUsingDifferentClient() {
         OrganizationRepresentation orgA = createOrganization("orga", true);
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
-        ClientRepresentation client = testRealm().clients().findByClientId("broker-app").get(0);
+        ClientRepresentation client = testRealm().clients().findClientByClientId("broker-app").orElseThrow();
         client.setId(null);
         client.setClientId("broker-app2");
         testRealm().clients().create(client).close();
@@ -738,7 +737,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         OrganizationRepresentation orgA = createOrganization("orga", true);
         MemberRepresentation member = addMember(testRealm().organizations().get(orgA.getId()), "member@" + orgA.getDomains().iterator().next().getName());
         testRealm().organizations().get(orgA.getId()).members().member(member.getId()).delete().close();
-        ClientRepresentation client = testRealm().clients().findByClientId("broker-app").get(0);
+        ClientRepresentation client = testRealm().clients().findClientByClientId("broker-app").orElseThrow();
         client.setId(null);
         client.setClientId("broker-app2");
         testRealm().clients().create(client).close();
@@ -843,7 +842,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         orgScope.setName("org");
         String createdId = ApiUtil.getCreatedId(testRealm().clientScopes().create(orgScope));
         testRealm().addDefaultDefaultClientScope(createdId);
-        ClientRepresentation client = testRealm().clients().findByClientId("broker-app").get(0);
+        ClientRepresentation client = testRealm().clients().findClientByClientId("broker-app").orElseThrow();
         testRealm().clients().get(client.getId()).addDefaultClientScope(createdId);
         getCleanup().addCleanup(() -> testRealm().clientScopes().get(createdId).remove());
 
@@ -887,7 +886,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         orgScope.setName("org");
         String createdId = ApiUtil.getCreatedId(testRealm().clientScopes().create(orgScope));
         testRealm().addDefaultDefaultClientScope(createdId);
-        ClientRepresentation client = testRealm().clients().findByClientId("broker-app").get(0);
+        ClientRepresentation client = testRealm().clients().findClientByClientId("broker-app").orElseThrow();
         testRealm().clients().get(client.getId()).addDefaultClientScope(createdId);
         getCleanup().addCleanup(() -> testRealm().clientScopes().get(createdId).remove());
 
@@ -917,8 +916,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         MemberRepresentation member = addMember(orgA, "member@" + orgARep.getDomains().iterator().next().getName());
         orgA.members().member(member.getId()).delete().close();
 
-        ClientRepresentation clientRep = testRealm().clients().findByClientId("broker-app").get(0);
-        ClientResource client = testRealm().clients().get(clientRep.getId());
+        ClientResource client = testRealm().clients().getByClientId("broker-app");
         ClientScopeRepresentation orgScopeRep = client.getOptionalClientScopes().stream().filter(scope -> "organization".equals(scope.getName())).findAny().orElse(null);
         client.removeOptionalClientScope(orgScopeRep.getId());
         client.addDefaultClientScope(orgScopeRep.getId());
@@ -964,7 +962,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         OrganizationRepresentation orgB = createOrganization("orgb", true);
         testRealm().organizations().get(orgB.getId()).members().addMember(member.getId()).close();
 
-        ClientRepresentation clientRep = testRealm().clients().findByClientId("broker-app").get(0);
+        ClientRepresentation clientRep = testRealm().clients().findClientByClientId("broker-app").orElseThrow();
         ClientResource client = testRealm().clients().get(clientRep.getId());
         ClientScopeRepresentation orgScopeRep = client.getOptionalClientScopes().stream().filter(scope -> "organization".equals(scope.getName())).findAny().orElse(null);
         orgScopeRep.setAttributes(Map.of(ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE, "false"));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingTest.java
@@ -755,7 +755,7 @@ public class ArtifactBindingTest extends AbstractSamlTest {
      // Won't work with openshift, because openshift wouldn't see ArtifactResolutionService
     @Test
     public void testSessionStateDuringArtifactBindingLogoutWithOneClient() {
-        ClientRepresentation salesRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0);
+        ClientRepresentation salesRep = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
         final String clientId = salesRep.getId();
 
         getCleanup()
@@ -823,10 +823,10 @@ public class ArtifactBindingTest extends AbstractSamlTest {
                     .update()
             );
 
-        ClientRepresentation salesRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0);
+        ClientRepresentation salesRep = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
         final String salesRepId = salesRep.getId();
 
-        ClientRepresentation salesRep2 = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST2).get(0);
+        ClientRepresentation salesRep2 = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST2).orElseThrow();
         final String salesRep2Id = salesRep2.getId();
 
         final AtomicReference<String> userSessionId = new AtomicReference<>();
@@ -1064,8 +1064,7 @@ public class ArtifactBindingTest extends AbstractSamlTest {
     public void testArtifactBindingIdentifierChangedWhenClientIdChanged() throws IOException {
         ClientRepresentation clientRepresentation = adminClient.realm(REALM_NAME)
                 .clients()
-                .findByClientId(SAML_CLIENT_ID_SALES_POST)
-                .get(0);
+                .findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
 
         String oldIdentifier = clientRepresentation.getAttributes().get(SamlConfigAttributes.SAML_ARTIFACT_BINDING_IDENTIFIER);
         assertThat(oldIdentifier, notNullValue());
@@ -1078,8 +1077,7 @@ public class ArtifactBindingTest extends AbstractSamlTest {
         ) {
             clientRepresentation = adminClient.realm(REALM_NAME)
                     .clients()
-                    .findByClientId(newClientId)
-                    .get(0);
+                    .findClientByClientId(newClientId).orElseThrow();
 
             String identifier = clientRepresentation.getAttributes().get(SamlConfigAttributes.SAML_ARTIFACT_BINDING_IDENTIFIER);
 
@@ -1089,8 +1087,7 @@ public class ArtifactBindingTest extends AbstractSamlTest {
 
         clientRepresentation = adminClient.realm(REALM_NAME)
                 .clients()
-                .findByClientId(SAML_CLIENT_ID_SALES_POST)
-                .get(0);
+                .findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
 
         assertThat(clientRepresentation.getAttributes().get(SamlConfigAttributes.SAML_ARTIFACT_BINDING_IDENTIFIER), equalTo(oldIdentifier));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AudienceProtocolMappersTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AudienceProtocolMappersTest.java
@@ -147,7 +147,7 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
         // this way it should contain the three apps by default
         this.testExpectedAudiences(SAML_CLIENT_ID_EMPLOYEE_2, "http://localhost:8280/employee/", "http://localhost:8280/employee-role-mapping/");
         // remove one of the groups (employee) and check the employee audience is removed
-        String employeeId = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee/").get(0).getId();
+        String employeeId = adminClient.realm(REALM_NAME).clients().findClientByClientId("http://localhost:8280/employee/").orElseThrow().getId();
         Assert.assertNotNull(employeeId);
         try (RoleScopeUpdater rsc = UserAttributeUpdater.forUserByUsername(adminClient, REALM_NAME, bburkeUser.getUsername())
                 .clientRoleScope(employeeId)
@@ -168,9 +168,9 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
             this.testExpectedAudiences(SAML_CLIENT_ID_EMPLOYEE_2);
 
             // add another client in the scope
-            String employee2Id = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee2/").get(0).getId();
+            String employee2Id = adminClient.realm(REALM_NAME).clients().findClientByClientId("http://localhost:8280/employee2/").orElseThrow().getId();
             Assert.assertNotNull(employee2Id);
-            String employeeId = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee/").get(0).getId();
+            String employeeId = adminClient.realm(REALM_NAME).clients().findClientByClientId("http://localhost:8280/employee/").orElseThrow().getId();
             Assert.assertNotNull(employeeId);
             List<RoleRepresentation> availables = adminClient.realm(REALM_NAME).clients().get(employee2Id).getScopeMappings().clientLevel(employeeId).listAvailable();
             assertThat(availables.size(), greaterThan(0));
@@ -196,9 +196,9 @@ public class AudienceProtocolMappersTest extends AbstractSamlTest {
 
         try {
             // add a mapping to the client scope to employee2.employee role (this way employee should be in the audience)
-            String employee2Id = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee2/").get(0).getId();
+            String employee2Id = adminClient.realm(REALM_NAME).clients().findClientByClientId("http://localhost:8280/employee2/").orElseThrow().getId();
             Assert.assertNotNull(employee2Id);
-            String employeeId = adminClient.realm(REALM_NAME).clients().findByClientId("http://localhost:8280/employee/").get(0).getId();
+            String employeeId = adminClient.realm(REALM_NAME).clients().findClientByClientId("http://localhost:8280/employee/").orElseThrow().getId();
             Assert.assertNotNull(employeeId);
             List<RoleRepresentation> availables = adminClient.realm(REALM_NAME).clientScopes().get(clientScopeId).getScopeMappings().clientLevel(employeeId).listAvailable();
             assertThat(availables.size(), greaterThan(0));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestNameIdFormatTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/AuthnRequestNameIdFormatTest.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.testsuite.saml;
 
-import java.util.List;
 
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientsResource;
@@ -36,7 +35,6 @@ import static org.keycloak.testsuite.util.SamlClient.Binding;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -128,9 +126,8 @@ public class AuthnRequestNameIdFormatTest extends AbstractSamlTest {
     @Test
     public void testRedirectLoginNoNameIdPolicyForcePostBinding() throws Exception {
         ClientsResource clients = adminClient.realm(REALM_NAME).clients();
-        List<ClientRepresentation> foundClients = clients.findByClientId(SAML_CLIENT_ID_SALES_POST);
-        assertThat(foundClients, hasSize(1));
-        ClientResource clientRes = clients.get(foundClients.get(0).getId());
+        ClientRepresentation foundClient = clients.findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
+        ClientResource clientRes = clients.get(foundClient.getId());
         ClientRepresentation client = clientRes.toRepresentation();
         client.getAttributes().put(SamlConfigAttributes.SAML_FORCE_POST_BINDING, "true");
         clientRes.update(client);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BrokerTest.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -458,7 +458,7 @@ public class BrokerTest extends AbstractSamlTest {
 
         try (SamlBackchannelArtifactResolveReceiver samlBackchannelArtifactResolveReceiver = new SamlBackchannelArtifactResolveReceiver(
                 8082,
-                realm.clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0)
+                realm.clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow()
         )) {
 
             IdentityProviderRepresentation rep = addIdentityProvider("https://saml.idp/saml");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/LogoutTest.java
@@ -102,9 +102,9 @@ public class LogoutTest extends AbstractSamlTest {
 
     @Before
     public void setup() {
-        salesRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0);
-        sales2Rep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST2).get(0);
-        salesSigRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST_SIG).get(0);
+        salesRep = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
+        sales2Rep = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST2).orElseThrow();
+        salesSigRep = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST_SIG).orElseThrow();
 
         adminClient.realm(REALM_NAME)
           .clients().get(salesRep.getId())
@@ -690,7 +690,7 @@ public class LogoutTest extends AbstractSamlTest {
 
     @Test
     public void testLogoutMandatoryDestinationUnsetRedirect() throws IOException {
-        testLogoutDestination(REDIRECT, 
+        testLogoutDestination(REDIRECT,
           builder -> builder
                        .transformObject(logoutReq -> { logoutReq.setDestination(null); })
                        .signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY),
@@ -700,7 +700,7 @@ public class LogoutTest extends AbstractSamlTest {
 
     @Test
     public void testLogoutMandatoryDestinationSetRedirect() throws IOException {
-        testLogoutDestination(REDIRECT, 
+        testLogoutDestination(REDIRECT,
           builder -> builder.signWith(SAML_CLIENT_SALES_POST_SIG_PRIVATE_KEY, SAML_CLIENT_SALES_POST_SIG_PUBLIC_KEY),
           LogoutTest::assertSamlLogoutRequest
         );

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlClientTest.java
@@ -36,7 +36,7 @@ public class SamlClientTest extends AbstractSamlTest {
 
     @Test
     public void testLoginWithOIDCClient() throws ParsingException, ConfigurationException, ProcessingException, IOException {
-        ClientRepresentation salesRep = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0);
+        ClientRepresentation salesRep = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
         adminClient.realm(REALM_NAME).clients().get(salesRep.getId()).update(ClientBuilder.edit(salesRep)
                         .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL).build());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlConsentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlConsentTest.java
@@ -35,8 +35,7 @@ public class SamlConsentTest extends AbstractSamlTest {
     public void rejectedConsentResponseTest() throws ParsingException, ConfigurationException, ProcessingException {
         ClientRepresentation client = adminClient.realm(REALM_NAME)
                 .clients()
-                .findByClientId(SAML_CLIENT_ID_SALES_POST)
-                .get(0);
+                .findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow();
 
         adminClient.realm(REALM_NAME)
                 .clients()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlRelayStateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/SamlRelayStateTest.java
@@ -48,7 +48,7 @@ public class SamlRelayStateTest extends AbstractSamlTest {
 
     @Test
     public void testRelayStateDoesNotRetainBetweenTwoRequestsRedirect() throws Exception {
-        String url = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0)
+        String url = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow()
                 .getAttributes().get(SamlProtocol.SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE);
         try (Closeable c = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST)
                 .setAttribute(SamlProtocol.SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE, null)
@@ -92,7 +92,7 @@ public class SamlRelayStateTest extends AbstractSamlTest {
 
     @Test
     public void testRelayStateDoesNotRetainBetweenTwoRequestsIdpInitiatedRedirect() throws Exception {
-        String url = adminClient.realm(REALM_NAME).clients().findByClientId(SAML_CLIENT_ID_SALES_POST).get(0)
+        String url = adminClient.realm(REALM_NAME).clients().findClientByClientId(SAML_CLIENT_ID_SALES_POST).orElseThrow()
                 .getAttributes().get(SamlProtocol.SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE);
         try (Closeable c = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_SALES_POST)
                 .setAttribute(SamlProtocol.SAML_ASSERTION_CONSUMER_URL_POST_ATTRIBUTE, null)

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/script/DeployedScriptPolicyTest.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
-import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.PermissionsResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -196,8 +195,6 @@ public class DeployedScriptPolicyTest extends AbstractAuthzTest {
     }
 
     private ClientResource getClient(RealmResource realm, String clientId) {
-        ClientsResource clients = realm.clients();
-        return clients.findByClientId(clientId).stream().map(representation -> clients.get(representation.getId())).findFirst()
-                .orElseThrow(() -> new RuntimeException("Expected client [resource-server-test]"));
+        return realm.clients().getByClientId(clientId);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -141,7 +141,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
 
         // Delete the cookies, while maintaining the server side session active
         super.deleteCookies();
-        
+
         // Login the same user again and verify the configured error message is shown
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
@@ -421,7 +421,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
 
             events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
         } finally {
-            testRealm().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).setDirectAccessGrantsEnabled(false);
+            testRealm().clients().findClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).orElseThrow().setDirectAccessGrantsEnabled(false);
             ApiUtil.resetUserPassword(testRealm().users().get(findUser("test-user@localhost").getId()), "password", false);
         }
     }


### PR DESCRIPTION
We have such a method org.keycloak.admin.client.resource.ClientsResource.findByClientId(String) that should return a single item, but it returns a List of ClientRepresentation.
 
for more details please check the issue description

Closes #39851

Signed-off-by: cherifyazid <yadzinov@gmail.com>
