### PR TITLE
Account console QR code generation for OID4VCI credentials is broken

### DIFF
--- a/js/apps/account-ui/src/api.ts
+++ b/js/apps/account-ui/src/api.ts
@@ -73,21 +73,19 @@ function checkResponse<T>(response: T) {
   return response;
 }
 
-export async function getIssuer(context: KeycloakContext<BaseEnvironment>) {
+export async function getVCIssuer(context: KeycloakContext<BaseEnvironment>) {
   const response = await request(
     joinPath(
-      "/realms/",
+      "/.well-known/openid-credential-issuer/realms/",
       context.environment.realm,
-      "/.well-known/openid-credential-issuer",
     ),
     context,
     {},
     new URL(
       joinPath(
         context.environment.serverBaseUrl,
-        "/realms/",
+        "/.well-known/openid-credential-issuer/realms/",
         context.environment.realm,
-        "/.well-known/openid-credential-issuer",
       ),
     ),
   );
@@ -105,9 +103,11 @@ export async function requestVCOffer(
     {
       searchParams: {
         credential_configuration_id: supportedCredentialConfiguration.id,
+        client_id: context.environment.clientId,
+        username: context.keycloak.tokenParsed?.preferred_username,
         type: "qr-code",
-        width: "500",
-        height: "500",
+        width: "300",
+        height: "300",
       },
     },
     new URL(

--- a/js/apps/account-ui/src/oid4vci/Oid4Vci.tsx
+++ b/js/apps/account-ui/src/oid4vci/Oid4Vci.tsx
@@ -14,7 +14,7 @@ import {
 } from "@patternfly/react-core";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getIssuer, requestVCOffer } from "../api";
+import { getVCIssuer, requestVCOffer } from "../api";
 import { CredentialsIssuer } from "../api/representations";
 import { Page } from "../components/page/Page";
 import { usePromise } from "../utils/usePromise";
@@ -33,7 +33,7 @@ export const Oid4Vci = () => {
   const [credentialsIssuer, setCredentialsIssuer] =
     useState<CredentialsIssuer>();
 
-  usePromise(() => getIssuer(context), setCredentialsIssuer);
+  usePromise(() => getVCIssuer(context), setCredentialsIssuer);
 
   const selectOptions = useMemo(() => {
     if (typeof credentialsIssuer !== "undefined") {
@@ -119,8 +119,8 @@ export const Oid4Vci = () => {
               {offerQRVisible && (
                 <ActionListItem>
                   <img
-                    width="500"
-                    height="500"
+                    width="300"
+                    height="300"
                     src={qrCode}
                     data-testid="qr-code"
                   />


### PR DESCRIPTION
closes #44623 

Marked as draft for now.

I've also removed warnings in the server.log (which were triggered by invoking deprecated OID4VCI well-known endpoint) and updated the size of QR code to 300x300, which is the size used also on setup OTP screen, so there is consistency in various Keycloak screens.

Screenshot for the reference:

<img width="670" height="584" alt="Screenshot from 2025-12-05 19-37-49" src="https://github.com/user-attachments/assets/90b13a27-7e23-447c-a333-3e9482ed4065" />
