### PR TITLE
Add stopSessionPolling when the document is loaded

### DIFF
--- a/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/authChecker.js
@@ -1,14 +1,14 @@
 const SESSION_POLLING_INTERVAL = 2000;
 const AUTH_SESSION_TIMEOUT_MILLISECS = 1000;
 const initialSession = getSession();
-const forms = Array.from(document.forms);
 let timeout;
 
 // Stop polling for a session when a form is submitted to prevent unexpected redirects.
 // This is required as Safari does not support the 'beforeunload' event properly.
 // See: https://bugs.webkit.org/show_bug.cgi?id=219102
-forms.forEach((form) =>
-  form.addEventListener("submit", () => stopSessionPolling()),
+document.addEventListener("DOMContentLoaded", () =>
+  Array.from(document.forms).forEach((form) =>
+    form.addEventListener("submit", () => stopSessionPolling()))
 );
 
 // Stop polling for a session when the page is unloaded to prevent unexpected redirects.


### PR DESCRIPTION
Closes #42730

Add the `stopSessionPolling` to forms when `DOMContentLoaded` event is called. I'm not sure this is the real cause for the original issue but it makes no harm.
