### PR TITLE
[admin-api-v2] Create client does not return 201 status code

### DIFF
--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 
@@ -22,10 +23,13 @@ public interface ClientApi {
     @Produces(MediaType.APPLICATION_JSON)
     ClientRepresentation getClient();
 
+    /**
+     * @return {@link ClientRepresentation} of created/updated client
+     */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    ClientRepresentation createOrUpdateClient(@Valid ClientRepresentation client);
+    Response createOrUpdateClient(@Valid ClientRepresentation client);
 
     @PATCH
     @Consumes(CONTENT_TYPE_MERGE_PATCH)

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.resources.KeycloakOpenAPI;
@@ -28,11 +29,14 @@ public interface ClientsApi {
     @Operation(summary = "Get all clients", description = "Returns a list of all clients in the realm")
     Stream<ClientRepresentation> getClients();
 
+    /**
+     * @return {@link ClientRepresentation} of created client
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(summary = "Create a new client", description = "Creates a new client in the realm")
-    ClientRepresentation createClient(@Valid ClientRepresentation client);
+    Response createClient(@Valid ClientRepresentation client);
 
     @Path("{id}")
     ClientApi client(@PathParam("id") String id);

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -147,7 +147,7 @@ public class ClientApiV2Test {
         request.setEntity(new StringEntity(mapper.writeValueAsString(rep)));
 
         try (var response = client.execute(request)) {
-            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertEquals(201, response.getStatusLine().getStatusCode());
             ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
             assertEquals("I'm new", client.getDescription());
         }
@@ -159,6 +159,32 @@ public class ClientApiV2Test {
             assertEquals(200, response.getStatusLine().getStatusCode());
             ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
             assertEquals("I'm updated", client.getDescription());
+        }
+    }
+
+    @Test
+    public void createClient() throws Exception {
+        HttpPost request = new HttpPost(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        setAuthHeader(request);
+        request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setEnabled(true);
+        rep.setClientId("client-123");
+        rep.setDescription("I'm new");
+
+        request.setEntity(new StringEntity(mapper.writeValueAsString(rep)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(),is(201));
+            ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
+            assertThat(client.getEnabled(),is(true));
+            assertThat(client.getClientId(),is("client-123"));
+            assertThat(client.getDescription(),is("I'm new"));
+        }
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(),is(409));
         }
     }
 
@@ -175,7 +201,7 @@ public class ClientApiV2Test {
         createRequest.setEntity(new StringEntity(mapper.writeValueAsString(rep)));
 
         try (var response = client.execute(createRequest)) {
-            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertEquals(201, response.getStatusLine().getStatusCode());
         }
 
         HttpGet getRequest = new HttpGet(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/to-delete");


### PR DESCRIPTION
- Closes #44540
- The POST endpoint now returns 201 response code
- For the `createOrUpdate()` PUT request, it also returns 201 when the client does not exist -> Is it ok for the operator and idempotency? As these response codes might be different
- As we're talking about polymorphic representation, we could use the `Response` type as the return type. WDYT? 