### PR TITLE
Add new indices on `offline_client_session`

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -96,10 +96,12 @@ make sure the users granted with the `realm-admin` role are expected to have thi
 The documentation is also updated with additional information about the different types of realm administrators.
 For more information, see link:{adminguide_link}#_fine_grained_permissions[Delegating realm administration using permissions].
 
-=== Added Database Indexes on `offline_client_session` table
+=== Added database indexes on `OFFLINE_CLIENT_SESSION` table
 
-Indexes have been added on `offline_client_session` table to improve query performance when retrieving or deleting offline client sessions.
-This change especially improves performance of deleting a client which was getting slower the more offline sessions existed for that client.
+This adds new indexes on `OFFLINE_CLIENT_SESSION` table to improve performance when retrieving or deleting client sessions.
+
+If those tables contain more than 300000 entries, {project_name} will skip the index creation by default during the automatic schema migration and instead log the SQL statement on the console during migration to be applied manually after {project_name}'s startup.
+See the link:{upgradingguide_link}[{upgradingguide_name}] for details on how to configure a different limit.
 
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features

--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -96,6 +96,11 @@ make sure the users granted with the `realm-admin` role are expected to have thi
 The documentation is also updated with additional information about the different types of realm administrators.
 For more information, see link:{adminguide_link}#_fine_grained_permissions[Delegating realm administration using permissions].
 
+=== Added Database Indexes on `offline_client_session` table
+
+Indexes have been added on `offline_client_session` table to improve query performance when retrieving or deleting offline client sessions.
+This change especially improves performance of deleting a client which was getting slower the more offline sessions existed for that client.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -196,6 +196,12 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         onClientRemoved(client.getId());
     }
 
+    /**
+     * Remove client sessions for a specific client.
+     * <p>
+     * We need to remove the client sessions for clients that are no longer present, as we would otherwise
+     * look up those non-existent clients again and again, and this would be slow as they would never be in the cache.
+     */
     private void onClientRemoved(String clientUUID) {
         logger.debugf("Client sessions removed for client %s",  clientUUID);
         StorageId clientStorageId = new StorageId(clientUUID);

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -209,7 +209,6 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             em.createNamedQuery("deleteClientSessionsByClient").setParameter("clientId", clientUUID).executeUpdate();
         } else {
             em.createNamedQuery("deleteClientSessionsByExternalClient")
-                    .setParameter("clientId", PersistentClientSessionEntity.EXTERNAL)
                     .setParameter("clientStorageProvider", clientStorageId.getProviderId())
                     .setParameter("externalClientId", clientStorageId.getExternalId())
                     .executeUpdate();
@@ -406,7 +405,6 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             query.setParameter("clientId", client.getId());
         } else {
             query = em.createNamedQuery("findClientSessionsByUserSessionAndExternalClient", PersistentClientSessionEntity.class);
-            query.setParameter("clientId", PersistentClientSessionEntity.EXTERNAL);
             query.setParameter("clientStorageProvider", clientStorageId.getProviderId());
             query.setParameter("externalClientId", clientStorageId.getExternalId());
         }
@@ -673,7 +671,6 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             query.setParameter("clientId", clientModel.getId());
         } else {
             query = em.createNamedQuery("findClientSessionsCountByExternalClient");
-            query.setParameter("clientId", PersistentClientSessionEntity.EXTERNAL);
             query.setParameter("clientStorageProvider", clientStorageId.getProviderId());
             query.setParameter("externalClientId", clientStorageId.getExternalId());
         }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -209,6 +209,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             em.createNamedQuery("deleteClientSessionsByClient").setParameter("clientId", clientUUID).executeUpdate();
         } else {
             em.createNamedQuery("deleteClientSessionsByExternalClient")
+                    .setParameter("clientId", PersistentClientSessionEntity.EXTERNAL)
                     .setParameter("clientStorageProvider", clientStorageId.getProviderId())
                     .setParameter("externalClientId", clientStorageId.getExternalId())
                     .executeUpdate();
@@ -405,6 +406,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             query.setParameter("clientId", client.getId());
         } else {
             query = em.createNamedQuery("findClientSessionsByUserSessionAndExternalClient", PersistentClientSessionEntity.class);
+            query.setParameter("clientId", PersistentClientSessionEntity.EXTERNAL);
             query.setParameter("clientStorageProvider", clientStorageId.getProviderId());
             query.setParameter("externalClientId", clientStorageId.getExternalId());
         }
@@ -671,6 +673,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
             query.setParameter("clientId", clientModel.getId());
         } else {
             query = em.createNamedQuery("findClientSessionsCountByExternalClient");
+            query.setParameter("clientId", PersistentClientSessionEntity.EXTERNAL);
             query.setParameter("clientStorageProvider", clientStorageId.getProviderId());
             query.setParameter("externalClientId", clientStorageId.getExternalId());
         }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -34,8 +34,8 @@ import java.io.Serializable;
  */
 @NamedQueries({
         @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
-        @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientStorageProvider = 'local'"),
-        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'"),
+        @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientStorageProvider != 'internal'"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
         @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
@@ -44,10 +44,10 @@ import java.io.Serializable;
         @NamedQuery(name="findClientSessionsByUserSession", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline"),
         @NamedQuery(name="findClientSessionsOrderedByIdInterval", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId >= :fromSessionId and sess.userSessionId <= :toSessionId order by sess.userSessionId"),
         @NamedQuery(name="findClientSessionsOrderedByIdExact", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds)"),
-        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId and sess.clientStorageProvider = 'local'"),
-        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId and sess.clientStorageProvider = 'local'"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'")
+        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientStorageProvider != 'internal'"),
+        @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientStorageProvider != 'internal'")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -35,7 +35,7 @@ import java.io.Serializable;
 @NamedQueries({
         @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
         @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId"),
-        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
+        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
         @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
@@ -45,9 +45,9 @@ import java.io.Serializable;
         @NamedQuery(name="findClientSessionsOrderedByIdInterval", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId >= :fromSessionId and sess.userSessionId <= :toSessionId order by sess.userSessionId"),
         @NamedQuery(name="findClientSessionsOrderedByIdExact", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId"),
-        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.clientId = :clientId andsess.clientId = :clientId and  sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
+        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId")
+        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -34,7 +34,7 @@ import java.io.Serializable;
  */
 @NamedQueries({
         @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
-        @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientStorageProvider = 'local'"),
         @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
         @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
@@ -44,9 +44,9 @@ import java.io.Serializable;
         @NamedQuery(name="findClientSessionsByUserSession", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline"),
         @NamedQuery(name="findClientSessionsOrderedByIdInterval", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId >= :fromSessionId and sess.userSessionId <= :toSessionId order by sess.userSessionId"),
         @NamedQuery(name="findClientSessionsOrderedByIdExact", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds)"),
-        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId and sess.clientStorageProvider = 'local'"),
         @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId and sess.clientStorageProvider = 'local'"),
         @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -35,7 +35,7 @@ import java.io.Serializable;
 @NamedQueries({
         @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
         @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId"),
-        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
+        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
         @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
@@ -45,9 +45,9 @@ import java.io.Serializable;
         @NamedQuery(name="findClientSessionsOrderedByIdInterval", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId >= :fromSessionId and sess.userSessionId <= :toSessionId order by sess.userSessionId"),
         @NamedQuery(name="findClientSessionsOrderedByIdExact", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds)"),
         @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId"),
-        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
+        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.clientId = :clientId andsess.clientId = :clientId and  sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
         @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId")
+        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -34,8 +34,8 @@ import java.io.Serializable;
  */
 @NamedQueries({
         @NamedQuery(name="deleteClientSessionsByRealm", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.realmId = :realmId)"),
-        @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId"),
-        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
+        @NamedQuery(name="deleteClientSessionsByClient", query="delete from PersistentClientSessionEntity sess where sess.clientId = :clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="deleteClientSessionsByExternalClient", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'"),
         @NamedQuery(name="deleteClientSessionsByClientStorageProvider", query="delete from PersistentClientSessionEntity sess where sess.clientStorageProvider = :clientStorageProvider"),
         @NamedQuery(name="deleteClientSessionsByUser", query="delete from PersistentClientSessionEntity sess where sess.userSessionId IN (select u.userSessionId from PersistentUserSessionEntity u where u.userId = :userId)"),
         @NamedQuery(name="deleteClientSessionsByUserSession", query="delete from PersistentClientSessionEntity sess where sess.userSessionId = :userSessionId and sess.offline = :offline"),
@@ -44,10 +44,10 @@ import java.io.Serializable;
         @NamedQuery(name="findClientSessionsByUserSession", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline"),
         @NamedQuery(name="findClientSessionsOrderedByIdInterval", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId >= :fromSessionId and sess.userSessionId <= :toSessionId order by sess.userSessionId"),
         @NamedQuery(name="findClientSessionsOrderedByIdExact", query="select sess from PersistentClientSessionEntity sess where sess.offline = :offline and sess.userSessionId IN (:userSessionIds)"),
-        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId"),
-        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId"),
-        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId")
+        @NamedQuery(name="findClientSessionsCountByClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientId = :clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="findClientSessionsCountByExternalClient", query="select count(sess) from PersistentClientSessionEntity sess where sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'"),
+        @NamedQuery(name="findClientSessionsByUserSessionAndClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientId=:clientId and sess.clientId != 'external'"),
+        @NamedQuery(name="findClientSessionsByUserSessionAndExternalClient", query="select sess from PersistentClientSessionEntity sess where sess.userSessionId=:userSessionId and sess.offline = :offline and sess.clientStorageProvider = :clientStorageProvider and sess.externalClientId = :externalClientId and sess.clientId = 'external'")
 })
 @Table(name="OFFLINE_CLIENT_SESSION")
 @Entity

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -27,6 +27,15 @@
         </preConditions>
         <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT">
             <column name="CLIENT_ID" type="VARCHAR(255)" />
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client-storage-provider">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER" />
+        </preConditions>
+        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER">
             <column name="CLIENT_STORAGE_PROVIDER" type="VARCHAR(36)" />
             <column name="EXTERNAL_CLIENT_ID" type="VARCHAR(255)"/>
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -27,15 +27,6 @@
         </preConditions>
         <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT">
             <column name="CLIENT_ID" type="VARCHAR(255)" />
-            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
-        </createIndex>
-    </changeSet>
-
-    <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client-storage-provider">
-        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER" />
-        </preConditions>
-        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER">
             <column name="CLIENT_STORAGE_PROVIDER" type="VARCHAR(36)" />
             <column name="EXTERNAL_CLIENT_ID" type="VARCHAR(255)"/>
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -32,7 +32,7 @@
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
         <modifySql dbms="postgresql">
-            <append value="WHERE CLIENT_ID != 'external'" />
+            <append value="WHERE CLIENT_STORAGE_PROVIDER = 'local'" />
         </modifySql>
     </changeSet>
 
@@ -50,18 +50,6 @@
         <modifySql dbms="postgresql">
             <append value="WHERE CLIENT_ID = 'external'" />
         </modifySql>
-    </changeSet>
-
-    <changeSet author="keycloak" id="26.5.0-index-offline-css-by-user-session-id">
-        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <not>
-                <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION" />
-            </not>
-        </preConditions>
-        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION">
-            <column name="USER_SESSION_ID" type="VARCHAR(255)"/>
-            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
-        </createIndex>
     </changeSet>
 
 </databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -17,6 +17,10 @@
   -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
+    <!-- These indexes IDX_OFFLINE_CSS_BY_CLIENT and IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER are used to retrieve
+    sessions by client and to count sessions by client. They are also used to remove client sessions for no-longer
+    existing clients from the table. -->
+
     <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
             <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT" />

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -32,7 +32,10 @@
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
         <modifySql dbms="postgresql">
-            <append value="WHERE CLIENT_STORAGE_PROVIDER = 'local'" />
+            <append value="WHERE CLIENT_ID != 'external'" />
+        </modifySql>
+        <modifySql dbms="mssql">
+            <append value="WHERE CLIENT_ID != 'external'" />
         </modifySql>
     </changeSet>
 
@@ -48,7 +51,10 @@
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
         <modifySql dbms="postgresql">
-            <append value="WHERE CLIENT_ID = 'external'" />
+            <append value="WHERE CLIENT_STORAGE_PROVIDER != 'internal'" />
+        </modifySql>
+        <modifySql dbms="mssql">
+            <append value="WHERE CLIENT_STORAGE_PROVIDER != 'internal'" />
         </modifySql>
     </changeSet>
 

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT" />
+        </preConditions>
+        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT">
+            <column name="CLIENT_ID" type="VARCHAR(255)" />
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client-storage-provider">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER" />
+        </preConditions>
+        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER">
+            <column name="CLIENT_STORAGE_PROVIDER" type="VARCHAR(36)" />
+            <column name="EXTERNAL_CLIENT_ID" type="VARCHAR(255)"/>
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.5.0-index-offline-css-by-user-session-id">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION" />
+        </preConditions>
+        <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION">
+            <column name="USER_SESSION_ID" type="VARCHAR(255)"/>
+            <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.5.0.xml
@@ -23,28 +23,40 @@
 
     <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT" />
+            <not>
+                <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT" />
+            </not>
         </preConditions>
         <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT">
             <column name="CLIENT_ID" type="VARCHAR(255)" />
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
+        <modifySql dbms="postgresql">
+            <append value="WHERE CLIENT_ID != 'external'" />
+        </modifySql>
     </changeSet>
 
     <changeSet author="keycloak" id="26.5.0-index-offline-css-by-client-storage-provider">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER" />
+            <not>
+                <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER" />
+            </not>
         </preConditions>
         <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_CLIENT_STORAGE_PROVIDER">
             <column name="CLIENT_STORAGE_PROVIDER" type="VARCHAR(36)" />
             <column name="EXTERNAL_CLIENT_ID" type="VARCHAR(255)"/>
             <column name="OFFLINE_FLAG" type="VARCHAR(4)"/>
         </createIndex>
+        <modifySql dbms="postgresql">
+            <append value="WHERE CLIENT_ID = 'external'" />
+        </modifySql>
     </changeSet>
 
     <changeSet author="keycloak" id="26.5.0-index-offline-css-by-user-session-id">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION" />
+            <not>
+                <indexExists tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION" />
+            </not>
         </preConditions>
         <createIndex tableName="OFFLINE_CLIENT_SESSION" indexName="IDX_OFFLINE_CSS_BY_USER_SESSION">
             <column name="USER_SESSION_ID" type="VARCHAR(255)"/>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -89,5 +89,6 @@
     <include file="META-INF/jpa-changelog-26.2.6.xml"/>
     <include file="META-INF/jpa-changelog-26.3.0.xml"/>
     <include file="META-INF/jpa-changelog-26.4.0.xml"/>
+    <include file="META-INF/jpa-changelog-26.5.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds a new indices to the `offline_client_session` table .

Closes #43516

I also thought whether its possible to use a different delete query, but I didn't came up with any. Also, I believe this index makes sense in general as for client sessions we might regular need to filter for a client.

This Index improves the following queries:
https://github.com/twobiers/keycloak/blob/1c05c8df630bc025d328f4b986798575d3cce7a5/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java#L37
https://github.com/twobiers/keycloak/blob/1c05c8df630bc025d328f4b986798575d3cce7a5/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java#L47

I decided to document this change explicitly, as the `offline_client_session` table is large and when Keycloak is not executing the migration due to its size, it's easier to spot from the release notes.