### PR TITLE
Fix OpenShift v4 IDP mapper error handling and baseUrl bug

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/IdentityProviderResource.java
@@ -290,7 +290,13 @@ public class IdentityProviderResource {
             throw new jakarta.ws.rs.NotFoundException();
         }
 
-        IdentityProvider<?> identityProviderInstance = createIdentityProviderInstance();
+        IdentityProvider<?> identityProviderInstance;
+        try {
+            identityProviderInstance = createIdentityProviderInstance();
+        } catch (Exception e) {
+            throw ErrorResponse.error("Could not get mapper types for identity provider [" + identityProviderModel.getProviderId() + "]: " + e.getMessage(), Response.Status.BAD_REQUEST);
+        }
+
         KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
         return sessionFactory.getProviderFactoriesStream(IdentityProviderMapper.class)
                 .map(IdentityProviderMapper.class::cast)

--- a/services/src/main/java/org/keycloak/social/openshift/OpenshiftV4IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/openshift/OpenshiftV4IdentityProvider.java
@@ -37,7 +37,7 @@ public class OpenshiftV4IdentityProvider extends AbstractOAuth2IdentityProvider<
     public OpenshiftV4IdentityProvider(KeycloakSession session, OpenshiftV4IdentityProviderConfig config) {
         super(session, config);
         final String baseUrl = Optional.ofNullable(config.getBaseUrl()).orElse(BASE_URL);
-        Map<String, Object> oauthDescriptor = getAuthJson(session, config.getBaseUrl());
+        Map<String, Object> oauthDescriptor = getAuthJson(session, baseUrl);
         logger.debugv("Openshift v4 OAuth descriptor: {0}", oauthDescriptor);
         config.setAuthorizationUrl((String) oauthDescriptor.get("authorization_endpoint"));
         config.setTokenUrl((String) oauthDescriptor.get("token_endpoint"));

--- a/services/src/test/java/org/keycloak/social/openshift/OpenshiftV4IdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/social/openshift/OpenshiftV4IdentityProviderTest.java
@@ -59,18 +59,16 @@ public class OpenshiftV4IdentityProviderTest {
         OpenshiftV4IdentityProviderConfig config = new OpenshiftV4IdentityProviderConfig(new IdentityProviderModel());
 
         //when
-        try {
+        IdentityBrokerException exception = Assert.assertThrows(IdentityBrokerException.class, () -> {
             new OpenshiftV4IdentityProvider(null, config) {
                 @Override
                 InputStream getOauthMetadataInputStream(KeycloakSession session, String baseUrl) {
                     throw new RuntimeException("Failed : HTTP error code : 500");
                 }
             };
-            Assert.fail();
-        } catch (IdentityBrokerException e) {
-            //then
-            //OK
-        }
+        });
+
+        Assert.assertNotNull("Error message should not be null", exception.getMessage());
     }
 
 }


### PR DESCRIPTION
When accessing the mappers tab for an OpenShift v4 Identity Provider with an invalid or unreachable Base URL, the Admin UI would display a generic error or require reload with no descriptive error message.

**This commit improves the error handling flow:**

1. OpenshiftV4IdentityProvider: Fixed constructor to pass the resolved baseUrl (with fallback to BASE_URL) instead of the potentially null config.getBaseUrl(). This ensures the correct URL is always used when fetching OAuth metadata.

2. IdentityProviderResource: Added try-catch around createIdentityProviderInstance() in getMapperTypes() to catch initialization failures and return a proper HTTP 400 error response with a descriptive error message to the frontend.

3. OpenshiftV4IdentityProviderTest: Updated testHttpClientErrors to use assertThrows for cleaner exception testing.

The error message now includes:
- The identity provider type that failed
- The original exception message from OpenshiftV4IdentityProvider
- Clear indication that mapper types could not be retrieved

Closes #43970

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->


**Below is the screenshot of how latest change looks in the UI**
![OPenshift](https://github.com/user-attachments/assets/6ccec2ff-3ef5-4b9f-ad0d-41b236c55518)


