### PR TITLE
feat(admin-ui): use BrowserRouter instead of HashRouter

### DIFF
--- a/js/apps/admin-ui/src/main.tsx
+++ b/js/apps/admin-ui/src/main.tsx
@@ -3,7 +3,7 @@ import "@patternfly/react-core/dist/styles/base.css";
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { createHashRouter, RouterProvider } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { i18n } from "./i18n/i18n";
 import { RootRoute } from "./routes";
 
@@ -12,7 +12,7 @@ import "./index.css";
 // Initialize required components before rendering app.
 await i18n.init();
 
-const router = createHashRouter([RootRoute]);
+const router = createBrowserRouter([RootRoute]);
 const container = document.getElementById("app");
 const root = createRoot(container!);
 


### PR DESCRIPTION
### Summary

_Replace the HashRouter used in the Admin UI with BrowserRouter._

Closes #32979