### PR TITLE
Allow ISO-8601 compatible format for the after field in workflow steps

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/DurationConverter.java
+++ b/common/src/main/java/org/keycloak/common/util/DurationConverter.java
@@ -1,0 +1,66 @@
+package org.keycloak.common.util;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Pattern;
+
+public class DurationConverter {
+
+    private static final String PERIOD = "P";
+    private static final String PERIOD_OF_TIME = "PT";
+    public static final Pattern DIGITS = Pattern.compile("^[-+]?\\d+$");
+    private static final Pattern DIGITS_AND_UNIT = Pattern.compile("^(?:[-+]?\\d+(?:\\.\\d+)?(?i)[hms])+$");
+    private static final Pattern DAYS = Pattern.compile("^[-+]?\\d+(?i)d$");
+    private static final Pattern MILLIS = Pattern.compile("^[-+]?\\d+(?i)ms$");
+
+    /**
+     * If the {@code value} starts with a number, then:
+     * <ul>
+     * <li>If the value is only a number, it is treated as a number of seconds.</li>
+     * <li>If the value is a number followed by {@code ms}, it is treated as a number of milliseconds.</li>
+     * <li>If the value is a number followed by {@code h}, {@code m}, or {@code s}, it is prefixed with {@code PT}
+     * and {@link Duration#parse(CharSequence)} is called.</li>
+     * <li>If the value is a number followed by {@code d}, it is prefixed with {@code P}
+     * and {@link Duration#parse(CharSequence)} is called.</li>
+     * </ul>
+     *
+     * Otherwise, {@link Duration#parse(CharSequence)} is called.
+     *
+     * @param value a string duration
+     * @return the parsed {@link Duration}
+     * @throws IllegalArgumentException in case of parse failure
+     */
+    public static Duration parseDuration(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        if (DIGITS.asPredicate().test(value)) {
+            return Duration.ofSeconds(Long.parseLong(value));
+        } else if (MILLIS.asPredicate().test(value)) {
+            return Duration.ofMillis(Long.parseLong(value.substring(0, value.length() - 2)));
+        }
+
+        try {
+            if (DIGITS_AND_UNIT.asPredicate().test(value)) {
+                return Duration.parse(PERIOD_OF_TIME + value);
+            } else if (DAYS.asPredicate().test(value)) {
+                return Duration.parse(PERIOD + value);
+            }
+
+            return Duration.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Checks whether the given value represents a positive duration.
+     *
+     * @param value a string duration following the same format as in {@link #parseDuration(String)}
+     * @return true if the value represents a positive duration, false otherwise
+     */
+    public static boolean isPositiveDuration(String value) {
+        Duration duration = parseDuration(value);
+        return duration != null && !duration.isNegative() && !duration.isZero();
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/workflows/WorkflowStepRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/workflows/WorkflowStepRepresentation.java
@@ -50,8 +50,8 @@ public final class WorkflowStepRepresentation extends AbstractWorkflowComponentR
         return getConfigValue(CONFIG_AFTER, String.class);
     }
 
-    public void setAfter(long ms) {
-        setConfig(CONFIG_AFTER, String.valueOf(ms));
+    public void setAfter(String after) {
+        setConfig(CONFIG_AFTER, after);
     }
 
     public String getPriority() {
@@ -84,21 +84,16 @@ public final class WorkflowStepRepresentation extends AbstractWorkflowComponentR
         }
 
         public Builder after(Duration duration) {
-            step.setAfter(duration.toMillis());
+            return after(String.valueOf(duration.getSeconds()));
+        }
+
+        public Builder after(String after) {
+            step.setAfter(after);
             return this;
         }
 
         public Builder id(String id) {
             step.setId(id);
-            return this;
-        }
-
-        public Builder before(WorkflowStepRepresentation targetStep, Duration timeBeforeTarget) {
-            // Calculate absolute time: targetStep.after - timeBeforeTarget
-            String targetAfter = targetStep.getConfig().get(CONFIG_AFTER).get(0);
-            long targetTime = Long.parseLong(targetAfter);
-            long thisTime = targetTime - timeBeforeTarget.toMillis();
-            step.setAfter(thisTime);
             return this;
         }
 

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/WorkflowResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/WorkflowResource.java
@@ -35,6 +35,6 @@ public interface WorkflowResource {
     @Path("bind/{type}/{resourceId}")
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
-    void bind(@PathParam("type") String type, @PathParam("resourceId") String resourceId, Long milliseconds);
+    void bind(@PathParam("type") String type, @PathParam("resourceId") String resourceId, String notBefore);
 
 }

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/DefaultWorkflowProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/DefaultWorkflowProvider.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import jakarta.ws.rs.BadRequestException;
 import org.jboss.logging.Logger;
+import org.keycloak.common.util.DurationConverter;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentFactory;
 import org.keycloak.component.ComponentModel;
@@ -228,8 +229,8 @@ public class DefaultWorkflowProvider implements WorkflowProvider {
                         if (isAlreadyScheduledInSession(event, workflow)) {
                             return;
                         }
-                        // If the workflow has a notBefore set, schedule the first step with it
-                        if (workflow.getNotBefore() != null && workflow.getNotBefore() > 0) {
+                        // If the workflow has a positive notBefore set, schedule the first step with it
+                        if (DurationConverter.isPositiveDuration(workflow.getNotBefore())) {
                             scheduleWorkflow(event, workflow);
                         } else {
                             DefaultWorkflowExecutionContext context = new DefaultWorkflowExecutionContext(session, workflow, event);
@@ -316,7 +317,7 @@ public class DefaultWorkflowProvider implements WorkflowProvider {
                 throw new WorkflowInvalidStateException("Workflow restart step must be the last step.");
             }
             boolean hasScheduledStep = steps.stream()
-                    .anyMatch(step -> Integer.parseInt(ofNullable(step.getAfter()).orElse("0")) > 0);
+                    .anyMatch(step -> DurationConverter.isPositiveDuration(step.getAfter()));
             if (!hasScheduledStep) {
                 throw new WorkflowInvalidStateException("A workflow with a restart step must have at least one step with a time delay.");
             }

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/RunWorkflowTask.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/RunWorkflowTask.java
@@ -3,6 +3,7 @@ package org.keycloak.models.workflow;
 import java.util.List;
 
 import org.jboss.logging.Logger;
+import org.keycloak.common.util.DurationConverter;
 import org.keycloak.models.KeycloakSession;
 
 class RunWorkflowTask extends WorkflowTransactionalTask {
@@ -34,7 +35,7 @@ class RunWorkflowTask extends WorkflowTransactionalTask {
         WorkflowStateProvider stateProvider = session.getProvider(WorkflowStateProvider.class);
 
         for (WorkflowStep step : stepsToRun) {
-            if (step.getAfter() > 0) {
+            if (DurationConverter.isPositiveDuration(step.getAfter())) {
                 // If a step has a time defined, schedule it and stop processing the other steps of workflow
                 log.debugf("Scheduling step %s to run in %d ms for resource %s (execution id: %s)",
                         step.getProviderId(), step.getAfter(), resourceId, executionId);

--- a/model/jpa/src/main/java/org/keycloak/models/workflow/ScheduleWorkflowTask.java
+++ b/model/jpa/src/main/java/org/keycloak/models/workflow/ScheduleWorkflowTask.java
@@ -32,7 +32,7 @@ final class ScheduleWorkflowTask extends WorkflowTransactionalTask {
         WorkflowStep firstStep = workflow.getSteps().findFirst().orElseThrow(() -> new WorkflowInvalidStateException("No steps found for workflow " + workflow.getName()));
         log.debugf("Scheduling first step '%s' of workflow '%s' for resource %s based on on event %s with notBefore %d",
                 firstStep.getProviderId(), workflow.getName(), event.getResourceId(), event.getOperation(), workflow.getNotBefore());
-        Long originalAfter = firstStep.getAfter();
+        String originalAfter = firstStep.getAfter();
         try {
             firstStep.setAfter(workflow.getNotBefore());
             WorkflowStateProvider stateProvider = session.getProvider(WorkflowStateProvider.class);

--- a/server-spi-private/src/main/java/org/keycloak/models/workflow/WorkflowStep.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/workflow/WorkflowStep.java
@@ -81,12 +81,12 @@ public class WorkflowStep implements Comparable<WorkflowStep> {
         }
     }
 
-    public void setAfter(Long ms) {
-        setConfig(CONFIG_AFTER, String.valueOf(ms));
+    public void setAfter(String after) {
+        setConfig(CONFIG_AFTER, after);
     }
 
-    public Long getAfter() {
-        return Long.valueOf(getConfig().getFirstOrDefault(CONFIG_AFTER, "0"));
+    public String getAfter() {
+        return getConfig().getFirst(CONFIG_AFTER);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowResource.java
+++ b/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowResource.java
@@ -61,13 +61,14 @@ public class WorkflowResource {
      *
      * @param type the resource type
      * @param resourceId the resource id
-     * @param notBefore optional notBefore time in milliseconds to schedule the first workflow step,
-     *                  it overrides the first workflow step time configuration (after).
+     * @param notBefore optional value representing the time to schedule the first workflow step, overriding the first
+     *                 step time configuration (after). The value is either an integer representing the seconds from now,
+     *                 an integer followed by 'ms' representing milliseconds from now, or an ISO-8601 date string.
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("bind/{type}/{resourceId}")
-    public void bind(@PathParam("type") ResourceType type, @PathParam("resourceId") String resourceId, Long notBefore) {
+    public void bind(@PathParam("type") ResourceType type, @PathParam("resourceId") String resourceId, String notBefore) {
         Object resource = provider.getResourceTypeSelector(type).resolveResource(resourceId);
 
         if (resource == null) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/AdhocWorkflowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/AdhocWorkflowTest.java
@@ -61,7 +61,7 @@ public class AdhocWorkflowTest extends AbstractWorkflowTest {
         try (Response response = managedRealm.admin().users().create(getUserRepresentation("alice", "Alice", "Wonderland", "alice@wornderland.org"))) {
             String id = ApiUtil.getCreatedId(response);
             try {
-                managedRealm.admin().workflows().workflow(workflow.getId()).bind(ResourceType.USERS.name(), id, Duration.ofDays(5).toMillis());
+                managedRealm.admin().workflows().workflow(workflow.getId()).bind(ResourceType.USERS.name(), id, "5D");
             } catch (Exception e) {
                 assertThat(e, instanceOf(BadRequestException.class));
             }
@@ -131,7 +131,7 @@ public class AdhocWorkflowTest extends AbstractWorkflowTest {
 
         try (Response response = managedRealm.admin().users().create(getUserRepresentation("alice", "Alice", "Wonderland", "alice@wornderland.org"))) {
             id = ApiUtil.getCreatedId(response);
-            managedRealm.admin().workflows().workflow(workflow.getId()).bind(ResourceType.USERS.name(), id, Duration.ofDays(5).toMillis());
+            managedRealm.admin().workflows().workflow(workflow.getId()).bind(ResourceType.USERS.name(), id, "5D");
         }
 
         runScheduledSteps(Duration.ZERO);
@@ -154,7 +154,8 @@ public class AdhocWorkflowTest extends AbstractWorkflowTest {
             }
         }));
 
-        managedRealm.admin().workflows().workflow(workflow.getId()).bind(ResourceType.USERS.name(), id, Duration.ofDays(10).toMillis());
+        // using seconds as the notBefore parameter just to check if this format is also working properly
+        managedRealm.admin().workflows().workflow(workflow.getId()).bind(ResourceType.USERS.name(), id, String.valueOf(Duration.ofDays(10).toSeconds()));
 
         runScheduledSteps(Duration.ZERO);
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/WorkflowManagementTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/model/workflow/WorkflowManagementTest.java
@@ -257,7 +257,7 @@ public class WorkflowManagementTest extends AbstractWorkflowTest {
 
         // revert conditions, but change one of the steps
         workflow.setConditions(null);
-        workflow.getSteps().get(0).setAfter(Duration.ofDays(8).toMillis());
+        workflow.getSteps().get(0).setAfter("8D"); // 8 days
         try (Response response = workflows.workflow(workflow.getId()).update(workflow)) {
             assertThat(response.getStatus(), is(Response.Status.BAD_REQUEST.getStatusCode()));
         }
@@ -638,7 +638,7 @@ public class WorkflowManagementTest extends AbstractWorkflowTest {
                 .build();
         try (Response response = managedRealm.admin().workflows().create(workflows)) {
             assertThat(response.getStatus(), is(Response.Status.BAD_REQUEST.getStatusCode()));
-            assertThat(response.readEntity(ErrorRepresentation.class).getErrorMessage(), equalTo("Step 'after' time condition cannot be negative."));
+            assertThat(response.readEntity(ErrorRepresentation.class).getErrorMessage(), equalTo("Step 'after' configuration cannot be negative."));
         }
     }
 


### PR DESCRIPTION
- aligns the format with what is used in the JPA connection provider pool max lifetime for time-based configurations

Closes #42913

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
