### PR TITLE
Fix CVE-2025-59250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <mssql.version>2022</mssql.version>
         <mssql.container>mcr.microsoft.com/mssql/server:${mssql.version}-latest</mssql.container>
         <!-- this is the mssql driver version also used in the Quarkus BOM -->
-        <mssql-jdbc.version>13.2.1.jre11</mssql-jdbc.version>
+        <mssql-jdbc.version>13.2.4.jre11</mssql-jdbc.version>
         <oracledb.version>23.5</oracledb.version>
         <oracledb.container>mirror.gcr.io/gvenzl/oracle-free:${oracledb.version}-slim-faststart</oracledb.container>
         <!-- this is the oracle driver version also used in the Quarkus BOM -->


### PR DESCRIPTION
Fix [CVE-2025-59250](https://avd.aquasec.com/nvd/2025/cve-2025-59250/) by bumping mssql jdbc driver version to 11.2.4

Signed-off-by: Maximilian Mantz <maximilian.mantz@yahoo.de>