### PR TITLE
[admin-api-v2] Cloud Native team as a code owner for Client API v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,7 @@
 /docs/guides/server/                                        @keycloak/cloud-native-maintainers @keycloak/maintainers
 /docs/guides/operator/                                      @keycloak/cloud-native-maintainers @keycloak/maintainers
 /integration/client-cli/admin-cli/                          @keycloak/cloud-native-maintainers @keycloak/maintainers
+/rest/admin-v2/                                             @keycloak/cloud-native-maintainers @keycloak/maintainers
 
 ###################################################################################################
 # UI (@keycloak/ui-maintainers)


### PR DESCRIPTION
@keycloak/cloud-native-maintainers It'd be good to be code owners of the Admin API v2 module.