### PR TITLE
[OID4VCI]: Realm-Configurable Time-Claim Normalization (Randomize/Round) to Mitigate Correlation

### DIFF
--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -166,6 +166,61 @@ curl -X PUT "https://localhost:8443/admin/realms/oid4vc-vci" \
 - **Avoid using `-k` in production**; instead, configure a **trusted TLS certificate**.
 ====
 
+==== Time-claim correlation mitigation
+
+To reduce unintended correlation across multiple issuances or presentations, you can normalize time-related claims by either randomizing them within a time window or rounding them to a coarse time unit. This behavior is opt-in and controlled by the following realm attributes:
+
+[cols="1,1,2", options="header"]
+|===
+| Attribute
+| Default
+| Description
+
+| `oid4vci.time.claims.strategy`
+| `off`
+| Strategy to apply to time claims. Supported values: `off`, `randomize`, `round`.
+
+| `oid4vci.time.randomize.window.seconds`
+| `86400`
+| When strategy is `randomize`, subtract a random number of seconds (0 to N) from the original timestamp to mitigate correlation attacks.
+
+| `oid4vci.time.round.unit`
+| `DAY`
+| When strategy is `round`, truncate timestamps to the selected unit boundary (UTC). Supported values: `MINUTE`, `HOUR`, `DAY`.
+|===
+
+How it is applied during issuance:
+
+- For JWT-VC, the credential `issuanceDate` is normalized at issuance; the JWT `nbf` is derived from the normalized value. If a mapper sets a VC `expirationDate`, it is normalized and emitted as JWT `exp`.
+- For SD-JWT VCs, time-related claims (`iat`, `nbf`, `exp`) are typically set using protocol mappers. Use the available OID4VC mappers, such as the Issued At Time Claim Mapper for `iat`, to populate these claims. Values are automatically normalized according to the realm strategy.
+
+Examples:
+
+[source,bash]
+----
+# Round to start of day (UTC)
+curl -X PUT "https://localhost:8443/admin/realms/oid4vc-vci" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "attributes": {
+          "oid4vci.time.claims.strategy": "round",
+          "oid4vci.time.round.unit": "DAY"
+        }
+      }'
+
+# Randomize within the last 24 hours
+curl -X PUT "https://localhost:8443/admin/realms/oid4vc-vci" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "attributes": {
+          "oid4vci.time.claims.strategy": "randomize",
+          "oid4vci.time.randomize.window.seconds": "86400"
+        }
+      }'
+----
+
 === Create Client Scopes with Mappers
 
 Client scopes define **which user attributes** are included in Verifiable Credentials (VCs). Therefore, they are considered the Verifiable Credential configuration itself. These scopes use **protocol mappers** to map specific claims into VCs and the protocol mappers will also contain the corresponding metadata for claims that is displayed at the Credential Issuer Metadata Endpoint.

--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -182,7 +182,7 @@ To reduce unintended correlation across multiple issuances or presentations, you
 
 | `oid4vci.time.randomize.window.seconds`
 | `86400`
-| When strategy is `randomize`, subtract a random number of seconds (0 to N) from the original timestamp to mitigate correlation attacks.
+| When strategy is `randomize`, subtract a random number of seconds between 0 and the value of this attribute from the original timestamp to mitigate correlation attacks.
 
 | `oid4vci.time.round.unit`
 | `SECOND`

--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -185,8 +185,8 @@ To reduce unintended correlation across multiple issuances or presentations, you
 | When strategy is `randomize`, subtract a random number of seconds (0 to N) from the original timestamp to mitigate correlation attacks.
 
 | `oid4vci.time.round.unit`
-| `DAY`
-| When strategy is `round`, truncate timestamps to the selected unit boundary (UTC). Supported values: `MINUTE`, `HOUR`, `DAY`.
+| `SECOND`
+| When strategy is `round`, truncate timestamps to the selected unit boundary (UTC). Supported values: `SECOND`, `MINUTE`, `HOUR`, `DAY`.
 |===
 
 How it is applied during issuance:

--- a/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/constants/Oid4VciConstants.java
@@ -30,6 +30,10 @@ public final class Oid4VciConstants {
 
     public static final String C_NONCE_LIFETIME_IN_SECONDS = "vc.c-nonce-lifetime-seconds";
 
+    public static final String TIME_CLAIMS_STRATEGY = "oid4vci.time.claims.strategy";
+    public static final String TIME_RANDOMIZE_WINDOW_SECONDS = "oid4vci.time.randomize.window.seconds";
+    public static final String TIME_ROUND_UNIT = "oid4vci.time.round.unit";
+
     // --- Keybinding/Credential Builder ---
     public static final String SOURCE_ENDPOINT = "source_endpoint";
     public static final String BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE = "batch_credential_issuance.batch_size";

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -17,16 +17,17 @@
 
 package org.keycloak.protocol.oid4vc.issuance;
 
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
-import org.jboss.logging.Logger;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.utils.StringUtil;
+
+import org.jboss.logging.Logger;
 
 /**
  * Utility to apply correlation-mitigation to time-related claims

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -35,7 +35,7 @@ import org.keycloak.utils.StringUtil;
  * Configuration via realm attributes (all optional):
  * - oid4vci.time.claims.strategy: off | randomize | round (default: off)
  * - oid4vci.time.randomize.window.seconds: integer seconds (default: 86400)
- * - oid4vci.time.round.unit: MINUTE | HOUR | DAY (default: DAY)
+ * - oid4vci.time.round.unit: SECOND | MINUTE | HOUR | DAY (default: SECOND)
  *
  * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
  */
@@ -54,6 +54,7 @@ public class TimeClaimNormalizer {
     }
 
     public enum RoundUnit {
+        SECOND,
         MINUTE,
         HOUR,
         DAY
@@ -65,7 +66,7 @@ public class TimeClaimNormalizer {
 
     private static final long DEFAULT_RANDOMIZE_WINDOW = 86400; // 24h default
     private static final Strategy DEFAULT_STRATEGY = Strategy.OFF;
-    private static final RoundUnit DEFAULT_ROUND_UNIT = RoundUnit.DAY;
+    private static final RoundUnit DEFAULT_ROUND_UNIT = RoundUnit.SECOND;
 
     public TimeClaimNormalizer(KeycloakSession session) {
         this(session.getContext().getRealm());
@@ -104,6 +105,7 @@ public class TimeClaimNormalizer {
         // Truncate in UTC by design to ensure consistent, timezone-independent rounding
         ZonedDateTime zdt = original.atZone(ZoneOffset.UTC);
         return switch (roundUnit) {
+            case SECOND -> zdt.truncatedTo(ChronoUnit.SECONDS).toInstant();
             case MINUTE -> zdt.truncatedTo(ChronoUnit.MINUTES).toInstant();
             case HOUR -> zdt.truncatedTo(ChronoUnit.HOURS).toInstant();
             case DAY -> zdt.toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.issuance;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import org.jboss.logging.Logger;
+import org.keycloak.utils.StringUtil;
+
+/**
+ * Utility to apply correlation-mitigation to time-related claims
+ * by either randomizing within a window or rounding to a unit.
+ * <p>
+ * Configuration via realm attributes (all optional):
+ * - oid4vci.time.claims.strategy: off | randomize | round (default: off)
+ * - oid4vci.time.randomize.window.seconds: integer seconds (default: 86400)
+ * - oid4vci.time.round.unit: MINUTE | HOUR | DAY (default: DAY)
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ */
+public class TimeClaimNormalizer {
+
+    private static final Logger logger = Logger.getLogger(TimeClaimNormalizer.class);
+
+    public static final String ATTR_STRATEGY = "oid4vci.time.claims.strategy";
+    public static final String ATTR_RANDOM_WINDOW = "oid4vci.time.randomize.window.seconds";
+    public static final String ATTR_ROUND_UNIT = "oid4vci.time.round.unit";
+
+    public enum Strategy {
+        OFF,
+        RANDOMIZE,
+        ROUND
+    }
+
+    public enum RoundUnit {
+        MINUTE,
+        HOUR,
+        DAY
+    }
+
+    private final Strategy strategy;
+    private final long randomizeWindowSeconds;
+    private final RoundUnit roundUnit;
+
+    private static final long DEFAULT_RANDOMIZE_WINDOW = 86400; // 24h default
+    private static final Strategy DEFAULT_STRATEGY = Strategy.OFF;
+    private static final RoundUnit DEFAULT_ROUND_UNIT = RoundUnit.DAY;
+
+    public TimeClaimNormalizer(KeycloakSession session) {
+        this(session.getContext().getRealm());
+    }
+
+    public TimeClaimNormalizer(RealmModel realm) {
+        this.strategy = parseStrategy(realm.getAttribute(ATTR_STRATEGY));
+        this.randomizeWindowSeconds = parseRandomizeWindow(realm.getAttribute(ATTR_RANDOM_WINDOW));
+        this.roundUnit = parseRoundUnit(realm.getAttribute(ATTR_ROUND_UNIT));
+    }
+
+    TimeClaimNormalizer(Strategy strategy, Long randomizeWindowSeconds, RoundUnit roundUnit) {
+        this.strategy = strategy == null ? DEFAULT_STRATEGY : strategy;
+        this.randomizeWindowSeconds =
+                randomizeWindowSeconds == null ? DEFAULT_RANDOMIZE_WINDOW : randomizeWindowSeconds;
+        this.roundUnit = roundUnit == null ? DEFAULT_ROUND_UNIT : roundUnit;
+    }
+
+    public Instant normalize(Instant original) {
+        if (original == null) {
+            return null;
+        }
+        return switch (strategy) {
+            case RANDOMIZE -> randomize(original);
+            case ROUND -> round(original);
+            case OFF -> original;
+        };
+    }
+
+    private Instant randomize(Instant original) {
+        long randomOffset = (long) (Math.random() * (randomizeWindowSeconds + 1));
+        return original.minusSeconds(randomOffset);
+    }
+
+    private Instant round(Instant original) {
+        // Truncate in UTC by design to ensure consistent, timezone-independent rounding
+        ZonedDateTime zdt = original.atZone(ZoneOffset.UTC);
+        return switch (roundUnit) {
+            case MINUTE -> zdt.truncatedTo(ChronoUnit.MINUTES).toInstant();
+            case HOUR -> zdt.truncatedTo(ChronoUnit.HOURS).toInstant();
+            case DAY -> zdt.toLocalDate().atStartOfDay(ZoneOffset.UTC).toInstant();
+        };
+    }
+
+    private static Strategy parseStrategy(String value) {
+        if (value == null) {
+            return DEFAULT_STRATEGY;
+        }
+        try {
+            return Strategy.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            logger.warnf("Invalid time-claim strategy '%s'. Using default '%s'", value, DEFAULT_STRATEGY);
+            return DEFAULT_STRATEGY;
+        }
+    }
+
+    private static long parseRandomizeWindow(String value) {
+        if (StringUtil.isBlank(value)) {
+            return DEFAULT_RANDOMIZE_WINDOW;
+        }
+        try {
+            long window = Long.parseLong(value.trim());
+            if (window <= 0) {
+                logger.warnf("Randomization window is zero or negative (%d), will be using default value", window);
+                return DEFAULT_RANDOMIZE_WINDOW;
+            }
+            return window;
+        } catch (NumberFormatException ex) {
+            logger.warnf("Invalid randomize window '%s'. Using default %d seconds", value, DEFAULT_RANDOMIZE_WINDOW);
+            return DEFAULT_RANDOMIZE_WINDOW;
+        }
+    }
+
+    private static RoundUnit parseRoundUnit(String value) {
+        if (value == null) {
+            return DEFAULT_ROUND_UNIT;
+        }
+        try {
+            return RoundUnit.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            logger.warnf("Invalid round unit '%s'. Using default '%s'", value, DEFAULT_ROUND_UNIT);
+            return DEFAULT_ROUND_UNIT;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -62,9 +62,9 @@ public class TimeClaimNormalizer {
     private final long randomizeWindowSeconds;
     private final RoundUnit roundUnit;
 
-    private static final long DEFAULT_RANDOMIZE_WINDOW = 86400; // 24h default
-    private static final Strategy DEFAULT_STRATEGY = Strategy.OFF;
-    private static final RoundUnit DEFAULT_ROUND_UNIT = RoundUnit.SECOND;
+    public static final long DEFAULT_RANDOMIZE_WINDOW = 86400; // 24h default
+    public static final Strategy DEFAULT_STRATEGY = Strategy.OFF;
+    public static final RoundUnit DEFAULT_ROUND_UNIT = RoundUnit.SECOND;
 
     public TimeClaimNormalizer(KeycloakSession session) {
         this(session.getContext().getRealm());

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -23,6 +23,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
+import org.keycloak.constants.Oid4VciConstants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.utils.StringUtil;
@@ -43,10 +44,6 @@ import org.jboss.logging.Logger;
 public class TimeClaimNormalizer {
 
     private static final Logger logger = Logger.getLogger(TimeClaimNormalizer.class);
-
-    public static final String ATTR_STRATEGY = "oid4vci.time.claims.strategy";
-    public static final String ATTR_RANDOM_WINDOW = "oid4vci.time.randomize.window.seconds";
-    public static final String ATTR_ROUND_UNIT = "oid4vci.time.round.unit";
 
     public enum Strategy {
         OFF,
@@ -74,9 +71,9 @@ public class TimeClaimNormalizer {
     }
 
     public TimeClaimNormalizer(RealmModel realm) {
-        this.strategy = parseStrategy(realm.getAttribute(ATTR_STRATEGY));
-        this.randomizeWindowSeconds = parseRandomizeWindow(realm.getAttribute(ATTR_RANDOM_WINDOW));
-        this.roundUnit = parseRoundUnit(realm.getAttribute(ATTR_ROUND_UNIT));
+        this.strategy = parseStrategy(realm.getAttribute(Oid4VciConstants.TIME_CLAIMS_STRATEGY));
+        this.randomizeWindowSeconds = parseRandomizeWindow(realm.getAttribute(Oid4VciConstants.TIME_RANDOMIZE_WINDOW_SECONDS));
+        this.roundUnit = parseRoundUnit(realm.getAttribute(Oid4VciConstants.TIME_ROUND_UNIT));
     }
 
     TimeClaimNormalizer(Strategy strategy, Long randomizeWindowSeconds, RoundUnit roundUnit) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
@@ -21,11 +21,15 @@ import java.time.Instant;
 import java.util.Optional;
 
 import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
 import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+import org.keycloak.models.KeycloakSession;
 
 public class JwtCredentialBuilder implements CredentialBuilder {
 
@@ -33,9 +37,23 @@ public class JwtCredentialBuilder implements CredentialBuilder {
     private static final String ID_CLAIM_KEY = "id";
 
     private final TimeProvider timeProvider;
+    private final UnaryOperator<Instant> issuanceTimeNormalizer;
 
     public JwtCredentialBuilder(TimeProvider timeProvider) {
-        this.timeProvider = timeProvider;
+        this(timeProvider, instant -> {
+            throw new IllegalStateException("KeycloakSession must not be null when defaulting issuance time");
+        });
+    }
+
+    public JwtCredentialBuilder(TimeProvider timeProvider, KeycloakSession session) {
+        this(timeProvider, new TimeClaimNormalizer(
+                Objects.requireNonNull(session, "KeycloakSession must not be null when defaulting issuance time")
+        )::normalize);
+    }
+
+    public JwtCredentialBuilder(TimeProvider timeProvider, UnaryOperator<Instant> issuanceTimeNormalizer) {
+        this.timeProvider = Objects.requireNonNull(timeProvider, "TimeProvider must not be null");
+        this.issuanceTimeNormalizer = Objects.requireNonNull(issuanceTimeNormalizer, "Issuance time normalizer must not be null");
     }
 
     @Override
@@ -52,10 +70,14 @@ public class JwtCredentialBuilder implements CredentialBuilder {
         verifiableCredential.setIssuer(credentialBuildConfig.getCredentialIssuer());
 
         // Get the issuance date from the credential. Since nbf is mandatory, we set it to the current time if not
-        // provided
-        long iat = Optional.ofNullable(verifiableCredential.getIssuanceDate())
-                .map(Instant::getEpochSecond)
-                .orElse((long) timeProvider.currentTimeSeconds());
+        // provided. Only normalize if we're using the default time, as VC issuanceDate is already normalized.
+        Instant issuanceInstant = Optional.ofNullable(verifiableCredential.getIssuanceDate())
+                .orElseGet(() -> {
+                    Instant defaultTime = Instant.ofEpochSecond(timeProvider.currentTimeSeconds());
+                    return issuanceTimeNormalizer.apply(defaultTime);
+                });
+
+        long iat = issuanceInstant.getEpochSecond();
 
         // set mandatory fields
         JsonWebToken jsonWebToken = new JsonWebToken()

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
@@ -18,18 +18,18 @@
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
 import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
-import java.util.Objects;
-import java.util.function.UnaryOperator;
-import org.keycloak.models.KeycloakSession;
 
 public class JwtCredentialBuilder implements CredentialBuilder {
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderFactory.java
@@ -50,6 +50,6 @@ public class JwtCredentialBuilderFactory implements CredentialBuilderFactory {
 
     @Override
     public CredentialBuilder create(KeycloakSession session, ComponentModel model) {
-        return new JwtCredentialBuilder(new OffsetTimeProvider());
+        return new JwtCredentialBuilder(new OffsetTimeProvider(), session);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
@@ -16,6 +16,17 @@
  */
 package org.keycloak.protocol.oid4vc.issuance.mappers;
 
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
+import org.keycloak.protocol.oid4vc.model.CredentialSubject;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -23,17 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
-import org.keycloak.protocol.ProtocolMapper;
-import org.keycloak.protocol.oid4vc.model.CredentialSubject;
-import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
-import org.keycloak.provider.ProviderConfigProperty;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Map issuance date to the credential, under the default claim name "iat"
@@ -74,7 +74,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
         ProviderConfigProperty truncateToTimeUnit = new ProviderConfigProperty();
         truncateToTimeUnit.setName(TRUNCATE_TO_TIME_UNIT_KEY);
         truncateToTimeUnit.setLabel("Truncate To Time Unit");
-        truncateToTimeUnit.setHelpText("Truncate time to the first second of the MINUTES, HOURS, HALF_DAYS, DAYS, WEEKS, MONTHS or YEARS. Such as to prevent correlation of credentials based on this time value.");
+        truncateToTimeUnit.setHelpText("Truncate time to the start of the selected unit. Supported: MINUTES, HOURS, HALF_DAYS, DAYS, WEEKS, MONTHS, YEARS. Such as to prevent correlation of credentials based on this time value.");
         truncateToTimeUnit.setType(ProviderConfigProperty.LIST_TYPE);
         truncateToTimeUnit.setOptions(List.of("MINUTES", "HOURS", "HALF_DAYS", "DAYS", "WEEKS", "MONTHS", "YEARS"));
         CONFIG_PROPERTIES.add(truncateToTimeUnit);
@@ -124,13 +124,16 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
                 .orElseGet(() -> Optional.ofNullable(verifiableCredential.getIssuanceDate())
                         .orElse(Instant.now()));
 
+        Instant normalizedIat = new TimeClaimNormalizer(userSessionModel.getRealm())
+                .normalize(iat);
+
         // truncate is possible. Return iat if not.
         Instant iatTrunc = Optional.ofNullable(mapperModel.getConfig())
                 .flatMap(config -> Optional.ofNullable(config.get(TRUNCATE_TO_TIME_UNIT_KEY)))
-                .filter(String::isEmpty)
+                .filter(val -> !val.isEmpty())
                 .map(ChronoUnit::valueOf)
-                .map(iat::truncatedTo)
-                .orElse(iat);
+                .map(normalizedIat::truncatedTo)
+                .orElse(normalizedIat);
 
         CredentialSubject credentialSubject = verifiableCredential.getCredentialSubject();
         credentialSubject.setClaims(propertyName, iatTrunc.getEpochSecond());

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
@@ -77,7 +77,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
         truncateToTimeUnit.setLabel("Truncate To Time Unit");
         truncateToTimeUnit.setHelpText("Truncate time to the start of the selected unit. Supported: SECONDS, MINUTES, HOURS, HALF_DAYS, DAYS, WEEKS, MONTHS, YEARS. Such as to prevent correlation of credentials based on this time value.");
         truncateToTimeUnit.setType(ProviderConfigProperty.LIST_TYPE);
-        truncateToTimeUnit.setOptions(List.of("MINUTES", "HOURS", "HALF_DAYS", "DAYS", "WEEKS", "MONTHS", "YEARS"));
+        truncateToTimeUnit.setOptions(List.of("SECONDS", "MINUTES", "HOURS", "HALF_DAYS", "DAYS", "WEEKS", "MONTHS", "YEARS"));
         CONFIG_PROPERTIES.add(truncateToTimeUnit);
 
         ProviderConfigProperty valueSource = new ProviderConfigProperty();
@@ -131,7 +131,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
         // truncate is possible. Return iat if not.
         Instant iatTrunc = Optional.ofNullable(mapperModel.getConfig())
                 .map(config -> config.get(TRUNCATE_TO_TIME_UNIT_KEY))
-                .filter(val -> val != null && !val.isEmpty())
+                .filter(val -> !val.isEmpty())
                 .map(ChronoUnit::valueOf)
                 .map(normalizedIat::truncatedTo)
                 .orElse(normalizedIat);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
@@ -75,7 +75,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
         ProviderConfigProperty truncateToTimeUnit = new ProviderConfigProperty();
         truncateToTimeUnit.setName(TRUNCATE_TO_TIME_UNIT_KEY);
         truncateToTimeUnit.setLabel("Truncate To Time Unit");
-        truncateToTimeUnit.setHelpText("Truncate time to the start of the selected unit. Supported: MINUTES, HOURS, HALF_DAYS, DAYS, WEEKS, MONTHS, YEARS. Such as to prevent correlation of credentials based on this time value.");
+        truncateToTimeUnit.setHelpText("Truncate time to the start of the selected unit. Supported: SECONDS, MINUTES, HOURS, HALF_DAYS, DAYS, WEEKS, MONTHS, YEARS. Such as to prevent correlation of credentials based on this time value.");
         truncateToTimeUnit.setType(ProviderConfigProperty.LIST_TYPE);
         truncateToTimeUnit.setOptions(List.of("MINUTES", "HOURS", "HALF_DAYS", "DAYS", "WEEKS", "MONTHS", "YEARS"));
         CONFIG_PROPERTIES.add(truncateToTimeUnit);
@@ -130,8 +130,8 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
 
         // truncate is possible. Return iat if not.
         Instant iatTrunc = Optional.ofNullable(mapperModel.getConfig())
-                .flatMap(config -> Optional.ofNullable(config.get(TRUNCATE_TO_TIME_UNIT_KEY)))
-                .filter(val -> !val.isEmpty())
+                .map(config -> config.get(TRUNCATE_TO_TIME_UNIT_KEY))
+                .filter(val -> val != null && !val.isEmpty())
                 .map(ChronoUnit::valueOf)
                 .map(normalizedIat::truncatedTo)
                 .orElse(normalizedIat);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
@@ -16,17 +16,6 @@
  */
 package org.keycloak.protocol.oid4vc.issuance.mappers;
 
-import org.keycloak.models.oid4vci.CredentialScopeModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.UserSessionModel;
-import org.keycloak.protocol.ProtocolMapper;
-import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
-import org.keycloak.protocol.oid4vc.model.CredentialSubject;
-import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
-import org.keycloak.provider.ProviderConfigProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -34,6 +23,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
+import org.keycloak.protocol.oid4vc.model.CredentialSubject;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Map issuance date to the credential, under the default claim name "iat"

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
@@ -17,8 +17,9 @@
 
 package org.keycloak.protocol.oid4vc.issuance;
 
-import org.junit.Test;
 import java.time.Instant;
+
+import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /*
  *  @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
@@ -95,7 +96,7 @@ public class TimeClaimNormalizerTest {
         assertFalse("Normalized time should not be after original time", normalized.isAfter(orig));
         // should be within the randomization window
         long diffSeconds = orig.getEpochSecond() - normalized.getEpochSecond();
-        assertFalse("Randomized time should be within window", diffSeconds > 3600);
+        assertTrue("Randomized time should be within window", diffSeconds <= 3600);
     }
 
     @Test
@@ -109,7 +110,7 @@ public class TimeClaimNormalizerTest {
         // So normalized should be <= original and within the window
         assertFalse("Normalized time should not be after original time", normalized.isAfter(orig));
         long diffSeconds = orig.getEpochSecond() - normalized.getEpochSecond();
-        assertFalse("Randomized time should be within window", diffSeconds > 3600);
+        assertTrue("Randomized time should be within window", diffSeconds <= 3600);
     }
 
 }

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.issuance;
+
+import org.junit.Test;
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+
+/*
+ *  @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ */
+public class TimeClaimNormalizerTest {
+
+    @Test
+    public void offStrategy_keepsOriginal() {
+        Instant orig = Instant.parse("2025-01-02T03:04:05Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.OFF, 0L, TimeClaimNormalizer.RoundUnit.DAY);
+        assertThat(n.normalize(orig), is(orig));
+    }
+
+    @Test
+    public void roundDay_truncatesToStartOfDayUtc() {
+        Instant orig = Instant.parse("2025-01-02T23:59:59Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.DAY);
+        Instant normalized = n.normalize(orig);
+        assertThat(normalized, is(Instant.parse("2025-01-02T00:00:00Z")));
+    }
+
+    @Test
+    public void roundHour_truncatesToHour() {
+        Instant orig = Instant.parse("2025-01-02T03:59:59Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.HOUR);
+        Instant normalized = n.normalize(orig);
+        assertThat(normalized, is(Instant.parse("2025-01-02T03:00:00Z")));
+    }
+
+    @Test
+    public void roundMinute_truncatesToMinute() {
+        Instant orig = Instant.parse("2025-01-02T03:04:59Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.MINUTE);
+        Instant normalized = n.normalize(orig);
+        assertThat(normalized, is(Instant.parse("2025-01-02T03:04:00Z")));
+    }
+
+    @Test
+    public void randomize_withinWindow_doesNotShiftIntoFuture() {
+        Instant orig = Instant.parse("2025-01-02T22:00:00Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);
+
+        Instant normalized = n.normalize(orig);
+
+        assertFalse("Normalized time should not be after original time", normalized.isAfter(orig));
+    }
+
+    @Test
+    public void randomize_withinWindow_alwaysBeforeOrEqualOriginal() {
+        Instant orig = Instant.parse("2025-01-02T22:00:00Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);
+        Instant normalized = n.normalize(orig);
+        assertFalse("Normalized time should not be after original time", normalized.isAfter(orig));
+        // should be within the randomization window
+        long diffSeconds = orig.getEpochSecond() - normalized.getEpochSecond();
+        assertFalse("Randomized time should be within window", diffSeconds > 3600);
+    }
+
+    @Test
+    public void randomize_alwaysRandomizesWithinWindow() {
+        Instant orig = Instant.parse("2025-01-02T22:00:00Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);
+
+        Instant normalized = n.normalize(orig);
+
+        // we always randomize within the window (0 to 3600 seconds back)
+        // So normalized should be <= original and within the window
+        assertFalse("Normalized time should not be after original time", normalized.isAfter(orig));
+        long diffSeconds = orig.getEpochSecond() - normalized.getEpochSecond();
+        assertFalse("Randomized time should be within window", diffSeconds > 3600);
+    }
+
+}

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
@@ -61,6 +61,22 @@ public class TimeClaimNormalizerTest {
     }
 
     @Test
+    public void roundSecond_truncatesToSecond() {
+        Instant orig = Instant.parse("2025-01-02T03:04:05.987654Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.SECOND);
+        Instant normalized = n.normalize(orig);
+        assertThat(normalized, is(Instant.parse("2025-01-02T03:04:05Z")));
+    }
+
+    @Test
+    public void defaultRoundUnit_isSecond() {
+        Instant orig = Instant.parse("2025-01-02T03:04:05.987654Z");
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, null, null);
+        Instant normalized = n.normalize(orig);
+        assertThat(normalized, is(Instant.parse("2025-01-02T03:04:05Z")));
+    }
+
+    @Test
     public void randomize_withinWindow_doesNotShiftIntoFuture() {
         Instant orig = Instant.parse("2025-01-02T22:00:00Z");
         TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialbuilder/JwtCredentialBuilderTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.testsuite.oid4vc.issuance.credentialbuilder;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +31,9 @@ import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.JwtCredentialBody
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.JwtCredentialBuilder;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
-import java.time.temporal.ChronoUnit;
 
 import static org.keycloak.OID4VCConstants.CREDENTIAL_SUBJECT;
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/JwtCredentialSignerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/JwtCredentialSignerTest.java
@@ -171,7 +171,8 @@ public class JwtCredentialSignerTest extends OID4VCTest {
 
         VerifiableCredential testCredential = getTestCredential(claims);
         JwtCredentialBuilder builder = new JwtCredentialBuilder(
-                new StaticTimeProvider(1000)
+                new StaticTimeProvider(1000),
+                session
         );
 
         CredentialBody credentialBody = builder.buildCredentialBody(

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -174,7 +174,8 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
     protected static OID4VCIssuerEndpoint prepareIssuerEndpoint(KeycloakSession session,
                                                                 AppAuthManager.BearerTokenAuthenticator authenticator) {
         JwtCredentialBuilder jwtCredentialBuilder = new JwtCredentialBuilder(
-                new StaticTimeProvider(1000));
+                new StaticTimeProvider(1000),
+                session);
         SdJwtCredentialBuilder sdJwtCredentialBuilder = new SdJwtCredentialBuilder();
 
         return prepareIssuerEndpoint(

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -496,7 +496,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
 
     protected static OID4VCIssuerEndpoint prepareIssuerEndpoint(KeycloakSession session,
                                                                 AppAuthManager.BearerTokenAuthenticator authenticator) {
-        JwtCredentialBuilder testJwtCredentialBuilder = new JwtCredentialBuilder(new StaticTimeProvider(5));
+        JwtCredentialBuilder testJwtCredentialBuilder = new JwtCredentialBuilder(new StaticTimeProvider(5), session);
         SdJwtCredentialBuilder testSdJwtCredentialBuilder = new SdJwtCredentialBuilder();
 
         return new OID4VCIssuerEndpoint(

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationSdJwtTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationSdJwtTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oid4vc.issuance.signing;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
+import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCIssuedAtTimeClaimMapper;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * SD-JWT variant: ensure realm-level rounding of issuanceDate propagates to iat when mapper sources from VC.
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ *
+ */
+public class OID4VCTimeNormalizationSdJwtTest extends OID4VCSdJwtIssuingEndpointTest {
+
+    @Test
+    public void testSdJwtIatRoundedViaRealmNormalizedIssuanceDate() {
+        // Configure realm to round time claims to DAY
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            session.getContext().getRealm().setAttribute("oid4vci.time.claims.strategy", "round");
+            session.getContext().getRealm().setAttribute("oid4vci.time.round.unit", "DAY");
+        });
+
+        String token = getBearerToken(oauth, client, sdJwtTypeCredentialClientScope.getName());
+        final String clientScopeString = toJsonString(sdJwtTypeCredentialClientScope);
+
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                // Add a protocol mapper that maps iat from VC issuanceDate (VALUE_SOURCE=VC)
+                ClientScopeRepresentation clientScope = fromJsonString(clientScopeString, ClientScopeRepresentation.class);
+                ProtocolMapperRepresentation pr = new ProtocolMapperRepresentation();
+                pr.setName("iat-from-vc");
+                pr.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+                pr.setProtocolMapper(OID4VCIssuedAtTimeClaimMapper.MAPPER_ID);
+                pr.setConfig(Map.of(
+                        OID4VCIssuedAtTimeClaimMapper.CLAIM_NAME, "iat",
+                        OID4VCIssuedAtTimeClaimMapper.VALUE_SOURCE, "VC"
+                ));
+                clientScope.getProtocolMappers().add(pr);
+
+                AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                authenticator.setTokenString(token);
+                OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
+
+                CredentialRequest credentialRequest = new CredentialRequest()
+                        .setCredentialConfigurationId(clientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
+
+                String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
+                Response response = issuerEndpoint.requestCredential(requestPayload);
+                assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+                CredentialResponse credentialResponse = JsonSerialization.mapper.convertValue(response.getEntity(), CredentialResponse.class);
+                assertNotNull(credentialResponse);
+
+                // Parse SD-JWT and check iat rounding (multiple of 86400)
+                SdJwtVP sdJwtVP = SdJwtVP.of(credentialResponse.getCredentials().get(0).getCredential().toString());
+                JsonWebToken jwt = TokenVerifier.create(sdJwtVP.getIssuerSignedJWT().toJws(), JsonWebToken.class).getToken();
+                Long iat = jwt.getIat();
+                assertNotNull(iat);
+                assertEquals(0, iat % 86400);
+            } catch (IOException | VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationSdJwtTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationSdJwtTest.java
@@ -17,9 +17,11 @@
 
 package org.keycloak.testsuite.oid4vc.issuance.signing;
 
+import java.io.IOException;
+import java.util.Map;
+
 import jakarta.ws.rs.core.Response;
-import org.apache.http.HttpStatus;
-import org.junit.Test;
+
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.constants.Oid4VciConstants;
@@ -35,8 +37,8 @@ import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.util.JsonSerialization;
 
-import java.io.IOException;
-import java.util.Map;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oid4vc.issuance.signing;
+
+import jakarta.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.util.JsonSerialization;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Integration tests validating time-claim normalization configuration and effects on JWT-VC.
+ *
+ * @author <a href="mailto:Rodrick.Awambeng@adorsys.com">Rodrick Awambeng</a>
+ *
+ */
+public class OID4VCTimeNormalizationTest extends OID4VCJWTIssuerEndpointTest {
+
+    @Test
+    public void testJwtVcNbfRoundedToStartOfDayUtc() {
+        // Configure realm to round time claims to DAY
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            session.getContext().getRealm().setAttribute("oid4vci.time.claims.strategy", "round");
+            session.getContext().getRealm().setAttribute("oid4vci.time.round.unit", "DAY");
+        });
+
+        final String scopeName = jwtTypeCredentialClientScope.getName();
+        String token = getBearerToken(oauth, client, scopeName);
+
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            try {
+                var authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                authenticator.setTokenString(token);
+                OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
+
+                CredentialRequest credentialRequest = new CredentialRequest()
+                        .setCredentialIdentifier(scopeName);
+
+                String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
+                Response response = issuerEndpoint.requestCredential(requestPayload);
+                assertEquals(HttpStatus.SC_OK, response.getStatus());
+
+                CredentialResponse credentialResponse = JsonSerialization.mapper
+                        .convertValue(response.getEntity(), CredentialResponse.class);
+                assertNotNull(credentialResponse);
+                String jwtString = (String) credentialResponse.getCredentials().get(0).getCredential();
+
+                JsonWebToken jwt = TokenVerifier.create(jwtString, JsonWebToken.class).getToken();
+                assertNotNull(jwt);
+
+                Long nbf = jwt.getNbf();
+                assertNotNull("nbf should be present", nbf);
+
+                // Assert nbf is truncated to start of day UTC (multiple of 86400)
+                assertEquals(0, nbf % 86400);
+
+                // Additionally, ensure issuance date inside vc claim (if present) aligns with the day boundary
+                Object vcObj = jwt.getOtherClaims().get("vc");
+                var vc = JsonSerialization.mapper.convertValue(vcObj, VerifiableCredential.class);
+                Instant issuance = vc.getIssuanceDate();
+                assertNotNull("issuanceDate should be present", issuance);
+                assertEquals(0, issuance.getEpochSecond() % 86400);
+            } catch (IOException | VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationTest.java
@@ -17,9 +17,11 @@
 
 package org.keycloak.testsuite.oid4vc.issuance.signing;
 
+import java.io.IOException;
+import java.time.Instant;
+
 import jakarta.ws.rs.core.Response;
-import org.apache.http.HttpStatus;
-import org.junit.Test;
+
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
@@ -30,8 +32,8 @@ import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.util.JsonSerialization;
 
-import java.io.IOException;
-import java.time.Instant;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
This PR implements realm-configurable correlation mitigation for time-related claims (iat, nbf, exp).

Key Changes:

- Adds TimeClaimNormalizer supporting rounding (minute/hour/day) or randomization within a configurable window.
- Applied at issuance in the issuer endpoint and leverages existing SD-JWT mappers.
- Includes unit and integration tests for both formats.
- Updates OID4VC documentation with changes

Closes #43399