### PR TITLE
[admin-api-v2] Incorrect DTO/DAO mapping

### DIFF
--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ClientModelMapper.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/ClientModelMapper.java
@@ -1,12 +1,16 @@
 package org.keycloak.models.mapper;
 
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.ServiceException;
 
 public interface ClientModelMapper {
 
-    ClientRepresentation fromModel(ClientModel model);
+    ClientRepresentation fromModel(KeycloakSession session, ClientModel model);
 
-    void toModel(ClientModel model, ClientRepresentation rep, RealmModel realm);
+    ClientModel toModel(KeycloakSession session, RealmModel realm, ClientModel existingModel, ClientRepresentation rep) throws ServiceException;
+
+    ClientModel toModel(KeycloakSession session, RealmModel realm, ClientRepresentation rep) throws ServiceException;
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/MapStructClientModelMapper.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/MapStructClientModelMapper.java
@@ -1,36 +1,119 @@
 package org.keycloak.models.mapper;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
+import org.keycloak.services.ServiceException;
+import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
 
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
+import org.mapstruct.ObjectFactory;
 
 @Mapper
 public interface MapStructClientModelMapper extends ClientModelMapper {
+
+    @Override
+    @ModelToRep
+    ClientRepresentation fromModel(@Context KeycloakSession session, ClientModel model);
+
+    // we don't want to ignore nulls so that we completely overwrite the state
+    @Override
+    @RepToModel
+    ClientModel toModel(@Context KeycloakSession session, @Context RealmModel realm, @MappingTarget ClientModel existingModel, ClientRepresentation rep) throws ServiceException;
+
+    @Override
+    @RepToModel
+    ClientModel toModel(@Context KeycloakSession session, @Context RealmModel realm, ClientRepresentation rep) throws ServiceException;
+
+    /*-------------------------------------*
+     *              MAPPERS                *
+     *-------------------------------------*/
+    @Mapping(target = "name", source = "displayName")
+    @Mapping(target = "baseUrl", source = "appUrl")
+    @Mapping(target = "redirectUris", source = "appRedirectUrls")
+    @Mapping(target = "authenticationFlowBindingOverrides", source = "loginFlows", ignore = true) // TODO
+    @Mapping(target = "publicClient", source = "auth.enabled", qualifiedByName = "isPublicClientPrimitive")
+    @Mapping(target = "clientAuthenticatorType", source = "auth.method")
+    @Mapping(target = "secret", source = "auth.secret")
+    @Mapping(target = "serviceAccountsEnabled", source = "serviceAccount.enabled")
+    @interface RepToModel {
+    }
+
     @Mapping(target = "displayName", source = "name")
     @Mapping(target = "appUrl", source = "baseUrl")
     @Mapping(target = "appRedirectUrls", source = "redirectUris")
     @Mapping(target = "loginFlows", source = "authenticationFlowBindingOverrides", ignore = true)
-    @Mapping(target = "auth", ignore = true) // TODO
+    @Mapping(target = "auth.enabled", source = "publicClient", qualifiedByName = "isPublicClient")
+    @Mapping(target = "auth.method", source = "clientAuthenticatorType")
+    @Mapping(target = "auth.secret", source = "secret")
+    @Mapping(target = "auth.certificate", ignore = true) // no cert in the representation
     @Mapping(target = "roles", source = "rolesStream", qualifiedByName = "getRoleStrings")
     @Mapping(target = "serviceAccount.enabled", source = "serviceAccountsEnabled")
-    @Mapping(target = "serviceAccount.roles", source = "rolesStream", qualifiedByName = "getServiceAccountRoles")
-    @Override
-    ClientRepresentation fromModel(ClientModel model);
+    @Mapping(target = "serviceAccount.roles", source = ".", qualifiedByName = "getServiceAccountRoles")
+    @interface ModelToRep {
+    }
 
-    // we don't want to ignore nulls so that we completely overwrite the state
-    @Override
-    void toModel(@MappingTarget ClientModel model, ClientRepresentation rep, @Context RealmModel realm);
+    /*-------------------------------------*
+     *          HELPER METHODS             *
+     *-------------------------------------*/
+    @ObjectFactory
+    default ClientModel createClientModel(@Context RealmModel realm, ClientRepresentation rep) {
+        // dummy add/remove to obtain a detached model
+        var model = realm.addClient(rep.getClientId());
+        realm.removeClient(model.getId());
+        return model;
+    }
+
+    @AfterMapping
+    default void addRoles(@MappingTarget ClientModel model, ClientRepresentation rep, @Context RealmModel realm, @Context KeycloakSession session) {
+        Optional.ofNullable(rep.getRoles())
+                .orElse(Collections.emptySet())
+                .stream()
+                .filter(role -> model.getRole(role) == null)
+                .forEach(model::addRole);
+
+        // Service Account roles
+        var serviceAccount = rep.getServiceAccount();
+        if (serviceAccount != null && serviceAccount.getEnabled() && !serviceAccount.getRoles().isEmpty()) {
+            new ClientManager(new RealmManager(session)).enableServiceAccount(model);
+            var sa = session.users().getServiceAccount(model);
+
+            serviceAccount.getRoles().forEach(role -> {
+                var foundRole = realm.getRole(role);
+                if (foundRole == null) {
+                    throw new ServiceException("Cannot assign role to the service account (field 'serviceAccount.roles') as it does not exist", Response.Status.BAD_REQUEST);
+                }
+                sa.grantRole(foundRole);
+            });
+        }
+    }
+
+    @Named("isPublicClientPrimitive")
+    default boolean isPublicClientPrimitive(Boolean authEnabled) {
+        var result = isPublicClient(authEnabled);
+        return result != null ? result : false;
+    }
+
+    @Named("isPublicClient")
+    default Boolean isPublicClient(Boolean authEnabled) {
+        return authEnabled != null ? !authEnabled : null;
+    }
 
     @Named("getRoleStrings")
     default Set<String> getRoleStrings(Stream<RoleModel> stream) {
@@ -38,9 +121,13 @@ public interface MapStructClientModelMapper extends ClientModelMapper {
     }
 
     @Named("getServiceAccountRoles")
-    default Set<String> getServiceAccountRoles(Stream<RoleModel> stream) {
-        return stream.filter(f -> true) //TODO check roles for SA
-                .map(RoleModel::getName)
-                .collect(Collectors.toSet());
+    default Set<String> getServiceAccountRoles(@Context KeycloakSession session, ClientModel client) {
+        if (client.isServiceAccountsEnabled()) {
+            return session.users().getServiceAccount(client)
+                    .getRoleMappingsStream()
+                    .map(RoleModel::getName)
+                    .collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/ClientRepresentation.java
@@ -1,6 +1,7 @@
 package org.keycloak.representations.admin.v2;
 
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import jakarta.validation.Valid;
@@ -211,6 +212,21 @@ public class ClientRepresentation extends BaseRepresentation {
         public void setCertificate(String certificate) {
             this.certificate = certificate;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Auth auth)) return false;
+            return Objects.equals(enabled, auth.enabled)
+                    && Objects.equals(method, auth.method)
+                    && Objects.equals(secret, auth.secret)
+                    && Objects.equals(certificate, auth.certificate);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(enabled, method, secret, certificate);
+        }
     }
 
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
@@ -238,5 +254,44 @@ public class ClientRepresentation extends BaseRepresentation {
         public void setRoles(Set<String> roles) {
             this.roles = roles;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ServiceAccount that)) return false;
+            return Objects.equals(enabled, that.enabled)
+                    && Objects.equals(roles, that.roles);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(enabled, roles);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientRepresentation that = (ClientRepresentation) o;
+        return Objects.equals(clientId, that.clientId)
+                && Objects.equals(displayName, that.displayName)
+                && Objects.equals(description, that.description)
+                && Objects.equals(protocol, that.protocol)
+                && Objects.equals(enabled, that.enabled)
+                && Objects.equals(appUrl, that.appUrl)
+                && Objects.equals(appRedirectUrls, that.appRedirectUrls)
+                && Objects.equals(loginFlows, that.loginFlows)
+                && Objects.equals(auth, that.auth)
+                && Objects.equals(webOrigins, that.webOrigins)
+                && Objects.equals(roles, that.roles)
+                && Objects.equals(serviceAccount, that.serviceAccount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clientId, displayName, description, protocol, enabled, appUrl, appRedirectUrls,
+                loginFlows, auth, webOrigins, roles, serviceAccount
+        );
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/ClientService.java
@@ -7,8 +7,6 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.services.Service;
 import org.keycloak.services.ServiceException;
-import org.keycloak.services.resources.admin.ClientResource;
-import org.keycloak.services.resources.admin.ClientsResource;
 
 public interface ClientService extends Service {
 
@@ -29,12 +27,12 @@ public interface ClientService extends Service {
 
     record CreateOrUpdateResult(ClientRepresentation representation, boolean created) {}
 
-    Optional<ClientRepresentation> getClient(ClientResource clientResource, RealmModel realm, String clientId, ClientProjectionOptions projectionOptions);
+    Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, ClientProjectionOptions projectionOptions);
 
-    Stream<ClientRepresentation> getClients(ClientsResource clientsResource, RealmModel realm, ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions);
+    Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions);
 
     Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions);
 
-    CreateOrUpdateResult createOrUpdate(ClientsResource clientsResource, ClientResource clientResource, RealmModel realm, ClientRepresentation client, boolean allowUpdate) throws ServiceException;
+    CreateOrUpdateResult createOrUpdate(RealmModel realm, ClientRepresentation client, boolean allowUpdate) throws ServiceException;
 
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -1,21 +1,29 @@
 package org.keycloak.services.client;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.mapper.ClientModelMapper;
 import org.keycloak.models.mapper.MapStructModelMapper;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.admin.v2.ClientRepresentation;
 import org.keycloak.representations.admin.v2.validation.CreateClientDefault;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.services.ServiceException;
 import org.keycloak.services.resources.admin.ClientResource;
 import org.keycloak.services.resources.admin.ClientsResource;
+import org.keycloak.services.resources.admin.RealmAdminResource;
 import org.keycloak.validation.jakarta.HibernateValidatorProvider;
 import org.keycloak.validation.jakarta.JakartaValidatorProvider;
 
@@ -24,31 +32,39 @@ public class DefaultClientService implements ClientService {
     private final KeycloakSession session;
     private final ClientModelMapper mapper;
     private final JakartaValidatorProvider validator;
+    private final RealmAdminResource realmAdminResource;
+    private final ClientsResource clientsResource;
+    private ClientResource clientResource;
 
-    public DefaultClientService(KeycloakSession session) {
+    public DefaultClientService(KeycloakSession session, RealmAdminResource realmAdminResource, ClientResource clientResource) {
         this.session = session;
+        this.realmAdminResource = realmAdminResource;
+        this.clientResource = clientResource;
+
+        this.clientsResource = realmAdminResource.getClients();
         this.mapper = new MapStructModelMapper().clients();
         this.validator = new HibernateValidatorProvider();
     }
 
+    public DefaultClientService(KeycloakSession session, RealmAdminResource realmAdminResource) {
+        this(session, realmAdminResource, null);
+    }
+
     @Override
-    public Optional<ClientRepresentation> getClient(ClientResource clientResource, RealmModel realm, String clientId,
-            ClientProjectionOptions projectionOptions) {
+    public Optional<ClientRepresentation> getClient(RealmModel realm, String clientId, ClientProjectionOptions projectionOptions) {
         // TODO: is the access map on the representation needed
         return Optional.ofNullable(clientResource).map(ClientResource::viewClientModel).map(model -> mapper.fromModel(session, model));
     }
 
     @Override
-    public Stream<ClientRepresentation> getClients(ClientsResource clientsResource, RealmModel realm,
-            ClientProjectionOptions projectionOptions, ClientSearchOptions searchOptions,
-            ClientSortAndSliceOptions sortAndSliceOptions) {
+    public Stream<ClientRepresentation> getClients(RealmModel realm, ClientProjectionOptions projectionOptions,
+                                                   ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions) {
         // TODO: is the access map on the representation needed
         return clientsResource.getClientModels(null, true, false, null, null, null).map(model -> mapper.fromModel(session, model));
     }
 
     @Override
-    public CreateOrUpdateResult createOrUpdate(ClientsResource clientsResource, ClientResource clientResource,
-            RealmModel realm, ClientRepresentation client, boolean allowUpdate) throws ServiceException {
+    public CreateOrUpdateResult createOrUpdate(RealmModel realm, ClientRepresentation client, boolean allowUpdate) throws ServiceException {
         boolean created = false;
         ClientModel model;
         if (clientResource != null) {
@@ -65,8 +81,11 @@ public class DefaultClientService implements ClientService {
             model = mapper.toModel(session, realm, client);
             var rep = ModelToRepresentation.toRepresentation(model, session);
             model = clientsResource.createClientModel(rep);
+            clientResource = clientsResource.getClient(model.getId());
         }
 
+        handleRoles(client.getRoles());
+        handleServiceAccount(model, client.getServiceAccount());
         var updated = mapper.fromModel(session, model);
 
         return new CreateOrUpdateResult(updated, created);
@@ -76,6 +95,91 @@ public class DefaultClientService implements ClientService {
     public Stream<ClientRepresentation> deleteClients(RealmModel realm, ClientSearchOptions searchOptions) {
         // TODO Auto-generated method stub
         return null;
+    }
+
+    /**
+     * Declaratively manage client roles - ensures the client has exactly the roles specified in 'rolesFromRep'
+     * <p>
+     * Reuses API v1 logic
+     */
+    protected void handleRoles(Set<String> rolesFromRep) {
+        var roleResource = clientResource.getRoleContainerResource();
+
+        Set<String> desiredRoleNames = Optional.ofNullable(rolesFromRep)
+                .orElse(Collections.emptySet());
+
+        Set<String> currentRoleNames = roleResource.getRoles(null, null, null, false)
+                .map(RoleRepresentation::getName)
+                .collect(Collectors.toSet());
+
+        // Add missing roles (in desiredRoleNames but not in currentRoleNames)
+        desiredRoleNames.stream()
+                .filter(roleName -> !currentRoleNames.contains(roleName))
+                .forEach(roleName -> roleResource.createRole(new RoleRepresentation(roleName, "", false)));
+
+        // Remove extra roles (in currentRoleNames but not in desiredRoleNames)
+        currentRoleNames.stream()
+                .filter(role -> !desiredRoleNames.contains(role))
+                .forEach(roleResource::deleteRole);
+    }
+
+    /**
+     * Declaratively manage service account - enables/disables it and ensures it has exactly the roles specified (realm and client roles)
+     * <p>
+     * Reuses API v1 logic
+     */
+    protected void handleServiceAccount(ClientModel model, ClientRepresentation.ServiceAccount serviceAccount) {
+        if (serviceAccount != null && serviceAccount.getEnabled() != null) {
+            ClientResource.updateClientServiceAccount(session, model, serviceAccount.getEnabled());
+
+            if (serviceAccount.getEnabled()) {
+                var clientRoleResource = clientResource.getRoleContainerResource();
+                var realmRoleResource = realmAdminResource.getRoleContainerResource();
+
+                var serviceAccountUser = session.users().getServiceAccount(model);
+                var serviceAccountRoleResource = realmAdminResource.users().user(clientResource.getServiceAccountUser().getId()).getRoleMappings();
+
+                Set<String> desiredRoleNames = Optional.ofNullable(serviceAccount.getRoles()).orElse(Collections.emptySet());
+                Set<RoleModel> currentRoles = serviceAccountUser.getRoleMappingsStream().collect(Collectors.toSet());
+                Set<String> currentRoleNames = currentRoles.stream().map(RoleModel::getName).collect(Collectors.toSet());
+
+                // Get missing roles (in desired but not in current)
+                List<RoleRepresentation> missingRoles = desiredRoleNames.stream()
+                        .filter(roleName -> !currentRoleNames.contains(roleName))
+                        .map(roleName -> {
+                            try {
+                                return clientRoleResource.getRole(roleName); // client role
+                            } catch (NotFoundException e) {
+                                try {
+                                    return realmRoleResource.getRole(roleName); // realm role
+                                } catch (NotFoundException e2) {
+                                    throw new ServiceException("Cannot assign role to the service account (field 'serviceAccount.roles') as it does not exist", Response.Status.BAD_REQUEST);
+                                }
+                            }
+                        })
+                        .toList();
+
+                // Add missing roles (in desired but not in current)
+                if (!missingRoles.isEmpty()) {
+                    serviceAccountRoleResource.addRealmRoleMappings(missingRoles);
+                }
+
+                // Get extra roles (in current but not in desired)
+                List<RoleRepresentation> extraRoles = currentRoles.stream()
+                        .filter(role -> !desiredRoleNames.contains(role.getName()))
+                        .map(ModelToRepresentation::toRepresentation)
+                        .toList();
+
+                // Remove extra roles (in current but not in desired)
+                if (!extraRoles.isEmpty()) {
+                    try {
+                        serviceAccountRoleResource.deleteRealmRoleMappings(extraRoles);
+                    } catch (NotFoundException e) {
+                        throw new ServiceException("Cannot unassign role from the service account (field 'serviceAccount.roles') as it does not exist", Response.Status.BAD_REQUEST);
+                    }
+                }
+            }
+        }
     }
 
 }

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApi.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/realm/DefaultRealmApi.java
@@ -19,7 +19,7 @@ public class DefaultRealmApi implements RealmApi {
     @Path("clients")
     @Override
     public ClientsApi clients() {
-        return new DefaultClientsApi(session, realmAdminResource.getClients());
+        return new DefaultClientsApi(session, realmAdminResource);
     }
 
 }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.tests.admin.client.v2;
 
+import java.util.Set;
+
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 
@@ -48,6 +50,7 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -274,6 +277,68 @@ public class ClientApiV2Test {
         try (var response = client.execute(request)) {
             assertEquals(401, response.getStatusLine().getStatusCode());
         }
+    }
+
+    @Test
+    public void createFullClient() throws Exception {
+        HttpPost request = new HttpPost(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        setAuthHeader(request);
+        request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        ClientRepresentation rep = getTestingFullClientRep();
+        request.setEntity(new StringEntity(mapper.writeValueAsString(rep)));
+
+        try (var response = client.execute(request)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            ClientRepresentation client = mapper.createParser(response.getEntity().getContent()).readValueAs(ClientRepresentation.class);
+            assertThat(client, is(rep));
+        }
+    }
+
+    @Test
+    public void createFullClientWrongServiceAccountRoles() throws Exception {
+        HttpPost request = new HttpPost(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        setAuthHeader(request);
+        request.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        ClientRepresentation rep = getTestingFullClientRep();
+        rep.getServiceAccount().setRoles(Set.of("non-existing", "bad-role"));
+        request.setEntity(new StringEntity(mapper.writeValueAsString(rep)));
+
+        try (var response = client.execute(request)) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+            assertThat(EntityUtils.toString(response.getEntity()), containsString("Cannot assign role to the service account (field 'serviceAccount.roles') as it does not exist"));
+        }
+    }
+
+    private ClientRepresentation getTestingFullClientRep() {
+        var rep = new ClientRepresentation();
+        rep.setClientId("my-client");
+        rep.setDisplayName("My Client");
+        rep.setDescription("This is My Client");
+        rep.setProtocol(ClientRepresentation.OIDC);
+        rep.setEnabled(true);
+        rep.setAppUrl("http://localhost:3000");
+        rep.setAppRedirectUrls(Set.of("http://localhost:3000", "http://localhost:3001"));
+        // no login flows -> only flow overrides map
+        // rep.setLoginFlows(Set.of("browser"));
+        var auth = new ClientRepresentation.Auth();
+        auth.setEnabled(true);
+        auth.setMethod("client-jwt");
+        auth.setSecret("secret-1234");
+        // no certificate inside the old rep
+        // auth.setCertificate("certificate-5678");
+        rep.setAuth(auth);
+        rep.setWebOrigins(Set.of("http://localhost:4000", "http://localhost:4001"));
+        rep.setRoles(Set.of("view-consent", "manage-account"));
+        var serviceAccount = new ClientRepresentation.ServiceAccount();
+        serviceAccount.setEnabled(true);
+        // TODO when roles are not set and SA is enabled, the default role 'default-roles-master' for the SA is used for the master realm
+        serviceAccount.setRoles(Set.of("default-roles-master"));
+        rep.setServiceAccount(serviceAccount);
+        // not implemented yet
+        // rep.setAdditionalFields(Map.of("key1", "val1", "key2", "val2"));
+        return rep;
     }
 
     // TODO Rewrite the tests to not need explicit auth. They should use the admin client directly.

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -822,17 +822,7 @@ public class ClientResource {
     }
 
     private void updateClientFromRep(ClientRepresentation rep, ClientModel client, KeycloakSession session) throws ModelDuplicateException {
-        UserModel serviceAccount = this.session.users().getServiceAccount(client);
-        boolean serviceAccountScopeAssigned = client.getClientScopes(true).containsKey(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE);
-        if (Boolean.TRUE.equals(rep.isServiceAccountsEnabled())) {
-            if (serviceAccount == null || !serviceAccountScopeAssigned) {
-                new ClientManager(new RealmManager(session)).enableServiceAccount(client);
-            }
-        } else if (Boolean.FALSE.equals(rep.isServiceAccountsEnabled()) || !client.isServiceAccountsEnabled()) {
-            if (serviceAccount != null || serviceAccountScopeAssigned) {
-                new ClientManager(new RealmManager(session)).disableServiceAccount(client);
-            }
-        }
+        updateClientServiceAccount(session, client, rep.isServiceAccountsEnabled());
 
         if (rep.getClientId() != null && !rep.getClientId().equals(client.getClientId())) {
             new ClientManager(new RealmManager(session)).clientIdChanged(client, rep);
@@ -849,6 +839,20 @@ public class ClientResource {
         RepresentationToModel.updateClient(rep, client, session);
         RepresentationToModel.updateClientProtocolMappers(rep, client);
         updateAuthorizationSettings(rep);
+    }
+
+    public static void updateClientServiceAccount(KeycloakSession session, ClientModel client, Boolean isServiceAccountEnabled) {
+        UserModel serviceAccount = session.users().getServiceAccount(client);
+        boolean serviceAccountScopeAssigned = client.getClientScopes(true).containsKey(ServiceAccountConstants.SERVICE_ACCOUNT_SCOPE);
+        if (Boolean.TRUE.equals(isServiceAccountEnabled)) {
+            if (serviceAccount == null || !serviceAccountScopeAssigned) {
+                new ClientManager(new RealmManager(session)).enableServiceAccount(client);
+            }
+        } else if (Boolean.FALSE.equals(isServiceAccountEnabled) || !client.isServiceAccountsEnabled()) {
+            if (serviceAccount != null || serviceAccountScopeAssigned) {
+                new ClientManager(new RealmManager(session)).disableServiceAccount(client);
+            }
+        }
     }
 
     private void updateAuthorizationSettings(ClientRepresentation rep) {


### PR DESCRIPTION
- Closes #44586
- Fixes `Representation --> Model` mapping
- Fixes `Model --> Representation` mapping
- The model mapping layer will be used even for the new polymorphic representations
- Declarative approach for roles (exactly the required for the client)
- Creates a service account when `serviceAccount.enabled` is true
- Declarative approach for service account roles (exactly the required for the client) - assign/unassign existing roles
- Adds `equals()` and `hashCode()` methods for better testing (would be nice to have Lombok for this :P)
- Simplified contract for ClientService (it is an internal thing that we use the Resources objects, so it does not have to be part of the service contract)
- Adds additional test cases to verify the proper update/create of a client + declarative approach

@vmuzikar @shawkins @Pepo48 Could you please check it? Thanks!


