### PR TITLE
fix: handle localized date formatting in message format

### DIFF
--- a/services/src/main/java/org/keycloak/theme/beans/MessageFormatterMethod.java
+++ b/services/src/main/java/org/keycloak/theme/beans/MessageFormatterMethod.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 
 import org.keycloak.theme.TemplatingUtil;
 
+import freemarker.template.SimpleDate;
 import freemarker.template.SimpleNumber;
 import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateMethodModelEx;
@@ -73,6 +74,8 @@ public class MessageFormatterMethod implements TemplateMethodModelEx {
                 item = scalar.getAsString();
             } else if (item instanceof SimpleNumber number) {
                 item = number.getAsNumber();
+            } else if (item instanceof SimpleDate date) {
+                item = date.getAsDate();
             }
 
             if (item instanceof String string) {

--- a/services/src/test/java/org/keycloak/theme/beans/MessageFormatterMethodTest.java
+++ b/services/src/test/java/org/keycloak/theme/beans/MessageFormatterMethodTest.java
@@ -18,9 +18,12 @@
 package org.keycloak.theme.beans;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.TimeZone;
 
+import freemarker.template.SimpleDate;
 import freemarker.template.SimpleNumber;
 import freemarker.template.SimpleScalar;
 import freemarker.template.TemplateModelException;
@@ -43,6 +46,7 @@ public class MessageFormatterMethodTest {
         properties.setProperty("client_admin-console", "Admin Console");
         properties.setProperty("realm_example-realm", "Example Realm");
         properties.setProperty("key", "foo {0,choice,0#foo|1#bar|1<{0} foobar} bar");
+        properties.setProperty("simpleKey", "{0}");
 
 
         MessageFormatterMethod fmt = new MessageFormatterMethod(locale, properties);
@@ -64,6 +68,27 @@ public class MessageFormatterMethodTest {
 
         msg = (String) fmt.exec(Arrays.asList(new SimpleScalar("key"),new SimpleNumber(2)));
         Assert.assertEquals("foo 2 foobar bar", msg);
+
+        msg = (String) fmt.exec(Arrays.asList(new SimpleScalar("simpleKey"),new SimpleNumber(2.5)));
+        Assert.assertEquals("2.5", msg);
+
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+
+            msg = (String) fmt.exec(Arrays.asList(new SimpleScalar("simpleKey"), new SimpleDate(new Date(1763721018000L), 2)));
+            Assert.assertTrue(msg.matches("11/21/25, 10:30.AM"));
+
+            MessageFormatterMethod germanFmt = new MessageFormatterMethod(Locale.GERMANY, properties);
+
+            msg = (String) germanFmt.exec(Arrays.asList(new SimpleScalar("simpleKey"), new SimpleNumber(2.5)));
+            Assert.assertEquals("2,5", msg);
+
+            msg = (String) germanFmt.exec(Arrays.asList(new SimpleScalar("simpleKey"), new SimpleDate(new Date(1763721018000L), 2)));
+            Assert.assertEquals("21.11.25, 10:30", msg);
+        } finally {
+            TimeZone.setDefault(defaultTimeZone);
+        }
     }
 
 }


### PR DESCRIPTION
Closes #44377

Handles `SimpleDate` (like `SimpleNumber`) in message formatter.
Added unit tests for locale-specific formatting.
