### PR TITLE
[admin-api-v2] Remove GlassFish Expressly dependency for Hibernate Validator

### DIFF
--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -145,6 +145,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.expressly</groupId>
+                    <artifactId>expressly</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- SmallRye -->

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/validation/HibernateValidatorFactoryCustomizer.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/validation/HibernateValidatorFactoryCustomizer.java
@@ -1,0 +1,17 @@
+package org.keycloak.quarkus.runtime.validation;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import io.quarkus.hibernate.validator.ValidatorFactoryCustomizer;
+import org.hibernate.validator.BaseHibernateValidatorConfiguration;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+
+@ApplicationScoped
+public class HibernateValidatorFactoryCustomizer implements ValidatorFactoryCustomizer {
+
+    @Override
+    public void customize(BaseHibernateValidatorConfiguration<?> configuration) {
+        // we do not need any 3rd party dependency for the Expression language handling (like expressly) as we do not use it
+        configuration.messageInterpolator(new ParameterMessageInterpolator());
+    }
+}


### PR DESCRIPTION
- Closes #43569

In the end, we can exclude the `expressly` dependency as we do not use the Expression Language (EL) for the Jakarta validation :tada: 

The default interpolator in Hibernate Validator uses EL to resolve things like `${validatedValue}`, `#{someBean.property}`, `${min}`, `${max}` in messages. `ParameterMessageInterpolator` ignores EL entirely - only simple parameter placeholders like ${min}, ${max}, are replaced. No EL dependency is required on the classpath. 

It is also recommended to use this interpolator in the Quarkus error message.

I think it's a very suitable approach for us, as the license exception is not very clear https://github.com/cncf/foundation/issues/1177

@keycloak/cloud-native Could you please check it? 

The dependency is not part of the distribution JARs:
<img width="1255" height="55" alt="image" src="https://github.com/user-attachments/assets/6c50154c-5a9f-4bbf-88a2-3ce9745cbd36" />

