### PR TITLE
Remove the trailing slash for base url in the account and admin tests

### DIFF
--- a/js/apps/account-ui/test/account-security/linked-accounts.spec.ts
+++ b/js/apps/account-ui/test/account-security/linked-accounts.spec.ts
@@ -58,12 +58,12 @@ test.describe("Linked accounts", () => {
         clientId: "groups-idp",
         clientSecret: "H0JaTc7VBu3HJR26vrzMxgidfJmgI5Dw",
         validateSignature: "false",
-        tokenUrl: `${SERVER_URL}realms/${externalTestBed.realm}/protocol/openid-connect/token`,
-        jwksUrl: `${SERVER_URL}realms/${externalTestBed.realm}/protocol/openid-connect/certs`,
-        issuer: `${SERVER_URL}realms/${externalTestBed.realm}`,
-        authorizationUrl: `${SERVER_URL}realms/${externalTestBed.realm}/protocol/openid-connect/auth`,
-        logoutUrl: `${SERVER_URL}realms/${externalTestBed.realm}/protocol/openid-connect/logout`,
-        userInfoUrl: `${SERVER_URL}realms/${externalTestBed.realm}/protocol/openid-connect/userinfo`,
+        tokenUrl: `${SERVER_URL}/realms/${externalTestBed.realm}/protocol/openid-connect/token`,
+        jwksUrl: `${SERVER_URL}/realms/${externalTestBed.realm}/protocol/openid-connect/certs`,
+        issuer: `${SERVER_URL}/realms/${externalTestBed.realm}`,
+        authorizationUrl: `${SERVER_URL}/realms/${externalTestBed.realm}/protocol/openid-connect/auth`,
+        logoutUrl: `${SERVER_URL}/realms/${externalTestBed.realm}/protocol/openid-connect/logout`,
+        userInfoUrl: `${SERVER_URL}/realms/${externalTestBed.realm}/protocol/openid-connect/userinfo`,
       },
     });
 

--- a/js/apps/account-ui/test/support/admin-client.ts
+++ b/js/apps/account-ui/test/support/admin-client.ts
@@ -3,7 +3,7 @@ import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/us
 import { ADMIN_PASSWORD, ADMIN_USERNAME, SERVER_URL } from "./common.ts";
 
 export const adminClient = new AdminClient({
-  baseUrl: SERVER_URL.toString(),
+  baseUrl: SERVER_URL,
 });
 
 await adminClient.auth({

--- a/js/apps/account-ui/test/support/common.ts
+++ b/js/apps/account-ui/test/support/common.ts
@@ -1,7 +1,7 @@
 import type UserRepresentation from "@keycloak/keycloak-admin-client/lib/defs/userRepresentation.js";
 import { generatePath } from "react-router-dom";
 
-export const SERVER_URL = new URL("http://localhost:8080");
+export const SERVER_URL = "http://localhost:8080";
 export const ACCOUNT_ROOT_PATH = "/realms/:realm/account" as const;
 export const ADMIN_ROOT_PATH = "/admin/:realm/console" as const;
 export const DEFAULT_REALM = "master";

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -13,7 +13,7 @@ import type { Credentials } from "@keycloak/keycloak-admin-client/lib/utils/auth
 
 class AdminClient {
   readonly #client = new KeycloakAdminClient({
-    baseUrl: "http://localhost:8080/",
+    baseUrl: "http://localhost:8080",
     realmName: "master",
   });
 


### PR DESCRIPTION
Closes #43863

Adjusting slashes for the JS testsuite.
