### PR TITLE
Bump Quarkus to 3.27.1 LTS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.27.0</quarkus.version>
-        <quarkus.build.version>3.27.0</quarkus.build.version>
+        <quarkus.version>3.27.1</quarkus.version>
+        <quarkus.build.version>3.27.1</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>
@@ -169,7 +169,7 @@
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->
-        <mssql-jdbc.version>13.2.0.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>13.2.1.jre11</mssql-jdbc.version>
         <oracledb.version>23.5</oracledb.version>
         <oracledb.container>mirror.gcr.io/gvenzl/oracle-free:${oracledb.version}-slim-faststart</oracledb.container>
         <!-- this is the oracle driver version also used in the Quarkus BOM -->


### PR DESCRIPTION
- Closes #43643

Quarkus 3.27.1 is [released](https://quarkus.io/blog/quarkus-3-27-1-released/) which fixes a CVE in the Microsoft SQL JDBC driver [CVE-2025-59250](https://nvd.nist.gov/vuln/detail/CVE-2025-59250) as per there [Changelog](https://github.com/quarkusio/quarkus/releases/tag/3.27.1)

This PR is to upgrade to Quarkus to 3.27.1  to resolve - [GHSA-m494-w24q-6f7w](https://github.com/advisories/GHSA-m494-w24q-6f7w)
