### PR TITLE
Allow extensions to skip identity linking after first broker login

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/AbstractIdpAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/AbstractIdpAuthenticator.java
@@ -53,6 +53,9 @@ public abstract class AbstractIdpAuthenticator implements Authenticator {
     // Set if nested firstBrokerLogin is detected, allowing to report a detailed error
     public static final String NESTED_FIRST_BROKER_CONTEXT = "NESTED_FIRST_BROKER_CONTEXT";
 
+    // Set if federated identity link should not be created after first broker login
+    public static final String SKIP_FEDERATED_IDENTITY_LINK = "SKIP_FEDERATED_IDENTITY_LINK";
+
     @Override
     public void authenticate(AuthenticationFlowContext context) {
         AuthenticationSessionModel authSession = context.getAuthenticationSession();

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -744,7 +744,8 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
             }
 
             // Add federated identity link here
-            if (!(federatedUser instanceof LightweightUserAdapter)) {
+            String skipFederatedIdentityLink = authSession.getAuthNote(AbstractIdpAuthenticator.SKIP_FEDERATED_IDENTITY_LINK);
+            if (!(federatedUser instanceof LightweightUserAdapter) && !Boolean.parseBoolean(skipFederatedIdentityLink)) {
                 checkOverrideLink(authSession, federatedUser, providerAlias);
 
                 FederatedIdentityModel federatedIdentityModel = new FederatedIdentityModel(context.getIdpConfig().getAlias(), context.getId(),


### PR DESCRIPTION
This PR allows extensions to skip the automatic/hard-coded identity linking after a successful first broker login.

The extension can disable auto linking behavior inside Keycloak by setting SKIP_FEDERATED_IDENTITY_LINK auth note like so:
```java
protected void authenticateImpl(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext)
{
    ...
    context.getAuthenticationSession().setAuthNote(AbstractIdpAuthenticator.SKIP_FEDERATED_IDENTITY_LINK, "true");
    context.success();
}
```

Here's a working plugin, which we aim to use in production soon, utilizing this proposed change:
https://github.com/BotoX/keycloak-custom-attribute-idp-linking

We're a large university where users can have multiple accounts depending on their role (employee & student).
It's possible that users switch between roles multiple times as they finish their studies, start working for the university, resume studying, start a PhD or work as a student assistant for a short amount of time, etc.
We'd like to offer ID Austria / eIDAS login to users, for all of their accounts.
So in our case **one broker ID** can point to **multiple accounts** in our keycloak realm.

The broker IDs are provisioned automatically in the background by us, manual account linking is not supported and not wanted.
Linking multiple accounts is not supported in keycloak either though, see the following issue:
https://github.com/keycloak/keycloak/issues/29317
Thus we need users to be able to choose which account they would like to login to every time they use the brokered login.

Unfortunately keycloak has hard-coded auto-linking in the first-broker-login flow here:
https://github.com/keycloak/keycloak/blob/167249dd6c7888926dd0496645c77e39aa70fb43/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java#L746-L754
which makes the choosing part by plugins impossible once a brokered login has been made.
(Unless the plugin incorporate a post login flow which unlinks the account again, but that sound really ugly and possibly error prone to me - see https://github.com/keycloak/keycloak/issues/13323)

Hence my proposal to add a simple AuthNote to allow authentication plugins to control this behavior.

Here's a video demonstration of our use case:
https://cloud.uni-graz.at/s/SKGFTS2nipgfrP6