### PR TITLE
[Backport 26.4] Prevent the username field from being rendered when running the identity-first login flow

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -505,6 +505,9 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
             attributes.put("url", new UrlBean(realm, theme, baseUri, this.actionUri));
             attributes.put("requiredActionUrl", new RequiredActionUrlFormatterMethod(realm, baseUri));
             attributes.put("auth", new AuthenticationContextBean(context, page));
+            if (authenticationSession != null && Boolean.parseBoolean(authenticationSession.getAuthNote(AbstractUsernameFormAuthenticator.USERNAME_HIDDEN))) {
+                attributes.put(LoginFormsProvider.USERNAME_HIDDEN, Boolean.TRUE.toString());
+            }
             setAttribute(Constants.EXECUTION, execution);
 
             if (realm.isInternationalizationEnabled()) {

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationContextBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationContextBean.java
@@ -25,6 +25,7 @@ import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationSelectionOption;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.forms.login.LoginFormsPages;
+import org.keycloak.sessions.AuthenticationSessionModel;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -49,7 +50,17 @@ public class AuthenticationContextBean {
 
 
     public boolean showUsername() {
-        return context != null && context.getUser() != null && context.getAuthenticationSession() != null && page!=LoginFormsPages.ERROR;
+        if (context == null) {
+            return false;
+        }
+
+        AuthenticationSessionModel authenticationSession = context.getAuthenticationSession();
+
+        if (Boolean.parseBoolean(authenticationSession.getAuthNote(AbstractUsernameFormAuthenticator.USERNAME_HIDDEN))) {
+            return getAttemptedUsername() != null;
+        }
+
+        return context.getUser() != null && authenticationSession != null && page!=LoginFormsPages.ERROR;
     }
 
     public boolean showResetCredentials() {

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -430,18 +430,7 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
 
         if (username != null) {
             authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
-            LoginFormsProvider form = context.form();
-
-            form.setAttributeMapper(attributes -> {
-                AuthenticationContextBean auth = (AuthenticationContextBean) attributes.get("auth");
-
-                if (auth != null) {
-                    attributes.put("auth", new OrganizationAwareAuthenticationContextBean(auth, true, username));
-                    attributes.put(LoginFormsProvider.USERNAME_HIDDEN, true);
-                }
-
-                return attributes;
-            });
+            authenticationSession.setAuthNote(AbstractUsernameFormAuthenticator.USERNAME_HIDDEN, Boolean.TRUE.toString());
         }
 
         context.attempted();

--- a/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareAuthenticationContextBean.java
+++ b/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareAuthenticationContextBean.java
@@ -26,17 +26,11 @@ public class OrganizationAwareAuthenticationContextBean extends AuthenticationCo
 
     private final AuthenticationContextBean delegate;
     private final boolean showTryAnotherWayLink;
-    private final String username;
 
     public OrganizationAwareAuthenticationContextBean(AuthenticationContextBean delegate, boolean showTryAnotherWayLink) {
-        this(delegate, showTryAnotherWayLink, null);
-    }
-
-    public OrganizationAwareAuthenticationContextBean(AuthenticationContextBean delegate, boolean showTryAnotherWayLink, String username) {
         super(null, null);
         this.delegate = delegate;
         this.showTryAnotherWayLink = showTryAnotherWayLink;
-        this.username = username;
     }
 
     @Override
@@ -52,7 +46,7 @@ public class OrganizationAwareAuthenticationContextBean extends AuthenticationCo
     }
 
     public boolean showUsername() {
-        return username != null || delegate.showUsername();
+        return delegate.showUsername();
     }
 
     public boolean showResetCredentials() {
@@ -60,9 +54,6 @@ public class OrganizationAwareAuthenticationContextBean extends AuthenticationCo
     }
 
     public String getAttemptedUsername() {
-        if (username == null) {
-            return delegate.getAttemptedUsername();
-        }
-        return username;
+        return delegate.getAttemptedUsername();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LanguageComboboxAwarePage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LanguageComboboxAwarePage.java
@@ -120,6 +120,8 @@ public abstract class LanguageComboboxAwarePage extends AbstractPage {
         try {
             driver.findElement(By.id("kc-attempted-username"));
             Assert.assertTrue(expectedAvailability);
+            // make sure the username field is not shown if the attempted username field is present
+            Assert.assertTrue(driver.findElements(By.id("username")).isEmpty());
         } catch (NoSuchElementException nse) {
             Assert.assertFalse(expectedAvailability);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
@@ -295,6 +295,23 @@ public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
         Assert.assertFalse(loginPage.isPasswordInputPresent());
     }
 
+    @Test
+    public void testAttemptedUsernameKeptAfterPasswordFailures() {
+        testRealm().organizations().get(createOrganization().getId());
+
+        openIdentityFirstLoginPage("user@noorg.org", false, null, false, false);
+
+        // check if the login page is shown
+        loginPage.assertAttemptedUsernameAvailability(true);
+        Assert.assertTrue(loginPage.isPasswordInputPresent());
+
+        for (int i = 0; i < 3; i++) {
+            loginPage.login("wrong-password");
+            loginPage.assertAttemptedUsernameAvailability(true);
+            Assert.assertTrue(loginPage.isPasswordInputPresent());
+        }
+    }
+
     private void runOnServer(RunOnServer function) {
         testingClient.server(bc.consumerRealmName()).run(function);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -203,7 +203,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
         driver.navigate().refresh();
 
-        Assert.assertTrue(loginPage.isUsernameInputPresent());
+        loginPage.assertAttemptedUsernameAvailability(true);
         Assert.assertTrue(loginPage.isPasswordInputPresent());
         Assert.assertTrue(loginPage.isSocialButtonPresent(idp.getAlias()));
         Assert.assertFalse(loginPage.isSocialButtonPresent(bc.getIDPAlias()));


### PR DESCRIPTION
Closes #43091

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
