### PR TITLE
# fix: semgrep-documentbuilderfactory-disallow-doctype-decl-missing 

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/SPMetadataDescriptor.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SPMetadataDescriptor.java
@@ -131,6 +131,7 @@ public class SPMetadataDescriptor {
         throws javax.xml.parsers.ParserConfigurationException
     {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         DocumentBuilder db = dbf.newDocumentBuilder();
         Document doc = db.newDocument();
 


### PR DESCRIPTION
This pull request resolves the Semgrep finding `documentbuilderfactory-disallow-doctype-decl-missing` by disabling DOCTYPE declarations in `DocumentBuilderFactory` to prevent XML External Entity (XXE) attacks.

## Issue
Semgrep identified that the `DocumentBuilderFactory` instance was created without disabling the DOCTYPE declaration:
`DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();`


By default, DOCTYPE is enabled, which makes the parser vulnerable to XXE attacks.

**Rule ID:** documentbuilderfactory-disallow-doctype-decl-missing  
**File:** saml-core/src/main/java/org/keycloak/saml/SPMetadataDescriptor.java  
**Line:** 134  

## Fix

The following feature flag has been added to disable DOCTYPE declarations:

```java
dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
```

Code change:
```
 DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 DocumentBuilder db = dbf.newDocumentBuilder();
 Document doc = db.newDocument();
```