### PR TITLE
ignores unknown json properties in dcr requests

### DIFF
--- a/core/src/main/java/org/keycloak/representations/oidc/OIDCClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/oidc/OIDCClientRepresentation.java
@@ -18,6 +18,7 @@
 package org.keycloak.representations.oidc;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OIDCClientRepresentation {
 
     // OIDC Dynamic client registration properties


### PR DESCRIPTION
Enables ignoring unknown JSON properties on OIDCClientRepresentation and adjusts / extends integration tests accordingly.

This is required to adhere to section 2 of RFC 7591 which documents that "the authorization server MUST ignore any client metadata sent by the client that it does not understand".

Closes #14946
