### PR TITLE
Add documentation warning about 0.0.0.0 binding in dev mode

### DIFF
--- a/docs/guides/getting-started/templates/start-keycloak-localhost.adoc
+++ b/docs/guides/getting-started/templates/start-keycloak-localhost.adoc
@@ -19,3 +19,5 @@ bin\kc.bat start-dev
 
 Using the `start-dev` option, you are starting {project_name} in development mode. In this mode, you can try out {project_name} for the first time to get it up and running quickly. This mode offers convenient defaults for developers, such as for developing a new {project_name} theme.
 
+WARNING: By default, {project_name} in development mode binds to all network addresses (`0.0.0.0`). This means your {project_name} instance may be accessible from other machines on your network, not just from your local machine. If you want to restrict access to localhost only, you can start the server with `--http-host=127.0.0.1`.
+

--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -186,6 +186,9 @@ You can start {project_name} in `development mode` or `production mode`. Each mo
 === Starting {project_name} in development mode
 Use development mode to try out {project_name} for the first time to get it up and running quickly. This mode offers convenient defaults for developers, such as for developing a new {project_name} theme.
 
+[NOTE]
+By default, when you start {project_name} in development mode, the server binds to all network addresses (`0.0.0.0`). This means your instance may be accessible from other machines on your network. If you want to restrict access to your local machine only, you can use the option `--http-host=127.0.0.1` when starting the server.
+
 To start in development mode, enter the following command:
 
 <@kc.startdev parameters=""/>

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -18,7 +18,7 @@ public class HttpOptions {
 
     public static final Option<String> HTTP_HOST = new OptionBuilder<>("http-host", String.class)
             .category(OptionCategory.HTTP)
-            .description("The HTTP Host.")
+            .description("The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0), which means the server may be accessible from other machines on your network. For local development, you can restrict access to localhost only by setting this to 127.0.0.1.")
             .defaultValue("0.0.0.0")
             .build();
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -228,7 +228,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -298,7 +298,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -276,7 +276,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -299,7 +299,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -244,7 +244,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -267,7 +267,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -275,7 +275,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -298,7 +298,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -273,7 +273,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -296,7 +296,10 @@ HTTP(S):
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination
                        proxy. Default: false.
---http-host <host>   The HTTP Host. Default: 0.0.0.0.
+--http-host <host>   The HTTP Host. By default, Keycloak binds to all network addresses (0.0.0.0),
+                       which means the server may be accessible from other machines on your
+                       network. For local development, you can restrict access to localhost only by
+                       setting this to 127.0.0.1. Default: 0.0.0.0.
 --http-max-queued-requests <requests>
                      Maximum number of queued HTTP requests. Use this to shed load in an overload
                        situation. Excess requests will return a "503 Server not Available" response.


### PR DESCRIPTION
## Add documentation warning about 0.0.0.0 binding in dev mode

This PR adds documentation to inform users that Keycloak in development mode binds to all network addresses (0.0.0.0) by default, which may make their instance accessible from other machines on the network.

### Changes
- Added a warning in the Getting Started guide (via included template file) explaining the 0.0.0.0 default and suggesting `--http-host=127.0.0.1` to restrict access to localhost
- Added a note in the server configuration documentation under the "Starting Keycloak in development mode" section
- Enhanced the description of the `HTTP_HOST` option in `HttpOptions.java` to clarify the default behavior and provide guidance for local development

### Notes
- The warning is added to `start-keycloak-localhost.adoc` which is included in `getting-started-zip.adoc` to avoid duplication and maintain consistency across the documentation
- Docker/container documentation was not modified as suggested in the issue discussion, since containerized environments typically have more controlled networking

Closes #43329