### PR TITLE
Efficient row-count on PostgreSQL for indexes

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -75,6 +75,13 @@ This prevents problems with client IDs or passwords that contain, for example, a
 
 To revert to the old behavior, change the client authentication to *Client secret sent as HTTP Basic authentication without URL encoding (deprecated)* (`client_secret_basic_unencoded`).
 
+=== Permissions of the database user for PostgreSQL
+
+If you are running on PostgreSQL as a database for {project_name}, ensure that the database user has `SELECT` permissions to the following tables to ensure an efficient upgrade: `pg_class`, `pg_namespace`.
+
+This is used during upgrades of {project_name} to determine an estimated number of rows in a table.
+If {project_name} does not have permissions to access these tables, it will log a warning and proceed with the less efficient `+SELECT COUNT(*) ...+` operation during the upgrade to determine the number of rows in tables affected by schema changes.
+
 === Not recommended to use org.keycloak.credential.UserCredentialManager directly in your extensions
 
 If you have user storage extension and you reference the class `org.keycloak.credential.UserCredentialManager` from your providers, it is recommended to avoid using this class directly as it might be

--- a/docs/documentation/upgrading/topics/migrate_db.adoc
+++ b/docs/documentation/upgrading/topics/migrate_db.adoc
@@ -28,6 +28,13 @@ To change the threshold, set the `index-creation-threshold` property, value for 
 kc.[sh|bat] start --spi-connections-liquibase--quarkus--index-creation-threshold=300000
 ----
 
+You can disable this feature by setting it to zero or a negative number:
+
+[source,bash]
+----
+kc.[sh|bat] start --spi-connections-liquibase--quarkus--index-creation-threshold=0
+----
+
 === Manual relational database migration
 
 To enable manual upgrading of the database schema, set the `migration-strategy` property value to "manual" for the

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -267,6 +267,8 @@ create database keycloak with encoding 'UTF8';
 
 == Preparing for PostgreSQL
 
+=== Writer and reader instances
+
 When running PostgreSQL reader and writer instances, {project_name} needs to always connect to the writer instance to do its work.
 When using the original PostgreSQL driver, {project_name} sets the `targetServerType` property of the PostgreSQL JDBC driver to `primary` to ensure that it always connects to a writable primary instance and never connects to a secondary reader instance in failover or switchover scenarios.
 
@@ -277,9 +279,15 @@ You can override this behavior by setting your own value for `targetServerType` 
 The `targetServerType` is only applied automatically to the primary datasource, as requirements might be different for additional datasources.
 ====
 
-[TIP]
-.Secure Your PostgreSQL Connection
-====
+=== Permissions of the database user
+
+Ensure that the database user has `SELECT` permissions to the following tables to ensure an efficient upgrade: `pg_class`, `pg_namespace`.
+
+This is used during upgrades of {project_name} to determine an estimated number of rows in a table.
+If {project_name} does not have permissions to access these tables, it will log a warning and proceed with the less efficient `+SELECT COUNT(*) ...+` operation during the upgrade to determine the number of rows in tables affected by schema changes.
+
+=== Secure your connection
+
 To secure your database connection, configure your PostgreSQL server to use TLS and perform full server certificate verification on the client side.
 
 **Server-side Configuration (Prerequisites):**
@@ -295,7 +303,6 @@ db-url=jdbc:postgresql://...?sslmode=verify-full&sslrootcert=/path/to/certificat
 
 * `sslmode=verify-full`: Forces TLS and verifies the server's identity against the trusted certificate.
 * `sslrootcert=/path/to/certificate`: The path to the server's public certificate file on the client machine.
-====
 
 [[preparing-keycloak-for-amazon-aurora-postgresql]]
 == Preparing for Amazon Aurora PostgreSQL

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/conn/DefaultLiquibaseConnectionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/conn/DefaultLiquibaseConnectionProvider.java
@@ -49,7 +49,7 @@ public class DefaultLiquibaseConnectionProvider implements LiquibaseConnectionPr
 
     public static final String INDEX_CREATION_THRESHOLD_PARAM = "keycloak.indexCreationThreshold";
 
-    private int indexCreationThreshold;
+    private long indexCreationThreshold;
     private Class<? extends Database> liquibaseDatabaseClazz;
 
     private static final AtomicBoolean INITIALIZATION = new AtomicBoolean(false);
@@ -97,7 +97,7 @@ public class DefaultLiquibaseConnectionProvider implements LiquibaseConnectionPr
     @SuppressWarnings("unchecked")
     @Override
     public void init(Config.Scope config) {
-        indexCreationThreshold = config.getInt("indexCreationThreshold", 300000);
+        indexCreationThreshold = config.getLong("indexCreationThreshold", 300000L);
         logger.debugf("indexCreationThreshold is %d", indexCreationThreshold);
 
         // We need to explicitly handle the default here as Config might not be MicroProfile and hence no actually server config exists


### PR DESCRIPTION
Closes #44057
Closes #42704

I tested this manually as follows when testing: 

* Test with PostgreSQL
* In the `migration_model` table, create an entry for 26.4.0 in addition to the 999.0.0 entry
* In the `databasechangelog`, remove `26.5.0-index-offline-css-by-client` and `26.5.0-index-offline-css-by-client-storage-provider`
* Drop the index `idx_offline_css_by_client` and `idx_offline_css_by_client_storage_provider` on `offline_client_session`
* Start Keycloak with `--spi-datastore-legacy-allow-migrate-existing-database-to-snapshot=true` and see that Keycloak performs the migration and adds the indexes

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
