### PR TITLE
Fix UserSessionProviderOfflineModelTest#testLoadUserSessionsWithNotDe…

### DIFF
--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
@@ -550,7 +550,7 @@ public class UserSessionPersisterProviderTest extends KeycloakModelTest {
     public void testNoSessions() {
         inComittedTransaction(session -> {
             UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
-            Stream<UserSessionModel> sessions = persister.loadUserSessionsStream(0, 1, true, "00000000-0000-0000-0000-000000000000");
+            Stream<UserSessionModel> sessions = persister.loadUserSessionsStream(0, 1, true, "");
             Assert.assertEquals(0, sessions.count());
         });
     }

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderOfflineModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionProviderOfflineModelTest.java
@@ -326,14 +326,14 @@ public class UserSessionProviderOfflineModelTest extends KeycloakModelTest {
                 if (!MultiSiteUtils.isPersistentSessionsEnabled() && InfinispanUtils.isEmbeddedInfinispan()) {
                     // This does not work with persistent user sessions because we currently have two transactions and the one that creates the offline user sessions is not committing the changes
                     // try to load user session from persister
-                    Assert.assertEquals(2, persister.loadUserSessionsStream(0, 10, true, "00000000-0000-0000-0000-000000000000").count());
+                    Assert.assertEquals(2, persister.loadUserSessionsStream(0, 10, true, "").count());
                 }
             });
 
             if (MultiSiteUtils.isPersistentSessionsEnabled() && InfinispanUtils.isEmbeddedInfinispan()) {
                 inComittedTransaction(session -> {
                     persister = session.getProvider(UserSessionPersisterProvider.class);
-                    Assert.assertEquals(2, persister.loadUserSessionsStream(0, 10, true, "00000000-0000-0000-0000-000000000000").count());
+                    Assert.assertEquals(2, persister.loadUserSessionsStream(0, 10, true, "").count());
                 });
             }
 


### PR DESCRIPTION
…letedOfflineClientSessions

Fixes #43886

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

From the logs below, the session ID starting with `-` is not visible from `UserSessionPersisterProvider.loadUserSessionsStream(0, 10, true, "00000000-0000-0000-0000-000000000000")` because the `-` has a lower ASCII value than `0`. 
```
16:05:17,286 INFO  [org.keycloak.testsuite.model.session.UserSessionProviderOfflineModelTest] (main) Persisted 3 sessions to UserSessionPersisterProvider
16:05:17,290 TRACE [org.keycloak.models.sessions.infinispan.changes.PersistentSessionsChangelogBasedTransaction] (main) Add_if_absent successfully called for entity '-1JPNB6KyBlJRRGtOG2UQVcM' to the cache 'sessions' . Lifespan: 35999710 ms, MaxIdle: 1799710 ms
16:05:17,290 TRACE [org.keycloak.models.sessions.infinispan.changes.PersistentSessionsChangelogBasedTransaction] (main) Add_if_absent successfully called for entity 'X4USEOYYs2JJeKsK63152AHp' to the cache 'offlineSessions' . Lifespan: 5183999710 ms, MaxIdle: 2591999710 ms
16:05:17,290 TRACE [org.keycloak.models.sessions.infinispan.changes.PersistentSessionsChangelogBasedTransaction] (main) Add_if_absent successfully called for entity '-1JPNB6KyBlJRRGtOG2UQVcM' to the cache 'offlineSessions' . Lifespan: 5183999710 ms, MaxIdle: 2591999710 ms
16:05:17,293 TRACE [org.keycloak.models.jpa.session.JpaUserSessionPersisterProvider] (main) Loaded 1 user sessions (offline=1, sessionIds=[X4USEOYYs2JJeKsK63152AHp])
```