### PR TITLE
Migrate the OTelProvider test to the new framework

### DIFF
--- a/testsuite/integration-arquillian/tests/base/testsuites/base-suite
+++ b/testsuite/integration-arquillian/tests/base/testsuites/base-suite
@@ -37,7 +37,6 @@ session,6
 sessionlimits,6
 ssl,6
 theme,6
-tracing,4
 transactions,6
 url,6
 user,4


### PR DESCRIPTION
Closes #43858

It accommodates changes from https://github.com/keycloak/keycloak/pull/43848

