### PR TITLE
[RLM] Add missing OpenAPI annotations to API methods

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/KeycloakOpenAPI.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakOpenAPI.java
@@ -57,6 +57,7 @@ public class KeycloakOpenAPI {
             public static final String SCOPE_MAPPINGS = "Scope Mappings";
             public static final String USERS = "Users";
             public static final String ORGANIZATIONS = "Organizations";
+            public static final String WORKFLOWS = "Workflows";
             private Tags() { }
         }
 

--- a/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowResource.java
+++ b/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowResource.java
@@ -21,8 +21,15 @@ import org.keycloak.representations.workflows.WorkflowRepresentation;
 import org.keycloak.services.ErrorResponse;
 
 import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMediaTypes;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+@Tag(name = KeycloakOpenAPI.Admin.Tags.WORKFLOWS)
 public class WorkflowResource {
 
     private final WorkflowProvider provider;
@@ -34,6 +41,10 @@ public class WorkflowResource {
     }
 
     @DELETE
+    @Operation(
+            summary = "Delete workflow",
+            description = "Delete the workflow and its configuration."
+    )
     public void delete() {
         try {
             provider.removeWorkflow(workflow);
@@ -46,6 +57,11 @@ public class WorkflowResource {
      * Update the workflow configuration. The method does not update the workflow steps.
      */
     @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Update workflow",
+            description = "Update the workflow configuration. This method does not update the workflow steps."
+    )
     public void update(WorkflowRepresentation rep) {
         try {
             provider.updateWorkflow(workflow, rep);
@@ -56,8 +72,15 @@ public class WorkflowResource {
 
     @GET
     @Produces({YAMLMediaTypes.APPLICATION_JACKSON_YAML, MediaType.APPLICATION_JSON})
+    @Operation(
+            summary = "Get workflow",
+            description = "Get the workflow representation. Optionally exclude the workflow id from the response."
+    )
     public WorkflowRepresentation toRepresentation(
-            @Parameter(description = "Indicates whether the workflow id should be included in the representation or not - defaults to true") @QueryParam("includeId") Boolean includeId
+            @Parameter(
+                    description = "Indicates whether the workflow id should be included in the representation or not - defaults to true"
+            )
+            @QueryParam("includeId") Boolean includeId
     ) {
         WorkflowRepresentation rep = provider.toRepresentation(workflow);
         if (Boolean.FALSE.equals(includeId)) {
@@ -72,13 +95,29 @@ public class WorkflowResource {
      * @param type the resource type
      * @param resourceId the resource id
      * @param notBefore optional value representing the time to schedule the first workflow step, overriding the first
-     *                 step time configuration (after). The value is either an integer representing the seconds from now,
-     *                 an integer followed by 'ms' representing milliseconds from now, or an ISO-8601 date string.
+     *                  step time configuration (after). The value is either an integer representing the seconds from now,
+     *                  an integer followed by 'ms' representing milliseconds from now, or an ISO-8601 date string.
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("activate/{type}/{resourceId}")
-    public void activate(@PathParam("type") ResourceType type, @PathParam("resourceId") String resourceId, String notBefore) {
+    @Operation(
+            summary = "Activate workflow for resource",
+            description = "Activate the workflow for the given resource type and identifier. Optionally schedule the first step using the notBefore parameter."
+    )
+    public void activate(
+            @Parameter(description = "Resource type")
+            @PathParam("type") ResourceType type,
+            @Parameter(description = "Resource identifier")
+            @PathParam("resourceId") String resourceId,
+            @Parameter(
+                    description = "Optional value representing the time to schedule the first workflow step. " +
+                            "The value is either an integer representing the seconds from now, " +
+                            "an integer followed by 'ms' representing milliseconds from now, " +
+                            "or an ISO-8601 date string."
+            )
+            String notBefore
+    ) {
         Object resource = provider.getResourceTypeSelector(type).resolveResource(resourceId);
 
         if (resource == null) {
@@ -101,7 +140,16 @@ public class WorkflowResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("deactivate/{type}/{resourceId}")
-    public void deactivate(@PathParam("type") ResourceType type, @PathParam("resourceId") String resourceId) {
+    @Operation(
+            summary = "Deactivate workflow for resource",
+            description = "Deactivate the workflow for the given resource type and identifier."
+    )
+    public void deactivate(
+            @Parameter(description = "Resource type")
+            @PathParam("type") ResourceType type,
+            @Parameter(description = "Resource identifier")
+            @PathParam("resourceId") String resourceId
+    ) {
         Object resource = provider.getResourceTypeSelector(type).resolveResource(resourceId);
 
         if (resource == null) {

--- a/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowsResource.java
+++ b/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowsResource.java
@@ -26,8 +26,15 @@ import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 
 import com.fasterxml.jackson.jakarta.rs.yaml.YAMLMediaTypes;
-import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+@Tag(name = KeycloakOpenAPI.Admin.Tags.WORKFLOWS)
 public class WorkflowsResource {
 
     private final KeycloakSession session;
@@ -45,6 +52,10 @@ public class WorkflowsResource {
 
     @POST
     @Consumes({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
+    @Operation(
+            summary = "Create workflow",
+            description = "Create a new workflow from the provided representation."
+    )
     public Response create(WorkflowRepresentation rep) {
         auth.realm().requireManageRealm();
 
@@ -57,7 +68,14 @@ public class WorkflowsResource {
     }
 
     @Path("{id}")
-    public WorkflowResource get(@PathParam("id") String id) {
+    @Operation(
+            summary = "Get workflow sub-resource",
+            description = "Locate the workflow sub-resource for the given identifier."
+    )
+    public WorkflowResource get(
+            @Parameter(description = "Workflow identifier")
+            @PathParam("id") String id
+    ) {
         auth.realm().requireManageRealm();
 
         Workflow workflow = provider.getWorkflow(id);
@@ -70,12 +88,20 @@ public class WorkflowsResource {
     }
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON, YAMLMediaTypes.APPLICATION_JACKSON_YAML})
+    @Produces({YAMLMediaTypes.APPLICATION_JACKSON_YAML, MediaType.APPLICATION_JSON})
+    @Operation(
+            summary = "List workflows",
+            description = "List workflows filtered by name and paginated using first and max parameters."
+    )
     public List<WorkflowRepresentation> list(
-            @Parameter(description = "A String representing the workflow name - either partial or exact") @QueryParam("search") String search,
-            @Parameter(description = "Boolean which defines whether the param 'search' must match exactly or not") @QueryParam("exact") Boolean exact,
-            @Parameter(description = "The position of the first result to be processed (pagination offset)") @QueryParam("first") @DefaultValue("0") Integer firstResult,
-            @Parameter(description = "The maximum number of results to be returned - defaults to 10") @QueryParam("max") @DefaultValue("10") Integer maxResults
+            @Parameter(description = "A String representing the workflow name - either partial or exact")
+            @QueryParam("search") String search,
+            @Parameter(description = "Boolean which defines whether the param 'search' must match exactly or not")
+            @QueryParam("exact") Boolean exact,
+            @Parameter(description = "The position of the first result to be processed (pagination offset)")
+            @QueryParam("first") @DefaultValue("0") Integer firstResult,
+            @Parameter(description = "The maximum number of results to be returned - defaults to 10")
+            @QueryParam("max") @DefaultValue("10") Integer maxResults
     ) {
         auth.realm().requireManageRealm();
 
@@ -87,7 +113,12 @@ public class WorkflowsResource {
     @Path("scheduled/{resource-id}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "List scheduled workflows for resource",
+            description = "Return workflows that have scheduled steps for the given resource identifier."
+    )
     public List<WorkflowRepresentation> getScheduledSteps(
+            @Parameter(description = "Identifier of the resource associated with the scheduled workflows")
             @PathParam("resource-id") String resourceId
     ) {
         auth.realm().requireManageRealm();


### PR DESCRIPTION
Add missing OpenAPI annotations to workflow admin API

This PR adds the missing OpenAPI annotations to the workflow-related Admin REST endpoints.
By completing these annotations, the generated OpenAPI specification and Swagger UI now include accurate metadata for all workflow operations.

**Changes**

Added @Tag, @Operation, and @Parameter annotations to:

WorkflowResource

WorkflowsResource

Standardized the ordering of @Produces values to follow Keycloak conventions (application/json first).

Added missing @Consumes(MediaType.APPLICATION_JSON) where required.

Improved description fields so the workflow activation, deactivation, and retrieval endpoints are fully documented.

Ensured consistency with existing Admin REST API documentation style.

**Notes**

This PR introduces no functional or behavioral changes.
It affects documentation only and is limited to OpenAPI metadata.

These updates enhance the clarity and completeness of the Admin REST API documentation for workflow features, especially as they mature in upcoming milestones.

Closes #42695