### PR TITLE
allow non-optimized commands to run without a separate java launch

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -178,8 +178,8 @@ public final class Environment {
         return Boolean.getBoolean(KC_CONFIG_REBUILD_CHECK);
     }
 
-    public static void setRebuildCheck() {
-        System.setProperty(KC_CONFIG_REBUILD_CHECK, "true");
+    public static void setRebuildCheck(boolean check) {
+        System.setProperty(KC_CONFIG_REBUILD_CHECK, Boolean.toString(check));
     }
 
     public static boolean isRebuilt() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -941,12 +941,11 @@ public class Picocli {
 
         if (!Environment.isRebuilt() && command instanceof AbstractAutoBuildCommand
                 && !cliArgs.contains(OPTIMIZED_BUILD_OPTION_LONG)) {
-            Environment.setRebuildCheck();
+            Environment.setRebuildCheck(true);
         }
 
-        String profile = parsedCommand.map(AbstractCommand::getInitProfile)
-                .orElseGet(() -> Optional.ofNullable(org.keycloak.common.util.Environment.getProfile())
-                        .orElse(Environment.PROD_PROFILE_VALUE));
+        String profile = Optional.ofNullable(org.keycloak.common.util.Environment.getProfile())
+                .or(() -> parsedCommand.map(AbstractCommand::getInitProfile)).orElse(Environment.PROD_PROFILE_VALUE);
 
         Environment.setProfile(profile);
         if (!cliArgs.contains(HelpAllMixin.HELP_ALL_OPTION)) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
@@ -66,7 +66,7 @@ public abstract class AbstractAutoBuildCommand extends AbstractCommand {
             Environment.setRebuildCheck(false);
             String runtimeProfile = getInitProfile();
             if (!Objects.equals(profile, runtimeProfile)) {
-                Environment.setProfile(getInitProfile());
+                Environment.setProfile(runtimeProfile);
                 Configuration.resetConfig();
             }
         }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -58,8 +59,16 @@ public abstract class AbstractAutoBuildCommand extends AbstractCommand {
         if (isRebuildCheck()) {
             if (requiresReAugmentation()) {
                 runReAugmentation();
+                return Optional.of(REBUILT_EXIT_CODE);
             }
-            return Optional.of(REBUILT_EXIT_CODE);
+            // clear the check, and change to the command runtime profile
+            String profile = org.keycloak.common.util.Environment.getProfile();
+            Environment.setRebuildCheck(false);
+            String runtimeProfile = getInitProfile();
+            if (!Objects.equals(profile, runtimeProfile)) {
+                Environment.setProfile(getInitProfile());
+                Configuration.resetConfig();
+            }
         }
         return Optional.empty();
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -52,10 +52,6 @@ public abstract class AbstractCommand implements Callable<Integer> {
      * Get the effective profile used when the config is initialized
      */
     public String getInitProfile() {
-        String configuredProfile = org.keycloak.common.util.Environment.getProfile();
-        if (configuredProfile != null) {
-            return configuredProfile; // the profile was already set by the cli or even ENV
-        }
         if (Environment.isRebuildCheck()) {
             // builds default to prod, if the profile is not overriden via the cli
             return Environment.PROD_PROFILE_VALUE;

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -397,7 +397,7 @@ public class PicocliTest extends AbstractConfigurationTest {
     private NonRunningPicocli build(Consumer<String> outChecker, String... args) {
         int code = CommandLine.ExitCode.OK;
         if (Stream.of(args).anyMatch("start-dev"::equals)) {
-            Environment.setRebuildCheck();
+            Environment.setRebuildCheck(true);
             code = AbstractAutoBuildCommand.REBUILT_EXIT_CODE;
         }
         NonRunningPicocli nonRunningPicocli = pseudoLaunch(args);
@@ -423,7 +423,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("build", "--db=dev-file");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("export", "--db=dev-file", "--file=file");
-        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertFalse(nonRunningPicocli.reaug);
     }
 
@@ -450,7 +450,7 @@ public class PicocliTest extends AbstractConfigurationTest {
         build("start-dev");
 
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("--profile=dev", "export", "--file=file");
-        assertEquals(AbstractAutoBuildCommand.REBUILT_EXIT_CODE, nonRunningPicocli.exitCode);
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertFalse(nonRunningPicocli.reaug);
     }
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -637,7 +637,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void testQuarkusLogPropDependentUponKeycloak() {
-        Environment.setRebuildCheck(); // will be reset by the system properties logic
+        Environment.setRebuildCheck(true); // will be reset by the system properties logic
         ConfigArgsConfigSource.setCliArgs("--log-level=something:debug");
         SmallRyeConfig config = createConfig();
         assertEquals("DEBUG", config.getConfigValue("quarkus.log.category.\"something\".level").getValue());

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
@@ -361,7 +361,7 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void testNestedBuildTimeLogging() {
-        Environment.setRebuildCheck(); // will be reset by the system properties logic
+        Environment.setRebuildCheck(true); // will be reset by the system properties logic
         ConfigArgsConfigSource.setCliArgs("");
         assertEquals("true", createConfig().getConfigValue("quarkus.log.console.enable").getValue());
     }


### PR DESCRIPTION
allow non-optimized commands to run without a separate java launch

Generallizes the reaug check so that we can run the command as long as reaug is not required.

closes: https://github.com/keycloak/keycloak/issues/43611

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
