### PR TITLE
Print a warning on duplicate options

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -956,22 +956,10 @@ public class Picocli {
 
     // Show warning about duplicated options in CLI
     public void warnOnDuplicatedOptionsInCli() {
-        var duplicatedOptions = ConfigArgsConfigSource.getDuplicatedArgs();
-        if (!duplicatedOptions.isEmpty()) {
-            Function<String, String> removeNamespace = option -> option.startsWith(NS_KEYCLOAK_PREFIX) ? option.substring(NS_KEYCLOAK_PREFIX.length()) : option;
-
-            var polishedOptionNames = duplicatedOptions.entrySet().stream()
-                    .map(option -> "%s (used value '%s')".formatted(removeNamespace.apply(option.getKey()), option.getValue()))
-                    .toList();
-
-            String duplicatedNames;
-            if (duplicatedOptions.size() > 2) {
-                duplicatedNames = "\n" + String.join("\n", polishedOptionNames.stream().map("- %s"::formatted).toList());
-            } else {
-                duplicatedNames = String.join(", ", polishedOptionNames);
-            }
-
-            warn("Duplicated options present in CLI: %s".formatted(duplicatedNames));
+        var duplicatedOptionsNames = ConfigArgsConfigSource.getDuplicatedArgNames();
+        if (!duplicatedOptionsNames.isEmpty()) {
+            warn("Duplicated options present in CLI: %s".formatted(String.join(", ", duplicatedOptionsNames)));
+            ConfigArgsConfigSource.clearDuplicatedArgNames();
         }
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -52,6 +52,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
     private static final String CLI_ARGS = "kc.config.args";
     public static final String NAME = "CliConfigSource";
     private static final Pattern ARG_KEY_VALUE_SPLIT = Pattern.compile("=");
+    private static Map<String, String> duplicates;
 
     protected ConfigArgsConfigSource() {
         super(parseArguments(), NAME, 600);
@@ -104,17 +105,25 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
 
     private static Map<String, String> parseArguments() {
         Map<String, String> properties = new HashMap<>();
+        duplicates = new HashMap<>();
 
         parseConfigArgs(getAllCliArgs(), new BiConsumer<String, String>() {
             @Override
             public void accept(String key, String value) {
                 PropertyMappers.getKcKeyFromCliKey(key).ifPresent(s -> {
+                    if (properties.containsKey(s)) {
+                        duplicates.put(s, value);
+                    }
                     properties.put(s, value);
                 });
             }
         }, ignored -> {});
 
         return properties;
+    }
+
+    public static Map<String, String> getDuplicatedArgs() {
+        return Collections.unmodifiableMap(duplicates);
     }
 
     public static void parseConfigArgs(List<String> args, BiConsumer<String, String> valueArgConsumer, Consumer<String> unaryConsumer) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -988,12 +988,12 @@ public class PicocliTest extends AbstractConfigurationTest {
     public void duplicatedCliOptions() {
         var nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-enabled=false");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), containsString("WARNING: Duplicated options present in CLI: http-access-log-enabled (used value 'false')"));
+        assertThat(nonRunningPicocli.getOutString(), containsString("WARNING: Duplicated options present in CLI: --http-access-log-enabled"));
         onAfter();
 
         nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-enabled=false", "--db=postgres", "--db=dev-mem");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), containsString("WARNING: Duplicated options present in CLI: db (used value 'dev-mem'), http-access-log-enabled (used value 'false')"));
+        assertThat(nonRunningPicocli.getOutString(), containsString("WARNING: Duplicated options present in CLI: --http-access-log-enabled, --db"));
         onAfter();
 
         nonRunningPicocli = pseudoLaunch("start-dev",
@@ -1001,15 +1001,24 @@ public class PicocliTest extends AbstractConfigurationTest {
                 "--db=postgres", "--db=dev-mem",
                 "--db-kind-my-store=mariadb", "--db-kind-my-store=dev-mem");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), containsString("Duplicated options present in CLI:"));
-        assertThat(nonRunningPicocli.getOutString(), containsString("- db-kind-my-store (used value 'dev-mem')"));
-        assertThat(nonRunningPicocli.getOutString(), containsString("- db (used value 'dev-mem')"));
-        assertThat(nonRunningPicocli.getOutString(), containsString("- http-access-log-enabled (used value 'false')"));
+        assertThat(nonRunningPicocli.getOutString(), containsString("Duplicated options present in CLI: --db-kind-my-store, --http-access-log-enabled, --db"));
         onAfter();
 
         nonRunningPicocli = pseudoLaunch("start-dev", "--non-existing=yes", "--non-existing=no");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getOutString(), not(containsString("WARNING: Duplicated options present in CLI: non-existing (used value 'no')")));
+        assertThat(nonRunningPicocli.getOutString(), not(containsString("WARNING: Duplicated options present in CLI: --non-existing")));
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: '--non-existing'"));
+        onAfter();
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "-Dsome.property=123", "-Dsome.property=456");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getOutString(), containsString("WARNING: Duplicated options present in CLI: -Dsome.property"));
+        onAfter();
+
+        nonRunningPicocli = pseudoLaunch("start-dev", "something-wrong=asdf", "something-wrong=not-here");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getOutString(), not(containsString("WARNING: Duplicated options present in CLI: something-wrong")));
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: 'something-wrong'"));
     }
 
     @Test


### PR DESCRIPTION
- Closes #43604

This can be easily done for CLI, but it might be challenging to do for other config sources - especially properties-based. I tried to find some general approach for all config sources, but AFAIK it's not  possible now. For 'keycloak.conf', or `quarkus.properties`, we can't simply find the duplicated values as the nature of Java's Properties does not support duplicates - it just uses the last value. 

For that case, this approach checks only duplicates on CLI side and the handle method is generalized and prepared for duplications in other config sources. 

I tried to handle duplicates directly in the CLI config source (ConfigArgsConfigSource), but it brings some other problems as printing it multiple times(f.e. during start-dev that requires augmentation, it's printed twice,..).

I think this approach is quite straighforward, and even the static state for duplicates should not cause any issue as the map is always recreated when the config source is created. 

@shawkins @vmuzikar @Pepo48 WDYT?