### PR TITLE
[OID4VCI]: Add backward compatibility for Draft 15 wallets (single proof support)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -77,7 +77,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryption;
 import org.keycloak.protocol.oid4vc.model.CredentialResponseEncryptionMetadata;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
-import org.keycloak.protocol.oid4vc.model.Proof;
+import org.keycloak.protocol.oid4vc.model.JwtProof;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.protocol.oid4vc.model.ErrorResponse;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
@@ -659,22 +659,7 @@ public class OID4VCIssuerEndpoint {
 
         try {
             CredentialRequest credentialRequest = JsonSerialization.mapper.readValue(requestPayload, CredentialRequest.class);
-
-            // Convert proof to proofs if proof is provided but proofs is not
-            if (credentialRequest.getProof() != null && credentialRequest.getProofs() == null) {
-                LOGGER.debugf("Converting single 'proof' field to 'proofs' array for backward compatibility");
-                Proof singleProof = credentialRequest.getProof();
-                Proofs proofsArray = new Proofs();
-                
-                // Convert single proof to proofs array format
-                if (singleProof.getJwt() != null) {
-                    proofsArray.setJwt(List.of(singleProof.getJwt()));
-                }
-                
-                credentialRequest.setProofs(proofsArray);
-                credentialRequest.setProof(null); // Clear the proof field to avoid confusion
-            }
-            
+            normalizeProofFields(credentialRequest);
             return credentialRequest;
         } catch (JsonProcessingException e) {
             String errorMessage = "Failed to parse JSON request: " + e.getMessage();
@@ -756,22 +741,7 @@ public class OID4VCIssuerEndpoint {
         // Parse decrypted content to CredentialRequest
         try {
             CredentialRequest credentialRequest = JsonSerialization.mapper.readValue(content, CredentialRequest.class);
-
-            // Convert proof to proofs if proof is provided but proofs is not
-            if (credentialRequest.getProof() != null && credentialRequest.getProofs() == null) {
-                LOGGER.debugf("Converting single 'proof' field to 'proofs' array for backward compatibility");
-                Proof singleProof = credentialRequest.getProof();
-                Proofs proofsArray = new Proofs();
-                
-                // Convert single proof to proofs array format
-                if (singleProof.getJwt() != null) {
-                    proofsArray.setJwt(List.of(singleProof.getJwt()));
-                }
-                
-                credentialRequest.setProofs(proofsArray);
-                credentialRequest.setProof(null); // Clear the proof field to avoid confusion
-            }
-            
+            normalizeProofFields(credentialRequest);
             return credentialRequest;
         } catch (JsonProcessingException e) {
             throw new JWEException("Failed to parse decrypted JWE payload: " + e.getMessage());
@@ -797,6 +767,36 @@ public class OID4VCIssuerEndpoint {
             }
         }
         throw new JWEException("Unsupported compression algorithm");
+    }
+
+    /**
+     * Normalizes legacy 'proof' field into 'proofs' and validates mutual exclusivity.
+     * <p>
+     * If a single 'proof' is present and 'proofs' is absent, converts it into a
+     * single-element JWT list under 'proofs' for backward compatibility.
+     * If both are present, throws a BadRequestException.
+     */
+    private void normalizeProofFields(CredentialRequest credentialRequest) {
+        if (credentialRequest == null) {
+            return;
+        }
+
+        if (credentialRequest.getProof() != null && credentialRequest.getProofs() != null) {
+            String message = "Both 'proof' and 'proofs' must not be present at the same time";
+            LOGGER.debug(message);
+            throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, message));
+        }
+
+        if (credentialRequest.getProof() != null) {
+            LOGGER.debugf("Converting single 'proof' field to 'proofs' array for backward compatibility");
+            JwtProof singleProof = credentialRequest.getProof();
+            Proofs proofsArray = new Proofs();
+            if (singleProof.getJwt() != null) {
+                proofsArray.setJwt(List.of(singleProof.getJwt()));
+            }
+            credentialRequest.setProofs(proofsArray);
+            credentialRequest.setProof(null);
+        }
     }
 
     private String selectKeyManagementAlg(CredentialResponseEncryptionMetadata metadata, JWK jwk) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
@@ -77,7 +77,7 @@ import static org.keycloak.services.clientpolicy.executor.FapiConstant.ALLOWED_A
  */
 public class AttestationValidatorUtil {
 
-    public static final String ATTESTATION_JWT_TYP = "key-attestation+jwt ";
+    public static final String ATTESTATION_JWT_TYP = "key-attestation+jwt";
     private static final String CACERTS_PATH = System.getProperty("javax.net.ssl.trustStore",
             System.getProperty("java.home") + "/lib/security/cacerts");
     private static final char[] DEFAULT_TRUSTSTORE_PASSWORD = System.getProperty(

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.protocol.oid4vc.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -35,6 +36,7 @@ import java.util.Optional;
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CredentialRequest {
 
     @JsonProperty("credential_configuration_id")
@@ -45,6 +47,9 @@ public class CredentialRequest {
 
     @JsonProperty("proofs")
     private Proofs proofs;
+
+    @JsonProperty("proof")
+    private Proof proof;
 
     // See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-format-identifier-3
     @JsonProperty("credential_definition")
@@ -77,6 +82,15 @@ public class CredentialRequest {
 
     public CredentialRequest setProofs(Proofs proofs) {
         this.proofs = proofs;
+        return this;
+    }
+
+    public Proof getProof() {
+        return proof;
+    }
+
+    public CredentialRequest setProof(Proof proof) {
+        this.proof = proof;
         return this;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialRequest.java
@@ -48,8 +48,13 @@ public class CredentialRequest {
     @JsonProperty("proofs")
     private Proofs proofs;
 
+    /**
+     * Deprecated: use {@link #proofs} instead.
+     * This field is kept only for backward compatibility with clients sending a single 'proof'.
+     */
+    @Deprecated
     @JsonProperty("proof")
-    private Proof proof;
+    private JwtProof proof;
 
     // See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-format-identifier-3
     @JsonProperty("credential_definition")
@@ -85,11 +90,11 @@ public class CredentialRequest {
         return this;
     }
 
-    public Proof getProof() {
+    public JwtProof getProof() {
         return proof;
     }
 
-    public CredentialRequest setProof(Proof proof) {
+    public CredentialRequest setProof(JwtProof proof) {
         this.proof = proof;
         return this;
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/JwtProof.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/JwtProof.java
@@ -21,14 +21,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Single Proof object for Credential Request in OID4VCI.
- * This represents a single proof with proof_type and jwt fields.
- * Used when the request contains a "proof" field (singular) instead of "proofs" (array).
+ * Deprecated: Represents a single JWT-based proof (historical 'proof' structure).
+ * Prefer using {@link Proofs} with the appropriate array field (e.g., jwt).
+ * This class is kept for backward compatibility only.
  *
  * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-credential-request">OID4VCI Credential Request</a>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Proof {
+@Deprecated
+public class JwtProof {
 
     @JsonProperty("jwt")
     private String jwt;
@@ -36,10 +37,10 @@ public class Proof {
     @JsonProperty("proof_type")
     private String proofType;
 
-    public Proof() {
+    public JwtProof() {
     }
 
-    public Proof(String jwt, String proofType) {
+    public JwtProof(String jwt, String proofType) {
         this.jwt = jwt;
         this.proofType = proofType;
     }
@@ -48,7 +49,7 @@ public class Proof {
         return jwt;
     }
 
-    public Proof setJwt(String jwt) {
+    public JwtProof setJwt(String jwt) {
         this.jwt = jwt;
         return this;
     }
@@ -57,7 +58,7 @@ public class Proof {
         return proofType;
     }
 
-    public Proof setProofType(String proofType) {
+    public JwtProof setProofType(String proofType) {
         this.proofType = proofType;
         return this;
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/Proof.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/Proof.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oid4vc.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Single Proof object for Credential Request in OID4VCI.
+ * This represents a single proof with proof_type and jwt fields.
+ * Used when the request contains a "proof" field (singular) instead of "proofs" (array).
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-15.html#name-credential-request">OID4VCI Credential Request</a>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Proof {
+
+    @JsonProperty("jwt")
+    private String jwt;
+
+    @JsonProperty("proof_type")
+    private String proofType;
+
+    public Proof() {
+    }
+
+    public Proof(String jwt, String proofType) {
+        this.jwt = jwt;
+        this.proofType = proofType;
+    }
+
+    public String getJwt() {
+        return jwt;
+    }
+
+    public Proof setJwt(String jwt) {
+        this.jwt = jwt;
+        return this;
+    }
+
+    public String getProofType() {
+        return proofType;
+    }
+
+    public Proof setProofType(String proofType) {
+        this.proofType = proofType;
+        return this;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -53,6 +53,7 @@ import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.OfferUriType;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedGrant;
+import org.keycloak.protocol.oid4vc.model.Proof;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
@@ -930,6 +931,64 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             } catch (BadRequestException e) {
                 ErrorResponse error = (ErrorResponse) e.getResponse().getEntity();
                 assertEquals(ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION, error.getError());
+            }
+        });
+    }
+
+    /**
+     * Test that verifies the conversion from 'proof' (singular) to 'proofs' (array) works correctly.
+     * This test ensures backward compatibility with clients that send 'proof' instead of 'proofs'.
+     */
+    @Test
+    public void testProofToProofsConversion() throws Exception {
+        String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
+        final String credentialConfigurationId = jwtTypeCredentialClientScope.getAttributes()
+                .get(CredentialScopeModel.CONFIGURATION_ID);
+
+        testingClient.server(TEST_REALM_NAME).run(session -> {
+            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            authenticator.setTokenString(token);
+            OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
+
+            // Test 1: Create a request with single proof field - should be converted to proofs array
+            CredentialRequest requestWithProof = new CredentialRequest()
+                    .setCredentialConfigurationId(credentialConfigurationId);
+
+            // Create a single proof object
+            Proof singleProof = new Proof()
+                    .setJwt("dummy-jwt")
+                    .setProofType("jwt");
+            requestWithProof.setProof(singleProof);
+
+            String requestPayload = JsonSerialization.writeValueAsString(requestWithProof);
+
+            try {
+                // This should work because the conversion happens in validateRequestEncryption
+                issuerEndpoint.requestCredential(requestPayload);
+            } catch (Exception e) {
+                // We expect JWT validation to fail, but the conversion should have worked
+                assertTrue("Error should be related to JWT validation, not conversion",
+                        e.getMessage().contains("Could not validate provided proof"));
+            }
+
+            // Test 2: Create a request with both proof and proofs fields - should fail validation
+            CredentialRequest requestWithBoth = new CredentialRequest()
+                    .setCredentialConfigurationId(credentialConfigurationId);
+
+            requestWithBoth.setProof(singleProof);
+
+            Proofs proofsArray = new Proofs();
+            proofsArray.setJwt(List.of("dummy-jwt"));
+            requestWithBoth.setProofs(proofsArray);
+
+            String bothFieldsPayload = JsonSerialization.writeValueAsString(requestWithBoth);
+
+            try {
+                issuerEndpoint.requestCredential(bothFieldsPayload);
+                Assert.fail("Expected BadRequestException when both proof and proofs are provided");
+            } catch (BadRequestException e) {
+                int statusCode = e.getResponse().getStatus();
+                assertEquals("Expected HTTP 400 Bad Request", 400, statusCode);
             }
         });
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -992,9 +992,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 assertEquals("Expected HTTP 400 Bad Request", 400, statusCode);
                 ErrorResponse error = (ErrorResponse) e.getResponse().getEntity();
                 assertEquals(ErrorType.INVALID_CREDENTIAL_REQUEST, error.getError());
-                assertTrue("Error description should mention proof and proofs exclusivity",
-                        error.getErrorDescription() != null && error.getErrorDescription().toLowerCase().contains("proof")
-                                && error.getErrorDescription().toLowerCase().contains("proofs"));
+                assertEquals("Both 'proof' and 'proofs' must not be present at the same time",
+                        error.getErrorDescription());
             }
         });
     }


### PR DESCRIPTION
This PR adds backward compatibility for wallets using OID4VCI Draft 15 by supporting both a single `proof` (Draft 15) and the `proofs` array (final spec). Single `proof` objects are automatically converted to the array format, and unknown or deprecated fields like `vct` are ignored. This ensures interoperability with legacy wallets while remaining compliant with the final specification.
Additionally, the trailing whitespace was removed from the `ATTESTATION_JWT_TYP` constant.

**Changes**
- Accept both `proof` (Draft 15) and `proofs` array (final spec) in credential requests
- Automatic conversion of single `proof` to `proofs` array
- Ignore unknown or deprecated fields during deserialization
- Removed trailing whitespace from `ATTESTATION_JWT_TYP` constant
- Added tests to verify proof conversion

Closes #43926 