### PR TITLE
Adding a graceful shutdown for the HTTP stack

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -38,6 +38,7 @@ import org.keycloak.provider.ProviderFactory;
 import org.keycloak.provider.Spi;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
+import org.keycloak.quarkus.runtime.filter.KeycloakGracefulShutdownFilter;
 import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.services.RejectNonNormalizedPathFilter;
 import org.keycloak.quarkus.runtime.storage.database.liquibase.FastServiceLocator;
@@ -159,5 +160,9 @@ public class KeycloakRecorder {
 
     public void configureProtoStreamSchemas(List<SerializationContextInitializer> schemas) {
         Marshalling.setSchemas(schemas);
+    }
+
+    public KeycloakGracefulShutdownFilter shutdownFilter() {
+        return new KeycloakGracefulShutdownFilter();
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/filter/KeycloakGracefulShutdownFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/filter/KeycloakGracefulShutdownFilter.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.filter;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.quarkus.runtime.shutdown.ShutdownListener;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.Http1xServerConnection;
+import io.vertx.core.http.impl.Http2ServerConnection;
+import io.vertx.ext.web.RoutingContext;
+import org.jboss.logging.Logger;
+
+/**
+ * Provide a graceful shutdown. Inspired by {@link io.quarkus.vertx.http.runtime.filters.GracefulShutdownFilter}.
+ * <p>
+ * This explores options while we wait for <a href="https://github.com/keycloak/keycloak/issues/43589">#43589</a>.
+ */
+public class KeycloakGracefulShutdownFilter implements ShutdownListener, Handler<RoutingContext> {
+
+    private static final Logger log = Logger.getLogger(KeycloakGracefulShutdownFilter.class);
+
+    private volatile boolean running = true;
+    private final AtomicInteger currentRequestCount = new AtomicInteger();
+    private final AtomicReference<ShutdownNotification> notification = new AtomicReference<>();
+
+    private final Handler<AsyncResult<Void>> requestDoneHandler = event -> {
+        int count = currentRequestCount.decrementAndGet();
+        if (!running && count == 0) {
+            executeNotification();
+        }
+    };
+    private volatile Long timer;
+
+    private void executeNotification() {
+        ShutdownNotification n = notification.get();
+        if (n != null && notification.compareAndSet(n, null)) {
+            log.info("All HTTP requests complete");
+            n.done();
+            if (timer != null) {
+                getVertx().cancelTimer(timer);
+            }
+        }
+    }
+
+    private Vertx getVertx() {
+        return CDI.current().select(Vertx.class).get();
+    }
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        currentRequestCount.incrementAndGet();
+        routingContext.addEndHandler(requestDoneHandler);
+        if (routingContext.request().version() == HttpVersion.HTTP_1_1) {
+            // For HTTP/1.1, check in the last moment where we can add the header if the shutdown is in progress
+            routingContext.addHeadersEndHandler(event -> {
+                if (!running) {
+                    final Http1xServerConnection connection = (Http1xServerConnection) routingContext.request().connection();
+                    // "Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2 and HTTP/3"
+                    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Connection
+                    // Therefore only add it for HTTP/1.1
+                    routingContext.response().headers().add(HttpHeaderNames.CONNECTION, "close");
+                    routingContext.addEndHandler(e -> {
+                        connection.close();
+                    });
+                }
+            });
+        }
+        else if (routingContext.request().version() == HttpVersion.HTTP_2) {
+            if (!running) {
+                // If shutdown is in progress, send the go away as early as possible
+                sendGoAwayForHttp2(routingContext);
+            } else {
+                routingContext.addEndHandler(event -> {
+                    // Check again at the end of the request if we should send a shutdown
+                    if (!running) {
+                        sendGoAwayForHttp2(routingContext);
+                    }
+                });
+            }
+        }
+        routingContext.next();
+    }
+
+    private static void sendGoAwayForHttp2(RoutingContext routingContext) {
+        final Http2ServerConnection connection = (Http2ServerConnection) routingContext.request().connection();
+        // GO_AWAY + 0 (NO_ERROR) = graceful shutdown; client will stop creating new streams on this connection
+        connection.goAway(0);
+    }
+
+    @Override
+    public void preShutdown(ShutdownNotification notification) {
+        this.notification.set(notification);
+        running = false;
+        if (currentRequestCount.get() == 0) {
+            if (this.notification.compareAndSet(notification, null)) {
+                notification.done();
+            }
+        } else {
+            log.info("Waiting for HTTP requests to complete");
+            timer = getVertx().setTimer(TimeUnit.SECONDS.toMillis(10), event -> {
+                if (this.notification.compareAndSet(notification, null)) {
+                    log.info("Timeout reached waiting for requests to complete");
+                    notification.done();
+                }
+            });
+        }
+    }
+
+}

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -94,15 +94,19 @@ quarkus.http.limits.max-header-size=65535
 kc.log-console-output=default
 kc.log-file=${kc.home.dir:default}${file.separator}data${file.separator}log${file.separator}keycloak.log
 
-#OpenAPI defaults
-quarkus.smallrye-openapi.path=/openapi
-quarkus.smallrye-openapi.store-schema-directory=${openapi.schema.target}
-quarkus.swagger-ui.path=${quarkus.smallrye-openapi.path}/ui
-quarkus.swagger-ui.always-include=true
-quarkus.swagger-ui.filter=true
-mp.openapi.filter=org.keycloak.quarkus.runtime.oas.OASModelFilter
 mp.openapi.extensions.smallrye.remove-unused-schemas.enable=true
-
+mp.openapi.filter=org.keycloak.quarkus.runtime.oas.OASModelFilter
 # Disable Error messages from smallrye.openapi
 # related issue: https://github.com/keycloak/keycloak/issues/41871
 quarkus.log.category."io.smallrye.openapi.runtime.scanner.dataobject".level=off
+quarkus.shutdown.delay=0s
+# This allows us to have our own Graceful Shutdown filter handle wait for all requests to complete while we wait for
+# https://github.com/keycloak/keycloak/issues/43589
+# A delay of 0s will shut down the server once all requests are completed.
+quarkus.shutdown.delay-enabled=true
+#OpenAPI defaults
+quarkus.smallrye-openapi.path=/openapi
+quarkus.smallrye-openapi.store-schema-directory=${openapi.schema.target}
+quarkus.swagger-ui.always-include=true
+quarkus.swagger-ui.filter=true
+quarkus.swagger-ui.path=${quarkus.smallrye-openapi.path}/ui

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
@@ -83,7 +83,7 @@ public class HealthDistTest {
                 .statusCode(200);
         when().get("/health/ready").then()
                 .statusCode(200)
-                .body("checks.size()", equalTo(2));
+                .body("checks.size()", equalTo(3));
         when().get("/lb-check").then()
                 .statusCode(404);
     }


### PR DESCRIPTION
Closes #43589
Closes #30986

TODO: 

* [ ] Make `quarkus.shutdown.delay` configurable via CLI. 
* [ ] Either use the same timeout for the graceful filter, or a different one. Not sure yet.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
