### PR TITLE
Hide the attribute for allowed IdPs when JWT auth capability is not enabled

### DIFF
--- a/js/apps/admin-ui/src/clients/add/CapabilityConfig.tsx
+++ b/js/apps/admin-ui/src/clients/add/CapabilityConfig.tsx
@@ -42,6 +42,12 @@ export const CapabilityConfig = ({
   const protocol = type || watch("protocol");
   const clientAuthentication = watch("publicClient");
   const authorization = watch("authorizationServicesEnabled");
+  const jwtAuthorizationGrantEnabled = watch(
+    convertAttributeNameToForm<FormFields>(
+      "attributes.oauth2.jwt.authorization.grant.enabled",
+    ),
+    false,
+  );
   const isFeatureEnabled = useIsFeatureEnabled();
   const [idps, setIdps] = useState<IdentityProviderRepresentation[]>([]);
   const [search, setSearch] = useState("");
@@ -425,7 +431,8 @@ export const CapabilityConfig = ({
             ]}
           />
           {isFeatureEnabled(Feature.JWTAuthorizationGrant) &&
-            showIdentityProviders && (
+            showIdentityProviders &&
+            jwtAuthorizationGrantEnabled.toString() === "true" && (
               <MultiValuedListComponent
                 name={convertAttributeNameToForm<FormFields>(
                   "attributes.oauth2.jwt.authorization.grant.idp",


### PR DESCRIPTION
Closes #43925

@mposolda @graziang Just a little change in the admin console to not show the IDP select if the JWT auth grant capability is not enabled. It's just a minor thing and I think that is not related with other changes in the queue. Let's see if there are no conflicts later. :smile: 