### PR TITLE
Add timeout option for keycloak-admin-client

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/agent.ts
+++ b/js/libs/keycloak-admin-client/src/resources/agent.ts
@@ -248,6 +248,9 @@ export class Agent {
         ...requestOptions,
         headers: requestHeaders,
         method,
+        ...(this.#client.timeout
+          ? { signal: AbortSignal.timeout(this.#client.timeout) }
+          : {}),
       });
 
       // now we get the response of the http request

--- a/js/libs/keycloak-admin-client/test/timeout.spec.ts
+++ b/js/libs/keycloak-admin-client/test/timeout.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { KeycloakAdminClient } from "../src/client.js";
+import { credentials } from "./constants.js";
+import { Server, createServer } from "node:http";
+
+describe("Timeout", () => {
+  let server: Server;
+
+  before(async () => {
+    server = createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      setTimeout(() => res.end("Hello, world!\n"), 1500);
+    });
+    server.listen(8888, "localhost");
+  });
+
+  after(async () => {
+    await server[Symbol.asyncDispose]();
+  });
+
+  void it("create without timeout", async () => {
+    const client = new KeycloakAdminClient({
+      baseUrl: "http://localhost:8888",
+    });
+
+    try {
+      await client.auth(credentials);
+    } catch (error) {
+      expect(error).to.be.an("Error");
+      expect((error as Error).message).to.contain("Unexpected token 'H'");
+      return;
+    }
+    expect.fail(null, null, "auth did not fail");
+  });
+
+  void it("create with timeout", async () => {
+    const client = new KeycloakAdminClient({
+      baseUrl: "http://localhost:8888",
+      timeout: 1000,
+    });
+
+    try {
+      await client.auth(credentials);
+    } catch (error) {
+      expect(error).to.be.an("DOMException");
+      expect((error as DOMException).message).to.contain(
+        "The operation was aborted due to timeout",
+      );
+      return;
+    }
+    expect.fail(null, null, "auth did not fail");
+  });
+});


### PR DESCRIPTION
Closes #42644

PR that adds the `timeout` to the `ConnectionConfig`. This is later transformed in the `signal` with the abort. The PR adds two little tests to check the timeout is applied at `fetch` level.
