### PR TITLE
fix: removing the fast start optimization

### DIFF
--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -264,7 +264,7 @@ The `--optimized` parameter tells {project_name} to assume a pre-built, already 
 You can enter all configuration options at startup; these options are the ones in <@links.server id="all-config"/> that are **not** marked with a tool icon.
 
 * If a build option is found at startup with a value that is equal to the value used when entering the `build`, that option gets silently ignored when you use the `--optimized` parameter.
-* If that option has a different value than the value used when a build was entered, a warning appears in the logs and the previously built value is used. For this value to take effect, run a new `build` before starting.
+* If that option has a different value than the value used when a build was entered, an error occurs. For this value to take effect, run a new `build` before starting.
 
 .Create an optimized build
 
@@ -288,8 +288,6 @@ https-certificate-file
 . Start the server with the optimized parameter
 +
     <@kc.start parameters="--optimized"/>
-
-You can achieve most optimizations to startup and runtime behavior by using the `build` command. Also, by using the `keycloak.conf` file as a configuration source, you avoid some steps at startup that would otherwise require command line parameters, such as initializing the CLI itself. As a result, the server starts up even faster.
 
 == Using system variables in the realm configuration
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -20,7 +20,6 @@ package org.keycloak.quarkus.runtime;
 import static org.keycloak.quarkus.runtime.Environment.getKeycloakModeFromProfile;
 import static org.keycloak.quarkus.runtime.Environment.isNonServerMode;
 import static org.keycloak.quarkus.runtime.Environment.isTestLaunchMode;
-import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +44,6 @@ import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.common.Version;
 import org.keycloak.quarkus.runtime.cli.command.AbstractNonServerCommand;
 import org.keycloak.quarkus.runtime.cli.command.DryRunMixin;
-import org.keycloak.quarkus.runtime.cli.command.Start;
 
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.annotations.QuarkusMain;
@@ -100,9 +98,6 @@ public class KeycloakMain implements QuarkusApplication {
             cliArgs = new ArrayList<>(cliArgs);
             // default to show help message
             cliArgs.add("-h");
-        } else if (isFastStart(cliArgs)) { // fast path for starting the server without bootstrapping CLI
-            Start.fastStart(picocli, Boolean.valueOf(System.getenv().get(DryRunMixin.KC_DRY_RUN_ENV)));
-            return;
         }
 
         // parse arguments and execute any of the configured commands
@@ -126,11 +121,6 @@ public class KeycloakMain implements QuarkusApplication {
                     sf);
             throw new RuntimeException("The ForkJoinPool has been initialized with the wrong thread factory");
         }
-    }
-
-    private static boolean isFastStart(List<String> cliArgs) {
-        // 'start --optimized' should start the server without parsing CLI
-        return cliArgs.size() == 2 && cliArgs.get(0).equals(Start.NAME) && cliArgs.stream().anyMatch(OPTIMIZED_BUILD_OPTION_LONG::equals);
     }
 
     public static void start(Picocli picocli, AbstractNonServerCommand command, ExecutionExceptionHandler errorHandler) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -170,6 +170,13 @@ public class Picocli {
                 addCommandOptions(cliArgs, cl);
             }
 
+            // ParseResult retain memory. Clear it, so it's not on the stack while the command runs
+            result = null;
+
+            // there's another ParseResult being created under the covers here.
+            // to reuse the previous result either means we need to duplicate the logic in the execute method
+            // or refactor the above logic so that it happens in the command logic
+            // We could also reduce the memory footprint of the ParseResult, but that looks a little hackish
             int exitCode = cmd.execute(argArray);
 
             exit(exitCode);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/HelpAllMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/HelpAllMixin.java
@@ -25,9 +25,6 @@ public final class HelpAllMixin {
 
     public static final String HELP_ALL_OPTION = "--help-all";
 
-    @CommandLine.Spec
-    private CommandLine.Model.CommandSpec spec;
-
     @CommandLine.Option(names = {HELP_ALL_OPTION}, usageHelp = true, description = "This same help message but with additional options.")
     public void setHelpAll(boolean allOptions) {
         Help.setAllOptions(true);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ImportRealmMixin.java
@@ -30,9 +30,6 @@ public final class ImportRealmMixin {
 
     public static final String IMPORT_REALM = "--import-realm";
 
-    @CommandLine.Spec
-    private CommandLine.Model.CommandSpec spec;
-
     @CommandLine.Option(names = IMPORT_REALM,
             description = "Import realms during startup by reading any realm configuration file from the 'data/import' directory.",
             paramLabel = NO_PARAM_LABEL,

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Start.java
@@ -19,12 +19,8 @@ package org.keycloak.quarkus.runtime.cli.command;
 
 import static org.keycloak.quarkus.runtime.cli.command.AbstractAutoBuildCommand.OPTIMIZED_BUILD_OPTION_LONG;
 
-import java.util.List;
-
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.Messages;
-import org.keycloak.common.profile.ProfileException;
-import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 
 import picocli.CommandLine;
@@ -63,19 +59,6 @@ public final class Start extends AbstractAutoBuildCommand {
     @Override
     public String getName() {
         return NAME;
-    }
-
-    public static void fastStart(Picocli picocli, boolean dryRun) {
-        try {
-            Start start = new Start();
-            start.optimizedMixin.optimized = true;
-            start.dryRunMixin.dryRun = dryRun;
-            start.setPicocli(picocli);
-            picocli.initConfig(List.of(OPTIMIZED_BUILD_OPTION_LONG), start);
-            picocli.exit(start.call());
-        } catch (PropertyException | ProfileException e) {
-            picocli.usageException(e.getMessage(), e.getCause());
-        }
     }
 
     @Override

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -474,7 +474,7 @@ public class PicocliTest extends AbstractConfigurationTest {
     }
 
     @Test
-    public void fastStartOptimizedSucceeds() {
+    public void startOptimizedSucceeds() {
         build("build", "--db=dev-file");
 
         System.setProperty("kc.http-enabled", "true");


### PR DESCRIPTION
closes: #38790 #42960

I mentioned before that the difference should be sub-10 millisecond, however that was using an even more aggressive optimization and doing benchmarking that included warmup then a lot of runs. 

With the more concise set of changes in this pr and just comparing cold vm starts, the average time difference on my system seems to around +60 milliseconds.

The additional memory footprint appears to be negliable as the previous changes elimiated most options, and the changes here get rid of extraneous picocli state.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
