### PR TITLE
[OID4VCI] Credential Offer must be created by Issuer not Holder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # Intellij
 ###################
 .idea
+.run
 *.iml
 !.idea/icon.png
 

--- a/core/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/core/src/main/java/org/keycloak/OAuth2Constants.java
@@ -164,7 +164,8 @@ public interface OAuth2Constants {
     String CNF = "cnf";
 
     // RAR - https://datatracker.ietf.org/doc/html/rfc9396
-    String AUTHORIZATION_DETAILS_PARAM = "authorization_details";
+    // Used as url parameter in AuthorizationRequest and as claim in TokenResponse
+    String AUTHORIZATION_DETAILS = "authorization_details";
 
     // DPoP - https://datatracker.ietf.org/doc/html/rfc9449
     String DPOP_HTTP_HEADER = "DPoP";
@@ -173,4 +174,7 @@ public interface OAuth2Constants {
     String DPOP_JWT_HEADER_TYPE = "dpop+jwt";
     String ALGS_ATTRIBUTE = "algs";
 
+    // OID4VCI - https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html
+    String OPENID_CREDENTIAL = "openid_credential";
+    String CREDENTIAL_IDENTIFIERS = "credential_identifiers";
 }

--- a/core/src/main/java/org/keycloak/util/JsonSerialization.java
+++ b/core/src/main/java/org/keycloak/util/JsonSerialization.java
@@ -51,6 +51,22 @@ public class JsonSerialization {
         prettyMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
+    public static String valueAsString(Object obj) {
+        try {
+            return mapper.writeValueAsString(obj);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static <T> T valueFromString(String string, Class<T> type) {
+        try {
+            return mapper.readValue(string, type);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
     public static void writeValueToStream(OutputStream os, Object obj) throws IOException {
         mapper.writeValue(os, obj);
     }

--- a/server-spi-private/src/main/java/org/keycloak/constants/OID4VCIConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/constants/OID4VCIConstants.java
@@ -18,13 +18,15 @@
 
 package org.keycloak.constants;
 
+import org.keycloak.representations.idm.RoleRepresentation;
+
 /**
  * Keycloak specific constants related to OID4VC and related functionality. Useful for example for internal constants (EG. name of Keycloak realm attributes).
  * For protocol constants defined in the specification, see {@link org.keycloak.OID4VCConstants}
  *
  * @author Pascal Knüppel
  */
-public final class Oid4VciConstants {
+public final class OID4VCIConstants {
 
     public static final String OID4VC_PROTOCOL = "oid4vc";
 
@@ -38,6 +40,9 @@ public final class Oid4VciConstants {
     public static final String SOURCE_ENDPOINT = "source_endpoint";
     public static final String BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE = "batch_credential_issuance.batch_size";
 
-    private Oid4VciConstants() {
+    public static final RoleRepresentation CREDENTIAL_OFFER_CREATE =
+            new RoleRepresentation("credential-offer-create", "Allow credential offer creation", false);
+
+    private OID4VCIConstants() {
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -25,14 +25,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 
 import static org.keycloak.OID4VCConstants.SD_JWT_VC_FORMAT;
-import static org.keycloak.constants.Oid4VciConstants.OID4VC_PROTOCOL;
+import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
 
 /**
  * This class acts as delegate for a {@link ClientScopeModel} implementation and adds additional functionality for
@@ -424,7 +424,7 @@ public class CredentialScopeModel implements ClientScopeModel {
 
     public Stream<Oid4vcProtocolMapperModel> getOid4vcProtocolMappersStream() {
         return clientScope.getProtocolMappersStream().filter(pm -> {
-            return Oid4VciConstants.OID4VC_PROTOCOL.equals(pm.getProtocol());
+            return OID4VCIConstants.OID4VC_PROTOCOL.equals(pm.getProtocol());
         }).map(Oid4vcProtocolMapperModel::new);
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -55,7 +55,7 @@ import org.keycloak.common.util.PemUtils;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.deployment.DeployedConfigurationsManager;
 import org.keycloak.models.AccountRoles;
@@ -1241,7 +1241,7 @@ public final class KeycloakModelUtils {
     public static List<String> getAcceptedClientScopeProtocols(ClientModel client) {
         List<String> acceptedClientProtocols;
         if (client.getProtocol() == null || "openid-connect".equals(client.getProtocol())) {
-            acceptedClientProtocols = List.of("openid-connect", Oid4VciConstants.OID4VC_PROTOCOL);
+            acceptedClientProtocols = List.of("openid-connect", OID4VCIConstants.OID4VC_PROTOCOL);
         }else {
             acceptedClientProtocols = List.of(client.getProtocol());
         }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.keycloak.Config;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
@@ -43,7 +43,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 
 import org.jboss.logging.Logger;
 
-import static org.keycloak.constants.Oid4VciConstants.OID4VC_PROTOCOL;
+import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
 import static org.keycloak.models.ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.CONFIGURATION_ID;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.CONTEXTS;
@@ -82,7 +82,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 	private static final String LAST_NAME_MAPPER = "last-name";
 	private static final String FIRST_NAME_MAPPER = "first-name";
 
-	public static final String PROTOCOL_ID = Oid4VciConstants.OID4VC_PROTOCOL;
+	public static final String PROTOCOL_ID = OID4VCIConstants.OID4VC_PROTOCOL;
 
 	private final Map<String, ProtocolMapperModel> builtins = new HashMap<>();
 
@@ -180,6 +180,8 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
     public int order() {
         return OIDCLoginProtocolFactory.UI_ORDER - 20;
     }
+
+    // Private ---------------------------------------------------------------------------------------------------------
 
     private void addClientScopeDefaults(ClientScopeModel clientScope) {
         ClientScopeRepresentation clientScopeRep = ModelToRepresentation.toRepresentation(clientScope);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessorFactory.java
@@ -23,6 +23,8 @@ import org.keycloak.protocol.oid4vc.OID4VCEnvironmentProviderFactory;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorFactory;
 
+import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
+
 /**
  * Factory for creating OID4VCI-specific authorization details processors.
  * This factory is only enabled when the OID4VCI feature is available.
@@ -31,7 +33,7 @@ import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorFactory;
  */
 public class OID4VCAuthorizationDetailsProcessorFactory implements AuthorizationDetailsProcessorFactory, OID4VCEnvironmentProviderFactory {
 
-    public static final String PROVIDER_ID = OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE;
+    public static final String PROVIDER_ID = OPENID_CREDENTIAL;
 
     @Override
     public AuthorizationDetailsProcessor create(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -107,7 +107,6 @@ import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantType;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
-import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.saml.processing.api.util.DeflateUtil;
@@ -694,8 +693,8 @@ public class OID4VCIssuerEndpoint {
 
             // Get the credential_configuration_id from AuthorizationDetails
             //
-            AuthorizationDetailsResponse authDetails = offerState.getAuthorizationDetails();
-            String credConfigId = (String) authDetails.getOtherClaims().get("credential_configuration_id");
+            OID4VCAuthorizationDetailsResponse authDetails = offerState.getAuthorizationDetails();
+            String credConfigId = authDetails.getCredentialConfigurationId();
             if (credConfigId == null) {
                 var errorMessage = "No credential_configuration_id in AuthorizationDetails";
                 throw new BadRequestException(getErrorResponse(UNKNOWN_CREDENTIAL_CONFIGURATION, errorMessage));

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.common.util.Time;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
@@ -64,7 +64,7 @@ import org.jboss.logging.Logger;
 
 import static org.keycloak.OID4VCConstants.SIGNED_METADATA_JWT_TYPE;
 import static org.keycloak.OID4VCConstants.WELL_KNOWN_OPENID_CREDENTIAL_ISSUER;
-import static org.keycloak.constants.Oid4VciConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE;
+import static org.keycloak.constants.OID4VCIConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE;
 import static org.keycloak.crypto.KeyType.RSA;
 import static org.keycloak.jose.jwk.RSAPublicJWK.RS256;
 
@@ -456,7 +456,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
         RealmModel realm = keycloakSession.getContext().getRealm();
         Map<String, SupportedCredentialConfiguration> supportedCredentialConfigurations =
                 keycloakSession.clientScopes()
-                        .getClientScopesByProtocol(realm, Oid4VciConstants.OID4VC_PROTOCOL)
+                        .getClientScopesByProtocol(realm, OID4VCIConstants.OID4VC_PROTOCOL)
                         .map(CredentialScopeModel::new)
                         .map(clientScope -> {
                             return SupportedCredentialConfiguration.parse(keycloakSession,

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -23,7 +23,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.utils.StringUtil;
@@ -71,9 +71,9 @@ public class TimeClaimNormalizer {
     }
 
     public TimeClaimNormalizer(RealmModel realm) {
-        this.strategy = parseStrategy(realm.getAttribute(Oid4VciConstants.TIME_CLAIMS_STRATEGY));
-        this.randomizeWindowSeconds = parseRandomizeWindow(realm.getAttribute(Oid4VciConstants.TIME_RANDOMIZE_WINDOW_SECONDS));
-        this.roundUnit = parseRoundUnit(realm.getAttribute(Oid4VciConstants.TIME_ROUND_UNIT));
+        this.strategy = parseStrategy(realm.getAttribute(OID4VCIConstants.TIME_CLAIMS_STRATEGY));
+        this.randomizeWindowSeconds = parseRandomizeWindow(realm.getAttribute(OID4VCIConstants.TIME_RANDOMIZE_WINDOW_SECONDS));
+        this.roundUnit = parseRoundUnit(realm.getAttribute(OID4VCIConstants.TIME_ROUND_UNIT));
     }
 
     TimeClaimNormalizer(Strategy strategy, Long randomizeWindowSeconds, RoundUnit roundUnit) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
@@ -1,0 +1,119 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+import java.beans.Transient;
+import java.util.Optional;
+
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
+import org.keycloak.protocol.oid4vc.model.PreAuthorizedGrant;
+import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
+import org.keycloak.provider.Provider;
+import org.keycloak.saml.RandomSecret;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public interface CredentialOfferStorage extends Provider {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    class CredentialOfferState {
+
+        private CredentialsOffer credentialsOffer;
+        private String clientId;
+        private String userId;
+        private String nonce;
+        private int expiration;
+        private AuthorizationDetailsResponse authorizationDetails;
+
+        public CredentialOfferState(CredentialsOffer credOffer, String clientId, String userId, int expiration) {
+            this.credentialsOffer = credOffer;
+            this.clientId = clientId;
+            this.userId = userId;
+            this.expiration = expiration;
+            this.nonce = Base64Url.encode(RandomSecret.createRandomSecret(64));
+        }
+
+        // For json serialization
+        CredentialOfferState() {
+        }
+
+        @Transient
+        public Optional<String> getPreAuthorizedCode() {
+            return Optional.ofNullable(credentialsOffer.getGrants())
+                    .map(PreAuthorizedGrant::getPreAuthorizedCode)
+                    .map(PreAuthorizedCode::getPreAuthorizedCode);
+        }
+
+        @Transient
+        public boolean isExpired() {
+            int currentTime = Time.currentTime();
+            return currentTime > expiration;
+        }
+
+        public CredentialsOffer getCredentialsOffer() {
+            return credentialsOffer;
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public String getNonce() {
+            return nonce;
+        }
+
+        public int getExpiration() {
+            return expiration;
+        }
+
+        public AuthorizationDetailsResponse getAuthorizationDetails() {
+            return authorizationDetails;
+        }
+
+        public void setAuthorizationDetails(AuthorizationDetailsResponse authorizationDetails) {
+            this.authorizationDetails = authorizationDetails;
+        }
+
+        void setCredentialsOffer(CredentialsOffer credentialsOffer) {
+            this.credentialsOffer = credentialsOffer;
+        }
+
+        void setClientId(String clientId) {
+            this.clientId = clientId;
+        }
+
+        void setUserId(String userId) {
+            this.userId = userId;
+        }
+
+        void setNonce(String nonce) {
+            this.nonce = nonce;
+        }
+
+        void setExpiration(int expiration) {
+            this.expiration = expiration;
+        }
+    }
+
+    void putOfferState(KeycloakSession session, CredentialOfferState entry);
+
+    CredentialOfferState findOfferStateByNonce(KeycloakSession session, String nonce);
+
+    CredentialOfferState findOfferStateByCode(KeycloakSession session, String code);
+
+    CredentialOfferState findOfferStateByCredentialId(KeycloakSession session, String credId);
+
+    void replaceOfferState(KeycloakSession session, CredentialOfferState entry);
+
+    void removeOfferState(KeycloakSession session, CredentialOfferState entry);
+
+    @Override
+    default void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import java.beans.Transient;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
@@ -22,10 +22,10 @@ import java.util.Optional;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedGrant;
-import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
 import org.keycloak.provider.Provider;
 import org.keycloak.saml.RandomSecret;
 
@@ -41,7 +41,7 @@ public interface CredentialOfferStorage extends Provider {
         private String userId;
         private String nonce;
         private int expiration;
-        private AuthorizationDetailsResponse authorizationDetails;
+        private OID4VCAuthorizationDetailsResponse authorizationDetails;
 
         public CredentialOfferState(CredentialsOffer credOffer, String clientId, String userId, int expiration) {
             this.credentialsOffer = credOffer;
@@ -88,11 +88,11 @@ public interface CredentialOfferStorage extends Provider {
             return expiration;
         }
 
-        public AuthorizationDetailsResponse getAuthorizationDetails() {
+        public OID4VCAuthorizationDetailsResponse getAuthorizationDetails() {
             return authorizationDetails;
         }
 
-        public void setAuthorizationDetails(AuthorizationDetailsResponse authorizationDetails) {
+        public void setAuthorizationDetails(OID4VCAuthorizationDetailsResponse authorizationDetails) {
             this.authorizationDetails = authorizationDetails;
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageFactory.java
@@ -1,0 +1,10 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface CredentialOfferStorageFactory extends ProviderFactory<CredentialOfferStorage> {
+
+    @Override
+    default void close() { }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import org.keycloak.provider.ProviderFactory;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageSpi.java
@@ -1,0 +1,10 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+import org.keycloak.provider.Spi;
+
+public class CredentialOfferStorageSpi implements Spi {
+    @Override public String getName() { return "credential-offer-storage"; }
+    @Override public Class<CredentialOfferStorage> getProviderClass() { return CredentialOfferStorage.class; }
+    @Override public Class<CredentialOfferStorageFactory> getProviderFactoryClass() { return CredentialOfferStorageFactory.class; }
+    @Override public boolean isInternal() { return false; }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorageSpi.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import org.keycloak.provider.Spi;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
@@ -1,0 +1,84 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsResponse;
+import org.keycloak.util.JsonSerialization;
+
+class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
+
+    private static final String ENTRY_KEY = "json";
+
+    @Override
+    public synchronized void putOfferState(KeycloakSession session, CredentialOfferState entry) {
+        var entryJson = JsonSerialization.valueAsString(entry);
+        session.singleUseObjects().put(entry.getNonce(), entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
+        entry.getPreAuthorizedCode().ifPresent(it -> {
+            session.singleUseObjects().put(it, entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
+        });
+        Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
+            ((OID4VCAuthorizationDetailsResponse) it).getCredentialIdentifiers().forEach( cid -> {
+                session.singleUseObjects().put(cid, entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
+            });
+        });
+    }
+
+    @Override
+    public synchronized CredentialOfferState findOfferStateByNonce(KeycloakSession session, String nonce) {
+        if (session.singleUseObjects().contains(nonce)) {
+            var entryJson = session.singleUseObjects().get(nonce).get(ENTRY_KEY);
+            return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized CredentialOfferState findOfferStateByCode(KeycloakSession session, String code) {
+        if (session.singleUseObjects().contains(code)) {
+            var entryJson = session.singleUseObjects().get(code).get(ENTRY_KEY);
+            return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
+        }
+        return null;
+    }
+
+    @Override
+    public CredentialOfferState findOfferStateByCredentialId(KeycloakSession session, String credId) {
+        if (session.singleUseObjects().contains(credId)) {
+            var entryJson = session.singleUseObjects().get(credId).get(ENTRY_KEY);
+            return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
+        }
+        return null;
+    }
+
+    public synchronized void replaceOfferState(KeycloakSession session, CredentialOfferState entry) {
+        var entryJson = JsonSerialization.valueAsString(entry);
+        session.singleUseObjects().replace(entry.getNonce(), Map.of(ENTRY_KEY, entryJson));
+        entry.getPreAuthorizedCode().ifPresent(it -> {
+            session.singleUseObjects().replace(it, Map.of(ENTRY_KEY, entryJson));
+        });
+        Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
+            ((OID4VCAuthorizationDetailsResponse) it).getCredentialIdentifiers().forEach( cid -> {
+                if (session.singleUseObjects().contains(cid)) {
+                    session.singleUseObjects().replace(cid, Map.of(ENTRY_KEY, entryJson));
+                } else {
+                    session.singleUseObjects().put(cid, entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
+                }
+            });
+        });
+    }
+
+    @Override
+    public synchronized void removeOfferState(KeycloakSession session, CredentialOfferState entry) {
+        session.singleUseObjects().remove(entry.getNonce());
+        entry.getPreAuthorizedCode().ifPresent(it -> {
+            session.singleUseObjects().remove(it);
+        });
+        Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
+            ((OID4VCAuthorizationDetailsResponse) it).getCredentialIdentifiers().forEach( cid -> {
+                session.singleUseObjects().remove(cid);
+            });
+        });
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsResponse;
 import org.keycloak.util.JsonSerialization;
 
 class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
@@ -35,7 +34,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
             session.singleUseObjects().put(it, entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
         });
         Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
-            ((OID4VCAuthorizationDetailsResponse) it).getCredentialIdentifiers().forEach( cid -> {
+            it.getCredentialIdentifiers().forEach( cid -> {
                 session.singleUseObjects().put(cid, entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
             });
         });
@@ -75,7 +74,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
             session.singleUseObjects().replace(it, Map.of(ENTRY_KEY, entryJson));
         });
         Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
-            ((OID4VCAuthorizationDetailsResponse) it).getCredentialIdentifiers().forEach( cid -> {
+            it.getCredentialIdentifiers().forEach( cid -> {
                 if (session.singleUseObjects().contains(cid)) {
                     session.singleUseObjects().replace(cid, Map.of(ENTRY_KEY, entryJson));
                 } else {
@@ -92,7 +91,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
             session.singleUseObjects().remove(it);
         });
         Optional.ofNullable(entry.getAuthorizationDetails()).ifPresent(it -> {
-            ((OID4VCAuthorizationDetailsResponse) it).getCredentialIdentifiers().forEach( cid -> {
+            it.getCredentialIdentifiers().forEach( cid -> {
                 session.singleUseObjects().remove(cid);
             });
         });

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
@@ -13,7 +13,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
 
     @Override
     public synchronized void putOfferState(KeycloakSession session, CredentialOfferState entry) {
-        var entryJson = JsonSerialization.valueAsString(entry);
+        String entryJson = JsonSerialization.valueAsString(entry);
         session.singleUseObjects().put(entry.getNonce(), entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
         entry.getPreAuthorizedCode().ifPresent(it -> {
             session.singleUseObjects().put(it, entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
@@ -28,7 +28,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     @Override
     public synchronized CredentialOfferState findOfferStateByNonce(KeycloakSession session, String nonce) {
         if (session.singleUseObjects().contains(nonce)) {
-            var entryJson = session.singleUseObjects().get(nonce).get(ENTRY_KEY);
+            String entryJson = session.singleUseObjects().get(nonce).get(ENTRY_KEY);
             return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
         }
         return null;
@@ -37,7 +37,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     @Override
     public synchronized CredentialOfferState findOfferStateByCode(KeycloakSession session, String code) {
         if (session.singleUseObjects().contains(code)) {
-            var entryJson = session.singleUseObjects().get(code).get(ENTRY_KEY);
+            String entryJson = session.singleUseObjects().get(code).get(ENTRY_KEY);
             return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
         }
         return null;
@@ -46,14 +46,14 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     @Override
     public CredentialOfferState findOfferStateByCredentialId(KeycloakSession session, String credId) {
         if (session.singleUseObjects().contains(credId)) {
-            var entryJson = session.singleUseObjects().get(credId).get(ENTRY_KEY);
+            String entryJson = session.singleUseObjects().get(credId).get(ENTRY_KEY);
             return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
         }
         return null;
     }
 
     public synchronized void replaceOfferState(KeycloakSession session, CredentialOfferState entry) {
-        var entryJson = JsonSerialization.valueAsString(entry);
+        String entryJson = JsonSerialization.valueAsString(entry);
         session.singleUseObjects().replace(entry.getNonce(), Map.of(ENTRY_KEY, entryJson));
         entry.getPreAuthorizedCode().ifPresent(it -> {
             session.singleUseObjects().replace(it, Map.of(ENTRY_KEY, entryJson));

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import java.util.Map;
@@ -12,7 +28,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     private static final String ENTRY_KEY = "json";
 
     @Override
-    public synchronized void putOfferState(KeycloakSession session, CredentialOfferState entry) {
+    public void putOfferState(KeycloakSession session, CredentialOfferState entry) {
         String entryJson = JsonSerialization.valueAsString(entry);
         session.singleUseObjects().put(entry.getNonce(), entry.getExpiration(), Map.of(ENTRY_KEY, entryJson));
         entry.getPreAuthorizedCode().ifPresent(it -> {
@@ -26,7 +42,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     }
 
     @Override
-    public synchronized CredentialOfferState findOfferStateByNonce(KeycloakSession session, String nonce) {
+    public CredentialOfferState findOfferStateByNonce(KeycloakSession session, String nonce) {
         if (session.singleUseObjects().contains(nonce)) {
             String entryJson = session.singleUseObjects().get(nonce).get(ENTRY_KEY);
             return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
@@ -35,7 +51,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     }
 
     @Override
-    public synchronized CredentialOfferState findOfferStateByCode(KeycloakSession session, String code) {
+    public CredentialOfferState findOfferStateByCode(KeycloakSession session, String code) {
         if (session.singleUseObjects().contains(code)) {
             String entryJson = session.singleUseObjects().get(code).get(ENTRY_KEY);
             return JsonSerialization.valueFromString(entryJson, CredentialOfferState.class);
@@ -52,7 +68,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
         return null;
     }
 
-    public synchronized void replaceOfferState(KeycloakSession session, CredentialOfferState entry) {
+    public void replaceOfferState(KeycloakSession session, CredentialOfferState entry) {
         String entryJson = JsonSerialization.valueAsString(entry);
         session.singleUseObjects().replace(entry.getNonce(), Map.of(ENTRY_KEY, entryJson));
         entry.getPreAuthorizedCode().ifPresent(it -> {
@@ -70,7 +86,7 @@ class InMemoryCredentialOfferStorage implements CredentialOfferStorage {
     }
 
     @Override
-    public synchronized void removeOfferState(KeycloakSession session, CredentialOfferState entry) {
+    public void removeOfferState(KeycloakSession session, CredentialOfferState entry) {
         session.singleUseObjects().remove(entry.getNonce());
         entry.getPreAuthorizedCode().ifPresent(it -> {
             session.singleUseObjects().remove(it);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorageFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorageFactory.java
@@ -1,0 +1,31 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class InMemoryCredentialOfferStorageFactory implements CredentialOfferStorageFactory {
+
+    private static CredentialOfferStorage INSTANCE;
+
+    @Override
+    public CredentialOfferStorage create(KeycloakSession session) {
+        if (INSTANCE==null) {
+            INSTANCE = new InMemoryCredentialOfferStorage();
+        }
+        return INSTANCE;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public String getId() {
+        return "in_memory";
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorageFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/InMemoryCredentialOfferStorageFactory.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
 import org.keycloak.Config;
@@ -10,7 +26,7 @@ public class InMemoryCredentialOfferStorageFactory implements CredentialOfferSto
 
     @Override
     public CredentialOfferStorage create(KeycloakSession session) {
-        if (INSTANCE==null) {
+        if (INSTANCE == null) {
             INSTANCE = new InMemoryCredentialOfferStorage();
         }
         return INSTANCE;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -34,7 +34,7 @@ import jakarta.annotation.Nullable;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  */
 public class JwtCNonceHandler implements CNonceHandler {
 
-    public static final String SOURCE_ENDPOINT = Oid4VciConstants.SOURCE_ENDPOINT;
+    public static final String SOURCE_ENDPOINT = OID4VCIConstants.SOURCE_ENDPOINT;
 
     public static final int NONCE_DEFAULT_LENGTH = 50;
 
@@ -80,7 +80,7 @@ public class JwtCNonceHandler implements CNonceHandler {
         RealmModel realm = keycloakSession.getContext().getRealm();
         final String issuer = OID4VCIssuerWellKnownProvider.getIssuer(keycloakSession.getContext());
         // TODO discussion about the attribute name to use
-        final Integer nonceLifetimeMillis = realm.getAttribute(Oid4VciConstants.C_NONCE_LIFETIME_IN_SECONDS, 60);
+        final Integer nonceLifetimeMillis = realm.getAttribute(OID4VCIConstants.C_NONCE_LIFETIME_IN_SECONDS, 60);
         audiences = Optional.ofNullable(audiences).orElseGet(Collections::emptyList);
         final Instant now = Instant.now();
         final long expiresAt = now.plus(nonceLifetimeMillis, ChronoUnit.SECONDS).getEpochSecond();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/ErrorType.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/ErrorType.java
@@ -26,6 +26,7 @@ package org.keycloak.protocol.oid4vc.model;
  */
 public enum ErrorType {
 
+    INVALID_CREDENTIAL_OFFER_REQUEST("invalid_credential_offer_request"),
     INVALID_CREDENTIAL_REQUEST("invalid_credential_request"),
     INVALID_TOKEN("invalid_token"),
     UNKNOWN_CREDENTIAL_CONFIGURATION("unknown_credential_configuration"),

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -160,7 +160,7 @@ public class SupportedCredentialConfiguration {
         return null;
     }
 
-    public CredentialConfigId deriveConfiId() {
+    public CredentialConfigId deriveConfigId() {
         return CredentialConfigId.from(id);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -386,9 +386,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             }
 
             // Store authorization_details from authorization/PAR request for later processing
-            String authorizationDetails = request.getAdditionalReqParams().get(OAuth2Constants.AUTHORIZATION_DETAILS_PARAM);
+            String authorizationDetails = request.getAdditionalReqParams().get(OAuth2Constants.AUTHORIZATION_DETAILS);
             if (authorizationDetails != null) {
-                authenticationSession.setClientNote(OAuth2Constants.AUTHORIZATION_DETAILS_PARAM, authorizationDetails);
+                authenticationSession.setClientNote(OAuth2Constants.AUTHORIZATION_DETAILS, authorizationDetails);
             }
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -51,7 +51,7 @@ import org.keycloak.services.util.DefaultClientSessionContext;
 
 import org.jboss.logging.Logger;
 
-import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS_PARAM;
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 import static org.keycloak.models.Constants.AUTHORIZATION_DETAILS_RESPONSE;
 
 /**
@@ -217,12 +217,12 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
 
         // Process authorization_details using provider discovery (if present in request)
         List<AuthorizationDetailsResponse> authorizationDetailsResponse = null;
-        if (formParams.getFirst(AUTHORIZATION_DETAILS_PARAM) != null) {
+        if (formParams.getFirst(AUTHORIZATION_DETAILS) != null) {
             authorizationDetailsResponse = processAuthorizationDetails(userSession, clientSessionCtx);
             if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
                 clientSessionCtx.setAttribute(AUTHORIZATION_DETAILS_RESPONSE, authorizationDetailsResponse);
             } else {
-                logger.debugf("No available AuthorizationDetailsProcessor being able to process authorization_details '%s'", formParams.getFirst(AUTHORIZATION_DETAILS_PARAM));
+                logger.debugf("No available AuthorizationDetailsProcessor being able to process authorization_details '%s'", formParams.getFirst(AUTHORIZATION_DETAILS));
             }
         }
 
@@ -251,7 +251,7 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
     protected void addCustomTokenResponseClaims(AccessTokenResponse res, ClientSessionContext clientSessionCtx) {
         List<AuthorizationDetailsResponse> authDetailsResponse = clientSessionCtx.getAttribute(AUTHORIZATION_DETAILS_RESPONSE, List.class);
         if (authDetailsResponse != null && !authDetailsResponse.isEmpty()) {
-            res.setOtherClaims(AUTHORIZATION_DETAILS_PARAM, authDetailsResponse);
+            res.setOtherClaims(AUTHORIZATION_DETAILS, authDetailsResponse);
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -44,7 +44,7 @@ import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import org.jboss.logging.Logger;
 
-import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS_PARAM;
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 
 /**
  * OAuth 2.0 Client Credentials Grant
@@ -160,9 +160,9 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
      * until RAR is fully implemented.
      */
     private void setAuthorizationDetailsNoteIfIncluded(AuthenticationSessionModel authSession) {
-        String authorizationDetails = formParams.getFirst(AUTHORIZATION_DETAILS_PARAM);
+        String authorizationDetails = formParams.getFirst(AUTHORIZATION_DETAILS);
         if (authorizationDetails != null) {
-            authSession.setClientNote(AUTHORIZATION_DETAILS_PARAM, authorizationDetails);
+            authSession.setClientNote(AUTHORIZATION_DETAILS, authorizationDetails);
         }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -67,7 +67,7 @@ import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
 
-import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS_PARAM;
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 
 /**
  * Base class for OAuth 2.0 grant types
@@ -278,7 +278,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
      * @return the authorization details response if processing was successful, null otherwise
      */
     protected List<AuthorizationDetailsResponse> processAuthorizationDetails(UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
-        String authorizationDetailsParam = formParams.getFirst(AUTHORIZATION_DETAILS_PARAM);
+        String authorizationDetailsParam = formParams.getFirst(AUTHORIZATION_DETAILS);
         if (authorizationDetailsParam != null) {
             try {
                 return session.getKeycloakSessionFactory()
@@ -312,7 +312,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
      */
     protected List<AuthorizationDetailsResponse> handleMissingAuthorizationDetails(UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
         try {
-            return session.getKeycloakSessionFactory()
+            var result = session.getKeycloakSessionFactory()
                     .getProviderFactoriesStream(AuthorizationDetailsProcessor.class)
                     .sorted((f1, f2) -> f2.order() - f1.order())
                     .map(f -> session.getProvider(AuthorizationDetailsProcessor.class, f.getId()))
@@ -320,6 +320,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
                     .filter(authzDetailsResponse -> authzDetailsResponse != null)
                     .findFirst()
                     .orElse(null);
+            return result;
         } catch (RuntimeException e) {
             logger.warnf(e, "Error when handling missing authorization_details");
             return null;
@@ -337,7 +338,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
      */
     protected List<AuthorizationDetailsResponse> processStoredAuthorizationDetails(UserSessionModel userSession, ClientSessionContext clientSessionCtx) throws CorsErrorResponseException {
         // Check if authorization_details was stored during authorization request (e.g., from PAR)
-        String storedAuthDetails = clientSessionCtx.getClientSession().getNote(AUTHORIZATION_DETAILS_PARAM);
+        String storedAuthDetails = clientSessionCtx.getClientSession().getNote(AUTHORIZATION_DETAILS);
         if (storedAuthDetails != null) {
             logger.debugf("Found authorization_details in client session, processing it");
             try {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -31,6 +31,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsResponse;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -165,7 +166,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
             }
 
-            var authorizationDetails = authorizationDetailsResponses.get(0);
+            var authorizationDetails = (OID4VCAuthorizationDetailsResponse) authorizationDetailsResponses.get(0);
             offerState.setAuthorizationDetails(authorizationDetails);
             offerStorage.replaceOfferState(session, offerState);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -87,7 +87,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         var appUserId = offerState.getUserId();
         var userModel = session.users().getUserByUsername(realm, appUserId);
-        if (userModel == null ) {
+        if (userModel == null) {
             var errorMessage = "No user model for: " + appUserId;
             event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
@@ -96,7 +96,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         var appClientId = offerState.getClientId();
         ClientModel clientModel = realm.getClientByClientId(appClientId);
-        if (clientModel == null ) {
+        if (clientModel == null) {
             var errorMessage = "No client model for: " + appClientId;
             event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -18,33 +18,34 @@
 package org.keycloak.protocol.oidc.grants;
 
 import java.util.List;
-import java.util.UUID;
 
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
-import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.TokenManager.AccessTokenResponseBuilder;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
-import org.keycloak.protocol.oidc.utils.OAuth2Code;
-import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.util.DefaultClientSessionContext;
+import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.MediaType;
 
 import org.jboss.logging.Logger;
 
-import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS_PARAM;
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
+import static org.keycloak.services.util.DefaultClientSessionContext.fromClientSessionAndScopeParameter;
 
 public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
@@ -63,70 +64,112 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         if (code == null) {
             // See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-token-request
             String errorMessage = "Missing parameter: " + PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM;
-            event.detail(Details.REASON, errorMessage);
-            event.error(Errors.INVALID_CODE);
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
                     errorMessage, Response.Status.BAD_REQUEST);
         }
-        OAuth2CodeParser.ParseResult result = OAuth2CodeParser.parseCode(session, code, realm, event);
-        if (result.isIllegalCode()) {
-            event.error(Errors.INVALID_CODE);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Code not valid",
-                    Response.Status.BAD_REQUEST);
+
+        var offerStorage = session.getProvider(CredentialOfferStorage.class);
+        var offerState = offerStorage.findOfferStateByCode(session, code);
+        if (offerState == null) {
+            var errorMessage = "No credential offer state for code: " + code;
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                    errorMessage, Response.Status.BAD_REQUEST);
         }
-        if (result.isExpiredCode()) {
+
+        if (offerState.isExpired()) {
             event.error(Errors.EXPIRED_CODE);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT, "Code is expired",
-                    Response.Status.BAD_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    "Code is expired", Response.Status.BAD_REQUEST);
         }
-        AuthenticatedClientSessionModel clientSession = result.getClientSession();
-        ClientSessionContext sessionContext = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession,
-                OAuth2Constants.SCOPE_OPENID, session);
+        var credOffer = offerState.getCredentialsOffer();
+
+        var appUserId = offerState.getUserId();
+        var userModel = session.users().getUserByUsername(realm, appUserId);
+        if (userModel == null ) {
+            var errorMessage = "No user model for: " + appUserId;
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        var appClientId = offerState.getClientId();
+        ClientModel clientModel = realm.getClientByClientId(appClientId);
+        if (clientModel == null ) {
+            var errorMessage = "No client model for: " + appClientId;
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        UserSessionModel userSession = session.sessions().createUserSession(null, realm, userModel, userModel.getUsername(),
+                null, "pre-authorized-code", false, null,
+                null, UserSessionModel.SessionPersistenceState.PERSISTENT);
+
+        AuthenticatedClientSessionModel clientSession = session.sessions().createClientSession(realm, clientModel, userSession);
+        String credentialConfigurationIds = JsonSerialization.valueAsString(credOffer.getCredentialConfigurationIds());
+        clientSession.setNote(OID4VCIssuerEndpoint.CREDENTIAL_CONFIGURATION_IDS_NOTE, credentialConfigurationIds);
+        clientSession.setNote(OIDCLoginProtocol.ISSUER, credOffer.getCredentialIssuer());
         clientSession.setNote(VC_ISSUANCE_FLOW, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE);
+
+        ClientSessionContext sessionContext = fromClientSessionAndScopeParameter(clientSession, OAuth2Constants.SCOPE_OPENID, session);
         sessionContext.setAttribute(Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE);
 
         // set the client as retrieved from the pre-authorized session
-        session.getContext().setClient(result.getClientSession().getClient());
+        session.getContext().setClient(clientModel);
+
+        // Process authorization_details using provider discovery
+        List<AuthorizationDetailsResponse> authorizationDetailsResponses = processAuthorizationDetails(userSession, sessionContext);
+        LOGGER.infof("Initial authorization_details processing result: %s", authorizationDetailsResponses);
+
+        // If no authorization_details were processed from the request, try to generate them from credential offer
+        if (authorizationDetailsResponses == null || authorizationDetailsResponses.isEmpty()) {
+            authorizationDetailsResponses = handleMissingAuthorizationDetails(userSession, sessionContext);
+        }
 
         AccessToken accessToken = tokenManager.createClientAccessToken(session,
                 clientSession.getRealm(),
                 clientSession.getClient(),
-                clientSession.getUserSession().getUser(),
-                clientSession.getUserSession(),
+                userSession.getUser(),
+                userSession,
                 sessionContext);
 
-        TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(
+        AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(
                 clientSession.getRealm(),
                 clientSession.getClient(),
                 event,
                 session,
-                clientSession.getUserSession(),
+                userSession,
                 sessionContext).accessToken(accessToken);
-
-        // Process authorization_details using provider discovery
-        List<AuthorizationDetailsResponse> authorizationDetailsResponse = processAuthorizationDetails(clientSession.getUserSession(), sessionContext);
-        LOGGER.infof("Initial authorization_details processing result: %s", authorizationDetailsResponse);
-
-        // If no authorization_details were processed from the request, try to generate them from credential offer
-        if (authorizationDetailsResponse == null || authorizationDetailsResponse.isEmpty()) {
-            authorizationDetailsResponse = handleMissingAuthorizationDetails(clientSession.getUserSession(), sessionContext);
-        }
 
         AccessTokenResponse tokenResponse;
         try {
             tokenResponse = responseBuilder.build();
         } catch (RuntimeException re) {
-            if ("cannot get encryption KEK".equals(re.getMessage())) {
-                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
-                        "cannot get encryption KEK", Response.Status.BAD_REQUEST);
+            String errorMessage = "cannot get encryption KEK";
+            if (errorMessage.equals(re.getMessage())) {
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, errorMessage, Response.Status.BAD_REQUEST);
             } else {
                 throw re;
             }
         }
 
-        // If authorization_details is present, add it to otherClaims
-        if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
-            tokenResponse.setOtherClaims(AUTHORIZATION_DETAILS_PARAM, authorizationDetailsResponse);
+        // If authorization_details is present, add it was added to otherClaims
+        if (authorizationDetailsResponses != null && !authorizationDetailsResponses.isEmpty()) {
+            if (authorizationDetailsResponses.size() > 1) {
+                String errorMessage = "Multiple authorization details are not supported";
+                event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                        errorMessage, Response.Status.BAD_REQUEST);
+
+            }
+
+            var authorizationDetails = authorizationDetailsResponses.get(0);
+            offerState.setAuthorizationDetails(authorizationDetails);
+            offerStorage.replaceOfferState(session, offerState);
+
+            tokenResponse.setOtherClaims(AUTHORIZATION_DETAILS, authorizationDetailsResponses);
         }
 
         event.success();
@@ -136,21 +179,5 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.CODE_TO_TOKEN;
-    }
-
-    /**
-     * Create a pre-authorized Code for the given client session.
-     *
-     * @param session                    - keycloak session to be used
-     * @param authenticatedClientSession - client session to be persisted
-     * @param expirationTime             - expiration time of the code, the code should be short-lived
-     * @return the pre-authorized code
-     */
-    public static String getPreAuthorizedCode(KeycloakSession session, AuthenticatedClientSessionModel authenticatedClientSession, int expirationTime) {
-        String codeId = UUID.randomUUID().toString();
-        String nonce = SecretGenerator.getInstance().randomString();
-        OAuth2Code oAuth2Code = new OAuth2Code(codeId, expirationTime, nonce, null, null, null, null, null,
-                authenticatedClientSession.getUserSession().getId());
-        return OAuth2CodeParser.persistCode(session, authenticatedClientSession, oAuth2Code);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2Code.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2Code.java
@@ -22,9 +22,9 @@ import java.util.Map;
 
 /**
  * Data associated with the oauth2 code.
- *
+ * <p>
  * Those data are typically valid just for the very short time - they're created at the point before we redirect to the application
- * after successful and they're removed when application sends requests to the token endpoint (code-to-token endpoint) to exchange the
+ * and removed when application sends requests to the token endpoint (code-to-token endpoint) to exchange the
  * single-use OAuth2 code parameter for those data.
  *
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -59,6 +59,18 @@ public class OAuth2Code {
     private final String userSessionId;
 
 
+    public OAuth2Code(String id, int expiration, String nonce, String scope, String userSessionId) {
+        this.id = id;
+        this.expiration = expiration;
+        this.nonce = nonce;
+        this.scope = scope;
+        this.redirectUriParam = null;
+        this.codeChallenge = null;
+        this.codeChallengeMethod = null;
+        this.dpopJkt = null;
+        this.userSessionId = userSessionId;
+    }
+
     public OAuth2Code(String id, int expiration, String nonce, String scope, String redirectUriParam,
                       String codeChallenge, String codeChallengeMethod, String dpopJkt, String userSessionId) {
         this.id = id;
@@ -85,7 +97,7 @@ public class OAuth2Code {
     }
 
 
-    public static final OAuth2Code deserializeCode(Map<String, String> data) {
+    public static OAuth2Code deserializeCode(Map<String, String> data) {
         return new OAuth2Code(data);
     }
 
@@ -93,7 +105,7 @@ public class OAuth2Code {
     public Map<String, String> serializeCode() {
         Map<String, String> result = new HashMap<>();
 
-        result.put(ID_NOTE, id.toString());
+        result.put(ID_NOTE, id);
         result.put(EXPIRATION_NOTE, String.valueOf(expiration));
         result.put(NONCE_NOTE, nonce);
         result.put(SCOPE_NOTE, scope);
@@ -105,7 +117,6 @@ public class OAuth2Code {
 
         return result;
     }
-
 
     public String getId() {
         return id;

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2CodeParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OAuth2CodeParser.java
@@ -40,13 +40,9 @@ public class OAuth2CodeParser {
 
     private static final Pattern DOT = Pattern.compile("\\.");
 
-
     /**
      * Will persist the code to the cache and return the object with the codeData and code correctly set
      *
-     * @param session
-     * @param clientSession
-     * @param codeData
      * @return code parameter to be used in OAuth2 handshake
      */
     public static String persistCode(KeycloakSession session, AuthenticatedClientSessionModel clientSession, OAuth2Code codeData) {
@@ -67,12 +63,6 @@ public class OAuth2CodeParser {
      * Will parse the code and retrieve the corresponding OAuth2Code and AuthenticatedClientSessionModel. Will also check if code wasn't already
      * used and if it wasn't expired. If it was already used (or other error happened during parsing), then returned parser will have "isIllegalCode"
      * set to true. If it was expired, the parser will have "isExpired" set to true
-     *
-     * @param session
-     * @param code
-     * @param realm
-     * @param event
-     * @return
      */
     public static ParseResult parseCode(KeycloakSession session, String code, RealmModel realm, EventBuilder event) {
         ParseResult result = new ParseResult(code);
@@ -180,5 +170,4 @@ public class OAuth2CodeParser {
             return this;
         }
     }
-
 }

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -77,6 +77,8 @@ import org.keycloak.utils.ReservedCharValidator;
 import org.keycloak.utils.SMTPUtil;
 import org.keycloak.utils.StringUtil;
 
+import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
+
 /**
  * Per request object
  *
@@ -97,7 +99,7 @@ public class RealmManager {
         return session;
     }
 
-    public RealmModel getKeycloakAdminstrationRealm() {
+    public RealmModel getKeycloakAdministrationRealm() {
         return getRealmByName(Config.getAdminRealm());
     }
 
@@ -246,7 +248,6 @@ public class RealmManager {
         viewUsers.addCompositeRole(queryGroups);
     }
 
-
     public String getRealmAdminClientId(RealmModel realm) {
         return Constants.REALM_MANAGEMENT_CLIENT_ID;
     }
@@ -254,8 +255,6 @@ public class RealmManager {
     public String getRealmAdminClientId(RealmRepresentation realm) {
         return Constants.REALM_MANAGEMENT_CLIENT_ID;
     }
-
-
 
     protected void setupRealmDefaults(RealmModel realm) {
         realm.setBrowserSecurityHeaders(BrowserSecurityHeaders.realmDefaultHeaders);
@@ -275,6 +274,13 @@ public class RealmManager {
         realm.setOTPPolicy(OTPPolicy.DEFAULT_POLICY);
         realm.setLoginWithEmailAllowed(true);
 
+        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI)) {
+            if (realm.getRole(CREDENTIAL_OFFER_CREATE.getName()) == null) {
+                RoleModel roleModel = realm.addRole(CREDENTIAL_OFFER_CREATE.getName());
+                roleModel.setDescription(CREDENTIAL_OFFER_CREATE.getDescription());
+            }
+        }
+
         realm.setEventsListeners(Collections.singleton("jboss-logging"));
     }
 
@@ -284,7 +290,7 @@ public class RealmManager {
         boolean removed = model.removeRealm(realm.getId());
         if (removed) {
             if (masterAdminClient != null) {
-                session.clients().removeClient(getKeycloakAdminstrationRealm(), masterAdminClient.getId());
+                session.clients().removeClient(getKeycloakAdministrationRealm(), masterAdminClient.getId());
             }
 
             UserSessionProvider sessions = session.sessions();

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -326,7 +326,7 @@ public class AdminConsole {
     }
 
     protected RealmModel getAdminstrationRealm(RealmManager realmManager) {
-        return realmManager.getKeycloakAdminstrationRealm();
+        return realmManager.getKeycloakAdministrationRealm();
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -97,7 +97,7 @@ public class AdminRoot {
     public Response masterRealmAdminConsoleRedirect() {
         KeycloakUriInfo adminUriInfo = session.getContext().getUri(UrlType.ADMIN);
         if (shouldRedirect(adminUriInfo)) {
-            RealmModel master = new RealmManager(session).getKeycloakAdminstrationRealm();
+            RealmModel master = new RealmManager(session).getKeycloakAdministrationRealm();
             return Response.status(302).location(
                     adminUriInfo.getBaseUriBuilder().path(AdminRoot.class).path(AdminRoot.class, "getAdminConsole").path("/").build(master.getName())
             ).build();

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageFactory
@@ -1,0 +1,1 @@
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.InMemoryCredentialOfferStorageFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -32,6 +32,7 @@ org.keycloak.protocol.oidc.rar.AuthorizationRequestParserSpi
 org.keycloak.services.resources.admin.ext.AdminRealmResourceSpi
 org.keycloak.theme.freemarker.FreeMarkerSPI
 org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderSpi
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorSpi
 org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandlerSpi

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTestOid4Vci.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTestOid4Vci.java
@@ -25,7 +25,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.Profile;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -48,7 +48,7 @@ public class ClientScopeTestOid4Vci extends AbstractClientScopeTest {
         ClientScopeRepresentation clientScope = new ClientScopeRepresentation();
         clientScope.setName("test-client-scope");
         clientScope.setDescription("test-client-scope-description");
-        clientScope.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+        clientScope.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
         clientScope.setAttributes(Map.of("test-attribute", "test-value"));
 
         String clientScopeId = null;

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenRequest.java
@@ -1,8 +1,11 @@
 package org.keycloak.testsuite.util.oauth;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
+import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -37,6 +40,11 @@ public class AccessTokenRequest extends AbstractHttpPostRequest<AccessTokenReque
 
     public AccessTokenRequest codeVerifier(String codeVerifier) {
         parameter(OAuth2Constants.CODE_VERIFIER, codeVerifier);
+        return this;
+    }
+
+    public AccessTokenRequest authorizationDetails(List<AuthorizationDetail> authDetails) {
+        parameter(OAuth2Constants.AUTHORIZATION_DETAILS, JsonSerialization.valueAsString(authDetails));
         return this;
     }
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenResponse.java
@@ -1,10 +1,14 @@
 package org.keycloak.testsuite.util.oauth;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
+import org.keycloak.util.JsonSerialization;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 
@@ -19,6 +23,7 @@ public class AccessTokenResponse extends AbstractHttpResponse {
     private String refreshToken;
     private String scope;
     private String sessionState;
+    private List<AuthorizationDetail> authorizationDetails;
 
     private Map<String, Object> otherClaims;
 
@@ -60,6 +65,11 @@ public class AccessTokenResponse extends AbstractHttpResponse {
                     break;
                 case OAuth2Constants.REFRESH_TOKEN:
                     refreshToken = (String) entry.getValue();
+                    break;
+                case OAuth2Constants.AUTHORIZATION_DETAILS:
+                    var valJson = JsonSerialization.valueAsString(entry.getValue());
+                    var arr = JsonSerialization.valueFromString(valJson, AuthorizationDetail[].class);
+                    authorizationDetails = Arrays.asList(arr);
                     break;
                 default:
                     otherClaims.put(entry.getKey(), entry.getValue());
@@ -108,4 +118,7 @@ public class AccessTokenResponse extends AbstractHttpResponse {
         return otherClaims;
     }
 
+    public List<AuthorizationDetail> getAuthorizationDetails() {
+        return authorizationDetails;
+    }
 }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/forms/PassThroughClientAuthenticator.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/forms/PassThroughClientAuthenticator.java
@@ -38,7 +38,9 @@ import org.keycloak.provider.ProviderConfigProperty;
 public class PassThroughClientAuthenticator extends AbstractClientAuthenticator {
 
     public static final String PROVIDER_ID = "testsuite-client-passthrough";
+
     public static String clientId = "test-app";
+    public static String namedClientId = "named-test-app";
 
     // If this parameter is present in the HTTP request, the error will be thrown during authentication
     public static final String TEST_ERROR_PARAM = "test_error_param";

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -1130,7 +1130,7 @@ public class TestingResourceProvider implements RealmResourceProvider {
         String code = "urn:oid4vci:code:" + UUID.randomUUID();
         CredentialsOffer credOffer = new CredentialsOffer()
                 .setCredentialIssuer(OID4VCIssuerWellKnownProvider.getIssuer(session.getContext()))
-                .setCredentialConfigurationIds(List.of("dummy-credential-config-id"))
+                .setCredentialConfigurationIds(List.of("oid4vc_natural_person"))
                 .setGrants(new PreAuthorizedGrant().setPreAuthorizedCode(
                     new PreAuthorizedCode().setPreAuthorizedCode(code)));
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -94,6 +94,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>compile</scope>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -94,11 +94,6 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>compile</scope>

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestingResource.java
@@ -457,7 +457,7 @@ public interface TestingResource {
      * @param events The events to be included
      */
     @POST
-    @Path("/email-event-litener-provide/add-events")
+    @Path("/email-event-listener-provide/add-events")
     @Consumes(MediaType.APPLICATION_JSON)
     public void addEventsToEmailEventListenerProvider(List<EventType> events);
 
@@ -466,7 +466,7 @@ public interface TestingResource {
      * @param events The events to be removed
      */
     @POST
-    @Path("/email-event-litener-provide/remove-events")
+    @Path("/email-event-listener-provide/remove-events")
     @Consumes(MediaType.APPLICATION_JSON)
     public void removeEventsToEmailEventListenerProvider(List<EventType> events);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
@@ -65,7 +65,6 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
         AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
 
         assertEquals("An access token should have successfully been returned.", HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
-        assertEquals("The correct session should have been used for the pre-authorized code.", userSessionId, accessTokenResponse.getSessionState());
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParEndpointTest.java
@@ -27,7 +27,7 @@ import org.keycloak.protocol.oidc.par.endpoints.ParEndpoint;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS_PARAM;
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 
 public class ParEndpointTest {
 
@@ -35,12 +35,12 @@ public class ParEndpointTest {
     public void testFlattenDecodedFormParametersRetainAuthorizationDetails() {
         var decodedFormParameters = new MultivaluedHashMap<String, String>();
         String authorizationDetails = "[{\"type\": \"urn:openfinanceuae:account-access-consent:v1.0\",\"foo\":\"bar\"},{\"type\": \"urn:openfinanceuae:account-access-consent:v1.0\",\"gugu\":\"gaga\"}]";
-        decodedFormParameters.put(AUTHORIZATION_DETAILS_PARAM, List.of(authorizationDetails));
+        decodedFormParameters.put(AUTHORIZATION_DETAILS, List.of(authorizationDetails));
         var params = new HashMap<String, String>();
 
         ParEndpoint.flattenDecodedFormParametersToParamsMap(decodedFormParameters, params);
 
-        Assert.assertEquals(authorizationDetails, params.get(AUTHORIZATION_DETAILS_PARAM));
+        Assert.assertEquals(authorizationDetails, params.get(AUTHORIZATION_DETAILS));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/OID4VCICredentialOfferMatrixTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/OID4VCICredentialOfferMatrixTest.java
@@ -1,0 +1,459 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.oid4vc.issuance;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.HttpHeaders;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.TokenVerifier;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
+import org.keycloak.protocol.oid4vc.model.CredentialRequest;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.testsuite.oid4vc.issuance.signing.OID4VCIssuerEndpointTest;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.util.JsonSerialization;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.directory.api.util.Strings;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
+
+import static org.keycloak.OAuth2Constants.CREDENTIAL_IDENTIFIERS;
+import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
+import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
+import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST;
+import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsernameId;
+import static org.keycloak.testsuite.forms.PassThroughClientAuthenticator.clientId;
+import static org.keycloak.testsuite.forms.PassThroughClientAuthenticator.namedClientId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+
+/**
+ * Credential Offer Validity Matrix
+ * <p>
+ * +----------+-----------+---------+---------+------------------------------------------------------+
+ * | pre-auth | clientId  | userId  | Valid   | Notes                                                |
+ * +----------+-----------+---------+---------+------------------------------------------------------+
+ * | no       | no        | no      | yes     | Generic offer; any logged-in user may redeem.        |
+ * | no       | no        | yes     | yes     | Offer restricted to a specific user.                 |
+ * | no       | yes       | no      | yes     | Bound to client; user determined at login.           |
+ * | no       | yes       | yes     | yes     | Bound to both client and user.                       |
+ * +----------+-----------+---------+---------+------------------------------------------------------+
+ * | yes      | no        | no      | no      | Pre-auth requires a user subject; missing userId.    |
+ * | yes      | no        | yes     | yes     | Pre-auth for a specific user; client issuer defined. |
+ * | yes      | yes       | no      | no      | Same as above; userId required.                      |
+ * | yes      | yes       | yes     | yes     | Fully constrained: user + client.                    |
+ * +----------+-----------+---------+---------+------------------------------------------------------+
+ */
+public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
+
+    String issUserId = "john";
+    String issClientId = clientId;
+
+    String namedUserId = "alice";
+
+    String credScopeName = jwtTypeCredentialScopeName;
+    String credConfigId = jwtTypeCredentialConfigurationIdName;
+
+    static class OfferTestContext {
+        boolean preAuthorized;
+        String issUser;
+        String issClient;
+        String appUser;
+        String appClient;
+        CredentialIssuer issuerMetadata;
+        OIDCConfigurationRepresentation authorizationMetadata;
+        SupportedCredentialConfiguration supportedCredentialConfiguration;
+    }
+
+    OfferTestContext newTestContext(boolean preAuth, String appClient, String appUser) {
+        var ctx = new OfferTestContext();
+        ctx.preAuthorized = preAuth;
+        ctx.issUser = issUserId;
+        ctx.issClient = issClientId;
+        ctx.appUser = appUser;
+        ctx.appClient = appClient;
+        ctx.issuerMetadata = getCredentialIssuerMetadata();
+        ctx.authorizationMetadata = getAuthorizationMetadata(ctx.issuerMetadata.getAuthorizationServers().get(0));
+        ctx.supportedCredentialConfiguration = ctx.issuerMetadata.getCredentialsSupported().get(credConfigId);
+        return ctx;
+    }
+
+    @Test
+    public void testVariousLogins() {
+        assertNotNull(getBearerTokenAndLogout(issClientId, issUserId, "openid"));
+        assertNotNull(getBearerTokenAndLogout(issClientId, namedUserId, "openid"));
+        assertNotNull(getBearerTokenAndLogout(namedClientId, issUserId, "openid"));
+        assertNotNull(getBearerTokenAndLogout(namedClientId, namedUserId, "openid"));
+    }
+
+    @Test
+    public void testCredentialWithoutOffer() throws Exception {
+
+        var ctx = newTestContext(false, null, namedUserId);
+
+        var authDetail = new AuthorizationDetail();
+        authDetail.setType(OPENID_CREDENTIAL);
+        authDetail.setCredentialConfigurationId(credConfigId);
+        authDetail.setLocations(List.of(ctx.issuerMetadata.getCredentialIssuer()));
+
+        // [TODO] Requires Credential scope in AuthorizationRequest although already given in AuthorizationDetails
+        // https://github.com/tdiesler/nessus-identity/issues/264
+        String accessToken = getBearerToken(issClientId, ctx.appUser, credScopeName, authDetail);
+
+        CredentialResponse credResponse = getCredentialByAuthDetail(ctx, accessToken, authDetail);
+        verifyCredentialResponse(ctx, credResponse);
+    }
+
+    @Test
+    public void testCredentialOffer_noPreAuth_noClientId_noUserId() throws Exception {
+        runCredentialOfferTest(newTestContext(false, null, null));
+    }
+
+    @Test
+    public void testCredentialOffer_noPreAuth_noClientId_UserId() throws Exception {
+        runCredentialOfferTest(newTestContext(false, null, namedUserId));
+    }
+
+    @Test
+    public void testCredentialOffer_noPreAuth_ClientId_noUserId() throws Exception {
+        runCredentialOfferTest(newTestContext(false, namedClientId, null));
+    }
+
+    @Test
+    public void testCredentialOffer_noPreAuth_ClientId_UserId() throws Exception {
+        runCredentialOfferTest(newTestContext(false, namedClientId, namedUserId));
+    }
+
+    // Pre Authorized --------------------------------------------------------------------------------------------------
+
+    @Test
+    public void testCredentialOffer_PreAuth_noClientId_noUserId() throws Exception {
+        try {
+            runCredentialOfferTest(newTestContext(true, null, null));
+            fail("Expected " + INVALID_CREDENTIAL_OFFER_REQUEST.name());
+        } catch (RuntimeException ex) {
+            List.of(INVALID_CREDENTIAL_OFFER_REQUEST.name(), "Pre-Authorized credential offer requires a target user")
+                    .forEach(it -> assertTrue(ex.getMessage().contains(it), ex.getMessage() + " does not contain " + it));
+        }
+    }
+
+    @Test
+    public void testCredentialOffer_PreAuth_noClientId_UserId() throws Exception {
+        runCredentialOfferTest(newTestContext(true, null, namedUserId));
+    }
+
+    @Test
+    public void testCredentialOffer_PreAuth_ClientId_noUserId() throws Exception {
+        try {
+            runCredentialOfferTest(newTestContext(true, namedClientId, null));
+            fail("Expected " + INVALID_CREDENTIAL_OFFER_REQUEST.name());
+        } catch (RuntimeException ex) {
+            List.of(INVALID_CREDENTIAL_OFFER_REQUEST.name(), "Pre-Authorized credential offer requires a target user")
+                    .forEach(it -> assertTrue(ex.getMessage().contains(it), ex.getMessage() + " does not contain " + it));
+        }
+    }
+
+    @Test
+    public void testCredentialOffer_PreAuth_ClientId_UserId() throws Exception {
+        runCredentialOfferTest(newTestContext(true, namedClientId, namedUserId));
+    }
+
+    void runCredentialOfferTest(OfferTestContext ctx) throws Exception {
+
+        // Issuer login
+        //
+        String issToken = getBearerToken(ctx.issClient, ctx.issUser, "openid");
+
+        // Exclude scope: <credScope>
+        // Require role: credential-offer-create
+        verifyTokenJwt(ctx, issToken,
+                List.of(), List.of(ctx.supportedCredentialConfiguration.getScope()),
+                List.of(CREDENTIAL_OFFER_CREATE.getName()), List.of());
+
+        // Retrieving the credential-offer-uri
+        //
+        String offerUri = getCredentialOfferUriUrl(ctx, issToken);
+
+        // Issuer logout in order to remove unwanted session state
+        //
+        logout(ctx.issUser);
+
+        try {
+
+            // Using the uri to get the actual credential offer
+            //
+            CredentialsOffer credOffer = getCredentialsOffer(ctx, offerUri);
+
+            if (credOffer.getCredentialConfigurationIds().size() > 1)
+                throw new IllegalStateException("Multiple credential configuration ids not supported in: " + JsonSerialization.valueAsString(credOffer));
+
+            if (ctx.preAuthorized) {
+
+                // Get an access token for the pre-authorized code (PAC)
+                //
+                // For a PAC access token, we treat all scopes and all roles as non-meaningful.
+                // The access token:
+                //  1. has no authenticated user, and therefore cannot carry any user roles
+                //  2. does not perform authorization-based scope filtering
+                //  3. does not derive scopes from the client configuration
+                //  4. does not reflect anything from the credential offer
+                //
+                AccessTokenResponse accessToken = getPreAuthorizedAccessTokenResponse(ctx, credOffer);
+                var authDetails = accessToken.getAuthorizationDetails();
+                if (authDetails == null)
+                    throw new IllegalStateException("No authorization_details in token response");
+                if (authDetails.size() > 1)
+                    throw new IllegalStateException("Multiple authorization_details in token response");
+
+                // Get the credential and verify
+                //
+                CredentialResponse credResponse = getCredentialByAuthDetail(ctx, accessToken.getAccessToken(), authDetails.get(0));
+                verifyCredentialResponse(ctx, credResponse);
+
+            } else {
+
+                String clientId = ctx.appClient != null ? ctx.appClient : namedClientId;
+                String userId = ctx.appUser != null ? ctx.appUser : namedUserId;
+                String credConfigId = credOffer.getCredentialConfigurationIds().get(0);
+
+                SupportedCredentialConfiguration credConfig = ctx.issuerMetadata.getCredentialsSupported().get(credConfigId);
+                String scope = credConfig.getScope();
+
+                String accessToken = getBearerToken(clientId, userId, scope);
+
+                // Get the credential and verify
+                //
+                CredentialResponse credResponse = getCredentialByOffer(ctx, accessToken, credOffer);
+                verifyCredentialResponse(ctx, credResponse);
+            }
+        } finally {
+            if (ctx.appUser != null) {
+                logout(ctx.appUser);
+            }
+        }
+    }
+
+    // Private ---------------------------------------------------------------------------------------------------------
+
+    private String getBearerToken(String clientId, String username, String scope) {
+        var client = testRealm().clients().findByClientId(clientId).get(0);
+        if (client.isDirectAccessGrantsEnabled()) {
+            return getBearerTokenDirectAccess(oauth, client, username, scope).getAccessToken();
+        } else {
+            return getBearerTokenCodeFlow(oauth, client, username, scope).getAccessToken();
+        }
+    }
+
+    private String getBearerToken(String clientId, String username, String scope, AuthorizationDetail... authDetail) {
+        var client = testRealm().clients().findByClientId(clientId).get(0);
+        var authCode = getAuthorizationCode(oauth, client, username, scope);
+        return getBearerToken(oauth, authCode, authDetail).getAccessToken();
+    }
+
+    private String getBearerTokenAndLogout(String clientId, String userId, String scope) {
+        String token = getBearerToken(clientId, userId, scope);
+        logout(userId);
+        return token;
+    }
+
+    private void logout(String userId) {
+        findUserByUsernameId(testRealm(), userId).logout();
+    }
+
+    private String getCredentialOfferUriUrl(OfferTestContext ctx, String token) throws Exception {
+        var offerURI = getCredentialOfferUri(ctx, token);
+        return offerURI.getIssuer() + offerURI.getNonce();
+    }
+
+    private CredentialOfferURI getCredentialOfferUri(OfferTestContext ctx, String token) throws Exception {
+        var credConfigId = ctx.supportedCredentialConfiguration.getId();
+        String credOfferUriUrl = getCredentialOfferUriUrl(credConfigId, ctx.preAuthorized, ctx.appUser, ctx.appClient);
+        HttpGet getCredentialOfferURI = new HttpGet(credOfferUriUrl);
+        getCredentialOfferURI.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        CloseableHttpResponse credentialOfferURIResponse = httpClient.execute(getCredentialOfferURI);
+        var statusCode = credentialOfferURIResponse.getStatusLine().getStatusCode();
+        if (HttpStatus.SC_OK != statusCode) {
+            HttpEntity entity = credentialOfferURIResponse.getEntity();
+            throw new IllegalStateException(EntityUtils.toString(entity));
+        }
+        String s = IOUtils.toString(credentialOfferURIResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+        CredentialOfferURI credentialOfferURI = JsonSerialization.valueFromString(s, CredentialOfferURI.class);
+        assertTrue(credentialOfferURI.getIssuer().startsWith(ctx.issuerMetadata.getCredentialIssuer()));
+        assertTrue(Strings.isNotEmpty(credentialOfferURI.getNonce()));
+        return credentialOfferURI;
+    }
+
+    private CredentialsOffer getCredentialsOffer(OfferTestContext ctx, String offerUri) throws Exception {
+        HttpGet getCredentialOffer = new HttpGet(offerUri);
+        CloseableHttpResponse credentialOfferResponse = httpClient.execute(getCredentialOffer);
+        var statusCode = credentialOfferResponse.getStatusLine().getStatusCode();
+        if (HttpStatus.SC_OK != statusCode) {
+            HttpEntity entity = credentialOfferResponse.getEntity();
+            throw new IllegalStateException(EntityUtils.toString(entity));
+        }
+        String s = IOUtils.toString(credentialOfferResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+        CredentialsOffer credOffer = JsonSerialization.valueFromString(s, CredentialsOffer.class);
+        assertEquals(List.of(ctx.supportedCredentialConfiguration.getId()), credOffer.getCredentialConfigurationIds());
+        return credOffer;
+    }
+
+    private AccessTokenResponse getPreAuthorizedAccessTokenResponse(OID4VCICredentialOfferMatrixTest.OfferTestContext ctx, CredentialsOffer credOffer) throws Exception {
+        PreAuthorizedCode preAuthorizedCode = credOffer.getGrants().getPreAuthorizedCode();
+        HttpPost postPreAuthorizedCode = new HttpPost(ctx.authorizationMetadata.getTokenEndpoint());
+        List<NameValuePair> parameters = new LinkedList<>();
+        parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
+        parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, preAuthorizedCode.getPreAuthorizedCode()));
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        postPreAuthorizedCode.setEntity(formEntity);
+        CloseableHttpResponse accessTokenResponse = httpClient.execute(postPreAuthorizedCode);
+        var statusCode = accessTokenResponse.getStatusLine().getStatusCode();
+        if (HttpStatus.SC_OK != statusCode) {
+            HttpEntity entity = accessTokenResponse.getEntity();
+            throw new IllegalStateException(EntityUtils.toString(entity));
+        }
+        return new AccessTokenResponse(accessTokenResponse);
+    }
+
+    private CredentialResponse getCredentialByAuthDetail(OfferTestContext ctx, String accessToken, AuthorizationDetail authDetail) throws Exception {
+        @SuppressWarnings("unchecked")
+        List<String> credIdentifiers = (List<String>) authDetail.getAdditionalFields().get(CREDENTIAL_IDENTIFIERS);
+        var credentialRequest = new CredentialRequest();
+        if (credIdentifiers != null) {
+            if (credIdentifiers.size() > 1)
+                throw new IllegalStateException("Multiple credential ids not supported");
+            credentialRequest.setCredentialIdentifier(credIdentifiers.get(0));
+        } else {
+            if (authDetail.getCredentialConfigurationId() == null)
+                throw new IllegalStateException("No credential_configuration_id in: " + JsonSerialization.valueAsString(authDetail));
+            credentialRequest.setCredentialConfigurationId(authDetail.getCredentialConfigurationId());
+        }
+        return sendCredentialRequest(ctx, accessToken, credentialRequest);
+    }
+
+    private CredentialResponse getCredentialByOffer(OfferTestContext ctx, String accessToken, CredentialsOffer credOffer) throws Exception {
+        List<String> credConfigIds = credOffer.getCredentialConfigurationIds();
+        if (credConfigIds.size() > 1)
+            throw new IllegalStateException("Multiple credential configuration ids not supported in: " + JsonSerialization.valueAsString(credOffer));
+        var credentialRequest = new CredentialRequest();
+        credentialRequest.setCredentialConfigurationId(credConfigIds.get(0));
+        return sendCredentialRequest(ctx, accessToken, credentialRequest);
+    }
+
+    private CredentialResponse sendCredentialRequest(OfferTestContext ctx, String accessToken, CredentialRequest credentialRequest) throws Exception {
+        HttpPost postCredential = new HttpPost(ctx.issuerMetadata.getCredentialEndpoint());
+        postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+        StringEntity stringEntity = new StringEntity(JsonSerialization.valueAsString(credentialRequest), ContentType.APPLICATION_JSON);
+        postCredential.setEntity(stringEntity);
+
+        CloseableHttpResponse credentialRequestResponse = httpClient.execute(postCredential);
+        var statusCode = credentialRequestResponse.getStatusLine().getStatusCode();
+        if (HttpStatus.SC_OK != statusCode) {
+            HttpEntity entity = credentialRequestResponse.getEntity();
+            throw new IllegalStateException(EntityUtils.toString(entity));
+        }
+
+        String s = IOUtils.toString(credentialRequestResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+        CredentialResponse credentialResponse = JsonSerialization.valueFromString(s, CredentialResponse.class);
+
+        assertNotNull(credentialResponse.getCredentials(), "The credentials array should be present in the response.");
+        assertFalse(credentialResponse.getCredentials().isEmpty(), "The credentials array should not be empty.");
+        return credentialResponse;
+    }
+
+    private void verifyCredentialResponse(OfferTestContext ctx, CredentialResponse credResponse) throws Exception {
+
+        var scope = ctx.supportedCredentialConfiguration.getScope();
+        CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
+        assertNotNull(credentialObj, "The first credential in the array should not be null.");
+
+        String expUsername = ctx.appUser != null ? ctx.appUser : namedUserId;
+
+        JsonWebToken jsonWebToken = TokenVerifier.create((String) credentialObj.getCredential(), JsonWebToken.class).getToken();
+        assertEquals("did:web:test.org", jsonWebToken.getIssuer());
+        Object vc = jsonWebToken.getOtherClaims().get("vc");
+        VerifiableCredential credential = JsonSerialization.mapper.convertValue(vc, VerifiableCredential.class);
+        assertEquals(List.of(scope), credential.getType());
+        assertEquals(URI.create("did:web:test.org"), credential.getIssuer());
+        assertEquals(expUsername + "@email.cz", credential.getCredentialSubject().getClaims().get("email"));
+    }
+
+    private void verifyTokenJwt(
+            OfferTestContext ctx,
+            String token,
+            List<String> includeScopes,
+            List<String> excludeScopes,
+            List<String> includeRoles,
+            List<String> excludeRoles
+    ) throws Exception {
+        JsonWebToken jwt = JsonSerialization.readValue(new JWSInput(token).getContent(), JsonWebToken.class);
+        var wasScopes = Arrays.stream(((String) jwt.getOtherClaims().get("scope")).split("\\s")).toList();
+        includeScopes.forEach(it -> assertTrue(wasScopes.contains(it), "Missing scope: " + it));
+        excludeScopes.forEach(it -> assertFalse(wasScopes.contains(it), "Invalid scope: " + it));
+
+        var allRoles = new ArrayList<String>();
+        var realmAccess = jwt.getOtherClaims().get("realm_access");
+        if (realmAccess != null) {
+            @SuppressWarnings("unchecked")
+            var realmRoles = ((Map<String, List<String>>) realmAccess).get("roles");
+            allRoles.addAll(realmRoles);
+        }
+        var resourceAccess = jwt.getOtherClaims().get("resource_access");
+        if (resourceAccess != null) {
+            @SuppressWarnings("unchecked")
+            var resourceAccessMapping = (Map<String, Map<String, List<String>>>) resourceAccess;
+            resourceAccessMapping.forEach((k, v) -> {
+                allRoles.addAll(v.get("roles"));
+            });
+        }
+        includeRoles.forEach(it -> assertTrue(allRoles.contains(it), "Missing role: " + it));
+        excludeRoles.forEach(it -> assertFalse(allRoles.contains(it), "Invalid role: " + it));
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/OID4VCICredentialOfferMatrixTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/OID4VCICredentialOfferMatrixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/OID4VCICredentialOfferMatrixTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/OID4VCICredentialOfferMatrixTest.java
@@ -69,11 +69,11 @@ import static org.keycloak.testsuite.admin.ApiUtil.findUserByUsernameId;
 import static org.keycloak.testsuite.forms.PassThroughClientAuthenticator.clientId;
 import static org.keycloak.testsuite.forms.PassThroughClientAuthenticator.namedClientId;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 /**
@@ -182,7 +182,7 @@ public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
             fail("Expected " + INVALID_CREDENTIAL_OFFER_REQUEST.name());
         } catch (RuntimeException ex) {
             List.of(INVALID_CREDENTIAL_OFFER_REQUEST.name(), "Pre-Authorized credential offer requires a target user")
-                    .forEach(it -> assertTrue(ex.getMessage().contains(it), ex.getMessage() + " does not contain " + it));
+                    .forEach(it -> assertTrue(ex.getMessage() + " does not contain " + it, ex.getMessage().contains(it)));
         }
     }
 
@@ -198,7 +198,7 @@ public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
             fail("Expected " + INVALID_CREDENTIAL_OFFER_REQUEST.name());
         } catch (RuntimeException ex) {
             List.of(INVALID_CREDENTIAL_OFFER_REQUEST.name(), "Pre-Authorized credential offer requires a target user")
-                    .forEach(it -> assertTrue(ex.getMessage().contains(it), ex.getMessage() + " does not contain " + it));
+                    .forEach(it -> assertTrue(ex.getMessage() + " does not contain " + it, ex.getMessage().contains(it)));
         }
     }
 
@@ -404,8 +404,8 @@ public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
         String s = IOUtils.toString(credentialRequestResponse.getEntity().getContent(), StandardCharsets.UTF_8);
         CredentialResponse credentialResponse = JsonSerialization.valueFromString(s, CredentialResponse.class);
 
-        assertNotNull(credentialResponse.getCredentials(), "The credentials array should be present in the response.");
-        assertFalse(credentialResponse.getCredentials().isEmpty(), "The credentials array should not be empty.");
+        assertNotNull("The credentials array should be present in the response", credentialResponse.getCredentials());
+        assertFalse("The credentials array should not be empty", credentialResponse.getCredentials().isEmpty());
         return credentialResponse;
     }
 
@@ -413,7 +413,7 @@ public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
 
         String scope = ctx.supportedCredentialConfiguration.getScope();
         CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
-        assertNotNull(credentialObj, "The first credential in the array should not be null.");
+        assertNotNull("The first credential in the array should not be null", credentialObj);
 
         String expUsername = ctx.appUser != null ? ctx.appUser : namedUserId;
 
@@ -436,8 +436,8 @@ public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
     ) throws Exception {
         JsonWebToken jwt = JsonSerialization.readValue(new JWSInput(token).getContent(), JsonWebToken.class);
         List<String> wasScopes = Arrays.stream(((String) jwt.getOtherClaims().get("scope")).split("\\s")).toList();
-        includeScopes.forEach(it -> assertTrue(wasScopes.contains(it), "Missing scope: " + it));
-        excludeScopes.forEach(it -> assertFalse(wasScopes.contains(it), "Invalid scope: " + it));
+        includeScopes.forEach(it -> assertTrue("Missing scope: " + it, wasScopes.contains(it)));
+        excludeScopes.forEach(it -> assertFalse("Invalid scope: " + it, wasScopes.contains(it)));
 
         List<String> allRoles = new ArrayList<>();
         Object realmAccess = jwt.getOtherClaims().get("realm_access");
@@ -454,7 +454,7 @@ public class OID4VCICredentialOfferMatrixTest extends OID4VCIssuerEndpointTest {
                 allRoles.addAll(v.get("roles"));
             });
         }
-        includeRoles.forEach(it -> assertTrue(allRoles.contains(it), "Missing role: " + it));
-        excludeRoles.forEach(it -> assertFalse(allRoles.contains(it), "Invalid role: " + it));
+        includeRoles.forEach(it -> assertTrue("Missing role: " + it, allRoles.contains(it)));
+        excludeRoles.forEach(it -> assertFalse("Invalid role: " + it, allRoles.contains(it)));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/mappers/OID4VCTargetRoleMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/mappers/OID4VCTargetRoleMapperTest.java
@@ -115,15 +115,12 @@ public class OID4VCTargetRoleMapperTest extends OID4VCTest {
 						return mergedRoles;
 					}
 			);
-		} else {
-			testRealm.getRoles()
-					.setClient(Map.of(existingClient.getClientId(),
-							List.of(getRoleRepresentation("testRole", existingClient.getClientId()))));
 		}
 
 		List<UserRepresentation> realmUsers = Optional.ofNullable(testRealm.getUsers()).map(ArrayList::new)
 				.orElse(new ArrayList<>());
-		realmUsers.add(getUserRepresentation(Map.of(existingClient.getClientId(), List.of("testRole"), "newClient", List.of("newRole"))));
+		realmUsers.add(getUserRepresentation("John Doe", List.of(),
+                Map.of(clientId, List.of("testRole"), "newClient", List.of("newRole"))));
 		testRealm.setUsers(realmUsers);
 	}
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
@@ -52,6 +52,8 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
 
+import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -62,8 +64,6 @@ import static org.junit.Assert.assertNotNull;
  * @author <a href="mailto:Forkim.Akwichek@adorsys.com">Forkim Akwichek</a>
  */
 public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEndpointTest {
-
-    public static final String OPENID_CREDENTIAL_TYPE = "openid_credential";
 
     /**
      * Test context for OID4VC tests
@@ -140,7 +140,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         claim.setMandatory(true);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setClaims(Arrays.asList(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -176,8 +176,8 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         assertNotNull("Credential identifiers should be present", authDetailResponse.getCredentialIdentifiers());
         assertEquals(1, authDetailResponse.getCredentialIdentifiers().size());
 
-        String credentialIdentifier = authDetailResponse.getCredentialIdentifiers().get(0);
-        assertNotNull("Credential identifier should not be null", credentialIdentifier);
+        String credentialConfigurationId = authDetailResponse.getCredentialConfigurationId();
+        assertNotNull("Credential configuration id should not be null", credentialConfigurationId);
 
         // Request the actual credential using the identifier
         HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
@@ -185,7 +185,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         CredentialRequest credentialRequest = new CredentialRequest();
-        credentialRequest.setCredentialIdentifier(credentialIdentifier);
+        credentialRequest.setCredentialConfigurationId(credentialConfigurationId);
 
         String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
         postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowWithPARTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowWithPARTest.java
@@ -53,7 +53,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
 
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE;
+import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -131,7 +131,7 @@ public class OID4VCAuthorizationCodeFlowWithPARTest extends OID4VCIssuerEndpoint
         claim.setMandatory(true);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(credentialConfigurationId);
         authDetail.setClaims(List.of(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -198,7 +198,7 @@ public class OID4VCAuthorizationCodeFlowWithPARTest extends OID4VCIssuerEndpoint
         assertEquals("Should have exactly one authorization detail", 1, authDetailsResponse.size());
 
         OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(0);
-        assertEquals("Type should be openid_credential", OPENID_CREDENTIAL_TYPE, authDetailResponse.getType());
+        assertEquals("Type should be openid_credential", OPENID_CREDENTIAL, authDetailResponse.getType());
         assertEquals("Credential configuration ID should match", credentialConfigurationId, authDetailResponse.getCredentialConfigurationId());
 
         // Verify claims are preserved
@@ -229,7 +229,7 @@ public class OID4VCAuthorizationCodeFlowWithPARTest extends OID4VCIssuerEndpoint
         postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         CredentialRequest credentialRequest = new CredentialRequest();
-        credentialRequest.setCredentialIdentifier(credentialIdentifier);
+        credentialRequest.setCredentialConfigurationId(credentialConfigurationId);
 
         String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
         postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));
@@ -263,7 +263,7 @@ public class OID4VCAuthorizationCodeFlowWithPARTest extends OID4VCIssuerEndpoint
         // Step 1: Create PAR request with INVALID authorization_details
         // Create authorization details with INVALID credential configuration ID
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId("INVALID_CONFIG_ID"); // This should cause failure
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
@@ -39,6 +39,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
@@ -56,7 +57,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
 
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE;
+import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -103,7 +104,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         Oid4vcTestContext ctx = new Oid4vcTestContext();
 
         String credentialConfigurationId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
-        HttpGet getCredentialOfferURI = new HttpGet(getBasePath(TEST_REALM_NAME) + "credential-offer-uri?credential_configuration_id=" + credentialConfigurationId);
+        HttpGet getCredentialOfferURI = new HttpGet(getCredentialOfferUriUrl(credentialConfigurationId));
         getCredentialOfferURI.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
 
         CredentialOfferURI credentialOfferURI;
@@ -144,7 +145,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
 
@@ -166,7 +167,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
             assertNotNull("authorization_details should be present in the response", authDetailsResponse);
             assertEquals(1, authDetailsResponse.size());
             OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(0);
-            assertEquals(OPENID_CREDENTIAL_TYPE, authDetailResponse.getType());
+            assertEquals(OPENID_CREDENTIAL, authDetailResponse.getType());
             assertEquals(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID), authDetailResponse.getCredentialConfigurationId());
             assertNotNull(authDetailResponse.getCredentialIdentifiers());
             assertEquals(1, authDetailResponse.getCredentialIdentifiers().size());
@@ -202,7 +203,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         claim.setMandatory(true);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setClaims(Arrays.asList(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -225,7 +226,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
             assertNotNull("authorization_details should be present in the response", authDetailsResponse);
             assertEquals(1, authDetailsResponse.size());
             OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(0);
-            assertEquals(OPENID_CREDENTIAL_TYPE, authDetailResponse.getType());
+            assertEquals(OPENID_CREDENTIAL, authDetailResponse.getType());
             assertEquals(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID), authDetailResponse.getCredentialConfigurationId());
             assertNotNull(authDetailResponse.getClaims());
             assertEquals(1, authDetailResponse.getClaims().size());
@@ -257,7 +258,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         claim.setMandatory(false);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setClaims(Arrays.asList(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -293,7 +294,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         claim.setMandatory(true);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setClaims(Arrays.asList(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -329,7 +330,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         claim.setMandatory(false);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setClaims(Arrays.asList(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -369,7 +370,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         // Missing credential_configuration_id - should fail
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
 
@@ -403,7 +404,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         claim.setMandatory(false);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
+        authDetail.setType(OPENID_CREDENTIAL);
         authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
         authDetail.setClaims(Arrays.asList(claim));
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
@@ -481,7 +482,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
                 String expectedConfigId = ctx.credentialsOffer.getCredentialConfigurationIds().get(i);
                 OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(i);
 
-                assertEquals(OPENID_CREDENTIAL_TYPE, authDetailResponse.getType());
+                assertEquals(OPENID_CREDENTIAL, authDetailResponse.getType());
                 assertEquals("Credential configuration ID should match the one from the offer",
                         expectedConfigId, authDetailResponse.getCredentialConfigurationId());
                 assertNotNull("Credential identifiers should be present", authDetailResponse.getCredentialIdentifiers());
@@ -502,18 +503,22 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
     @Test
     public void testCompleteFlowWithCredentialOfferBasedAuthorizationDetails() throws Exception {
         String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
+
         Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
+        PreAuthorizedCode preAuthorizedCode = ctx.credentialsOffer.getGrants().getPreAuthorizedCode();
 
         // Step 1: Request token without authorization_details parameter (no scope needed)
         HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
         List<NameValuePair> parameters = new LinkedList<>();
         parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrantTypeFactory.GRANT_TYPE));
-        parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, ctx.credentialsOffer.getGrants().getPreAuthorizedCode().getPreAuthorizedCode()));
+        parameters.add(new BasicNameValuePair(PreAuthorizedCodeGrantTypeFactory.CODE_REQUEST_PARAM, preAuthorizedCode.getPreAuthorizedCode()));
 
         UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
         postPreAuthorizedCode.setEntity(formEntity);
 
-        String credentialIdentifier = null;
+        String credentialIdentifier;
+        String credentialConfigurationId;
+        OID4VCAuthorizationDetailsResponse authDetailResponse;
         try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
             assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
             String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -524,46 +529,94 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
                     ctx.credentialsOffer.getCredentialConfigurationIds().size(), authDetailsResponse.size());
 
             // Use the first authorization detail for credential request
-            OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(0);
+            authDetailResponse = authDetailsResponse.get(0);
             assertNotNull("Credential identifiers should be present", authDetailResponse.getCredentialIdentifiers());
             assertEquals(1, authDetailResponse.getCredentialIdentifiers().size());
 
             credentialIdentifier = authDetailResponse.getCredentialIdentifiers().get(0);
             assertNotNull("Credential identifier should not be null", credentialIdentifier);
+
+            credentialConfigurationId = authDetailResponse.getCredentialConfigurationId();
+            assertNotNull("Credential configuration id should not be null", credentialConfigurationId);
         }
 
         // Step 2: Request the actual credential using ONLY the identifier (no credential_configuration_id)
-        // This tests that the mapping from credential identifier to credential configuration ID works correctly
-        HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
-        postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
-        postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        // This tests that the mapping from credential identifier to credential configuration ID works as expected.
+        //
+        // The Pre-Authorized code flow is treated as a separate authentication event.
+        // Even if the underlying user and client match an existing session.
+        // A new user session is created because:
+        //      * The pre-auth code is defined as a standalone authentication mechanism.
+        //      * It does not assume the caller already has an authenticated session.
+        //      * It must guarantee isolation of state tied to the VC issuance flow.
+        {
+            HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
+            postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+            postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
-        CredentialRequest credentialRequest = new CredentialRequest();
-        credentialRequest.setCredentialIdentifier(credentialIdentifier);
+            CredentialRequest credentialRequest = new CredentialRequest();
+            credentialRequest.setCredentialIdentifier(credentialIdentifier);
 
-        String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
-        postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));
+            String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
+            postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));
 
-        try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
-            assertEquals(HttpStatus.SC_OK, credentialResponse.getStatusLine().getStatusCode());
-            String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+            try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
+                assertEquals(HttpStatus.SC_OK, credentialResponse.getStatusLine().getStatusCode());
+                String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
 
-            // Parse the credential response
-            CredentialResponse parsedResponse = JsonSerialization.readValue(responseBody, CredentialResponse.class);
-            assertNotNull("Credential response should not be null", parsedResponse);
-            assertNotNull("Credentials should be present", parsedResponse.getCredentials());
-            assertEquals("Should have exactly one credential", 1, parsedResponse.getCredentials().size());
+                // Parse the credential response
+                CredentialResponse parsedResponse = JsonSerialization.readValue(responseBody, CredentialResponse.class);
+                assertNotNull("Credential response should not be null", parsedResponse);
+                assertNotNull("Credentials should be present", parsedResponse.getCredentials());
+                assertEquals("Should have exactly one credential", 1, parsedResponse.getCredentials().size());
 
-            // Step 3: Verify that the issued credential structure is valid
-            CredentialResponse.Credential credentialWrapper = parsedResponse.getCredentials().get(0);
-            assertNotNull("Credential wrapper should not be null", credentialWrapper);
+                // Step 3: Verify that the issued credential structure is valid
+                CredentialResponse.Credential credentialWrapper = parsedResponse.getCredentials().get(0);
+                assertNotNull("Credential wrapper should not be null", credentialWrapper);
 
-            // The credential is stored as Object, so we need to cast it
-            Object credentialObj = credentialWrapper.getCredential();
-            assertNotNull("Credential object should not be null", credentialObj);
+                // The credential is stored as Object, so we need to cast it
+                Object credentialObj = credentialWrapper.getCredential();
+                assertNotNull("Credential object should not be null", credentialObj);
 
-            // Verify the credential structure based on format
-            verifyCredentialStructure(credentialObj);
+                // Verify the credential structure based on format
+                verifyCredentialStructure(credentialObj);
+            }
+        }
+
+        // Step 3: Request a credential using the credentialConfigurationId
+        //
+        {
+            HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
+            postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+            postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+
+            CredentialRequest credentialRequest = new CredentialRequest();
+            credentialRequest.setCredentialConfigurationId(credentialConfigurationId);
+
+            String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
+            postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));
+
+            try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
+                assertEquals(HttpStatus.SC_OK, credentialResponse.getStatusLine().getStatusCode());
+                String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+
+                // Parse the credential response
+                CredentialResponse parsedResponse = JsonSerialization.readValue(responseBody, CredentialResponse.class);
+                assertNotNull("Credential response should not be null", parsedResponse);
+                assertNotNull("Credentials should be present", parsedResponse.getCredentials());
+                assertEquals("Should have exactly one credential", 1, parsedResponse.getCredentials().size());
+
+                // Step 3: Verify that the issued credential structure is valid
+                CredentialResponse.Credential credentialWrapper = parsedResponse.getCredentials().get(0);
+                assertNotNull("Credential wrapper should not be null", credentialWrapper);
+
+                // The credential is stored as Object, so we need to cast it
+                Object credentialObj = credentialWrapper.getCredential();
+                assertNotNull("Credential object should not be null", credentialObj);
+
+                // Verify the credential structure based on format
+                verifyCredentialStructure(credentialObj);
+            }
         }
     }
 
@@ -603,7 +656,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
                 String expectedConfigId = ctx.credentialsOffer.getCredentialConfigurationIds().get(i);
 
                 // Verify structure
-                assertEquals("Type should be openid_credential", OPENID_CREDENTIAL_TYPE, authDetail.getType());
+                assertEquals("Type should be openid_credential", OPENID_CREDENTIAL, authDetail.getType());
                 assertEquals("Credential configuration ID should match the one from the offer",
                         expectedConfigId, authDetail.getCredentialConfigurationId());
                 assertNotNull("Credential identifiers should be present", authDetail.getCredentialIdentifiers());
@@ -633,6 +686,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
     @Test
     public void testCompleteFlowWithClaimsValidation() throws Exception {
         String token = getBearerToken(oauth, client, getCredentialClientScope().getName());
+        String credConfigId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         Oid4vcTestContext ctx = prepareOid4vcTestContext(token);
 
         // Step 1: Request token with authorization details containing specific claims
@@ -650,13 +704,13 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         claim.setMandatory(true);
 
         AuthorizationDetail authDetail = new AuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL_TYPE);
-        authDetail.setCredentialConfigurationId(getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID));
-        authDetail.setClaims(Arrays.asList(claim));
+        authDetail.setType(OPENID_CREDENTIAL);
+        authDetail.setCredentialConfigurationId(credConfigId);
         authDetail.setLocations(Collections.singletonList(ctx.credentialIssuer.getCredentialIssuer()));
+        authDetail.setClaims(List.of(claim));
 
         List<AuthorizationDetail> authDetails = List.of(authDetail);
-        String authDetailsJson = JsonSerialization.writeValueAsString(authDetails);
+        String authDetailsJson = JsonSerialization.valueAsString(authDetails);
 
         HttpPost postPreAuthorizedCode = new HttpPost(ctx.openidConfig.getTokenEndpoint());
         List<NameValuePair> parameters = new LinkedList<>();
@@ -667,6 +721,8 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         postPreAuthorizedCode.setEntity(formEntity);
 
         String credentialIdentifier;
+        String credentialConfigurationId;
+        OID4VCAuthorizationDetailsResponse authDetailResponse;
         try (CloseableHttpResponse tokenResponse = httpClient.execute(postPreAuthorizedCode)) {
             assertEquals(HttpStatus.SC_OK, tokenResponse.getStatusLine().getStatusCode());
             String responseBody = IOUtils.toString(tokenResponse.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -674,21 +730,25 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
             assertNotNull("authorization_details should be present in the response", authDetailsResponse);
             assertEquals(1, authDetailsResponse.size());
 
-            OID4VCAuthorizationDetailsResponse authDetailResponse = authDetailsResponse.get(0);
+            authDetailResponse = authDetailsResponse.get(0);
             assertNotNull("Credential identifiers should be present", authDetailResponse.getCredentialIdentifiers());
             assertEquals(1, authDetailResponse.getCredentialIdentifiers().size());
 
             credentialIdentifier = authDetailResponse.getCredentialIdentifiers().get(0);
             assertNotNull("Credential identifier should not be null", credentialIdentifier);
+
+            credentialConfigurationId = authDetailResponse.getCredentialConfigurationId();
+            assertNotNull("Credential configuration id should not be null", credentialConfigurationId);
         }
 
-        // Step 2: Request the actual credential using the identifier
+        // Step 2: Request the actual credential using the identifier and config id
         HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
         postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
 
         CredentialRequest credentialRequest = new CredentialRequest();
         credentialRequest.setCredentialIdentifier(credentialIdentifier);
+        credentialRequest.setCredentialConfigurationId(credentialConfigurationId);
 
         String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
         postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
@@ -748,7 +748,6 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
 
         CredentialRequest credentialRequest = new CredentialRequest();
         credentialRequest.setCredentialIdentifier(credentialIdentifier);
-        credentialRequest.setCredentialConfigurationId(credentialConfigurationId);
 
         String requestBody = JsonSerialization.writeValueAsString(credentialRequest);
         postCredential.setEntity(new StringEntity(requestBody, StandardCharsets.UTF_8));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsTypesSupportedTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationDetailsTypesSupportedTest.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.Profile;
-import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -34,7 +33,7 @@ import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE;
+import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -74,7 +73,7 @@ public class OID4VCAuthorizationDetailsTypesSupportedTest extends OID4VCIssuerEn
             // Verify that it contains openid_credential
             List<String> supportedTypes = oauthConfig.getAuthorizationDetailsTypesSupported();
             assertTrue("authorization_details_types_supported should contain openid_credential",
-                    supportedTypes.contains(OID4VCAuthorizationDetailsProcessor.OPENID_CREDENTIAL_TYPE));
+                    supportedTypes.contains(OPENID_CREDENTIAL));
 
         }
     }
@@ -94,7 +93,7 @@ public class OID4VCAuthorizationDetailsTypesSupportedTest extends OID4VCIssuerEn
             assertNotNull("Authorization server should support authorization_details_types_supported",
                     authServerConfig.getAuthorizationDetailsTypesSupported());
             assertTrue("Authorization server should support openid_credential",
-                    authServerConfig.getAuthorizationDetailsTypesSupported().contains(OPENID_CREDENTIAL_TYPE));
+                    authServerConfig.getAuthorizationDetailsTypesSupported().contains(OPENID_CREDENTIAL));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCCredentialOfferCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCCredentialOfferCorsTest.java
@@ -255,11 +255,7 @@ public class OID4VCCredentialOfferCorsTest extends OID4VCIssuerEndpointTest {
     }
 
     private String getCredentialOfferUriUrl() {
-        return getBasePath("test") + "credential-offer-uri?credential_configuration_id=" + jwtTypeCredentialConfigurationIdName;
-    }
-
-    private String getCredentialOfferUrl(String sessionCode) {
-        return getBasePath("test") + "credential-offer/" + sessionCode;
+        return getCredentialOfferUriUrl(jwtTypeCredentialConfigurationIdName);
     }
 
     private String getSessionCodeFromOfferUri(String accessToken) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointEncryptionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointEncryptionTest.java
@@ -38,6 +38,7 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
@@ -75,6 +76,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
     @Test
     public void testRequestCredentialWithEncryption() {
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
         testingClient
                 .server(TEST_REALM_NAME)
@@ -93,7 +95,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
                     PrivateKey privateKey = (PrivateKey) jwkPair.get("privateKey");
 
                     CredentialRequest credentialRequest = new CredentialRequest()
-                            .setCredentialIdentifier(scopeName)
+                            .setCredentialConfigurationId(credConfigId)
                             .setCredentialResponseEncryption(
                                     new CredentialResponseEncryption()
                                             .setEnc(A256GCM)
@@ -169,6 +171,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
     @Test
     public void testEncryptedCredentialRequest() {
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
         testingClient.server(TEST_REALM_NAME).run(session -> {
             try {
@@ -194,7 +197,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
                 PrivateKey responsePrivateKey = (PrivateKey) jwkPair.get("privateKey");
 
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setCredentialIdentifier(scopeName)
+                        .setCredentialConfigurationId(credConfigId)
                         .setCredentialResponseEncryption(
                                 new CredentialResponseEncryption()
                                         .setEnc(A256GCM)
@@ -234,6 +237,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
     @Test
     public void testEncryptedCredentialRequestWithCompression() {
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
         testingClient.server(TEST_REALM_NAME).run(session -> {
             try {
@@ -262,7 +266,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
 
                 // Create credential request with response encryption parameters
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setCredentialIdentifier(scopeName)
+                        .setCredentialConfigurationId(credConfigId)
                         .setCredentialResponseEncryption(
                                 new CredentialResponseEncryption()
                                         .setEnc(A256GCM)
@@ -474,6 +478,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
     @Test
     public void testRequestCredentialWithInvalidJWK() throws Throwable {
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
         testingClient.server(TEST_REALM_NAME).run(session -> {
             AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
@@ -483,7 +488,7 @@ public class OID4VCIssuerEndpointEncryptionTest extends OID4VCIssuerEndpointTest
             // Invalid JWK (missing modulus but WITH alg parameter)
             JWK jwk = JWKParser.create().parse("{\"kty\":\"RSA\",\"alg\":\"RSA-OAEP-256\",\"e\":\"AQAB\"}").getJwk();
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setCredentialIdentifier(scopeName)
+                    .setCredentialConfigurationId(credConfigId)
                     .setCredentialResponseEncryption(
                             new CredentialResponseEncryption()
                                     .setEnc("A256GCM")

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -35,6 +35,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
@@ -54,7 +56,7 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwe.JWE;
 import org.keycloak.jose.jwe.JWEException;
@@ -79,6 +81,7 @@ import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
 import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
 import org.keycloak.representations.JsonWebToken;
@@ -88,6 +91,7 @@ import org.keycloak.representations.idm.ComponentExportRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.services.managers.AuthenticationManager;
@@ -110,12 +114,14 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.jboss.logging.Logger;
 import org.junit.Before;
 
+import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
 import static org.keycloak.jose.jwe.JWEConstants.A256GCM;
 import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP;
 import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP_256;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIAL_OFFER_URI_CODE_SCOPE;
 import static org.keycloak.protocol.oid4vc.model.ProofType.JWT;
 import static org.keycloak.testsuite.forms.PassThroughClientAuthenticator.clientId;
+import static org.keycloak.testsuite.forms.PassThroughClientAuthenticator.namedClientId;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -139,33 +145,31 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
     protected static ClientScopeRepresentation minimalJwtTypeCredentialClientScope;
 
     protected CloseableHttpClient httpClient;
+
     protected ClientRepresentation client;
+    protected ClientRepresentation namedClient;
+
+    record OAuth2CodeEntry(String key, OAuth2Code code) {}
 
     protected boolean shouldEnableOid4vci() {
         return true;
     }
 
-    protected static String prepareSessionCode(KeycloakSession session, AppAuthManager.BearerTokenAuthenticator authenticator, String note) {
+    protected static OAuth2CodeEntry prepareSessionCode(KeycloakSession session, AppAuthManager.BearerTokenAuthenticator authenticator, String note) {
         AuthenticationManager.AuthResult authResult = authenticator.authenticate();
         UserSessionModel userSessionModel = authResult.session();
         AuthenticatedClientSessionModel authenticatedClientSessionModel = userSessionModel.getAuthenticatedClientSessionByClient(
                 authResult.client().getId());
-        String codeId = SecretGenerator.getInstance().randomString();
-        String nonce = SecretGenerator.getInstance().randomString();
-        OAuth2Code oAuth2Code = new OAuth2Code(codeId,
+        OAuth2Code oauth2Code = new OAuth2Code(
+                SecretGenerator.getInstance().randomString(),
                 Time.currentTime() + 6000,
-                nonce,
+                SecretGenerator.getInstance().randomString(),
                 CREDENTIAL_OFFER_URI_CODE_SCOPE,
-                null,
-                null,
-                null,
-                null,
                 authenticatedClientSessionModel.getUserSession().getId());
 
-        String oauthCode = OAuth2CodeParser.persistCode(session, authenticatedClientSessionModel, oAuth2Code);
-
-        authenticatedClientSessionModel.setNote(oauthCode, note);
-        return oauthCode;
+        var nonce = OAuth2CodeParser.persistCode(session, authenticatedClientSessionModel, oauth2Code);
+        authenticatedClientSessionModel.setNote(nonce, note);
+        return new OAuth2CodeEntry(nonce, oauth2Code);
     }
 
     protected static OID4VCIssuerEndpoint prepareIssuerEndpoint(KeycloakSession session,
@@ -201,6 +205,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         CryptoIntegration.init(this.getClass().getClassLoader());
         httpClient = HttpClientBuilder.create().build();
         client = testRealm().clients().findByClientId(clientId).get(0);
+        namedClient = testRealm().clients().findByClientId(namedClientId).get(0);
 
         // Lookup the pre-installed oid4vc_natural_person client scope
         sdJwtTypeNaturalPersonClientScope = requireExistingClientScope(sdJwtTypeNaturalPersonScopeName);
@@ -228,13 +233,23 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
                 null,
                 null);
 
-        // Assign the registered optional client scopes to the client
-        assignOptionalClientScopeToClient(sdJwtTypeCredentialClientScope.getId(), client.getClientId());
-        assignOptionalClientScopeToClient(jwtTypeCredentialClientScope.getId(), client.getClientId());
-        assignOptionalClientScopeToClient(minimalJwtTypeCredentialClientScope.getId(), client.getClientId());
+        List.of(client, namedClient).forEach(client -> {
+            var clientId = client.getClientId();
 
-        // Enable OID4VCI for the client by default, but allow tests to override
-        setClientOid4vciEnabled(clientId, shouldEnableOid4vci());
+            // Assign the registered optional client scopes to the client
+            assignOptionalClientScopeToClient(sdJwtTypeNaturalPersonClientScope.getId(), clientId);
+            assignOptionalClientScopeToClient(sdJwtTypeCredentialClientScope.getId(), clientId);
+            assignOptionalClientScopeToClient(jwtTypeCredentialClientScope.getId(), clientId);
+            assignOptionalClientScopeToClient(minimalJwtTypeCredentialClientScope.getId(), clientId);
+
+            assignOptionalClientScopeToClient(sdJwtTypeNaturalPersonClientScope.getId(), clientId);
+            assignOptionalClientScopeToClient(sdJwtTypeCredentialClientScope.getId(), clientId);
+            assignOptionalClientScopeToClient(jwtTypeCredentialClientScope.getId(), clientId);
+            assignOptionalClientScopeToClient(minimalJwtTypeCredentialClientScope.getId(), clientId);
+
+            // Enable OID4VCI for the client by default, but allow tests to override
+            setClientOid4vciEnabled(clientId, shouldEnableOid4vci());
+        });
     }
 
     private ClientResource findClientByClientId(RealmResource realm, String clientId) {
@@ -264,7 +279,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         // Create a new ClientScope if not found
         ClientScopeRepresentation clientScope = new ClientScopeRepresentation();
         clientScope.setName(scopeName);
-        clientScope.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+        clientScope.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
         Map<String, String> attributes =
                 new HashMap<>(Map.of(ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE, "true",
                         CredentialScopeModel.EXPIRY_IN_SECONDS, "15"));
@@ -531,6 +546,29 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         return contextRoot + "/auth/.well-known/openid-credential-issuer/realms/" + realm;
     }
 
+    protected String getCredentialOfferUriUrl(String configId) {
+        return getCredentialOfferUriUrl(configId, true, "john");
+    }
+
+    protected String getCredentialOfferUriUrl(String configId, boolean preAuthorized, String targetUser) {
+        return getCredentialOfferUriUrl(configId, preAuthorized, targetUser, null);
+    }
+
+    protected String getCredentialOfferUriUrl(String configId, Boolean preAuthorized, String appUserId, String appClientId) {
+        String res = getBasePath("test") + "credential-offer-uri?credential_configuration_id=" + configId;
+        if (preAuthorized != null)
+            res += "&pre_authorized=" + preAuthorized;
+        if (appClientId != null)
+            res += "&client_id=" + appClientId;
+        if (appUserId != null)
+            res += "&user_id=" + appUserId;
+        return res;
+    }
+
+    protected String getCredentialOfferUrl(String nonce) {
+        return getBasePath("test") + "credential-offer/" + nonce;
+    }
+
     protected void requestCredential(String token,
                                      String credentialEndpoint,
                                      SupportedCredentialConfiguration offeredCredential,
@@ -569,6 +607,24 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         }
     }
 
+    public OIDCConfigurationRepresentation getAuthorizationMetadata(String authServerUrl) {
+        HttpGet getOpenidConfiguration = new HttpGet(authServerUrl + "/.well-known/openid-configuration");
+        try (CloseableHttpResponse response = httpClient.execute(getOpenidConfiguration)) {
+            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+            String s = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+            return JsonSerialization.readValue(s, OIDCConfigurationRepresentation.class);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public SupportedCredentialConfiguration getSupportedCredentialConfigurationByScope(CredentialIssuer metadata, String scope) {
+        var result = metadata.getCredentialsSupported().values().stream()
+                .filter(it -> it.getScope().equals(scope))
+                .findFirst().orElse(null);
+        return result;
+    }
+
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
         if (testRealm.getComponents() == null) {
@@ -583,15 +639,15 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
                 getRsaEncKeyProvider(RSA_OAEP, "enc-key-oaep", 101));
 
         // Find existing client representation
-        ClientRepresentation existingClient = testRealm.getClients().stream()
-                .filter(client -> client.getClientId().equals(clientId))
-                .findFirst()
+        Map<String, ClientRepresentation> realmClients = testRealm.getClients().stream()
+                .collect(Collectors.toMap(ClientRepresentation::getClientId, Function.identity()));
+        ClientRepresentation existingClient = Optional.ofNullable(realmClients.get(clientId))
                 .orElseThrow(() -> new IllegalStateException("Client with ID " + clientId + " not found in realm"));
 
         // Add a role to an existing client
-        if (testRealm.getRoles() != null) {
-            Map<String, List<RoleRepresentation>> clientRoles = testRealm.getRoles().getClient();
-            clientRoles.merge(
+        RolesRepresentation realmRoles = testRealm.getRoles();
+        if (realmRoles != null) {
+            realmRoles.getClient().merge(
                     existingClient.getClientId(),
                     List.of(getRoleRepresentation("testRole", existingClient.getClientId())),
                     (existingRoles, newRoles) -> {
@@ -600,15 +656,12 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
                         return mergedRoles;
                     }
             );
-        } else {
-            testRealm.getRoles()
-                    .setClient(Map.of(existingClient.getClientId(),
-                            List.of(getRoleRepresentation("testRole", existingClient.getClientId()))));
         }
 
-        List<UserRepresentation> realmUsers = Optional.ofNullable(testRealm.getUsers()).map(ArrayList::new)
-                .orElse(new ArrayList<>());
-        realmUsers.add(getUserRepresentation(Map.of(existingClient.getClientId(), List.of("testRole"))));
+        Map<String, List<String>> clientRoles = Map.of(clientId, List.of("testRole"));
+        List<UserRepresentation> realmUsers = Optional.ofNullable(testRealm.getUsers()).map(ArrayList::new).orElse(new ArrayList<>());
+        realmUsers.add(getUserRepresentation("John Doe", List.of(CREDENTIAL_OFFER_CREATE.getName()), clientRoles));
+        realmUsers.add(getUserRepresentation("Alice Wonderland", List.of(), Map.of()));
         testRealm.setUsers(realmUsers);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -167,7 +167,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
                 CREDENTIAL_OFFER_URI_CODE_SCOPE,
                 authenticatedClientSessionModel.getUserSession().getId());
 
-        var nonce = OAuth2CodeParser.persistCode(session, authenticatedClientSessionModel, oauth2Code);
+        String nonce = OAuth2CodeParser.persistCode(session, authenticatedClientSessionModel, oauth2Code);
         authenticatedClientSessionModel.setNote(nonce, note);
         return new OAuth2CodeEntry(nonce, oauth2Code);
     }
@@ -234,7 +234,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
                 null);
 
         List.of(client, namedClient).forEach(client -> {
-            var clientId = client.getClientId();
+            String clientId = client.getClientId();
 
             // Assign the registered optional client scopes to the client
             assignOptionalClientScopeToClient(sdJwtTypeNaturalPersonClientScope.getId(), clientId);
@@ -619,7 +619,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
     }
 
     public SupportedCredentialConfiguration getSupportedCredentialConfigurationByScope(CredentialIssuer metadata, String scope) {
-        var result = metadata.getCredentialsSupported().values().stream()
+        SupportedCredentialConfiguration result = metadata.getCredentialsSupported().values().stream()
                 .filter(it -> it.getScope().equals(scope))
                 .findFirst().orElse(null);
         return result;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
@@ -61,7 +61,6 @@ import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.ProofTypesSupported;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
-import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -88,7 +87,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.keycloak.OID4VCConstants.SIGNED_METADATA_JWT_TYPE;
-import static org.keycloak.constants.Oid4VciConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE;
+import static org.keycloak.constants.OID4VCIConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE;
 import static org.keycloak.jose.jwe.JWEConstants.A256GCM;
 import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP;
 import static org.keycloak.jose.jwe.JWEConstants.RSA_OAEP_256;
@@ -782,32 +781,5 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerEndpointTest 
                         session.realms().removeRealm(testRealm.getId());
                     }
                 });
-    }
-
-    public static void extendConfigureTestRealm(RealmRepresentation testRealm, ClientRepresentation clientRepresentation) {
-        if (testRealm.getComponents() == null) {
-            testRealm.setComponents(new MultivaluedHashMap<>());
-        }
-
-        testRealm.getComponents().add("org.keycloak.keys.KeyProvider", getRsaKeyProvider(RSA_KEY));
-        testRealm.getComponents().add("org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilder", getCredentialBuilderProvider(Format.JWT_VC));
-
-        if (testRealm.getClients() != null) {
-            testRealm.getClients().add(clientRepresentation);
-        } else {
-            testRealm.setClients(new ArrayList<>(List.of(clientRepresentation)));
-        }
-
-        if (testRealm.getUsers() != null) {
-            testRealm.getUsers().add(OID4VCTest.getUserRepresentation(Map.of(clientRepresentation.getClientId(), List.of("testRole"))));
-        } else {
-            testRealm.setUsers(new ArrayList<>(List.of(OID4VCTest.getUserRepresentation(Map.of(clientRepresentation.getClientId(), List.of("testRole"))))));
-        }
-
-        if (testRealm.getAttributes() != null) {
-            testRealm.getAttributes().put("issuerDid", TEST_DID.toString());
-        } else {
-            testRealm.setAttributes(new HashMap<>(Map.of("issuerDid", TEST_DID.toString())));
-        }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointDisabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointDisabledTest.java
@@ -6,7 +6,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
-import org.keycloak.protocol.oid4vc.model.OfferUriType;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.testsuite.Assert;
@@ -36,7 +35,7 @@ public class OID4VCJWTIssuerEndpointDisabledTest extends OID4VCIssuerEndpointTes
 
             // Test getCredentialOfferURI
             CorsErrorResponseException offerUriException = Assert.assertThrows(CorsErrorResponseException.class, () ->
-                    issuerEndpoint.getCredentialOfferURI("test-credential", OfferUriType.URI, 0, 0)
+                    issuerEndpoint.getCredentialOfferURI("test-credential")
             );
             assertEquals("Should fail with 403 Forbidden when client is not OID4VCI-enabled",
                     Response.Status.FORBIDDEN.getStatusCode(), offerUriException.getResponse().getStatus());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -243,8 +243,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                             .setGrants(new PreAuthorizedGrant().setPreAuthorizedCode(new PreAuthorizedCode().setPreAuthorizedCode("the-code")))
                             .setCredentialConfigurationIds(List.of("credential-configuration-id"));
 
-                    var offerStorage = session.getProvider(CredentialOfferStorage.class);
-                    var offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() + 60);
+                    CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
+                    CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() + 60);
                     offerStorage.putOfferState(session, offerState);
 
                     // The cache transactions need to be committed explicitly in the test. Without that, the OAuth2Code will only be committed to

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -35,9 +35,12 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage.CredentialOfferState;
 import org.keycloak.protocol.oid4vc.model.Claim;
 import org.keycloak.protocol.oid4vc.model.ClaimDisplay;
 import org.keycloak.protocol.oid4vc.model.Claims;
@@ -50,7 +53,6 @@ import org.keycloak.protocol.oid4vc.model.ErrorResponse;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.JwtProof;
-import org.keycloak.protocol.oid4vc.model.OfferUriType;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCode;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedGrant;
 import org.keycloak.protocol.oid4vc.model.Proofs;
@@ -59,9 +61,8 @@ import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.representations.JsonWebToken;
-import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AppAuthManager.BearerTokenAuthenticator;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
 
@@ -90,19 +91,20 @@ import static org.junit.Assert.fail;
  * Test from org.keycloak.testsuite.oid4vc.issuance.signing.OID4VCIssuerEndpointTest
  */
 public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
+
     // ----- getCredentialOfferUri
 
     @Test
     public void testGetCredentialOfferUriUnsupportedCredential() {
         String token = getBearerToken(oauth);
         testingClient.server(TEST_REALM_NAME).run((session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
 
             OID4VCIssuerEndpoint oid4VCIssuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
             CorsErrorResponseException exception = Assert.assertThrows(CorsErrorResponseException.class, () ->
-                    oid4VCIssuerEndpoint.getCredentialOfferURI("inexistent-id", OfferUriType.URI, 0, 0)
+                    oid4VCIssuerEndpoint.getCredentialOfferURI("inexistent-id")
             );
             assertEquals("Should return BAD_REQUEST", Response.Status.BAD_REQUEST.getStatusCode(),
                     exception.getResponse().getStatus());
@@ -112,12 +114,12 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testGetCredentialOfferUriUnauthorized() {
         testingClient.server(TEST_REALM_NAME).run((session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(null);
             OID4VCIssuerEndpoint oid4VCIssuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
             CorsErrorResponseException exception = Assert.assertThrows(CorsErrorResponseException.class, () ->
-                    oid4VCIssuerEndpoint.getCredentialOfferURI("test-credential", OfferUriType.URI, 0, 0)
+                    oid4VCIssuerEndpoint.getCredentialOfferURI("test-credential", true, "john")
             );
             assertEquals("Should return BAD_REQUEST", Response.Status.BAD_REQUEST.getStatusCode(),
                     exception.getResponse().getStatus());
@@ -127,12 +129,12 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testGetCredentialOfferUriInvalidToken() {
         testingClient.server(TEST_REALM_NAME).run((session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString("invalid-token");
             OID4VCIssuerEndpoint oid4VCIssuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
             CorsErrorResponseException exception = Assert.assertThrows(CorsErrorResponseException.class, () ->
-                    oid4VCIssuerEndpoint.getCredentialOfferURI("test-credential", OfferUriType.URI, 0, 0)
+                    oid4VCIssuerEndpoint.getCredentialOfferURI("test-credential", true, "john")
             );
             assertEquals("Should return BAD_REQUEST", Response.Status.BAD_REQUEST.getStatusCode(),
                     exception.getResponse().getStatus());
@@ -148,15 +150,11 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
         testingClient.server(TEST_REALM_NAME).run((session) -> {
             try {
-                AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(
-                        session);
+                BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                 authenticator.setTokenString(token);
                 OID4VCIssuerEndpoint oid4VCIssuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
-                Response response = oid4VCIssuerEndpoint.getCredentialOfferURI(credentialConfigurationId,
-                        OfferUriType.URI,
-                        0,
-                        0);
+                Response response = oid4VCIssuerEndpoint.getCredentialOfferURI(credentialConfigurationId);
 
                 assertEquals("An offer uri should have been returned.", HttpStatus.SC_OK, response.getStatus());
                 CredentialOfferURI credentialOfferURI = JsonSerialization.mapper.convertValue(response.getEntity(),
@@ -177,7 +175,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             testingClient
                     .server(TEST_REALM_NAME)
                     .run((session) -> {
-                        AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                        BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                         authenticator.setTokenString(null);
                         OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
                         Response response = issuerEndpoint.getCredentialOffer("nonce");
@@ -193,7 +191,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             testingClient
                     .server(TEST_REALM_NAME)
                     .run((session -> {
-                        AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                        BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                         authenticator.setTokenString(token);
                         OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
                         issuerEndpoint.getCredentialOffer(null);
@@ -208,7 +206,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             testingClient
                     .server(TEST_REALM_NAME)
                     .run((session -> {
-                        AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                        BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                         authenticator.setTokenString(token);
                         OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
                         issuerEndpoint.getCredentialOffer("unpreparedNonce");
@@ -223,11 +221,11 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
             testingClient
                     .server(TEST_REALM_NAME)
                     .run((session -> {
-                        AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                        BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                         authenticator.setTokenString(token);
-                        String sessionCode = prepareSessionCode(session, authenticator, "invalidNote");
+                        String nonce = prepareSessionCode(session, authenticator, "invalidNote").key();
                         OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
-                        issuerEndpoint.getCredentialOffer(sessionCode);
+                        issuerEndpoint.getCredentialOffer(nonce);
                     }));
         });
     }
@@ -238,25 +236,28 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         testingClient
                 .server(TEST_REALM_NAME)
                 .run((session) -> {
-                    AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                    BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                     authenticator.setTokenString(token);
-                    CredentialsOffer credentialsOffer = new CredentialsOffer()
+                    CredentialsOffer credOffer = new CredentialsOffer()
                             .setCredentialIssuer("the-issuer")
                             .setGrants(new PreAuthorizedGrant().setPreAuthorizedCode(new PreAuthorizedCode().setPreAuthorizedCode("the-code")))
                             .setCredentialConfigurationIds(List.of("credential-configuration-id"));
 
-                    String sessionCode = prepareSessionCode(session, authenticator, JsonSerialization.writeValueAsString(credentialsOffer));
+                    var offerStorage = session.getProvider(CredentialOfferStorage.class);
+                    var offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() + 60);
+                    offerStorage.putOfferState(session, offerState);
+
                     // The cache transactions need to be committed explicitly in the test. Without that, the OAuth2Code will only be committed to
                     // the cache after .run((session)-> ...)
                     session.getTransactionManager().commit();
                     OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
-                    Response credentialOfferResponse = issuerEndpoint.getCredentialOffer(sessionCode);
+                    Response credentialOfferResponse = issuerEndpoint.getCredentialOffer(offerState.getNonce());
                     assertEquals("The offer should have been returned.", HttpStatus.SC_OK, credentialOfferResponse.getStatus());
                     Object credentialOfferEntity = credentialOfferResponse.getEntity();
                     assertNotNull("An actual offer should be in the response.", credentialOfferEntity);
 
                     CredentialsOffer retrievedCredentialsOffer = JsonSerialization.mapper.convertValue(credentialOfferEntity, CredentialsOffer.class);
-                    assertEquals("The offer should be the one prepared with for the session.", credentialsOffer, retrievedCredentialsOffer);
+                    assertEquals("The offer should be the one prepared with for the session.", credOffer, retrievedCredentialsOffer);
                 });
     }
 
@@ -265,7 +266,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testRequestCredentialUnauthorized() {
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(null);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
             CredentialRequest credentialRequest = new CredentialRequest()
@@ -285,7 +286,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testRequestCredentialInvalidToken() {
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString("token");
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
             CredentialRequest credentialRequest = new CredentialRequest()
@@ -311,8 +312,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         try {
             withCausePropagation(() -> {
                 testingClient.server(TEST_REALM_NAME).run((session -> {
-                    AppAuthManager.BearerTokenAuthenticator authenticator =
-                            new AppAuthManager.BearerTokenAuthenticator(session);
+                    BearerTokenAuthenticator authenticator =
+                            new BearerTokenAuthenticator(session);
                     authenticator.setTokenString(token);
 
                     // Prepare the issue endpoint with no credential builders.
@@ -337,7 +338,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         String token = getBearerToken(oauth);
         withCausePropagation(() -> {
             testingClient.server(TEST_REALM_NAME).run(session -> {
-                AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                 authenticator.setTokenString(token);
                 OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
                 CredentialRequest credentialRequest = new CredentialRequest()
@@ -352,14 +353,15 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
     @Test
     public void testRequestCredential() {
-        final String scopeName = jwtTypeCredentialClientScope.getName();
+        String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setCredentialIdentifier(scopeName);
+                    .setCredentialConfigurationId(credConfigId);
 
             String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
 
@@ -392,27 +394,22 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     }
 
     @Test
-    public void testRequestCredentialWithConfigurationIdNotSet() {
+    public void testRequestCredentialWithNeitherIdSet() {
         final String scopeName = minimalJwtTypeCredentialClientScope.getName();
         String token = getBearerToken(oauth, client, scopeName);
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
-            CredentialRequest credentialRequest = new CredentialRequest()
-                    .setCredentialIdentifier(scopeName);
-
-            String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
-
-            Response credentialResponse = issuerEndpoint.requestCredential(requestPayload);
-            assertEquals("The credential request should be answered successfully.",
-                    HttpStatus.SC_OK, credentialResponse.getStatus());
-            assertNotNull("A credential should be responded.", credentialResponse.getEntity());
-            CredentialResponse credentialResponseVO = JsonSerialization.mapper
-                    .convertValue(credentialResponse.getEntity(), CredentialResponse.class);
-            String credentialString = (String) credentialResponseVO.getCredentials().get(0).getCredential();
-            SdJwtVP sdJwtVP = SdJwtVP.of(credentialString);
-            assertNotNull("A valid credential string should have been responded", sdJwtVP);
+            CredentialRequest credentialRequest = new CredentialRequest();
+            try {
+                String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
+                issuerEndpoint.requestCredential(requestPayload);
+                Assert.fail("Expected BadRequestException due to unknown credential identifier");
+            } catch (BadRequestException e) {
+                ErrorResponse error = (ErrorResponse) e.getResponse().getEntity();
+                assertEquals(ErrorType.MISSING_CREDENTIAL_IDENTIFIER_AND_CONFIGURATION_ID, error.getError());
+            }
         });
     }
 
@@ -430,9 +427,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         // 1. Retrieving the credential-offer-uri
         final String credentialConfigurationId = jwtTypeCredentialClientScope.getAttributes()
                 .get(CredentialScopeModel.CONFIGURATION_ID);
-        HttpGet getCredentialOfferURI = new HttpGet(getBasePath(TEST_REALM_NAME)
-                + "credential-offer-uri?credential_configuration_id="
-                + credentialConfigurationId);
+        HttpGet getCredentialOfferURI = new HttpGet(getCredentialOfferUriUrl(credentialConfigurationId));
         getCredentialOfferURI.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         CloseableHttpResponse credentialOfferURIResponse = httpClient.execute(getCredentialOfferURI);
 
@@ -602,15 +597,16 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
     @Test
     public void testRequestCredentialWithNotificationId() {
-        String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
+        String token = getBearerToken(oauth, client, scopeName);
 
         testingClient.server(TEST_REALM_NAME).run((session) -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
             CredentialRequest credentialRequest = new CredentialRequest()
-                    .setCredentialIdentifier(scopeName);
+                    .setCredentialConfigurationId(credConfigId);
 
             String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
 
@@ -639,12 +635,13 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     @Test
     public void testRequestMultipleCredentialsWithProofs() {
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
         String cNonce = getCNonce();
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
             try {
-                AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+                BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
                 authenticator.setTokenString(token);
                 String issuer = OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
 
@@ -654,7 +651,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
 
                 CredentialRequest request = new CredentialRequest()
-                        .setCredentialIdentifier(scopeName)
+                        .setCredentialConfigurationId(credConfigId)
                         .setProofs(proofs);
 
                 OID4VCIssuerEndpoint endpoint = prepareIssuerEndpoint(session, authenticator);
@@ -874,7 +871,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
@@ -901,7 +898,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
@@ -931,7 +928,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             // Prepare endpoint with no credential builders to simulate missing builder for the configured format
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator, Map.of());
@@ -963,7 +960,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .get(CredentialScopeModel.CONFIGURATION_ID);
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            AppAuthManager.BearerTokenAuthenticator authenticator = new AppAuthManager.BearerTokenAuthenticator(session);
+            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
             authenticator.setTokenString(token);
             OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointDisabledTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointDisabledTest.java
@@ -6,7 +6,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
-import org.keycloak.protocol.oid4vc.model.OfferUriType;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.testsuite.Assert;
@@ -36,7 +35,7 @@ public class OID4VCSdJwtIssuingEndpointDisabledTest extends OID4VCIssuerEndpoint
 
             // Test getCredentialOfferURI
             CorsErrorResponseException offerUriException = Assert.assertThrows(CorsErrorResponseException.class, () ->
-                    issuerEndpoint.getCredentialOfferURI("test-credential", OfferUriType.URI, 0, 0)
+                    issuerEndpoint.getCredentialOfferURI("test-credential")
             );
             assertEquals("Should fail with 403 Forbidden when client is not OID4VCI-enabled",
                     Response.Status.FORBIDDEN.getStatusCode(), offerUriException.getResponse().getStatus());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtIssuingEndpointTest.java
@@ -32,7 +32,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -231,7 +231,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                         final String nonceEndpoint = OID4VCIssuerWellKnownProvider.getNonceEndpoint(session.getContext());
                         try {
                             // make the exp-value negative to set the exp-time in the past
-                            session.getContext().getRealm().setAttribute(Oid4VciConstants.C_NONCE_LIFETIME_IN_SECONDS, -1);
+                            session.getContext().getRealm().setAttribute(OID4VCIConstants.C_NONCE_LIFETIME_IN_SECONDS, -1);
                             String cNonce = cNonceHandler.buildCNonce(List.of(credentialsEndpoint),
                                                                       Map.of(JwtCNonceHandler.SOURCE_ENDPOINT, nonceEndpoint));
                             Proofs proof = new Proofs().setJwt(List.of(generateJwtProof(getCredentialIssuer(session), cNonce)));
@@ -241,7 +241,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                             testRequestTestCredential(session, clientScope, token, proof);
                         } finally {
                             // make sure other tests are not affected by the changed realm-attribute
-                            session.getContext().getRealm().removeAttribute(Oid4VciConstants.C_NONCE_LIFETIME_IN_SECONDS);
+                            session.getContext().getRealm().removeAttribute(OID4VCIConstants.C_NONCE_LIFETIME_IN_SECONDS);
                         }
                     })));
             Assert.fail("Should have thrown an exception");
@@ -303,9 +303,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
 
         // 1. Retrieving the credential-offer-uri
         final String credentialConfigurationId = clientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
-        HttpGet getCredentialOfferURI = new HttpGet(getBasePath(TEST_REALM_NAME) +
-                "credential-offer-uri?credential_configuration_id=" +
-                credentialConfigurationId);
+        HttpGet getCredentialOfferURI = new HttpGet(getCredentialOfferUriUrl(credentialConfigurationId));
         getCredentialOfferURI.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
         CloseableHttpResponse credentialOfferURIResponse = httpClient.execute(getCredentialOfferURI);
 
@@ -515,7 +513,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
     public static ProtocolMapperRepresentation getJtiGeneratedIdMapper() {
         ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
         protocolMapperRepresentation.setName("generated-id-mapper");
-        protocolMapperRepresentation.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+        protocolMapperRepresentation.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
         protocolMapperRepresentation.setId(UUID.randomUUID().toString());
         protocolMapperRepresentation.setProtocolMapper("oid4vc-generated-id-mapper");
         protocolMapperRepresentation.setConfig(Map.of(
@@ -530,7 +528,7 @@ public class OID4VCSdJwtIssuingEndpointTest extends OID4VCIssuerEndpointTest {
                 .addClientScope(realmModel, jwtTypeCredentialScopeName);
         credentialScope.setAttribute(CredentialScopeModel.CREDENTIAL_IDENTIFIER,
                 jwtTypeCredentialScopeName);
-        credentialScope.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+        credentialScope.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
         return credentialScope;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
@@ -29,6 +29,7 @@ import java.security.Security;
 import java.security.cert.Certificate;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,7 +54,7 @@ import org.keycloak.common.util.CertificateUtils;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.PemUtils;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.ECDSASignatureSignerContext;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
@@ -70,6 +71,7 @@ import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.AttestationValidatorUtil;
 import org.keycloak.protocol.oid4vc.issuance.keybinding.JwtProofValidator;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCIssuedAtTimeClaimMapper;
+import org.keycloak.protocol.oid4vc.model.AuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.Format;
@@ -91,7 +93,8 @@ import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.UserBuilder;
-import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.AccessTokenRequest;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.util.JsonSerialization;
 
@@ -336,7 +339,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 		ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
 		protocolMapperRepresentation.setName("role-mapper");
 		protocolMapperRepresentation.setId(UUID.randomUUID().toString());
-		protocolMapperRepresentation.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+		protocolMapperRepresentation.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
 		protocolMapperRepresentation.setProtocolMapper("oid4vc-target-role-mapper");
 		protocolMapperRepresentation.setConfig(
 				Map.of("claim.name", "roles", "clientId", clientId)
@@ -347,7 +350,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 	public static ProtocolMapperRepresentation getIdMapper() {
 		ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
 		protocolMapperRepresentation.setName("id-mapper");
-		protocolMapperRepresentation.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+		protocolMapperRepresentation.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
 		protocolMapperRepresentation.setId(UUID.randomUUID().toString());
 		protocolMapperRepresentation.setProtocolMapper("oid4vc-subject-id-mapper");
 		protocolMapperRepresentation.setConfig(Map.of());
@@ -357,7 +360,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 	public static ProtocolMapperRepresentation getStaticClaimMapper(String scopeName) {
 		ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
 		protocolMapperRepresentation.setName(UUID.randomUUID().toString());
-		protocolMapperRepresentation.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+		protocolMapperRepresentation.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
 		protocolMapperRepresentation.setId(UUID.randomUUID().toString());
 		protocolMapperRepresentation.setProtocolMapper("oid4vc-static-claim-mapper");
 		protocolMapperRepresentation.setConfig(
@@ -394,25 +397,36 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 		return componentExportRepresentation;
 	}
 
-	public static UserRepresentation getUserRepresentation(Map<String, List<String>> clientRoles) {
-		UserBuilder userBuilder = UserBuilder.create()
-				.id(KeycloakModelUtils.generateId())
-				.username("john")
-				.enabled(true)
-				.email("john@email.cz")
-				.emailVerified(true)
-				.firstName("John")
-				.lastName("Doe")
-				.password("password")
-				.role("account", "manage-account")
-				.role("account", "view-profile");
+    public static UserRepresentation getUserRepresentation(
+            String fullName,
+            List<String> realmRoles,
+            Map<String, List<String>> clientRoles
+    ) {
+        String[] nameToks = fullName.split("\\s");
+        String firstName = nameToks[0];
+        String lastName = nameToks[1];
+        String username = firstName.toLowerCase();
+        UserBuilder userBuilder = UserBuilder.create()
+                .id(KeycloakModelUtils.generateId())
+                .username(username)
+                .enabled(true)
+                .email(username + "@email.cz")
+                .emailVerified(true)
+                .firstName(firstName)
+                .lastName(lastName)
+                .password("password")
+                .role("account", "manage-account")
+                .role("account", "view-profile");
 
-		clientRoles.entrySet().forEach(entry -> {
-			entry.getValue().forEach(role -> userBuilder.role(entry.getKey(), role));
-		});
-
-		return userBuilder.build();
-	}
+        // When Keycloak issues a token for a user and client:
+        //
+        //  1. It looks up all effective realm roles and all effective client roles assigned to the user.
+        //  2. The token includes only those roles that the user actually has.
+        //
+        realmRoles.forEach(userBuilder::addRoles);
+        clientRoles.forEach((cid, roles) -> roles.forEach(role -> userBuilder.role(cid, role)));
+        return userBuilder.build();
+    }
 
 	public static RoleRepresentation getRoleRepresentation(String roleName, String clientId) {
 
@@ -423,27 +437,62 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 		return role;
 	}
 
-	protected String getBearerToken(OAuthClient oAuthClient) {
-		return getBearerToken(oAuthClient, null);
+    protected String getAuthorizationCode(OAuthClient oAuthClient, ClientRepresentation client, String username, String scope) {
+        if (client != null) {
+            oAuthClient.client(client.getClientId(), client.getSecret());
+        }
+        if (scope != null) {
+            oAuthClient.scope(scope);
+        }
+        var authorizationEndpointResponse = oAuthClient.doLogin(username,"password");
+        return authorizationEndpointResponse.getCode();
+    }
+
+    protected String getBearerToken(OAuthClient oauthClient) {
+		return getBearerToken(oauthClient, null);
 	}
 
-	protected String getBearerToken(OAuthClient oAuthClient, ClientRepresentation client) {
-		return getBearerToken(oAuthClient, client, null);
+	protected String getBearerToken(OAuthClient oauthClient, ClientRepresentation client) {
+		return getBearerToken(oauthClient, client, null);
 	}
 
-	protected String getBearerToken(OAuthClient oAuthClient, ClientRepresentation client, String credentialScopeName) {
-		if (client != null) {
-			oAuthClient.client(client.getClientId(), client.getSecret());
-		}
-		if (credentialScopeName != null) {
-			oAuthClient.scope(credentialScopeName);
-		}
-		AuthorizationEndpointResponse authorizationEndpointResponse = oAuthClient.doLogin("john",
-				"password");
-		return oAuthClient.doAccessTokenRequest(authorizationEndpointResponse.getCode()).getAccessToken();
+	protected String getBearerToken(OAuthClient oauthClient, ClientRepresentation client, String scope) {
+        return getBearerToken(oauthClient, client, "john", scope);
 	}
 
-	public static class StaticTimeProvider implements TimeProvider {
+    protected String getBearerToken(OAuthClient oauthClient, ClientRepresentation client, String username, String scope) {
+        return getBearerTokenCodeFlow(oauthClient, client, username, scope).getAccessToken();
+    }
+
+    protected AccessTokenResponse getBearerToken(OAuthClient oauthClient, String authCode, AuthorizationDetail... authDetail) {
+        AccessTokenRequest accessTokenRequest = oauthClient.accessTokenRequest(authCode);
+        if (authDetail != null) {
+            accessTokenRequest.authorizationDetails(Arrays.asList(authDetail));
+        }
+        AccessTokenResponse tokenResponse = accessTokenRequest.send();
+        if (!tokenResponse.isSuccess()) {
+            throw new IllegalStateException(tokenResponse.getErrorDescription());
+        }
+        return tokenResponse;
+    }
+
+    protected AccessTokenResponse getBearerTokenCodeFlow(OAuthClient oauthClient, ClientRepresentation client, String username, String scope) {
+        var authCode = getAuthorizationCode(oauthClient, client, username, scope);
+        return oauthClient.accessTokenRequest(authCode).send();
+    }
+
+    protected AccessTokenResponse getBearerTokenDirectAccess(OAuthClient oauthClient, ClientRepresentation client, String username, String scope) {
+        if (client != null) {
+            oauthClient.client(client.getClientId(), client.getSecret());
+        }
+        if (scope != null) {
+            oauthClient.scope(scope);
+        }
+        var accessTokenResponse = oauthClient.doPasswordGrantRequest(username, "password");
+        return accessTokenResponse;
+    }
+
+    public static class StaticTimeProvider implements TimeProvider {
 		private final int currentTimeInS;
 
 		public StaticTimeProvider(int currentTimeInS) {
@@ -464,7 +513,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 	protected ProtocolMapperRepresentation getUserAttributeMapper(String subjectProperty, String attributeName) {
 		ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
 		protocolMapperRepresentation.setName(attributeName + "-mapper");
-		protocolMapperRepresentation.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+		protocolMapperRepresentation.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
 		protocolMapperRepresentation.setId(UUID.randomUUID().toString());
 		protocolMapperRepresentation.setProtocolMapper("oid4vc-user-attribute-mapper");
 		protocolMapperRepresentation.setConfig(
@@ -478,7 +527,7 @@ public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 	protected ProtocolMapperRepresentation getIssuedAtTimeMapper(String subjectProperty, String truncateToTimeUnit, String valueSource) {
 		ProtocolMapperRepresentation protocolMapperRepresentation = new ProtocolMapperRepresentation();
 		protocolMapperRepresentation.setName(subjectProperty + "-oid4vc-issued-at-time-claim-mapper");
-		protocolMapperRepresentation.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+		protocolMapperRepresentation.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
 		protocolMapperRepresentation.setId(UUID.randomUUID().toString());
 		protocolMapperRepresentation.setProtocolMapper("oid4vc-issued-at-time-claim-mapper");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationSdJwtTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationSdJwtTest.java
@@ -24,7 +24,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
-import org.keycloak.constants.Oid4VciConstants;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCIssuedAtTimeClaimMapper;
@@ -68,7 +68,7 @@ public class OID4VCTimeNormalizationSdJwtTest extends OID4VCSdJwtIssuingEndpoint
                 ClientScopeRepresentation clientScope = fromJsonString(clientScopeString, ClientScopeRepresentation.class);
                 ProtocolMapperRepresentation pr = new ProtocolMapperRepresentation();
                 pr.setName("iat-from-vc");
-                pr.setProtocol(Oid4VciConstants.OID4VC_PROTOCOL);
+                pr.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
                 pr.setProtocolMapper(OID4VCIssuedAtTimeClaimMapper.MAPPER_ID);
                 pr.setConfig(Map.of(
                         OID4VCIssuedAtTimeClaimMapper.CLAIM_NAME, "iat",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTimeNormalizationTest.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
@@ -55,6 +56,7 @@ public class OID4VCTimeNormalizationTest extends OID4VCJWTIssuerEndpointTest {
         });
 
         final String scopeName = jwtTypeCredentialClientScope.getName();
+        String credConfigId = jwtTypeCredentialClientScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
         String token = getBearerToken(oauth, client, scopeName);
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
@@ -64,7 +66,7 @@ public class OID4VCTimeNormalizationTest extends OID4VCJWTIssuerEndpointTest {
                 OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
 
                 CredentialRequest credentialRequest = new CredentialRequest()
-                        .setCredentialIdentifier(scopeName);
+                        .setCredentialConfigurationId(credConfigId);
 
                 String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
                 Response response = issuerEndpoint.requestCredential(requestPayload);

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/testrealm.json
@@ -405,6 +405,7 @@
       "clientId": "named-test-app",
       "name": "My Named Test App",
       "enabled": true,
+      "directAccessGrantsEnabled": true,
       "baseUrl": "http://localhost:8180/namedapp/base",
       "redirectUris": [
         "http://localhost:8180/namedapp/base/*",


### PR DESCRIPTION
closes #44116

This PR introduces CredentialOfferState that is decoupled from the any login session. It is acted upon getCredentialOffer and (later) upon getCredential. To create a credential offer, one must have the credential-offer-create role i.e. this is an issuer admin task and not something anybody can do. The credential offer is potentially bound to a target clientId and/or a target userId. Other constraints could also be enforced through this mechanism.

Once, the credential-offer-uri has been created successfully and (somehow) delivered to the wallet. There is no pre-requisite of any existing login session to redeem the credential-offer. 

Credential Offer Validity Matrix
| pre-auth | clientId | userId | Valid | Notes                                               |
|----------|----------|--------|-------|-----------------------------------------------------|
| no       | no       | no     | yes   | Generic offer; any logged-in user may redeem.       |
| no       | no       | yes    | yes   | Offer restricted to a specific user.                |
| no       | yes      | no     | yes   | Bound to client; user determined at login.          |
| no       | yes      | yes    | yes   | Bound to both client and user.                      |
|----------|----------|--------|-------|-----------------------------------------------------|
| yes      | no       | no     | no    | Pre-auth requires a user subject; missing userId.   |
| yes      | yes      | no     | no    | Same as above; userId required.                     |
| yes      | no       | yes    | yes   | Pre-auth for a specific user; client unconstrained. |
| yes      | yes      | yes    | yes   | Fully constrained: user + client.                   |

In the pre-auth offer case, the AccessTokenResponse does contain one AuthorizationDetail with both properties (i.e. credential_identifiers, credential_configuration_id). This is now natively supported in AccessTokenResponse.

The spec talks about what the wallet has to use in the CredentialRequest. It must use a  credential identifier in the pre-auth case - this is now enforced in the endpoint.

Using the credential_configuration_id in the CredentialRequest is still supported.
Using the credential scope as credential identifier is (imho) a hack that was used by many test cases - support for that has been removed and tests have been migrated to credential_configuration_id.

The credential endpoint now does this ...

```
        // When the CredentialRequest contains a credential identifier the caller must have gone through the
        // CredentialOffer process or otherwise have set up a valid CredentialOfferState

        if (credentialRequestVO.getCredentialIdentifier() != null) {
            var credId = credentialRequestVO.getCredentialIdentifier();

            // Retrieve the associated credential offer state
            //
            var offerStorage = session.getProvider(CredentialOfferStorage.class);
            var offerState = offerStorage.findOfferStateByCredentialId(session, credId);
            if (offerState == null) {
                var errorMessage = "No credential offer state for credential id: " + credId;
                throw new BadRequestException(getErrorResponse(UNKNOWN_CREDENTIAL_IDENTIFIER, errorMessage));
            }

            var authDetails = offerState.getAuthorizationDetails();
            String credConfigId = (String) authDetails.getOtherClaims().get("credential_configuration_id");

            if (credConfigId == null) {
                var errorMessage = "Cannot credential configuration mapping for: " + credId;
                throw new BadRequestException(getErrorResponse(UNKNOWN_CREDENTIAL_CONFIGURATION, errorMessage));
            }
```

In short, a credential identifier can (currently) only be obtained through a pre-auth credential offer.

The tests that have a credential identifier, now also use it.