### PR TITLE
Manage service accounts when updating a client using registration

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -55,6 +55,7 @@ import org.keycloak.services.clientregistration.policy.ClientRegistrationPolicyM
 import org.keycloak.services.clientregistration.policy.RegistrationAuth;
 import org.keycloak.services.managers.ClientManager;
 import org.keycloak.services.managers.RealmManager;
+import org.keycloak.services.resources.admin.ClientResource;
 import org.keycloak.validation.ValidationUtil;
 
 /**
@@ -171,6 +172,7 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier modified", Response.Status.BAD_REQUEST);
         }
 
+        ClientResource.updateClientServiceAccount(session, client, rep.isServiceAccountsEnabled());
         RepresentationToModel.updateClient(rep, client, session);
         RepresentationToModel.updateClientProtocolMappers(rep, client);
         RepresentationToModel.updateClientScopes(rep, client);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientRegistrationTest.java
@@ -42,6 +42,7 @@ import org.keycloak.client.registration.Auth;
 import org.keycloak.client.registration.ClientRegistration;
 import org.keycloak.client.registration.ClientRegistrationException;
 import org.keycloak.client.registration.HttpErrorException;
+import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.events.Errors;
 import org.keycloak.models.Constants;
@@ -152,6 +153,26 @@ public class ClientRegistrationTest extends AbstractClientRegistrationTest {
             fail("Expected NotFoundException");
         } catch (NotFoundException e) {
         }
+    }
+
+    @Test
+    public void updateServiceAccount() throws Exception {
+        authManageClients();
+        ClientRepresentation client = buildClient();
+        final ClientRepresentation createdClient = registerClient(client);
+
+        client = reg.get(CLIENT_ID);
+        assertFalse(client.isServiceAccountsEnabled());
+        assertTrue(adminClient.realm(REALM_NAME).users().search(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + client.getClientId(), true).isEmpty());
+        client.setServiceAccountsEnabled(true);
+        client = reg.update(client);
+        assertTrue(client.isServiceAccountsEnabled());
+        assertFalse(adminClient.realm(REALM_NAME).users().search(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + client.getClientId(), true).isEmpty());
+
+        client.setServiceAccountsEnabled(false);
+        client = reg.update(client);
+        assertFalse(client.isServiceAccountsEnabled());
+        assertTrue(adminClient.realm(REALM_NAME).users().search(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + client.getClientId(), true).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Closes #44257

Little PR to manage the service account in the registration part. It was only done in the create method. Test added.
