### PR TITLE
Align placeholder syntax for realm names in documentation

### DIFF
--- a/docs/documentation/server_admin/topics/admin-cli.adoc
+++ b/docs/documentation/server_admin/topics/admin-cli.adoc
@@ -167,9 +167,9 @@ ENDPOINT is a target resource URI and can be absolute (starting with `http:` or 
 SERVER_URI/admin/realms/REALM/ENDPOINT
 ----
 
-For example, if you authenticate against the server http://localhost:8080{kc_base_path} and realm is `master`, using `users` as ENDPOINT creates the http://localhost:8080{kc_admins_path}/realms/master/users resource URL.
+For example, if you authenticate against the server http://localhost:8080{kc_base_path} and realm is `{realm-name}`, using `users` as ENDPOINT creates the http://localhost:8080{kc_admins_path}/realms/{realm-name}/users resource URL.
 
-If you set ENDPOINT to `clients`, the effective resource URI is http://localhost:8080{kc_admins_path}/realms/master/clients.
+If you set ENDPOINT to `clients`, the effective resource URI is http://localhost:8080{kc_admins_path}/realms/{realm-name}/clients.
 
 {project_name} has a `realms` endpoint that is the container for realms. It resolves to:
 [options="nowrap"]
@@ -193,7 +193,7 @@ $ kcadm.sh config credentials --server http://localhost:8080{kc_base_path} --rea
 $ kcadm.sh create users -s username=testuser -s enabled=true -r demorealm
 ----
 
-In this example, you start a session authenticated as the `admin` user in the `master` realm. You then perform a POST call against the resource URL `http://localhost:8080{kc_admins_path}/realms/demorealm/users`.
+In this example, you start a session authenticated as the `admin` user in the `master` realm. You then perform a POST call against the resource URL `http://localhost:8080{kc_admins_path}/realms/{realm-name}/users`.
 
 The `create` and `update` commands send a JSON body to the server. You can use `-f FILENAME` to read a pre-made document from a file. When you can use the `-f -` option, {project_name} reads the message body from the standard input. You can specify individual attributes and their values, as seen in the `create users` example. {project_name} composes the attributes into a JSON body and sends them to the server.
 
@@ -968,7 +968,7 @@ The response is in `.zip` format.
 For example:
 [options="nowrap",subs="attributes+"]
 ----
-$ kcadm.sh get http://localhost:8080{kc_admins_path}/realms/demorealm/clients/8f271c35-44e3-446f-8953-b0893810ebe7/installation/providers/docker-v2-compose-yaml -r demorealm > keycloak-docker-compose-yaml.zip
+$ kcadm.sh get http://localhost:8080{kc_admins_path}/realms/{realm-name}/clients/{client-id}/installation/providers/docker-v2-compose-yaml -r {realm-name} > keycloak-docker-compose-yaml.zip
 ----
 
 [discrete]

--- a/docs/documentation/server_admin/topics/authentication/flows.adoc
+++ b/docs/documentation/server_admin/topics/authentication/flows.adoc
@@ -437,7 +437,7 @@ Sometimes it can be useful for the client application to directly redirect the u
 user clicks *Register* or *Forget password* on the normal login screen. Automatic redirect to the registration or reset-credentials screen can be done as follows:
 
 * When the client wants the user to be redirected directly to the registration, the OIDC client should add parameter `prompt=create` to the login request. As a deprecated alternative, clients can replace the very last
-snippet from the OIDC login URL path (`/auth`) with `/registrations` . So the full URL might be similar to the following: `https://keycloak.example.com/realms/your_realm/protocol/openid-connect/registrations`.
+snippet from the OIDC login URL path (`/auth`) with `/registrations` . So the full URL might be similar to the following: `https://keycloak.example.com/realms/{realm-name}/protocol/openid-connect/registrations`.
 The `prompt=create` is recommended as it is https://openid.net/specs/openid-connect-prompt-create-1_0.html[a specification standard].
 
 * When the client wants a user to be redirected directly to the `Reset credentials` flow, the OIDC client should replace the very last snippet from the OIDC login URL path (`/auth`) with `/forgot-credentials` .

--- a/docs/documentation/server_admin/topics/authentication/x509.adoc
+++ b/docs/documentation/server_admin/topics/authentication/x509.adoc
@@ -204,7 +204,7 @@ curl \
   -d "grant_type=password" \
   --cacert /tmp/truststore.pem \
   --cert /tmp/keystore.pem:kssecret \
-  "https://localhost:8543/realms/test/protocol/openid-connect/token"
+  "https://localhost:8543/realms/{realm-name}/protocol/openid-connect/token"
 ----
 
 The file `/tmp/truststore.pem` points to the file with the truststore containing the certificate of the {project_name} server. The file `/tmp/keystore.pem` contains

--- a/docs/documentation/upgrading/topics/changes/changes-18_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-18_0_0.adoc
@@ -22,7 +22,7 @@ from CLIENT_SCOPE, CLIENT where CLIENT_SCOPE.REALM_ID='test' and CLIENT_SCOPE.NA
 = OpenID Connect Logout
 
 Previous versions of {project_name} had supported automatic logout of the user and redirecting to the application by opening logout endpoint URL such as
-`http(s)://example-host/auth/realms/my-realm-name/protocol/openid-connect/logout?redirect_uri=encodedRedirectUri`. While that implementation was easy to use, it had potentially negative impact
+`http(s)://example-host/auth/realms/{realm-name}/protocol/openid-connect/logout?redirect_uri=encodedRedirectUri`. While that implementation was easy to use, it had potentially negative impact
 on performance and security. The new version has better support for logout based on the OpenID Connect RP-Initiated Logout specification. The parameter `redirect_uri` is no longer supported; also,
 in the new version, the user needs to confirm the logout. It is possible to omit the confirmation and do automatic redirect to the application when you include parameter `post_logout_redirect_uri`
 together with the parameter `id_token_hint` with the ID Token used for login.

--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -266,7 +266,7 @@ To keep the old behavior, update your realm configuration and extend the session
 = Support for legacy `redirect_uri` parameter and SPI options has been removed
 
 Previous versions of {project_name} had supported automatic logout of the user and redirecting to the application by opening logout endpoint URL such as
-`http(s)://example-host/auth/realms/my-realm-name/protocol/openid-connect/logout?redirect_uri=encodedRedirectUri`. This functionality was deprecated in {project_name} 18 and has been removed in this version in favor of following the OpenID Connect specification.
+`http(s)://example-host/auth/realms/{realm-name}/protocol/openid-connect/logout?redirect_uri=encodedRedirectUri`. This functionality was deprecated in {project_name} 18 and has been removed in this version in favor of following the OpenID Connect specification.
 
 As part of this change the following related configuration options for the SPI have been removed:
 


### PR DESCRIPTION
## Summary
This PR standardizes placeholder syntax in documentation URLs by replacing hardcoded realm names with the {realm-name} placeholder for improved clarity and consistency.

## Changes
- Replaced hardcoded realm names (master, demorealm, my-realm-name, your_realm, test, oid4vc-vci) with {realm-name} placeholder
- Updated 5 documentation files across server_admin and upgrading guides
- Also introduced {client-id} placeholder where applicable

## Files Changed
- server_admin/topics/admin-cli.adoc
- server_admin/topics/authentication/flows.adoc
- server_admin/topics/authentication/x509.adoc
- upgrading/topics/changes/changes-18_0_0.adoc
- upgrading/topics/changes/changes-26_0_0.adoc

Closes #33018