### PR TITLE
[admin-api-v2] SPIs for ModelMapper and JakartaValidator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1147,6 +1147,11 @@
             </dependency>
             <dependency>
                 <groupId>org.keycloak</groupId>
+                <artifactId>keycloak-admin-v2-providers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.keycloak</groupId>
                 <artifactId>keycloak-admin-v2-rest</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -426,6 +426,17 @@
 
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-v2-providers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-v2-rest</artifactId>
             <exclusions>
                 <exclusion>

--- a/rest/admin-v2/api/pom.xml
+++ b/rest/admin-v2/api/pom.xml
@@ -46,33 +46,8 @@
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
     </dependencies>
-    
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>
-                        -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
-                    </compilerArgument>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>org.mapstruct</groupId>
-                            <artifactId>mapstruct-processor</artifactId>
-                            <version>${org.mapstruct.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/rest/admin-v2/api/pom.xml
+++ b/rest/admin-v2/api/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>keycloak-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ModelMapper.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ModelMapper.java
@@ -1,7 +1,11 @@
 package org.keycloak.models.mapper;
 
-public interface ModelMapper {
+import org.keycloak.provider.Provider;
+
+public interface ModelMapper extends Provider {
 
     ClientModelMapper clients();
+
+    default void close() {}
 
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ModelMapperFactory.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ModelMapperFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface ModelMapperFactory extends ProviderFactory<ModelMapper> {
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ModelMapperSpi.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ModelMapperSpi.java
@@ -1,0 +1,28 @@
+package org.keycloak.models.mapper;
+
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class ModelMapperSpi implements Spi {
+    public static final String NAME = "model-mapper";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends ModelMapper> getProviderClass() {
+        return ModelMapper.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<ModelMapper>> getProviderFactoryClass() {
+        return ModelMapperFactory.class;
+    }
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -16,19 +16,18 @@ import org.keycloak.representations.admin.v2.validation.CreateClientDefault;
 import org.keycloak.services.ServiceException;
 import org.keycloak.services.resources.admin.ClientResource;
 import org.keycloak.services.resources.admin.ClientsResource;
-import org.keycloak.validation.jakarta.HibernateValidatorProvider;
-import org.keycloak.validation.jakarta.JakartaValidatorProvider;
+import org.keycloak.validation.jakarta.JakartaValidator;
 
 // TODO
 public class DefaultClientService implements ClientService {
     private final KeycloakSession session;
     private final ClientModelMapper mapper;
-    private final JakartaValidatorProvider validator;
+    private final JakartaValidator validator;
 
     public DefaultClientService(KeycloakSession session) {
         this.session = session;
         this.mapper = session.getProvider(ModelMapper.class).clients();
-        this.validator = new HibernateValidatorProvider();
+        this.validator = session.getProvider(JakartaValidator.class);
     }
 
     @Override

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -9,7 +9,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.mapper.ClientModelMapper;
-import org.keycloak.models.mapper.MapStructModelMapper;
+import org.keycloak.models.mapper.ModelMapper;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.representations.admin.v2.validation.CreateClientDefault;
@@ -27,7 +27,7 @@ public class DefaultClientService implements ClientService {
 
     public DefaultClientService(KeycloakSession session) {
         this.session = session;
-        this.mapper = new MapStructModelMapper().clients();
+        this.mapper = session.getProvider(ModelMapper.class).clients();
         this.validator = new HibernateValidatorProvider();
     }
 

--- a/rest/admin-v2/api/src/main/java/org/keycloak/validation/jakarta/JakartaValidator.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/validation/jakarta/JakartaValidator.java
@@ -7,11 +7,15 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 
-public interface JakartaValidatorProvider {
+import org.keycloak.provider.Provider;
 
+public interface JakartaValidator extends Provider {
     <T> void validate(T object, Class<?>... groups) throws ConstraintViolationException;
 
     void validate(Function<Validator, Set<ConstraintViolation<?>>> validation) throws ConstraintViolationException;
 
     Validator getValidator();
+
+    default void close() {
+    }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/validation/jakarta/JakartaValidatorFactory.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/validation/jakarta/JakartaValidatorFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.validation.jakarta;
+
+import org.keycloak.provider.ProviderFactory;
+
+public interface JakartaValidatorFactory extends ProviderFactory<JakartaValidator> {
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/validation/jakarta/JakartaValidatorSpi.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/validation/jakarta/JakartaValidatorSpi.java
@@ -1,0 +1,29 @@
+package org.keycloak.validation.jakarta;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class JakartaValidatorSpi implements Spi {
+    public static final String NAME = "jakarta-validator";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return JakartaValidator.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<?>> getProviderFactoryClass() {
+        return JakartaValidatorFactory.class;
+    }
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+}

--- a/rest/admin-v2/api/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/rest/admin-v2/api/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -1,0 +1,1 @@
+org.keycloak.models.mapper.ModelMapperSpi

--- a/rest/admin-v2/api/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/rest/admin-v2/api/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -1,1 +1,2 @@
 org.keycloak.models.mapper.ModelMapperSpi
+org.keycloak.validation.jakarta.JakartaValidatorSpi

--- a/rest/admin-v2/pom.xml
+++ b/rest/admin-v2/pom.xml
@@ -17,5 +17,6 @@
         <module>rest</module>
         <module>api</module>
         <module>tests</module>
+        <module>providers</module>
     </modules>
 </project>

--- a/rest/admin-v2/providers/pom.xml
+++ b/rest/admin-v2/providers/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.keycloak</groupId>
+        <artifactId>keycloak-admin-v2-parent</artifactId>
+        <version>999.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>keycloak-admin-v2-providers</artifactId>
+    <name>Keycloak Admin API v2 Providers Layer</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-v2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgument>
+                        -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
+                    </compilerArgument>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/rest/admin-v2/providers/pom.xml
+++ b/rest/admin-v2/providers/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>keycloak-admin-v2-providers</artifactId>
-    <name>Keycloak Admin API v2 Providers Layer</name>
+    <name>Keycloak Admin API v2 Providers</name>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -27,6 +27,10 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
         </dependency>
     </dependencies>
 

--- a/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/models/mapper/MapStructClientModelMapper.java
+++ b/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/models/mapper/MapStructClientModelMapper.java
@@ -1,4 +1,4 @@
-package org.keycloak.models.mapper;
+package org.keycloak.admin.providers.models.mapper;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
+import org.keycloak.models.mapper.ClientModelMapper;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 
 import org.mapstruct.Context;

--- a/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/models/mapper/MapStructModelMapper.java
+++ b/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/models/mapper/MapStructModelMapper.java
@@ -1,4 +1,7 @@
-package org.keycloak.models.mapper;
+package org.keycloak.admin.providers.models.mapper;
+
+import org.keycloak.models.mapper.ClientModelMapper;
+import org.keycloak.models.mapper.ModelMapper;
 
 import org.mapstruct.factory.Mappers;
 

--- a/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/models/mapper/MapStructModelMapperFactory.java
+++ b/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/models/mapper/MapStructModelMapperFactory.java
@@ -1,0 +1,39 @@
+package org.keycloak.admin.providers.models.mapper;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.mapper.ModelMapperFactory;
+
+public class MapStructModelMapperFactory implements ModelMapperFactory {
+    public static final String PROVIDER_ID = "default";
+    private static MapStructModelMapper SINGLETON;
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public MapStructModelMapper create(KeycloakSession session) {
+        if (SINGLETON == null) {
+            SINGLETON = new MapStructModelMapper();
+        }
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/validation/HibernateValidatorFactory.java
+++ b/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/validation/HibernateValidatorFactory.java
@@ -1,0 +1,36 @@
+package org.keycloak.admin.providers.validation;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.validation.jakarta.JakartaValidator;
+import org.keycloak.validation.jakarta.JakartaValidatorFactory;
+
+public class HibernateValidatorFactory implements JakartaValidatorFactory {
+    public static final String PROVIDER_ID = "default";
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public JakartaValidator create(KeycloakSession session) {
+        return new HibernateValidatorProvider();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/validation/HibernateValidatorProvider.java
+++ b/rest/admin-v2/providers/src/main/java/org/keycloak/admin/providers/validation/HibernateValidatorProvider.java
@@ -1,4 +1,4 @@
-package org.keycloak.validation.jakarta;
+package org.keycloak.admin.providers.validation;
 
 import java.util.Set;
 import java.util.function.Function;
@@ -8,11 +8,13 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 
-public class HibernateValidatorProvider implements JakartaValidatorProvider {
+import org.keycloak.validation.jakarta.JakartaValidator;
 
-    private final Validator validator = CDI.current().select(Validator.class).get();
+public class HibernateValidatorProvider implements JakartaValidator {
+    private final Validator validator;
 
     public HibernateValidatorProvider() {
+        this.validator = CDI.current().select(Validator.class).get();
     }
 
     @Override

--- a/rest/admin-v2/providers/src/main/resources/META-INF/services/org.keycloak.models.mapper.ModelMapperFactory
+++ b/rest/admin-v2/providers/src/main/resources/META-INF/services/org.keycloak.models.mapper.ModelMapperFactory
@@ -1,0 +1,1 @@
+org.keycloak.admin.providers.models.mapper.MapStructModelMapperFactory

--- a/rest/admin-v2/providers/src/main/resources/META-INF/services/org.keycloak.validation.jakarta.JakartaValidatorFactory
+++ b/rest/admin-v2/providers/src/main/resources/META-INF/services/org.keycloak.validation.jakarta.JakartaValidatorFactory
@@ -1,0 +1,1 @@
+org.keycloak.admin.providers.validation.HibernateValidatorFactory

--- a/rest/admin-v2/rest/pom.xml
+++ b/rest/admin-v2/rest/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-v2-providers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
         </dependency>
         <dependency>

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/DefaultClientsApi.java
@@ -18,15 +18,14 @@ import org.keycloak.services.ServiceException;
 import org.keycloak.services.client.ClientService;
 import org.keycloak.services.client.DefaultClientService;
 import org.keycloak.services.resources.admin.ClientsResource;
-import org.keycloak.validation.jakarta.HibernateValidatorProvider;
-import org.keycloak.validation.jakarta.JakartaValidatorProvider;
+import org.keycloak.validation.jakarta.JakartaValidator;
 
 public class DefaultClientsApi implements ClientsApi {
     private final KeycloakSession session;
     private final RealmModel realm;
     private final HttpResponse response;
     private final ClientService clientService;
-    private final JakartaValidatorProvider validator;
+    private final JakartaValidator validator;
     private final ClientsResource clientsResource;
 
     public DefaultClientsApi(KeycloakSession session, ClientsResource clientsResource) {
@@ -34,7 +33,7 @@ public class DefaultClientsApi implements ClientsApi {
         this.realm = Objects.requireNonNull(session.getContext().getRealm());
         this.clientService = new DefaultClientService(session);
         this.response = session.getContext().getHttpResponse();
-        this.validator = new HibernateValidatorProvider();
+        this.validator = session.getProvider(JakartaValidator.class);
         this.clientsResource = clientsResource;
     }
 


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/44535
- The MapStruct and HibernateValidator should not lie in the `api` module
- Created the proposed `providers` module, where we can put the implementation
- More reasoning about benefits in the parent issue
- SPIs are not enabled based on the ClientAPI v2 feature - I think we can have them enabled by default + after merging https://github.com/keycloak/keycloak/pull/44527, we can potentially use the `DefaultAdminApi.isApiEnabled()`

@vmuzikar @shawkins @Pepo48 Could you please check it? Thanks!
