### PR TITLE
Check offline scope is still assigned when performing a refresh (26.2)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -205,6 +205,14 @@ public class AccessTokenIntrospectionProvider<T extends AccessToken> implements 
             return false;
         }
 
+        if (userSession.isOffline() && !UserSessionUtil.isOfflineAccessGranted(
+                session, userSession.getAuthenticatedClientSessionByClient(client.getId()))) {
+            logger.debugf("Offline session invalid because offline access not granted anymore");
+            eventBuilder.detail(Details.REASON, "Offline session invalid because offline access not granted anymore");
+            eventBuilder.error(Errors.SESSION_EXPIRED);
+            return false;
+        }
+
         if (!verifyTokenReuse()) {
             return false;
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -228,6 +228,10 @@ public class TokenManager {
             throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Stale token");
         }
 
+        if (userSession.isOffline() && !UserSessionUtil.isOfflineAccessGranted(session, clientSession)) {
+            throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Offline session invalid because offline access not granted anymore");
+        }
+
         // Case when offline token is migrated from previous version
         if (oldTokenScope == null && userSession.isOffline()) {
             logger.debugf("Migrating offline token of user '%s' for client '%s' of realm '%s'", user.getUsername(), client.getClientId(), realm.getName());

--- a/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/UserSessionUtil.java
@@ -6,12 +6,14 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
+import org.keycloak.OAuth2Constants;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.events.Errors;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.ImpersonationSessionNote;
 import org.keycloak.models.KeycloakSession;
@@ -187,6 +189,16 @@ public class UserSessionUtil {
             }
 
         };
+    }
+
+    public static boolean isOfflineAccessGranted(KeycloakSession session, AuthenticatedClientSessionModel clientSession) {
+        if (clientSession == null) {
+            return false;
+        }
+
+        ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(
+                clientSession, OAuth2Constants.OFFLINE_ACCESS, session);
+        return clientSessionCtx.getClientScopesStream().anyMatch((s -> OAuth2Constants.OFFLINE_ACCESS.equals(s.getName())));
     }
 
     private static void attachAuthenticationSession(KeycloakSession session, UserSessionModel userSession, ClientModel client) {

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -164,6 +164,11 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
         return this;
     }
 
+    public ClientAttributeUpdater removeOptionalClientScope(String clientScope) {
+        rep.getOptionalClientScopes().remove(clientScope);
+        return this;
+    }
+
     public ClientAttributeUpdater setDirectAccessGrantsEnabled(Boolean directAccessGranted) {
         rep.setDirectAccessGrantsEnabled(directAccessGranted);
         return this;


### PR DESCRIPTION
Closes #43734

PR:             https://github.com/keycloak/keycloak/pull/43745
Commit:         https://github.com/keycloak/keycloak/commit/e0c1f2ee0fd14ba76338d9c2c213d45d0e857450
PR branch:      backport-43745-26.2
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.2

