### PR TITLE
Prevent slash duplication in request URLs

### DIFF
--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "camelize-ts": "^3.0.0",
-    "url-join": "^5.0.0",
     "url-template": "^3.1.1"
   },
   "devDependencies": {

--- a/js/libs/keycloak-admin-client/src/utils/joinPath.ts
+++ b/js/libs/keycloak-admin-client/src/utils/joinPath.ts
@@ -1,0 +1,22 @@
+const PATH_SEPARATOR = "/";
+
+export function joinPath(...paths: string[]) {
+  const normalizedPaths = paths.map((path, index) => {
+    const isFirst = index === 0;
+    const isLast = index === paths.length - 1;
+
+    // Strip out any leading slashes from the path.
+    if (!isFirst && path.startsWith(PATH_SEPARATOR)) {
+      path = path.slice(1);
+    }
+
+    // Strip out any trailing slashes from the path.
+    if (!isLast && path.endsWith(PATH_SEPARATOR)) {
+      path = path.slice(0, -1);
+    }
+
+    return path;
+  }, []);
+
+  return normalizedPaths.join(PATH_SEPARATOR);
+}

--- a/js/libs/keycloak-admin-client/test/groups.spec.ts
+++ b/js/libs/keycloak-admin-client/test/groups.spec.ts
@@ -5,8 +5,8 @@ import { KeycloakAdminClient } from "../src/client.js";
 import type ClientRepresentation from "../src/defs/clientRepresentation.js";
 import type GroupRepresentation from "../src/defs/groupRepresentation.js";
 import type RoleRepresentation from "../src/defs/roleRepresentation.js";
+import type { SubGroupQuery } from "../src/resources/groups.js";
 import { credentials } from "./constants.js";
-import { SubGroupQuery } from "../src/resources/groups.js";
 
 const expect = chai.expect;
 

--- a/js/libs/keycloak-admin-client/test/joinPaths.spec.ts
+++ b/js/libs/keycloak-admin-client/test/joinPaths.spec.ts
@@ -1,0 +1,23 @@
+import { expect } from "chai";
+import { joinPath } from "../lib/utils/joinPath.js";
+
+describe("joinPath", () => {
+  it("returns an empty string when no paths are provided", () => {
+    expect(joinPath()).to.equal("");
+  });
+
+  it("joins paths", () => {
+    expect(joinPath("foo", "bar", "baz")).to.equal("foo/bar/baz");
+    expect(joinPath("foo", "/bar", "baz")).to.equal("foo/bar/baz");
+    expect(joinPath("foo", "bar/", "baz")).to.equal("foo/bar/baz");
+    expect(joinPath("foo", "/bar/", "baz")).to.equal("foo/bar/baz");
+  });
+
+  it("joins paths with leading slashes", () => {
+    expect(joinPath("/foo", "bar", "baz")).to.equal("/foo/bar/baz");
+  });
+
+  it("joins paths with trailing slashes", () => {
+    expect(joinPath("foo", "bar", "baz/")).to.equal("foo/bar/baz/");
+  });
+});

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -331,9 +331,6 @@ importers:
       camelize-ts:
         specifier: ^3.0.0
         version: 3.0.0
-      url-join:
-        specifier: ^5.0.0
-        version: 5.0.0
       url-template:
         specifier: ^3.1.1
         version: 3.1.1
@@ -4205,10 +4202,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  url-join@5.0.0:
-    resolution: {integrity: sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   url-template@3.1.1:
     resolution: {integrity: sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==}
@@ -8701,8 +8694,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  url-join@5.0.0: {}
 
   url-template@3.1.1: {}
 


### PR DESCRIPTION
Prevents the admin client from duplicating slashes in request URLs, which can make the request URL invalid.

Closes #44269

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
