### PR TITLE
Differentiate Error Messages for OTP Authentication Failures in Direct Grant Flow (Fixes #31616)

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/events/Errors.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Errors.java
@@ -38,6 +38,7 @@ public interface Errors {
     String USER_DISABLED = "user_disabled";
     String USER_TEMPORARILY_DISABLED = "user_temporarily_disabled";
     String INVALID_USER_CREDENTIALS = "invalid_user_credentials";
+    String INVALID_OTP_CREDENTIALS = "invalid_otp_credentials";
     String INVALID_AUTHENTICATION_SESSION = "invalid_authentication_session";
     String DIFFERENT_USER_AUTHENTICATING = "different_user_authenticating";
     String DIFFERENT_USER_AUTHENTICATED = "different_user_authenticated";

--- a/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateOTP.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/directgrant/ValidateOTP.java
@@ -51,8 +51,8 @@ public class ValidateOTP extends AbstractDirectGrantAuthenticator implements Cre
             if (context.getExecution().isConditional()) {
                 context.attempted();
             } else if (context.getExecution().isRequired()) {
-                context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
-                Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid user credentials");
+                context.getEvent().error(Errors.INVALID_OTP_CREDENTIALS);
+                Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid OTP credentials");
                 context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
             }
             return;
@@ -72,16 +72,16 @@ public class ValidateOTP extends AbstractDirectGrantAuthenticator implements Cre
             if (context.getUser() != null) {
                 context.getEvent().user(context.getUser());
             }
-            context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
-            Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid user credentials");
+            context.getEvent().error(Errors.INVALID_OTP_CREDENTIALS);
+            Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid OTP credentials");
             context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return;
         }
         boolean valid = getCredentialProvider(context.getSession()).isValid(context.getRealm(), context.getUser(), new UserCredentialModel(credentialId, OTPCredentialModel.TYPE, otp));
         if (!valid) {
             context.getEvent().user(context.getUser());
-            context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
-            Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid user credentials");
+            context.getEvent().error(Errors.INVALID_OTP_CREDENTIALS);
+            Response challengeResponse = errorResponse(Response.Status.UNAUTHORIZED.getStatusCode(), "invalid_grant", "Invalid OTP credentials");
             context.failure(AuthenticationFlowError.INVALID_USER, challengeResponse);
             return;
         }


### PR DESCRIPTION
### Summary

This PR implements the enhancement requested in **#31616**, by providing distinct
error handling for OTP authentication failures during the Direct Grant (Resource
Owner Password Credentials) flow.

Previously, incorrect OTP codes triggered the same event error
(`invalid_user_credentials`) and error_description used for wrong username or
password. This made it difficult for administrators and SIEM systems to
understand whether authentication failed at the primary credential step or at
the OTP/MFA step.

With this change, OTP failures now produce a dedicated event error and a clear
error_description, while maintaining full OAuth2 compliance.

---

### What This PR Changes

#### ✔ Introduces new event error constant
- `invalid_otp_credentials` added to `Errors.java`

#### ✔ Updates ValidateOTP to emit OTP-specific errors
When OTP validation fails:
- `event.error(Errors.INVALID_OTP_CREDENTIALS)`
- HTTP 401 response:

> error=invalid_grant
> error_description="Invalid OTP credentials"


Password failures continue to behave as before:
- `invalid_user_credentials`
- `"Invalid username or password"`

---

### Why This Is Needed

Differentiating OTP failures improves:

- MFA observability
- Security event analysis
- Audit trail accuracy
- Troubleshooting for administrators
- Detection of OTP brute-force attempts or MFA misconfiguration

This enhancement gives clearer insight into authentication flow failures without
impacting API compatibility or OAuth2 error semantics.

---

### Backward Compatibility

- OAuth2 `error` remains `invalid_grant` (protocol compliance)
- No changes to public APIs or SPIs
- No functional changes outside Direct Grant OTP validation
- Existing clients continue to behave as before

---

### Request for Review

Tagging maintainers for authentication flow and login logic:

@pedroigor @mposolda @stianst @abstractj

---

### Issue Link
Closes #31616
