### PR TITLE
Skip checksum validation for 2.5.0-unicode-oracle, that is preventing…

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-2.5.0.xml
@@ -26,9 +26,7 @@
      </changeSet>
 
     <changeSet author="hmlnarik@redhat.com" id="2.5.0-unicode-oracle">
-        <validCheckSum>7:e4c7e8f2256210aee71ddc42f538b57a</validCheckSum>
-        <validCheckSum>8:8b6fd445958882efe55deb26fc541a7b</validCheckSum>
-        <validCheckSum>9:3a32bace77c84d7678d035a7f5a8084e</validCheckSum>
+        <validCheckSum>1:ANY</validCheckSum>
         <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
             <dbms type="oracle" />
         </preConditions>


### PR DESCRIPTION
… migrations when schema name changes

Closes #43564

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
