### PR TITLE
Handle `RuntimeException` thrown in `SAMLParser.parse()`

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParser.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParser.java
@@ -118,13 +118,18 @@ public class SAMLParser extends AbstractParser {
                     throw logger.parserException(new RuntimeException(ErrorCodes.UNKNOWN_START_ELEMENT + name + "::location="
                             + startElement.getLocation()));
                 }
+                try {
+                    return pf.create().parse(xmlEventReader);
+                } catch (RuntimeException e) {
+                     throw logger.parserException(e);
+                }
 
-                return pf.create().parse(xmlEventReader);
             }
 
             StaxParserUtil.getNextEvent(xmlEventReader);
         }
 
-        throw new RuntimeException(ErrorCodes.FAILED_PARSING + "SAML Parsing has failed");
+        throw logger.parserException(
+            new RuntimeException(ErrorCodes.FAILED_PARSING + "SAML Parsing has failed"));
     }
 }


### PR DESCRIPTION
resolves https://github.com/keycloak/keycloak/issues/44606

Reporter: Pavel Nekrasov ([p.nekrasov@fobos-nt.ru](mailto:p.nekrasov@fobos-nt.ru)).
