### PR TITLE
Delete the user in test "creates a user with a password credential"

### DIFF
--- a/js/apps/admin-ui/test/users/main.spec.ts
+++ b/js/apps/admin-ui/test/users/main.spec.ts
@@ -15,7 +15,10 @@ import {
 import { DEFAULT_REALM } from "../utils/constants.ts";
 import { selectItem } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
-import { assertNotificationMessage } from "../utils/masthead.ts";
+import {
+  assertNotificationMessage,
+  selectActionToggleItem,
+} from "../utils/masthead.ts";
 import { confirmModal } from "../utils/modal.ts";
 import { goToUsers } from "../utils/sidebar.ts";
 import {
@@ -105,6 +108,10 @@ test.describe("User creation", () => {
 
     await confirmModal(page);
     await confirmModal(page);
+
+    await selectActionToggleItem(page, "Delete");
+    await confirmModal(page);
+    await assertNotificationMessage(page, "The user has been deleted");
   });
 });
 


### PR DESCRIPTION
Closes #43523

The root problem is an error when deleting the realm after the test. It's related to the required action assigned when the user is created. Just doing the workaround of deleting the user before inside the test. If there is a real error on delete realm it should be manage in another issue. Although probably is something related to H2 (I couldn't reproduce with mariadb). I have tested this 100 times locally with no error (and it always failed before reaching the 100 executions).
