### PR TITLE
[OID4VCI]: Fix: Allow assignment of OID4VCI client scopes to clients in admin UI

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/details/SearchFilter.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/SearchFilter.tsx
@@ -18,10 +18,12 @@ import {
   clientScopeTypesSelectOptions,
 } from "../../components/client-scope/ClientScopeTypes";
 import type { Row } from "../../clients/scopes/ClientScopes";
+import useIsFeatureEnabled, { Feature } from "../../utils/useIsFeatureEnabled";
+import { useMemo } from "react";
 
 export type SearchType = "name" | "type" | "protocol";
 export const PROTOCOLS = ["all", "saml", "openid-connect"] as const;
-export type ProtocolType = (typeof PROTOCOLS)[number];
+export type ProtocolType = (typeof PROTOCOLS)[number] | "oid4vc";
 
 export const nameFilter =
   (search = "") =>
@@ -100,6 +102,14 @@ export const SearchToolbar = ({
 }: SearchToolbarProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const isFeatureEnabled = useIsFeatureEnabled();
+  const protocols = useMemo<readonly ProtocolType[]>(
+    () =>
+      isFeatureEnabled(Feature.OpenId4VCI)
+        ? ([...PROTOCOLS, "oid4vc"] as const)
+        : PROTOCOLS,
+    [isFeatureEnabled],
+  );
 
   return (
     <>
@@ -178,7 +188,7 @@ export const SearchToolbar = ({
               }}
             >
               <SelectList>
-                {PROTOCOLS.map((type) => (
+                {protocols.map((type) => (
                   <SelectOption key={type} value={type}>
                     {t(`protocolTypes.${type}`)}
                   </SelectOption>

--- a/js/apps/admin-ui/src/clients/AdvancedTab.tsx
+++ b/js/apps/admin-ui/src/clients/AdvancedTab.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { ScrollForm } from "@keycloak/keycloak-ui-shared";
 import type { AddAlertFunction } from "@keycloak/keycloak-ui-shared";
 import { convertAttributeNameToForm, toUpperCase } from "../util";
+import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
 import type { FormFields, SaveOptions } from "./ClientDetails";
 import { AdvancedSettings } from "./advanced/AdvancedSettings";
 import { AuthenticationOverrides } from "./advanced/AuthenticationOverrides";
@@ -15,10 +16,7 @@ import { FineGrainOpenIdConnect } from "./advanced/FineGrainOpenIdConnect";
 import { FineGrainSamlEndpointConfig } from "./advanced/FineGrainSamlEndpointConfig";
 import { OpenIdConnectCompatibilityModes } from "./advanced/OpenIdConnectCompatibilityModes";
 import { OpenIdVerifiableCredentials } from "./advanced/OpenIdVerifiableCredentials";
-import useIsFeatureEnabled, { Feature } from "../utils/useIsFeatureEnabled";
-
-const PROTOCOL_OIDC = "openid-connect";
-const PROTOCOL_OID4VC = "oid4vc";
+import { PROTOCOL_OIDC, PROTOCOL_OID4VC } from "./constants";
 
 export const parseResult = (
   result: GlobalRequestResult,

--- a/js/apps/admin-ui/src/clients/constants.ts
+++ b/js/apps/admin-ui/src/clients/constants.ts
@@ -1,0 +1,2 @@
+export const PROTOCOL_OIDC = "openid-connect";
+export const PROTOCOL_OID4VC = "oid4vc";

--- a/js/apps/admin-ui/test/clients/assign-oid4vci-client-scope.spec.ts
+++ b/js/apps/admin-ui/test/clients/assign-oid4vci-client-scope.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import { v4 as uuid } from "uuid";
+import { createTestBed } from "../support/testbed.ts";
+import { login } from "../utils/login.ts";
+import { goToClientScopes, goToClients, goToRealm } from "../utils/sidebar.ts";
+import { clickTableToolbarItem, getRowByCellText } from "../utils/table.ts";
+import { clickSaveButton, selectItem } from "../utils/form.ts";
+import { toClients } from "../../src/clients/routes/Clients.tsx";
+import { createClient, continueNext, save as saveClient } from "./utils.ts";
+
+test("OIDC client can assign OID4VCI client scopes", async ({ page }) => {
+  await using testBed = await createTestBed();
+
+  await login(page, { to: toClients({ realm: testBed.realm }) });
+  await goToRealm(page, testBed.realm);
+
+  const clientScopeName = `oid4vci-scope-${uuid()}`;
+  await goToClientScopes(page);
+  await clickTableToolbarItem(page, "Create client scope");
+  await selectItem(page, "#kc-protocol", "OpenID for Verifiable Credentials");
+  await page.getByTestId("name").fill(clientScopeName);
+  await clickSaveButton(page);
+  await expect(page.getByText("Client scope created")).toBeVisible();
+
+  const clientId = `oidc-client-${uuid()}`;
+  await goToClients(page);
+  await createClient(page, { clientId, protocol: "OpenID Connect" });
+  await continueNext(page);
+  await saveClient(page);
+  await expect(page.getByText("Client created successfully")).toBeVisible();
+
+  await goToClients(page);
+  await expect(getRowByCellText(page, clientId)).toBeVisible();
+  await getRowByCellText(page, clientId).click();
+
+  await page.getByTestId("clientScopesTab").click();
+  await page.getByTestId("clientScopesSetupTab").click();
+  await page.getByRole("button", { name: "Add client scope" }).click();
+
+  await page.getByTestId("filter-type-dropdown").click();
+  await page.getByTestId("filter-type-dropdown-item").click();
+  await page.locator(".kc-protocolType-select").click();
+  await page
+    .getByRole("option", { name: "OpenID for Verifiable Credentials" })
+    .click();
+
+  await expect(
+    page.getByRole("gridcell", { name: clientScopeName }),
+  ).toBeVisible();
+
+  const scopeRow = page.getByRole("row", { name: clientScopeName });
+  await scopeRow.getByRole("checkbox").click();
+
+  await page.getByTestId("add-dropdown").click();
+  await page.getByRole("menuitem", { name: "Optional" }).click();
+
+  await expect(page.getByText("Scope mapping updated")).toBeVisible();
+
+  await expect(
+    page.getByRole("row", { name: new RegExp(clientScopeName, "i") }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
This PR updates the Keycloak admin UI to display and allow assignment of OID4VCI client scopes for clients, enabling administrators to complete the credential issuance flow.

**Changes**
- Updated scope filtering to include `oid4vc` protocol scopes for clients.
- Enhanced the protocol filter to include **OpenID for Verifiable Credentials** when the feature is enabled.
- Added E2E tests to verify visibility and assignment of OID4VC scopes to clients.

Closes #43899