### PR TITLE
Add webauthn for organization authenticator when org is selected

### DIFF
--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -357,6 +357,10 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             form.addError(new FormMessage("Your email domain matches the " + organization.getName() + " organization but you don't have an account yet."));
         }
 
+        // user is null, setup webauthn data if enabled
+        if (webauthnAuth.isPasskeysEnabled()) {
+            webauthnAuth.fillContextForm(context);
+        }
         context.challenge(form.createLoginUsername());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysOrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/webauthn/passwordless/PasskeysOrganizationAuthenticationTest.java
@@ -117,6 +117,23 @@ public class PasskeysOrganizationAuthenticationTest extends AbstractWebAuthnVirt
                     .assertEvent();
 
             logout();
+            events.clear();
+
+            // login forcing the organization
+            oauth.scope("organization:email");
+            oauth.openLoginForm();
+            WaitUtils.waitForPageToLoad();
+
+            appPage.assertCurrent();
+
+            events.expectLogin()
+                    .user(user.getId())
+                    .detail(Details.USERNAME, user.getUsername())
+                    .detail(Details.CREDENTIAL_TYPE, WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                    .detail(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true")
+                    .assertEvent();
+
+            logout();
         }
     }
 


### PR DESCRIPTION
Closes #44735

Adding the webauthn initialization when the organization is enforced. There was an oversight and it was not added when this code path was executed. Added a test for it.
