### PR TITLE
Added validation for client session timeout post comparing the realm session timeouts

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_0.adoc
@@ -1,11 +1,25 @@
 // ------------------------ Breaking changes ------------------------  //
 == Breaking changes
 
-= Loopback Hostname Verification on Windows
+Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
+In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
+
+=== Loopback Hostname Verification on Windows
 
 Setups on Windows that previously relied on custom machine names or non-standard hostnames for loopback (for example, `127.0.0.1` resolving to a custom name) may require updates to their trusted domain configuration. Only `localhost` and `*.localhost` are now recognized for loopback verification.
 
 {project_name} now consistently normalizes loopback addresses to `localhost` for domain verification across all platforms. This change ensures predictable behavior for trusted domain checks, regardless of the underlying OS.
+
+=== Validation of client session timeouts
+
+Previous versions did not validate client specific settings against the realm settings for SSO session idle and max lifetime, including the remember me settings of the realm.
+This leads to those settings either not being effective with unexpected results to administrators,
+or to refresh tokens issued where the user session might have already expired when the client was trying to refresh the token.
+
+{project_name} now validates that a client specific settings for Client Session Idle and Client Session Max does not exceed the realm settings when a client is created or updated, and will show a validation error when the validation fails.
+It does currently not validate the client settings when the realm SSO settings or remember me changes, though this might change in future releases.
+
+You are only affected by the change if you have configured a client-specific Client Session Idle and Client Session Max setting in the Advanced tab of the client configuration that exceeds the realm settings.
 
 // ------------------------ Notable changes ------------------------ //
 == Notable changes

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -347,4 +347,10 @@ public class Messages {
     public static final String CONFIRM_ORGANIZATION_MEMBERSHIP = "organization.confirm-membership";
     public static final String CONFIRM_ORGANIZATION_MEMBERSHIP_TITLE = "organization.confirm-membership.title";
     public static final String REGISTER_ORGANIZATION_MEMBER = "organization.member.register.title";
+
+   // Client sessions
+    public static final String CLIENT_IDLE_REMEMBERME = "clientIdleExceedsRealmRememberMeIdle";
+    public static final String CLIENT_IDLE = "clientSessionIdleTimeoutExceedsRealm";
+    public static final String CLIENT_MAXLIFE_SPAN = "clientSessionMaxLifespanExceedsRealm";
+    public static final String CLIENT_MAXLIFESPAN_REMEMBERME = "clientSessionMaxLifespanExceedsRealmRememberMeMaxSpan";
 }

--- a/services/src/main/java/org/keycloak/validation/DefaultClientValidationProvider.java
+++ b/services/src/main/java/org/keycloak/validation/DefaultClientValidationProvider.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.keycloak.authentication.authenticators.util.LoAUtil;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
@@ -41,6 +42,7 @@ import org.keycloak.protocol.saml.SamlConfigAttributes;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.ResolveRelative;
 import org.keycloak.utils.StringUtil;
 
@@ -193,6 +195,7 @@ public class DefaultClientValidationProvider implements ClientValidationProvider
         validateJwks(context);
         validateDefaultAcrValues(context);
         validateMinimumAcrValue(context);
+        validateClientSessionTimeout(context);
 
         return context.toResult();
     }
@@ -205,7 +208,7 @@ public class DefaultClientValidationProvider implements ClientValidationProvider
         new CibaClientValidation(context).validate();
         validateDefaultAcrValues(context);
         validateMinimumAcrValue(context);
-
+        //context.getSession().getContext().getRealm().
         return context.toResult();
     }
 
@@ -218,6 +221,7 @@ public class DefaultClientValidationProvider implements ClientValidationProvider
 
     private void validateUrls(ValidationContext<ClientModel> context) {
         ClientModel client = context.getObjectToValidate();
+
 
         // Use a fake URL for validating relative URLs as we may not be validating clients in the context of a request (import at startup)
         String authServerUrl = "https://localhost/auth";
@@ -419,6 +423,73 @@ public class DefaultClientValidationProvider implements ClientValidationProvider
                     context.addError("minimumAcrValue", "Minimum ACR value needs to be value specified in the ACR-To-Loa mapping or number level from set realm browser flow");
                 }
             }
+        }
+    }
+    private void validateClientSessionTimeout(ValidationContext<ClientModel> context) {
+        ClientModel clientModel = context.getObjectToValidate();
+        if (clientModel == null ) return;
+        RealmModel realmModel =  clientModel.getRealm();
+        if (realmModel == null ) return;
+
+        //Realm values
+        int realmIdle = realmModel.getSsoSessionIdleTimeout();
+        int realmMax = realmModel.getSsoSessionMaxLifespan();
+        int realmRememberIdle = realmModel.getSsoSessionIdleTimeoutRememberMe();
+        int realmRememberMax = realmModel.getSsoSessionMaxLifespanRememberMe();
+
+        boolean rememberMeEnabled = realmModel.isRememberMe();
+
+        Integer clientIdle = parseIntAttribute(clientModel.getAttribute(OIDCConfigAttributes.CLIENT_SESSION_IDLE_TIMEOUT));
+        Integer clientMax = parseIntAttribute(clientModel.getAttribute(OIDCConfigAttributes.CLIENT_SESSION_MAX_LIFESPAN));
+
+        if(!rememberMeEnabled) {
+            // Client idle Timeout validation on Remember me disabled
+            if (clientIdle != null && clientIdle > realmIdle) {
+                context.addError(
+                        OIDCConfigAttributes.CLIENT_SESSION_IDLE_TIMEOUT,
+                        "Client session idle timeout cannot exceed realm SSO session idle timeout.",
+                        Messages.CLIENT_IDLE
+                );
+            }
+
+            // Max Lifespan validation on Remember me disabled
+            if (clientMax != null && clientMax > realmMax) {
+                context.addError(
+                        OIDCConfigAttributes.CLIENT_SESSION_MAX_LIFESPAN,
+                        "Client session max lifespan cannot exceed realm SSO session max lifespan.",
+                        Messages.CLIENT_MAXLIFE_SPAN
+                );
+            }
+        } else {
+            int allowedMaxIdleTimeIfRememberMeEnabled = Math.max(realmIdle, realmRememberIdle);
+            int allowedMaxSpanIfRememberMeEnabled = Math.max(realmMax,realmRememberMax);
+
+            //Client idle Timeout validation on Remember me enabled
+            if (clientIdle != null && clientIdle > allowedMaxIdleTimeIfRememberMeEnabled) {
+                context.addError(
+                        OIDCConfigAttributes.CLIENT_SESSION_IDLE_TIMEOUT,
+                        "Client session idle timeout cannot exceed realm SSO session idle timeout and RememberMe idle timeout.",
+                        Messages.CLIENT_IDLE_REMEMBERME
+                );
+            }
+
+            // Max Lifespan validation on Remember me enabled
+            if (clientMax != null && clientMax > allowedMaxSpanIfRememberMeEnabled) {
+                context.addError(
+                        OIDCConfigAttributes.CLIENT_SESSION_MAX_LIFESPAN,
+                        "Client session max lifespan cannot exceed realm SSO session max lifespan and RememberMe Max span.",
+                        Messages.CLIENT_MAXLIFESPAN_REMEMBERME
+                );
+            }
+        }
+
+    }
+
+    private Integer parseIntAttribute(String value) {
+        try {
+            return (value == null || value.isEmpty()) ? null : Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 }

--- a/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/admin/messages/messages_en.properties
@@ -46,6 +46,15 @@ pairwiseRedirectURIsMismatch=Client redirect URIs does not match redirect URIs f
 
 duplicatedJwksSettings=The "Use JWKS" switch and the switch "Use JWKS URL" cannot be ON at the same time.
 
+# Shown to an admin when they enter a client specific SSO idle timeout that fails validation
+clientIdleExceedsRealmRememberMeIdle=Client session idle timeout cannot exceed realm SSO session idle timeout and RememberMe idle timeout.
+# Shown to an admin when they enter a client specific SSO idle timeout that fails validation
+clientSessionIdleTimeoutExceedsRealm=Client session idle timeout cannot exceed realm SSO session idle timeout.
+# Shown to an admin when they enter a client specific SSO max lifetime that fails validation
+clientSessionMaxLifespanExceedsRealm=Client session max lifespan cannot exceed realm SSO session max lifespan.
+# Shown to an admin when they enter a client specific SSO max lifetime that fails validation
+clientSessionMaxLifespanExceedsRealmRememberMeMaxSpan=Client session max lifespan cannot exceed realm SSO session max lifespan and RememberMe Max span.
+
 error-invalid-value=Invalid value.
 error-invalid-blank=Please specify value.
 error-empty=Please specify value.


### PR DESCRIPTION
session timeouts

Closes #41019

This PR adds validation for client-level  session timeout to ensure they do not exceed the realm-level SSOconfiguration.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
