### PR TITLE
Manage the error when the admin console reads the certificate info

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2173,6 +2173,7 @@ policyEnforcementModeHelp=The policy enforcement mode dictates how policies are 
 selectAUser=Select a user
 groupCreated=Group created
 generateError=Could not generate a new key pair and certificate {{error}}
+getKeyInfoError=Could not read the certificate information {{error}}
 testClusterSuccess=Successfully verified availability for\: {{successNodes}}
 whoWillAppearLinkTextRoles=Who will appear in this user list?
 attestationPreference.not\ specified=Not specified

--- a/js/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -69,7 +69,14 @@ export const Keys = ({
   });
 
   useFetch(
-    () => adminClient.clients.getKeyInfo({ id: clientId, attr }),
+    async () => {
+      try {
+        return await adminClient.clients.getKeyInfo({ id: clientId, attr });
+      } catch (error) {
+        addError("getKeyInfoError", error);
+        return {} as CertificateRepresentation;
+      }
+    },
     (info) => setKeyInfo(info),
     [key],
   );

--- a/services/src/main/java/org/keycloak/services/util/CertificateInfoHelper.java
+++ b/services/src/main/java/org/keycloak/services/util/CertificateInfoHelper.java
@@ -75,6 +75,9 @@ public class CertificateInfoHelper {
 
         try {
             JSONWebKeySet keySet = JsonSerialization.readValue(jwks, JSONWebKeySet.class);
+            if (keySet == null || keySet.getKeys() == null) {
+                throw new IllegalStateException("Certificate not found");
+            }
             JWK publicKeyJwk = JWKSUtils.getKeyForUse(keySet, JWK.Use.SIG);
             if (publicKeyJwk == null) {
                 throw new IllegalStateException("Certificate not found for use sig");


### PR DESCRIPTION
Closes #43547

After https://github.com/keycloak/keycloak/issues/33820 the certificate endpoint can return errors. The admin console does not expect that. A general error is displayed and the user cannot do anything to fix the situation. With this PR the error is managed, a popup error message is displayed saying the cert cannot be read, and the user can import/generate a new key/certificate normally.

<img width="966" height="282" alt="Screenshot From 2025-10-24 08-21-54" src="https://github.com/user-attachments/assets/88ad3af9-88de-4bcb-b08c-f32d58d34013" />

Reaching this situation is rare. Because currently the import from the jwks file fails, so the console does not allow this scenario. So the bad json should come from a migration (previously it was a free textarea) or managed directly using `kcadm` or similar. The invalid key never worked, so just an UI error.