### PR TITLE
fix: reverting dev property key changes (#44293)

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -77,9 +77,10 @@ quarkus.http.limits.max-header-size=65535
 %dev.kc.http-enabled=true
 %dev.kc.hostname-strict=false
 %dev.kc.cache=local
-%dev.kc.spi-theme--cache--themes=false
-%dev.kc.spi-theme--cache--templates=false
-%dev.kc.spi-theme--static--max-age=-1
+# Theme no-cache defaults for dev - these are not standard spi properties, there is no provider
+%dev.kc.spi-theme--cache-themes=false
+%dev.kc.spi-theme--cache-templates=false
+%dev.kc.spi-theme--static-max-age=-1
 
 # The default configuration when running import, export, bootstrap-admin
 %nonserver.kc.http-enabled=true

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -54,6 +54,8 @@ import org.keycloak.spi.infinispan.impl.embedded.DefaultCacheEmbeddedConfigProvi
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.postgresql.xa.PGXADataSource;
 
+import static org.junit.Assert.assertFalse;
+
 public class ConfigurationTest extends AbstractConfigurationTest {
 
     @Test
@@ -424,6 +426,14 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         System.setProperty("kc.prop3", "val3");
         config = createConfig();
         Assert.assertEquals("foo-val3", config.getConfigValue("quarkus.datasource.bar").getValue());
+    }
+
+    @Test
+    public void testDevThemeProperties() {
+        assertNull(initConfig("theme").getBoolean("cacheThemes"));
+
+        System.setProperty(org.keycloak.common.util.Environment.PROFILE, "dev");
+        assertFalse(initConfig("theme").getBoolean("cacheThemes"));
     }
 
     @Test


### PR DESCRIPTION
closes: #44287


(cherry picked from commit 731414e44a8cc4fe50d6c86b519a1ba9b383e7e1)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
