### PR TITLE
 [OID4VCI] Adjust OID4VC request logging verbosity

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -323,12 +323,12 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
      * @return the authorization details response if generation was successful, null otherwise
      */
     private List<AuthorizationDetailsResponse> generateAuthorizationDetailsFromCredentialOffer(AuthenticatedClientSessionModel clientSession) {
-        logger.info("Processing authorization_details from credential offer");
+        logger.debug("Processing authorization_details from credential offer");
 
         // Get supported credentials
         Map<String, SupportedCredentialConfiguration> supportedCredentials = OID4VCIssuerWellKnownProvider.getSupportedCredentials(session);
         if (supportedCredentials == null || supportedCredentials.isEmpty()) {
-            logger.info("No supported credentials found, cannot generate authorization_details from credential offer");
+            logger.debug("No supported credentials found, cannot generate authorization_details from credential offer");
             return null;
         }
 
@@ -336,7 +336,7 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
         List<String> credentialConfigurationIds = extractCredentialConfigurationIds(clientSession);
 
         if (credentialConfigurationIds == null || credentialConfigurationIds.isEmpty()) {
-            logger.info("No credential_configuration_ids found in credential offer, cannot generate authorization_details");
+            logger.debug("No credential_configuration_ids found in credential offer, cannot generate authorization_details");
             return null;
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -1481,13 +1481,13 @@ public class OID4VCIssuerEndpoint {
                                     ". The requested claims are not available in the user profile.");
                         }
                     } else {
-                        LOGGER.infof("Stored claims list is null or empty");
+                        LOGGER.debug("Stored claims list is null or empty");
                     }
                 } catch (Exception e) {
                     LOGGER.errorf(e, "Failed to parse stored claims for scope %s", scope);
                 }
             } else {
-                LOGGER.infof("No stored claims found for scope %s", scope);
+                LOGGER.debugf("No stored claims found for scope %s", scope);
             }
             // No claims filtering requested, all claims are valid
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/DisplayObject.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/DisplayObject.java
@@ -97,8 +97,7 @@ public class DisplayObject {
             // lets say we have an invalid value we should not kill the whole execution if just the display value is
             // broken
             LOGGER.debug(e.getMessage(), e);
-            LOGGER.info(String.format("Failed to parse display-metadata for credential: %s", credentialScope.getName()),
-                        e.getMessage());
+            LOGGER.warn("Failed to parse display-metadata for credential '{}': {}", credentialScope.getName(), e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
This PR lowers request-scoped INFO logs in OID4VC issuance to DEBUG and warn on malformed display metadata so lifecycle logging stays clean while still surfacing misconfigurations.

Closes #44675