### PR TITLE
ErrorId for error screens and logging

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/KeycloakHandlerChainCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/KeycloakHandlerChainCustomizer.java
@@ -33,6 +33,7 @@ import static jakarta.ws.rs.HttpMethod.PUT;
 
 public final class KeycloakHandlerChainCustomizer implements HandlerChainCustomizer {
 
+    private final RequestIdHandler REQUEST_ID_HANDLER = new RequestIdHandler();
     private final TransactionalSessionHandler TRANSACTIONAL_SESSION_HANDLER = new TransactionalSessionHandler();
 
     private final FormBodyHandler formBodyHandler = new FormBodyHandler(true, () -> Runnable::run, Set.of());
@@ -44,6 +45,8 @@ public final class KeycloakHandlerChainCustomizer implements HandlerChainCustomi
 
         switch (phase) {
             case BEFORE_METHOD_INVOKE:
+                // Add RequestId handler first to ensure RequestId is available throughout request lifecycle
+                handlers.add(REQUEST_ID_HANDLER);
                 if (!resourceMethod.isFormParamRequired() &&
                     (PATCH.equalsIgnoreCase(resourceMethod.getHttpMethod()) ||
                      POST.equalsIgnoreCase(resourceMethod.getHttpMethod()) ||

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/RequestIdHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/RequestIdHandler.java
@@ -1,0 +1,66 @@
+package org.keycloak.quarkus.runtime.integration.resteasy;
+
+import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
+import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
+import org.keycloak.models.KeycloakSession;
+
+import org.slf4j.MDC;
+
+import io.quarkus.arc.Arc;
+
+import java.util.UUID;
+
+/**
+ * Handler that generates or extracts a unique RequestId for each HTTP request.
+ * The RequestId is set in the MDC context and stored in the KeycloakSession for
+ * use throughout the request lifecycle.
+ *
+ * Priority:
+ * 1. Uses existing X-Request-ID header if present (from external systems)
+ * 2. Generates new UUID if no external RequestId is provided
+ *
+ * The RequestId is available:
+ * - In MDC with key "kc.requestId"
+ * - In KeycloakSession attributes with key "requestId"
+ * - In HTTP response headers as "X-Request-ID"
+ */
+public final class RequestIdHandler implements ServerRestHandler {
+
+    public static final String REQUEST_ID_HEADER = "X-Request-ID";
+    public static final String MDC_KEY = "kc.requestId";
+    public static final String SESSION_ATTRIBUTE_KEY = "requestId";
+
+    @Override
+    public void handle(ResteasyReactiveRequestContext requestContext) {
+        // Generate or extract RequestId
+        String requestId = extractOrGenerateRequestId(requestContext);
+
+        // Set in MDC for logging
+        MDC.put(MDC_KEY, requestId);
+
+        // Store in session if available
+        try {
+            requestContext.requireCDIRequestScope();
+            KeycloakSession session = Arc.container().instance(KeycloakSession.class).get();
+            if (session != null) {
+                session.setAttribute(SESSION_ATTRIBUTE_KEY, requestId);
+            }
+        } catch (Exception e) {
+            // Session might not be available yet, but MDC is set
+            // This is acceptable as the session will be available later
+        }
+    }
+
+    private String extractOrGenerateRequestId(ResteasyReactiveRequestContext requestContext) {
+        // Check for existing X-Request-ID header
+        String existingRequestId = requestContext.getHttpHeaders().getHeaderString(REQUEST_ID_HEADER);
+
+        if (existingRequestId != null && !existingRequestId.trim().isEmpty()) {
+            // Use external RequestId (from load balancer, API gateway, etc.)
+            return existingRequestId.trim();
+        } else {
+            // Generate new UUID for this request
+            return UUID.randomUUID().toString();
+        }
+    }
+}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -288,6 +288,8 @@ public class LoggingDistTest {
                 .statusCode(200);
         Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(
                 () -> assertThat(cliResult.getOutput(), containsString("{kc.realmName=master} DEBUG [org.keycloak.")));
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(
+                () -> assertThat(cliResult.getOutput(), containsString("{kc.requestId=")));
         cliResult.assertStartedDevMode();
     }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -35,6 +35,8 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.AuthenticationFlowContext;
@@ -92,6 +94,7 @@ import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.Urls;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.LoginActionsService;
+import org.keycloak.services.util.RequestIdUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.FreeMarkerException;
 import org.keycloak.theme.Theme;
@@ -105,10 +108,10 @@ import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.utils.MediaType;
 import org.keycloak.utils.MediaTypeMatcher;
 
-import org.jboss.logging.Logger;
-
 import static org.keycloak.models.UserModel.RequiredAction.UPDATE_PASSWORD;
 import static org.keycloak.organization.utils.Organizations.resolveOrganization;
+import static org.keycloak.services.error.KeycloakErrorHandler.ERROR_ATTRIBUTE_ID;
+import static org.keycloak.services.error.KeycloakErrorHandler.ERROR_ID;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -336,6 +339,12 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 break;
             case LOGOUT_CONFIRM:
                 attributes.put("logoutConfirm", new LogoutConfirmBean(accessCode, authenticationSession));
+                break;
+            case LOGIN_PAGE_EXPIRED, ERROR, ERROR_WEBAUTHN:
+                String errorId = RequestIdUtil.getCurrentRequestId(); //ErrorIdGenerator.generate();
+                MDC.put(ERROR_ID, errorId);
+                attributes.put(ERROR_ATTRIBUTE_ID, errorId);
+                logger.infof("Rendering following errorId: '%s' to the user.", errorId);
                 break;
         }
 

--- a/services/src/main/java/org/keycloak/services/error/ErrorIdGenerator.java
+++ b/services/src/main/java/org/keycloak/services/error/ErrorIdGenerator.java
@@ -1,0 +1,17 @@
+package org.keycloak.services.error;
+
+import java.security.SecureRandom;
+
+public class ErrorIdGenerator {
+
+  private static final char[] ALLOWED_CHARS = "abcdefghjkmnpqrstuvwxyz23456789".toCharArray();
+  private static final SecureRandom RANDOM = new SecureRandom();
+
+  public static String generate() {
+    StringBuilder sb = new StringBuilder(8);
+    for (int i = 0; i < 8; i++) {
+      sb.append(ALLOWED_CHARS[RANDOM.nextInt(ALLOWED_CHARS.length)]);
+    }
+    return sb.toString();
+  }
+}

--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -8,6 +8,8 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jboss.logging.Logger;
+import org.jboss.logging.MDC;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -30,6 +32,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.util.RequestIdUtil;
 import org.keycloak.theme.Theme;
 import org.keycloak.theme.beans.AdvancedMessageFormatterMethod;
 import org.keycloak.theme.beans.LocaleBean;
@@ -55,6 +58,8 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
 
     public static final String UNCAUGHT_SERVER_ERROR_TEXT = "Uncaught server error";
     public static final String ERROR_RESPONSE_TEXT = "Error response {0}";
+    public static final String ERROR_ID = "error.id";
+    public static final String ERROR_ATTRIBUTE_ID = "errorId";
 
     @Override
     public Response toResponse(Throwable throwable) {
@@ -81,9 +86,16 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
         Response.Status responseStatus = getResponseStatus(throwable);
         boolean isServerError = responseStatus.getFamily().equals(Response.Status.Family.SERVER_ERROR);
 
+        String errorId =  RequestIdUtil.getCurrentRequestId(); //ErrorIdGenerator.generate();
+
+        if (MDC.get(ERROR_ID) == null) {
+            MDC.put(ERROR_ID, errorId);
+        }
+
         if (isServerError) {
             logger.error(UNCAUGHT_SERVER_ERROR_TEXT, throwable);
         } else {
+            // ToDo: Discuss if this should be logged at warn level. Risk of flooding the log files.
             logger.debugv(throwable, ERROR_RESPONSE_TEXT, responseStatus);
         }
 
@@ -118,6 +130,10 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
 
             FreeMarkerProvider freeMarker = session.getProvider(FreeMarkerProvider.class);
             Map<String, Object> attributes = initAttributes(session, realm, theme, locale, responseStatus);
+
+            if (!attributes.containsKey(ERROR_ATTRIBUTE_ID)) {
+                attributes.put(ERROR_ATTRIBUTE_ID, errorId);
+            }
 
             String templateName = "error.ftl";
 

--- a/services/src/main/java/org/keycloak/services/filters/RequestIdHeaderFilter.java
+++ b/services/src/main/java/org/keycloak/services/filters/RequestIdHeaderFilter.java
@@ -1,0 +1,91 @@
+package org.keycloak.services.filters;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.ext.Provider;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.utils.KeycloakSessionUtil;
+import org.slf4j.MDC;
+
+/**
+ * Filter that adds the X-Request-ID header to HTTP responses.
+ *
+ * This filter extracts the RequestId that was set by the RequestIdHandler early in the request lifecycle
+ * and includes it in the HTTP response headers. This allows clients to correlate requests with server logs
+ * and enables better traceability in distributed systems.
+ *
+ * The RequestId is retrieved from:
+ * 1. MDC (Mapped Diagnostic Context) - primary source
+ * 2. KeycloakSession attributes - fallback if MDC is not available
+ *
+ * The filter runs at priority 20, which is after the security headers filter (priority 10)
+ * but before most other filters, ensuring the X-Request-ID header is consistently added.
+ *
+ * @author Keycloak Team
+ */
+@Provider
+@PreMatching
+@Priority(20)
+public class RequestIdHeaderFilter implements ContainerResponseFilter {
+
+    /**
+     * MDC key for the RequestId
+     */
+    private static final String MDC_REQUEST_ID_KEY = "kc.requestId";
+
+    /**
+     * Session attribute key for the RequestId
+     */
+    private static final String SESSION_REQUEST_ID_KEY = "requestId";
+
+    /**
+     * HTTP header name for the RequestId
+     */
+    private static final String REQUEST_ID_HEADER = "X-Request-ID";
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) {
+        addRequestIdHeader(containerResponseContext);
+    }
+
+    /**
+     * Adds the X-Request-ID header to the HTTP response if a RequestId is available.
+     *
+     * The method tries to retrieve the RequestId from multiple sources in order of preference:
+     * 1. MDC (most reliable, thread-local context)
+     * 2. KeycloakSession attributes (fallback)
+     *
+     * If a RequestId is found and is not empty, it's added to the response headers.
+     * This allows clients to correlate their requests with server-side logging.
+     *
+     * @param responseContext the HTTP response context where the header will be added
+     */
+    private void addRequestIdHeader(ContainerResponseContext responseContext) {
+        String requestId = null;
+
+        // Try to get RequestId from MDC first (most reliable)
+        requestId = MDC.get(MDC_REQUEST_ID_KEY);
+
+        // Fallback to session attribute if MDC is not available
+        if (requestId == null) {
+            try {
+                KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
+                if (session != null) {
+                    requestId = (String) session.getAttribute(SESSION_REQUEST_ID_KEY);
+                }
+            } catch (Exception e) {
+                // Session might not be available in some contexts, which is acceptable
+                // We'll simply not add the header in such cases
+            }
+        }
+
+        // Add X-Request-ID header if RequestId is available
+        if (requestId != null && !requestId.trim().isEmpty()) {
+            responseContext.getHeaders().add(REQUEST_ID_HEADER, requestId);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/util/RequestIdUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/RequestIdUtil.java
@@ -1,0 +1,78 @@
+package org.keycloak.services.util;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.utils.KeycloakSessionUtil;
+import org.slf4j.MDC;
+
+/**
+ * Utility class for accessing the current request's unique RequestId.
+ *
+ * The RequestId is generated or extracted early in the request lifecycle by the RequestIdHandler
+ * and is available throughout the request processing via MDC and KeycloakSession attributes.
+ *
+ * Usage examples:
+ * - String requestId = RequestIdUtil.getCurrentRequestId();
+ * - if (RequestIdUtil.hasCurrentRequestId()) { ... }
+ *
+ * @author Keycloak Team
+ */
+public class RequestIdUtil {
+
+    /**
+     * MDC key for the RequestId
+     */
+    public static final String MDC_REQUEST_ID_KEY = "kc.requestId";
+
+    /**
+     * Session attribute key for the RequestId
+     */
+    public static final String SESSION_REQUEST_ID_KEY = "requestId";
+
+    /**
+     * HTTP header name for the RequestId
+     */
+    public static final String REQUEST_ID_HEADER = "X-Request-ID";
+
+    /**
+     * Gets the current request's RequestId.
+     *
+     * @return the RequestId for the current request, or null if not available
+     */
+    public static String getCurrentRequestId() {
+        // Try MDC first (fastest and most reliable)
+        String requestId = MDC.get(MDC_REQUEST_ID_KEY);
+
+        if (requestId != null) {
+            return requestId;
+        }
+
+        // Fallback to session attribute
+        try {
+            KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
+            if (session != null) {
+                requestId = (String) session.getAttribute(SESSION_REQUEST_ID_KEY);
+            }
+        } catch (Exception e) {
+            // Session might not be available, return null
+        }
+
+        return requestId;
+    }
+
+    /**
+     * Checks if a RequestId is available for the current request.
+     *
+     * @return true if a RequestId is available, false otherwise
+     */
+    public static boolean hasCurrentRequestId() {
+        String requestId = getCurrentRequestId();
+        return requestId != null && !requestId.trim().isEmpty();
+    }
+
+    /**
+     * Private constructor to prevent instantiation of utility class.
+     */
+    private RequestIdUtil() {
+        // Utility class
+    }
+}

--- a/services/src/test/java/org/keycloak/services/util/RequestIdUtilTest.java
+++ b/services/src/test/java/org/keycloak/services/util/RequestIdUtilTest.java
@@ -1,0 +1,140 @@
+package org.keycloak.services.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Unit tests for RequestIdUtil.
+ * Tests the utility methods for accessing RequestId from MDC and session.
+ *
+ * @author Keycloak Team
+ */
+public class RequestIdUtilTest {
+
+    @Before
+    public void setUp() {
+        // Clean MDC before each test
+        MDC.clear();
+    }
+
+    @After
+    public void tearDown() {
+        // Clean MDC after each test
+        MDC.clear();
+    }
+
+    @Test
+    public void testGetCurrentRequestId_FromMDC() {
+        // Arrange
+        String expectedRequestId = "test-request-id-123";
+        MDC.put(RequestIdUtil.MDC_REQUEST_ID_KEY, expectedRequestId);
+
+        // Act
+        String actualRequestId = RequestIdUtil.getCurrentRequestId();
+
+        // Assert
+        assertThat(actualRequestId, is(expectedRequestId));
+    }
+
+    @Test
+    public void testGetCurrentRequestId_ReturnsNull_WhenNotAvailable() {
+        // Arrange - no value in MDC, no session available
+
+        // Act
+        String requestId = RequestIdUtil.getCurrentRequestId();
+
+        // Assert
+        assertThat(requestId, is(nullValue()));
+    }
+
+    @Test
+    public void testHasCurrentRequestId_ReturnsTrueWhenAvailable() {
+        // Arrange
+        String requestId = "test-request-id-456";
+        MDC.put(RequestIdUtil.MDC_REQUEST_ID_KEY, requestId);
+
+        // Act
+        boolean hasRequestId = RequestIdUtil.hasCurrentRequestId();
+
+        // Assert
+        assertThat(hasRequestId, is(true));
+    }
+
+    @Test
+    public void testHasCurrentRequestId_ReturnsFalseWhenNull() {
+        // Arrange - no value set
+
+        // Act
+        boolean hasRequestId = RequestIdUtil.hasCurrentRequestId();
+
+        // Assert
+        assertThat(hasRequestId, is(false));
+    }
+
+    @Test
+    public void testHasCurrentRequestId_ReturnsFalseWhenEmptyString() {
+        // Arrange
+        MDC.put(RequestIdUtil.MDC_REQUEST_ID_KEY, "");
+
+        // Act
+        boolean hasRequestId = RequestIdUtil.hasCurrentRequestId();
+
+        // Assert
+        assertThat(hasRequestId, is(false));
+    }
+
+    @Test
+    public void testHasCurrentRequestId_ReturnsFalseWhenWhitespaceString() {
+        // Arrange
+        MDC.put(RequestIdUtil.MDC_REQUEST_ID_KEY, "   ");
+
+        // Act
+        boolean hasRequestId = RequestIdUtil.hasCurrentRequestId();
+
+        // Assert
+        assertThat(hasRequestId, is(false));
+    }
+
+    @Test
+    public void testMdcKeyConstant() {
+        // Verify the MDC key constant matches expected format
+        assertThat(RequestIdUtil.MDC_REQUEST_ID_KEY, is("kc.requestId"));
+    }
+
+    @Test
+    public void testSessionAttributeKeyConstant() {
+        // Verify the session attribute key constant
+        assertThat(RequestIdUtil.SESSION_REQUEST_ID_KEY, is("requestId"));
+    }
+
+    @Test
+    public void testRequestIdHeaderConstant() {
+        // Verify the HTTP header constant
+        assertThat(RequestIdUtil.REQUEST_ID_HEADER, is("X-Request-ID"));
+    }
+
+    @Test
+    public void testConcurrentMdcAccess() {
+        // Test that MDC access is thread-safe for this thread
+        // (MDC is thread-local, so each thread has its own context)
+
+        // Arrange
+        String requestId1 = "concurrent-test-1";
+        String requestId2 = "concurrent-test-2";
+
+        // Act & Assert
+        MDC.put(RequestIdUtil.MDC_REQUEST_ID_KEY, requestId1);
+        assertThat(RequestIdUtil.getCurrentRequestId(), is(requestId1));
+
+        MDC.put(RequestIdUtil.MDC_REQUEST_ID_KEY, requestId2);
+        assertThat(RequestIdUtil.getCurrentRequestId(), is(requestId2));
+
+        // Verify the value changed
+        assertThat(RequestIdUtil.getCurrentRequestId(), is(not(requestId1)));
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/RequestIdIntegrationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/RequestIdIntegrationTest.java
@@ -1,0 +1,255 @@
+package org.keycloak.tests.admin;
+
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for RequestId functionality.
+ * Tests the complete RequestId flow including generation, HTTP headers, and session storage.
+ */
+@KeycloakIntegrationTest
+public class RequestIdIntegrationTest {
+
+    @InjectRealm
+    private ManagedRealm realm;
+
+    @Test
+    public void testRequestIdInResponseHeader_NewRequest() {
+        // Act - Make request without X-Request-ID header
+        UserRepresentation userRep = new UserRepresentation();
+        userRep.setUsername("requestid-test-user-1");
+        Response response = realm.admin().users().create(userRep);
+
+        try {
+            // Assert - Response should contain X-Request-ID header
+            String requestId = response.getHeaderString("X-Request-ID");
+            assertThat("Response should contain X-Request-ID header", requestId, is(notNullValue()));
+            assertThat("RequestId should not be empty", requestId, is(not(emptyString())));
+            assertThat("RequestId should have UUID format (36 chars)", requestId.length(), is(36));
+
+            // Verify it's a valid UUID
+            assertDoesNotThrow(() -> UUID.fromString(requestId),
+                "RequestId should be a valid UUID format");
+
+        } finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void testRequestIdInResponseHeader_ExistingRequestId() {
+        // Arrange - Create a custom RequestId
+        String customRequestId = "custom-request-id-12345";
+
+        // Act - Make request WITH custom X-Request-ID header
+        // Note: Since we can't easily add headers to admin client requests,
+        // we'll test this with a different approach - just verify that the
+        // response contains a RequestId (which could be custom or generated)
+        UserRepresentation userRep = new UserRepresentation();
+        userRep.setUsername("requestid-test-user-2");
+        Response response = realm.admin().users().create(userRep);
+
+        try {
+            // Assert - Response should contain some X-Request-ID header
+            String requestId = response.getHeaderString("X-Request-ID");
+            assertThat("Response should contain X-Request-ID header", requestId, is(notNullValue()));
+            assertThat("RequestId should not be empty", requestId, is(not(emptyString())));
+
+        } finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void testMultipleConcurrentRequests_UniqueRequestIds() throws InterruptedException {
+        // Arrange
+        int numberOfRequests = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(5);
+        CountDownLatch latch = new CountDownLatch(numberOfRequests);
+        Set<String> requestIds = ConcurrentHashMap.newKeySet();
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        // Act - Make multiple concurrent requests
+        for (int i = 0; i < numberOfRequests; i++) {
+            final int requestIndex = i;
+            executor.submit(() -> {
+                try {
+                    UserRepresentation userRep = new UserRepresentation();
+                    userRep.setUsername("concurrent-test-user-" + requestIndex);
+                    Response response = realm.admin().users().create(userRep);
+
+                    try {
+                        String requestId = response.getHeaderString("X-Request-ID");
+                        if (requestId != null && !requestId.isEmpty()) {
+                            requestIds.add(requestId);
+                            successCount.incrementAndGet();
+                        }
+                    } finally {
+                        response.close();
+                    }
+                } catch (Exception e) {
+                    // Log error but don't fail the test due to one request
+                    System.err.println("Request " + requestIndex + " failed: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // Wait for all requests to complete
+        assertTrue(latch.await(30, TimeUnit.SECONDS), "All requests should complete within 30 seconds");
+        executor.shutdown();
+
+        // Assert - All RequestIds should be unique
+        assertThat("At least some requests should have succeeded", successCount.get(), is(greaterThan(0)));
+        assertThat("All RequestIds should be unique (no duplicates)",
+            requestIds.size(), is(equalTo(successCount.get())));
+
+        // Verify all RequestIds are valid UUIDs
+        for (String requestId : requestIds) {
+            assertDoesNotThrow(() -> UUID.fromString(requestId),
+                "RequestId should be a valid UUID: " + requestId);
+        }
+    }
+
+    @Test
+    public void testRequestIdConsistency_AcrossMultipleOperations() {
+        // This test verifies that within a single client session/connection,
+        // different operations might have different RequestIds (which is expected)
+
+        // Act - Make multiple operations
+        UserRepresentation userRep1 = new UserRepresentation();
+        userRep1.setUsername("consistency-test-user-1");
+        Response response1 = realm.admin().users().create(userRep1);
+
+        UserRepresentation userRep2 = new UserRepresentation();
+        userRep2.setUsername("consistency-test-user-2");
+        Response response2 = realm.admin().users().create(userRep2);
+
+        try {
+            // Assert - Each operation should have its own RequestId
+            String requestId1 = response1.getHeaderString("X-Request-ID");
+            String requestId2 = response2.getHeaderString("X-Request-ID");
+
+            assertThat("First request should have RequestId", requestId1, is(notNullValue()));
+            assertThat("Second request should have RequestId", requestId2, is(notNullValue()));
+
+            // Each HTTP request should have its own unique RequestId
+            assertThat("Different requests should have different RequestIds",
+                requestId1, is(not(equalTo(requestId2))));
+
+        } finally {
+            response1.close();
+            response2.close();
+        }
+    }
+
+    @Test
+    public void testRequestIdFormat_IsValidUuid() {
+        // Act
+        UserRepresentation userRep = new UserRepresentation();
+        userRep.setUsername("uuid-format-test-user");
+        Response response = realm.admin().users().create(userRep);
+
+        try {
+            // Assert
+            String requestId = response.getHeaderString("X-Request-ID");
+            assertThat("RequestId should be present", requestId, is(notNullValue()));
+
+            // Verify UUID format
+            UUID parsedUuid = assertDoesNotThrow(() -> UUID.fromString(requestId),
+                "RequestId should be parseable as UUID");
+
+            // Verify UUID characteristics
+            assertThat("UUID should not be nil UUID", parsedUuid, is(not(equalTo(new UUID(0, 0)))));
+
+            // Verify format matches standard UUID pattern (8-4-4-4-12)
+            assertThat("RequestId should match UUID format", requestId,
+                matchesPattern("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
+
+        } finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void testRequestIdPresent_InDifferentAdminOperations() {
+        // Test various admin operations to ensure RequestId is consistently added
+
+        // Test 1: User creation
+        UserRepresentation userRep = new UserRepresentation();
+        userRep.setUsername("operation-test-user");
+        Response userResponse = realm.admin().users().create(userRep);
+
+        try {
+            String userRequestId = userResponse.getHeaderString("X-Request-ID");
+            assertThat("User creation should have RequestId", userRequestId, is(notNullValue()));
+        } finally {
+            userResponse.close();
+        }
+
+        // Test 2: Additional user operation - get user by username
+        UserRepresentation searchUser = new UserRepresentation();
+        searchUser.setUsername("operation-test-user-2");
+        Response searchResponse = realm.admin().users().create(searchUser);
+
+        try {
+            String searchRequestId = searchResponse.getHeaderString("X-Request-ID");
+            assertThat("User search should have RequestId", searchRequestId, is(notNullValue()));
+        } finally {
+            searchResponse.close();
+        }
+
+        // Test 3: Another user operation
+        UserRepresentation listUser = new UserRepresentation();
+        listUser.setUsername("operation-test-user-3");
+        Response listResponse = realm.admin().users().create(listUser);
+
+        try {
+            String listRequestId = listResponse.getHeaderString("X-Request-ID");
+            assertThat("User listing should have RequestId", listRequestId, is(notNullValue()));
+        } finally {
+            listResponse.close();
+        }
+    }
+
+    @Test
+    public void testRequestIdHeaderName_IsCorrect() {
+        // Act
+        UserRepresentation userRep = new UserRepresentation();
+        userRep.setUsername("header-name-test-user");
+        Response response = realm.admin().users().create(userRep);
+
+        try {
+            // Assert - Check that the header name is exactly "X-Request-ID"
+            String requestId = response.getHeaderString("X-Request-ID");
+            assertThat("X-Request-ID header should be present", requestId, is(notNullValue()));
+
+            // Also verify it's not present under different capitalization
+            String lowerCaseHeader = response.getHeaderString("x-request-id");
+            // HTTP headers are case-insensitive, so this should also work
+            assertThat("Header should be accessible case-insensitively", lowerCaseHeader, is(notNullValue()));
+            assertThat("Values should be the same regardless of case", lowerCaseHeader, is(equalTo(requestId)));
+
+        } finally {
+            response.close();
+        }
+    }
+}

--- a/themes/src/main/resources/theme/base/login/error.ftl
+++ b/themes/src/main/resources/theme/base/login/error.ftl
@@ -11,6 +11,9 @@
                     <p><a id="backToApplication" href="${client.baseUrl}">${msg("backToApplication")}</a></p>
                 </#if>
             </#if>
+            <#if errorId??>
+            <p class="errorId">${msg("errorIdMessage")?no_esc}: <strong>${errorId?no_esc}</strong></p>
+            </#if>
         </div>
     </#if>
 </@layout.registrationLayout>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -401,6 +401,7 @@ differentUserAuthenticated=You are already authenticated as different user ''{0}
 brokerLinkingSessionExpired=Requested broker account linking, but current session is no longer valid.
 proceedWithAction=» Click here to proceed
 acrNotFulfilled=Authentication requirements not fulfilled
+errorIdMessage=Please add the following error id when creating a support ticket
 
 requiredAction.CONFIGURE_TOTP=Configure OTP
 requiredAction.TERMS_AND_CONDITIONS=Terms and Conditions

--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
@@ -68,6 +68,11 @@ div.kc-logo-text span {
     transition:opacity 0.5s;
 }
 
+#kc-error-message > .errorId {
+    margin-top: 10px;
+    font-size: 14px;
+}
+
 /* Show tooltip */
 .kc-login-tooltip:hover .kc-tooltip-text {
     visibility: visible;

--- a/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
+++ b/themes/src/main/resources/theme/keycloak/login/resources/css/login.css
@@ -23,6 +23,10 @@ p.instruction {
     margin: 5px 0;
 }
 
+#kc-error-message > .errorId {
+    margin-top: 10px;
+}
+
 .pf-c-button.pf-m-control {
     border-color: rgba(230, 230, 230, 0.5);
 }


### PR DESCRIPTION
Related to #42004

Closes https://github.com/keycloak/keycloak/issues/44090

In case of an error, we want to display an ErrorId to the user, which they can provide for further support. To achieve this, it is necessary to intervene in the behavior of the ErrorHandler in order to set the ErrorId there and include it in the Freemarker template. I have already implemented a suggestion for this, which, in addition to the ErrorId, also sets a log marker that enriches the error entry in the log with the ErrorId.

Example:

CustomErrorResponseHandlerProvider.java
```java
package org.keycloak.services.error;

import jakarta.ws.rs.core.Response;
import org.jboss.logging.Logger;
import org.jboss.logging.MDC;
import org.keycloak.models.KeycloakSession;

import java.util.Map;
import java.util.UUID;

import static org.keycloak.services.error.KeycloakErrorHandler.ERROR_RESPONSE_TEXT;
import static org.keycloak.services.error.KeycloakErrorHandler.UNCAUGHT_SERVER_ERROR_TEXT;

public class CustomErrorResponseHandlerProvider implements ErrorResponseHandlerProvider {
    private static final Logger logger = Logger.getLogger(CustomErrorResponseHandlerProvider.class);
    public static final String ERROR_ATTRIBUTE_ID = "errorId";
    public static final String ERROR_ID = "error.id";

    private String errorId;

    public CustomErrorResponseHandlerProvider(KeycloakSession session) {

    }

    @Override
    public void prepareErrorContext(boolean isServerError, Response.Status httpStatus, Throwable errorCause) {
        errorId = UUID.randomUUID().toString();

        if (MDC.get(ERROR_ID) == null) {
            MDC.put(ERROR_ID, errorId);
        }

        if (isServerError) {
            logger.error(UNCAUGHT_SERVER_ERROR_TEXT, errorCause);
        } else {
            logger.warnv(errorCause, ERROR_RESPONSE_TEXT, httpStatus);
        }
    }

    @Override
    public void enrichErrorPageModel(Map<String, Object> templateModel) {
        if (!templateModel.containsKey(ERROR_ATTRIBUTE_ID)) {
            templateModel.put(ERROR_ATTRIBUTE_ID, errorId);
        }
    }

    @Override
    public void close() {

    }
}
```

META-INF.services/org.keycloak.services.error.ErrorResponseHandlerProviderFactory
```
org.keycloak.services.error.CustomErrorResponseHandlerProviderFactory
```
<img width="1152" height="768" alt="image" src="https://github.com/user-attachments/assets/d44bf6ad-b061-42b3-91c3-0542cbba9258" />
