### PR TITLE
fix: simplify debug handling and remove the 0.0.0.0 default

### DIFF
--- a/quarkus/CONTRIBUTING.md
+++ b/quarkus/CONTRIBUTING.md
@@ -104,7 +104,7 @@ The `kc.sh|bat` script allows you to remotely debug the distribution. For that, 
 kc.sh --debug start-dev
 ```
 
-By default, the debug port is available at `8787` on localhost. Additionally, you can specify IPv4 or bracketed IPv6 addresses with optional ports, e.g. `--debug 127.0.0.1`, `--debug 127.0.0.1:8786`, `--debug [::1]`, `--debug [::1]:8785`. Make sure to exercise caution when setting IP addresses in the `--debug` parameter, since a value such as `--debug 0.0.0.0:8787` will expose the debug port to all network interfaces!
+By default, the debug port is available at `8787` on localhost. Additionally, you can specify IPv4 or bracketed IPv6 addresses with optional ports, e.g. `--debug 127.0.0.1:8786`, `--debug [::1]:8785`. Make sure to exercise caution when setting IP addresses in the `--debug` parameter, since a value such as `--debug 0.0.0.0:8787` will expose the debug port to all network interfaces!
 
 An additional environment variable `DEBUG_SUSPEND` can be set to suspend the JVM, when launched in debug mode. The `DEBUG_SUSPEND` variable supports the following values:
 

--- a/quarkus/CONTRIBUTING.md
+++ b/quarkus/CONTRIBUTING.md
@@ -104,7 +104,7 @@ The `kc.sh|bat` script allows you to remotely debug the distribution. For that, 
 kc.sh --debug start-dev
 ```
 
-By default, the debug port is available at `8787`. Additionally, you can specify IPv4 or bracketed IPv6 addresses with optional ports, e.g. `--debug 127.0.0.1`, `--debug 127.0.0.1:8786`, `--debug [::1]`, `--debug [::1]:8785`. Make sure to exercise caution when setting IP addresses in the `--debug` parameter, since a value such as `--debug 0.0.0.0:8787` will expose the debug port to all network interfaces!
+By default, the debug port is available at `8787` on localhost. Additionally, you can specify IPv4 or bracketed IPv6 addresses with optional ports, e.g. `--debug 127.0.0.1`, `--debug 127.0.0.1:8786`, `--debug [::1]`, `--debug [::1]:8785`. Make sure to exercise caution when setting IP addresses in the `--debug` parameter, since a value such as `--debug 0.0.0.0:8787` will expose the debug port to all network interfaces!
 
 An additional environment variable `DEBUG_SUSPEND` can be set to suspend the JVM, when launched in debug mode. The `DEBUG_SUSPEND` variable supports the following values:
 

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -22,10 +22,33 @@ if "%OS%" == "Windows_NT" (
 set SERVER_OPTS=-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus-log-max-startup-records=10000 -Dpicocli.disable.closures=true
 
 set DEBUG_MODE=false
-set DEBUG_PORT_VAR=8787
-set DEBUG_ADDRESS=0.0.0.0:%DEBUG_PORT_VAR%
+set DEBUG_ADDRESS=8787
 set DEBUG_SUSPEND_VAR=n
 set CONFIG_ARGS=
+
+if NOT "x%KC_DEBUG%" == "x" (
+    set DEBUG_MODE=%KC_DEBUG%
+) else (
+    if NOT "x%DEBUG%" == "x" (
+        set DEBUG_MODE=%DEBUG%
+    )
+)
+
+if NOT "x%KC_DEBUG_PORT%" == "x" (
+    set DEBUG_ADDRESS=!KC_DEBUG_PORT!
+) else (
+    if NOT "x%DEBUG_PORT%" == "x" (
+        set DEBUG_ADDRESS=!DEBUG_PORT!
+    )
+)
+
+if NOT "x%KC_DEBUG_SUSPEND%" == "x" (
+    set DEBUG_SUSPEND_VAR=%KC_DEBUG_SUSPEND%
+) else (
+    if NOT "x%DEBUG_SUSPEND%" == "x" (
+        set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
+    )
+)
 
 rem Read command-line args, the ~ removes the quotes from the parameter
 :READ-ARGS
@@ -35,20 +58,9 @@ if "%KEY%" == "" (
 )
 if "%KEY%" == "--debug" (
     set DEBUG_MODE=true
-    if 1%2 EQU +1%2 (
-        rem Plain port
-        set DEBUG_ADDRESS=0.0.0.0:%2
+    (echo %2 | findstr /R "^[0-9][0-9]*$" >nul || echo %2 | findstr /R "^[0-9].*\." >nul || echo %2 | findstr /R "^\[.*:.*\]" >nul) && (
+        set DEBUG_ADDRESS=%2
         shift
-    ) else (
-        rem IPv4 or IPv6 address with optional port
-        (echo %2 | findstr /R "[0-9].*\." >nul || echo %2 | findstr /R "\[.*:.*\]" >nul) && (
-            (echo %2 | findstr /R "]:[0-9][0-9]*" >nul || echo %2 | findstr /R "^[0-9].*:[0-9][0-9]*" >nul) && (
-                set DEBUG_ADDRESS=%2
-            ) || (
-                set DEBUG_ADDRESS=%2:%DEBUG_PORT_VAR%
-            )
-            shift
-        )
     )
     shift
     goto READ-ARGS
@@ -140,36 +152,15 @@ if not "x%JAVA_OPTS_APPEND%" == "x" (
     set JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_APPEND%
 )
 
-if NOT "x%KC_DEBUG%" == "x" (
-    set DEBUG_MODE=%KC_DEBUG%
-) else (
-    if NOT "x%DEBUG%" == "x" (
-        set DEBUG_MODE=%DEBUG%
-    )
-)
-
-if NOT "x%KC_DEBUG_PORT%" == "x" (
-    set DEBUG_PORT_VAR=%KC_DEBUG_PORT%
-    set DEBUG_ADDRESS=0.0.0.0:!DEBUG_PORT_VAR!
-) else (
-    if NOT "x%DEBUG_PORT%" == "x" (
-        set DEBUG_PORT_VAR=%DEBUG_PORT%
-        set DEBUG_ADDRESS=0.0.0.0:!DEBUG_PORT_VAR!
-    )
-)
-
-if NOT "x%KC_DEBUG_SUSPEND%" == "x" (
-    set DEBUG_SUSPEND_VAR=%KC_DEBUG_SUSPEND%
-) else (
-    if NOT "x%DEBUG_SUSPEND%" == "x" (
-        set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
-    )
-)
-
 rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
     echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
     if errorlevel == 1 (
+        rem Handle no port
+        (echo %2 | findstr /R "^[0-9][0-9]*" >nul || echo %2 | findstr /R ":[0-9][0-9]*$" >nul) && (
+        ) || (
+            set DEBUG_ADDRESS=%DEBUG_ADDRESS%:8787
+        )
         set JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_ADDRESS%,server=y,suspend=%DEBUG_SUSPEND_VAR%
     ) else (
         echo Debug already enabled in JAVA_OPTS, ignoring --debug argument

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -156,11 +156,6 @@ rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
     echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
     if errorlevel == 1 (
-        rem Handle no port
-        (echo %2 | findstr /R "^[0-9][0-9]*" >nul || echo %2 | findstr /R ":[0-9][0-9]*$" >nul) && (
-        ) || (
-            set DEBUG_ADDRESS=%DEBUG_ADDRESS%:8787
-        )
         set JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_ADDRESS%,server=y,suspend=%DEBUG_SUSPEND_VAR%
     ) else (
         echo Debug already enabled in JAVA_OPTS, ignoring --debug argument

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -35,10 +35,10 @@ if NOT "x%KC_DEBUG%" == "x" (
 )
 
 if NOT "x%KC_DEBUG_PORT%" == "x" (
-    set DEBUG_ADDRESS=!KC_DEBUG_PORT!
+    set DEBUG_ADDRESS=%KC_DEBUG_PORT%
 ) else (
     if NOT "x%DEBUG_PORT%" == "x" (
-        set DEBUG_ADDRESS=!DEBUG_PORT!
+        set DEBUG_ADDRESS=%DEBUG_PORT%
     )
 )
 
@@ -58,15 +58,12 @@ if "%KEY%" == "" (
 )
 if "%KEY%" == "--debug" (
     set DEBUG_MODE=true
-    (echo %2 | findstr /R "^[0-9][0-9]*$" >nul || echo %2 | findstr /R "^[0-9].*\." >nul || echo %2 | findstr /R "^\[.*:.*\]" >nul) && (
-        set DEBUG_ADDRESS=%2
-        shift
+    if NOT "x%~2" == "x" (
+        echo %~2 | findstr /R "^[0-9[]" >nul && (
+            set DEBUG_ADDRESS=%~2
+            shift
+        )
     )
-    shift
-    goto READ-ARGS
-)
-if "%KEY%" == "start-dev" (
-    set CONFIG_ARGS=%CONFIG_ARGS% --profile=dev %KEY%
     shift
     goto READ-ARGS
 )

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -41,7 +41,7 @@ SERVER_OPTS="$SERVER_OPTS -Dpicocli.disable.closures=true"
 SERVER_OPTS="$SERVER_OPTS -Dquarkus-log-max-startup-records=10000"
 CLASSPATH_OPTS="'$(abs_path "../lib/quarkus-run.jar")'"
 
-DEBUG_MODE="${KC_DEBUG_MODE:-${DEBUG:-false}}"
+DEBUG_MODE="${KC_DEBUG:-${DEBUG:-false}}"
 DEBUG_ADDRESS="${KC_DEBUG_PORT:-${DEBUG_PORT:-8787}}"
 DEBUG_SUSPEND="${KC_DEBUG_SUSPEND:-${DEBUG_SUSPEND:-n}}"
 
@@ -136,10 +136,6 @@ fi
 if [ "$DEBUG_MODE" = "true" ]; then
     DEBUG_OPT="$(echo "$JAVA_OPTS" | $GREP "\-agentlib:jdwp")"
     if [ -z "$DEBUG_OPT" ]; then
-        # Handle no port
-        if ! echo "$DEBUG_ADDRESS" | grep -Eq '((^[0-9]+)|(:[0-9]+))$'; then
-           DEBUG_ADDRESS="$DEBUG_ADDRESS:8787"
-        fi
         JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_ADDRESS,server=y,suspend=$DEBUG_SUSPEND"
     else
         echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -137,7 +137,7 @@ if [ "$DEBUG_MODE" = "true" ]; then
     DEBUG_OPT="$(echo "$JAVA_OPTS" | $GREP "\-agentlib:jdwp")"
     if [ -z "$DEBUG_OPT" ]; then
         # Handle no port
-        if ! echo "$DEBUG_ADDRESS" | grep -Eq '(^[0-9]+)|(:[0-9]+)$'; then
+        if ! echo "$DEBUG_ADDRESS" | grep -Eq '((^[0-9]+)|(:[0-9]+))$'; then
            DEBUG_ADDRESS="$DEBUG_ADDRESS:8787"
         fi
         JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=$DEBUG_ADDRESS,server=y,suspend=$DEBUG_SUSPEND"


### PR DESCRIPTION
closes: #43160

Changes:
- make sure the cli has precedence over the env
- remove the 0.0.0.0 default
- simplify the logic - supporting just an ip address is possible with just a late check.

@Pepo48 can you please validate the windows logic as well?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
