### PR TITLE
Exclude remote DBs from schema tests

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/db/CaseSensitiveSchemaTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/db/CaseSensitiveSchemaTest.java
@@ -12,9 +12,10 @@ import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 
 @KeycloakIntegrationTest(config = CaseSensitiveSchemaTest.CaseSensitiveServerConfig.class)
+// Remotely running databases do not support running SQL init scripts.
 // MSSQL does not support setting the default schema per session
 // TiDb does not support setting the default schema per session.
-@DisabledForDatabases({"mssql", "tidb"})
+@DisabledForDatabases({ "remote", "mssql", "tidb" })
 public class CaseSensitiveSchemaTest extends AbstractDBSchemaTest {
 
     @InjectTestDatabase(config = CaseSensitiveDatabaseConfig.class)

--- a/tests/base/src/test/java/org/keycloak/tests/db/PreserveSchemaCaseLiquibaseTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/db/PreserveSchemaCaseLiquibaseTest.java
@@ -13,10 +13,11 @@ import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 
 @KeycloakIntegrationTest(config = PreserveSchemaCaseLiquibaseTest.PreserveSchemaCaseServerConfig.class)
+// Remotely running databases do not support running SQL init scripts.
 // MSSQL does not support setting the default schema per session.
 // TiDb does not support setting the default schema per session.
 // Oracle image does not support configuring user/databases with '-'
-@DisabledForDatabases({ "mssql", "oracle", "tidb" })
+@DisabledForDatabases({ "remote", "mssql", "oracle", "tidb" })
 public class PreserveSchemaCaseLiquibaseTest extends AbstractDBSchemaTest {
 
     @InjectTestDatabase(config = PreserveSchemaCaseDatabaseConfig.class, lifecycle = LifeCycle.CLASS)


### PR DESCRIPTION
Continuing the work from #44373