### PR TITLE
Use http for the DockerClientTest to avoid certificate issues (26.2)

### DIFF
--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/ServerURLs.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/util/ServerURLs.java
@@ -21,7 +21,9 @@ import static java.lang.Integer.parseInt;
 
 public class ServerURLs {
     public static final boolean AUTH_SERVER_SSL_REQUIRED = Boolean.parseBoolean(System.getProperty("auth.server.ssl.required", "true"));
-    public static final String AUTH_SERVER_PORT = AUTH_SERVER_SSL_REQUIRED ? System.getProperty("auth.server.https.port", "8543") : System.getProperty("auth.server.http.port", "8180");
+    public static final String AUTH_SERVER_PORT_HTTP = System.getProperty("auth.server.http.port", "8180");
+    public static final String AUTH_SERVER_PORT_HTTPS = System.getProperty("auth.server.https.port", "8543");
+    public static final String AUTH_SERVER_PORT = AUTH_SERVER_SSL_REQUIRED ? AUTH_SERVER_PORT_HTTPS : AUTH_SERVER_PORT_HTTP;
     public static final String AUTH_SERVER_SCHEME = AUTH_SERVER_SSL_REQUIRED ? "https" : "http";
     public static final String AUTH_SERVER_HOST = System.getProperty("auth.server.host", "localhost");
     public static final String AUTH_SERVER_HOST2 = System.getProperty("auth.server.host2", AUTH_SERVER_HOST);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/docker/DockerClientTest.java
@@ -29,8 +29,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assume.assumeTrue;
-import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT;
-import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SCHEME;
+import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_PORT_HTTP;
 import static org.keycloak.testsuite.util.WaitUtils.pause;
 
 @EnableFeature(Profile.Feature.DOCKER)
@@ -105,9 +104,9 @@ public class DockerClientTest extends AbstractKeycloakTest {
 
         final Map<String, String> environment = new HashMap<>();
         environment.put("REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY", "/tmp");
-        environment.put("REGISTRY_AUTH_TOKEN_REALM", AUTH_SERVER_SCHEME + "://" + hostIp + ":" + AUTH_SERVER_PORT + "/auth/realms/" + REALM_ID + "/protocol/docker-v2/auth");
+        environment.put("REGISTRY_AUTH_TOKEN_REALM", "http://" + hostIp + ":" + AUTH_SERVER_PORT_HTTP + "/auth/realms/" + REALM_ID + "/protocol/docker-v2/auth");
         environment.put("REGISTRY_AUTH_TOKEN_SERVICE", CLIENT_ID);
-        environment.put("REGISTRY_AUTH_TOKEN_ISSUER", AUTH_SERVER_SCHEME + "://" + hostIp + ":" + AUTH_SERVER_PORT + "/auth/realms/" + REALM_ID);
+        environment.put("REGISTRY_AUTH_TOKEN_ISSUER", "http://" + hostIp + ":" + AUTH_SERVER_PORT_HTTP + "/auth/realms/" + REALM_ID);
         environment.put("REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE", "/opt/kc-certs/" + tmpCertFile.getCanonicalFile().getName());
         environment.put("INSECURE_REGISTRY", "--insecure-registry " + REGISTRY_HOSTNAME + ":" + REGISTRY_PORT);
 


### PR DESCRIPTION
Closes #44117

PR:             https://github.com/keycloak/keycloak/pull/44126
Commit:         https://github.com/keycloak/keycloak/commit/fb13aa50390ddfb03cce2bd2f798e5547d2c433c
PR branch:      backport-44126-26.2
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.2

