### PR TITLE
Add support for cloudflare turnstile

### DIFF
--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -39,3 +39,11 @@ This provides a more fine-grained way to manage features and eliminates the need
 The `feature-<name>` option takes precedence over both `features` and `features-disabled`.
 
 For more details, see the https://www.keycloak.org/server/features[Enabling and disabling features] guide.
+
+= Cloudflare Turnstile support
+
+{project_name} has integration with Cloudflare Turnstile as a CAPTCHA provider.
+
+Turnstile can be configured to protect registration forms, login flows, and password reset pages.
+
+For more details, see the link:{adminguide_link}#proc-enabling-turnstile_server_administration_guide[{adminguide_name}].

--- a/docs/documentation/server_admin/topics/assembly-managing-users.adoc
+++ b/docs/documentation/server_admin/topics/assembly-managing-users.adoc
@@ -30,6 +30,7 @@ include::users/proc-allow-user-to-delete-account.adoc[leveloffset=+2]
 
 include::users/con-user-impersonation.adoc[leveloffset=+2]
 include::users/proc-enabling-recaptcha.adoc[leveloffset=+2]
+include::users/proc-enabling-turnstile.adoc[leveloffset=+2]
 
 include::users/ref-personal-data-collected.adoc[leveloffset=+2]
 

--- a/docs/documentation/server_admin/topics/users/proc-enabling-turnstile.adoc
+++ b/docs/documentation/server_admin/topics/users/proc-enabling-turnstile.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// server_admin/topics/users.adoc
+
+[id="proc-enabling-turnstile_{context}"]
+= Enabling Cloudflare Turnstile
+
+[role="_abstract"]
+To safeguard registration against bots, {project_name} has integration with https://www.cloudflare.com/application-services/products/turnstile/[Cloudflare Turnstile]. Turnstile can be used to protect registration forms, login forms, and password reset flows.
+
+== Common setup
+
+Before configuring Turnstile for any authentication flow, complete the following steps:
+
+. In your Cloudflare account, navigate to *Turnstile* and click *Add Site*.
+. Create a Turnstile site key and note the site key and secret key.
++
+NOTE: For testing, use Cloudflare's test keys. Site Key: `1x00000000000000000000AA`, Secret Key: `1x0000000000000000000000000000000AA`.
++
+. In the {project_name} Admin Console, update the Content Security Policy:
+.. Click *Realm Settings* in the menu.
+.. Click the *Security Defenses* tab.
+.. Update the *Content-Security-Policy* header. Example: `frame-src 'self' https://challenges.cloudflare.com;`
+
+[[procedure_turnstile_registration]]
+== Registration
+
+To protect the registration form with Turnstile:
+
+. Click *Authentication* in the menu, then click the *Flows* tab.
+. Select *Registration* from the list.
+. Set the *Turnstile* requirement to *Required*.
+. Click the *gear icon* ⚙️ on the *Turnstile* row and configure:
+.. Enter the *Turnstile Site Key* and *Turnstile Secret*.
+.. (Optional) Set the *Action Name* to `register`.
+.. (Optional) Select a *Theme*: `auto`, `light`, or `dark`.
+.. (Optional) Select a *Size*: `normal`, `flexible`, or `compact`.
+.. Click *Save*.
+
+[[procedure_turnstile_login]]
+== Login
+
+To protect the login form with Turnstile:
+
+. Click *Authentication* in the menu, then click the *Flows* tab.
+. Duplicate the *Browser* flow and bind it to the *Browser flow*.
+. Edit the flow:
+.. Delete the *Username Password Form* step.
+.. Add *Username Password Form with Turnstile*.
+.. Set the requirement to *Required*.
+. Configure Turnstile (click the *gear icon* ⚙️):
+.. Enter the *Turnstile Site Key* and *Turnstile Secret*.
+.. Set the *Action Name* to `login`.
+.. (Optional) Configure *Theme* and *Size*.
+.. Click *Save*.
+
+[[procedure_turnstile_reset]]
+== Password reset
+
+To protect the password reset flow with Turnstile:
+
+. Click *Authentication* in the menu, then click the *Flows* tab.
+. Duplicate the *Reset Credentials* flow and bind it to the *Reset credentials flow*.
+. Edit the flow:
+.. Delete the *Choose User* step.
+.. Add *Choose User with Turnstile*.
+.. Set the requirement to *Required*.
+. Configure Turnstile (click the *gear icon* ⚙️):
+.. Enter the *Turnstile Site Key* and *Turnstile Secret*.
+.. Set the *Action Name* to `reset`.
+.. (Optional) Configure *Theme* and *Size*.
+.. Click *Save*.

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordFormWithTurnstile.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordFormWithTurnstile.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser;
+
+import java.util.Map;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.WebAuthnConstants;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.authenticators.util.TurnstileHelper;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.validation.Validation;
+
+/**
+ * Username/Password form with Turnstile support
+ */
+public class UsernamePasswordFormWithTurnstile extends UsernamePasswordForm {
+
+    public UsernamePasswordFormWithTurnstile(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+        
+        // Check if this is a WebAuthn/passkey submission first
+        // Passkey submissions should bypass Turnstile validation since the user didn't interact with the form
+        if (webauthnAuth != null && webauthnAuth.isPasskeysEnabled()
+                && (formData.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA) || formData.containsKey(WebAuthnConstants.ERROR))) {
+            // webauth form submission, try to action using the webauthn authenticator
+            webauthnAuth.action(context);
+            return;
+        }
+        
+        // Validate Turnstile for normal username/password submissions
+        if (context.getAuthenticatorConfig() != null) {
+            String captcha = formData.getFirst(TurnstileHelper.CF_TURNSTILE_RESPONSE);
+            Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+
+            if (TurnstileHelper.validateConfig(config)) {
+                if (Validation.isBlank(captcha) || !validateTurnstile(context, captcha, config)) {
+                    context.getEvent().error(org.keycloak.events.Errors.INVALID_USER_CREDENTIALS);
+                    Response challengeResponse = challenge(context, org.keycloak.services.messages.Messages.TURNSTILE_FAILED);
+                    context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+                    return;
+                }
+            }
+        }
+
+        // Continue with normal username/password validation
+        super.action(context);
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, jakarta.ws.rs.core.MultivaluedMap<String, String> formData) {
+        LoginFormsProvider form = context.form();
+        // Add Turnstile to form if configured
+        if (context.getAuthenticatorConfig() != null) {
+            Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+            TurnstileHelper.addTurnstileToForm(form, config, context.getSession(),
+                    context.getUser(), TurnstileHelper.DEFAULT_ACTION_LOGIN);
+        }
+        if (formData != null && !formData.isEmpty()) {
+            form.setFormData(formData);
+        }
+        return form.createLoginUsernamePassword();
+    }
+
+    @Override
+    protected Response challenge(AuthenticationFlowContext context, String error, String field) {
+        // Keep WebAuthn/passkeys behavior aligned with base class
+        if (isConditionalPasskeysEnabled(context.getUser())) {
+            webauthnAuth.fillContextForm(context);
+        }
+
+        LoginFormsProvider form = context.form()
+                .setExecution(context.getExecution().getId());
+
+        if (error != null) {
+            if (field != null) {
+                form.addError(new org.keycloak.models.utils.FormMessage(field, error));
+            } else {
+                form.setError(error);
+            }
+        }
+
+        // Add Turnstile to form if configured
+        if (context.getAuthenticatorConfig() != null) {
+            Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+            TurnstileHelper.addTurnstileToForm(form, config, context.getSession(),
+                    context.getUser(), TurnstileHelper.DEFAULT_ACTION_LOGIN);
+        }
+
+        return createLoginForm(form);
+    }
+
+    protected boolean validateTurnstile(AuthenticationFlowContext context, String captcha, Map<String, String> config) {
+        String remoteAddr = context.getConnection().getRemoteAddr();
+        return TurnstileHelper.validateTurnstile(context.getSession(), captcha, config, remoteAddr);
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordFormWithTurnstileFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordFormWithTurnstileFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.authenticators.util.TurnstileHelper;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+/**
+ * Factory for Username/Password form with Turnstile
+ */
+public class UsernamePasswordFormWithTurnstileFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "auth-userpass-form-turnstile";
+
+    @Override
+    public String getDisplayType() {
+        return "Username Password Form with Turnstile";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return PasswordCredentialModel.TYPE;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Validates a username and password with Cloudflare Turnstile CAPTCHA.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(TurnstileHelper.SITE_KEY)
+                .label("Turnstile Site Key")
+                .helpText("The site key from Cloudflare Turnstile.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+                .property()
+                .name(TurnstileHelper.SECRET_KEY)
+                .label("Turnstile Secret")
+                .helpText("The secret key from Cloudflare Turnstile.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .secret(true)
+                .add()
+                .property()
+                .name(TurnstileHelper.ACTION)
+                .label("Action Name")
+                .helpText("A meaningful name for this Turnstile context (e.g. login).")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue(TurnstileHelper.DEFAULT_ACTION_LOGIN)
+                .add()
+                .property()
+                .name(TurnstileHelper.THEME)
+                .label("Theme")
+                .helpText("The theme for the Turnstile widget.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options("auto", "light", "dark")
+                .defaultValue(TurnstileHelper.DEFAULT_THEME)
+                .add()
+                .property()
+                .name(TurnstileHelper.SIZE)
+                .label("Size")
+                .helpText("The size of the Turnstile widget.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options("normal", "flexible", "compact")
+                .defaultValue(TurnstileHelper.DEFAULT_SIZE)
+                .add()
+                .build();
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new UsernamePasswordFormWithTurnstile(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUserWithTurnstile.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUserWithTurnstile.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.resetcred;
+
+import java.util.Map;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.authenticators.util.TurnstileHelper;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.services.validation.Validation;
+
+/**
+ * Reset Credential Choose User with Turnstile support
+ */
+public class ResetCredentialChooseUserWithTurnstile extends ResetCredentialChooseUser {
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        addTurnstileToFormIfConfigured(context);
+        super.authenticate(context);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        // Validate Turnstile first if configured
+        if (context.getAuthenticatorConfig() != null) {
+            MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+            String captcha = formData.getFirst(TurnstileHelper.CF_TURNSTILE_RESPONSE);
+            Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+
+            if (TurnstileHelper.validateConfig(config)) {
+                if (Validation.isBlank(captcha) || !validateTurnstile(context, captcha, config)) {
+                    context.getEvent().error(org.keycloak.events.Errors.INVALID_USER_CREDENTIALS);
+                    Response challengeResponse = createChallengeWithError(context, "turnstileFailed");
+                    context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+                    return;
+                }
+            }
+        }
+
+        // Continue with normal reset credential logic
+        super.action(context);
+    }
+
+    protected void addTurnstileToFormIfConfigured(AuthenticationFlowContext context) {
+        if (context.getAuthenticatorConfig() == null) {
+            return;
+        }
+
+        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+        if (!TurnstileHelper.validateConfig(config)) {
+            return;
+        }
+
+        LoginFormsProvider form = context.form();
+        if (form == null) {
+            return;
+        }
+
+        TurnstileHelper.addTurnstileToForm(form, config, context.getSession(),
+                context.getUser(), TurnstileHelper.DEFAULT_ACTION_RESET);
+    }
+
+    protected Response createChallengeWithError(AuthenticationFlowContext context, String error) {
+        LoginFormsProvider form = context.form();
+        if (error != null) {
+            form.setError(error);
+        }
+
+        addTurnstileToFormIfConfigured(context);
+
+        return form.createPasswordReset();
+    }
+
+    protected boolean validateTurnstile(AuthenticationFlowContext context, String captcha, Map<String, String> config) {
+        String remoteAddr = context.getConnection().getRemoteAddr();
+        return TurnstileHelper.validateTurnstile(context.getSession(), captcha, config, remoteAddr);
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUserWithTurnstileFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUserWithTurnstileFactory.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.resetcred;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.authenticators.util.TurnstileHelper;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+/**
+ * Factory for Reset Credential Choose User with Turnstile
+ */
+public class ResetCredentialChooseUserWithTurnstileFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "reset-choose-user-turnstile";
+
+    @Override
+    public String getDisplayType() {
+        return "Choose User with Turnstile";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return null;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Choose a user to reset credentials for with Cloudflare Turnstile CAPTCHA protection";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(TurnstileHelper.SITE_KEY)
+                .label("Turnstile Site Key")
+                .helpText("The site key from Cloudflare Turnstile.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+                .property()
+                .name(TurnstileHelper.SECRET_KEY)
+                .label("Turnstile Secret")
+                .helpText("The secret key from Cloudflare Turnstile.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .secret(true)
+                .add()
+                .property()
+                .name(TurnstileHelper.ACTION)
+                .label("Action Name")
+                .helpText("A meaningful name for this Turnstile context (e.g. reset).")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue(TurnstileHelper.DEFAULT_ACTION_RESET)
+                .add()
+                .property()
+                .name(TurnstileHelper.THEME)
+                .label("Theme")
+                .helpText("The theme for the Turnstile widget.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options("auto", "light", "dark")
+                .defaultValue(TurnstileHelper.DEFAULT_THEME)
+                .add()
+                .property()
+                .name(TurnstileHelper.SIZE)
+                .label("Size")
+                .helpText("The size of the Turnstile widget.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options("normal", "flexible", "compact")
+                .defaultValue(TurnstileHelper.DEFAULT_SIZE)
+                .add()
+                .build();
+    }
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return new ResetCredentialChooseUserWithTurnstile();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/util/TurnstileHelper.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/util/TurnstileHelper.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.util;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.connections.httpclient.HttpClientProvider;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.ServicesLogger;
+import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.StringUtil;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.jboss.logging.Logger;
+
+/**
+ * Helper class for Cloudflare Turnstile CAPTCHA integration.
+ * Provides common functionality for Turnstile validation and form integration.
+ */
+public class TurnstileHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(TurnstileHelper.class);
+
+    // Form field name for Turnstile response token
+    public static final String CF_TURNSTILE_RESPONSE = "cf-turnstile-response";
+
+    // Configuration keys
+    public static final String SITE_KEY = "site.key";
+    public static final String SECRET_KEY = "secret.key";
+    public static final String ACTION = "action";
+    public static final String THEME = "theme";
+    public static final String SIZE = "size";
+
+    // Turnstile API endpoints
+    public static final String TURNSTILE_SCRIPT_URL = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+    public static final String TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+    // Default configuration values
+    public static final String DEFAULT_ACTION_REGISTER = "register";
+    public static final String DEFAULT_ACTION_LOGIN = "login";
+    public static final String DEFAULT_ACTION_RESET = "reset";
+    public static final String DEFAULT_THEME = "auto";
+    public static final String DEFAULT_SIZE = "normal";
+
+    // Reference category for provider configuration
+    public static final String TURNSTILE_REFERENCE_CATEGORY = "turnstile";
+
+    private TurnstileHelper() {
+        // Utility class, prevent instantiation
+    }
+
+    /**
+     * Validates that required Turnstile configuration is present.
+     *
+     * @param config the configuration map
+     * @return true if site key and secret key are configured
+     */
+    public static boolean validateConfig(Map<String, String> config) {
+        return config != null &&
+                !StringUtil.isNullOrEmpty(config.get(SITE_KEY)) &&
+                !StringUtil.isNullOrEmpty(config.get(SECRET_KEY));
+    }
+
+
+    /**
+     * Validates a Turnstile response token with Cloudflare's verification API.
+     *
+     * @param session the Keycloak session
+     * @param captcha the Turnstile response token from the client
+     * @param config the authenticator configuration
+     * @param remoteAddr the client's remote IP address (optional)
+     * @return true if validation succeeds
+     */
+    public static boolean validateTurnstile(KeycloakSession session, String captcha, Map<String, String> config, String remoteAddr) {
+        LOGGER.trace("Verifying Turnstile using Cloudflare API");
+        CloseableHttpClient httpClient = session.getProvider(HttpClientProvider.class).getHttpClient();
+
+        HttpPost post = new HttpPost(TURNSTILE_VERIFY_URL);
+        List<NameValuePair> formparams = new LinkedList<>();
+        formparams.add(new BasicNameValuePair("secret", config.get(SECRET_KEY)));
+        formparams.add(new BasicNameValuePair("response", captcha));
+        if (remoteAddr != null) {
+            formparams.add(new BasicNameValuePair("remoteip", remoteAddr));
+        }
+
+        try {
+            UrlEncodedFormEntity form = new UrlEncodedFormEntity(formparams, StandardCharsets.UTF_8);
+            post.setEntity(form);
+            
+            try (CloseableHttpResponse response = httpClient.execute(post)) {
+                InputStream content = response.getEntity().getContent();
+                try {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> json = JsonSerialization.readValue(content, Map.class);
+                    return Boolean.TRUE.equals(json.get("success"));
+                } finally {
+                    EntityUtils.consumeQuietly(response.getEntity());
+                }
+            }
+        } catch (Exception e) {
+            ServicesLogger.LOGGER.turnstileFailed(e);
+        }
+        return false;
+    }
+
+    /**
+     * Adds Turnstile widget attributes to a login form.
+     *
+     * @param form the login form provider
+     * @param config the authenticator configuration
+     * @param session the Keycloak session
+     * @param user the user (may be null)
+     * @param defaultAction the default action name if not configured
+     */
+    public static void addTurnstileToForm(LoginFormsProvider form, Map<String, String> config,
+                                           KeycloakSession session, UserModel user, String defaultAction) {
+        if (!validateConfig(config)) {
+            return;
+        }
+
+        String userLanguageTag = session.getContext().resolveLocale(user).toLanguageTag();
+        String action = StringUtil.isNullOrEmpty(config.get(ACTION)) ? defaultAction : config.get(ACTION);
+        String theme = StringUtil.isNullOrEmpty(config.get(THEME)) ? DEFAULT_THEME : config.get(THEME);
+        String size = StringUtil.isNullOrEmpty(config.get(SIZE)) ? DEFAULT_SIZE : config.get(SIZE);
+
+        form.setAttribute("turnstileRequired", true);
+        form.setAttribute("turnstileSiteKey", config.get(SITE_KEY));
+        form.setAttribute("turnstileAction", action);
+        form.setAttribute("turnstileTheme", theme);
+        form.setAttribute("turnstileSize", size);
+        form.setAttribute("turnstileLanguage", userLanguageTag);
+        form.addScript(TURNSTILE_SCRIPT_URL);
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationTurnstile.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationTurnstile.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.forms;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.FormAction;
+import org.keycloak.authentication.FormActionFactory;
+import org.keycloak.authentication.FormContext;
+import org.keycloak.authentication.ValidationContext;
+import org.keycloak.authentication.authenticators.util.TurnstileHelper;
+import org.keycloak.events.Errors;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.FormMessage;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.services.validation.Validation;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Adds Cloudflare Turnstile CAPTCHA to registration forms.
+ */
+public class RegistrationTurnstile implements FormAction, FormActionFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(RegistrationTurnstile.class);
+    public static final String PROVIDER_ID = "registration-turnstile-action";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Turnstile";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Adds Cloudflare Turnstile to the form.";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return TurnstileHelper.TURNSTILE_REFERENCE_CATEGORY;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return new AuthenticationExecutionModel.Requirement[] {
+                AuthenticationExecutionModel.Requirement.REQUIRED,
+                AuthenticationExecutionModel.Requirement.DISABLED
+        };
+    }
+
+    @Override
+    public void buildPage(FormContext context, LoginFormsProvider form) {
+        LOGGER.trace("Building page with Turnstile");
+
+        Map<String, String> config = null;
+        if (context.getAuthenticatorConfig() != null) {
+            config = context.getAuthenticatorConfig().getConfig();
+        }
+
+        if (config == null) {
+            form.addError(new FormMessage(null, Messages.TURNSTILE_NOT_CONFIGURED));
+            return;
+        }
+
+        if (!TurnstileHelper.validateConfig(config)) {
+            form.addError(new FormMessage(null, Messages.TURNSTILE_NOT_CONFIGURED));
+            return;
+        }
+
+        TurnstileHelper.addTurnstileToForm(form, config, context.getSession(),
+                context.getUser(), TurnstileHelper.DEFAULT_ACTION_REGISTER);
+    }
+
+    @Override
+    public void validate(ValidationContext context) {
+        MultivaluedMap<String, String> formData = context.getHttpRequest().getDecodedFormParameters();
+        String captcha = formData.getFirst(TurnstileHelper.CF_TURNSTILE_RESPONSE);
+        LOGGER.trace("Got Turnstile captcha: " + captcha);
+
+        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+
+        if (!Validation.isBlank(captcha)) {
+            String remoteAddr = context.getConnection().getRemoteAddr();
+            if (TurnstileHelper.validateTurnstile(context.getSession(), captcha, config, remoteAddr)) {
+                context.success();
+                return;
+            }
+        }
+
+        List<FormMessage> errors = new ArrayList<>();
+        errors.add(new FormMessage(null, Messages.TURNSTILE_FAILED));
+        context.error(Errors.INVALID_REGISTRATION);
+        context.validationError(formData, errors);
+        context.excludeOtherErrors();
+    }
+
+    @Override
+    public void success(FormContext context) {
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public FormAction create(KeycloakSession session) {
+        return this;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(TurnstileHelper.SITE_KEY)
+                .label("Turnstile Site Key")
+                .helpText("The site key from Cloudflare Turnstile.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+                .property()
+                .name(TurnstileHelper.SECRET_KEY)
+                .label("Turnstile Secret")
+                .helpText("The secret key from Cloudflare Turnstile.")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .secret(true)
+                .add()
+                .property()
+                .name(TurnstileHelper.ACTION)
+                .label("Action Name")
+                .helpText("A meaningful name for this Turnstile context (e.g. login, register).")
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue(TurnstileHelper.DEFAULT_ACTION_REGISTER)
+                .add()
+                .property()
+                .name(TurnstileHelper.THEME)
+                .label("Theme")
+                .helpText("The theme for the Turnstile widget.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options("auto", "light", "dark")
+                .defaultValue(TurnstileHelper.DEFAULT_THEME)
+                .add()
+                .property()
+                .name(TurnstileHelper.SIZE)
+                .label("Size")
+                .helpText("The size of the Turnstile widget.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options("normal", "flexible", "compact")
+                .defaultValue(TurnstileHelper.DEFAULT_SIZE)
+                .add()
+                .build();
+    }
+}

--- a/services/src/main/java/org/keycloak/services/ServicesLogger.java
+++ b/services/src/main/java/org/keycloak/services/ServicesLogger.java
@@ -148,6 +148,10 @@ public interface ServicesLogger extends BasicLogger {
     void recaptchaFailed(@Cause Exception e);
 
     @LogMessage(level = ERROR)
+    @Message(id=112, value="Turnstile failed")
+    void turnstileFailed(@Cause Exception e);
+
+    @LogMessage(level = ERROR)
     @Message(id=29, value="Failed to send email")
     void failedToSendEmail(@Cause Exception e);
 

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -93,6 +93,9 @@ public class Messages {
     public static final String RECAPTCHA_FAILED = "recaptchaFailed";
     public static final String RECAPTCHA_NOT_CONFIGURED = "recaptchaNotConfigured";
 
+    public static final String TURNSTILE_FAILED = "turnstileFailed";
+    public static final String TURNSTILE_NOT_CONFIGURED = "turnstileNotConfigured";
+
     public static final String EMAIL_EXISTS = "emailExistsMessage";
     public static final String EMAIL_VERIFICATION_PENDING = "emailVerificationPending";
 

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -17,6 +17,7 @@
 
 org.keycloak.authentication.authenticators.browser.CookieAuthenticatorFactory
 org.keycloak.authentication.authenticators.browser.UsernamePasswordFormFactory
+org.keycloak.authentication.authenticators.browser.UsernamePasswordFormWithTurnstileFactory
 org.keycloak.authentication.authenticators.browser.UsernameFormFactory
 org.keycloak.authentication.authenticators.browser.PasswordFormFactory
 org.keycloak.authentication.authenticators.browser.OTPFormAuthenticatorFactory
@@ -33,6 +34,7 @@ org.keycloak.authentication.authenticators.directgrant.ValidateOTP
 org.keycloak.authentication.authenticators.directgrant.ValidatePassword
 org.keycloak.authentication.authenticators.directgrant.ValidateUsername
 org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUser
+org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUserWithTurnstileFactory
 org.keycloak.authentication.authenticators.resetcred.ResetCredentialEmail
 org.keycloak.authentication.authenticators.resetcred.ResetOTP
 org.keycloak.authentication.authenticators.resetcred.ResetPassword

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.FormActionFactory
@@ -19,4 +19,5 @@ org.keycloak.authentication.forms.RegistrationPassword
 org.keycloak.authentication.forms.RegistrationUserCreation
 org.keycloak.authentication.forms.RegistrationRecaptcha
 org.keycloak.authentication.forms.RegistrationRecaptchaEnterprise
+org.keycloak.authentication.forms.RegistrationTurnstile
 org.keycloak.authentication.forms.RegistrationTermsAndConditions

--- a/services/src/test/java/org/keycloak/authentication/authenticators/util/TurnstileHelperTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/util/TurnstileHelperTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit tests for TurnstileHelper configuration validation
+ */
+public class TurnstileHelperTest {
+
+    @Test
+    public void testValidateConfig_WithValidConfig() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SITE_KEY, "test-site-key");
+        config.put(TurnstileHelper.SECRET_KEY, "test-secret-key");
+
+        assertTrue(TurnstileHelper.validateConfig(config));
+    }
+
+    @Test
+    public void testValidateConfig_WithNullConfig() {
+        assertFalse(TurnstileHelper.validateConfig(null));
+    }
+
+    @Test
+    public void testValidateConfig_WithMissingSiteKey() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SECRET_KEY, "test-secret-key");
+
+        assertFalse(TurnstileHelper.validateConfig(config));
+    }
+
+    @Test
+    public void testValidateConfig_WithMissingSecretKey() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SITE_KEY, "test-site-key");
+
+        assertFalse(TurnstileHelper.validateConfig(config));
+    }
+
+    @Test
+    public void testValidateConfig_WithEmptySiteKey() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SITE_KEY, "");
+        config.put(TurnstileHelper.SECRET_KEY, "test-secret-key");
+
+        assertFalse(TurnstileHelper.validateConfig(config));
+    }
+
+    @Test
+    public void testValidateConfig_WithEmptySecretKey() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SITE_KEY, "test-site-key");
+        config.put(TurnstileHelper.SECRET_KEY, "");
+
+        assertFalse(TurnstileHelper.validateConfig(config));
+    }
+
+
+    @Test
+    public void testConstants() {
+        assertEquals("cf-turnstile-response", TurnstileHelper.CF_TURNSTILE_RESPONSE);
+        assertEquals("site.key", TurnstileHelper.SITE_KEY);
+        assertEquals("secret.key", TurnstileHelper.SECRET_KEY);
+        assertEquals("action", TurnstileHelper.ACTION);
+        assertEquals("theme", TurnstileHelper.THEME);
+        assertEquals("size", TurnstileHelper.SIZE);
+        assertEquals("https://challenges.cloudflare.com/turnstile/v0/api.js", TurnstileHelper.TURNSTILE_SCRIPT_URL);
+        assertEquals("https://challenges.cloudflare.com/turnstile/v0/siteverify", TurnstileHelper.TURNSTILE_VERIFY_URL);
+        assertEquals("register", TurnstileHelper.DEFAULT_ACTION_REGISTER);
+        assertEquals("login", TurnstileHelper.DEFAULT_ACTION_LOGIN);
+        assertEquals("reset", TurnstileHelper.DEFAULT_ACTION_RESET);
+        assertEquals("auto", TurnstileHelper.DEFAULT_THEME);
+        assertEquals("normal", TurnstileHelper.DEFAULT_SIZE);
+        assertEquals("turnstile", TurnstileHelper.TURNSTILE_REFERENCE_CATEGORY);
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/ProvidersTest.java
@@ -70,6 +70,8 @@ public class ProvidersTest extends AbstractAuthenticationTest {
         addProviderInfo(expected, RegistrationRecaptchaEnterprise.PROVIDER_ID, "reCAPTCHA Enterprise", "Adds Google reCAPTCHA Enterprise to the form.");
         addProviderInfo(expected, "registration-password-action", "Password Validation",
                 "Validates that password matches password confirmation field.  It also will store password in user's credential store.");
+        addProviderInfo(expected, "registration-turnstile-action", "Turnstile",
+                "Adds Cloudflare Turnstile to the form.");
         addProviderInfo(expected, "registration-user-creation", "Registration User Profile Creation",
                 "This action must always be first! Validates the username and user profile of the user in validation phase.  " +
                         "In success phase, this will create the user in the database including his user profile.");
@@ -144,6 +146,8 @@ public class ProvidersTest extends AbstractAuthenticationTest {
         addProviderInfo(result, "auth-spnego", "Kerberos", kerberosHelpMessage);
         addProviderInfo(result, "auth-username-password-form", "Username Password Form",
                 "Validates a username and password from login form.");
+        addProviderInfo(result, "auth-userpass-form-turnstile", "Username Password Form with Turnstile",
+                "Validates a username and password with Cloudflare Turnstile CAPTCHA.");
         addProviderInfo(result, "auth-x509-client-username-form", "X509/Validate Username Form",
                 "Validates username and password from X509 client certificate received as a part of mutual SSL handshake.");
         addProviderInfo(result, "direct-grant-auth-x509-username", "X509/Validate Username",
@@ -170,6 +174,7 @@ public class ProvidersTest extends AbstractAuthenticationTest {
                 "Validates a password from login form. Username may be already known from identity provider authentication");
         addProviderInfo(result, "reset-credential-email", "Send Reset Email", "Send email to user and wait for response.");
         addProviderInfo(result, "reset-credentials-choose-user", "Choose User", "Choose a user to reset credentials for");
+        addProviderInfo(result, "reset-choose-user-turnstile", "Choose User with Turnstile", "Choose a user to reset credentials for with Cloudflare Turnstile CAPTCHA protection");
         addProviderInfo(result, "reset-otp", "Reset OTP", "Removes existing OTP configurations (if chosen) and sets the 'Configure OTP' required action.");
         addProviderInfo(result, "reset-password", "Reset Password", "Sets the Update Password required action if execution is REQUIRED.  " +
                 "Will also set it if execution is OPTIONAL and the password is currently configured for it.");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/TurnstileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/TurnstileTest.java
@@ -1,0 +1,599 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.forms;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.authentication.authenticators.browser.UsernamePasswordFormWithTurnstileFactory;
+import org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUserWithTurnstileFactory;
+import org.keycloak.authentication.authenticators.util.TurnstileHelper;
+import org.keycloak.authentication.forms.RegistrationTurnstile;
+import org.keycloak.events.Details;
+import org.keycloak.events.Errors;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.utils.DefaultAuthenticationFlows;
+import org.keycloak.representations.idm.AuthenticationExecutionInfoRepresentation;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.pages.AppPage;
+import org.keycloak.testsuite.pages.ErrorPage;
+import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.pages.LoginPasswordResetPage;
+import org.keycloak.testsuite.pages.RegisterPage;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Integration tests for Cloudflare Turnstile CAPTCHA functionality.
+ * Tests registration, login, and password reset flows with Turnstile protection.
+ */
+public class TurnstileTest extends AbstractTestRealmKeycloakTest {
+
+    // Cloudflare test keys that always pass validation
+    // https://developers.cloudflare.com/turnstile/reference/testing/
+    private static final String TEST_SITE_KEY = "1x00000000000000000000AA";
+    private static final String TEST_SECRET_KEY = "1x0000000000000000000000000000000AA";
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
+
+    @Page
+    protected AppPage appPage;
+
+    @Page
+    protected LoginPage loginPage;
+
+    @Page
+    protected RegisterPage registerPage;
+
+    @Page
+    protected ErrorPage errorPage;
+
+    @Page
+    protected LoginPasswordResetPage resetPasswordPage;
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+    }
+
+    @Before
+    public void cleanupFlows() {
+        // Clean up any custom flows from previous tests
+        List<AuthenticationFlowRepresentation> flows = testRealm().flows().getFlows();
+        for (AuthenticationFlowRepresentation flow : flows) {
+            if (flow.getAlias().startsWith("RegistrationWith") ||
+                flow.getAlias().startsWith("BrowserWith") ||
+                flow.getAlias().startsWith("ResetWith")) {
+                testRealm().flows().deleteFlow(flow.getId());
+            }
+        }
+    }
+
+    /**
+     * Test that Turnstile widget is rendered on registration form when configured.
+     */
+    @Test
+    public void testTurnstileOnRegistrationForm() {
+        String flowAlias = "RegistrationWithTurnstile";
+        try {
+            configureRegistrationFlowWithTurnstile();
+
+            loginPage.open();
+            loginPage.clickRegister();
+            registerPage.assertCurrent();
+
+            assertTurnstileWidgetPresent();
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.REGISTRATION_FLOW);
+        }
+    }
+
+    /**
+     * Test that registration fails without valid Turnstile response.
+     */
+    @Test
+    public void testRegistrationFailsWithoutTurnstileResponse() {
+        String flowAlias = "RegistrationWithTurnstile";
+        try {
+            configureRegistrationFlowWithTurnstile();
+
+            loginPage.open();
+            loginPage.clickRegister();
+            registerPage.assertCurrent();
+
+            // Try to register without Turnstile response
+            registerPage.register("firstName", "lastName", "test@test.com",
+                "test-user", "password", "password");
+
+            registerPage.assertCurrent();
+            String pageSource = driver.getPageSource();
+            assertThat("Should show Turnstile error", pageSource,
+                containsString("Invalid Turnstile verification"));
+
+            events.expectRegister("test-user", "test@test.com")
+                .user((String) null)
+                .error(Errors.INVALID_REGISTRATION)
+                .assertEvent();
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.REGISTRATION_FLOW);
+        }
+    }
+
+    /**
+     * Test that Turnstile configuration validation works.
+     */
+    @Test
+    public void testTurnstileConfigurationValidation() {
+        String flowAlias = "RegistrationWithInvalidTurnstile";
+        try {
+            // Create flow with configuration missing the secret key
+            createFlowWithTurnstile(flowAlias,
+                "Registration flow with invalid Turnstile config",
+                RegistrationTurnstile.PROVIDER_ID,
+                createTurnstileConfigWithoutSecretKey(),
+                AuthenticationExecutionModel.Requirement.REQUIRED);
+
+            // Set as registration flow
+            RealmRepresentation realm = testRealm().toRepresentation();
+            realm.setRegistrationFlow(flowAlias);
+            testRealm().update(realm);
+
+            loginPage.open();
+            loginPage.clickRegister();
+            registerPage.assertCurrent();
+
+            // Registration should show error about missing configuration
+            String pageSource = driver.getPageSource();
+            assertThat("Should show configuration error", pageSource,
+                containsString("Turnstile is required, but not configured"));
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.REGISTRATION_FLOW);
+        }
+    }
+
+    /**
+     * Test Turnstile on login form.
+     */
+    @Test
+    public void testTurnstileOnLoginForm() {
+        String flowAlias = "BrowserWithTurnstile";
+        try {
+            configureBrowserFlowWithTurnstile();
+
+            loginPage.open();
+            loginPage.assertCurrent();
+
+            assertTurnstileWidgetPresent();
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.BROWSER_FLOW);
+        }
+    }
+
+    /**
+     * Test that login fails without valid Turnstile response.
+     */
+    @Test
+    public void testLoginFailsWithoutTurnstileResponse() {
+        String flowAlias = "BrowserWithTurnstile";
+        try {
+            configureBrowserFlowWithTurnstile();
+
+            loginPage.open();
+            loginPage.assertCurrent();
+
+            // Try to login without Turnstile response
+            loginPage.login("test-user@localhost", "password");
+
+            loginPage.assertCurrent();
+            String pageSource = driver.getPageSource();
+            assertThat("Should show Turnstile error", pageSource,
+                containsString("Invalid Turnstile verification"));
+
+            events.expectLogin()
+                .user((String) null)
+                .session((String) null)
+                .error(Errors.INVALID_USER_CREDENTIALS)
+                .removeDetail(Details.CONSENT)
+                .assertEvent();
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.BROWSER_FLOW);
+        }
+    }
+
+    /**
+     * Test Turnstile on password reset form.
+     */
+    @Test
+    public void testTurnstileOnPasswordResetForm() {
+        String flowAlias = "ResetWithTurnstile";
+        try {
+            configureResetCredentialsFlowWithTurnstile();
+
+            loginPage.open();
+            loginPage.resetPassword();
+            resetPasswordPage.assertCurrent();
+
+            assertTurnstileWidgetPresent();
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW);
+        }
+    }
+
+    /**
+     * Test that password reset fails without valid Turnstile response.
+     */
+    @Test
+    public void testPasswordResetFailsWithoutTurnstileResponse() {
+        String flowAlias = "ResetWithTurnstile";
+        try {
+            configureResetCredentialsFlowWithTurnstile();
+
+            loginPage.open();
+            loginPage.resetPassword();
+            resetPasswordPage.assertCurrent();
+
+            // Try to reset password without Turnstile response
+            resetPasswordPage.changePassword("test-user@localhost");
+
+            resetPasswordPage.assertCurrent();
+            String pageSource = driver.getPageSource();
+            assertThat("Should show Turnstile error", pageSource,
+                containsString("Invalid Turnstile verification"));
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW);
+        }
+    }
+
+    /**
+     * Test that Turnstile theme configuration is applied.
+     */
+    @Test
+    public void testTurnstileThemeConfiguration() {
+        String flowAlias = "RegistrationWithCustomTurnstile";
+        try {
+            Map<String, String> config = createTurnstileConfig();
+            config.put(TurnstileHelper.THEME, "dark");
+            config.put(TurnstileHelper.SIZE, "compact");
+            config.put(TurnstileHelper.ACTION, "custom_register");
+
+            createFlowWithTurnstile(flowAlias,
+                "Registration flow with custom Turnstile config",
+                RegistrationTurnstile.PROVIDER_ID,
+                config,
+                AuthenticationExecutionModel.Requirement.REQUIRED);
+
+            RealmRepresentation realm = testRealm().toRepresentation();
+            realm.setRegistrationFlow(flowAlias);
+            testRealm().update(realm);
+
+            loginPage.open();
+            loginPage.clickRegister();
+            registerPage.assertCurrent();
+
+            String pageSource = driver.getPageSource();
+            assertThat("Theme should be set to dark", pageSource,
+                containsString("data-theme=\"dark\""));
+            assertThat("Size should be set to compact", pageSource,
+                containsString("data-size=\"compact\""));
+            assertThat("Action should be custom_register", pageSource,
+                containsString("data-action=\"custom_register\""));
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.REGISTRATION_FLOW);
+        }
+    }
+
+
+    /**
+     * Test that Turnstile can be disabled without breaking flows.
+     */
+    @Test
+    public void testTurnstileDisabled() {
+        String flowAlias = "RegistrationWithDisabledTurnstile";
+        try {
+            createFlowWithTurnstile(flowAlias,
+                "Registration flow with disabled Turnstile",
+                RegistrationTurnstile.PROVIDER_ID,
+                createTurnstileConfig(),
+                AuthenticationExecutionModel.Requirement.DISABLED);
+
+            RealmRepresentation realm = testRealm().toRepresentation();
+            realm.setRegistrationFlow(flowAlias);
+            testRealm().update(realm);
+
+            loginPage.open();
+            loginPage.clickRegister();
+            registerPage.assertCurrent();
+
+            // Verify Turnstile widget is NOT present
+            String pageSource = driver.getPageSource();
+            Assert.assertFalse("Turnstile widget should not be present",
+                pageSource.contains("cf-turnstile"));
+
+            // Registration should work without Turnstile
+            registerPage.register("firstName", "lastName", "test@test.com",
+                "test-user", "password", "password");
+
+            appPage.assertCurrent();
+        } finally {
+            revertFlows(flowAlias, DefaultAuthenticationFlows.REGISTRATION_FLOW);
+        }
+    }
+
+    // Helper methods
+
+    private void configureRegistrationFlowWithTurnstile() {
+        String flowAlias = "RegistrationWithTurnstile";
+        createFlowWithTurnstile(flowAlias,
+            "Registration flow with Turnstile",
+            RegistrationTurnstile.PROVIDER_ID,
+            createTurnstileConfig(),
+            AuthenticationExecutionModel.Requirement.REQUIRED);
+
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setRegistrationFlow(flowAlias);
+        testRealm().update(realm);
+    }
+
+    private void configureBrowserFlowWithTurnstile() {
+        String flowAlias = "BrowserWithTurnstile";
+        
+        // Create a copy of the browser flow
+        AuthenticationFlowRepresentation browserFlow = testRealm().flows()
+            .getFlows()
+            .stream()
+            .filter(f -> f.getAlias().equals(DefaultAuthenticationFlows.BROWSER_FLOW))
+            .findFirst()
+            .orElseThrow();
+
+        AuthenticationFlowRepresentation newFlow = new AuthenticationFlowRepresentation();
+        newFlow.setAlias(flowAlias);
+        newFlow.setDescription("Browser flow with Turnstile");
+        newFlow.setProviderId("basic-flow");
+        newFlow.setTopLevel(true);
+        newFlow.setBuiltIn(false);
+
+        Response response = testRealm().flows().createFlow(newFlow);
+        response.close();
+
+        // Add Username Password Form with Turnstile execution
+        Map<String, Object> data = new HashMap<>();
+        data.put("provider", UsernamePasswordFormWithTurnstileFactory.PROVIDER_ID);
+        testRealm().flows().addExecution(flowAlias, data);
+
+        // Get the execution and configure it
+        List<AuthenticationExecutionInfoRepresentation> executions = 
+            testRealm().flows().getExecutions(flowAlias);
+        AuthenticationExecutionInfoRepresentation execution = executions.stream()
+            .filter(e -> e.getProviderId().equals(UsernamePasswordFormWithTurnstileFactory.PROVIDER_ID))
+            .findFirst()
+            .orElseThrow();
+
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
+        testRealm().flows().updateExecutions(flowAlias, execution);
+
+        // Configure Turnstile
+        AuthenticatorConfigRepresentation config = new AuthenticatorConfigRepresentation();
+        config.setAlias("turnstile-browser");
+        config.setConfig(createTurnstileConfig());
+        response = testRealm().flows().newExecutionConfig(execution.getId(), config);
+        response.close();
+
+        // Set as browser flow
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setBrowserFlow(flowAlias);
+        testRealm().update(realm);
+    }
+
+    private void configureResetCredentialsFlowWithTurnstile() {
+        String flowAlias = "ResetWithTurnstile";
+        
+        // Create a copy of the reset credentials flow
+        AuthenticationFlowRepresentation newFlow = new AuthenticationFlowRepresentation();
+        newFlow.setAlias(flowAlias);
+        newFlow.setDescription("Reset credentials flow with Turnstile");
+        newFlow.setProviderId("basic-flow");
+        newFlow.setTopLevel(true);
+        newFlow.setBuiltIn(false);
+
+        Response response = testRealm().flows().createFlow(newFlow);
+        response.close();
+
+        // Add Choose User with Turnstile execution
+        Map<String, Object> data = new HashMap<>();
+        data.put("provider", ResetCredentialChooseUserWithTurnstileFactory.PROVIDER_ID);
+        testRealm().flows().addExecution(flowAlias, data);
+
+        // Get the execution and configure it
+        List<AuthenticationExecutionInfoRepresentation> executions = 
+            testRealm().flows().getExecutions(flowAlias);
+        AuthenticationExecutionInfoRepresentation execution = executions.stream()
+            .filter(e -> e.getProviderId().equals(ResetCredentialChooseUserWithTurnstileFactory.PROVIDER_ID))
+            .findFirst()
+            .orElseThrow();
+
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
+        testRealm().flows().updateExecutions(flowAlias, execution);
+
+        // Configure Turnstile
+        AuthenticatorConfigRepresentation config = new AuthenticatorConfigRepresentation();
+        config.setAlias("turnstile-reset");
+        config.setConfig(createTurnstileConfig());
+        response = testRealm().flows().newExecutionConfig(execution.getId(), config);
+        response.close();
+
+        // Set as reset credentials flow
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setResetCredentialsFlow(flowAlias);
+        testRealm().update(realm);
+    }
+
+    private Map<String, String> createTurnstileConfig() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SITE_KEY, TEST_SITE_KEY);
+        config.put(TurnstileHelper.SECRET_KEY, TEST_SECRET_KEY);
+        config.put(TurnstileHelper.ACTION, "register");
+        config.put(TurnstileHelper.THEME, "auto");
+        config.put(TurnstileHelper.SIZE, "normal");
+        return config;
+    }
+
+    private Map<String, String> createTurnstileConfigWithoutSecretKey() {
+        Map<String, String> config = new HashMap<>();
+        config.put(TurnstileHelper.SITE_KEY, TEST_SITE_KEY);
+        // SECRET_KEY intentionally omitted for testing missing secret key scenario
+        return config;
+    }
+
+    /**
+     * Verify that Turnstile widget is present on the current page.
+     */
+    private void assertTurnstileWidgetPresent() {
+        String pageSource = driver.getPageSource();
+        assertThat("Turnstile script should be loaded", pageSource,
+            containsString("challenges.cloudflare.com/turnstile/v0/api.js"));
+        assertThat("Turnstile widget should be present", pageSource,
+            containsString("cf-turnstile"));
+        assertThat("Site key should be configured", pageSource,
+            containsString(TEST_SITE_KEY));
+    }
+
+    /**
+     * Create a flow with a Turnstile execution and optional custom configuration.
+     *
+     * @param flowAlias The alias for the new flow
+     * @param description Description of the flow
+     * @param providerId The Turnstile provider ID
+     * @param config Turnstile configuration
+     * @param requirement Execution requirement level
+     */
+    private void createFlowWithTurnstile(String flowAlias, String description, String providerId,
+                                          Map<String, String> config,
+                                          AuthenticationExecutionModel.Requirement requirement) {
+        // Create top-level registration flow
+        AuthenticationFlowRepresentation topFlow = new AuthenticationFlowRepresentation();
+        topFlow.setAlias(flowAlias);
+        topFlow.setDescription(description);
+        topFlow.setProviderId("basic-flow");
+        topFlow.setTopLevel(true);
+        topFlow.setBuiltIn(false);
+
+        Response response = testRealm().flows().createFlow(topFlow);
+        response.close();
+
+        // Create registration form sub-flow (form-flow is required for FormActions)
+        String formFlowAlias = flowAlias + " form";
+        AuthenticationFlowRepresentation formFlow = new AuthenticationFlowRepresentation();
+        formFlow.setAlias(formFlowAlias);
+        formFlow.setDescription(description + " form");
+        formFlow.setProviderId("form-flow");
+        formFlow.setTopLevel(false);
+        formFlow.setBuiltIn(false);
+
+        response = testRealm().flows().createFlow(formFlow);
+        response.close();
+
+        // Add the form sub-flow as an execution to the top-level flow
+        Map<String, Object> formFlowExecution = new HashMap<>();
+        formFlowExecution.put("provider", "registration-page-form");
+        testRealm().flows().addExecutionFlow(flowAlias, formFlowExecution);
+
+        // Get the form flow execution and link it to our form sub-flow
+        List<AuthenticationExecutionInfoRepresentation> topLevelExecutions =
+            testRealm().flows().getExecutions(flowAlias);
+        AuthenticationExecutionInfoRepresentation formFlowExec = topLevelExecutions.stream()
+            .filter(e -> e.getProviderId().equals("registration-page-form"))
+            .findFirst()
+            .orElseThrow();
+
+        formFlowExec.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED.name());
+        formFlowExec.setFlowId(testRealm().flows().getFlows().stream()
+            .filter(f -> f.getAlias().equals(formFlowAlias))
+            .findFirst()
+            .orElseThrow()
+            .getId());
+        testRealm().flows().updateExecutions(flowAlias, formFlowExec);
+
+        // Now add Turnstile to the form sub-flow
+        Map<String, Object> data = new HashMap<>();
+        data.put("provider", providerId);
+        testRealm().flows().addExecution(formFlowAlias, data);
+
+        // Get the execution and configure it
+        List<AuthenticationExecutionInfoRepresentation> executions =
+            testRealm().flows().getExecutions(formFlowAlias);
+        AuthenticationExecutionInfoRepresentation execution = executions.stream()
+            .filter(e -> e.getProviderId().equals(providerId))
+            .findFirst()
+            .orElseThrow();
+
+        execution.setRequirement(requirement.name());
+        testRealm().flows().updateExecutions(formFlowAlias, execution);
+
+        // Configure Turnstile
+        AuthenticatorConfigRepresentation configRep = new AuthenticatorConfigRepresentation();
+        configRep.setAlias(flowAlias + "-config");
+        configRep.setConfig(config);
+        response = testRealm().flows().newExecutionConfig(execution.getId(), configRep);
+        response.close();
+    }
+
+    /**
+     * Revert realm flows to defaults and delete the custom flow.
+     * Pattern based on BrowserFlowTest.revertFlows()
+     */
+    private void revertFlows(String flowToDeleteAlias, String defaultFlowAlias) {
+        List<AuthenticationFlowRepresentation> flows = testRealm().flows().getFlows();
+
+        // Find the flow to delete
+        AuthenticationFlowRepresentation flowToDelete = flows.stream()
+            .filter(f -> f.getAlias().equals(flowToDeleteAlias))
+            .findFirst()
+            .orElse(null);
+
+        // If flow exists, delete it and restore defaults if needed
+        if (flowToDelete != null) {
+            // Restore default flow in realm if needed
+            RealmRepresentation realm = testRealm().toRepresentation();
+            if (defaultFlowAlias != null) {
+                if (defaultFlowAlias.equals(DefaultAuthenticationFlows.REGISTRATION_FLOW)) {
+                    realm.setRegistrationFlow(defaultFlowAlias);
+                } else if (defaultFlowAlias.equals(DefaultAuthenticationFlows.BROWSER_FLOW)) {
+                    realm.setBrowserFlow(defaultFlowAlias);
+                } else if (defaultFlowAlias.equals(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW)) {
+                    realm.setResetCredentialsFlow(defaultFlowAlias);
+                }
+                testRealm().update(realm);
+            }
+
+            testRealm().flows().deleteFlow(flowToDelete.getId());
+        }
+    }
+}

--- a/themes/src/main/resources/theme/base/login/login-reset-password.ftl
+++ b/themes/src/main/resources/theme/base/login/login-reset-password.ftl
@@ -1,4 +1,5 @@
 <#import "template.ftl" as layout>
+<#import "turnstile.ftl" as turnstile>
 <@layout.registrationLayout displayInfo=true displayMessage=!messagesPerField.existsError('username'); section>
     <#if section = "header">
         ${msg("emailForgotTitle")}
@@ -17,6 +18,9 @@
                     </#if>
                 </div>
             </div>
+
+            <@turnstile.turnstileWidget />
+
             <div class="${properties.kcFormGroupClass!} ${properties.kcFormSettingClass!}">
                 <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
                     <div class="${properties.kcFormOptionsWrapperClass!}">

--- a/themes/src/main/resources/theme/base/login/login.ftl
+++ b/themes/src/main/resources/theme/base/login/login.ftl
@@ -1,5 +1,6 @@
 <#import "template.ftl" as layout>
 <#import "passkeys.ftl" as passkeys>
+<#import "turnstile.ftl" as turnstile>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
         ${msg("loginAccountTitle")}
@@ -71,6 +72,8 @@
                             </div>
 
                       </div>
+
+                      <@turnstile.turnstileWidget />
 
                       <div id="kc-form-buttons" class="${properties.kcFormGroupClass!}">
                           <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -82,6 +82,8 @@ linkIdpActionMessage=Do you want to link your account with {0}?
 
 recaptchaFailed=Invalid Recaptcha
 recaptchaNotConfigured=Recaptcha is required, but not configured
+turnstileFailed=Invalid Turnstile verification
+turnstileNotConfigured=Turnstile is required, but not configured
 consentDenied=Consent denied.
 
 noAccount=New user?

--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -1,6 +1,7 @@
 <#import "template.ftl" as layout>
 <#import "user-profile-commons.ftl" as userProfileCommons>
 <#import "register-commons.ftl" as registerCommons>
+<#import "turnstile.ftl" as turnstile>
 <@layout.registrationLayout displayMessage=messagesPerField.exists('global') displayRequiredFields=true; section>
     <#if section = "header">
         <#if messageHeader??>
@@ -80,6 +81,8 @@
                     </div>
                 </div>
             </#if>
+
+            <@turnstile.turnstileWidget />
 
             <div class="${properties.kcFormGroupClass!}">
                 <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">

--- a/themes/src/main/resources/theme/base/login/turnstile.ftl
+++ b/themes/src/main/resources/theme/base/login/turnstile.ftl
@@ -1,0 +1,39 @@
+<#--
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
+<#--
+  Macro for rendering Cloudflare Turnstile CAPTCHA widget.
+  This macro should be used consistently across all forms (login, register, reset password)
+  that require Turnstile protection.
+  
+  The macro checks for the turnstileRequired attribute and renders the widget
+  with the configured parameters (site key, action, theme, size, language).
+-->
+<#macro turnstileWidget>
+    <#if turnstileRequired??>
+        <div class="form-group">
+            <div class="${properties.kcInputWrapperClass!}">
+                <div class="cf-turnstile" 
+                     data-sitekey="${turnstileSiteKey}" 
+                     data-action="${turnstileAction}" 
+                     data-theme="${turnstileTheme}" 
+                     data-size="${turnstileSize}" 
+                     data-language="${turnstileLanguage}"></div>
+            </div>
+        </div>
+    </#if>
+</#macro>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-reset-password.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-reset-password.ftl
@@ -1,6 +1,7 @@
 <#import "template.ftl" as layout>
 <#import "field.ftl" as field>
 <#import "buttons.ftl" as buttons>
+<#import "turnstile.ftl" as turnstile>
 <@layout.registrationLayout displayInfo=true displayMessage=!messagesPerField.existsError('username'); section>
     <#if section = "header">
         ${msg("emailForgotTitle")}
@@ -10,6 +11,8 @@
                 <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
             </#assign>
             <@field.input name="username" label=label value=auth.attemptedUsername!'' autofocus=true />
+
+            <@turnstile.turnstileWidget />
 
             <@buttons.actionGroup>
               <@buttons.button id="kc-form-buttons" label="doSubmit" class=["kcButtonPrimaryClass", "kcButtonBlockClass"]/>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
@@ -3,6 +3,7 @@
 <#import "buttons.ftl" as buttons>
 <#import "social-providers.ftl" as identityProviders>
 <#import "passkeys.ftl" as passkeys>
+<#import "turnstile.ftl" as turnstile>
 <@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
 <!-- template: login.ftl -->
 
@@ -31,6 +32,8 @@
                             </#if>
                         </@field.password>
                     </#if>
+
+                    <@turnstile.turnstileWidget />
 
                     <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
                     <@buttons.loginButton />

--- a/themes/src/main/resources/theme/keycloak.v2/login/register.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/register.ftl
@@ -3,6 +3,7 @@
 <#import "user-profile-commons.ftl" as userProfileCommons>
 <#import "register-commons.ftl" as registerCommons>
 <#import "password-validation.ftl" as validator>
+<#import "turnstile.ftl" as turnstile>
 <@layout.registrationLayout displayMessage=messagesPerField.exists('global') displayRequiredFields=true; section>
 <!-- template: register.ftl -->
 
@@ -33,6 +34,8 @@
                     </div>
                 </div>
             </#if>
+
+            <@turnstile.turnstileWidget />
 
             <#if recaptchaRequired?? && !(recaptchaVisible!false)>
                 <script>

--- a/themes/src/main/resources/theme/keycloak.v2/login/turnstile.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/turnstile.ftl
@@ -1,0 +1,39 @@
+<#--
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ -->
+
+<#--
+  Macro for rendering Cloudflare Turnstile CAPTCHA widget.
+  This macro should be used consistently across all forms (login, register, reset password)
+  that require Turnstile protection.
+  
+  The macro checks for the turnstileRequired attribute and renders the widget
+  with the configured parameters (site key, action, theme, size, language).
+-->
+<#macro turnstileWidget>
+    <#if turnstileRequired??>
+        <div class="form-group">
+            <div class="${properties.kcInputWrapperClass!}">
+                <div class="cf-turnstile" 
+                     data-sitekey="${turnstileSiteKey}" 
+                     data-action="${turnstileAction}" 
+                     data-theme="${turnstileTheme}" 
+                     data-size="${turnstileSize}" 
+                     data-language="${turnstileLanguage}"></div>
+            </div>
+        </div>
+    </#if>
+</#macro>


### PR DESCRIPTION
This PR adds native support for Cloudflare Turnstile as a CAPTCHA provider in Keycloak, providing a privacy-friendly alternative to reCAPTCHA. Turnstile can protect registration forms, login flows, and password reset pages with customizable themes and sizes.

Closes #44305

### New Authentication flows
- **RegistrationTurnstile**: Form action for protecting registration flows
- **UsernamePasswordFormWithTurnstile**: Authenticator for login forms with Turnstile protection
- **ResetCredentialChooseUserWithTurnstile**: Authenticator for password reset flows