### PR TITLE
[OID4VCI] Add spec-compliant JWT VC issuer well-known endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.ext.Provider;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oauth2.OAuth2WellKnownProviderFactory;
+import org.keycloak.protocol.oid4vc.issuance.JWTVCIssuerWellKnownProviderFactory;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProviderFactory;
 import org.keycloak.services.cors.Cors;
 
@@ -73,6 +74,7 @@ public class ServerMetadataResource {
         // you can add codes here considering the current status of the implementation (preview, experimental).
         if (OAuth2WellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
         if (OID4VCIssuerWellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
+        if (JWTVCIssuerWellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
         return false;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -70,6 +70,7 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.JWTVCIssuerWellKnownProviderFactory;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsResponse;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
@@ -559,6 +560,17 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         var contextRoot = suiteContext.getAuthServerInfo().getContextRoot();
         // [TODO] This should be contextRoot/.well-known/openid-credential-issuer/auth/realms/...
         return contextRoot + "/auth/.well-known/openid-credential-issuer/realms/" + realm;
+    }
+
+    protected String getSpecCompliantRealmMetadataPath(String realm) {
+        var contextRoot = suiteContext.getAuthServerInfo().getContextRoot();
+        // [TODO] This should be contextRoot/.well-known/jwt-vc-issuer/auth/realms/...
+        return contextRoot + "/auth/.well-known/" + JWTVCIssuerWellKnownProviderFactory.PROVIDER_ID + "/realms/" + realm;
+    }
+
+    protected String getLegacyJwtVcRealmMetadataPath(String realm) {
+        var contextRoot = suiteContext.getAuthServerInfo().getContextRoot();
+        return contextRoot + "/auth/realms/" + realm + "/.well-known/" + JWTVCIssuerWellKnownProviderFactory.PROVIDER_ID;
     }
 
     protected String getCredentialOfferUriUrl(String configId) {


### PR DESCRIPTION
- Adds server-level support for /.well-known/jwt-vc-issuer/realms/{realm} while preserving the legacy realm-scoped endpoint with deprecation headers.
- Updates JWT VC metadata consumer URL construction to insert /.well-known/jwt-vc-issuer per draft-ietf-oauth-sd-jwt-vc-13.
- Adds integration test verifying the new path returns issuer metadata and that the old path still works but emits deprecation headers.

Closes #44256
