### PR TITLE
Sort realms alphabetically in manage realms list

### DIFF
--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
 import { DEFAULT_REALM } from "../utils/constants.ts";
@@ -117,6 +117,13 @@ test.describe.serial("Realm tests", () => {
 
     await goToClients(page);
     await assertRowExists(page, "account-console");
+  });
+
+  test("should be sorted alphabetically", async ({ page }) => {
+    const realms = await page
+      .locator(".pf-v5-c-table tr td:nth-child(2)")
+      .allInnerTexts();
+    expect(realms.every((v, i, a) => !i || a[i - 1] <= v)).toBeTruthy();
   });
 
   test("should disable preview if json very long", async ({ page }) => {

--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
 import { DEFAULT_REALM } from "../utils/constants.ts";
@@ -21,6 +21,7 @@ import {
   goToRealmSection,
   getTextArea,
   assertTextAreaContains,
+  assertRealmsSorted,
 } from "./realm.ts";
 
 const testRealmName = `Test-realm-${uuid()}`;
@@ -123,12 +124,7 @@ test.describe.serial("Realm tests", () => {
     const realms = await page
       .locator(".pf-v5-c-table tr td:nth-child(2)")
       .allInnerTexts();
-    expect(
-      realms.every((value, index, realms) => {
-        if (index === 0) return true;
-        return realms[index - 1] <= value;
-      }),
-    ).toBeTruthy();
+    assertRealmsSorted(realms, 3);
   });
 
   test("should disable preview if json very long", async ({ page }) => {

--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -123,7 +123,12 @@ test.describe.serial("Realm tests", () => {
     const realms = await page
       .locator(".pf-v5-c-table tr td:nth-child(2)")
       .allInnerTexts();
-    expect(realms.every((v, i, a) => !i || a[i - 1] <= v)).toBeTruthy();
+    expect(
+      realms.every((value, index, realms) => {
+        if (index === 0) return true;
+        return realms[index - 1] <= value;
+      }),
+    ).toBeTruthy();
   });
 
   test("should disable preview if json very long", async ({ page }) => {

--- a/js/apps/admin-ui/test/masthead/realm.ts
+++ b/js/apps/admin-ui/test/masthead/realm.ts
@@ -50,3 +50,13 @@ export function getTextArea(page: Page) {
 export async function assertTextAreaContains(page: Page, content: string) {
   await expect(getTextArea(page)).toContainText(content);
 }
+
+export function assertRealmsSorted(realms: string[], length: number) {
+  expect(realms.length).toBeGreaterThanOrEqual(length);
+  expect(
+    realms.every((value, index, realms) => {
+      if (index === 0) return true;
+      return realms[index - 1] <= value;
+    }),
+  ).toBeTruthy();
+}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RealmEntity.java
@@ -51,8 +51,8 @@ import org.hibernate.annotations.Nationalized;
 @Table(name="REALM")
 @Entity
 @NamedQueries({
-        @NamedQuery(name="getAllRealmIds", query="select realm.id from RealmEntity realm"),
-        @NamedQuery(name="getRealmIdsWithNameContaining", query="select realm.id from RealmEntity realm where LOWER(realm.name) like CONCAT('%', LOWER(:search), '%') or LOWER(realm.displayName) like CONCAT('%', LOWER(:search), '%')"),
+        @NamedQuery(name="getAllRealmIds", query="select realm.id from RealmEntity realm order by realm.name"),
+        @NamedQuery(name="getRealmIdsWithNameContaining", query="select realm.id from RealmEntity realm where LOWER(realm.name) like CONCAT('%', LOWER(:search), '%') or LOWER(realm.displayName) like CONCAT('%', LOWER(:search), '%') order by realm.name"),
         @NamedQuery(name="getRealmIdByName", query="select realm.id from RealmEntity realm where realm.name = :name"),
         @NamedQuery(name="getRealmIdsWithProviderType", query="select distinct c.realm.id from ComponentEntity c where c.providerType = :providerType"),
 })

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
@@ -1,5 +1,7 @@
 package org.keycloak.admin.ui.rest;
 
+import java.util.Comparator;
+import java.util.Locale;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.DefaultValue;
@@ -59,6 +61,7 @@ public class UIRealmsResource {
 
         return session.realms().getRealmsStream(search)
                 .filter(realm -> eval.canView(realm) || eval.isAdmin(realm))
+                .sorted(Comparator.comparing((RealmModel realm) -> realm.getName().toLowerCase(Locale.ROOT)))
                 .skip(first)
                 .limit(max)
                 .map((RealmModel realm) -> new RealmNameRepresentation(realm.getName(), realm.getDisplayName()));

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/UIRealmsResource.java
@@ -1,7 +1,5 @@
 package org.keycloak.admin.ui.rest;
 
-import java.util.Comparator;
-import java.util.Locale;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.DefaultValue;
@@ -61,7 +59,6 @@ public class UIRealmsResource {
 
         return session.realms().getRealmsStream(search)
                 .filter(realm -> eval.canView(realm) || eval.isAdmin(realm))
-                .sorted(Comparator.comparing((RealmModel realm) -> realm.getName().toLowerCase(Locale.ROOT)))
                 .skip(first)
                 .limit(max)
                 .map((RealmModel realm) -> new RealmNameRepresentation(realm.getName(), realm.getDisplayName()));


### PR DESCRIPTION
Closes #44667.

This makes realms list behaves in a consistent way with other lists in Clients, Users, Scopes, etc...

### Tests
```
cd js/apps/admin-ui
pnpm exec playwright install
pnpm test:integration -- test/masthead/realm.spec.ts
```
