### PR TITLE
fix: allow for --optimized to receive signals

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -171,8 +171,14 @@ if [ "$PRINT_ENV" = "true" ]; then
   echo "Using JAVA_RUN_OPTS: $JAVA_RUN_OPTS"
 fi
 
-eval "'$JAVA'" "$JAVA_RUN_OPTS"
-status=$?
+# trap the signals that should be forwarded to the java process
+trap 'status=143; while [ -z "$PID" ]; do sleep 1; done; kill -TERM $PID; wait $pid' TERM INT
+# run the java process in the background using the current stdin
+eval "{ '$JAVA' $JAVA_RUN_OPTS <&3 3<&- & } 3<&0"
+# obtain the pid, and await the exit status
+PID=$!; wait $PID; status=$?
+# remove the trap as signals can be directly handled
+trap - TERM INT
 # only exit code 10 means that implicit reaugmentation occurred and a relaunch is needed 
 if [ $status = 10 ]; then
   JAVA_RUN_OPTS="-Dkc.config.built=true $JAVA_RUN_OPTS"

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -172,7 +172,7 @@ if [ "$PRINT_ENV" = "true" ]; then
 fi
 
 # trap the signals that should be forwarded to the java process
-trap 'status=143; while [ -z "$PID" ]; do sleep 1; done; kill -TERM $PID; wait $pid' TERM INT
+trap 'status=143; while [ -z "$PID" ]; do sleep 0.1; done; kill -TERM $PID; wait $PID' TERM INT
 # run the java process in the background using the current stdin
 eval "{ '$JAVA' $JAVA_RUN_OPTS <&3 3<&- & } 3<&0"
 # obtain the pid, and await the exit status

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -92,6 +92,23 @@ public class StartCommandDistTest {
         cliResult.assertNoError("The following build time options");
     }
 
+    @Test
+    @RawDistOnly(reason = "Containers are immutable")
+    void terminateStartOptimized(KeycloakDistribution dist) {
+        CLIResult cliResult = dist.run("build", "--db=dev-file");
+        cliResult.assertBuild();
+
+        dist.setManualStop(true);
+        cliResult = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
+        cliResult.assertStarted();
+
+        // if the child java process does not clean up, then subsequent start will fail
+        dist.stop();
+
+        cliResult = dist.run("start", "--optimized", "--http-enabled=true", "--hostname-strict=false");
+        cliResult.assertStarted();
+    }
+
     @DryRun
     @Test
     @Launch({ "--profile=dev", "start",  "--db=dev-file" })


### PR DESCRIPTION
closes: #43561

We have two options:
1. The approach in this fix - keep the use of the background process
2. Go back to only performing the build check with a background process

The reason I want to stick with 1 is that it will keep us moving toward a state we we can more efficiently refine the --optimized concept. This is demonstrated in https://github.com/keycloak/keycloak/pull/43591 - which use the same technique as --optimized the run the command in the background process if it doesn't need reaugmentation.

The approach is to trap signals we are interested in forwarding to the underlying process. Any other signals, such as triggering threaddumps are expected to be sent directly to the java process. Forwarding stdin makes the bootstrap-admin commands work as expected, and the subprocess does recognize that a terminal is attached so the auto-coloring works the same way as well.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
