### PR TITLE
Separate trust domain and issuer fields in SPIFFE identity provider

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
@@ -104,7 +104,7 @@ public class FederatedJWTClientAuthenticator
                 ? clientAssertionState.getToken().getIssuer()
                 : toIssuer(clientAssertionState.getToken().getSubject());
             if (issuer == null) {
-                LOGGER.debug(
+                LOGGER.debugf(
                     "Could not determine issuer from client assertion subject: %s. Skipping.",
                     clientAssertionState.getToken().getSubject()
                 );
@@ -122,7 +122,7 @@ public class FederatedJWTClientAuthenticator
                     issuer
                 );
             if (identityProviderModel == null) {
-                LOGGER.debug(
+                LOGGER.debugf(
                     "No Identity Provider found with issuer '%s'. Skipping.",
                     issuer
                 );

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/FederatedJWTClientAuthenticator.java
@@ -1,11 +1,5 @@
 package org.keycloak.authentication.authenticators.client;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.jboss.logging.Logger;
 import org.keycloak.Config;
 import org.keycloak.OAuth2Constants;
@@ -25,42 +19,28 @@ import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.resources.IdentityBrokerService;
 
-public class FederatedJWTClientAuthenticator
-    extends AbstractClientAuthenticator
-    implements EnvironmentDependentProviderFactory {
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-    private static final Logger LOGGER = Logger.getLogger(
-        FederatedJWTClientAuthenticator.class
-    );
+public class FederatedJWTClientAuthenticator extends AbstractClientAuthenticator implements EnvironmentDependentProviderFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(FederatedJWTClientAuthenticator.class);
 
     public static final String PROVIDER_ID = "federated-jwt";
 
-    public static final String JWT_CREDENTIAL_ISSUER_KEY =
-        "jwt.credential.issuer";
-    public static final String JWT_CREDENTIAL_SUBJECT_KEY =
-        "jwt.credential.sub";
+    public static final String JWT_CREDENTIAL_ISSUER_KEY = "jwt.credential.issuer";
+    public static final String JWT_CREDENTIAL_SUBJECT_KEY = "jwt.credential.sub";
 
     private static final List<ProviderConfigProperty> CLIENT_CONFIG = List.of(
-        new ProviderConfigProperty(
-            JWT_CREDENTIAL_ISSUER_KEY,
-            "Identity provider",
-            "Issuer of the client assertion",
-            ProviderConfigProperty.STRING_TYPE,
-            null
-        ),
-        new ProviderConfigProperty(
-            JWT_CREDENTIAL_SUBJECT_KEY,
-            "Federated subject",
-            "External clientId (subject)",
-            ProviderConfigProperty.STRING_TYPE,
-            null
-        )
+            new ProviderConfigProperty(JWT_CREDENTIAL_ISSUER_KEY, "Identity provider", "Issuer of the client assertion", ProviderConfigProperty.STRING_TYPE, null),
+            new ProviderConfigProperty(JWT_CREDENTIAL_SUBJECT_KEY, "Federated subject", "External clientId (subject)", ProviderConfigProperty.STRING_TYPE, null)
     );
 
-    private static final Set<String> SUPPORTED_ASSERTION_TYPES = Set.of(
-        OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT,
-        SpiffeConstants.CLIENT_ASSERTION_TYPE
-    );
+    private static final Set<String> SUPPORTED_ASSERTION_TYPES = Set.of(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT, SpiffeConstants.CLIENT_ASSERTION_TYPE);
 
     @Override
     public String getId() {
@@ -70,168 +50,58 @@ public class FederatedJWTClientAuthenticator
     @Override
     public void authenticateClient(ClientAuthenticationFlowContext context) {
         try {
-            ClientAssertionState clientAssertionState = context.getState(
-                ClientAssertionState.class,
-                ClientAssertionState.supplier()
-            );
+            ClientAssertionState clientAssertionState = context.getState(ClientAssertionState.class, ClientAssertionState.supplier());
 
-            if (
-                clientAssertionState == null ||
-                clientAssertionState.getClientAssertionType() == null
-            ) {
-                LOGGER.debugf(
-                    "Request is not a client assertion authentication. Skipping."
-                );
-                context.attempted();
+            if (clientAssertionState == null || clientAssertionState.getClientAssertionType() == null) {
                 return;
             }
 
-            if (
-                !SUPPORTED_ASSERTION_TYPES.contains(
-                    clientAssertionState.getClientAssertionType()
-                )
-            ) {
-                LOGGER.debugf(
-                    "Client assertion type '%s' is not supported by this authenticator. Skipping.",
-                    clientAssertionState.getClientAssertionType()
-                );
-                context.attempted();
+            if (!SUPPORTED_ASSERTION_TYPES.contains(clientAssertionState.getClientAssertionType())) {
                 return;
             }
 
-            final String issuer = clientAssertionState.getToken().getIssuer() !=
-                null
-                ? clientAssertionState.getToken().getIssuer()
-                : toIssuer(clientAssertionState.getToken().getSubject());
-            if (issuer == null) {
-                LOGGER.debugf(
-                    "Could not determine issuer from client assertion subject: %s. Skipping.",
-                    clientAssertionState.getToken().getSubject()
-                );
-                context.attempted();
-                return;
-            }
+            final String issuer = clientAssertionState.getToken().getIssuer() != null ?
+                    clientAssertionState.getToken().getIssuer() :
+                    toIssuer(clientAssertionState.getToken().getSubject());
+            if (issuer == null) return;
 
-            AlternativeLookupProvider lookupProvider = context
-                .getSession()
-                .getProvider(AlternativeLookupProvider.class);
+            AlternativeLookupProvider lookupProvider = context.getSession().getProvider(AlternativeLookupProvider.class);
 
-            IdentityProviderModel identityProviderModel =
-                lookupProvider.lookupIdentityProviderFromIssuer(
+            IdentityProviderModel identityProviderModel = lookupProvider.lookupIdentityProviderFromIssuer(context.getSession(), issuer);
+            ClientAssertionIdentityProvider identityProvider = getClientAssertionIdentityProvider(context.getSession(), identityProviderModel);
+            if (identityProvider == null) return;
+
+            String federatedClientId = clientAssertionState.getToken().getSubject();
+
+            ClientModel client = lookupProvider.lookupClientFromClientAttributes(
                     context.getSession(),
-                    issuer
-                );
-            if (identityProviderModel == null) {
-                LOGGER.debugf(
-                    "No Identity Provider found with issuer '%s'. Skipping.",
-                    issuer
-                );
-                context.attempted();
-                return;
-            }
-
-            ClientAssertionIdentityProvider identityProvider =
-                getClientAssertionIdentityProvider(
-                    context.getSession(),
-                    identityProviderModel
-                );
-            if (identityProvider == null) {
-                LOGGER.debugf(
-                    "IdP '%s' was found but does not support client assertions. Skipping.",
-                    identityProviderModel.getAlias()
-                );
-                context.attempted();
-                return;
-            }
-
-            String federatedClientId = clientAssertionState
-                .getToken()
-                .getSubject();
-
-            ClientModel client =
-                lookupProvider.lookupClientFromClientAttributes(
-                    context.getSession(),
-                    Map.of(
-                        FederatedJWTClientAuthenticator.JWT_CREDENTIAL_ISSUER_KEY,
-                        identityProviderModel.getAlias(),
-                        FederatedJWTClientAuthenticator.JWT_CREDENTIAL_SUBJECT_KEY,
-                        federatedClientId
-                    )
-                );
-            if (client == null) {
-                LOGGER.debugf(
-                    "No client found with attributes: issuer='%s', subject='%s'. Skipping.",
-                    identityProviderModel.getAlias(),
-                    federatedClientId
-                );
-                context.attempted();
-                return;
-            }
+                    Map.of(FederatedJWTClientAuthenticator.JWT_CREDENTIAL_ISSUER_KEY, identityProviderModel.getAlias(), FederatedJWTClientAuthenticator.JWT_CREDENTIAL_SUBJECT_KEY, federatedClientId));
+            if (client == null) return;
 
             clientAssertionState.setClient(client);
 
-            if (!PROVIDER_ID.equals(client.getClientAuthenticatorType())) {
-                LOGGER.debugf(
-                    "Client '%s' is not configured for this authenticator (is '%s'). Skipping.",
-                    client.getClientId(),
-                    client.getClientAuthenticatorType()
-                );
-                context.attempted();
-                return;
-            }
-
-            LOGGER.infof(
-                "Found client '%s' configured for federated JWT authentication via IdP '%s'. Verifying assertion...",
-                client.getClientId(),
-                identityProviderModel.getAlias()
-            );
+            if (!PROVIDER_ID.equals(client.getClientAuthenticatorType())) return;
 
             if (identityProvider.verifyClientAssertion(context)) {
-                LOGGER.infof(
-                    "Client assertion verified successfully for client '%s'.",
-                    client.getClientId()
-                );
                 context.success();
             } else {
-                LOGGER.debugf(
-                    "Client assertion verification FAILED for client '%s' by IdP '%s'.",
-                    client.getClientId(),
-                    identityProviderModel.getAlias()
-                );
-                context.failure(
-                    AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS
-                );
+                context.failure(AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS);
             }
         } catch (Exception e) {
-            LOGGER.error(
-                "Authentication failed due to an unexpected exception",
-                e
-            );
+            LOGGER.warn("Authentication failed", e);
             context.failure(AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS);
         }
     }
 
-    private ClientAssertionIdentityProvider getClientAssertionIdentityProvider(
-        KeycloakSession session,
-        IdentityProviderModel identityProviderModel
-    ) {
+    private ClientAssertionIdentityProvider getClientAssertionIdentityProvider(KeycloakSession session, IdentityProviderModel identityProviderModel) {
         if (identityProviderModel == null) {
             return null;
         }
-        IdentityProvider<?> identityProvider =
-            IdentityBrokerService.getIdentityProvider(
-                session,
-                identityProviderModel
-            );
-        if (
-            identityProvider instanceof
-                ClientAssertionIdentityProvider clientAssertionProvider
-        ) {
+        IdentityProvider<?> identityProvider = IdentityBrokerService.getIdentityProvider(session, identityProviderModel);
+        if (identityProvider instanceof ClientAssertionIdentityProvider clientAssertionProvider) {
             return clientAssertionProvider;
         } else {
-            throw new RuntimeException(
-                "Provider does not support client assertions"
-            );
+            throw new RuntimeException("Provider does not support client assertions");
         }
     }
 
@@ -285,11 +155,10 @@ public class FederatedJWTClientAuthenticator
             URI uri = new URI(subject);
             String scheme = uri.getScheme();
             String authority = uri.getRawAuthority();
-            return scheme != null && authority != null
-                ? scheme + "://" + authority
-                : null;
+            return scheme != null && authority != null ? scheme + "://" + authority : null;
         } catch (URISyntaxException e) {
             return null;
         }
     }
+
 }

--- a/services/src/main/java/org/keycloak/broker/spiffe/SpiffeIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/spiffe/SpiffeIdentityProviderConfig.java
@@ -11,6 +11,7 @@ import static org.keycloak.common.util.UriUtils.checkUrl;
 public class SpiffeIdentityProviderConfig extends IdentityProviderModel {
 
     public static final String BUNDLE_ENDPOINT_KEY = "bundleEndpoint";
+    public static final String TRUST_DOMAIN_KEY = "trustDomain";
 
     private static final Pattern TRUST_DOMAIN_PATTERN = Pattern.compile("spiffe://[a-z0-9.\\-_]*");
 
@@ -41,7 +42,7 @@ public class SpiffeIdentityProviderConfig extends IdentityProviderModel {
     }
 
     public String getTrustDomain() {
-        return getConfig().get(ISSUER);
+        return getConfig().get(TRUST_DOMAIN_KEY);
     }
 
     public String getBundleEndpoint() {
@@ -53,8 +54,8 @@ public class SpiffeIdentityProviderConfig extends IdentityProviderModel {
         super.validate(realm);
 
         String trustDomain = getTrustDomain();
-        if (trustDomain == null || !TRUST_DOMAIN_PATTERN.matcher(trustDomain).matches()) {
-            throw new IllegalArgumentException("Invalid trust domain name");
+        if (trustDomain == null || trustDomain.isBlank() || !TRUST_DOMAIN_PATTERN.matcher(trustDomain).matches()) {
+            throw new IllegalArgumentException("Invalid SPIFFE Trust Domain format. Must match 'spiffe://...'");
         }
 
         checkUrl(realm.getSslRequired(), getBundleEndpoint(), BUNDLE_ENDPOINT_KEY);

--- a/services/src/main/java/org/keycloak/broker/spiffe/SpiffeIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/broker/spiffe/SpiffeIdentityProviderFactory.java
@@ -6,7 +6,9 @@ import org.keycloak.common.Profile;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
 
+import java.util.List;
 import java.util.Map;
 
 public class SpiffeIdentityProviderFactory extends AbstractIdentityProviderFactory<SpiffeIdentityProvider> implements EnvironmentDependentProviderFactory {
@@ -36,6 +38,26 @@ public class SpiffeIdentityProviderFactory extends AbstractIdentityProviderFacto
     @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of(
+            new ProviderConfigProperty(
+                SpiffeIdentityProviderConfig.TRUST_DOMAIN_KEY,
+                "SPIFFE Trust Domain",
+                "The trust domain of the SPIFFE identity (e.g., 'spiffe://example.com'). This is used for validation.",
+                ProviderConfigProperty.STRING_TYPE,
+                null
+            ),
+            new ProviderConfigProperty(
+                SpiffeIdentityProviderConfig.BUNDLE_ENDPOINT_KEY,
+                "JWKS Bundle Endpoint",
+                "The URL of the SPIFFE bundle endpoint that provides the JWKS for signature validation.",
+                ProviderConfigProperty.STRING_TYPE,
+                null
+            )
+        );
     }
 
     @Override


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Currently, the SPIFFE identity provider (in preview) assumes the issuer (`iss`) in a JWT-SVID token is the SPIFFE trust domain when looking up the identity provider. However, in some cases, it is not feasible for the issuer to be the same as the trust domain; in implementations like SPIRE, it may be necessary for the `iss` to be an HTTPS URL such that it can be used by federated systems for key verification.

This PR proposes separating out the trust domain and the issuer.
