### PR TITLE
Fix logical error in Danish email verification message

### DIFF
--- a/themes/src/main/resources-community/theme/base/email/messages/messages_da.properties
+++ b/themes/src/main/resources-community/theme/base/email/messages/messages_da.properties
@@ -1,6 +1,6 @@
 emailVerificationSubject=Verificer email
-emailVerificationBody=Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse \n\n{0}\n\nDette link vil udløbe inden for {3}.\n\nHvis det var dig der har oprettet denne konto, bedes du se bort fra denne mail.
-emailVerificationBodyHtml=<p>Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse</p><p><a href="{0}">Link til email verificering</a></p><p>Dette link vil udløbe inden for {3}.</p><p>Hvis det var dig der har oprettet denne konto, bedes du se bort fra denne mail.</p>
+emailVerificationBody=Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse \n\n{0}\n\nDette link vil udløbe inden for {3}.\n\nHvis det ikke var dig der har oprettet denne konto, bedes du se bort fra denne mail.
+emailVerificationBodyHtml=<p>Nogen har oprettet en {2} konto med denne email adresse. Hvis dette var dig, bedes du trykke på forbindet herunder for at verificere din email adresse</p><p><a href="{0}">Link til email verificering</a></p><p>Dette link vil udløbe inden for {3}.</p><p>Hvis det ikke var dig der har oprettet denne konto, bedes du se bort fra denne mail.</p>
 emailTestSubject=[KEYCLOAK] - SMTP test besked
 emailTestBody=Dette er en test besked
 emailTestBodyHtml=<p>Dette er en test besked</p>


### PR DESCRIPTION
Added missing 'ikke' (not) to correctly instruct users to ignore
  the email if they did NOT create the account.

Fixes #44342

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
