### PR TITLE
Credential offer endpoint has parameter user_id, but expects username

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -88,9 +88,15 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         var credOffer = offerState.getCredentialsOffer();
 
         var appUserId = offerState.getUserId();
-        var userModel = session.users().getUserByUsername(realm, appUserId);
+        var userModel = session.users().getUserById(realm, appUserId);
         if (userModel == null) {
-            var errorMessage = "No user model for: " + appUserId;
+            var errorMessage = "No user with ID: " + appUserId;
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+        if (!userModel.isEnabled()) {
+            var errorMessage = "User '" + userModel.getUsername() + "' disabled";
             event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
                     errorMessage, Response.Status.BAD_REQUEST);

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -1134,7 +1134,7 @@ public class TestingResourceProvider implements RealmResourceProvider {
                 .setGrants(new PreAuthorizedGrant().setPreAuthorizedCode(
                     new PreAuthorizedCode().setPreAuthorizedCode(code)));
 
-        String userId = userSession.getUser().getUsername();
+        String userId = userSession.getUser().getId();
         var offerStorage = session.getProvider(CredentialOfferStorage.class);
         offerStorage.putOfferState(session, new CredentialOfferState(credOffer, clientId, userId, expiration));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -569,14 +569,14 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         return getCredentialOfferUriUrl(configId, preAuthorized, targetUser, null);
     }
 
-    protected String getCredentialOfferUriUrl(String configId, Boolean preAuthorized, String appUserId, String appClientId) {
+    protected String getCredentialOfferUriUrl(String configId, Boolean preAuthorized, String appUsername, String appClientId) {
         String res = getBasePath("test") + "credential-offer-uri?credential_configuration_id=" + configId;
         if (preAuthorized != null)
             res += "&pre_authorized=" + preAuthorized;
         if (appClientId != null)
             res += "&client_id=" + appClientId;
-        if (appUserId != null)
-            res += "&user_id=" + appUserId;
+        if (appUsername != null)
+            res += "&username=" + appUsername;
         return res;
     }
 


### PR DESCRIPTION
closes #44642

PR also checks if user is enabled (This was not done beforehand).

The user reference in CredentialOffer is still user_id as it is internal and lookup by ID is a bit more efficient than lookup by username.
