### PR TITLE
Fix logical error in Danish email verification message

### DIFF
--- a/themes/src/main/resources-community/theme/base/email/messages/messages_da.properties
+++ b/themes/src/main/resources-community/theme/base/email/messages/messages_da.properties
@@ -1,6 +1,6 @@
 emailVerificationSubject=Verificer email
-emailVerificationBody=Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse \n\n{0}\n\nDette link vil udløbe inden for {3}.\n\nHvis det var dig der har oprettet denne konto, bedes du se bort fra denne mail.
-emailVerificationBodyHtml=<p>Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse</p><p><a href="{0}">Link til email verificering</a></p><p>Dette link vil udløbe inden for {3}.</p><p>Hvis det var dig der har oprettet denne konto, bedes du se bort fra denne mail.</p>
+emailVerificationBody=Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse \n\n{0}\n\nDette link vil udløbe inden for {3}.\n\nHvis det ikke var dig der har oprettet denne konto, bedes du se bort fra denne mail.
+emailVerificationBodyHtml=<p>Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse</p><p><a href="{0}">Link til email verificering</a></p><p>Dette link vil udløbe inden for {3}.</p><p>Hvis det ikke var dig der har oprettet denne konto, bedes du se bort fra denne mail.</p>
 emailTestSubject=[KEYCLOAK] - SMTP test besked
 emailTestBody=Dette er en test besked
 emailTestBodyHtml=<p>Dette er en test besked</p>


### PR DESCRIPTION
## Summary
Fixed logical error in Danish email verification message - added missing negation "ikke" (not).

The message was telling users to ignore the email if they DID create the account, when it should say to ignore it
if they DIDN'T.

## Changes
- Updated `emailVerificationBody` (line 2) in `messages_da.properties`
- Updated `emailVerificationBodyHtml` (line 3) in `messages_da.properties`
- Changed "Hvis det var dig" → "Hvis det ikke var dig"

Fixes #44342

