### PR TITLE
[Backport 26.4] Email should be set when email as username is enabled and email is read-only

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -264,6 +264,7 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
             RealmModel realm = session.getContext().getRealm();
 
             if ((UserModel.USERNAME.equals(name) && realm.isRegistrationEmailAsUsername())
+                || isReadableOrWritableDuringRegistration(name)
                 || !isManagedAttribute(name)) {
                 continue;
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterWithUserProfileTest.java
@@ -688,6 +688,10 @@ public class RegisterWithUserProfileTest extends AbstractTestRealmKeycloakTest {
         registerPage.registerWithEmailAsUsername("firstName", "lastName", "myusername1@keycloak.org", generatePassword());
 
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        UserRepresentation user = testRealm().users().search("myusername1@keycloak.org").get(0);
+        assertEquals("myusername1@keycloak.org", user.getEmail());
+        UserRepresentation rep = testRealm().users().get(user.getId()).toRepresentation();
+        assertEquals("myusername1@keycloak.org", rep.getEmail());
     }
 
     private void assertUserRegistered(String userId, String username, String email, String firstName, String lastName) {


### PR DESCRIPTION
Closes #43718

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
