### PR TITLE
[OID4VCI] Ensure `openid_credential` is one of `authorization_details_types_supported` on the Authorization Server metadata

### DIFF
--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -202,6 +202,9 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("authorization_response_iss_parameter_supported")
     private Boolean authorizationResponseIssParameterSupported;
 
+    @JsonProperty("authorization_details_types_supported")
+    private List<String> authorizationDetailsTypesSupported;
+
     protected Map<String, Object> otherClaims = new HashMap<String, Object>();
 
     public String getIssuer() {
@@ -664,5 +667,13 @@ public class OIDCConfigurationRepresentation {
 
     public void setPromptValuesSupported(List<String> promptValuesSupported) {
         this.promptValuesSupported = promptValuesSupported;
+    }
+
+    public List<String> getAuthorizationDetailsTypesSupported() {
+        return authorizationDetailsTypesSupported;
+    }
+
+    public void setAuthorizationDetailsTypesSupported(List<String> authorizationDetailsTypesSupported) {
+        this.authorizationDetailsTypesSupported = authorizationDetailsTypesSupported;
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
@@ -34,6 +34,11 @@ import java.util.List;
 public interface AuthorizationDetailsProcessor extends Provider {
 
     /**
+     * Checks if this processor should be regarded as supported in the running context.
+     */
+    boolean isSupported();
+
+    /**
      * Processes the authorization_details parameter and returns a response if this processor
      * is able to handle the given authorization_details parameter.
      *

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -53,6 +53,11 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
     }
 
     @Override
+    public boolean isSupported() {
+        return session.getContext().getRealm().isVerifiableCredentialsEnabled();
+    }
+
+    @Override
     public List<AuthorizationDetailsResponse> process(UserSessionModel userSession, ClientSessionContext clientSessionCtx, String authorizationDetailsParameter) {
         if (authorizationDetailsParameter == null) {
             return null; // authorization_details is optional

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessorFactory.java
@@ -31,7 +31,7 @@ import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorFactory;
  */
 public class OID4VCAuthorizationDetailsProcessorFactory implements AuthorizationDetailsProcessorFactory, OID4VCEnvironmentProviderFactory {
 
-    public static final String PROVIDER_ID = "oid4vci-authorization-details-processor";
+    public static final String PROVIDER_ID = OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE;
 
     @Override
     public AuthorizationDetailsProcessor create(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -27,6 +27,7 @@ import org.keycloak.crypto.ClientSignatureVerifierProvider;
 import org.keycloak.crypto.ContentEncryptionProvider;
 import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
@@ -214,6 +215,10 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         config.setMtlsEndpointAliases(mtlsEndpointAliases);
 
         config.setAuthorizationResponseIssParameterSupported(true);
+
+        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI) && realm.isVerifiableCredentialsEnabled()) {
+            config.setAuthorizationDetailsTypesSupported(List.of(OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE));
+        }
 
         config = checkConfigOverride(config);
         return config;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsTypesSupportedTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsTypesSupportedTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oid4vc.issuance.signing;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.common.Profile;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.util.AdminClientUtil;
+import org.keycloak.testsuite.util.oauth.OAuthClient;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE;
+
+/**
+ * Test to verify that authorization_details_types_supported is included in the OAuth Authorization Server
+ * metadata endpoint (/.well-known/oauth-authorization-server/) and that credential issuance works with
+ * authorization_details when scope is absent.
+ */
+@EnableFeature(value = Profile.Feature.OID4VC_VCI, skipRestart = true)
+public class OID4VCAuthorizationDetailsTypesSupportedTest extends OID4VCIssuerEndpointTest {
+
+    @Before
+    public void enableOpenID4VC() {
+        enableOpenID4VC(true);
+    }
+
+    public void enableOpenID4VC(boolean enabled) {
+        RealmRepresentation realmRep = adminClient.realm(TEST_REALM_NAME).toRepresentation();
+        realmRep.setVerifiableCredentialsEnabled(enabled);
+        adminClient.realm(TEST_REALM_NAME).update(realmRep);
+    }
+
+    @Test
+    public void testAuthorizationDetailsTypesSupportedInOAuthAuthorizationServerMetadata() {
+        try (Client client = AdminClientUtil.createResteasyClient()) {
+            // Get OAuth Authorization Server metadata as required by OID4VC spec
+            OIDCConfigurationRepresentation oauthConfig = getOAuth2WellKnownConfiguration(client);
+
+            // Verify that authorization_details_types_supported is present
+            assertNotNull("authorization_details_types_supported should be present",
+                    oauthConfig.getAuthorizationDetailsTypesSupported());
+
+            // Verify that it contains openid_credential
+            List<String> supportedTypes = oauthConfig.getAuthorizationDetailsTypesSupported();
+            assertTrue("authorization_details_types_supported should contain openid_credential",
+                    supportedTypes.contains(OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE));
+
+        }
+    }
+
+    @Test
+    public void testCredentialIssuerAuthorizationServerMetadata() {
+        try (Client client = AdminClientUtil.createResteasyClient()) {
+            // Get credential issuer metadata
+            CredentialIssuer credentialIssuer = getCredentialIssuerMetadata();
+            assertNotNull("Credential issuer should not be null", credentialIssuer);
+            assertNotNull("Authorization servers should be present", credentialIssuer.getAuthorizationServers());
+            assertFalse("Authorization servers should not be empty", credentialIssuer.getAuthorizationServers().isEmpty());
+
+            // Verify the authorization server from credential issuer metadata
+            String authServerUri = credentialIssuer.getAuthorizationServers().get(0);
+            OIDCConfigurationRepresentation authServerConfig = getOAuth2WellKnownConfiguration(client, authServerUri + "/.well-known/oauth-authorization-server");
+            assertNotNull("Authorization server should support authorization_details_types_supported",
+                    authServerConfig.getAuthorizationDetailsTypesSupported());
+            assertTrue("Authorization server should support openid_credential",
+                    authServerConfig.getAuthorizationDetailsTypesSupported().contains(OPENID_CREDENTIAL_TYPE));
+        }
+    }
+
+    @Test
+    public void testAuthorizationDetailsTypesSupportedNotInOAuth2WellKnownWhenOID4VCDisabled() {
+        // Disable OID4VC for this realm
+        enableOpenID4VC(false);
+
+        try (Client client = AdminClientUtil.createResteasyClient()) {
+            // Get OAuth2 well-known configuration
+            OIDCConfigurationRepresentation oauth2Config = getOAuth2WellKnownConfiguration(client);
+
+            // Verify that authorization_details_types_supported is not present
+            assertNull("authorization_details_types_supported should not be present when OID4VC is disabled",
+                    oauth2Config.getAuthorizationDetailsTypesSupported());
+
+        }
+    }
+
+    private OIDCConfigurationRepresentation getOAuth2WellKnownConfiguration(Client client) {
+        return getOAuth2WellKnownConfiguration(client, OAuthClient.AUTH_SERVER_ROOT + "/.well-known/oauth-authorization-server/realms/test");
+    }
+
+    private OIDCConfigurationRepresentation getOAuth2WellKnownConfiguration(Client client, String oauth2WellKnownUri) {
+        Response response = client.target(oauth2WellKnownUri)
+                .request()
+                .get();
+
+        assertEquals("OAuth Authorization Server metadata endpoint should return 200", 200, response.getStatus());
+
+        return response.readEntity(OIDCConfigurationRepresentation.class);
+    }
+}


### PR DESCRIPTION
I'm sending this PR on behalf of @forkimenjeckayang, on vacation.
Closes #43398 

## Summary

This PR implements the OID4VC specification requirement to include `authorization_details_types_supported` in the OAuth Authorization Server metadata endpoint. This enables credential issuance using `authorization_details` when scope is absent, as required by the OID4VC specification.

## Test Coverage

- **Metadata validation**: Verifies `authorization_details_types_supported` is present and contains `openid_credential`
- **End-to-end flow**: Complete credential issuance using `authorization_details`
- **Cross-reference validation**: Ensures credential issuer metadata points to correct OAuth server
- **Feature flag testing**: Validates behavior when OID4VC is disabled