### PR TITLE
Disable TiDB testing in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,7 +577,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        db: [postgres, mysql, oracle, mssql, mariadb, tidb]
+        db: [postgres, mysql, oracle, mssql, mariadb]
       fail-fast: false
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Closes #44829

Signed-off-by: stianst <stianst@gmail.com>
(cherry picked from commit 058200062cfb9a2d15a09b72a12b536ab9ae6b2c)
