### PR TITLE
Fix duplicate mapper save error by auto-navigating after creation

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/MappingDetails.tsx
@@ -170,6 +170,9 @@ export default function MappingDetails() {
         }
       }
       addAlert(t(`mapping${key}Success`), AlertVariant.success);
+      if (!isUpdating) {
+        navigate(toDetails());
+      }
     } catch (error) {
       addError(`mapping${key}Error`, error);
     }

--- a/js/apps/admin-ui/test/client-scope/mappers.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/mappers.spec.ts
@@ -114,13 +114,18 @@ test.describe("Mappers tab", () => {
     await page.getByRole("button", { name: "Add mapper" }).click();
     await page.getByRole("menuitem", { name: "By configuration" }).click();
 
-    await page.locator('[role="dialog"]').getByText("Audience", { exact: true }).click();
+    await page
+      .locator('[role="dialog"]')
+      .getByText("Audience", { exact: true })
+      .click();
     await page.getByTestId("name").fill(mapperName);
     await clickSaveButton(page);
     await assertNotificationMessage(page, "Mapping successfully created");
 
     await assertRowExists(page, mapperName);
-    await page.getByRole("button", { name: "Add mapper" }).waitFor({ state: "visible" });
+    await page
+      .getByRole("button", { name: "Add mapper" })
+      .waitFor({ state: "visible" });
 
     await removeMappers(page, [mapperName]);
   });

--- a/js/apps/admin-ui/test/client-scope/mappers.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/mappers.spec.ts
@@ -99,4 +99,29 @@ test.describe("Mappers tab", () => {
 
     await removeMappers(page, mapperNames);
   });
+
+  test("auto-navigates after creating an Audience mapper", async ({ page }) => {
+    const mapperName = "test-audience-mapper";
+
+    await using testBed = await createTestBed(testBedData);
+
+    await login(page, { to: toClientScopes({ realm: testBed.realm }) });
+
+    await searchItem(page, placeHolderClientScope, "test-scope");
+    await clickTableRowItem(page, "test-scope");
+    await goToMappersTab(page);
+
+    await page.getByRole("button", { name: "Add mapper" }).click();
+    await page.getByRole("menuitem", { name: "By configuration" }).click();
+
+    await page.locator('[role="dialog"]').getByText("Audience", { exact: true }).click();
+    await page.getByTestId("name").fill(mapperName);
+    await clickSaveButton(page);
+    await assertNotificationMessage(page, "Mapping successfully created");
+
+    await assertRowExists(page, mapperName);
+    await page.getByRole("button", { name: "Add mapper" }).waitFor({ state: "visible" });
+
+    await removeMappers(page, [mapperName]);
+  });
 });

--- a/js/apps/admin-ui/test/client-scope/mappers.ts
+++ b/js/apps/admin-ui/test/client-scope/mappers.ts
@@ -1,7 +1,6 @@
 import { type Page, expect } from "@playwright/test";
 import {
   assertSelectValue,
-  clickCancelButton,
   clickSaveButton,
   selectItem,
 } from "../utils/form.ts";
@@ -54,7 +53,6 @@ export async function addMappersByConfiguration(page: Page, mappers: string[]) {
     await page.getByTestId("name").fill(mapperName);
     await clickSaveButton(page);
     await assertNotificationMessage(page, "Mapping successfully created");
-    await clickCancelButton(page);
   }
 }
 


### PR DESCRIPTION
After successfully creating a new protocol mapper in the Admin UI, the page now automatically navigates back to the mapper list. This prevents users from accidentally clicking Save again, which previously caused a duplicate mapper error.

Changes:
- Auto-navigate to mapper list after successful mapper creation
- Remove clickCancelButton workaround from existing test
- Add new test specifically for Audience mapper auto-navigation

Closes #43948

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
