### PR TITLE
In ClientRegistrationAuth, EventBuilder#error invocations fail with IllegalStateException

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
@@ -34,6 +34,7 @@ import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientInitialAccessModel;
 import org.keycloak.models.ClientModel;
@@ -164,6 +165,7 @@ public class ClientRegistrationAuth {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+			event.event(EventType.CLIENT_REGISTER_ERROR);
             event.error(cpe.getError());
             throw forbidden(cpe.getMessage());
         }
@@ -217,6 +219,7 @@ public class ClientRegistrationAuth {
                 event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
                 event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
                 event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+				event.event(EventType.CLIENT_INFO_ERROR);
                 event.error(cpe.getError());
                 throw forbidden(cpe.getMessage());
             }
@@ -242,6 +245,7 @@ public class ClientRegistrationAuth {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+			event.event(EventType.CLIENT_UPDATE_ERROR);
             event.error(cpe.getError());
             throw forbidden(cpe.getMessage());
         }
@@ -261,6 +265,7 @@ public class ClientRegistrationAuth {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+			event.event(EventType.CLIENT_DELETE_ERROR);
             event.error(cpe.getError());
             throw forbidden(cpe.getMessage());
         }


### PR DESCRIPTION
Closes #44263

Invoking `EventBuilder#error` before `EventBuilder#event` leads to an `IllegalStateException` because of:

https://github.com/keycloak/keycloak/blob/22deeda2c09c55a60979f9a1bc6cc55c0739a0c7/server-spi-private/src/main/java/org/keycloak/events/EventBuilder.java#L227-L230

Because of that, each error happening in `ClientRegistrationAuth`:
- ends up with an HTTP status code 500
- is never traced in the event log

This PR prepends every invocation of `EventBuilder#event` in `ClientRegistrationAuth` with an invocation to `EventBuilder#event`.