### PR TITLE
fix #43819 - partial import fails to overwrite existing groups

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -821,6 +821,8 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         em.createNamedQuery("deleteGroupRoleMappingsByGroup").setParameter("group", groupEntity).executeUpdate();
 
         em.remove(groupEntity);
+        // flush removal to avoid ModelDuplicateException when re-importing group (see Issue #43819)
+        em.flush();
         return true;
 
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -821,8 +821,6 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         em.createNamedQuery("deleteGroupRoleMappingsByGroup").setParameter("group", groupEntity).executeUpdate();
 
         em.remove(groupEntity);
-        // flush removal to avoid ModelDuplicateException when re-importing group (see Issue #43819)
-        em.flush();
         return true;
 
 

--- a/services/src/main/java/org/keycloak/partialimport/PartialImportManager.java
+++ b/services/src/main/java/org/keycloak/partialimport/PartialImportManager.java
@@ -20,6 +20,7 @@ package org.keycloak.partialimport;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.keycloak.connections.jpa.support.EntityManagers;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.PartialImportRepresentation;
@@ -60,6 +61,7 @@ public class PartialImportManager {
 
         for (PartialImport partialImport : partialImports) {
             partialImport.removeOverwrites(realm, session);
+            EntityManagers.flush(session, false);
             results.addAllResults(partialImport.doImport(rep, realm, session));
         }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/AbstractPartialImportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/AbstractPartialImportTest.java
@@ -143,10 +143,10 @@ public class AbstractPartialImportTest {
         piRep.setUsers(users);
     }
 
-    protected void addGroups() {
+    protected void addGroups(int numEntities) {
         List<GroupRepresentation> groups = new ArrayList<>();
 
-        for (int i=0; i < NUM_ENTITIES; i++) {
+        for (int i=0; i < numEntities; i++) {
             GroupRepresentation group = new GroupRepresentation();
             group.setName(GROUP_PREFIX + i);
             group.setPath("/" + GROUP_PREFIX + i);
@@ -154,6 +154,10 @@ public class AbstractPartialImportTest {
         }
 
         piRep.setGroups(groups);
+    }
+
+    protected void addGroups() {
+        addGroups(NUM_ENTITIES);
     }
 
     protected void addClients(boolean withServiceAccounts) {
@@ -294,10 +298,10 @@ public class AbstractPartialImportTest {
     protected void testOverwrite(int numberEntities) {
         setOverwrite();
         PartialImportResults results = doImport();
-        assertEquals(numberEntities, results.getAdded());
+        assertEquals(numberEntities, results.getAdded(), results.getErrorMessage());
 
         results = doImport();
-        assertEquals(numberEntities, results.getOverwritten());
+        assertEquals(numberEntities, results.getOverwritten(), results.getErrorMessage());
     }
 
     private static class PartialImportRealmConfig implements RealmConfig {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportGroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportGroupTest.java
@@ -48,4 +48,10 @@ public class PartialImportGroupTest extends AbstractPartialImportTest {
         addGroups();
         testOverwrite();
     }
+
+    @Test
+    public void testAddSingleGroupOverwrite() {
+        addGroups(1);
+        testOverwrite(1);
+    }
 }


### PR DESCRIPTION
- when removal is delayed until insertion of the newly imported group this causes a duplicate key constrain violation (`Key (realm_id, parent_group, name)`)
- fixed by flushing group removals

It seems that even when testing with `KC_TEST_DATABASE=postgres` the realm provider is not actually used by the admin tests.
https://github.com/keycloak/keycloak/blob/2fc54196760ee95b6805aedf39d015213a7e5ae7/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportGroupTest.java#L45-L49

fixes #43819