### PR TITLE
Add debug logging to keycloak_ec2_installer ansible-playbook

### DIFF
--- a/.github/scripts/ansible/keycloak_remote_installer.sh
+++ b/.github/scripts/ansible/keycloak_remote_installer.sh
@@ -11,6 +11,6 @@ CLUSTER_NAME=$2
 KEYCLOAK_SRC=$3
 MAVEN_ARCHIVE=$4
 
-ansible-playbook -i ${CLUSTER_NAME}_${REGION}_inventory.yml keycloak.yml \
+ansible-playbook -vvvv -i ${CLUSTER_NAME}_${REGION}_inventory.yml keycloak.yml \
   -e "keycloak_src=\"${KEYCLOAK_SRC}\"" \
   -e "maven_archive=\"${MAVEN_ARCHIVE}\""


### PR DESCRIPTION
Closes #44327

This adds logs like the following which should allow us to hopefully determine the root cause of ssh connection issues if they are encountered on future actions:

```
<52.205.131.108> ESTABLISH SSH CONNECTION FOR USER: ec2-user
<52.205.131.108> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o 'IdentityFile="keycloak_1185eb5_us-east-1.pem"' -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o 'User="ec2-user"' -o ConnectTimeout=10 -o 'ControlPath="/home/runner/.ansible/cp/9d071e680b"' -o NumberOfPasswordPrompts=1 52.205.131.108 '/bin/sh -c '"'"'echo ~ec2-user && sleep 0'"'"''
<52.205.131.108> (0, b'/home/ec2-user\n', b'')
```