### PR TITLE
[26.4] Utilise community wording in downstream high-availability guides

### DIFF
--- a/docs/guides/high-availability/partials/tested-load.adoc
+++ b/docs/guides/high-availability/partials/tested-load.adoc
@@ -1,18 +1,11 @@
 <@profile.ifProduct>
-
 == Maximum load
-
-* 100,000 users
-* 300 requests per second
-
 </@profile.ifProduct>
 <@profile.ifCommunity>
-
 == Tested load
+</@profile.ifCommunity>
 
 We regularly test {project_name} with the following load:
 
 * 100,000 users
 * 300 requests per second
-
-</@profile.ifCommunity>

--- a/docs/guides/high-availability/single-cluster/introduction.adoc
+++ b/docs/guides/high-availability/single-cluster/introduction.adoc
@@ -106,9 +106,7 @@ See the <@links.ha id="single-cluster-concepts-memory-and-cpu-sizing" /> {sectio
 [#single-cluster-limitations]
 == Limitations
 
-<@profile.ifCommunity>
 Even with the additional redundancy of three availability-zones, downtime can still occur when:
-</@profile.ifCommunity>
 
 * Simultaneous node failures occur
 * Rolling out {project_name} upgrades


### PR DESCRIPTION
Closes #44428