### PR TITLE
fix: refining https-protocols documentation

### DIFF
--- a/docs/guides/server/enabletls.adoc
+++ b/docs/guides/server/enabletls.adoc
@@ -52,7 +52,7 @@ However, as a temporary work-around, you can enable deprecated protocols by runn
 
 <@kc.start parameters="--https-protocols=<protocol>[,<protocol>]"/>
 
-To also allow TLSv1.2, use a command such as the following: `kc.sh start --https-protocols=TLSv1.3,TLSv1.2`.
+For example to only enable TLSv1.3, use a command such as the following: `kc.sh start --https-protocols=TLSv1.3`.
 
 == Switching the HTTPS port
 {project_name} listens for HTTPS traffic on port `8443`. To change this port, use the following command:

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -61,8 +61,10 @@ public class HttpOptions {
 
     public static final Option<List<String>> HTTPS_PROTOCOLS = OptionBuilder.listOptionBuilder("https-protocols", String.class)
             .category(OptionCategory.HTTP)
-            .description("The list of protocols to explicitly enable.")
-            .defaultValue(Arrays.asList("TLSv1.3,TLSv1.2"))
+            .description("The list of protocols to explicitly enable. If a value is not supported by the JRE / security configuration, it will be silently ignored.")
+            .expectedValues(Arrays.asList("TLSv1.3", "TLSv1.2"))
+            .strictExpectedValues(false)
+            .defaultValue(Arrays.asList("TLSv1.3", "TLSv1.2"))
             .build();
 
     public static final Option<String> HTTPS_CERTIFICATES_RELOAD_PERIOD = new OptionBuilder<>("https-certificates-reload-period", String.class)

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -257,7 +257,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -336,7 +336,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -305,7 +305,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -337,7 +337,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -271,7 +271,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -303,7 +303,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -304,7 +304,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -336,7 +336,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -302,7 +302,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -334,7 +334,9 @@ HTTP(S):
                        no value is set, it defaults to 'BCFKS'.
 --https-port <port>  The used HTTPS port. Default: 8443.
 --https-protocols <protocols>
-                     The list of protocols to explicitly enable. Default: TLSv1.3,TLSv1.2.
+                     The list of protocols to explicitly enable. If a value is not supported by the
+                       JRE / security configuration, it will be silently ignored. Possible values
+                       are: TLSv1.3, TLSv1.2, or a custom one. Default: TLSv1.3,TLSv1.2.
 --https-trust-store-file <file>
                      The trust store which holds the certificate information of the certificates to
                        trust.


### PR DESCRIPTION
closes: #43164

Changed the example to mirror the current quarkus docs, rather than implying that TLSv1.2 is not enabled by default. Also made the option documentation clearer wrt expected values - we may want to log an issue against quarkus to more strongly validate, or we can do this as a breaking change with #43332

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
