### PR TITLE
Move link changed for developer.mozilla.org (26.4)

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_0_0.adoc
@@ -443,7 +443,7 @@ Make sure to update your code to `await` these methods.
 
 == A secure context is now required
 
-Keycloak JS now requires a link:https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts[secure context] to run. The reason for this is that the library now uses the Web Crypto API for various cryptographic functions. This API is only available in secure contexts, which are contexts that are served over HTTPS, `localhost` or a `.localhost` domain. If you are using the library in a non-secure context you'll need to update your development environment to use a secure context.
+Keycloak JS now requires a link:https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Secure_Contexts[secure context] to run. The reason for this is that the library now uses the Web Crypto API for various cryptographic functions. This API is only available in secure contexts, which are contexts that are served over HTTPS, `localhost` or a `.localhost` domain. If you are using the library in a non-secure context you'll need to update your development environment to use a secure context.
 
 = Stricter startup behavior for build-time options
 


### PR DESCRIPTION
Closes #44661

PR:             https://github.com/keycloak/keycloak/pull/44663
Commit:         https://github.com/keycloak/keycloak/commit/44cf6d68086b716500d1b77a6e4c22e0bf849348
PR branch:      backport-44663-26.4
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.4

