### PR TITLE
Use PrivateKey directly when decrypting SAML

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/SAMLDecryptionKeysLocator.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SAMLDecryptionKeysLocator.java
@@ -17,9 +17,6 @@
 
 package org.keycloak.protocol.saml;
 
-
-
-import java.security.Key;
 import java.security.PrivateKey;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,7 +25,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.keycloak.common.util.DerUtils;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.models.KeycloakSession;
@@ -155,14 +151,7 @@ public class SAMLDecryptionKeysLocator implements XMLEncryptionUtil.DecryptionKe
         return keysStream
                 .map(KeyWrapper::getPrivateKey)
                 .filter(Objects::nonNull)
-                .map(Key::getEncoded)
-                .map(encoded -> {
-                    try {
-                        return DerUtils.decodePrivateKey(encoded);
-                    } catch (Exception e) {
-                        throw new RuntimeException("Could not decode private key.", e);
-                    }
-                })
+                .map(PrivateKey.class::cast)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Closes #44289

I'm just removing the decoding part and directly casting to `PrivateKey`. In the `KeyWrapper` the `getPrivateKey` should return just that, and we are doing the cast directly in other parts already. Besides, the decryption checks that the encryption algorithm is understood by keycloak (`rsa-oaep`, `rsa-oaep-mgf1p` or `rsa-1_5`) and it is translated to the correct internal algorithm (`RSA_OAEP` or `RSA1_5`). So I expect that any `KeyProvider` is going to return a `PrivateKey` here. I tested the CI is OK with the change.

The reporter seems to be implementing their own keys provider to use an HSM, and therefore the encoded part is not available for the hardware key.
