### PR TITLE
Test Framework support for remotely running Databases

### DIFF
--- a/test-framework/HOW_TO_RUN.md
+++ b/test-framework/HOW_TO_RUN.md
@@ -122,12 +122,43 @@ Valid values:
 | oracle   | Oracle test container                   |
 | postgres | PostgreSQL test container               |
 | tidb     | TiDb test container                     |
+| remote   | Connect to a remotely running database  |
 
 Configuration:
 
 | Value                                               | Description                                                                                                                                                                 |
 |-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `kc.test.database.reuse` / `KC_TEST_DATABASE_REUSE` | Set to true to enable reuse of database. Requires [enabling reuse for Testcontainers](https://java.testcontainers.org/features/reuse/) (`TESTCONTAINERS_REUSE_ENABLE=true`) |
+
+#### Remote Database
+
+If connecting to a remotely running database is desired, the following options need to be specified:
+
+Option prefix: `kc.test.database.` / `KC_TEST_DATABASE_`
+
+| Option                              | Description                                                         | Required? |
+|-------------------------------------|---------------------------------------------------------------------|-----------|
+| `vendor`/`VENDOR`                   | Database vendor (valid values mentioned above)                      | yes       |
+| `user`/`USER`                       | Username of the database user                                       | yes       |
+| `password`/`PASSWORD`               | Password of the database user                                       | yes       |
+| `url`/`URL`                         | Full database JDBC URL                                              | yes       |
+| `driver`/`DRIVER`                   | Fully qualified class name of the JDBC driver                       | no        |
+| `driver.artifact`/`DRIVER_ARTIFACT` | Maven artifact containing the driver in format `groupId:artifactId` | no        |
+
+Because some databases may require a special driver, you can specify it to the Keycloak server. To use it, Keycloak needs
+to add it as a dependency, which is why you need to specify the Maven artifact coordinates.
+
+For example, you want to run tests with an Oracle database which needs a specific jdbc driver. You would run:
+```shell
+KC_TEST_DATABASE=remote \
+  KC_TEST_DATABASE_VENDOR=oracle \
+  KC_TEST_DATABASE_USER=testUser \
+  KC_TEST_DATABASE_PASSWORD=password \
+  KC_TEST_DATABASE_URL=jdbc:oracle:thin:@localhost:1521/keycloak \
+  KC_TEST_DATABASE_DRIVER=oracle.jdbc.OracleDriver \
+  KC_TEST_DATABASE_DRIVER_ARTIFACT=com.oracle.database.jdbc:ojdbc17 \
+  mvn test
+```
 
 ### Browser
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/CoreTestFrameworkExtension.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/CoreTestFrameworkExtension.java
@@ -2,6 +2,7 @@ package org.keycloak.testframework;
 
 import org.keycloak.testframework.admin.AdminClientFactorySupplier;
 import org.keycloak.testframework.admin.AdminClientSupplier;
+import org.keycloak.testframework.database.RemoteDatabaseSupplier;
 import org.keycloak.testframework.http.SimpleHttpSupplier;
 import org.keycloak.testframework.https.ManagedCertificates;
 import org.keycloak.testframework.infinispan.InfinispanExternalServerSupplier;
@@ -43,6 +44,7 @@ public class CoreTestFrameworkExtension implements TestFrameworkExtension {
                 new KeycloakUrlsSupplier(),
                 new DevMemDatabaseSupplier(),
                 new DevFileDatabaseSupplier(),
+                new RemoteDatabaseSupplier(),
                 new SysLogServerSupplier(),
                 new EventsSupplier(),
                 new AdminEventsSupplier(),

--- a/test-framework/core/src/main/java/org/keycloak/testframework/config/Config.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/config/Config.java
@@ -53,11 +53,6 @@ public class Config {
             return null;
         }
     }
-    public static <T> T getValueTypeConfig(Class<?> valueType, String name, T defaultValue, Class<T> type) {
-        name = getValueTypeFQN(valueType, name);
-        Optional<T> optionalValue = config.getOptionalValue(name, type);
-        return optionalValue.orElse(defaultValue);
-    }
 
     public static String getValueTypeFQN(Class<?> valueType, String name) {
         return "kc.test." + valueTypeAlias.getAlias(valueType) + "." + name;

--- a/test-framework/core/src/main/java/org/keycloak/testframework/database/AbstractContainerTestDatabase.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/database/AbstractContainerTestDatabase.java
@@ -82,7 +82,7 @@ public abstract class AbstractContainerTestDatabase implements TestDatabase {
     }
 
     public String getDatabase() {
-;        return config.getDatabase() == null ? "keycloak" : config.getDatabase();
+        return config.getDatabase() == null ? "keycloak" : config.getDatabase();
     }
 
     public String getUsername() {

--- a/test-framework/core/src/main/java/org/keycloak/testframework/database/RemoteDatabaseSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/database/RemoteDatabaseSupplier.java
@@ -1,0 +1,41 @@
+package org.keycloak.testframework.database;
+
+import org.keycloak.testframework.annotations.InjectTestDatabase;
+import org.keycloak.testframework.config.Config;
+import org.keycloak.testframework.injection.InstanceContext;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+public class RemoteDatabaseSupplier extends AbstractDatabaseSupplier {
+
+    public static final String NAME = "remote";
+
+    @Override
+    public String getAlias() {
+        return NAME;
+    }
+
+    @Override
+    TestDatabase getTestDatabase() {
+        return new RemoteTestDatabase();
+    }
+
+    private String getDriverDependencyArtifact() {
+        return Config.getValueTypeConfig(TestDatabase.class, "driver.artifact", null, String.class);
+    }
+
+    @Override
+    public KeycloakServerConfigBuilder intercept(KeycloakServerConfigBuilder serverConfig, InstanceContext<TestDatabase, InjectTestDatabase> instanceContext) {
+        serverConfig = super.intercept(serverConfig, instanceContext);
+
+        String dependencyArtifact = getDriverDependencyArtifact();
+        if (dependencyArtifact != null) {
+            String[] artifact = dependencyArtifact.split(":");
+            if (artifact.length != 2) {
+                throw new IllegalArgumentException("Invalid dependency artifact " + dependencyArtifact);
+            }
+            serverConfig.dependency(artifact[0], artifact[1]);
+        }
+        return serverConfig;
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/database/RemoteTestDatabase.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/database/RemoteTestDatabase.java
@@ -1,0 +1,63 @@
+package org.keycloak.testframework.database;
+
+import org.keycloak.testframework.config.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+public class RemoteTestDatabase implements TestDatabase {
+
+    @Override
+    public void start(DatabaseConfiguration databaseConfiguration) {
+        // noop
+    }
+
+    @Override
+    public void stop() {
+        // noop
+    }
+
+    private String getDatabaseVendor() {
+        return getRequiredDbConfigOption("vendor");
+    }
+
+    private String getJdbcUrl() {
+        return getRequiredDbConfigOption("url");
+    }
+
+    private String getUsername() {
+        return getRequiredDbConfigOption("user");
+    }
+
+    private String getPassword() {
+        return getRequiredDbConfigOption("password");
+    }
+
+    private String getDatabaseDriver() {
+        return Config.getValueTypeConfig(TestDatabase.class, "driver", null, String.class);
+    }
+
+    private static String getRequiredDbConfigOption(String option) {
+        String value = Config.getValueTypeConfig(TestDatabase.class, option, null, String.class);
+        if (value == null) {
+            throw new NoSuchElementException("Missing required config for a remote DB: " + Config.getValueTypeFQN(TestDatabase.class, option));
+        }
+        return value;
+    }
+
+    @Override
+    public Map<String, String> serverConfig() {
+        Map<String, String> serverConfig = new HashMap<>(Map.of(
+                "db", getDatabaseVendor(),
+                "db-url", getJdbcUrl(),
+                "db-username", getUsername(),
+                "db-password", getPassword()
+        ));
+        if (getDatabaseDriver() != null) {
+            serverConfig.put("db-driver", getDatabaseDriver());
+        }
+
+        return serverConfig;
+    }
+}

--- a/test-framework/db-mysql/src/main/java/org/keycloak/testframework/database/MySQLDatabaseSupplier.java
+++ b/test-framework/db-mysql/src/main/java/org/keycloak/testframework/database/MySQLDatabaseSupplier.java
@@ -4,7 +4,7 @@ public class MySQLDatabaseSupplier extends AbstractDatabaseSupplier {
 
     @Override
     public String getAlias() {
-        return "mysql";
+        return MySQLTestDatabase.NAME;
     }
 
     @Override


### PR DESCRIPTION
Part of #41940

This PR enables testing with a remote database (such as Aurora, MariaDB, ...), instead of a containerized one from the TestContainers library. 

An example of running tests with a remote Postgres db:
```shell
KC_TEST_DATABASE=remote \
  KC_TEST_DATABASE_VENDOR=postgres \
  KC_TEST_DATABASE_USER=testUser \
  KC_TEST_DATABASE_PASSWORD=password \
  KC_TEST_DATABASE_URL=jdbc:postgresql://localhost:5432/keycloak \
  mvn test -Dtest=DatabaseTestSuite
```

All supported databases should work, except when using an Oracle database with an embedded Keycloak server (described in #38991).
Clustered Keycloak server is not tested.