### PR TITLE
[OID4VCI] Realign naming of attribute configuring algorithms for credential

### DIFF
--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -248,7 +248,7 @@ Create a JSON file (e.g., `client-scopes.json`) with the following content:
     "vc.verifiable_credential_type": "my-vct",
     "vc.supported_credential_types": "credential-type-1,credential-type-2",
     "vc.credential_contexts": "context-1,context-2",
-    "vc.credential_signing_alg_values_supported": "ES256",
+    "vc.credential_signing_alg": "ES256",
     "vc.cryptographic_binding_methods_supported": "jwk",
     "vc.signing_key_id": "key-id-123456",
     "vc.display": "[{\"name\": \"IdentityCredential\", \"logo\": {\"uri\": \"https://university.example.edu/public/logo.png\", \"alt_text\": \"a square logo of a university\"}, \"locale\": \"en-US\", \"background_color\": \"#12107c\", \"text_color\": \"#FFFFFF\"}]",
@@ -358,9 +358,9 @@ _Default_: `$\{name}+`
 | The context values of the Verifiable Credential Type. +
 _Default_: `$\{name}+`
 
-| `vc.credential_signing_alg_values_supported`
+| `vc.credential_signing_alg`
 | optional
-| Supported signature algorithms for this credential. +
+| Supported signature algorithm for this credential. +
 _Default_: All asymmetric signing algorithms backed by realm keys.
 
 | `vc.cryptographic_binding_methods_supported`

--- a/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
+++ b/docs/documentation/server_admin/topics/oid4vci/vc-issuer-configuration.adoc
@@ -248,7 +248,7 @@ Create a JSON file (e.g., `client-scopes.json`) with the following content:
     "vc.verifiable_credential_type": "my-vct",
     "vc.supported_credential_types": "credential-type-1,credential-type-2",
     "vc.credential_contexts": "context-1,context-2",
-    "vc.proof_signing_alg_values_supported": "ES256",
+    "vc.credential_signing_alg_values_supported": "ES256",
     "vc.cryptographic_binding_methods_supported": "jwk",
     "vc.signing_key_id": "key-id-123456",
     "vc.display": "[{\"name\": \"IdentityCredential\", \"logo\": {\"uri\": \"https://university.example.edu/public/logo.png\", \"alt_text\": \"a square logo of a university\"}, \"locale\": \"en-US\", \"background_color\": \"#12107c\", \"text_color\": \"#FFFFFF\"}]",
@@ -358,10 +358,10 @@ _Default_: `$\{name}+`
 | The context values of the Verifiable Credential Type. +
 _Default_: `$\{name}+`
 
-| `vc.proof_signing_alg_values_supported`
+| `vc.credential_signing_alg_values_supported`
 | optional
 | Supported signature algorithms for this credential. +
-_Default_: All present keys supporting JWS algorithms in the realm.
+_Default_: All asymmetric signing algorithms backed by realm keys.
 
 | `vc.cryptographic_binding_methods_supported`
 | optional

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -72,10 +72,9 @@ public class CredentialScopeModel implements ClientScopeModel {
     public static final String CONTEXTS = "vc.credential_contexts";
 
     /**
-     * If the credential is only meant for specific signing algorithms the global default list can be overridden here.
-     * The global default list is retrieved from the available keys in the realm.
+     * The credential signature algorithm. If it is not configured, then the realm active key is used to sign the verifiable credential
      */
-    public static final String SIGNING_ALG_VALUES_SUPPORTED = "vc.credential_signing_alg_values_supported";
+    public static final String SIGNING_ALG = "vc.credential_signing_alg";
 
     /**
      * if the credential is only meant for specific cryptographic binding algorithms the global default list can be
@@ -269,20 +268,12 @@ public class CredentialScopeModel implements ClientScopeModel {
         clientScope.setAttribute(CONTEXTS, String.join(",", vcContexts));
     }
 
-    public List<String> getSigningAlgsSupported() {
-        return Optional.ofNullable(clientScope.getAttribute(SIGNING_ALG_VALUES_SUPPORTED))
-                       .map(s -> s.split(","))
-                       .map(Arrays::asList)
-                       .orElse(Collections.emptyList());
+    public String getSigningAlg() {
+        return clientScope.getAttribute(SIGNING_ALG);
     }
 
-    public void setSigningAlgsSupported(String signingAlgsSupported) {
-        clientScope.setAttribute(SIGNING_ALG_VALUES_SUPPORTED, signingAlgsSupported);
-    }
-
-    public void setSigningAlgsSupported(List<String> signingAlgsSupported) {
-        clientScope.setAttribute(SIGNING_ALG_VALUES_SUPPORTED,
-                                 String.join(",", signingAlgsSupported));
+    public void setSigningAlg(String signingAlgsSupported) {
+        clientScope.setAttribute(SIGNING_ALG, signingAlgsSupported);
     }
 
     public List<String> getCryptographicBindingMethods() {

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -72,10 +72,10 @@ public class CredentialScopeModel implements ClientScopeModel {
     public static final String CONTEXTS = "vc.credential_contexts";
 
     /**
-     * if the credential is only meant for specific signing algorithms the global default list can be overridden here.
+     * If the credential is only meant for specific signing algorithms the global default list can be overridden here.
      * The global default list is retrieved from the available keys in the realm.
      */
-    public static final String SIGNING_ALG_VALUES_SUPPORTED = "vc.proof_signing_alg_values_supported";
+    public static final String SIGNING_ALG_VALUES_SUPPORTED = "vc.credential_signing_alg_values_supported";
 
     /**
      * if the credential is only meant for specific cryptographic binding algorithms the global default list can be

--- a/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/oid4vci/CredentialScopeModel.java
@@ -272,8 +272,8 @@ public class CredentialScopeModel implements ClientScopeModel {
         return clientScope.getAttribute(SIGNING_ALG);
     }
 
-    public void setSigningAlg(String signingAlgsSupported) {
-        clientScope.setAttribute(SIGNING_ALG, signingAlgsSupported);
+    public void setSigningAlg(String signingAlg) {
+        clientScope.setAttribute(SIGNING_ALG, signingAlg);
     }
 
     public List<String> getCryptographicBindingMethods() {

--- a/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
+++ b/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderFactory;
 
 /**
@@ -51,25 +50,6 @@ public class CryptoUtils {
                 .filter(entry -> entry.getValue() != null)
                 .filter(entry -> entry.getValue().isAsymmetricAlgorithm())
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Returns the asymmetric signature algorithms supported given the keys in the realm.
-     *
-     * @param session The Keycloak session
-     * @param realm   The realm model
-     * @return List of asymmetric signature algorithm names
-     */
-    public static List<String> getSupportedAsymmetricSignatureAlgorithms(
-            KeycloakSession session, RealmModel realm
-    ) {
-        List<String> globalAsymmetricSignAlgs = getSupportedAsymmetricSignatureAlgorithms(session);
-        return session.keys().getKeysStream(realm)
-                .filter(key -> KeyUse.SIG.equals(key.getUse()))
-                .map(KeyWrapper::getAlgorithm)
-                .filter(globalAsymmetricSignAlgs::contains)
-                .distinct()
                 .collect(Collectors.toList());
     }
 

--- a/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
+++ b/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderFactory;
 
 /**
@@ -50,6 +51,25 @@ public class CryptoUtils {
                 .filter(entry -> entry.getValue() != null)
                 .filter(entry -> entry.getValue().isAsymmetricAlgorithm())
                 .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the asymmetric signature algorithms supported given the keys in the realm.
+     *
+     * @param session The Keycloak session
+     * @param realm   The realm model
+     * @return List of asymmetric signature algorithm names
+     */
+    public static List<String> getSupportedAsymmetricSignatureAlgorithms(
+            KeycloakSession session, RealmModel realm
+    ) {
+        List<String> globalAsymmetricSignAlgs = getSupportedAsymmetricSignatureAlgorithms(session);
+        return session.keys().getKeysStream(realm)
+                .filter(key -> KeyUse.SIG.equals(key.getUse()))
+                .map(KeyWrapper::getAlgorithm)
+                .filter(globalAsymmetricSignAlgs::contains)
+                .distinct()
                 .collect(Collectors.toList());
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -452,7 +452,6 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      */
     public static Map<String, SupportedCredentialConfiguration> getSupportedCredentials(KeycloakSession keycloakSession) {
         List<String> globalSupportedSigningAlgorithms = getSupportedAsymmetricSignatureAlgorithms(keycloakSession);
-        List<String> realmSupportedSigningAlgorithms = getRealmSupportedAsymmetricSignatureAlgorithms(keycloakSession);
 
         RealmModel realm = keycloakSession.getContext().getRealm();
         Map<String, SupportedCredentialConfiguration> supportedCredentialConfigurations =
@@ -462,8 +461,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                         .map(clientScope -> {
                             return SupportedCredentialConfiguration.parse(keycloakSession,
                                     clientScope,
-                                    globalSupportedSigningAlgorithms,
-                                    realmSupportedSigningAlgorithms
+                                    globalSupportedSigningAlgorithms
                             );
                         })
                         .collect(Collectors.toMap(SupportedCredentialConfiguration::getId, sc -> sc, (sc1, sc2) -> sc1));
@@ -474,12 +472,10 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
     public static SupportedCredentialConfiguration toSupportedCredentialConfiguration(KeycloakSession keycloakSession,
                                                                                       CredentialScopeModel credentialModel) {
         List<String> globalSupportedSigningAlgorithms = getSupportedAsymmetricSignatureAlgorithms(keycloakSession);
-        List<String> realmSupportedSigningAlgorithms = getRealmSupportedAsymmetricSignatureAlgorithms(keycloakSession);
 
         return SupportedCredentialConfiguration.parse(keycloakSession,
                 credentialModel,
-                globalSupportedSigningAlgorithms,
-                realmSupportedSigningAlgorithms);
+                globalSupportedSigningAlgorithms);
     }
 
     /**
@@ -520,13 +516,6 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      */
     public static List<String> getSupportedAsymmetricSignatureAlgorithms(KeycloakSession session) {
         return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
-    }
-
-    /**
-     * Returns the supported asymmetric signature algorithms in the context realm.
-     */
-    public static List<String> getRealmSupportedAsymmetricSignatureAlgorithms(KeycloakSession session) {
-        return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session, session.getContext().getRealm());
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -452,6 +452,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      */
     public static Map<String, SupportedCredentialConfiguration> getSupportedCredentials(KeycloakSession keycloakSession) {
         List<String> globalSupportedSigningAlgorithms = getSupportedAsymmetricSignatureAlgorithms(keycloakSession);
+        List<String> realmSupportedSigningAlgorithms = getRealmSupportedAsymmetricSignatureAlgorithms(keycloakSession);
 
         RealmModel realm = keycloakSession.getContext().getRealm();
         Map<String, SupportedCredentialConfiguration> supportedCredentialConfigurations =
@@ -461,7 +462,8 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
                         .map(clientScope -> {
                             return SupportedCredentialConfiguration.parse(keycloakSession,
                                     clientScope,
-                                    globalSupportedSigningAlgorithms
+                                    globalSupportedSigningAlgorithms,
+                                    realmSupportedSigningAlgorithms
                             );
                         })
                         .collect(Collectors.toMap(SupportedCredentialConfiguration::getId, sc -> sc, (sc1, sc2) -> sc1));
@@ -472,9 +474,12 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
     public static SupportedCredentialConfiguration toSupportedCredentialConfiguration(KeycloakSession keycloakSession,
                                                                                       CredentialScopeModel credentialModel) {
         List<String> globalSupportedSigningAlgorithms = getSupportedAsymmetricSignatureAlgorithms(keycloakSession);
+        List<String> realmSupportedSigningAlgorithms = getRealmSupportedAsymmetricSignatureAlgorithms(keycloakSession);
+
         return SupportedCredentialConfiguration.parse(keycloakSession,
                 credentialModel,
-                globalSupportedSigningAlgorithms);
+                globalSupportedSigningAlgorithms,
+                realmSupportedSigningAlgorithms);
     }
 
     /**
@@ -515,6 +520,13 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      */
     public static List<String> getSupportedAsymmetricSignatureAlgorithms(KeycloakSession session) {
         return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session);
+    }
+
+    /**
+     * Returns the supported asymmetric signature algorithms in the context realm.
+     */
+    public static List<String> getRealmSupportedAsymmetricSignatureAlgorithms(KeycloakSession session) {
+        return CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(session, session.getContext().getRealm());
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -451,7 +451,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      * and the credentials supported by the clients available in the session.
      */
     public static Map<String, SupportedCredentialConfiguration> getSupportedCredentials(KeycloakSession keycloakSession) {
-        List<String> globalSupportedSigningAlgorithms = getSupportedSignatureAlgorithms(keycloakSession);
+        List<String> globalSupportedSigningAlgorithms = getSupportedAsymmetricSignatureAlgorithms(keycloakSession);
 
         RealmModel realm = keycloakSession.getContext().getRealm();
         Map<String, SupportedCredentialConfiguration> supportedCredentialConfigurations =
@@ -471,7 +471,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
 
     public static SupportedCredentialConfiguration toSupportedCredentialConfiguration(KeycloakSession keycloakSession,
                                                                                       CredentialScopeModel credentialModel) {
-        List<String> globalSupportedSigningAlgorithms = getSupportedSignatureAlgorithms(keycloakSession);
+        List<String> globalSupportedSigningAlgorithms = getSupportedAsymmetricSignatureAlgorithms(keycloakSession);
         return SupportedCredentialConfiguration.parse(keycloakSession,
                 credentialModel,
                 globalSupportedSigningAlgorithms);
@@ -499,18 +499,6 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
      */
     public static String getCredentialsEndpoint(KeycloakContext context) {
         return getIssuer(context) + "/protocol/" + OID4VCLoginProtocolFactory.PROTOCOL_ID + "/" + OID4VCIssuerEndpoint.CREDENTIAL_PATH;
-    }
-
-    public static List<String> getSupportedSignatureAlgorithms(KeycloakSession session) {
-        RealmModel realm = session.getContext().getRealm();
-        KeyManager keyManager = session.keys();
-
-        return keyManager.getKeysStream(realm)
-                .filter(key -> KeyUse.SIG.equals(key.getUse()))
-                .map(KeyWrapper::getAlgorithm)
-                .filter(algorithm -> algorithm != null && !algorithm.isEmpty())
-                .distinct()
-                .collect(Collectors.toList());
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -23,11 +23,11 @@ import java.util.Optional;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.utils.StringUtil;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.collections4.ListUtils;
 
 /**
  * A supported credential, as used in the Credentials Issuer Metadata in OID4VCI
@@ -92,13 +92,11 @@ public class SupportedCredentialConfiguration {
      * @param credentialScope                  The scope that holds the credentials configuration
      * @param globalSupportedSigningAlgorithms added as a parameter to avoid reading the global config from the session
      *                                         for each credential
-     * @param realmSupportedSigningAlgorithms  the signing algorithms supported by active keys in the realm
      * @return the credentials configuration that was entered into the ClientScope
      */
     public static SupportedCredentialConfiguration parse(KeycloakSession keycloakSession,
                                                          CredentialScopeModel credentialScope,
-                                                         List<String> globalSupportedSigningAlgorithms,
-                                                         List<String> realmSupportedSigningAlgorithms) {
+                                                         List<String> globalSupportedSigningAlgorithms) {
         SupportedCredentialConfiguration credentialConfiguration = new SupportedCredentialConfiguration();
 
         String credentialConfigurationId = Optional.ofNullable(credentialScope.getCredentialConfigurationId())
@@ -120,13 +118,12 @@ public class SupportedCredentialConfiguration {
         ProofTypesSupported proofTypesSupported = ProofTypesSupported.parse(keycloakSession,
                                                                             keyAttestationsRequired,
                                                                             globalSupportedSigningAlgorithms);
-         credentialConfiguration.setProofTypesSupported(proofTypesSupported);
+        credentialConfiguration.setProofTypesSupported(proofTypesSupported);
 
-        List<String> signingAlgsSupported = credentialScope.getSigningAlgsSupported();
-        signingAlgsSupported = signingAlgsSupported.isEmpty() ? realmSupportedSigningAlgorithms :
-                // if the config has listed different algorithms than supported by keycloak we must use the
-                // intersection of the configuration with the actual supported algorithms.
-                ListUtils.intersection(signingAlgsSupported, realmSupportedSigningAlgorithms);
+        // Return single configured value for the signature algorithm if any
+        String signingAlgSupported = credentialScope.getSigningAlg();
+        List<String> signingAlgsSupported = StringUtil.isBlank(signingAlgSupported) ? globalSupportedSigningAlgorithms :
+                Collections.singletonList(signingAlgSupported);
         credentialConfiguration.setCredentialSigningAlgValuesSupported(signingAlgsSupported);
 
         // TODO resolve value dynamically from provider implementations?

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -92,11 +92,13 @@ public class SupportedCredentialConfiguration {
      * @param credentialScope                  The scope that holds the credentials configuration
      * @param globalSupportedSigningAlgorithms added as a parameter to avoid reading the global config from the session
      *                                         for each credential
+     * @param realmSupportedSigningAlgorithms  the signing algorithms supported by active keys in the realm
      * @return the credentials configuration that was entered into the ClientScope
      */
     public static SupportedCredentialConfiguration parse(KeycloakSession keycloakSession,
                                                          CredentialScopeModel credentialScope,
-                                                         List<String> globalSupportedSigningAlgorithms) {
+                                                         List<String> globalSupportedSigningAlgorithms,
+                                                         List<String> realmSupportedSigningAlgorithms) {
         SupportedCredentialConfiguration credentialConfiguration = new SupportedCredentialConfiguration();
 
         String credentialConfigurationId = Optional.ofNullable(credentialScope.getCredentialConfigurationId())
@@ -121,10 +123,10 @@ public class SupportedCredentialConfiguration {
          credentialConfiguration.setProofTypesSupported(proofTypesSupported);
 
         List<String> signingAlgsSupported = credentialScope.getSigningAlgsSupported();
-        signingAlgsSupported = signingAlgsSupported.isEmpty() ? globalSupportedSigningAlgorithms :
+        signingAlgsSupported = signingAlgsSupported.isEmpty() ? realmSupportedSigningAlgorithms :
                 // if the config has listed different algorithms than supported by keycloak we must use the
                 // intersection of the configuration with the actual supported algorithms.
-                ListUtils.intersection(signingAlgsSupported, globalSupportedSigningAlgorithms);
+                ListUtils.intersection(signingAlgsSupported, realmSupportedSigningAlgorithms);
         credentialConfiguration.setCredentialSigningAlgValuesSupported(signingAlgsSupported);
 
         // TODO resolve value dynamically from provider implementations?

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
@@ -566,9 +566,16 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerEndpointTest 
                 assertEquals(expectedProofTypesSupported,
                         ProofTypesSupported.fromJsonString(proofTypesSupportedString));
 
-                List<String> expectedSigningAlgs = OID4VCIssuerWellKnownProvider.getSupportedSignatureAlgorithms(session);
+                List<String> expectedSigningAlgs = OID4VCIssuerWellKnownProvider.getSupportedAsymmetricSignatureAlgorithms(session);
                 MatcherAssert.assertThat(signingAlgsSupported,
                         Matchers.containsInAnyOrder(expectedSigningAlgs.toArray()));
+                
+                // Assert that all returned algorithms are asymmetric
+                for (String algorithm : signingAlgsSupported) {
+                    SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, algorithm);
+                    assertNotNull("SignatureProvider should exist for algorithm: " + algorithm, signatureProvider);
+                    assertTrue("Algorithm " + algorithm + " should be asymmetric", signatureProvider.isAsymmetricAlgorithm());
+                }
             })));
         } catch (Throwable e) {
             throw new RuntimeException(e);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerWellKnownProviderTest.java
@@ -543,12 +543,7 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerEndpointTest 
         MatcherAssert.assertThat(proofTypesSupported.getSupportedProofTypes().keySet(),
                 Matchers.containsInAnyOrder(ProofType.JWT, ProofType.ATTESTATION));
 
-        List<String> expectedProofSigningAlgs = List.of(
-                Algorithm.PS256, Algorithm.PS384, Algorithm.PS512,
-                Algorithm.RS256, Algorithm.RS384, Algorithm.RS512,
-                Algorithm.ES256, Algorithm.ES384, Algorithm.ES512,
-                Algorithm.EdDSA
-        );
+        List<String> expectedProofSigningAlgs = getAllAsymmetricAlgorithms();
 
         KeyAttestationsRequired expectedKeyAttestationsRequired;
         if (Boolean.parseBoolean(clientScope.getAttributes().get(CredentialScopeModel.KEY_ATTESTATION_REQUIRED))) {
@@ -592,15 +587,22 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerEndpointTest 
                         session, keyAttestationsRequired, actualProofSigningAlgs);
                 assertEquals(expectedProofTypesSupported, actualProofTypesSupported);
 
-                List<String> expectedSigningAlgs = List.of(Algorithm.RS256);
                 MatcherAssert.assertThat(signingAlgsSupported,
-                        Matchers.containsInAnyOrder(expectedSigningAlgs.toArray()));
+                        Matchers.containsInAnyOrder(getAllAsymmetricAlgorithms().toArray()));
             })));
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
 
         compareClaims(expectedFormat, supportedConfig.getCredentialMetadata().getClaims(), clientScope.getProtocolMappers());
+    }
+
+    private static List<String> getAllAsymmetricAlgorithms() {
+        return List.of(
+                Algorithm.PS256, Algorithm.PS384, Algorithm.PS512,
+                Algorithm.RS256, Algorithm.RS384, Algorithm.RS512,
+                Algorithm.ES256, Algorithm.ES384, Algorithm.ES512,
+                Algorithm.EdDSA);
     }
 
     private void compareDisplay(SupportedCredentialConfiguration supportedConfig, ClientScopeRepresentation clientScope) {


### PR DESCRIPTION
This PR renames the credential signing algorithm attribute for clarity and updates the default filter settings to match the new naming. No functional changes beyond renaming and filtering adjustments.

Closes #44621

