### PR TITLE
fix: forcing the namespace for the servicemonitor check

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceMonitorDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceMonitorDependentResource.java
@@ -51,7 +51,7 @@ public class KeycloakServiceMonitorDependentResource extends CRUDKubernetesDepen
                 return false;
             }
 
-            if (!isCRDInstalled(dependentResource, context, (KeycloakServiceMonitorDependentResource)dependentResource)) {
+            if (!isCRDInstalled(dependentResource, context, (KeycloakServiceMonitorDependentResource)dependentResource, primary.getMetadata().getNamespace())) {
                 context.managedWorkflowAndDependentResourceContext().put(SERVICE_MONITOR_WARNING, WARN_CRD_NOT_INSTALLED);
                 return false;
             }
@@ -60,7 +60,8 @@ public class KeycloakServiceMonitorDependentResource extends CRUDKubernetesDepen
         }
 
         private boolean isCRDInstalled(DependentResource<ServiceMonitor, Keycloak> dependentResource,
-                Context<Keycloak> context, KeycloakServiceMonitorDependentResource serviceMonitorDependentResource) {
+                Context<Keycloak> context, KeycloakServiceMonitorDependentResource serviceMonitorDependentResource,
+                String namespace) {
             if (serviceMonitorDependentResource.crdInstalled != null) {
                 return serviceMonitorDependentResource.crdInstalled;
             }
@@ -74,7 +75,7 @@ public class KeycloakServiceMonitorDependentResource extends CRUDKubernetesDepen
                 public void onClose(WatcherException cause) {
                 }
             };
-            try (var watch = context.getClient().resources(dependentResource.resourceType()).watch(dummyWatcher)) {
+            try (var watch = context.getClient().resources(dependentResource.resourceType()).inNamespace(namespace).watch(dummyWatcher)) {
                 serviceMonitorDependentResource.crdInstalled = true;
                 return true;
             } catch (KubernetesClientException e) {


### PR DESCRIPTION
closes: #43774

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit d9e3f55b69264e45467a752803f0f0665c123607)
