### PR TITLE
Mask certain HTTP headers in the HTTP access log

### DIFF
--- a/docs/documentation/release_notes/topics/26_5_0.adoc
+++ b/docs/documentation/release_notes/topics/26_5_0.adoc
@@ -30,6 +30,13 @@ You can specify these headers via the `tracing-header-<header>` wildcard option,
 
 For more details, see the  link:{tracingguide_link}[{tracingguide_name}] guide.
 
+= Sensitive Keycloak information is not displayed in the HTTP Access log
+
+If you are using the HTTP Access logging capability, sensitive information is omitted.
+It means that tokens in the 'Authorization' HTTP header and specific sensitive Keycloak cookies are not shown.
+
+For more information, see https://www.keycloak.org/server/logging#http-access-logging[Configuring logging].
+
 = Enable/disable features via a single option
 
 You can now enable or disable individual features using the `feature-<name>` option (like `feature-spiffe=enabled`).

--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -141,6 +141,10 @@ See the link:{upgradingguide_link}[{upgradingguide_name}] for details on how to 
 
 When enabling authorization on a new client (creating a Resource Server), Keycloak no longer automatically creates a "Default Resource", a "Default Policy," and a "Default Permission."
 
+=== HTTP Access log does not contain specific sensitive information
+
+Specific sensitive information is omitted from the HTTP Access log, such as the value of the `Authorization` HTTP header. Moreover, values of specific sensitive {project_name} cookies, such as `KEYCLOAK_SESSION`, `KEYCLOAK_IDENTITY`, or `AUTH_SESSION_ID`, are also omitted.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -288,7 +288,7 @@ You can even specify your own pattern with your required data to be logged, such
 <@kc.start parameters="--http-access-log-pattern='%A %{METHOD} %{REQUEST_URL} %{i,User-Agent}'"/>
 
 WARNING: HTTP Access logs may contain sensitive HTTP headers like `Authorization`, `Cookie`, or external API keys references.
-Be careful with using the `long` pattern or printing the headers by the custom format - you should use it only for development purposes.
+The `Authorization` header and specific sensitive {project_name} cookies are automatically omitted from the HTTP Access log.
 
 Consult the https://quarkus.io/guides/http-reference#configuring-http-access-logs[Quarkus documentation] for the full list of variables that can be used.
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpAccessLogOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpAccessLogOptions.java
@@ -1,5 +1,7 @@
 package org.keycloak.config;
 
+import java.util.List;
+
 public class HttpAccessLogOptions {
 
     public static final Option<Boolean> HTTP_ACCESS_LOG_ENABLED = new OptionBuilder<>("http-access-log-enabled", Boolean.class)
@@ -19,5 +21,23 @@ public class HttpAccessLogOptions {
     public static final Option<String> HTTP_ACCESS_LOG_EXCLUDE = new OptionBuilder<>("http-access-log-exclude", String.class)
             .category(OptionCategory.HTTP_ACCESS_LOG)
             .description("A regular expression that can be used to exclude some paths from logging. For instance, '/realms/my-realm/.*' will exclude all subsequent endpoints for realm 'my-realm' from the log.")
+            .build();
+
+    // check the CookieType
+    public static final List<String> HIDDEN_COOKIE_VALUES = List.of(
+            "AUTH_SESSION_ID",
+            "KC_AUTH_SESSION_HASH",
+            "KEYCLOAK_IDENTITY",
+            "KEYCLOAK_SESSION",
+            "AUTH_SESSION_ID_LEGACY",
+            "KEYCLOAK_IDENTITY_LEGACY",
+            "KEYCLOAK_SESSION_LEGACY"
+    );
+
+    public static final Option<List<String>> HTTP_ACCESS_LOG_MASKED_COOKIES = OptionBuilder.listOptionBuilder("http-access-log-masked-cookies", String.class)
+            .category(OptionCategory.HTTP_ACCESS_LOG)
+            .description("Set of HTTP Cookie headers whose values must be masked when the 'long' pattern or '%{ALL_REQUEST_HEADERS}' format is enabled with the 'http-access-log-pattern' option.")
+            .hidden() // hidden for now as we do not have the full Quarkus support for this yet
+            .defaultValue(HIDDEN_COOKIE_VALUES)
             .build();
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
@@ -23,6 +23,10 @@ public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
                 fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_EXCLUDE)
                         .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogEnabled, ACCESS_LOG_ENABLED_MSG)
                         .to("quarkus.http.access-log.exclude-pattern")
+                        .build(),
+                fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_MASKED_COOKIES)
+                        .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogEnabled, ACCESS_LOG_ENABLED_MSG)
+                        .to("quarkus.http.access-log.masked-cookies") // not existing in current Quarkus version yet. Used in the CustomAllRequestHeadersAttribute
                         .build()
         );
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/CustomAllRequestHeadersAttribute.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/logging/CustomAllRequestHeadersAttribute.java
@@ -1,0 +1,151 @@
+package org.keycloak.quarkus.runtime.logging;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import org.keycloak.quarkus.runtime.configuration.Configuration;
+
+import io.quarkus.vertx.http.runtime.attribute.AllRequestHeadersAttribute;
+import io.quarkus.vertx.http.runtime.attribute.ExchangeAttribute;
+import io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder;
+import io.quarkus.vertx.http.runtime.attribute.ReadOnlyAttributeException;
+import io.smallrye.config.ConfigValue;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+// modified AllRequestHeadersAttribute class -> https://github.com/quarkusio/quarkus/blob/main/extensions/vertx-http/runtime/src/main/java/io/quarkus/vertx/http/runtime/attribute/AllRequestHeadersAttribute.java
+// remove once current Quarkus version includes the https://github.com/quarkusio/quarkus/pull/50672
+public class CustomAllRequestHeadersAttribute implements ExchangeAttribute {
+
+    //---------------------Keycloak-changes-BEGIN----------------------------//
+    private static Set<String> getMaskedCookies(){
+        return Optional.ofNullable(Configuration.getConfigValue("quarkus.http.access-log.masked-cookies"))
+                .map(ConfigValue::getValue)
+                .map(f -> f.split(","))
+                .map(f -> new HashSet<>(Arrays.stream(f).toList()))
+                .orElseGet(HashSet::new);
+    }
+    //---------------------Keycloak-changes-END----------------------------//
+
+    private static final String AUTHORIZATION_HEADER = String.valueOf(HttpHeaders.AUTHORIZATION).toLowerCase();
+    private static final String COOKIE_HEADER = String.valueOf(HttpHeaders.COOKIE).toLowerCase();
+
+    private final Set<String> maskedHeaders;
+    private final Set<String> maskedCookies;
+
+    CustomAllRequestHeadersAttribute() {
+        this(Set.of(), Set.of());
+    }
+
+    CustomAllRequestHeadersAttribute(Set<String> maskedHeaders, Set<String> maskedCookies) {
+        this.maskedHeaders = toLowerCaseStringSet(maskedHeaders);
+        this.maskedCookies = toLowerCaseStringSet(maskedCookies);
+    }
+
+    private static Set<String> toLowerCaseStringSet(Set<String> set) {
+        return set.stream().map(String::toLowerCase).collect(Collectors.toSet());
+    }
+
+    @Override
+    public String readAttribute(RoutingContext exchange) {
+        return readAttribute(exchange.request().headers());
+    }
+
+    String readAttribute(MultiMap headers) {
+        if (headers.isEmpty()) {
+            return null;
+        } else {
+            final StringJoiner joiner = new StringJoiner(System.lineSeparator());
+
+            for (Map.Entry<String, String> header : headers) {
+                joiner.add(header.getKey() + ": " + maskHeaderValue(header.getKey(), header.getValue()));
+            }
+
+            return joiner.toString();
+        }
+    }
+
+    String maskHeaderValue(String headerName, String headerValue) {
+        if (headerValue == null) {
+            return null;
+        }
+
+        String headerNameLowerCase = headerName.toLowerCase();
+
+        if (AUTHORIZATION_HEADER.equals(headerNameLowerCase)) {
+            return maskAuthorizationHeaderValue(headerValue);
+        }
+
+        if (COOKIE_HEADER.equals(headerNameLowerCase)) {
+            return maskCookieHeaderValue(headerValue);
+        }
+
+        if (maskedHeaders.contains(headerNameLowerCase)) {
+            return "...";
+        }
+
+        return headerValue;
+    }
+
+    private String maskAuthorizationHeaderValue(String headerValue) {
+        int idx = headerValue.indexOf(' ');
+        final String scheme = idx > 0 ? headerValue.substring(0, idx) : null;
+
+        if (scheme != null) {
+            return scheme + " ...";
+        } else {
+            return "...";
+        }
+    }
+
+    private String maskCookieHeaderValue(String headerValue) {
+        int idx = headerValue.indexOf('=');
+
+        final String cookieName = idx > 0 ? headerValue.substring(0, idx) : null;
+
+        if (cookieName != null && maskedCookies.contains(cookieName.toLowerCase())) {
+            return cookieName + "=...";
+        }
+
+        return headerValue;
+    }
+
+    @Override
+    public void writeAttribute(RoutingContext exchange, String newValue) throws ReadOnlyAttributeException {
+        throw new ReadOnlyAttributeException("Headers", newValue);
+    }
+
+    public static final class Builder implements ExchangeAttributeBuilder {
+
+        @Override
+        public String name() {
+            return "Headers";
+        }
+
+        @Override
+        public ExchangeAttribute build(final String token) {
+            if (token.equals("%{ALL_REQUEST_HEADERS}")) {
+                //---------------------Keycloak-changes-BEGIN----------------------------//
+                return new CustomAllRequestHeadersAttribute(Set.of(), getMaskedCookies());
+                //---------------------Keycloak-changes-END----------------------------//
+            }
+            return null;
+        }
+
+        @Override
+        public int priority() {
+            //---------------------Keycloak-changes-BEGIN----------------------------//
+            // increase the priority
+            return new AllRequestHeadersAttribute.Builder().priority() + 1;
+            //---------------------Keycloak-changes-END----------------------------//
+        }
+
+    }
+
+}

--- a/quarkus/runtime/src/main/resources/META-INF/services/io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder
+++ b/quarkus/runtime/src/main/resources/META-INF/services/io.quarkus.vertx.http.runtime.attribute.ExchangeAttributeBuilder
@@ -1,0 +1,1 @@
+org.keycloak.quarkus.runtime.logging.CustomAllRequestHeadersAttribute$Builder


### PR DESCRIPTION
- Closes #43811
-------------
- Maintain the `CustomAllRequestHeadersAttribute` on our own until Quarkus has the fix included (changes necessary for Keycloak are marked)
- It automatically omits the information about the `Authorization` HTTP header value, such as tokens.
- Certain Keycloak cookies values are also omitted from the log: https://github.com/keycloak/keycloak/pull/44475/files#diff-84b8e8a0ac3d785229a1f97fc214aa466ebfd3df27891b3313213b7dfb5d2ca0R27
- Follow-up task to provide the ability to specify additional masked headers and cookies: https://github.com/keycloak/keycloak/issues/44433
- If we accept to go this way, I'll create a follow-up issue to remove this workaround. 