### PR TITLE
[client-api-v2] Use embedded mode for tests in IDE

### DIFF
--- a/rest/admin-v2/tests/pom.xml
+++ b/rest/admin-v2/tests/pom.xml
@@ -45,6 +45,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
+                        <kc.test.server>distribution</kc.test.server>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <java.util.concurrent.ForkJoinPool.common.threadFactory>io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory</java.util.concurrent.ForkJoinPool.common.threadFactory>
                     </systemPropertyVariables>

--- a/rest/admin-v2/tests/src/test/resources/keycloak-test.properties
+++ b/rest/admin-v2/tests/src/test/resources/keycloak-test.properties
@@ -1,5 +1,8 @@
 kc.test.log.level=WARN
 
+# Start embedded mode in IDE and distribution when running with Maven
+kc.test.server=embedded
+
 kc.test.log.filter=true
 
 kc.test.log.category."org.keycloak.tests".level=INFO


### PR DESCRIPTION
Fixing tests or experimenting with the new functionality for Client API v2 is quite hard as after every change made to the feature, you need to rebuild the distribution in order to see the changes. 

I'd propose to start the embedded Quarkus server when executing tests in IDE, and full distribution (default) when executing via Maven. 

@shawkins @vmuzikar @Pepo48 Could you please check it? Thanks!

@vaceksimon @stianst @lhanusov Could you please check it? And would you accept these changes as default behavior even for your framework? 