### PR TITLE
[Docs] Warn users about printing headers in HTTP access logs (#44353)

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -283,6 +283,9 @@ You can even specify your own pattern with your required data to be logged, such
 
 <@kc.start parameters="--http-access-log-pattern='%A %{METHOD} %{REQUEST_URL} %{i,User-Agent}'"/>
 
+WARNING: HTTP Access logs may contain sensitive HTTP headers like `Authorization`, `Cookie`, or external API keys references.
+Be careful with using the `long` pattern or printing the headers by the custom format - you should use it only for development purposes.
+
 Consult the https://quarkus.io/guides/http-reference#configuring-http-access-logs[Quarkus documentation] for the full list of variables that can be used.
 
 ==== Exclude specific URL paths


### PR DESCRIPTION
- Closes #43156

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit a71ceee8f138cefb86fc16794eb47562da97fba6)
