### PR TITLE
[OID4VCI] Mandatory claims are not enforced for OID4VCI

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapper.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oid4vc.issuance.mappers;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -157,5 +158,35 @@ public abstract class OID4VCMapper implements ProtocolMapper, OID4VCEnvironmentP
      */
     public abstract void setClaim(Map<String, Object> claims,
                                   UserSessionModel userSessionModel);
+
+    /**
+     * Creates new map "claimsWithPrefix" with the resolved claims including path prefix
+     *
+     * @param claimsOrig Map with the original claims, which were returned by {@link #setClaim(Map, UserSessionModel)} . This method usually just reads from this map
+     * @param claimsWithPrefix Map with the claims including path prefix. This method might write to this map
+     */
+    public void setClaimWithMetadataPrefix(Map<String, Object> claimsOrig, Map<String, Object> claimsWithPrefix) {
+        List<String> attributePath = getMetadataAttributePath();
+        String propertyName = attributePath.get(attributePath.size() - 1);
+        if (claimsOrig.get(propertyName) != null) {
+            Object claimValue = claimsOrig.get(propertyName);
+            Map<String, Object> current = claimsWithPrefix;
+
+            for (int i = 0; i < attributePath.size() ; i++) {
+                String currentSnippetName = attributePath.get(i);
+                if (i < attributePath.size() - 1) {
+                    Map<String, Object> obj = (Map<String, Object>) current.get(currentSnippetName);
+                    if (obj == null) {
+                         obj = new HashMap<>();
+                         current.put(currentSnippetName, obj);
+                    }
+                    current = obj;
+                } else {
+                    // Last element
+                    current.put(currentSnippetName, claimValue);
+                }
+            }
+        }
+    }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/ClaimsPathPointer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/ClaimsPathPointer.java
@@ -220,13 +220,13 @@ public class ClaimsPathPointer {
                 // Optional claims that don't exist are simply not included
             } catch (IllegalArgumentException e) {
                 if (Boolean.TRUE.equals(claim.getMandatory())) {
-                    // Log error for mandatory claims before re-throwing
-                    logger.errorf("Failed to process mandatory claim path %s: %s", path, e.getMessage());
+                    // Log warning for mandatory claims before re-throwing
+                    logger.warnf("Failed to process mandatory claim path %s: %s", path, e.getMessage());
                     // Re-throw for mandatory claims
                     throw e;
                 }
-                // For optional claims, log warning and continue
-                logger.warnf("Failed to process optional claim path %s: %s", path, e.getMessage());
+                // For optional claims, log debug and continue
+                logger.debugf("Failed to process optional claim path %s: %s", path, e.getMessage());
             }
         }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJwtAuthorizationCodeFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJwtAuthorizationCodeFlowTest.java
@@ -43,7 +43,12 @@ public class OID4VCJwtAuthorizationCodeFlowTest extends OID4VCAuthorizationCodeF
 
     @Override
     protected String getExpectedClaimPath() {
-        return "given_name";
+        return "family_name";
+    }
+
+    @Override
+    protected String getFirstNameProtocolMapperName() {
+        return "givenName";
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtAuthorizationCodeFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtAuthorizationCodeFlowTest.java
@@ -49,6 +49,11 @@ public class OID4VCSdJwtAuthorizationCodeFlowTest extends OID4VCAuthorizationCod
     }
 
     @Override
+    protected String getFirstNameProtocolMapperName() {
+        return "firstName-mapper";
+    }
+
+    @Override
     protected void verifyCredentialStructure(Object credentialObj) {
         assertNotNull("Credential object should not be null", credentialObj);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/oid4vc/test-credential-mappers.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/oid4vc/test-credential-mappers.json
@@ -25,7 +25,7 @@
       "protocolMapper": "oid4vc-user-attribute-mapper",
       "config": {
         "claim.name": "family_name",
-        "userProperty": "lastName",
+        "userAttribute": "lastName",
         "vc.mandatory": "false",
         "vc.display": "[{\"name\": \"اسم العائلة\", \"locale\": \"ar-SA\"}, {\"name\": \"Nachname\", \"locale\": \"de-DE\"}, {\"name\": \"Family Name\", \"locale\": \"en-US\"}, {\"name\": \"Apellido\", \"locale\": \"es-ES\"}, {\"name\": \"نام خانوادگی\", \"locale\": \"fa-IR\"}, {\"name\": \"Sukunimi\", \"locale\": \"fi-FI\"}, {\"name\": \"Nom de famille\", \"locale\": \"fr-FR\"}, {\"name\": \"परिवार का नाम\", \"locale\": \"hi-IN\"}, {\"name\": \"Cognome\", \"locale\": \"it-IT\"}, {\"name\": \"姓\", \"locale\": \"ja-JP\"}, {\"name\": \"өөрийн нэр\", \"locale\": \"mn-MN\"}, {\"name\": \"Achternaam\", \"locale\": \"nl-NL\"}, {\"name\": \"Sobrenome\", \"locale\": \"pt-PT\"}, {\"name\": \"Efternamn\", \"locale\": \"sv-SE\"}, {\"name\": \"خاندانی نام\", \"locale\": \"ur-PK\"}]"
       }


### PR DESCRIPTION
closes #44796

Summary of the changes:

- PR fixes the issues 1-3 mentioned in the description of #44796 . I've created separate issue #44961 for the "Issue 4" from the #44796 description and hope to address that as a follow-up

- When the claim is configured as "Mandatory" either in the protocol-mapper or in the `authorization_details` parameter, it is enforced that the claim is really present in the credential response.

- The check for mandatory claims was already implemented in `OID4VCIssuerEndpoint.validateRequestedClaimsArePresent` , however it did not work (due the lots of nested try/catch blocks, which caused thrown exception to be incorrectly caught and not propagated to the caller). Added automated tests to make sure that this is not broken anymore

- It works for both `sd-jwt` credentials as well as for `jwt_vc` verifiable credentials. In case of `jwt_vc` verifiable credentials, there was one tricky thing as the `authorization_details` mandatory claim has the full path (including `credentialSubject`) but the claims returned by protocol mappers method `setClaimsForSubject` returns claims in the "flat map" without `credentialSubject` . I've introduced another method `setClaimsWithMetadataPrefix` to the `OID4VCMapper`, which creates the map with whole "metadata attribute path" (in case of `jwt_vc` credential, the returned map contains single `credentialSubject` claim with the other claims as sub-claims of it). That works with checking the mandatory claim for `jwt_vc` credential. The original map returned by `setClaimsForSubject` is still kept and used in the subsequent steps for credential building (I did not want to refactor that part as it might be quite a lot of changes, so instead introduced that new method `setClaimsWithMetadataPrefix` ). 
