### PR TITLE
Possible overflow in brute force computation

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/RealmAttributeUpdater.java
@@ -106,6 +106,21 @@ public class RealmAttributeUpdater extends ServerResourceUpdater<RealmAttributeU
         return this;
     }
 
+    public RealmAttributeUpdater setWaitIncrementSeconds(Integer value) {
+        rep.setWaitIncrementSeconds(value);
+        return this;
+    }
+
+    public RealmAttributeUpdater setMaxFailureWaitSeconds(Integer value) {
+        rep.setMaxFailureWaitSeconds(value);
+        return this;
+    }
+
+    public RealmAttributeUpdater setMaxDeltaTimeSeconds(Integer value) {
+        rep.setMaxDeltaTimeSeconds(value);
+        return this;
+    }
+
     public RealmAttributeUpdater setEventsListeners(List<String> eventListanets) {
         rep.setEventsListeners(eventListanets);
         return this;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -540,6 +540,22 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         loginSuccess();
     }
 
+    // Issue 30939
+    @Test
+    public void testNoOverflowDuringBruteForceCalculation() throws Exception {
+        int waitTime = Integer.MAX_VALUE - 172800; // Max int value without 2 days
+
+        try (RealmAttributeUpdater updater = new RealmAttributeUpdater(testRealm())
+                .setWaitIncrementSeconds(waitTime)
+                .setMaxFailureWaitSeconds(waitTime)
+                .setMaxDeltaTimeSeconds(900) // 15 minutes
+                .update()) {
+            loginInvalidPassword("test-user@localhost");
+            loginInvalidPassword("test-user@localhost");
+            expectTemporarilyDisabled();
+        }
+    }
+
     @Test
     public void testByMultipleStrategy() throws Exception {
 


### PR DESCRIPTION
closes #30939

The configuration attributes related to brute-force have type `Integer` on `RealmRepresentation` (For example `RealmRepresentation.waitIncrementSeconds` ). And admin console UI as well as server does not allow to configure bigger value than `Integer.MAX_VALUE` . This is correct behavior. Also it is not possible to configure negative values for those attributes, which is also correct.

However the overflow can happen during brute-force calculation as there are various types configured as `Integer` and computation is doing some multiplications, dividing and other operations. In the fix, I am trying to use `long` during calculation on most places to avoid overflow and negative value passed to `userLoginFailure.failedLoginNotBefore` (which could happen in some circumstances before this fix).
