### PR TITLE
Set auth flow status for FederatedJWTClientAuthenticator

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
@@ -104,7 +104,7 @@ public class FederatedJWTClientAuthenticator
                 ? clientAssertionState.getToken().getIssuer()
                 : toIssuer(clientAssertionState.getToken().getSubject());
             if (issuer == null) {
-                LOGGER.debug(
+                LOGGER.debugf(
                     "Could not determine issuer from client assertion subject: %s. Skipping.",
                     clientAssertionState.getToken().getSubject()
                 );
@@ -122,7 +122,7 @@ public class FederatedJWTClientAuthenticator
                     issuer
                 );
             if (identityProviderModel == null) {
-                LOGGER.debug(
+                LOGGER.debugf(
                     "No Identity Provider found with issuer '%s'. Skipping.",
                     issuer
                 );


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Addresses https://github.com/keycloak/keycloak/issues/43394.

Uses `context.attempted()` to update the Authentication Flow Status for the new FederatedJWTClientAuthenticator.
I've also included debug logging which I found helpful to diagnose the underlying problem (in my case, the SPIFFE identity provider lookup).

(my first Java in years, and my contribution to Keycloak, so apologies in advance if it's not quite right..).