### PR TITLE
Improve JWT Assertion Validation using client validators

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/JWTAuthorizationGrantProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/JWTAuthorizationGrantProvider.java
@@ -18,5 +18,8 @@ package org.keycloak.broker.provider;
 import org.keycloak.protocol.oidc.JWTAuthorizationGrantValidationContext;
 
 public interface JWTAuthorizationGrantProvider {
-    BrokeredIdentityContext validateAuthorizationGrantAssertion(JWTAuthorizationGrantValidationContext assertion);
+
+    BrokeredIdentityContext validateAuthorizationGrantAssertion(JWTAuthorizationGrantValidationContext assertion) throws IdentityBrokerException;
+
+    int getAllowedClockSkew();
 }

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/JWTAuthorizationGrantValidationContext.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/JWTAuthorizationGrantValidationContext.java
@@ -1,151 +1,22 @@
 package org.keycloak.protocol.oidc;
 
-import org.keycloak.OAuth2Constants;
-import org.keycloak.common.util.Time;
 import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.models.ClientModel;
-import org.keycloak.representations.IDToken;
 import org.keycloak.representations.JsonWebToken;
 
-import java.util.Collections;
-import java.util.List;
 
-public class JWTAuthorizationGrantValidationContext {
+public interface JWTAuthorizationGrantValidationContext {
 
-    private final String assertion;
+    String getAssertion();
 
-    private final ClientModel client;
+    JsonWebToken getJWT();
 
-    private JsonWebToken jwt;
+    JWSInput getJws();
 
-    private final String expectedAudience;
-
-    private JWSInput jws;
-
-    private final long currentTime;
-
-    public JWTAuthorizationGrantValidationContext(String assertion, ClientModel client, String expectedAudience) {
-        this.assertion = assertion;
-        this.client = client;
-        this.expectedAudience = expectedAudience;
-        this.currentTime = Time.currentTimeMillis();
+    default String getIssuer() {
+        return getJWT().getIssuer();
     }
 
-    public void validateJWTFormat() {
-        try {
-            this.jws = new JWSInput(assertion);
-            this.jwt = jws.readJsonContent(JsonWebToken.class);
-        }
-        catch (Exception e) {
-            failure("The provided assertion is not a valid JWT");
-        }
-    }
-
-    public void validateAssertionParameters() {
-        if (assertion == null) {
-            failure("Missing parameter:" + OAuth2Constants.ASSERTION);
-        }
-    }
-
-    public void validateClient() {
-        if (client.isPublicClient()) {
-            failure("Public client not allowed to use authorization grant");
-        }
-
-        String val = client.getAttribute(OIDCConfigAttributes.JWT_AUTHORIZATION_GRANT_ENABLED);
-        if (!Boolean.parseBoolean(val)) {
-            throw new RuntimeException("JWT Authorization Grant is not supported for the requested client");
-        }
-
-    }
-
-    public void validateTokenActive() {
-        JsonWebToken token = getJWT();
-        int allowedClockSkew = getAllowedClockSkew();
-        int maxExp = getMaximumExpirationTime();
-        long lifespan;
-
-        if (token.getExp() == null) {
-            failure("Token exp claim is required");
-        }
-
-        if (!token.isActive(allowedClockSkew)) {
-            failure("Token is not active");
-        }
-
-        lifespan = token.getExp() - currentTime;
-
-        if (token.getIat() == null) {
-            if (lifespan > maxExp) {
-                failure("Token expiration is too far in the future and iat claim not present in token");
-            }
-        } else {
-            if (token.getIat() - allowedClockSkew > currentTime) {
-                failure("Token was issued in the future");
-            }
-            lifespan = Math.min(lifespan, maxExp);
-            if (lifespan <= 0) {
-                failure("Token is not active");
-            }
-            if (currentTime > token.getIat() + maxExp) {
-                failure("Token was issued too far in the past to be used now");
-            }
-        }
-    }
-
-    public void validateAudience() {
-        JsonWebToken token = getJWT();
-        List<String> expectedAudiences = getExpectedAudiences();
-        if (!token.hasAnyAudience(expectedAudiences)) {
-            failure("Invalid token audience");
-        }
-    }
-
-    public void validateIssuer() {
-        if (jwt == null || jwt.getIssuer() == null) {
-            failure("Missing claim: " + OAuth2Constants.ISSUER);
-        }
-    }
-
-    public void validateSubject() {
-        if (jwt == null || jwt.getSubject() == null) {
-            failure("Missing claim: " + IDToken.SUBJECT);
-        }
-    }
-
-    public void failure(String errorMessage) {
-        throw new RuntimeException(errorMessage);
-    }
-
-    public JsonWebToken getJWT() {
-        return jwt;
-    }
-
-    public JWSInput getJws() {
-        return jws;
-    }
-
-    public String getIssuer() {
-        return jwt.getIssuer();
-    }
-
-    public String getSubject() {
-        return jwt.getSubject();
-    }
-
-    public String getAssertion() {
-        return assertion;
-    }
-
-    private List<String> getExpectedAudiences() {
-        return Collections.singletonList(expectedAudience);
-    }
-
-    private int getAllowedClockSkew() {
-        return 15;
-    }
-
-    private int getMaximumExpirationTime() {
-        return 300;
+    default String getSubject() {
+        return getJWT().getSubject();
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AbstractBaseJWTValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AbstractBaseJWTValidator.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.keycloak.authentication.authenticators.client;
+
+import java.util.List;
+import org.jboss.logging.Logger;
+import org.keycloak.common.util.Time;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.SingleUseObjectProvider;
+import org.keycloak.representations.JsonWebToken;
+
+/**
+ * Base validator for JWT authorization grant and JWT client validators.
+ *
+ * @author rmartinc
+ */
+public abstract class AbstractBaseJWTValidator {
+
+    private static final Logger logger = Logger.getLogger(AbstractBaseJWTValidator.class);
+
+    protected final ClientAssertionState clientAssertionState;
+    protected final KeycloakSession session;
+    protected final int currentTime;
+
+    public AbstractBaseJWTValidator(KeycloakSession session, ClientAssertionState clientAssertionState) {
+        this.session = session;
+        this.clientAssertionState = clientAssertionState;
+        this.currentTime = Time.currentTime();
+    }
+
+    public ClientAssertionState getState() {
+        return clientAssertionState;
+    }
+
+    public String getClientAssertion() {
+        return clientAssertionState.getClientAssertion();
+    }
+
+    public JWSInput getJws() {
+        return clientAssertionState.getJws();
+    }
+
+    public boolean validateTokenActive(int allowedClockSkew, int maxExp, boolean reusePermitted) {
+        JsonWebToken token = clientAssertionState.getToken();
+        long lifespan;
+
+        if (token.getExp() == null) {
+            return failure("Token exp claim is required");
+        }
+
+        if (!token.isActive(allowedClockSkew)) {
+            return failure("Token is not active");
+        }
+
+        lifespan = token.getExp() - currentTime;
+
+        if (token.getIat() == null) {
+            if (lifespan > maxExp) {
+                return failure("Token expiration is too far in the future and iat claim not present in token");
+            }
+        } else {
+            if (token.getIat() - allowedClockSkew > currentTime) {
+                return failure("Token was issued in the future");
+            }
+            lifespan = Math.min(lifespan, maxExp);
+            if (lifespan <= 0) {
+                return failure("Token is not active");
+            }
+            if (currentTime > token.getIat() + maxExp) {
+                return failure("Token was issued too far in the past to be used now");
+            }
+        }
+
+        if (!reusePermitted) {
+            if (token.getId() == null) {
+                return failure("Token jti claim is required");
+            }
+
+            if (!validateTokenReuse(lifespan)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected boolean validateTokenReuse(long lifespanInSecs) {
+        final JsonWebToken token = clientAssertionState.getToken();
+        final String tokenId = token.getId();
+        SingleUseObjectProvider singleUseCache = session.singleUseObjects();
+        if (singleUseCache.putIfAbsent(tokenId, lifespanInSecs)) {
+            logger.tracef("Added token '%s' to single-use cache. Lifespan: %d seconds, issuedFor: %s", tokenId, lifespanInSecs, token.getIssuedFor());
+        } else {
+            logger.warnf("Token '%s' already used when for issuedFor '%s'.", tokenId, token.getIssuedFor());
+            return failure("Token reuse detected");
+        }
+        return true;
+    }
+
+    public boolean validateTokenAudience(List<String> expectedAudiences, boolean multipleAudienceAllowed) {
+        JsonWebToken token = clientAssertionState.getToken();
+        if (!token.hasAnyAudience(expectedAudiences)) {
+            return failure("Invalid token audience");
+        }
+
+        if (!multipleAudienceAllowed && token.getAudience().length > 1) {
+            return failure("Multiple audiences not allowed");
+        }
+
+        return true;
+    }
+
+    public boolean validateSignatureAlgorithm(String expectedSignatureAlg) {
+        JWSInput jws = clientAssertionState.getJws();
+
+        if (jws.getHeader().getAlgorithm() == null) {
+            return failure("Invalid signature algorithm");
+        }
+
+        if (expectedSignatureAlg != null) {
+            if (!expectedSignatureAlg.equals(jws.getHeader().getAlgorithm().name())) {
+                return failure("Invalid signature algorithm");
+            }
+        }
+
+        return true;
+    }
+
+    private boolean failure(String errorDescription) {
+        failureCallback(errorDescription);
+        return false;
+    }
+
+    protected abstract void failureCallback(String errorDescription);
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientValidator.java
@@ -51,7 +51,7 @@ public class JWTClientValidator extends AbstractJWTClientValidator {
     }
 
     protected int getMaximumExpirationTime() {
-        return OIDCAdvancedConfigWrapper.fromClientModel(client).getTokenEndpointAuthSigningMaxExp();
+        return OIDCAdvancedConfigWrapper.fromClientModel(clientAssertionState.getClient()).getTokenEndpointAuthSigningMaxExp();
     }
 
     @Override
@@ -61,7 +61,7 @@ public class JWTClientValidator extends AbstractJWTClientValidator {
 
     @Override
     protected String getExpectedSignatureAlgorithm() {
-        return OIDCAdvancedConfigWrapper.fromClientModel(client).getTokenEndpointAuthSigningAlg();
+        return OIDCAdvancedConfigWrapper.fromClientModel(clientAssertionState.getClient()).getTokenEndpointAuthSigningAlg();
     }
 
 }

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -1069,9 +1069,13 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     }
 
     @Override
-    public BrokeredIdentityContext validateAuthorizationGrantAssertion(JWTAuthorizationGrantValidationContext context) {
+    public BrokeredIdentityContext validateAuthorizationGrantAssertion(JWTAuthorizationGrantValidationContext context) throws IdentityBrokerException {
 
-        //TODO: proper assertion validation
+        // verify signature
+        if (!verify(context.getJws())) {
+            throw new IdentityBrokerException("Invalid signature");
+        }
+
         BrokeredIdentityContext user = new BrokeredIdentityContext(context.getJWT().getSubject(), getConfig());
         user.setUsername(context.getJWT().getSubject());
         user.setIdp(this);
@@ -1079,4 +1083,8 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
 
     }
 
+    @Override
+    public int getAllowedClockSkew() {
+        return getConfig().getAllowedClockSkew();
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantValidator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.protocol.oidc.grants;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.authenticators.client.AbstractBaseJWTValidator;
+import org.keycloak.authentication.authenticators.client.ClientAssertionState;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.JWTAuthorizationGrantValidationContext;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.JsonWebToken;
+
+/**
+ * Validator for JWT Authorization grant that extends AbstractBaseJWTValidator and
+ * implements the JWTAuthorizationGrantValidationContext interface.
+ *
+ * @author rmartinc
+ */
+public class JWTAuthorizationGrantValidator extends AbstractBaseJWTValidator implements JWTAuthorizationGrantValidationContext {
+
+    public static JWTAuthorizationGrantValidator createValidator(KeycloakSession session, ClientModel client, String assertion) {
+        if (assertion == null) {
+            throw new RuntimeException("Missing parameter:" + OAuth2Constants.ASSERTION);
+        }
+        try {
+            JWSInput jws = new JWSInput(assertion);
+            JsonWebToken jwt = jws.readJsonContent(JsonWebToken.class);
+            ClientAssertionState clientAssertionState = new ClientAssertionState(client, OAuth2Constants.JWT_AUTHORIZATION_GRANT, assertion, jws, jwt);
+            return new JWTAuthorizationGrantValidator(session, clientAssertionState);
+        } catch (JWSInputException e) {
+            throw new RuntimeException("The provided assertion is not a valid JWT");
+        }
+    }
+
+    private JWTAuthorizationGrantValidator(KeycloakSession session, ClientAssertionState clientAssertionState) {
+        super(session, clientAssertionState);
+    }
+
+    public void validateClient() {
+        if (clientAssertionState.getClient().isPublicClient()) {
+            failureCallback("Public client not allowed to use authorization grant");
+        }
+
+        String val = clientAssertionState.getClient().getAttribute(OIDCConfigAttributes.JWT_AUTHORIZATION_GRANT_ENABLED);
+        if (!Boolean.parseBoolean(val)) {
+            throw new RuntimeException("JWT Authorization Grant is not supported for the requested client");
+        }
+    }
+
+    public void validateIssuer() {
+        if (getJWT().getIssuer() == null) {
+            failureCallback("Missing claim: " + OAuth2Constants.ISSUER);
+        }
+    }
+
+    public void validateSubject() {
+        if (getJWT().getSubject() == null) {
+            failureCallback("Missing claim: " + IDToken.SUBJECT);
+        }
+    }
+
+    @Override
+    public JsonWebToken getJWT() {
+        return clientAssertionState.getToken();
+    }
+
+    @Override
+    public String getAssertion() {
+        return clientAssertionState.getClientAssertion();
+    }
+
+    @Override
+    protected void failureCallback(String errorDescription) {
+        throw new RuntimeException(errorDescription);
+    }
+}

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthIdentityProvider.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthIdentityProvider.java
@@ -57,6 +57,10 @@ public class OAuthIdentityProvider {
         return new OAuthIdentityProviderKeys(config);
     }
 
+    public OAuthIdentityProviderKeys getKeys() {
+        return keys;
+    }
+
     public int getKeysRequestCount() {
         return keysRequestCount;
     }


### PR DESCRIPTION
Closes #43642

The PR creates a new intermediate class `AbstractJWTValidator` with part of the methods that previously were in `AbstractJWTClientValidator`. Class `JWTAuthorizationGrantValidationContext` in `server-spi-private` is now an interface (very limited now, but we can add mode methods if needed) and the real code has been moved to `JWTAuthorizationJWTValidator` in `services` which extends the `AbstractJWTValidator` to inherit the old methods. This way the code is shared. The signature validation is performed in the IdP side, and we can move more parts to the IdP if we want. So the current code is something in the middle. The token is validated using the client validator, but the signature is checked by the IdP. Draft for the moment. Questions:

* Do you see this OK? Or do you prefer move signature to the client validator part? Or vice-versa, move token validations to the IdP side? It's a bit repeated in both sides.
* The `nbf` claim is not checked now, I have just detected it. The client validator was not doing it before, so I will add later.
* I have added the options we have currently in the IdP side (clockSkew and algorithm), but there are other options that we can add: token lifespan (default is 5m=300s) and reusePermitted (default to false). Do we want them or is it OK using fixed values for now?

I need to polish this a bit but the I want to hear your comments about the three questions before. :smile: 
