### PR TITLE
[OID4VCI]: Fix OID4VCI scope save to drop empty fields and apply defaults

### DIFF
--- a/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
+++ b/js/apps/admin-ui/src/client-scopes/details/ScopeForm.tsx
@@ -29,6 +29,7 @@ import {
 import { convertAttributeNameToForm, convertToFormValues } from "../../util";
 import useIsFeatureEnabled, { Feature } from "../../utils/useIsFeatureEnabled";
 import { toClientScopes } from "../routes/ClientScopes";
+import { removeEmptyOid4vcAttributes } from "./oid4vciAttributes";
 
 const OID4VC_PROTOCOL = "oid4vc";
 const VC_FORMAT_JWT_VC = "jwt_vc";
@@ -167,10 +168,19 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
     convertToFormValues(clientScope ?? {}, setValue);
   }, [clientScope, setValue]);
 
+  /* Form-level validation handles correctness; here we only prune known optional
+     OID4VC fields when empty. If new attributes are added, extend
+     OID4VC_ATTRIBUTE_KEYS (and related validation) so they participate in cleanup. */
+  const onSubmit = (values: ClientScopeDefaultOptionalType) => {
+    const isOid4vc = values.protocol === OID4VC_PROTOCOL;
+    const cleaned = isOid4vc ? removeEmptyOid4vcAttributes(values) : values;
+    save(cleaned);
+  };
+
   return (
     <FormAccess
       role="manage-clients"
-      onSubmit={handleSubmit(save)}
+      onSubmit={handleSubmit(onSubmit)}
       isHorizontal
     >
       <FormProvider {...form}>
@@ -331,6 +341,9 @@ export const ScopeForm = ({ clientScope, save }: ScopeFormProps) => {
               labelIcon={t("credentialLifetimeHelp")}
               type="number"
               min={1}
+              defaultValue={
+                clientScope?.attributes?.["vc.expiry_in_seconds"] ?? "31536000"
+              }
             />
             <SelectControl
               id="kc-vc-format"

--- a/js/apps/admin-ui/src/client-scopes/details/oid4vciAttributes.ts
+++ b/js/apps/admin-ui/src/client-scopes/details/oid4vciAttributes.ts
@@ -1,0 +1,59 @@
+import { ClientScopeDefaultOptionalType } from "../../components/client-scope/ClientScopeTypes";
+import { convertAttributeNameToForm } from "../../util";
+
+/* OID4VC attributes we explicitly clean up when empty/whitespace-only.
+   Keep this list in sync with optional OID4VC form fields; add to it when
+   new string/number-like attributes are introduced that should be pruned. */
+export const OID4VC_ATTRIBUTE_KEYS = [
+  "vc.credential_configuration_id",
+  "vc.credential_identifier",
+  "vc.issuer_did",
+  "vc.expiry_in_seconds",
+  "vc.credential_build_config.token_jws_type",
+  "vc.supported_credential_types",
+  "vc.credential_signing_alg",
+  "vc.verifiable_credential_type",
+  "vc.credential_build_config.sd_jwt.visible_claims",
+  "vc.display",
+] as const;
+
+const isEmptyValue = (value: unknown) =>
+  value === null ||
+  value === undefined ||
+  (typeof value === "string" && value.trim() === "");
+
+/** Prune known optional OID4VC attributes from the payload when they are empty. */
+export const removeEmptyOid4vcAttributes = (
+  values: ClientScopeDefaultOptionalType,
+): ClientScopeDefaultOptionalType => {
+  const fieldNames = OID4VC_ATTRIBUTE_KEYS.map((attr) =>
+    convertAttributeNameToForm<ClientScopeDefaultOptionalType>(
+      `attributes.${attr}`,
+    ),
+  );
+
+  /* Shallow copies are sufficient while OID4VC attributes stay flat; if we add
+     nested objects under attributes.vc.* we should switch to a deep clone here. */
+  const cleanedValues = { ...values } as Record<string, unknown>;
+  const hadAttributes = Boolean(cleanedValues.attributes);
+  const cleanedAttributes = {
+    ...(cleanedValues.attributes as Record<string, unknown> | undefined),
+  };
+
+  for (const fieldName of fieldNames) {
+    const attrKey = fieldName.replace(/^attributes\./, "");
+    if (isEmptyValue(cleanedAttributes?.[attrKey])) {
+      delete cleanedAttributes[attrKey];
+    }
+  }
+
+  if (Object.keys(cleanedAttributes).length === 0) {
+    if (hadAttributes) {
+      delete cleanedValues.attributes;
+    }
+  } else {
+    cleanedValues.attributes = cleanedAttributes;
+  }
+
+  return cleanedValues as unknown as ClientScopeDefaultOptionalType;
+};

--- a/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
@@ -159,7 +159,6 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     await page
       .getByTestId(OID4VCI_FIELDS.TOKEN_JWS_TYPE)
       .fill(TEST_VALUES.TOKEN_JWS_TYPE);
-
     await selectItem(
       page,
       OID4VCI_FIELDS.SIGNING_ALGORITHM,
@@ -423,6 +422,35 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     await expect(page.locator("#kc-vc-format")).toContainText(
       "SD-JWT VC (dc+sd-jwt)",
     );
+  });
+
+  test("should omit optional OID4VCI fields when left blank", async ({
+    page,
+  }) => {
+    await using testBed = await createTestBed();
+    const testClientScopeName = `oid4vci-blank-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+    await createClientScopeAndSelectProtocolAndFormat(
+      page,
+      testBed,
+      "SD-JWT VC (dc+sd-jwt)",
+    );
+
+    await page.getByTestId("name").fill(testClientScopeName);
+
+    await clickSaveButton(page);
+    await expect(page.getByText("Client scope created")).toBeVisible();
+
+    await navigateBackAndVerifyClientScope(page, testBed, testClientScopeName);
+
+    await expect(page.getByTestId(OID4VCI_FIELDS.ISSUER_DID)).toHaveValue("");
+    await expect(page.locator(OID4VCI_FIELDS.SIGNING_ALGORITHM)).toHaveValue(
+      "",
+    );
+    await expect(page.locator(OID4VCI_FIELDS.HASH_ALGORITHM)).toContainText(
+      "SHA-256",
+    );
+    await expect(page.getByTestId(OID4VCI_FIELDS.DISPLAY)).toHaveValue("");
   });
 
   test("should conditionally show/hide fields when format changes", async ({

--- a/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
+++ b/js/apps/admin-ui/test/client-scope/oid4vci-client-scope.spec.ts
@@ -444,9 +444,7 @@ test.describe("OID4VCI Client Scope Functionality", () => {
     await navigateBackAndVerifyClientScope(page, testBed, testClientScopeName);
 
     await expect(page.getByTestId(OID4VCI_FIELDS.ISSUER_DID)).toHaveValue("");
-    await expect(page.locator(OID4VCI_FIELDS.SIGNING_ALGORITHM)).toHaveValue(
-      "",
-    );
+    await expect(page.locator(OID4VCI_FIELDS.SIGNING_ALGORITHM)).toHaveText("");
     await expect(page.locator(OID4VCI_FIELDS.HASH_ALGORITHM)).toContainText(
       "SHA-256",
     );

--- a/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
+++ b/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderFactory;
 
 /**
@@ -51,25 +50,6 @@ public class CryptoUtils {
                 .filter(entry -> entry.getValue() != null)
                 .filter(entry -> entry.getValue().isAsymmetricAlgorithm())
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
-    }
-
-    /**
-     * Returns the asymmetric signature algorithms supported given the keys in the realm.
-     *
-     * @param session The Keycloak session
-     * @param realm   The realm model
-     * @return List of asymmetric signature algorithm names
-     */
-    public static List<String> getSupportedAsymmetricSignatureAlgorithms(
-            KeycloakSession session, RealmModel realm
-    ) {
-        List<String> globalAsymmetricSignAlgs = getSupportedAsymmetricSignatureAlgorithms(session);
-        return session.keys().getKeysStream(realm)
-                .filter(key -> KeyUse.SIG.equals(key.getUse()))
-                .map(KeyWrapper::getAlgorithm)
-                .filter(globalAsymmetricSignAlgs::contains)
-                .distinct()
                 .collect(Collectors.toList());
     }
 

--- a/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
+++ b/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderFactory;
 
 /**
@@ -50,6 +51,25 @@ public class CryptoUtils {
                 .filter(entry -> entry.getValue() != null)
                 .filter(entry -> entry.getValue().isAsymmetricAlgorithm())
                 .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the asymmetric signature algorithms supported given the keys in the realm.
+     *
+     * @param session The Keycloak session
+     * @param realm   The realm model
+     * @return List of asymmetric signature algorithm names
+     */
+    public static List<String> getSupportedAsymmetricSignatureAlgorithms(
+            KeycloakSession session, RealmModel realm
+    ) {
+        List<String> globalAsymmetricSignAlgs = getSupportedAsymmetricSignatureAlgorithms(session);
+        return session.keys().getKeysStream(realm)
+                .filter(key -> KeyUse.SIG.equals(key.getUse()))
+                .map(KeyWrapper::getAlgorithm)
+                .filter(globalAsymmetricSignAlgs::contains)
+                .distinct()
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
##  Description
- Strip empty optional OID4VCI attributes on save so backend defaults (scope-name fallbacks, realm algs) apply instead of storing empty strings.  
- Keep dropdown-backed fields untouched; retain existing defaulted values (format, lifetime, visible claims, token JWS type, etc.).  
- Add Playwright coverage to ensure optional fields left blank remain empty on reload (not persisted).

## Testing
- Created OID4VCI scope with blank optional fields; saved and reloaded — optional inputs stay blank, defaults remain intact.  
- Existing OID4VCI tests pass.

closes #44846
closes #44807

## Depends on
- **Issue**: https://github.com/keycloak/keycloak/issues/44849