### PR TITLE
ModelTests are broken after consolidating config logic

### DIFF
--- a/testsuite/model/src/main/java/org/keycloak/testsuite/model/Config.java
+++ b/testsuite/model/src/main/java/org/keycloak/testsuite/model/Config.java
@@ -121,10 +121,10 @@ public class Config implements ConfigProvider {
         }
 
         @Override
-        public String get(String key, String defaultValue) {
+        public String get(String key) {
             String v = replaceProperties(getConfig().get(prefix + key));
             if (v == null || v.isEmpty()) {
-                v = System.getProperty("keycloak." + prefix + key, defaultValue);
+                v = System.getProperty("keycloak." + prefix + key);
             }
             return v != null && ! v.isEmpty() ? v : null;
         }


### PR DESCRIPTION
- Closes #44700

This should be a sufficient fix as only the `get()` is required to be overridden. 

@shawkins Could you please check it? 

Wondering why it did not fail in the CI for that PR. EDIT: they're conditional on `ci-store` condition