### PR TITLE
Executor for checking claims in JWT assertions

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
+++ b/core/src/main/java/org/keycloak/jose/jws/JWSInput.java
@@ -24,6 +24,8 @@ import org.keycloak.common.util.Base64Url;
 import org.keycloak.jose.JOSE;
 import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -92,6 +94,14 @@ public class JWSInput implements JOSE {
     }
 
     public <T> T readJsonContent(Class<T> type) throws JWSInputException {
+        try {
+            return JsonSerialization.readValue(content, type);
+        } catch (IOException e) {
+            throw new JWSInputException(e);
+        }
+    }
+
+    public <T> T readJsonContent(TypeReference<T> type) throws JWSInputException {
         try {
             return JsonSerialization.readValue(content, type);
         } catch (IOException e) {

--- a/core/src/main/java/org/keycloak/util/JsonSerialization.java
+++ b/core/src/main/java/org/keycloak/util/JsonSerialization.java
@@ -86,6 +86,10 @@ public class JsonSerialization {
         return mapper.readValue(bytes, type);
     }
 
+    public static <T> T readValue(byte[] bytes, TypeReference<T> type) throws IOException {
+        return mapper.readValue(bytes, type);
+    }
+
     public static <T> T readValue(String string, TypeReference<T> type) throws IOException {
         return mapper.readValue(string, type);
     }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutor.java
@@ -16,18 +16,21 @@
  */
 package org.keycloak.services.clientpolicy.executor;
 
-import java.util.List;
 import java.util.Map;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.JWTAuthorizationGrantValidationContext;
+import org.keycloak.protocol.oidc.TokenExchangeContext;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.JWTAuthorizationGrantContext;
+import org.keycloak.services.clientpolicy.context.TokenExchangeRequestContext;
+import org.keycloak.utils.StringUtil;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -48,7 +51,7 @@ public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JW
 
     @Override
     public String getProviderId() {
-        return DownscopeAssertionGrantEnforcerExecutorFactory.PROVIDER_ID;
+        return JWTClaimEnforcerExecutorFactory.PROVIDER_ID;
     }
 
     @Override
@@ -61,8 +64,8 @@ public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JW
         @JsonProperty("claim-name")
         protected String claimName;
 
-        @JsonProperty("allowed-values")
-        protected List<String> allowedValues;
+        @JsonProperty("allowed-value")
+        protected String allowedValue;
 
         public String getClaimName() {
             return claimName;
@@ -72,12 +75,12 @@ public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JW
             this.claimName = claimName;
         }
 
-        public List<String> getAllowedValues() {
-            return allowedValues;
+        public String getAllowedValue() {
+            return allowedValue;
         }
 
-        public void setAllowedValues(List<String> allowedValues) {
-            this.allowedValues = allowedValues;
+        public void setAllowedValue(String allowedValue) {
+            this.allowedValue = allowedValue;
         }
     }
 
@@ -87,18 +90,26 @@ public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JW
             case JWT_AUTHORIZATION_GRANT -> {
                 JWTAuthorizationGrantContext jwtAuthnGrantContext = ((JWTAuthorizationGrantContext) context);
                 JWTAuthorizationGrantValidationContext jwtContext = jwtAuthnGrantContext.getAuthorizationGrantContext();
-                checkClaims(getAccessTokenAsMapFromAssertion(jwtContext.getAssertion()));
+                checkClaims(getAccessTokenMapFromJWTString(jwtContext.getAssertion()));
+            }
+            case TOKEN_EXCHANGE_REQUEST -> {
+                TokenExchangeContext tokenExchangeContext = ((TokenExchangeRequestContext) context).getTokenExchangeContext();
+                if (!OAuth2Constants.ACCESS_TOKEN_TYPE.equals(tokenExchangeContext.getParams().getSubjectTokenType())) {
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Parameter 'subject_token' should be access_token for the executor");
+                }
+                checkClaims(getAccessTokenMapFromJWTString(tokenExchangeContext.getParams().getSubjectToken()));
             }
         }
     }
 
-    private Map<String, Object> getAccessTokenAsMapFromAssertion(String assertion) throws ClientPolicyException {
+    private  Map<String, Object> getAccessTokenMapFromJWTString(String jwt) throws ClientPolicyException {
         try {
-            return new  JWSInput(assertion).readJsonContent(new TypeReference<>() {});
+            return new  JWSInput(jwt).readJsonContent(new TypeReference<>() {});
         } catch (JWSInputException e) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Assertion contains an invalid access token");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "JWT is not valid");
         }
     }
+
     private void checkClaims(Map<String, Object> tokenMap) throws ClientPolicyException {
         String claimName = configuration.getClaimName();
         // Validate configuration
@@ -106,7 +117,7 @@ public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JW
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST,  "Invalid configuration");
         }
 
-        List<String> allowedValues = configuration.getAllowedValues();
+        String allowedValue = configuration.getAllowedValue();
 
         // Extract claim value
         Object claimValue = tokenMap.get(claimName);
@@ -114,33 +125,24 @@ public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JW
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Required claim '" + claimName + "' is missing from the token");
         }
 
-        // If allowedValues is empty validate only if the claim exists
-        if (allowedValues == null || allowedValues.isEmpty()) {
+        // If allowedValue is empty validate only if the claim exists
+        if (StringUtil.isBlank(allowedValue)) {
             return;
         }
 
         //allow only numbers or strings
         if (!isAllowedClaimType(claimValue)) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Claim value is not allowed");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Value type for claim '" + claimName + "' not allowed");
         }
 
         String stringValue = String.valueOf(claimValue);
-        boolean matches = allowedValues.stream().anyMatch(allowed -> matchesAllowed(stringValue, allowed));
-        if (!matches) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Claim '" + claimName + "' not allowed");
+
+        if (!stringValue.matches(allowedValue)) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Value for claim '" + claimName + "' not allowed");
         }
     }
 
     private boolean isAllowedClaimType(Object claimValue) {
         return claimValue instanceof String || claimValue instanceof Number;
     }
-
-    private boolean matchesAllowed(String actual, String allowed) {
-        if (allowed.contains("*")) {
-            String regex = allowed.replace("*", ".*");
-            return actual.matches(regex);
-        }
-        return actual.equals(allowed);
-    }
-
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.JWTAuthorizationGrantValidationContext;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.JWTAuthorizationGrantContext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class JWTClaimEnforcerExecutor implements ClientPolicyExecutorProvider<JWTClaimEnforcerExecutor.Configuration> {
+
+    private final KeycloakSession session;
+    private Configuration configuration;
+
+    public JWTClaimEnforcerExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void setupConfiguration(JWTClaimEnforcerExecutor.Configuration config) {
+        this.configuration = config;
+    }
+
+    @Override
+    public String getProviderId() {
+        return DownscopeAssertionGrantEnforcerExecutorFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public Class<Configuration> getExecutorConfigurationClass() {
+        return Configuration.class;
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+
+        @JsonProperty("claim-name")
+        protected String claimName;
+
+        @JsonProperty("allowed-values")
+        protected List<String> allowedValues;
+
+        public String getClaimName() {
+            return claimName;
+        }
+
+        public void setClaimName(String claimName) {
+            this.claimName = claimName;
+        }
+
+        public List<String> getAllowedValues() {
+            return allowedValues;
+        }
+
+        public void setAllowedValues(List<String> allowedValues) {
+            this.allowedValues = allowedValues;
+        }
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case JWT_AUTHORIZATION_GRANT -> {
+                JWTAuthorizationGrantContext jwtAuthnGrantContext = ((JWTAuthorizationGrantContext) context);
+                JWTAuthorizationGrantValidationContext jwtContext = jwtAuthnGrantContext.getAuthorizationGrantContext();
+                checkClaims(getAccessTokenAsMapFromAssertion(jwtContext.getAssertion()));
+            }
+        }
+    }
+
+    private Map<String, Object> getAccessTokenAsMapFromAssertion(String assertion) throws ClientPolicyException {
+        try {
+            return new  JWSInput(assertion).readJsonContent(new TypeReference<>() {});
+        } catch (JWSInputException e) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Assertion contains an invalid access token");
+        }
+    }
+    private void checkClaims(Map<String, Object> tokenMap) throws ClientPolicyException {
+        String claimName = configuration.getClaimName();
+        // Validate configuration
+        if (claimName == null) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST,  "Invalid configuration");
+        }
+
+        List<String> allowedValues = configuration.getAllowedValues();
+
+        // Extract claim value
+        Object claimValue = tokenMap.get(claimName);
+        if (claimValue == null) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Required claim '" + claimName + "' is missing from the token");
+        }
+
+        // If allowedValues is empty validate only if the claim exists
+        if (allowedValues == null || allowedValues.isEmpty()) {
+            return;
+        }
+
+        //allow only numbers or strings
+        if (!isAllowedClaimType(claimValue)) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Claim value is not allowed");
+        }
+
+        String stringValue = String.valueOf(claimValue);
+        boolean matches = allowedValues.stream().anyMatch(allowed -> matchesAllowed(stringValue, allowed));
+        if (!matches) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Claim '" + claimName + "' not allowed");
+        }
+    }
+
+    private boolean isAllowedClaimType(Object claimValue) {
+        return claimValue instanceof String || claimValue instanceof Number;
+    }
+
+    private boolean matchesAllowed(String actual, String allowed) {
+        if (allowed.contains("*")) {
+            String regex = allowed.replace("*", ".*");
+            return actual.matches(regex);
+        }
+        return actual.equals(allowed);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutorFactory.java
@@ -29,7 +29,7 @@ public class JWTClaimEnforcerExecutorFactory implements ClientPolicyExecutorProv
 
     public static final String CLAIM_NAME = "claim-name";
 
-    public static final String ALLOWED_VALUES = "allowed-values";
+    public static final String ALLOWED_VALUE = "allowed-value";
 
     @Override
     public ClientPolicyExecutorProvider create(KeycloakSession session) {
@@ -44,12 +44,11 @@ public class JWTClaimEnforcerExecutorFactory implements ClientPolicyExecutorProv
             null
     );
 
-    private static final ProviderConfigProperty ALLOWED_VALUES_PROPERTY = new ProviderConfigProperty(
-            ALLOWED_VALUES,
-            "Allowed Values",
-            "List of allowed values that the JWT claim can contain. You can use wildcards '*' to match any sequence of characters. " +
-                    "If left empty, only the presence of the claim is enforced.",
-            ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+    private static final ProviderConfigProperty ALLOWED_VALUE_PROPERTY = new ProviderConfigProperty(
+            ALLOWED_VALUE,
+            "Allowed Value",
+            "Value that the JWT claim must match. Regular expressions are supported. If left empty, only the presence of the claim is enforced.",
+            ProviderConfigProperty.STRING_TYPE,
             null
     );
 
@@ -73,17 +72,17 @@ public class JWTClaimEnforcerExecutorFactory implements ClientPolicyExecutorProv
     @Override
     public String getHelpText() {
         return """
-           Enforces the presence and specific values of claim in a JWT.
-           - The configured claim must be present in the received JWT.
-           - If allowed values are empty, only the presence of the claim is enforced.
-           - If allowed values are set, the claim's value must match one of them.
-           - Wildcards '*' are supported for flexible value matching (e.g., 'admin*' matches 'admin123').
-           - Only claims of type string or number are allowed; multi-valued, arrays, maps, or other JSON objects are not supported.
-           """;
+        The executor enforces the presence and specific values of a claim in a JWT.
+        It is applied in client requests where an existing JWT token is passed, such as a JWT Authorization Grant request (RFC 7523) or Standard Token Exchange request.
+        The configured claim must be present in the received JWT.
+        If allowed value is empty, only the presence of the claim is enforced.
+        If allowed value is set, the claim's value must match the configured regular expression.
+        Only claims of type string or number are allowed; multi-valued, arrays, maps, or other JSON objects are not supported.
+        """;
     }
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return List.of(CLAIM_NAME_PROPERTY, ALLOWED_VALUES_PROPERTY);
+        return List.of(CLAIM_NAME_PROPERTY, ALLOWED_VALUE_PROPERTY);
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/JWTClaimEnforcerExecutorFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.List;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class JWTClaimEnforcerExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "jwt-claim-enforcer";
+
+    public static final String CLAIM_NAME = "claim-name";
+
+    public static final String ALLOWED_VALUES = "allowed-values";
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new JWTClaimEnforcerExecutor(session);
+    }
+
+    private static final ProviderConfigProperty CLAIM_NAME_PROPERTY = new ProviderConfigProperty(
+            CLAIM_NAME,
+            "Claim Name",
+            "The name of the JWT claim to enforce. This claim must be present in the token for validation.",
+            ProviderConfigProperty.STRING_TYPE,
+            null
+    );
+
+    private static final ProviderConfigProperty ALLOWED_VALUES_PROPERTY = new ProviderConfigProperty(
+            ALLOWED_VALUES,
+            "Allowed Values",
+            "List of allowed values that the JWT claim can contain. You can use wildcards '*' to match any sequence of characters. " +
+                    "If left empty, only the presence of the claim is enforced.",
+            ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+            null
+    );
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return """
+           Enforces the presence and specific values of claim in a JWT.
+           - The configured claim must be present in the received JWT.
+           - If allowed values are empty, only the presence of the claim is enforced.
+           - If allowed values are set, the claim's value must match one of them.
+           - Wildcards '*' are supported for flexible value matching (e.g., 'admin*' matches 'admin123').
+           - Only claims of type string or number are allowed; multi-valued, arrays, maps, or other JSON objects are not supported.
+           """;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of(CLAIM_NAME_PROPERTY, ALLOWED_VALUES_PROPERTY);
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -31,3 +31,4 @@ org.keycloak.services.clientpolicy.executor.SamlSignatureEnforcerExecutorFactory
 org.keycloak.services.clientpolicy.executor.AuthenticationFlowSelectorExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureClientAuthenticationAssertionExecutorFactory
 org.keycloak.services.clientpolicy.executor.DownscopeAssertionGrantEnforcerExecutorFactory
+org.keycloak.services.clientpolicy.executor.JWTClaimEnforcerExecutorFactory

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmConfigBuilder.java
@@ -251,13 +251,13 @@ public class RealmConfigBuilder {
         return this;
     }
 
-    public RealmConfigBuilder clientProfile(ClientProfileRepresentation clienProfileRep) {
+    public RealmConfigBuilder clientProfile(ClientProfileRepresentation clientProfileRep) {
         ClientProfilesRepresentation clientProfiles = rep.getParsedClientProfiles();
         if (clientProfiles == null) {
             clientProfiles = new ClientProfilesRepresentation();
         }
         List<ClientProfileRepresentation> profiles = clientProfiles.getProfiles();
-        profiles.add(clienProfileRep);
+        profiles.add(clientProfileRep);
         rep.setParsedClientProfiles(clientProfiles);
         return this;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantJWTClaimsClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantJWTClaimsClientPoliciesTest.java
@@ -1,0 +1,155 @@
+package org.keycloak.tests.oauth;
+
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.clientpolicy.condition.GrantTypeConditionFactory;
+import org.keycloak.services.clientpolicy.executor.JWTClaimEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.JWTClaimEnforcerExecutorFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientPolicyBuilder;
+import org.keycloak.testframework.realm.ClientProfileBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+public class JWTAuthorizationGrantJWTClaimsClientPoliciesTest extends BaseAbstractJWTAuthorizationGrantTest {
+
+    @InjectRealm(config = JWTAuthorizationGrantRealmConfig.class)
+    protected ManagedRealm realm;
+
+    @Test
+    public void testClaimPresenceOnly() {
+        updateExecutorConfig("username", null);
+
+        JsonWebToken assertionJwt = createDefaultAuthorizationGrantToken();
+
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertFailurePolicy("invalid_request", "Required claim 'username' is missing from the token", response, events.poll());
+
+        assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("username", "anyvalue");
+        response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertSuccess("test-app", response);
+    }
+
+    @Test
+    public void testSubjectClaimExactMatch() {
+        updateExecutorConfig("sub", List.of("basic-user-id-1"));
+
+        JsonWebToken assertionJwt = createDefaultAuthorizationGrantToken();
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertFailurePolicy("invalid_request", "Claim 'sub' not allowed", response, events.poll());
+    }
+
+    @Test
+    public void testClaimExactMatch() {
+        updateExecutorConfig("username", List.of("test-username"));
+
+        JsonWebToken assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("username", "test-username");
+
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertSuccess("test-app", response);
+
+        assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("username", "wronguser");
+        response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertFailurePolicy("invalid_request", "Claim 'username' not allowed", response, events.poll());
+    }
+
+    @Test
+    public void testClaimWildcardMatch() {
+        updateExecutorConfig("username", List.of("test-username*"));
+
+        JsonWebToken assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("username", "test-username123");
+
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertSuccess("test-app", response);
+
+        assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("username", "wronguser");
+        response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertFailurePolicy("invalid_request", "Claim 'username' not allowed", response, events.poll());
+    }
+
+    @Test
+    public void testClaimNumberMatch() {
+        updateExecutorConfig("level", List.of("3", "5", "6*"));
+
+        JsonWebToken assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("level", 3);
+
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertSuccess("test-app", response);
+
+        assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("level", 61);
+
+        response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertSuccess("test-app", response);
+
+        assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("level", 2);
+        response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertFailurePolicy("invalid_request", "Claim 'level' not allowed", response, events.poll());
+    }
+
+    @Test
+    public void testClaimNowAllowedType() {
+        updateExecutorConfig("username",  List.of("test-username"));
+
+        JsonWebToken assertionJwt = createDefaultAuthorizationGrantToken();
+        assertionJwt.getOtherClaims().put("username", Map.of("test-username","asdf"));
+
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(identityProvider.encodeToken(assertionJwt)).send();
+        assertFailurePolicy("invalid_request", "Claim value is not allowed", response, events.poll());
+    }
+
+    protected void updateExecutorConfig(String claimName, List<String> allowedValues) {
+        JWTClaimEnforcerExecutor.Configuration claimsConfig = new JWTClaimEnforcerExecutor.Configuration();
+        claimsConfig.setClaimName(claimName);
+        claimsConfig.setAllowedValues(allowedValues);
+        updateExecutorConfig(claimsConfig);
+    }
+    protected void updateExecutorConfig(JWTClaimEnforcerExecutor.Configuration newConfig) {
+
+        realm.updateWithCleanup(r -> {
+
+            JWTClaimEnforcerExecutor.Configuration claimsConfig = new JWTClaimEnforcerExecutor.Configuration();
+            claimsConfig.setClaimName("username");
+            claimsConfig.setAllowedValues(List.of("test-username"));
+            r.clientProfile(ClientProfileBuilder.create()
+                    .name("executor")
+                    .description("executor description")
+                    .executor(JWTClaimEnforcerExecutorFactory.PROVIDER_ID, newConfig)
+                    .build());
+
+            r.clientPolicy(ClientPolicyBuilder.create()
+                    .name("policy")
+                    .description("description of policy")
+                    .condition(GrantTypeConditionFactory.PROVIDER_ID, ClientPolicyBuilder.grantTypeConditionConfiguration(
+                            OAuth2Constants.JWT_AUTHORIZATION_GRANT))
+                    .profile("executor")
+                    .build());
+
+            return r;
+        });
+    }
+
+    public static class JWTAuthorizationGrantRealmConfig extends OIDCIdentityProviderJWTAuthorizationGrantTest.JWTAuthorizationGrantRealmConfig {
+
+        @Override
+        public RealmConfigBuilder configure(RealmConfigBuilder realm) {
+            super.configure(realm);
+            return realm;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ProtocolMappersUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ProtocolMappersUpdater.java
@@ -63,6 +63,17 @@ public class ProtocolMappersUpdater extends ServerResourceUpdater<ProtocolMapper
         return this;
     }
 
+    public ProtocolMappersUpdater removeByName(String name) {
+        for (Iterator<ProtocolMapperRepresentation> it = rep.iterator(); it.hasNext();) {
+            ProtocolMapperRepresentation mapper = it.next();
+            if (name.equals(mapper.getName())) {
+                it.remove();
+                break;
+            }
+        }
+        return this;
+    }
+
     private void update(List<ProtocolMapperRepresentation> expectedMappers) {
         List<ProtocolMapperRepresentation> currentMappers = resource.getMappers();
 


### PR DESCRIPTION
Closes #44443

- Only one claim can be configured per executor
- You can configure a list of allowed values and use wildcards
- If the list of allowed values is empty, only the presence of the claim in the JWT is checked
- Only strings or numbers are allowed, for lists or other objects, the check will fail.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
