### PR TITLE
Ability to define workflows with YAML

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -787,6 +787,7 @@ class KeycloakProcessor {
     void index(BuildProducer<IndexDependencyBuildItem> indexDependencyBuildItemBuildProducer) {
         indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem("org.liquibase", "liquibase-core"));
         indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem("org.keycloak", "keycloak-services"));
+        indexDependencyBuildItemBuildProducer.produce(new IndexDependencyBuildItem("com.fasterxml.jackson.jakarta.rs", "jackson-jakarta-rs-yaml-provider"));
     }
 
     @BuildStep

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -655,6 +655,12 @@
             <artifactId>jna</artifactId>
         </dependency>
 
+        <!-- YAML -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -183,6 +183,11 @@
             <version>${woodstox.version}</version>    <!-- this version has to match that of used in Wildfly -->
             <scope>test</scope>
         </dependency>
+        <!-- YAML -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>

--- a/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowsResource.java
+++ b/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowsResource.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMediaTypes;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
@@ -37,7 +38,7 @@ public class WorkflowsResource {
     }
 
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
     public Response create(WorkflowRepresentation rep) {
         try {
             Workflow workflow = manager.toModel(rep);
@@ -49,7 +50,7 @@ public class WorkflowsResource {
 
     @Path("set")
     @POST
-    @Consumes(MediaType.APPLICATION_JSON)
+    @Consumes({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
     public Response createAll(WorkflowSetRepresentation workflows) {
         for (WorkflowRepresentation workflow : Optional.ofNullable(workflows.getWorkflows()).orElse(List.of())) {
             create(workflow).close();


### PR DESCRIPTION
Closes #42687

This PR adds an ability define workflows in YAML format. It add support for accepting application/yaml content type for 

-  `WorkflowsResource.create`
-  `WorkflowsResource.createAll`

endpoints. The support for admin UI remains to be added as follow-up, as well as potential ability to produce YAML response.

It can be tested by following:

```bash
curl -X POST \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/yaml" \
  -d 'name: workflow' \
  http://localhost:8080/admin/realms/master/workflows

```

or

```bash
curl -X POST \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/yaml"  \
  -d 'name: workflow
      uses: event-based-workflow
      enabled: true                                           
      on:                         
        - USER_LOGIN
      if:                    
        - uses: has-identity-provider-link
          with:
            alias: google
      steps:
        - uses: set-user-required-action
          with:
            action: MY_CUSTOM_ACTION' \
  http://localhost:8080/admin/realms/master/workflows
```
for `create` endpoint.

```bash
curl -X POST \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/yaml" \
  -d '- name: workflow_alpha
      - name: workflow_beta' \
  http://localhost:8080/admin/realms/master/workflows/set
```
for `createAll` endpoint.

NOTE: Without https://github.com/keycloak/keycloak/pull/43560 the requests above fails with NPE.
