### PR TITLE
MessageFormatterMethod should detect and map SimpleNumber

### DIFF
--- a/services/src/main/java/org/keycloak/theme/beans/MessageFormatterMethod.java
+++ b/services/src/main/java/org/keycloak/theme/beans/MessageFormatterMethod.java
@@ -19,6 +19,7 @@ package org.keycloak.theme.beans;
 
 import static java.util.Optional.ofNullable;
 
+import freemarker.template.SimpleNumber;
 import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateMethodModelEx;
 import freemarker.template.TemplateModelException;
@@ -67,11 +68,14 @@ public class MessageFormatterMethod implements TemplateMethodModelEx {
     private List<Object> resolve(List<Object> list) {
         ArrayList<Object> result = new ArrayList<>();
         for (Object item: list) {
-            if (item instanceof SimpleScalar) {
-                item = ((SimpleScalar) item).getAsString();
+            if (item instanceof SimpleScalar scalar) {
+                item = scalar.getAsString();
+            } else if (item instanceof SimpleNumber number) {
+                item = number.getAsNumber();
             }
-            if (item instanceof String) {
-                result.add(TemplatingUtil.resolveVariables((String) item, messages));
+
+            if (item instanceof String string) {
+                result.add(TemplatingUtil.resolveVariables(string, messages));
             } else {
                 result.add(item);
             }

--- a/services/src/test/java/org/keycloak/theme/beans/MessageFormatterMethodTest.java
+++ b/services/src/test/java/org/keycloak/theme/beans/MessageFormatterMethodTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.theme.beans;
 
+import freemarker.template.SimpleNumber;
+import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateModelException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -40,6 +42,7 @@ public class MessageFormatterMethodTest {
         properties.setProperty("backToClient", "Back to {0}");
         properties.setProperty("client_admin-console", "Admin Console");
         properties.setProperty("realm_example-realm", "Example Realm");
+        properties.setProperty("key", "foo {0,choice,0#foo|1#bar|1<{0} foobar} bar");
 
 
         MessageFormatterMethod fmt = new MessageFormatterMethod(locale, properties);
@@ -52,5 +55,15 @@ public class MessageFormatterMethodTest {
 
         msg = (String) fmt.exec(Arrays.asList("backToClient", "client '${client_admin-console}' from '${realm_example-realm}'."));
         Assert.assertEquals("Back to client 'Admin Console' from 'Example Realm'.", msg);
+
+        msg = (String) fmt.exec(Arrays.asList(new SimpleScalar("key"),new SimpleNumber(0)));
+        Assert.assertEquals("foo foo bar", msg);
+
+        msg = (String) fmt.exec(Arrays.asList(new SimpleScalar("key"),new SimpleNumber(1)));
+        Assert.assertEquals("foo bar bar", msg);
+
+        msg = (String) fmt.exec(Arrays.asList(new SimpleScalar("key"),new SimpleNumber(2)));
+        Assert.assertEquals("foo 2 foobar bar", msg);
     }
+
 }


### PR DESCRIPTION
Closes #43993

Fixes: java.lang.IllegalArgumentException: Cannot format given Object as a Number

freemarker.template.SimpleNumber was added as is, expected was freemarker.template.Number from java.text.NumberFormat::format
