### PR TITLE
Use normal scope parameter checking for the JWT Authorization grant

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
@@ -106,8 +106,7 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
             event.user(user);
             event.detail(Details.USERNAME, user.getUsername());
 
-            String scopeParam = formParams.getFirst(OAuth2Constants.SCOPE);
-            //TODO: scopes processing
+            String scopeParam = getRequestedScopes();
 
             RootAuthenticationSessionModel rootAuthSession = new AuthenticationSessionManager(session).createAuthenticationSession(realm, false);
             AuthenticationSessionModel authSession = createSessionModel(rootAuthSession, user, client, scopeParam);
@@ -116,11 +115,12 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
             event.session(userSession);
             ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(this.session, userSession, authSession);
             return createTokenResponse(user, userSession, clientSessionCtx, scopeParam, true, null);
-        }
-        catch (Exception e) {
+        } catch (CorsErrorResponseException e) {
+            throw e;
+        } catch (Exception e) {
             event.detail(Details.REASON, e.getMessage());
             event.error(Errors.INVALID_REQUEST);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, e.getMessage(), Response.Status.BAD_REQUEST);
         }
     }
 


### PR DESCRIPTION
Closes #43646

Just using the inherited method `getRequestedScopes` to check the `scope` parameter is valid for the client, as in any other grant (removing the TODO). I have done an extra change to return the error `invalid_grant` instead of `invalid_request`, to follow spec [RFC 7523 - Authorization Grant Processing](https://datatracker.ietf.org/doc/html/rfc7523#section-3.1).
