### PR TITLE
Ensure the logout endpoint removes the authentication session

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -232,28 +232,6 @@ public class LogoutEndpoint {
             }
         }
 
-        AuthenticationSessionModel logoutSession = AuthenticationManager.createOrJoinLogoutSession(session, realm, new AuthenticationSessionManager(session), null, true, true);
-        session.getContext().setAuthenticationSession(logoutSession);
-        if (uiLocales != null) {
-            logoutSession.setClientNote(LocaleSelectorProvider.CLIENT_REQUEST_LOCALE, uiLocales);
-        }
-        if (validatedRedirectUri != null) {
-            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_REDIRECT_URI, validatedRedirectUri);
-        }
-        if (state != null) {
-            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_STATE_PARAM, state);
-        }
-        if (initiatingIdp != null) {
-            logoutSession.setAuthNote(AuthenticationManager.LOGOUT_INITIATING_IDP, initiatingIdp);
-        }
-        if (idToken != null) {
-            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_VALIDATED_ID_TOKEN_SESSION_STATE, idToken.getSessionState());
-            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_VALIDATED_ID_TOKEN_ISSUED_AT, String.valueOf(idToken.getIat()));
-        }
-
-        LoginFormsProvider loginForm = session.getProvider(LoginFormsProvider.class)
-                .setAuthenticationSession(logoutSession);
-
         UserSessionModel userSession = null;
 
         // Check if we have session in the browser. If yes and it is different session than referenced by id_token_hint, the confirmation should be displayed
@@ -274,6 +252,29 @@ public class LogoutEndpoint {
         if (userSession == null && idToken != null && idToken.getSessionState() != null) {
             userSession = session.sessions().getUserSession(realm, idToken.getSessionState());
         }
+
+        AuthenticationSessionModel logoutSession = AuthenticationManager.createOrJoinLogoutSession(session, realm,
+                new AuthenticationSessionManager(session), userSession, true, true);
+        session.getContext().setAuthenticationSession(logoutSession);
+        if (uiLocales != null) {
+            logoutSession.setClientNote(LocaleSelectorProvider.CLIENT_REQUEST_LOCALE, uiLocales);
+        }
+        if (validatedRedirectUri != null) {
+            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_REDIRECT_URI, validatedRedirectUri);
+        }
+        if (state != null) {
+            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_STATE_PARAM, state);
+        }
+        if (initiatingIdp != null) {
+            logoutSession.setAuthNote(AuthenticationManager.LOGOUT_INITIATING_IDP, initiatingIdp);
+        }
+        if (idToken != null) {
+            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_VALIDATED_ID_TOKEN_SESSION_STATE, idToken.getSessionState());
+            logoutSession.setAuthNote(OIDCLoginProtocol.LOGOUT_VALIDATED_ID_TOKEN_ISSUED_AT, String.valueOf(idToken.getIat()));
+        }
+
+        LoginFormsProvider loginForm = session.getProvider(LoginFormsProvider.class)
+                .setAuthenticationSession(logoutSession);
 
         // Try to figure user because of localization
         if (userSession != null) {


### PR DESCRIPTION
Closes #43853

The logout endpoint, when logging out out of band using the `id_token_hint`, should take into account the auth session in case it still exists. For that the `createOrJoinLogoutSession` should be called after, when the user session is known. This way, we are doing the same that is executed for the refresh token, or when deleting a session using the admin console, the `backchannelLogout` is executed with the user session is passed ([here](https://github.com/keycloak/keycloak/blob/26.4.2/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java#L319)). New test added with the very specific conditions needed to reach this issue.
