### PR TITLE
Fix logger call to align arguments with format pattern

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -287,7 +287,7 @@ public final class CacheConfigurator {
 
             setMemoryMaxCount(keycloakConfig, name, builder);
             if (builder.memory().maxCount() == -1) {
-                logger.infof("Offline sessions should have a max count set to avoid excessive memory usage. Setting a default cache limit of %d for cache %s.", name, SESSIONS_CACHE_DEFAULT_MAX);
+                logger.infof("Offline sessions should have a max count set to avoid excessive memory usage. Setting a default cache limit of %d for cache %s.", SESSIONS_CACHE_DEFAULT_MAX, name);
                 builder.memory().maxCount(SESSIONS_CACHE_DEFAULT_MAX);
             }
             if (builder.clustering().hash().attributes().attribute(HashConfiguration.NUM_OWNERS).get() != 1 &&


### PR DESCRIPTION
Aligns the arguments to `logger.infof()` with what is expected for the format string.

fixes #44229