### PR TITLE
Improve SimpleHttp API

### DIFF
--- a/core/src/main/java/org/keycloak/util/JsonSerialization.java
+++ b/core/src/main/java/org/keycloak/util/JsonSerialization.java
@@ -38,17 +38,24 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
  * @version $Revision: 1 $
  */
 public class JsonSerialization {
-    public static final ObjectMapper mapper = new ObjectMapper();
-    public static final ObjectMapper prettyMapper = new ObjectMapper();
+    public static final ObjectMapper mapper = objectMapperWithDefaults();
+    public static final ObjectMapper prettyMapper = prettyObjectMapperWithDefaults();
 
-    static {
+    public static ObjectMapper objectMapperWithDefaults() {
+        ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());
         mapper.registerModule(new JavaTimeModule());
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return mapper;
+    }
+
+    public static ObjectMapper prettyObjectMapperWithDefaults() {
+        ObjectMapper prettyMapper = new ObjectMapper();
         prettyMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         prettyMapper.enable(SerializationFeature.INDENT_OUTPUT);
         prettyMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return prettyMapper;
     }
 
     public static void writeValueToStream(OutputStream os, Object obj) throws IOException {
@@ -107,8 +114,10 @@ public class JsonSerialization {
         }
 
         ObjectNode objectNode = createObjectNode();
-        JsonParser jsonParser = mapper.getFactory().createParser(writeValueAsBytes(pojo));
-        JsonNode jsonNode = jsonParser.readValueAsTree();
+        JsonNode jsonNode;
+        try (JsonParser jsonParser = mapper.getFactory().createParser(writeValueAsBytes(pojo))) {
+            jsonNode = jsonParser.readValueAsTree();
+        }
 
         if (!jsonNode.isObject()) {
             throw new RuntimeException("JsonNode [" + jsonNode + "] is not a object.");

--- a/server-spi-private/src/main/java/org/keycloak/http/simple/SimpleHttp.java
+++ b/server-spi-private/src/main/java/org/keycloak/http/simple/SimpleHttp.java
@@ -2,6 +2,7 @@ package org.keycloak.http.simple;
 
 import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.client.HttpClient;
@@ -9,15 +10,17 @@ import org.apache.http.client.config.RequestConfig;
 
 public class SimpleHttp {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = JsonSerialization.objectMapperWithDefaults();
 
     private final HttpClient client;
     private long maxConsumedResponseSize;
     private RequestConfig requestConfig;
+    private ObjectMapper objectMapper;
 
     private SimpleHttp(HttpClient client, long maxConsumedResponseSize) {
         this.client = client;
         this.maxConsumedResponseSize = maxConsumedResponseSize;
+        this.objectMapper = DEFAULT_OBJECT_MAPPER;
     }
 
     public static SimpleHttp create(KeycloakSession session) {
@@ -31,6 +34,11 @@ public class SimpleHttp {
 
     public SimpleHttp withRequestConfig(RequestConfig requestConfig) {
         this.requestConfig = requestConfig;
+        return this;
+    }
+
+    public SimpleHttp withObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         return this;
     }
 
@@ -67,6 +75,8 @@ public class SimpleHttp {
         return doRequest(url, SimpleHttpMethod.PATCH);
     }
 
-    public SimpleHttpRequest doOptions(String url) { return doRequest(url, SimpleHttpMethod.OPTIONS); }
+    public SimpleHttpRequest doOptions(String url) {
+        return doRequest(url, SimpleHttpMethod.OPTIONS);
+    }
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/http/simple/SimpleHttpMethod.java
+++ b/server-spi-private/src/main/java/org/keycloak/http/simple/SimpleHttpMethod.java
@@ -1,6 +1,6 @@
 package org.keycloak.http.simple;
 
-enum SimpleHttpMethod {
+public enum SimpleHttpMethod {
 
     GET, DELETE, HEAD, PUT, PATCH, POST, OPTIONS
 

--- a/server-spi-private/src/main/java/org/keycloak/http/simple/SimpleHttpRequest.java
+++ b/server-spi-private/src/main/java/org/keycloak/http/simple/SimpleHttpRequest.java
@@ -120,6 +120,10 @@ public class SimpleHttpRequest {
         return entity;
     }
 
+    public SimpleHttpMethod getMethod() {
+        return method;
+    }
+
     public SimpleHttpRequest json(Object entity) {
         this.entity = entity;
         return this;


### PR DESCRIPTION
- Expose configured HTTP method from SimpleHttpRequest - needed by extensions / libraries that wants to enrich the SimpleHTTP call
- Use same ObjectMapper configuration as in JsonSerialization used by the deprecated SimpleHTTP to produce consistent json output.
- Allow to configure the ObjectMapper to use by SimpleHttp - this enables custom JSON formats
- Expose ObjectMapper factory methods in JsonSerialization - allows consistent JSON serialization.

Fixes #43701

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
