### PR TITLE
Change event field to protected in LoginActionsService

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -154,7 +154,7 @@ public class LoginActionsService {
 
     protected final KeycloakSession session;
 
-    private EventBuilder event;
+    protected EventBuilder event;
 
     public static UriBuilder loginActionsBaseUrl(UriInfo uriInfo) {
         UriBuilder baseUriBuilder = uriInfo.getBaseUriBuilder();


### PR DESCRIPTION
Closes #44690 

Allow access to event field if LoginActionsService is extended.