### PR TITLE
Disable GroupTest#createMultiDeleteMultiReadMulti for MSSQL

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
@@ -54,6 +54,7 @@ import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.conditions.DisabledForDatabases;
 import org.keycloak.testframework.events.AdminEventAssertion;
 import org.keycloak.testframework.realm.ClientConfigBuilder;
 import org.keycloak.testframework.realm.GroupConfigBuilder;
@@ -116,6 +117,7 @@ public class GroupTest extends AbstractGroupTest {
 
     
     @Test
+    @DisabledForDatabases("mssql")
     public void createMultiDeleteMultiReadMulti() {
         // create multiple groups
         List<String> groupUuuids = new ArrayList<>();


### PR DESCRIPTION
Closes #42166

The PR disables GroupTest#createMultiDeleteMultiReadMulti for MSSQL database.

Other DBs, like PostgreSQL, Oracle, or MySQL (InnoDB) use a different model called Multiversion Concurrency Control (MVCC), where readers don't block writers, and writers don't block readers. When the reader thread queries the groups, it sees a consistent "snapshot" of the data from a point in time and doesn't need to lock the rows that the main thread is trying to delete. This completely avoids the locking conflict.

MSSQL uses different mechanism to handle concurrent access than other DBs. MSSQL's default behavior uses shared read locks and exclusive write locks.

MSSQL offers an option `READ_COMMITTED_SNAPSHOT` which changes a default behavior of READ_COMMITED isolation level in a way that any transaction will automatically run under row versioning semantics. 

I've enabled the setting by updating `MSSQLServerTestDatabase`:

```java
    @Override
    public List<String> getPostStartCommand() {
        // Adding -N for encryption and -C to trust the self-signed certificate
        String sqlCmdOptions = String.format("-U sa -P '%s' -N -C", getPassword());

        String createDbCommand = String.format("/opt/mssql-tools18/bin/sqlcmd %s -Q 'CREATE DATABASE %s;'", sqlCmdOptions, getDatabase());
        String alterDbCommand = String.format("/opt/mssql-tools18/bin/sqlcmd %s -d %s -Q 'ALTER DATABASE %s SET READ_COMMITTED_SNAPSHOT ON;'", sqlCmdOptions, getDatabase(), getDatabase());

        // Redirect stdout and stderr (2>&1) of the whole sequence to a log file for debugging
        String fullCommand = String.format("(%s && %s) > /tmp/setup-script.log 2>&1", createDbCommand, alterDbCommand);

        return List.of("sh", "-c", fullCommand);
    }
```

With this setting the rate of failures dropped, but did not solve it.

I suspected `PESSIMISTIC_WRITE` lock mode which is used upon retrieving the GroupEntity from persistence context during deletion. This path looked promising as I was able to get 300 successful runs locally, but I was seeing the issue in GHA and eventually I was able to see it locally as well (roughly 20 fails from 1000 runs).

I was trying to use different logic when deleting groups. Current implementation uses recursive call to delete subgroups. I tried to collect all IDs which are about to be deleted first and then delete group role mappings in bulk and then proceed with deletion of groups one by one.

```java
    @Override
    public boolean removeGroup(RealmModel realm, GroupModel group) {
        if (group == null) {
            return false;
        }

        // Collect all group IDs in the hierarchy, starting with the children.
        List<String> groupIdsToDelete = new ArrayList<>();
        collectGroupIds(group, groupIdsToDelete);

        // Delete group role mappings in bulk
        CriteriaBuilder cb = em.getCriteriaBuilder();
        CriteriaDelete<GroupRoleMappingEntity> deleteQuery = cb.createCriteriaDelete(GroupRoleMappingEntity.class);
        Root<GroupRoleMappingEntity> root = deleteQuery.from(GroupRoleMappingEntity.class);
        deleteQuery.where(root.join("group").get("id").in(groupIdsToDelete));
        em.createQuery(deleteQuery).executeUpdate();

        // Loop through the list and delete one by one.
        groupIdsToDelete.stream().map(realm::getGroupById).filter(Objects::nonNull).forEach(groupToDelete -> removeSingleGroup(realm, groupToDelete));

        return true;
    }

    private void collectGroupIds(GroupModel group, List<String> groupIds) {
        // Add children first to maintain deletion order later
        group.getSubGroupsStream().forEach(subGroup -> collectGroupIds(subGroup, groupIds));
        groupIds.add(group.getId());
    }

    private void removeSingleGroup(RealmModel realm, GroupModel group) {
        GroupModel.GroupRemovedEvent event = new GroupModel.GroupRemovedEvent() {
            @Override
            public RealmModel getRealm() {
                return realm;
            }

            @Override
            public GroupModel getGroup() {
                return group;
            }

            @Override
            public KeycloakSession getKeycloakSession() {
                return session;
            }
        };
        session.getKeycloakSessionFactory().publish(event);

        session.users().preRemove(realm, group);
        realm.removeDefaultGroup(group);

        GroupEntity groupEntity = em.find(GroupEntity.class, group.getId(), LockModeType.PESSIMISTIC_WRITE);
        if (groupEntity == null) return;

        em.remove(groupEntity);
    } 
```

It did not help to solve the issue. I tried to capture a deadlock graph directly from SQL server:

```java
    @Override
    public List<String> getPostStartCommand() {
        // Adding -N for encryption and -C to trust the self-signed certificate
        String sqlCmdOptions = String.format("-U sa -P '%s' -N -C", getPassword());

        String createDbCommand = String.format("/opt/mssql-tools18/bin/sqlcmd %s -Q 'CREATE DATABASE %s;'", sqlCmdOptions, getDatabase());
        String alterDbCommand = String.format("/opt/mssql-tools18/bin/sqlcmd %s -d %s -Q 'ALTER DATABASE %s SET READ_COMMITTED_SNAPSHOT ON;'", sqlCmdOptions, getDatabase(), getDatabase());

        String createEventSessionCommand = String.format(
                "/opt/mssql-tools18/bin/sqlcmd %s -d master -Q \"" +
                        "IF NOT EXISTS (SELECT * FROM sys.server_event_sessions WHERE name = 'system_health') " +
                        "CREATE EVENT SESSION [system_health] ON SERVER " +
                        "ADD EVENT sqlserver.xml_deadlock_report " +
                        "ADD TARGET package0.event_file(SET filename=N'system_health.xel',max_file_size=(5),max_rollover_files=(4)) " +
                        "WITH (STARTUP_STATE=ON); " +
                        "ALTER EVENT SESSION [system_health] ON SERVER STATE = START;\"",
                sqlCmdOptions);

        // Redirect stdout and stderr (2>&1) of the whole sequence to a log file for debugging
        String fullCommand = String.format("(%s && %s && %s) > /tmp/setup-script.log 2>&1",
                createDbCommand,
                alterDbCommand,
                createEventSessionCommand);

        return List.of("sh", "-c", fullCommand);
    }
```
and 

```bash
$ docker exec 152ab242d3df /opt/mssql-tools18/bin/sqlcmd \
-U sa -P $PASSWORD -N -C -d master \
-Q "SET QUOTED_IDENTIFIER ON; SELECT ib.value('.', 'NVARCHAR(MAX)') AS conflicting_query FROM (SELECT CAST(xet.target_data AS xml) AS Target_Data FROM sys.dm_xe_sessions AS xes JOIN sys.dm_xe_session_targets AS xet ON xes.address = xet.event_session_address WHERE xes.name = 'system_health' AND xet.target_name = 'ring_buffer') AS T CROSS APPLY Target_Data.nodes('//RingBufferTarget/event[@name=\"xml_deadlock_report\"]/data/value/deadlock/process-list/process/inputbuf') AS InputBuf(ib);"
conflicting_query                                                                                                                                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

(@P0 varchar(8000),@P1 int,@P2 varchar(8000),@P3 int,@P4 int)select ge1_0.ID from KEYCLOAK_GROUP ge1_0 where ge1_0.REALM_ID= @P0 and ge1_0.TYPE= @P1 and ge1_0.PARENT_GROUP= @P2 and lower(ge1_0.NAME) like lower('%%') order by ge1_0.NAME offset  @P3 rows fe

(@P0 varchar(8000))delete from KEYCLOAK_GROUP where ID= @P0                                                                                                                                                                                                    

(@P0 varchar(8000),@P1 int,@P2 varchar(8000),@P3 int,@P4 int)select ge1_0.ID from KEYCLOAK_GROUP ge1_0 where ge1_0.REALM_ID= @P0 and ge1_0.TYPE= @P1 and ge1_0.PARENT_GROUP= @P2 and lower(ge1_0.NAME) like lower('%%') order by ge1_0.NAME offset  @P3 rows fe

(@P0 varchar(8000))delete from KEYCLOAK_GROUP where ID= @P0                                                                                                                                                                                                    

(4 rows affected)
```

The graph shows two conflicting queries
Query 1 (Reader): A long-running, table-scanning `SELECT ... from KEYCLOAK_GROUP ... ORDER BY ...` originating from `getTopLevelGroupsStream`.
Query 2 (Writer): A simple `DELETE from KEYCLOAK_GROUP where ID = @P0` originating from the `em.remove()` call in the `removeGroup` method.

There is also `ALLOW_SNAPSHOT_ISOLATION` setting, which might help. It should let each transaction work with a consistent snapshot of the database as it existed when the transaction started — without being blocked by other concurrent transactions. 

It allows setting transaction isolation level to "snapshot". This setting is applies per connection, not globally. 

I was testing it by executing

```java
em.createNativeQuery("SET TRANSACTION ISOLATION LEVEL SNAPSHOT").executeUpdate();
```

before deleting the group, but it didn't help. It seems that this setting has to be done before the transaction starts.

Something like 

```java
connection.setTransactionIsolation(ISQLServerConnection.TRANSACTION_SNAPSHOT);
```
might be set on the connection but it would require a direct dependency on the Microsoft SQL Server JDBC driver class. Another alternative would be to use `0x1000`, but I'm not sure how future proof that would be:
https://github.com/microsoft/mssql-jdbc/blob/7f4a3a33a01a59d9c3891099997df1f89652064d/src/main/java/com/microsoft/sqlserver/jdbc/ISQLServerConnection.java#L24

Also I didn't investigate deeply possible drawbacks using `SNAPSHOT` isolation for all transactions in MSSQL. I didn't proceed further as at this point it seems that disabling the test is the most viable option.