### PR TITLE
fix: switching to Boolean instead of boolean

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -327,7 +327,7 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
         if (!specBuilder.hasDnsPolicy()) {
             specBuilder.withDnsPolicy("ClusterFirst");
         }
-        boolean automount = keycloakCR.getSpec().getAutomountServiceAccountToken();
+        boolean automount = !Boolean.FALSE.equals(keycloakCR.getSpec().getAutomountServiceAccountToken());
         specBuilder.withAutomountServiceAccountToken(automount);
         handleScheduling(keycloakCR, schedulingLabels, specBuilder);
 
@@ -472,7 +472,7 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
             if (useServiceCaCrt) {
                 truststores += "," + SERVICE_CA_CRT;
             }
-        
+
             // include the kube CA if the user is not controlling KC_TRUSTSTORE_PATHS via the unsupported or the additional
             varMap.putIfAbsent(KC_TRUSTSTORE_PATHS, new EnvVarBuilder().withName(KC_TRUSTSTORE_PATHS).withValue(truststores).build());
         }

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -164,7 +164,7 @@ public class KeycloakSpec {
 
     @JsonProperty("automountServiceAccountToken")
     @JsonPropertyDescription("Set this to to false to disable automounting the default ServiceAccount Token and Service CA. This is enabled by default.")
-    private boolean automountServiceAccountToken = true;
+    private Boolean automountServiceAccountToken;
 
     public HttpSpec getHttpSpec() {
         return httpSpec;
@@ -391,10 +391,11 @@ public class KeycloakSpec {
         this.serviceMonitorSpec = serviceMonitorSpec;
     }
 
-    public boolean getAutomountServiceAccountToken() {
+    public Boolean getAutomountServiceAccountToken() {
         return automountServiceAccountToken;
     }
-    public void setAutomountServiceAccountToken(boolean automountServiceAccountToken) {
+
+    public void setAutomountServiceAccountToken(Boolean automountServiceAccountToken) {
         this.automountServiceAccountToken = automountServiceAccountToken;
     }
 }


### PR DESCRIPTION
closes: #38843

Using Boolean is preferable to a defaulted boolean because it won't end up in the serializated representation / stored unnecessarily.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
