### PR TITLE
fix: simplify debug handling and remove the 0.0.0.0 default (#43574)

### DIFF
--- a/quarkus/CONTRIBUTING.md
+++ b/quarkus/CONTRIBUTING.md
@@ -104,7 +104,7 @@ The `kc.sh|bat` script allows you to remotely debug the distribution. For that, 
 kc.sh --debug start-dev
 ```
 
-By default, the debug port is available at `8787`. Additionally, you can specify IPv4 or bracketed IPv6 addresses with optional ports, e.g. `--debug 127.0.0.1`, `--debug 127.0.0.1:8786`, `--debug [::1]`, `--debug [::1]:8785`. Make sure to exercise caution when setting IP addresses in the `--debug` parameter, since a value such as `--debug 0.0.0.0:8787` will expose the debug port to all network interfaces!
+By default, the debug port is available at `8787` on localhost. Additionally, you can specify IPv4 or bracketed IPv6 addresses with optional ports, e.g. `--debug 127.0.0.1:8786`, `--debug [::1]:8785`. Make sure to exercise caution when setting IP addresses in the `--debug` parameter, since a value such as `--debug 0.0.0.0:8787` will expose the debug port to all network interfaces!
 
 An additional environment variable `DEBUG_SUSPEND` can be set to suspend the JVM, when launched in debug mode. The `DEBUG_SUSPEND` variable supports the following values:
 

--- a/quarkus/dist/src/main/content/bin/kc.bat
+++ b/quarkus/dist/src/main/content/bin/kc.bat
@@ -22,10 +22,33 @@ if "%OS%" == "Windows_NT" (
 set SERVER_OPTS=-Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dquarkus-log-max-startup-records=10000 -Dpicocli.disable.closures=true
 
 set DEBUG_MODE=false
-set DEBUG_PORT_VAR=8787
-set DEBUG_ADDRESS=0.0.0.0:%DEBUG_PORT_VAR%
+set DEBUG_ADDRESS=8787
 set DEBUG_SUSPEND_VAR=n
 set CONFIG_ARGS=
+
+if NOT "x%KC_DEBUG%" == "x" (
+    set DEBUG_MODE=%KC_DEBUG%
+) else (
+    if NOT "x%DEBUG%" == "x" (
+        set DEBUG_MODE=%DEBUG%
+    )
+)
+
+if NOT "x%KC_DEBUG_PORT%" == "x" (
+    set DEBUG_ADDRESS=%KC_DEBUG_PORT%
+) else (
+    if NOT "x%DEBUG_PORT%" == "x" (
+        set DEBUG_ADDRESS=%DEBUG_PORT%
+    )
+)
+
+if NOT "x%KC_DEBUG_SUSPEND%" == "x" (
+    set DEBUG_SUSPEND_VAR=%KC_DEBUG_SUSPEND%
+) else (
+    if NOT "x%DEBUG_SUSPEND%" == "x" (
+        set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
+    )
+)
 
 rem Read command-line args, the ~ removes the quotes from the parameter
 :READ-ARGS
@@ -35,26 +58,12 @@ if "%KEY%" == "" (
 )
 if "%KEY%" == "--debug" (
     set DEBUG_MODE=true
-    if 1%2 EQU +1%2 (
-        rem Plain port
-        set DEBUG_ADDRESS=0.0.0.0:%2
-        shift
-    ) else (
-        rem IPv4 or IPv6 address with optional port
-        (echo %2 | findstr /R "[0-9].*\." >nul || echo %2 | findstr /R "\[.*:.*\]" >nul) && (
-            (echo %2 | findstr /R "]:[0-9][0-9]*" >nul || echo %2 | findstr /R "^[0-9].*:[0-9][0-9]*" >nul) && (
-                set DEBUG_ADDRESS=%2
-            ) || (
-                set DEBUG_ADDRESS=%2:%DEBUG_PORT_VAR%
-            )
+    if NOT "x%~2" == "x" (
+        echo %~2 | findstr /R "^[0-9[]" >nul && (
+            set DEBUG_ADDRESS=%~2
             shift
         )
     )
-    shift
-    goto READ-ARGS
-)
-if "%KEY%" == "start-dev" (
-    set CONFIG_ARGS=%CONFIG_ARGS% --profile=dev %KEY%
     shift
     goto READ-ARGS
 )
@@ -138,32 +147,6 @@ set "JAVA_OPTS=%JAVA_OPTS% %JAVA_LOCALE%"
 if not "x%JAVA_OPTS_APPEND%" == "x" (
     echo "Appending additional Java properties to JAVA_OPTS"
     set JAVA_OPTS=%JAVA_OPTS% %JAVA_OPTS_APPEND%
-)
-
-if NOT "x%KC_DEBUG%" == "x" (
-    set DEBUG_MODE=%KC_DEBUG%
-) else (
-    if NOT "x%DEBUG%" == "x" (
-        set DEBUG_MODE=%DEBUG%
-    )
-)
-
-if NOT "x%KC_DEBUG_PORT%" == "x" (
-    set DEBUG_PORT_VAR=%KC_DEBUG_PORT%
-    set DEBUG_ADDRESS=0.0.0.0:!DEBUG_PORT_VAR!
-) else (
-    if NOT "x%DEBUG_PORT%" == "x" (
-        set DEBUG_PORT_VAR=%DEBUG_PORT%
-        set DEBUG_ADDRESS=0.0.0.0:!DEBUG_PORT_VAR!
-    )
-)
-
-if NOT "x%KC_DEBUG_SUSPEND%" == "x" (
-    set DEBUG_SUSPEND_VAR=%KC_DEBUG_SUSPEND%
-) else (
-    if NOT "x%DEBUG_SUSPEND%" == "x" (
-        set DEBUG_SUSPEND_VAR=%DEBUG_SUSPEND%
-    )
 )
 
 rem Set debug settings if not already set

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -42,9 +42,8 @@ SERVER_OPTS="$SERVER_OPTS -Dquarkus-log-max-startup-records=10000"
 CLASSPATH_OPTS="'$(abs_path "../lib/quarkus-run.jar")'"
 
 DEBUG_MODE="${KC_DEBUG:-${DEBUG:-false}}"
-DEBUG_PORT="${KC_DEBUG_PORT:-${DEBUG_PORT:-8787}}"
+DEBUG_ADDRESS="${KC_DEBUG_PORT:-${DEBUG_PORT:-8787}}"
 DEBUG_SUSPEND="${KC_DEBUG_SUSPEND:-${DEBUG_SUSPEND:-n}}"
-DEBUG_ADDRESS="0.0.0.0:$DEBUG_PORT"
 
 esceval() {
     printf '%s\n' "$1" | sed "s/'/'\\\\''/g; 1 s/^/'/; $ s/$/'/"
@@ -55,20 +54,9 @@ do
     case "$1" in
       --debug)
           DEBUG_MODE=true
-          if [ -n "$2" ]; then
-              # Plain port
-              if echo "$2" | grep -Eq '^[0-9]+$'; then
-                  DEBUG_ADDRESS="0.0.0.0:$2"
-                  shift
-              # IPv4 or bracketed IPv6 with optional port
-              elif echo "$2" | grep -Eq '^(([0-9.]+)|(\[[0-9A-Fa-f:]+\]))'; then
-                  if echo "$2" | grep -Eq ':[0-9]+$'; then
-                      DEBUG_ADDRESS="$2"
-                  else
-                      DEBUG_ADDRESS="$2:$DEBUG_PORT"
-                  fi
-                  shift
-              fi
+          if echo "$2" | grep -Eq '^([0-9]|\[)'; then
+              DEBUG_ADDRESS=$2
+              shift
           fi
           ;;
       --)


### PR DESCRIPTION
* fix: simplify debug handling and remove the 0.0.0.0 default

closes: #43160

Signed-off-by: Steve Hawkins <shawkins@redhat.com>

* Update quarkus/dist/src/main/content/bin/kc.sh

Co-authored-by: Václav Muzikář <vaclav@muzikari.cz>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>

* removing the ability to specify just the ip

Signed-off-by: Steve Hawkins <shawkins@redhat.com>

* Apply suggestions from code review

Co-authored-by: Peter Zaoral <pepo48@gmail.com>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>

---------

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
Signed-off-by: Steven Hawkins <shawkins@redhat.com>
Co-authored-by: Václav Muzikář <vaclav@muzikari.cz>
Co-authored-by: Peter Zaoral <pepo48@gmail.com>
(cherry picked from commit 9e98f2bf961f68853cea6fbec58b512ed8be7ca9)
