### PR TITLE
Better events for jwt-bearer and check all details in the tests

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -39,7 +39,9 @@ public interface Details {
     String AUTH_TYPE = "auth_type";
     String AUTH_METHOD = "auth_method";
     String IDENTITY_PROVIDER = "identity_provider";
+    String IDENTITY_PROVIDER_ISSUER = "identity_provider_issuer";
     String IDENTITY_PROVIDER_USERNAME = "identity_provider_identity";
+    String IDENTITY_PROVIDER_USER_ID = "identity_provider_user_id";
     String IDENTITY_PROVIDER_BROKER_SESSION_ID = "identity_provider_broker_session_id";
     String REGISTER_METHOD = "register_method";
     String USERNAME = "username";

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
@@ -58,6 +58,8 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
 
             JWTAuthorizationGrantValidator authorizationGrantContext = JWTAuthorizationGrantValidator.createValidator(
                     context.getSession(), client, assertion, formParams.getFirst(OAuth2Constants.SCOPE));
+            event.detail(Details.IDENTITY_PROVIDER_ISSUER, authorizationGrantContext.getIssuer());
+            event.detail(Details.IDENTITY_PROVIDER_USER_ID, authorizationGrantContext.getSubject());
 
             //client must be confidential
             authorizationGrantContext.validateClient();
@@ -73,6 +75,7 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
             if (identityProviderModel == null) {
                 throw new RuntimeException("No Identity Provider for provided issuer");
             }
+            event.detail(Details.IDENTITY_PROVIDER, identityProviderModel.getAlias());
 
             if(!OIDCAdvancedConfigWrapper.fromClientModel(context.getClient()).getJWTAuthorizationGrantAllowedIdentityProviders().contains(identityProviderModel.getAlias())) {
                 throw new RuntimeException("Identity Provider is not allowed for the client");

--- a/test-framework/core/src/main/java/org/keycloak/testframework/events/EventAssertion.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/events/EventAssertion.java
@@ -42,6 +42,16 @@ public class EventAssertion {
         return this;
     }
 
+    public EventAssertion sessionId(String sessionId) {
+        Assertions.assertEquals(sessionId, event.getSessionId());
+        return this;
+    }
+
+    public EventAssertion userId(String userId) {
+        Assertions.assertEquals(userId, event.getUserId());
+        return this;
+    }
+
     public EventAssertion details(String key, String value) {
         if (value != null) {
             MatcherAssert.assertThat(event.getDetails(), Matchers.hasEntry(key, value));

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantDownscopeClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantDownscopeClientPoliciesTest.java
@@ -33,19 +33,19 @@ public class JWTAuthorizationGrantDownscopeClientPoliciesTest extends BaseAbstra
         // test with all the scopes
         String jwt = identityProvider.encodeToken(createDefaultAuthorizationGrantToken("email profile address"));
         AccessTokenResponse response = oAuthClient.openid(false).scope("address").jwtAuthorizationGrantRequest(jwt).send();
-        AccessToken token = assertSuccess("test-app", "basic-user", response);
+        AccessToken token = assertSuccess("test-app", response);
         MatcherAssert.assertThat(List.of(token.getScope().split(" ")), Matchers.containsInAnyOrder("email", "profile", "address"));
 
         // test with less scopes => downscope
         jwt = identityProvider.encodeToken(createDefaultAuthorizationGrantToken("email profile address"));
         response = oAuthClient.openid(false).scope(null).jwtAuthorizationGrantRequest(jwt).send();
-        token = assertSuccess("test-app", "basic-user", response);
+        token = assertSuccess("test-app", response);
         MatcherAssert.assertThat(List.of(token.getScope().split(" ")), Matchers.containsInAnyOrder("email", "profile"));
 
         // test default scopes are restricted if not present in initial token
         jwt = identityProvider.encodeToken(createDefaultAuthorizationGrantToken("profile address"));
         response = oAuthClient.openid(false).scope("address").jwtAuthorizationGrantRequest(jwt).send();
-        token = assertSuccess("test-app", "basic-user", response);
+        token = assertSuccess("test-app", response);
         MatcherAssert.assertThat(List.of(token.getScope().split(" ")), Matchers.containsInAnyOrder("profile", "address"));
 
         // test requesting a valid optional scope for the client but not present initially

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
@@ -2,9 +2,11 @@ package org.keycloak.tests.oauth;
 
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.events.Details;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmConfigBuilder;
 import org.keycloak.testsuite.util.IdentityProviderBuilder;
@@ -29,7 +31,10 @@ public class OIDCIdentityProviderJWTAuthorizationGrantTest extends AbstractJWTAu
 
         String jwt = getIdentityProvider().encodeToken(createAuthorizationGrantToken("basic-user-id", oAuthClient.getEndpoints().getIssuer(), IDP_ISSUER));
         AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        assertFailure("JWT Authorization Granted is not enabled for the identity provider", response, events.poll());
+        EventAssertion event = assertFailure("JWT Authorization Granted is not enabled for the identity provider", response, events.poll());
+        event.details(Details.IDENTITY_PROVIDER, IDP_ALIAS);
+        event.details(Details.IDENTITY_PROVIDER_ISSUER, IDP_ISSUER);
+        event.details(Details.IDENTITY_PROVIDER_USER_ID, "basic-user-id");
     }
 
     @Test


### PR DESCRIPTION
Closes #44137

PR that adds some details to the events in the `jwt-bearer` grant. Reading the issue, I just missed the scopes in the assertion but they are not added in any other place (if you think that it is important just let me know). The details added are the issuer and the subject of the assertion when the JWT is parsed, and the IdP alias once located by keycloak. The events were already checked in the tests, but the details are better checked now.
