### PR TITLE
task: testing servicemonitor patching

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceMonitorDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceMonitorDependentResource.java
@@ -29,6 +29,7 @@ import io.quarkus.logging.Log;
 )
 public class KeycloakServiceMonitorDependentResource extends CRUDKubernetesDependentResource<ServiceMonitor, Keycloak> {
 
+    public static final String OPEN_METRICS_PROTOCOL = "OpenMetricsText1.0.0";
     public static final String WARN_METRICS_NOT_ENABLED = "A ServiceMonitor will not be created because `metrics-enabled` is not true.";
     public static final String WARN_CRD_NOT_INSTALLED = "A ServiceMonitor will not be created because the ServiceMonitor CRD is not installed.";
 
@@ -106,7 +107,7 @@ public class KeycloakServiceMonitorDependentResource extends CRUDKubernetesDepen
                 .withNewSelector()
                   .addToMatchLabels(Utils.allInstanceLabels(primary))
                 .endSelector()
-                .withScrapeProtocols("OpenMetricsText1.0.0")
+                .withScrapeProtocols(OPEN_METRICS_PROTOCOL)
                 .addNewEndpoint()
                   .withInterval(spec.getInterval())
                   .withPath(endpoint.relativePath() + "metrics")

--- a/operator/src/main/kubernetes/kubernetes.yml
+++ b/operator/src/main/kubernetes/kubernetes.yml
@@ -85,6 +85,7 @@ rules:
       - list
       - update
       - watch
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ServiceMonitorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ServiceMonitorTest.java
@@ -51,6 +51,18 @@ public class ServiceMonitorTest extends BaseOperatorTest {
             assertThat(sm).isNotNull();
             assertThat(sm.getSpec().getEndpoints()).hasSize(1);
         });
+
+        // make sure the desired state is maintained
+        var sm = getServiceMonitor(kc);
+        sm.getMetadata().setResourceVersion(null);
+        sm.getSpec().setScrapeProtocols(List.of("PrometheusText0.0.4"));
+        assertThat(k8sclient.resource(sm).patch().getSpec().getScrapeProtocols())
+                .doesNotContain(KeycloakServiceMonitorDependentResource.OPEN_METRICS_PROTOCOL);
+
+        Awaitility.await().untilAsserted(() -> {
+            assertThat(getServiceMonitor(kc).getSpec().getScrapeProtocols())
+                    .contains(KeycloakServiceMonitorDependentResource.OPEN_METRICS_PROTOCOL);
+        });
     }
 
     @Test


### PR DESCRIPTION
closes: #43778

No backport is needed - tested without the RBAC change and things still worked fine. I'm not quite sure then when the patch permission is checked with SSA, but to keep it consistent with the other resources I went ahead and added it.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
