### PR TITLE
Deprecate `org.keycloak.common.util.Base64` and `org.keycloak.common.util.Base64Url`

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/config/PemUtils.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/config/PemUtils.java
@@ -20,7 +20,6 @@
 package org.keycloak.adapters.saml.config;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -34,11 +33,11 @@ import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jboss.logging.Logger;
 import org.keycloak.common.crypto.CryptoConstants;
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.PemException;
 
 /**
@@ -125,9 +124,9 @@ public class PemUtils {
     private static byte[] pemToDer(String pem) {
         try {
             pem = removeBeginEnd(pem);
-            return Base64.decode(pem);
-        } catch (IOException ioe) {
-            throw new PemException(ioe);
+            return Base64.getDecoder().decode(pem);
+        } catch (IllegalArgumentException iae) {
+            throw new PemException(iae);
         }
     }
 

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -46,7 +47,6 @@ import org.keycloak.adapters.spi.AuthChallenge;
 import org.keycloak.adapters.spi.AuthOutcome;
 import org.keycloak.adapters.spi.HttpFacade;
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.dom.saml.v2.SAML2Object;
@@ -689,7 +689,7 @@ public abstract class AbstractSamlAuthenticationHandler implements SamlAuthentic
 
         try {
             //byte[] decodedSignature = RedirectBindingUtil.urlBase64Decode(signature);
-            byte[] decodedSignature = Base64.decode(signature);
+            byte[] decodedSignature = Base64.getDecoder().decode(signature);
             byte[] rawQueryBytes = rawQuery.getBytes(StandardCharsets.UTF_8);
 
             SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.getFromXmlMethod(decodedAlgorithm);

--- a/common/src/main/java/org/keycloak/common/crypto/PemUtilsProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/PemUtilsProvider.java
@@ -18,7 +18,6 @@
 package org.keycloak.common.crypto;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -26,9 +25,8 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 
-import org.keycloak.common.util.Base64;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.DerUtils;
 import org.keycloak.common.util.PemException;
 
@@ -129,9 +127,9 @@ public abstract class PemUtilsProvider {
     public byte[] pemToDer(String pem) {
         try {
             pem = removeBeginEnd(pem);
-            return Base64.decode(pem);
-        } catch (IOException ioe) {
-            throw new PemException(ioe);
+            return Base64.getDecoder().decode(pem);
+        } catch (IllegalArgumentException iae) {
+            throw new PemException(iae);
         }
     }
 
@@ -144,7 +142,7 @@ public abstract class PemUtilsProvider {
     }
 
     public String generateThumbprint(String[] certChain, String encoding) throws NoSuchAlgorithmException{
-        return Base64Url.encode(generateThumbprintBytes(certChain, encoding));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(generateThumbprintBytes(certChain, encoding));
     }
 
     private byte[] generateThumbprintBytes(String[] certChain, String encoding) throws NoSuchAlgorithmException {

--- a/common/src/main/java/org/keycloak/common/util/Base64.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64.java
@@ -153,6 +153,7 @@ import java.io.IOException;
  * @author rob@iharder.net
  * @version 2.3.7
  */
+@Deprecated
 public class Base64
 {
 

--- a/common/src/main/java/org/keycloak/common/util/Base64Url.java
+++ b/common/src/main/java/org/keycloak/common/util/Base64Url.java
@@ -22,6 +22,7 @@ package org.keycloak.common.util;
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
  */
+@Deprecated
 public class Base64Url {
     public static String encode(byte[] bytes) {
         String s = Base64.encodeBytes(bytes);

--- a/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
+++ b/core/src/main/java/org/keycloak/KeycloakSecurityContext.java
@@ -17,7 +17,6 @@
 
 package org.keycloak;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.DelegatingSerializationFilter;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
@@ -27,6 +26,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Base64;
 
 /**
  * Available in secured requests under HttpServletRequest.getAttribute()
@@ -103,7 +103,7 @@ public class KeycloakSecurityContext implements Serializable {
         String[] parts = encoded.split("\\.");
         if (parts.length < 2 || parts.length > 3) throw new IllegalArgumentException("Parsing error");
 
-        byte[] bytes = Base64Url.decode(parts[1]);
+        byte[] bytes = Base64.getUrlDecoder().decode(parts[1]);
         return JsonSerialization.readValue(bytes, clazz);
     }
 

--- a/core/src/main/java/org/keycloak/jose/JOSEParser.java
+++ b/core/src/main/java/org/keycloak/jose/JOSEParser.java
@@ -3,7 +3,7 @@ package org.keycloak.jose;
 import java.io.IOException;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.keycloak.common.util.Base64Url;
+import java.util.Base64;
 import org.keycloak.jose.jwe.JWE;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
@@ -31,7 +31,7 @@ public class JOSEParser {
         JsonNode header;
 
         try {
-            header = JsonSerialization.readValue(Base64Url.decode(parts[0]), JsonNode.class);
+            header = JsonSerialization.readValue(Base64.getUrlDecoder().decode(parts[0]), JsonNode.class);
         } catch (IOException cause) {
             throw new RuntimeException("Failed to parse JWT header", cause);
         }

--- a/core/src/main/java/org/keycloak/jose/jwk/EdECUtilsImpl.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/EdECUtilsImpl.java
@@ -26,8 +26,8 @@ import java.security.spec.EdECPoint;
 import java.security.spec.EdECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.NamedParameterSpec;
+import java.util.Base64;
 import java.util.Optional;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
@@ -82,7 +82,7 @@ class EdECUtilsImpl implements EdECUtils {
             throw new RuntimeException("Invalid JWK representation of OKP type algorithm");
         }
 
-        byte[] decodedX = Base64Url.decode(x);
+        byte[] decodedX = Base64.getUrlDecoder().decode(x);
         if (decodedX.length != bytesLength) {
             throw new RuntimeException("Invalid JWK representation of OKP type public key");
         }
@@ -137,7 +137,7 @@ class EdECUtilsImpl implements EdECUtils {
             yCoordinateLittleEndianBytes[yCoordinateLittleEndianBytes.length - 1] |= -128; // 0b10000000
         }
 
-        return Optional.ofNullable(Base64Url.encode(yCoordinateLittleEndianBytes));
+        return Optional.ofNullable(Base64.getUrlEncoder().withoutPadding().encodeToString(yCoordinateLittleEndianBytes));
     }
 
     private static byte[] reverseBytes(byte[] array) {

--- a/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKBuilder.java
@@ -24,10 +24,10 @@ import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.Algorithm;
@@ -105,8 +105,8 @@ public class JWKBuilder {
         k.setKeyType(KeyType.RSA);
         k.setAlgorithm(algorithm);
         k.setPublicKeyUse(keyUse == null ? KeyUse.SIG.getSpecName() : keyUse.getSpecName());
-        k.setModulus(Base64Url.encode(toIntegerBytes(rsaKey.getModulus())));
-        k.setPublicExponent(Base64Url.encode(toIntegerBytes(rsaKey.getPublicExponent())));
+        k.setModulus(Base64.getUrlEncoder().withoutPadding().encodeToString(toIntegerBytes(rsaKey.getModulus())));
+        k.setPublicExponent(Base64.getUrlEncoder().withoutPadding().encodeToString(toIntegerBytes(rsaKey.getPublicExponent())));
 
         if (certificates != null && !certificates.isEmpty()) {
             String[] certificateChain = new String[certificates.size()];
@@ -148,8 +148,8 @@ public class JWKBuilder {
         k.setAlgorithm(algorithm);
         k.setPublicKeyUse(keyUse == null ? DEFAULT_PUBLIC_KEY_USE.getSpecName() : keyUse.getSpecName());
         k.setCrv("P-" + fieldSize);
-        k.setX(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
-        k.setY(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+        k.setX(Base64.getUrlEncoder().withoutPadding().encodeToString(toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64.getUrlEncoder().withoutPadding().encodeToString(toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
 
         if (certificates != null && !certificates.isEmpty()) {
             String[] certificateChain = new String[certificates.size()];

--- a/core/src/main/java/org/keycloak/jose/jwk/JWKParser.java
+++ b/core/src/main/java/org/keycloak/jose/jwk/JWKParser.java
@@ -26,8 +26,8 @@ import java.security.spec.ECPublicKeySpec;
 import java.security.spec.RSAPublicKeySpec;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Base64;
 import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.util.JsonSerialization;
 
@@ -99,8 +99,8 @@ public class JWKParser {
             throw new RuntimeException("Fail to retrieve ECPublicJWK.CRV, ECPublicJWK.X or ECPublicJWK.Y field.");
         }
 
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
 
         String name;
         switch (crv) {
@@ -131,8 +131,8 @@ public class JWKParser {
     }
 
     private static PublicKey createRSAPublicKey(JsonNode jwk) {
-        BigInteger modulus = new BigInteger(1, Base64Url.decode(jwk.path(RSAPublicJWK.MODULUS).asText(null)));
-        BigInteger publicExponent = new BigInteger(1, Base64Url.decode(jwk.path(RSAPublicJWK.PUBLIC_EXPONENT).asText(null)));
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(jwk.path(RSAPublicJWK.MODULUS).asText(null)));
+        BigInteger publicExponent = new BigInteger(1, Base64.getUrlDecoder().decode(jwk.path(RSAPublicJWK.PUBLIC_EXPONENT).asText(null)));
 
         try {
             KeyFactory kf = KeyFactory.getInstance("RSA");

--- a/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSBuilder.java
@@ -18,8 +18,6 @@
 package org.keycloak.jose.jws;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.keycloak.common.util.Base64;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.crypto.HMACProvider;
@@ -32,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -72,7 +71,7 @@ public class JWSBuilder {
         this.x5c = x5c.stream()
                 .map(x509Certificate -> {
                     try {
-                        return Base64.encodeBytes(x509Certificate.getEncoded());
+                        return Base64.getEncoder().encodeToString(x509Certificate.getEncoded());
                     } catch (CertificateEncodingException e) {
                         throw new RuntimeException(e);
                     }
@@ -143,13 +142,13 @@ public class JWSBuilder {
         }
         if (contentType != null) builder.append(",\"cty\":\"").append(contentType).append("\"");
         builder.append("}");
-        return Base64Url.encode(builder.toString().getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(builder.toString().getBytes(StandardCharsets.UTF_8));
     }
 
     protected String encodeAll(StringBuilder encoding, byte[] signature) {
         encoding.append('.');
         if (signature != null) {
-            encoding.append(Base64Url.encode(signature));
+            encoding.append(Base64.getUrlEncoder().withoutPadding().encodeToString(signature));
         }
         return encoding.toString();
     }
@@ -161,7 +160,7 @@ public class JWSBuilder {
     protected void encode(String sigAlgName, byte[] data, StringBuilder encoding) {
         encoding.append(encodeHeader(sigAlgName));
         encoding.append('.');
-        encoding.append(Base64Url.encode(data));
+        encoding.append(Base64.getUrlEncoder().withoutPadding().encodeToString(data));
     }
 
     protected byte[] marshalContent() {

--- a/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
@@ -17,12 +17,12 @@
 
 package org.keycloak.jose.jws;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.JOSE;
 import org.keycloak.util.JsonSerialization;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -47,13 +47,13 @@ public class JWSInput implements JOSE {
             encodedHeader = parts[0];
             encodedContent = parts[1];
             encodedSignatureInput = encodedHeader + '.' + encodedContent;
-            content = Base64Url.decode(encodedContent);
+            content = Base64.getUrlDecoder().decode(encodedContent);
             if (parts.length > 2) {
                 encodedSignature = parts[2];
-                signature = Base64Url.decode(encodedSignature);
+                signature = Base64.getUrlDecoder().decode(encodedSignature);
 
             }
-            byte[] headerBytes = Base64Url.decode(encodedHeader);
+            byte[] headerBytes = Base64.getUrlDecoder().decode(encodedHeader);
             header = JsonSerialization.readValue(headerBytes, JWSHeader.class);
         } catch (Throwable t) {
             throw new JWSInputException(t);

--- a/core/src/main/java/org/keycloak/jose/jws/crypto/HMACProvider.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/HMACProvider.java
@@ -18,7 +18,6 @@
 package org.keycloak.jose.jws.crypto;
 
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSInput;
 
@@ -29,6 +28,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -84,7 +84,7 @@ public class HMACProvider implements SignatureProvider {
     public static boolean verify(JWSInput input, SecretKey key) {
         try {
             byte[] signature = sign(input.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), input.getHeader().getAlgorithm(), key);
-            return MessageDigest.isEqual(signature, Base64Url.decode(input.getEncodedSignature()));
+            return MessageDigest.isEqual(signature, Base64.getUrlDecoder().decode(input.getEncodedSignature()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -94,7 +94,7 @@ public class HMACProvider implements SignatureProvider {
     public static boolean verify(JWSInput input, byte[] sharedSecret) {
         try {
             byte[] signature = sign(input.getEncodedSignatureInput().getBytes(StandardCharsets.UTF_8), input.getHeader().getAlgorithm(), sharedSecret);
-            return MessageDigest.isEqual(signature, Base64Url.decode(input.getEncodedSignature()));
+            return MessageDigest.isEqual(signature, Base64.getUrlDecoder().decode(input.getEncodedSignature()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.jose.jws.crypto;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.HashException;
 import org.keycloak.crypto.JavaAlgorithm;
 
@@ -25,6 +24,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.Base64;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -72,13 +72,13 @@ public class HashUtils {
         int hashLength = full ? hash.length : hash.length / 2;
         byte[] hashInput = Arrays.copyOf(hash, hashLength);
 
-        return Base64Url.encode(hashInput);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashInput);
     }
 
     public static String sha256UrlEncodedHash(String input, Charset charset) {
         byte[] inputBytes = input.getBytes(charset);
         byte[] hashedOutput = hash(JavaAlgorithm.SHA256, inputBytes);
-        return Base64Url.encode(hashedOutput);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashedOutput);
     }
 
 }

--- a/core/src/main/java/org/keycloak/sdjwt/SdJwtUtils.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwtUtils.java
@@ -22,7 +22,6 @@ import java.security.SecureRandom;
 import java.util.Optional;
 
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.jws.crypto.HashUtils;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -32,6 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.util.Base64;
 
 /**
  *
@@ -43,7 +43,7 @@ public class SdJwtUtils {
     private static final SecureRandom RANDOM = new SecureRandom();
 
     public static String encodeNoPad(byte[] bytes) {
-        return Base64Url.encode(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
     public static String encodeNoPad(String input) {
@@ -51,7 +51,7 @@ public class SdJwtUtils {
     }
 
     public static byte[] decodeNoPad(String encoded) {
-        return Base64Url.decode(encoded);
+        return Base64.getUrlDecoder().decode(encoded);
     }
 
     public static String hashAndBase64EncodeNoPad(byte[] disclosureBytes, String hashAlg) {

--- a/core/src/main/java/org/keycloak/sdjwt/vp/SdJwtVP.java
+++ b/core/src/main/java/org/keycloak/sdjwt/vp/SdJwtVP.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.JavaAlgorithm;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
@@ -43,6 +42,7 @@ import org.keycloak.sdjwt.SdJwtVerificationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Base64;
 
 /**
  * @author <a href="mailto:francis.pouatcha@adorsys.com">Francis Pouatcha</a>
@@ -150,7 +150,7 @@ public class SdJwtVP {
             disclosures.put(disclosureDigest, disclosure);
             ArrayNode disclosureData;
             try {
-                disclosureData = (ArrayNode) SdJwtUtils.mapper.readTree(Base64Url.decode(disclosure));
+                disclosureData = (ArrayNode) SdJwtUtils.mapper.readTree(Base64.getUrlDecoder().decode(disclosure));
                 claims.put(disclosureDigest, disclosureData);
             } catch (IOException e) {
                 throw new IllegalArgumentException("Invalid disclosure data");

--- a/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
+++ b/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
@@ -17,13 +17,11 @@
 
 package org.keycloak.util;
 
-import org.keycloak.common.util.Base64;
-
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * The default implementation is compliant with <a href="https://datatracker.ietf.org/doc/html/rfc2617">RFC 2617</a>
@@ -33,7 +31,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class BasicAuthHelper {
     public static String createHeader(String username, String password) {
-        return "Basic " + Base64.encodeBytes((username + ':' + password).getBytes(StandardCharsets.UTF_8));
+        return "Basic " + Base64.getEncoder().encodeToString((username + ':' + password).getBytes(StandardCharsets.UTF_8));
     }
 
     public static String[] parseHeader(String header) {
@@ -45,8 +43,8 @@ public class BasicAuthHelper {
 
         String val;
         try {
-            val = new String(Base64.decode(header.substring(6)));
-        } catch (IOException e) {
+            val = new String(Base64.getDecoder().decode(header.substring(6)));
+        } catch (IllegalArgumentException e) {
             return null;
         }
 

--- a/core/src/main/java/org/keycloak/util/JWKSUtils.java
+++ b/core/src/main/java/org/keycloak/util/JWKSUtils.java
@@ -21,7 +21,6 @@ import org.jboss.logging.Logger;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.PublicKeysWrapper;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.jose.jwk.ECPublicJWK;
 import org.keycloak.jose.jwk.JSONWebKeySet;
@@ -34,6 +33,7 @@ import org.keycloak.jose.jws.crypto.HashUtils;
 import java.io.IOException;
 import java.security.PublicKey;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -171,7 +171,7 @@ public class JWKSUtils {
 
             byte[] bytes = JsonSerialization.writeValueAsBytes(members);
             byte[] hash = HashUtils.hash(hashAlg, bytes);
-            return Base64Url.encode(hash);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
         } catch (IOException ex) {
             logger.debugf(ex, "Failed to compute JWK thumbprint for key '%s'.", key.getKeyId());
             return null;

--- a/core/src/test/java/org/keycloak/RSAVerifierTest.java
+++ b/core/src/test/java/org/keycloak/RSAVerifierTest.java
@@ -23,7 +23,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.Time;
 import org.keycloak.jose.jwk.JWK;
@@ -39,6 +38,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -107,8 +107,8 @@ public abstract class RSAVerifierTest {
 
         List<String> x5c = tokenVerifier.getHeader().getX5c();
         Assert.assertEquals(2, x5c.size());
-        Assert.assertEquals(Base64.encodeBytes(idpCertificate.getEncoded()), x5c.get(0));
-        Assert.assertEquals(Base64.encodeBytes(caCertificate.getEncoded()), x5c.get(1));
+        Assert.assertEquals(Base64.getEncoder().encodeToString(idpCertificate.getEncoded()), x5c.get(0));
+        Assert.assertEquals(Base64.getEncoder().encodeToString(caCertificate.getEncoded()), x5c.get(1));
         Assert.assertEquals(JsonSerialization.mapper.convertValue(jwk, Map.class),
                             JsonSerialization.mapper.convertValue(tokenVerifier.getHeader().getKey(), Map.class));
     }

--- a/core/src/test/java/org/keycloak/jose/JWETest.java
+++ b/core/src/test/java/org/keycloak/jose/JWETest.java
@@ -22,7 +22,6 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.jose.jwe.JWE;
 import org.keycloak.jose.jwe.JWEConstants;
@@ -41,6 +40,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.KeyPair;
+import java.util.Base64;
 
 /**
  * This is not tested in keycloak-core. The subclasses should be created in the crypto modules to make sure it is tested with corresponding modules (bouncycastle VS bouncycastle-fips)
@@ -225,7 +225,7 @@ public abstract class JWETest {
         // See example "A.3" from JWE specification - https://tools.ietf.org/html/rfc7516#page-41
         String externalJwe = "eyJhbGciOiJBMTI4S1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.6KB707dM9YTIgHtLvtgWQ8mKwboJW3of9locizkDTHzBC2IlrT1oOQ.AxY8DCtDaGlsbGljb3RoZQ.KDlTtXchhZTGufMYmOYGS4HffxPSUrfmqCHXaI9wOGY.U0m_YmjN04DJvceFICbCVQ";
 
-        byte[] aesKey = Base64Url.decode("GawgguFyGrWKav7AX4VKUg");
+        byte[] aesKey = Base64.getUrlDecoder().decode("GawgguFyGrWKav7AX4VKUg");
         SecretKeySpec aesKeySpec = new SecretKeySpec(aesKey, "AES");
 
         JWE jwe = new JWE();

--- a/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
+++ b/core/src/test/java/org/keycloak/jose/jwk/JWKTest.java
@@ -20,7 +20,6 @@ package org.keycloak.jose.jwk;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.crypto.JavaAlgorithm;
@@ -39,6 +38,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -162,8 +162,8 @@ public abstract class JWKTest {
         assertNotNull(ecJwk.getX());
         assertNotNull(ecJwk.getY());
 
-        byte[] xBytes = Base64Url.decode(ecJwk.getX());
-        byte[] yBytes = Base64Url.decode(ecJwk.getY());
+        byte[] xBytes = Base64.getUrlDecoder().decode(ecJwk.getX());
+        byte[] yBytes = Base64.getUrlDecoder().decode(ecJwk.getY());
 
         final int expectedSize = (publicKey.getParams().getCurve().getField().getFieldSize() + 7) / 8;
         assertEquals(expectedSize, xBytes.length);

--- a/core/src/test/java/org/keycloak/sdjwt/TestSettings.java
+++ b/core/src/test/java/org/keycloak/sdjwt/TestSettings.java
@@ -30,7 +30,6 @@ import java.security.spec.ECPublicKeySpec;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.crypto.ECDSASignatureSignerContext;
 import org.keycloak.crypto.ECDSASignatureVerifierContext;
@@ -40,6 +39,7 @@ import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Base64;
 
 /**
  * Import test-settings from:
@@ -133,8 +133,8 @@ public class TestSettings {
 
         ECParameterSpec ecSpec = getECParameterSpec(ECDSA_CURVE_2_SPECS_NAMES.get(curveName));
 
-        byte[] xBytes = Base64Url.decode(base64UrlEncodedX);
-        byte[] yBytes = Base64Url.decode(base64UrlEncodedY);
+        byte[] xBytes = Base64.getUrlDecoder().decode(base64UrlEncodedX);
+        byte[] yBytes = Base64.getUrlDecoder().decode(base64UrlEncodedY);
 
         try {
             KeyFactory keyFactory = KeyFactory.getInstance("EC");
@@ -158,9 +158,9 @@ public class TestSettings {
 
         ECParameterSpec ecSpec = getECParameterSpec(ECDSA_CURVE_2_SPECS_NAMES.get(curveName));
 
-        byte[] dBytes = Base64Url.decode(base64UrlEncodedD);
-        byte[] xBytes = Base64Url.decode(base64UrlEncodedX);
-        byte[] yBytes = Base64Url.decode(base64UrlEncodedY);
+        byte[] dBytes = Base64.getUrlDecoder().decode(base64UrlEncodedD);
+        byte[] xBytes = Base64.getUrlDecoder().decode(base64UrlEncodedX);
+        byte[] yBytes = Base64.getUrlDecoder().decode(base64UrlEncodedY);
 
         try {
             KeyFactory keyFactory = KeyFactory.getInstance("EC");

--- a/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/TestCompareSdJwt.java
+++ b/core/src/test/java/org/keycloak/sdjwt/sdjwtvp/TestCompareSdJwt.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.sdjwt.IssuerSignedJWT;
 import org.keycloak.sdjwt.SdJwtUtils;
 import org.keycloak.sdjwt.vp.SdJwtVP;
@@ -33,6 +32,7 @@ import org.keycloak.sdjwt.vp.SdJwtVP;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Base64;
 
 /**
  * This class will try to test conformity to the spec by comparing json objects.
@@ -105,7 +105,7 @@ public class TestCompareSdJwt {
 
     private static JsonNode toJsonNode(String base64EncodedString) {
         try {
-            return SdJwtUtils.mapper.readTree(Base64Url.decode(base64EncodedString));
+            return SdJwtUtils.mapper.readTree(Base64.getUrlDecoder().decode(base64EncodedString));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCEcdhEsAlgorithmProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCEcdhEsAlgorithmProvider.java
@@ -37,6 +37,7 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 import javax.crypto.KeyAgreement;
 
@@ -49,7 +50,6 @@ import org.bouncycastle.crypto.util.DigestFactory;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.bouncycastle.jce.spec.ECNamedCurveSpec;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.jose.jwe.JWEHeader;
@@ -124,7 +124,7 @@ public class BCEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
     }
 
     private byte[] base64UrlDecode(String encoded) {
-        return Base64Url.decode(encoded == null ? "" : encoded);
+        return Base64.getUrlDecoder().decode(encoded == null ? "" : encoded);
     }
 
     private static KeyPair generateEcKeyPair(ECParameterSpec params) {
@@ -167,8 +167,8 @@ public class BCEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
         int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
         k.setCrv("P-" + fieldSize);
         k.setKeyType(KeyType.EC);
-        k.setX(Base64Url.encode(JWKUtil.toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
-        k.setY(Base64Url.encode(JWKUtil.toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+        k.setX(Base64.getUrlEncoder().withoutPadding().encodeToString(JWKUtil.toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64.getUrlEncoder().withoutPadding().encodeToString(JWKUtil.toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
         return k;
     }
 
@@ -187,8 +187,8 @@ public class BCEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
             throw new IllegalArgumentException("JWK y must be set");
         }
 
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
 
         String name = nistToSecCurveName(crv);
         try {

--- a/crypto/default/src/main/java/org/keycloak/crypto/hash/Argon2PasswordHashProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/hash/Argon2PasswordHashProvider.java
@@ -1,8 +1,8 @@
 package org.keycloak.crypto.hash;
 
+import java.util.Base64;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.credential.hash.PasswordHashProvider;
 import org.keycloak.credential.hash.Salt;
@@ -130,7 +130,7 @@ public class Argon2PasswordHashProvider implements PasswordHashProvider {
 
                 byte[] result = new byte[hashLength];
                 generator.generateBytes(rawPassword.toCharArray(), result);
-                return Base64.encodeBytes(result);
+                return Base64.getEncoder().encodeToString(result);
             });
         } finally {
             cpuCoreSemaphore.release();

--- a/crypto/default/src/test/java/org/keycloak/crypto/def/test/BCEcdhEsAlgorithmProviderTest.java
+++ b/crypto/default/src/test/java/org/keycloak/crypto/def/test/BCEcdhEsAlgorithmProviderTest.java
@@ -30,6 +30,7 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
@@ -39,7 +40,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Environment;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.def.BCEcdhEsAlgorithmProvider;
@@ -78,8 +78,8 @@ public class BCEcdhEsAlgorithmProviderTest {
         PublicKey encryptionPublicKey = getPublicKey("P-256", "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
                 "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck");
         byte[] derivedKey = BCEcdhEsAlgorithmProvider.deriveKey(encryptionPublicKey, ephemeralPrivateKey, 128,
-                "A128GCM", Base64Url.decode("QWxpY2U"), Base64Url.decode("Qm9i"));
-        Assert.assertEquals("VqqN6vgjbSBcIijNcacQGg", Base64Url.encode(derivedKey));
+                "A128GCM", Base64.getUrlDecoder().decode("QWxpY2U"), Base64.getUrlDecoder().decode("Qm9i"));
+        Assert.assertEquals("VqqN6vgjbSBcIijNcacQGg", Base64.getUrlEncoder().withoutPadding().encodeToString(derivedKey));
     }
 
     @Test
@@ -105,8 +105,8 @@ public class BCEcdhEsAlgorithmProviderTest {
 
     private PublicKey getPublicKey(String crv, String xStr, String yStr)
             throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
         ECPoint point = new ECPoint(x, y);
         String name = nistToSecCurveName(crv);
         ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec(name);
@@ -118,7 +118,7 @@ public class BCEcdhEsAlgorithmProviderTest {
 
     private PrivateKey getPrivateKey(String crv, String dStr)
             throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
-        BigInteger d = new BigInteger(1, Base64Url.decode(dStr));
+        BigInteger d = new BigInteger(1, Base64.getUrlDecoder().decode(dStr));
         String name = nistToSecCurveName(crv);
         ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec(name);
         ECParameterSpec params = new ECNamedCurveSpec(name, spec.getCurve(), spec.getG(), spec.getN());

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronEcdhEsAlgorithmProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronEcdhEsAlgorithmProvider.java
@@ -33,6 +33,7 @@ import java.security.SecureRandom;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
+import java.util.Base64;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyAgreement;
@@ -42,7 +43,6 @@ import org.jose4j.jwe.kdf.ConcatKeyDerivationFunction;
 import org.jose4j.keys.EcKeyUtil;
 import org.jose4j.keys.EllipticCurves;
 import org.jose4j.lang.JoseException;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.jose.jwe.JWEHeader;
@@ -117,7 +117,7 @@ public class ElytronEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
     }
 
     private byte[] base64UrlDecode(String encoded) {
-        return Base64Url.decode(encoded == null ? "" : encoded);
+        return Base64.getUrlDecoder().decode(encoded == null ? "" : encoded);
     }
 
     private static KeyPair generateEcKeyPair(ECParameterSpec params) {
@@ -147,8 +147,8 @@ public class ElytronEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
         int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
         k.setCrv("P-" + fieldSize);
         k.setKeyType(KeyType.EC);
-        k.setX(Base64Url.encode(JWKUtil.toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
-        k.setY(Base64Url.encode(JWKUtil.toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+        k.setX(Base64.getUrlEncoder().withoutPadding().encodeToString(JWKUtil.toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64.getUrlEncoder().withoutPadding().encodeToString(JWKUtil.toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
         return k;
     }
 
@@ -167,8 +167,8 @@ public class ElytronEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
             throw new IllegalArgumentException("JWK y must be set");
         }
 
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
 
         EcKeyUtil ecKeyUtil = new EcKeyUtil();
         try {

--- a/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronEcdhEsAlgorithmProviderTest.java
+++ b/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronEcdhEsAlgorithmProviderTest.java
@@ -25,6 +25,7 @@ import java.security.NoSuchProviderException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 import org.jose4j.keys.EcKeyUtil;
 import org.jose4j.keys.EllipticCurves;
@@ -32,7 +33,6 @@ import org.jose4j.lang.JoseException;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.elytron.ElytronEcdhEsAlgorithmProvider;
 import org.keycloak.jose.jwe.JWE;
@@ -63,8 +63,8 @@ public class ElytronEcdhEsAlgorithmProviderTest {
         PublicKey encryptionPublicKey = getPublicKey("P-256", "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
                 "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck");
         byte[] derivedKey = ElytronEcdhEsAlgorithmProvider.deriveKey(encryptionPublicKey, ephemeralPrivateKey, 128,
-                "A128GCM", Base64Url.decode("QWxpY2U"), Base64Url.decode("Qm9i"));
-        Assert.assertEquals("VqqN6vgjbSBcIijNcacQGg", Base64Url.encode(derivedKey));
+                "A128GCM", Base64.getUrlDecoder().decode("QWxpY2U"), Base64.getUrlDecoder().decode("Qm9i"));
+        Assert.assertEquals("VqqN6vgjbSBcIijNcacQGg", Base64.getUrlEncoder().withoutPadding().encodeToString(derivedKey));
     }
 
     @Test
@@ -90,14 +90,14 @@ public class ElytronEcdhEsAlgorithmProviderTest {
     }
 
     private PublicKey getPublicKey(String crv, String xStr, String yStr) throws JoseException {
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
         EcKeyUtil ecKeyUtil = new EcKeyUtil();
         return ecKeyUtil.publicKey(x, y, EllipticCurves.getSpec(crv));
     }
 
     private PrivateKey getPrivateKey(String crv, String dStr) throws JoseException {
-        BigInteger d = new BigInteger(1, Base64Url.decode(dStr));
+        BigInteger d = new BigInteger(1, Base64.getUrlDecoder().decode(dStr));
         EcKeyUtil ecKeyUtil = new EcKeyUtil();
         return ecKeyUtil.privateKey(d, EllipticCurves.getSpec(crv));
     }

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSEcdhEsAlgorithmProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSEcdhEsAlgorithmProvider.java
@@ -37,6 +37,7 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -54,7 +55,6 @@ import org.bouncycastle.crypto.fips.FipsEC;
 import org.bouncycastle.crypto.fips.FipsKDF;
 import org.bouncycastle.crypto.fips.FipsKDF.AgreementKDFPRF;
 import org.bouncycastle.jcajce.spec.ECDomainParameterSpec;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyType;
 import org.keycloak.jose.jwe.JWEHeader;
@@ -133,7 +133,7 @@ public class BCFIPSEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
     }
 
     private byte[] base64UrlDecode(String encoded) {
-        return Base64Url.decode(encoded == null ? "" : encoded);
+        return Base64.getUrlDecoder().decode(encoded == null ? "" : encoded);
     }
 
     private static KeyPair generateEcKeyPair(ECParameterSpec params) {
@@ -172,8 +172,8 @@ public class BCFIPSEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
         int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
         k.setCrv("P-" + fieldSize);
         k.setKeyType(KeyType.EC);
-        k.setX(Base64Url.encode(JWKUtil.toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
-        k.setY(Base64Url.encode(JWKUtil.toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+        k.setX(Base64.getUrlEncoder().withoutPadding().encodeToString(JWKUtil.toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64.getUrlEncoder().withoutPadding().encodeToString(JWKUtil.toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
         return k;
     }
 
@@ -192,8 +192,8 @@ public class BCFIPSEcdhEsAlgorithmProvider implements JWEAlgorithmProvider {
             throw new IllegalArgumentException("JWK y must be set");
         }
 
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
 
         try {
             ECPoint point = new ECPoint(x, y);

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/BCFIPSEcdhEsAlgorithmProviderTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/BCFIPSEcdhEsAlgorithmProviderTest.java
@@ -29,6 +29,7 @@ import java.security.spec.ECPoint;
 import java.security.spec.ECPrivateKeySpec;
 import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
@@ -37,7 +38,6 @@ import org.bouncycastle.jcajce.spec.ECDomainParameterSpec;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.fips.BCFIPSEcdhEsAlgorithmProvider;
 import org.keycloak.jose.jwe.JWE;
@@ -66,8 +66,8 @@ public class BCFIPSEcdhEsAlgorithmProviderTest {
         PublicKey encryptionPublicKey = getPublicKey("P-256", "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ",
                 "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck");
         byte[] derivedKey = BCFIPSEcdhEsAlgorithmProvider.deriveKey(encryptionPublicKey, ephemeralPrivateKey, 128,
-                "A128GCM", Base64Url.decode("QWxpY2U"), Base64Url.decode("Qm9i"));
-        Assert.assertEquals("VqqN6vgjbSBcIijNcacQGg", Base64Url.encode(derivedKey));
+                "A128GCM", Base64.getUrlDecoder().decode("QWxpY2U"), Base64.getUrlDecoder().decode("Qm9i"));
+        Assert.assertEquals("VqqN6vgjbSBcIijNcacQGg", Base64.getUrlEncoder().withoutPadding().encodeToString(derivedKey));
     }
 
     @Test
@@ -93,8 +93,8 @@ public class BCFIPSEcdhEsAlgorithmProviderTest {
 
     private PublicKey getPublicKey(String crv, String xStr, String yStr)
             throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
-        BigInteger x = new BigInteger(1, Base64Url.decode(xStr));
-        BigInteger y = new BigInteger(1, Base64Url.decode(yStr));
+        BigInteger x = new BigInteger(1, Base64.getUrlDecoder().decode(xStr));
+        BigInteger y = new BigInteger(1, Base64.getUrlDecoder().decode(yStr));
         ECPoint point = new ECPoint(x, y);
         X9ECParameters ecParams = NISTNamedCurves.getByName(crv);
         ECParameterSpec params = new ECDomainParameterSpec(
@@ -106,7 +106,7 @@ public class BCFIPSEcdhEsAlgorithmProviderTest {
 
     private PrivateKey getPrivateKey(String crv, String dStr)
             throws InvalidKeySpecException, NoSuchAlgorithmException, NoSuchProviderException {
-        BigInteger d = new BigInteger(1, Base64Url.decode(dStr));
+        BigInteger d = new BigInteger(1, Base64.getUrlDecoder().decode(dStr));
         X9ECParameters ecParams = NISTNamedCurves.getByName(crv);
         ECParameterSpec params = new ECDomainParameterSpec(
                 new ECDomainParameters(ecParams.getCurve(), ecParams.getG(), ecParams.getN(), ecParams.getH()));

--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/impl/SPNEGOAuthenticator.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/impl/SPNEGOAuthenticator.java
@@ -24,7 +24,6 @@ import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.Oid;
 import org.jboss.logging.Logger;
 import org.keycloak.common.constants.KerberosConstants;
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.KerberosSerializationUtils;
 import org.keycloak.federation.kerberos.CommonKerberosConfig;
 import org.keycloak.federation.kerberos.KerberosPrincipal;
@@ -33,6 +32,7 @@ import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosTicket;
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -164,9 +164,9 @@ public class SPNEGOAuthenticator {
         GSSCredential gssCredential = manager.createCredential(null, GSSCredential.INDEFINITE_LIFETIME, supportedMechs, GSSCredential.ACCEPT_ONLY);
         GSSContext gssContext = manager.createContext(gssCredential);
 
-        byte[] inputToken = Base64.decode(spnegoToken);
+        byte[] inputToken = Base64.getDecoder().decode(spnegoToken);
         byte[] respToken = gssContext.acceptSecContext(inputToken, 0, inputToken.length);
-        responseToken = Base64.encodeBytes(respToken);
+        responseToken = Base64.getEncoder().withoutPadding().encodeToString(respToken);
 
         return gssContext;
     }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -19,7 +19,6 @@ package org.keycloak.storage.ldap.idm.store.ldap;
 
 import javax.naming.NameAlreadyBoundException;
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.Base64;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.LDAPConstants;
 import org.keycloak.models.ModelException;
@@ -47,8 +46,8 @@ import javax.naming.directory.ModificationItem;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -485,7 +484,7 @@ public class LDAPIdentityStore implements IdentityStore {
                         Object val = enumm.next();
 
                         if (val instanceof byte[]) { // byte[]
-                            String attrVal = Base64.encodeBytes((byte[]) val);
+                            String attrVal = Base64.getEncoder().encodeToString((byte[]) val);
                             attrValues.add(attrVal);
                         } else { // String
                             String attrVal = val.toString().trim();
@@ -599,9 +598,9 @@ public class LDAPIdentityStore implements IdentityStore {
             }
 
             try {
-                byte[] bytes = Base64.decode(value);
+                byte[] bytes = Base64.getDecoder().decode(value);
                 attr.add(bytes);
-            } catch (IOException ioe) {
+            } catch (IllegalArgumentException iae) {
                 logger.warnf("Wasn't able to Base64 decode the attribute value. Ignoring attribute update. Attribute: %s, Attribute value: %s", attrName, attrValue);
             }
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/RootAuthenticationSessionAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/RootAuthenticationSessionAdapter.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.sessions.infinispan;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
@@ -34,6 +33,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Base64;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -123,7 +123,7 @@ public class RootAuthenticationSessionAdapter implements RootAuthenticationSessi
 
         AuthenticationSessionEntity authSessionEntity = new AuthenticationSessionEntity();
         authSessionEntity.setClientUUID(client.getId());
-        String tabId = Base64Url.encode(SecretGenerator.getInstance().randomBytes(8));
+        String tabId = Base64.getUrlEncoder().withoutPadding().encodeToString(SecretGenerator.getInstance().randomBytes(8));
         int timestamp = Time.currentTime();
 
         RootAuthenticationSessionUpdateTask task = new RootAuthenticationSessionUpdateTask() {

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/authsession/RootAuthenticationSessionUpdater.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/remote/updater/authsession/RootAuthenticationSessionUpdater.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.models.sessions.infinispan.changes.remote.updater.authsession;
 
-import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
@@ -33,6 +32,7 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -166,7 +166,7 @@ public class RootAuthenticationSessionUpdater extends BaseUpdater<String, RootAu
 
         AuthenticationSessionEntity authSessionEntity = new AuthenticationSessionEntity();
         authSessionEntity.setClientUUID(client.getId());
-        String newTabId = Base64Url.encode(SecretGenerator.getInstance().randomBytes(8));
+        String newTabId = Base64.getUrlEncoder().withoutPadding().encodeToString(SecretGenerator.getInstance().randomBytes(8));
         int timestamp = Time.currentTime();
 
         addAndApplyChange(entity -> {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserCredentialStore.java
@@ -17,7 +17,6 @@
 package org.keycloak.models.jpa;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.Base64;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.UserCredentialStore;
 import org.keycloak.models.KeycloakSession;
@@ -33,6 +32,7 @@ import jakarta.persistence.TypedQuery;
 
 import java.util.List;
 import jakarta.persistence.LockModeType;
+import java.util.Base64;
 
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -105,7 +105,7 @@ public class JpaUserCredentialStore implements UserCredentialStore {
         // Backwards compatibility - users from previous version still have "salt" in the DB filled.
         // We migrate it to new secretData format on-the-fly
         if (entity.getSalt() != null) {
-            String newSecretData = entity.getSecretData().replace("__SALT__", Base64.encodeBytes(entity.getSalt()));
+            String newSecretData = entity.getSecretData().replace("__SALT__", Base64.getEncoder().withoutPadding().encodeToString(entity.getSalt()));
             entity.setSecretData(newSecretData);
             entity.setSalt(null);
         }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -17,7 +17,6 @@
 package org.keycloak.storage.jpa;
 
 import org.jboss.logging.Logger;
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
@@ -62,6 +61,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import jakarta.persistence.LockModeType;
+import java.util.Base64;
 
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
 import static org.keycloak.utils.StreamsUtil.closing;
@@ -652,7 +652,7 @@ public class JpaUserFederatedStorageProvider implements
         // Backwards compatibility - users from previous version still have "salt" in the DB filled.
         // We migrate it to new secretData format on-the-fly
         if (entity.getSalt() != null) {
-            String newSecretData = entity.getSecretData().replace("__SALT__", Base64.encodeBytes(entity.getSalt()));
+            String newSecretData = entity.getSecretData().replace("__SALT__", Base64.getEncoder().encodeToString(entity.getSalt()));
             entity.setSecretData(newSecretData);
             entity.setSalt(null);
         }


### PR DESCRIPTION
Replaced usages with JDK Base64 implementation.

Partial progress: common, core

