### PR TITLE
fix: redoing the watching logic to provide a better status

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -16,11 +16,13 @@
  */
 package org.keycloak.operator.controllers;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ContainerState;
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.readiness.Readiness;
@@ -226,6 +228,11 @@ public class KeycloakController implements Reconciler<Keycloak> {
         } else if (isRolling(existingDeployment)) {
             status.addRollingUpdateMessage("Rolling out deployment update");
         }
+
+        watchedResources.getMissing(existingDeployment, ConfigMap.class)
+                .ifPresent(m -> status.addWarningMessage("The following ConfigMaps are missing: " + m));
+        watchedResources.getMissing(existingDeployment, Secret.class)
+                .ifPresent(m -> status.addWarningMessage("The following Secrets are missing: " + m));
 
         distConfigurator.validateOptions(keycloakCR, status);
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/WatchedResources.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/WatchedResources.java
@@ -17,20 +17,55 @@
 
 package org.keycloak.operator.controllers;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.keycloak.operator.Utils;
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
-import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import jakarta.enterprise.context.ApplicationScoped;
-import org.keycloak.operator.Utils;
 
 @ApplicationScoped
 public class WatchedResources {
+
+    public static class Watched {
+        public static Watched of(String... values) {
+            Watched result = new Watched();
+            Stream.of(values).forEach(v -> result.add(v, null));
+            return result;
+        }
+
+        Map<String, Boolean> map = new LinkedHashMap<String, Boolean>();
+
+        public void add(String name, Boolean optional) {
+            map.merge(name, optional != null && optional, (b1, b2) -> b1 && b2);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Watched other = (Watched) obj;
+            return Objects.equals(map, other.map);
+        }
+
+    }
+
     public static final String KEYCLOAK_WATCHED_HASH_ANNOTATION_PREFIX = "operator.keycloak.org/watched-";
     public static final String KEYCLOAK_WATCHING_ANNOTATION_PREFIX = "operator.keycloak.org/watching-";
     public static final String KEYCLOAK_MISSING_ANNOTATION_PREFIX = "operator.keycloak.org/missing-";
@@ -39,45 +74,43 @@ public class WatchedResources {
      * @param deployment mutable resource being reconciled, it will be updated with
      *                   annotations
      */
-    public <T extends HasMetadata> void annotateDeployment(List<String> names, Class<T> type, StatefulSet deployment,
-            KubernetesClient client) {
-        List<T> current = fetch(names, type, deployment.getMetadata().getNamespace(), client);
+    public <T extends HasMetadata> void annotateDeployment(Watched watched, Class<T> type, StatefulSet deployment, Context<Keycloak> context) {
+        if (watched.map.isEmpty()) {
+            return;
+        }
+
+        List<T> current = new ArrayList<>();
+        List<String> missing = new ArrayList<>();
+        watched.map.entrySet().stream().forEach(e -> {
+            var resource = context.getClient().resources(type)
+            .inNamespace(deployment.getMetadata().getNamespace()).withName(e.getKey()).get();
+            if (resource == null) {
+                if (!e.getValue()) {
+                    missing.add(e.getKey());
+                }
+            } else {
+                current.add(resource);
+            }
+        });
+
         String plural = HasMetadata.getPlural(type);
-        deployment.getMetadata().getAnnotations().put(WatchedResources.KEYCLOAK_MISSING_ANNOTATION_PREFIX + plural,
-                Boolean.valueOf(current.size() < names.size()).toString());
-        deployment.getMetadata().getAnnotations().put(WatchedResources.KEYCLOAK_WATCHING_ANNOTATION_PREFIX + plural,
-                String.join(";", names));
+        if (!missing.isEmpty()) {
+            deployment.getMetadata().getAnnotations().put(WatchedResources.KEYCLOAK_MISSING_ANNOTATION_PREFIX + plural, String.join(", ", missing));
+        }
+        deployment.getMetadata().getAnnotations().put(WatchedResources.KEYCLOAK_WATCHING_ANNOTATION_PREFIX + plural, Boolean.TRUE.toString());
         deployment.getSpec().getTemplate().getMetadata().getAnnotations()
-                .put(WatchedResources.KEYCLOAK_WATCHED_HASH_ANNOTATION_PREFIX + HasMetadata.getKind(type).toLowerCase() + "-hash", getHash(current));
+                .put(WatchedResources.KEYCLOAK_WATCHED_HASH_ANNOTATION_PREFIX + HasMetadata.getKind(type).toLowerCase() + "-hash", Utils.hash(current));
     }
 
-    public boolean hasMissing(StatefulSet deployment) {
-        return deployment.getMetadata().getAnnotations().entrySet().stream()
-                .anyMatch(e -> e.getKey().startsWith(WatchedResources.KEYCLOAK_MISSING_ANNOTATION_PREFIX)
-                        && Boolean.parseBoolean(e.getValue()));
+    public Optional<String> getMissing(StatefulSet deployment, Class<?> type) {
+        String plural = HasMetadata.getPlural(type);
+        return Optional.ofNullable(deployment.getMetadata().getAnnotations().get(WatchedResources.KEYCLOAK_MISSING_ANNOTATION_PREFIX + plural));
     }
 
     public boolean isWatching(StatefulSet deployment) {
         return deployment.getMetadata().getAnnotations().entrySet().stream()
                 .anyMatch(e -> e.getKey().startsWith(WatchedResources.KEYCLOAK_WATCHING_ANNOTATION_PREFIX)
                         && e.getValue() != null && !e.getValue().isEmpty());
-    }
-
-    public <T extends HasMetadata> String getHash(List<T> current) {
-        return Utils.hash(current);
-    }
-
-    private <T extends HasMetadata> List<T> fetch(List<String> names, Class<T> type, String namespace,
-            KubernetesClient client) {
-        return names.stream().map(n -> client.resources(type).inNamespace(namespace).withName(n).get())
-                .filter(Objects::nonNull).collect(Collectors.toList());
-    }
-
-    public List<String> getNames(StatefulSet deployment, Class<? extends HasMetadata> type) {
-        return Optional
-                .ofNullable(deployment.getMetadata().getAnnotations().get(WatchedResources.KEYCLOAK_WATCHING_ANNOTATION_PREFIX + HasMetadata.getPlural(type)))
-                .filter(watching -> !watching.isEmpty())
-                .map(watching -> watching.split(";")).map(Arrays::asList).orElse(List.of());
     }
 
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -119,6 +119,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
         // CR
         var kc = getTestKeycloakDeployment(true);
         var deploymentName = kc.getMetadata().getName();
+        k8sclient.resource(K8sUtils.getDefaultTlsSecret()).withTimeout(30, SECONDS).delete();
         deployKeycloak(k8sclient, kc, false, false);
 
         // Check Operator has deployed Keycloak and the statefulset exists, this allows for the watched secret to be picked up
@@ -129,7 +130,7 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
         Awaitility.await().ignoreExceptions().untilAsserted(() -> {
             assertThat(stsResource.get()).isNotNull();
             Keycloak keycloak = keycloakResource.get();
-            CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.HAS_ERRORS, false);
+            CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.HAS_ERRORS, false, "example-tls-secret");
             CRAssert.assertKeycloakStatusCondition(keycloak, KeycloakStatusCondition.READY, false);
         });
     }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakTruststoresTests.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakTruststoresTests.java
@@ -30,6 +30,7 @@ import org.keycloak.operator.testsuite.unit.WatchedResourcesTest;
 import org.keycloak.operator.testsuite.utils.K8sUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
 import static org.keycloak.operator.testsuite.utils.K8sUtils.getResourceFromFile;
@@ -48,12 +49,12 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
         Awaitility.await().ignoreExceptions().untilAsserted(() -> {
             StatefulSet statefulSet = stsResource.get();
             assertEquals("true",
-                    statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_SECRETS_ANNOTATION));
-            assertTrue(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_WATCHING_ANNOTATION)
+                    statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_WATCHING_ANNOTATION));
+            assertTrue(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_SECRETS_ANNOTATION)
                     .contains("xyz"));
             assertEquals("true",
-                    statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION));
-            assertTrue(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_WATCHING_CONFIGMAPS_ANNOTATION)
+                    statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_WATCHING_CONFIGMAPS_ANNOTATION));
+            assertTrue(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION)
                     .contains("abc"));
         });
     }
@@ -72,13 +73,11 @@ public class KeycloakTruststoresTests extends BaseOperatorTest {
         deployKeycloak(k8sclient, kc, true);
         Resource<StatefulSet> stsResource = k8sclient.resources(StatefulSet.class).withName(deploymentName);
         StatefulSet statefulSet = stsResource.get();
-        assertEquals("false",
-                statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_SECRETS_ANNOTATION));
+        assertNull(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_SECRETS_ANNOTATION));
         assertTrue(statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getVolumeMounts().stream()
                 .anyMatch(v -> v.getMountPath()
                         .equals("/opt/keycloak/conf/truststores/secret-example-truststore-secret")));
-        assertEquals("false",
-                statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION));
+        assertNull(statefulSet.getMetadata().getAnnotations().get(WatchedResourcesTest.KEYCLOAK_MISSING_CONFIGMAPS_ANNOTATION));
         assertTrue(statefulSet.getSpec().getTemplate().getSpec().getContainers().get(0).getVolumeMounts().stream()
                 .anyMatch(v -> v.getMountPath()
                         .equals("/opt/keycloak/conf/truststores/configmap-abc")));

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -57,6 +57,7 @@ import org.keycloak.operator.controllers.KeycloakDistConfigurator;
 import org.keycloak.operator.controllers.KeycloakRealmImportJobDependentResource;
 import org.keycloak.operator.controllers.KeycloakUpdateJobDependentResource;
 import org.keycloak.operator.controllers.WatchedResources;
+import org.keycloak.operator.controllers.WatchedResources.Watched;
 import org.keycloak.operator.crds.v2alpha1.CRDUtils;
 import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakBuilder;
@@ -603,7 +604,7 @@ public class PodTemplateTest {
                 .findFirst().orElseThrow();
         assertThat(volume.getConfigMap().getName()).isEqualTo("cm");
 
-        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(List.of("cm")), Mockito.eq(ConfigMap.class), Mockito.any(), Mockito.any());
+        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(Watched.of("cm")), Mockito.eq(ConfigMap.class), Mockito.any(), Mockito.any());
     }
 
     @Test
@@ -878,7 +879,7 @@ public class PodTemplateTest {
         envVar = env.get("SECRET");
         assertEquals("key", envVar.getValueFrom().getSecretKeyRef().getKey());
 
-        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(List.of("example-tls-secret", "instance-initial-admin", "my-secret")), Mockito.eq(Secret.class), Mockito.any(), Mockito.any());
+        Mockito.verify(this.watchedResources).annotateDeployment(Mockito.eq(Watched.of("example-tls-secret", "instance-initial-admin", "my-secret")), Mockito.eq(Secret.class), Mockito.any(), Mockito.any());
     }
 
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/WatchedResourcesTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/WatchedResourcesTest.java
@@ -17,23 +17,21 @@
 
 package org.keycloak.operator.testsuite.unit;
 
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
-import io.quarkus.test.junit.QuarkusTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
-import org.keycloak.operator.controllers.WatchedResources;
-
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.keycloak.operator.Utils;
+import org.keycloak.operator.controllers.WatchedResources;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 
 @QuarkusTest
 public class WatchedResourcesTest {
@@ -49,19 +47,12 @@ public class WatchedResourcesTest {
 
     @Test
     public void testHashing() {
-        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", watchedResources.getHash(List.of()));
-        assertEquals("b5655bfe4d4e130f5023a76a5de0906cf84eb5895bda5d44642673f9eb4024bf", watchedResources.getHash(List.of(newSecret(Map.of("a", "b")), newSecret(Map.of("c", "d")))));
+        assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", Utils.hash(List.of()));
+        assertEquals("b5655bfe4d4e130f5023a76a5de0906cf84eb5895bda5d44642673f9eb4024bf", Utils.hash(List.of(newSecret(Map.of("a", "b")), newSecret(Map.of("c", "d")))));
         assertEquals("d526224334e65c71095be909b2d14c52f1589abb84a3c76fbe79dd75d7132fbb",
-                watchedResources.getHash(List.of(new ConfigMapBuilder().withNewMetadata().withName("x")
+                Utils.hash(List.of(new ConfigMapBuilder().withNewMetadata().withName("x")
                         .withAnnotations(Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()))
                         .endMetadata().withData(Map.of("a", "b")).build())));
-    }
-
-    @Test
-    public void testGetSecretNames() {
-        assertEquals(List.of(), watchedResources.getNames(new StatefulSetBuilder().withNewMetadata().addToAnnotations(WatchedResourcesTest.KEYCLOAK_WATCHING_ANNOTATION, "").endMetadata().build(), Secret.class));
-        assertEquals(Arrays.asList("something"), watchedResources.getNames(new StatefulSetBuilder().withNewMetadata().addToAnnotations(WatchedResourcesTest.KEYCLOAK_WATCHING_ANNOTATION, "something").endMetadata().build(), Secret.class));
-        assertEquals(Arrays.asList("x", "y"), watchedResources.getNames(new StatefulSetBuilder().withNewMetadata().addToAnnotations(WatchedResourcesTest.KEYCLOAK_WATCHING_ANNOTATION, "x;y").endMetadata().build(), Secret.class));
     }
 
     private Secret newSecret(Map<String, String> data) {


### PR DESCRIPTION
closes: #43777

At one point I believe the StatefulSet status showed what secrets / configmaps were missing and we would then put that on the keycloak status. This does not seem to be the case anymore. These changes add missing non-optional configmaps and secrets as warnings.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
