### PR TITLE
OID4VCI credentials have invalid subject id value

### DIFF
--- a/core/src/main/java/org/keycloak/OID4VCConstants.java
+++ b/core/src/main/java/org/keycloak/OID4VCConstants.java
@@ -22,6 +22,23 @@ public class OID4VCConstants {
     public static final String CLAIM_NAME_ISSUER = "iss";
     public static final String CLAIM_NAME_CNF = "cnf";
     public static final String CLAIM_NAME_JWK = "jwk";
+    public static final String CLAIM_NAME_SUB = "sub";
+    public static final String CLAIM_NAME_VC = "vc";
+    public static final String CLAIM_NAME_VCT = "vct";
+
+    // The JWT identifier uniquely identifies a SD_JWT credential
+    // It is useful for:
+    //   * replay protection of the SD-JWT
+    //   * introspection caches
+    //   * deduplication
+    //   * credential revocation tracking (optional)
+    public static final String CLAIM_NAME_JTI = "jti";
+
+    // The credential subject identifier
+    //   * A stable identifier for the VC subject
+    //   * Would in most cases be the subject's DID
+    //   * Can be mapped to user attributes
+    public static final String CLAIM_NAME_SUBJECT_ID = "id";
 
     public static final String KEYBINDING_JWT_TYP = "kb+jwt";
 

--- a/core/src/main/java/org/keycloak/util/JsonSerialization.java
+++ b/core/src/main/java/org/keycloak/util/JsonSerialization.java
@@ -59,6 +59,14 @@ public class JsonSerialization {
         }
     }
 
+    public static String valueAsPrettyString(Object obj) {
+        try {
+            return prettyMapper.writeValueAsString(obj);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
     public static <T> T valueFromString(String string, Class<T> type) {
         try {
             return mapper.readValue(string, type);

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -31,6 +31,7 @@ import static org.keycloak.utils.StringUtil.isNotBlank;
  * @version $Revision: 1 $
  */
 public interface UserModel extends RoleMapperModel {
+    String ID = "id";
     String USERNAME = "username";
     String FIRST_NAME = "firstName";
     String LAST_NAME = "lastName";

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -29,6 +29,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
@@ -43,6 +44,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 
 import org.jboss.logging.Logger;
 
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_SUBJECT_ID;
 import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
 import static org.keycloak.models.ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.CONFIGURATION_ID;
@@ -88,11 +90,11 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 
 	@Override
 	public void init(Config.Scope config) {
-		builtins.put(SUBJECT_ID_MAPPER, OID4VCSubjectIdMapper.create("subject id", "id"));
+		builtins.put(SUBJECT_ID_MAPPER, OID4VCSubjectIdMapper.create(SUBJECT_ID_MAPPER, CLAIM_NAME_SUBJECT_ID, UserModel.ID));
 		builtins.put(USERNAME_MAPPER, OID4VCUserAttributeMapper.create(USERNAME_MAPPER, "username", "username", false));
 		builtins.put(EMAIL_MAPPER, OID4VCUserAttributeMapper.create(EMAIL_MAPPER, "email", "email", false));
 		builtins.put(FIRST_NAME_MAPPER, OID4VCUserAttributeMapper.create(FIRST_NAME_MAPPER, "firstName", "firstName", false));
-		builtins.put(LAST_NAME_MAPPER, OID4VCUserAttributeMapper.create(LAST_NAME_MAPPER, "lastName", "familyName", false));
+		builtins.put(LAST_NAME_MAPPER, OID4VCUserAttributeMapper.create(LAST_NAME_MAPPER, "familyName", "lastName", false));
 	}
 
 	@Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
@@ -27,14 +27,16 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
+import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.Format;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_SUBJECT_ID;
+
 public class JwtCredentialBuilder implements CredentialBuilder {
 
     private static final String VC_CLAIM_KEY = "vc";
-    private static final String ID_CLAIM_KEY = "id";
 
     private final TimeProvider timeProvider;
     private final UnaryOperator<Instant> issuanceTimeNormalizer;
@@ -90,12 +92,9 @@ public class JwtCredentialBuilder implements CredentialBuilder {
         Optional.ofNullable(verifiableCredential.getExpirationDate())
                 .ifPresent(d -> jsonWebToken.exp(d.getEpochSecond()));
 
-        // subject id should only be set if the credential subject has an id.
-        Optional.ofNullable(
-                        verifiableCredential
-                                .getCredentialSubject()
-                                .getClaims()
-                                .get(ID_CLAIM_KEY))
+        // sub should only be set if the credential subject has an id.
+        CredentialSubject subject = verifiableCredential.getCredentialSubject();
+        Optional.ofNullable(subject.getClaims().get(CLAIM_NAME_SUBJECT_ID))
                 .map(Object::toString)
                 .ifPresent(jsonWebToken::subject);
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCSubjectIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCSubjectIdMapper.java
@@ -21,20 +21,23 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.provider.ProviderConfigProperty;
 
-import org.apache.commons.collections4.ListUtils;
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_SUBJECT_ID;
 
 /**
- * Sets an ID for the credential, either randomly generated or statically configured
+ * Sets an ID for the credential subject, either by attribute mapping or statically configured
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */
@@ -48,10 +51,31 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
         ProviderConfigProperty idPropertyNameConfig = new ProviderConfigProperty();
         idPropertyNameConfig.setName(CLAIM_NAME);
         idPropertyNameConfig.setLabel("ID Property Name");
-        idPropertyNameConfig.setHelpText("Name of the property to contain the id.");
-        idPropertyNameConfig.setDefaultValue("id");
+        idPropertyNameConfig.setHelpText("Name of the property to contain the subject id.");
         idPropertyNameConfig.setType(ProviderConfigProperty.STRING_TYPE);
+        idPropertyNameConfig.setDefaultValue(CLAIM_NAME_SUBJECT_ID);
         CONFIG_PROPERTIES.add(idPropertyNameConfig);
+
+        ProviderConfigProperty userAttributeConfig = new ProviderConfigProperty();
+        userAttributeConfig.setName(USER_ATTRIBUTE_KEY);
+        userAttributeConfig.setLabel("User attribute");
+        userAttributeConfig.setHelpText("The user attribute that maps to the subject id.");
+        userAttributeConfig.setType(ProviderConfigProperty.LIST_TYPE);
+        userAttributeConfig.setOptions(List.of(UserModel.USERNAME, UserModel.EMAIL, UserModel.ID));
+        userAttributeConfig.setDefaultValue(UserModel.ID);
+        CONFIG_PROPERTIES.add(userAttributeConfig);
+    }
+
+    public static ProtocolMapperModel create(String name, String claimName, String userAttribute) {
+        var mapperModel = new ProtocolMapperModel();
+        mapperModel.setName(name);
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(CLAIM_NAME, claimName);
+        configMap.put(USER_ATTRIBUTE_KEY, userAttribute);
+        mapperModel.setConfig(configMap);
+        mapperModel.setProtocol(OID4VCLoginProtocolFactory.PROTOCOL_ID);
+        mapperModel.setProtocolMapper(MAPPER_ID);
+        return mapperModel;
     }
 
     @Override
@@ -59,34 +83,25 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
         return CONFIG_PROPERTIES;
     }
 
-    @Override
-    public List<String> getMetadataAttributePath() {
-        return ListUtils.union(getAttributePrefix(), List.of("id"));
-    }
-
-    public static ProtocolMapperModel create(String name, String subjectId) {
-        var mapperModel = new ProtocolMapperModel();
-        mapperModel.setName(name);
-        Map<String, String> configMap = new HashMap<>();
-        configMap.put(CLAIM_NAME, subjectId);
-        mapperModel.setConfig(configMap);
-        mapperModel.setProtocol(OID4VCLoginProtocolFactory.PROTOCOL_ID);
-        mapperModel.setProtocolMapper(MAPPER_ID);
-        return mapperModel;
-    }
-
-    public void setClaim(VerifiableCredential verifiableCredential,
-                         UserSessionModel userSessionModel) {
+    public void setClaim(VerifiableCredential verifiableCredential, UserSessionModel userSessionModel) {
         // nothing to do for the mapper.
     }
 
     @Override
     public void setClaim(Map<String, Object> claims, UserSessionModel userSessionModel) {
+        UserModel userModel = userSessionModel.getUser();
         List<String> attributePath = getMetadataAttributePath();
         String propertyName = attributePath.get(attributePath.size() - 1);
-        claims.put(propertyName,
-                   mapperModel.getConfig().getOrDefault(OID4VCMapper.CLAIM_NAME,
-                                                        String.format("urn:uuid:%s", UUID.randomUUID())));
+        String userAttributeName = mapperModel.getConfig().get(OID4VCMapper.USER_ATTRIBUTE_KEY);
+        Consumer<String> userIdConsumer = (val) -> claims.put(propertyName, val);
+        if (UserModel.ID.equals(userAttributeName)) {
+            userIdConsumer.accept(userModel.getId());
+        } else {
+            KeycloakModelUtils.resolveAttribute(userModel, userAttributeName, false).stream()
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .ifPresent(userIdConsumer);
+        }
     }
 
     @Override
@@ -96,7 +111,7 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
 
     @Override
     public String getHelpText() {
-        return "Assigns a subject ID to the credentials subject. If no specific id is configured, a randomly generated one is used.";
+        return "Assigns a subject ID to the credentials subject. The default is the user's id, others can be selected.";
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCSubjectIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCSubjectIdMapper.java
@@ -32,12 +32,13 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.provider.ProviderConfigProperty;
 
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_SUBJECT_ID;
 
 /**
- * Sets an ID for the credential subject, either by attribute mapping or statically configured
+ * Sets an ID for the credential subject, either from User ID or by attribute mapping
  *
  * @author <a href="https://github.com/wistefan">Stefan Wiedemann</a>
  */
@@ -50,8 +51,8 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
     static {
         ProviderConfigProperty idPropertyNameConfig = new ProviderConfigProperty();
         idPropertyNameConfig.setName(CLAIM_NAME);
-        idPropertyNameConfig.setLabel("ID Property Name");
-        idPropertyNameConfig.setHelpText("Name of the property to contain the subject id.");
+        idPropertyNameConfig.setLabel(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME_LABEL);
+        idPropertyNameConfig.setHelpText("Name of the claim to insert into the token. This can be a fully qualified name such as 'address.street'. In case that 'id' is used as a value of this configuration property, it would be mapped into sd-jwt credential as claim 'sub'.");
         idPropertyNameConfig.setType(ProviderConfigProperty.STRING_TYPE);
         idPropertyNameConfig.setDefaultValue(CLAIM_NAME_SUBJECT_ID);
         CONFIG_PROPERTIES.add(idPropertyNameConfig);
@@ -59,7 +60,7 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
         ProviderConfigProperty userAttributeConfig = new ProviderConfigProperty();
         userAttributeConfig.setName(USER_ATTRIBUTE_KEY);
         userAttributeConfig.setLabel("User attribute");
-        userAttributeConfig.setHelpText("The user attribute that maps to the subject id.");
+        userAttributeConfig.setHelpText("The name of the user attribute that maps to the subject id.");
         userAttributeConfig.setType(ProviderConfigProperty.LIST_TYPE);
         userAttributeConfig.setOptions(List.of(UserModel.USERNAME, UserModel.EMAIL, UserModel.ID));
         userAttributeConfig.setDefaultValue(UserModel.ID);
@@ -111,7 +112,7 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
 
     @Override
     public String getHelpText() {
-        return "Assigns a subject ID to the credentials subject. The default is the user's id, others can be selected.";
+        return "Sets an ID for the credential subject, either from User ID or by attribute mapping.";
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCUserAttributeMapper.java
@@ -97,12 +97,12 @@ public class OID4VCUserAttributeMapper extends OID4VCMapper {
         }
     }
 
-    public static ProtocolMapperModel create(String mapperName, String userAttribute, String propertyName,
+    public static ProtocolMapperModel create(String mapperName, String claimName, String userAttribute,
                                              boolean aggregateAttributes) {
         ProtocolMapperModel mapperModel = new ProtocolMapperModel();
         mapperModel.setName(mapperName);
         Map<String, String> configMap = new HashMap<>();
-        configMap.put(CLAIM_NAME, propertyName);
+        configMap.put(CLAIM_NAME, claimName);
         configMap.put(USER_ATTRIBUTE_KEY, userAttribute);
         configMap.put(AGGREGATE_ATTRIBUTES_KEY, Boolean.toString(aggregateAttributes));
         mapperModel.setConfig(configMap);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilderTest.java
@@ -35,10 +35,10 @@ import org.keycloak.sdjwt.vp.SdJwtVP;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.Test;
 
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_ISSUER;
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_SD;
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_SD_HASH_ALGORITHM;
-import static org.keycloak.protocol.oid4vc.issuance.credentialbuilder.SdJwtCredentialBuilder.ISSUER_CLAIM;
-import static org.keycloak.protocol.oid4vc.issuance.credentialbuilder.SdJwtCredentialBuilder.VERIFIABLE_CREDENTIAL_TYPE_CLAIM;
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -112,11 +112,11 @@ public class SdJwtCredentialBuilderTest extends CredentialBuilderTest {
 
         assertEquals("The issuer should be set in the token.",
                 issuerDid,
-                jwt.getPayload().get(ISSUER_CLAIM).asText());
+                jwt.getPayload().get(CLAIM_NAME_ISSUER).asText());
 
         assertEquals("The type should be included",
                 credentialBuildConfig.getCredentialType(),
-                jwt.getPayload().get(VERIFIABLE_CREDENTIAL_TYPE_CLAIM).asText());
+                jwt.getPayload().get(CLAIM_NAME_VCT).asText());
 
         assertEquals("The JWS token type should be included",
                 credentialBuildConfig.getTokenJwsType(),

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -712,19 +712,20 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     assertNotNull("The jwt_vc-credential can optionally provide a claims claim.",
                             jwtVcClaims);
 
-                    assertEquals(5, jwtVcClaims.size());
+                    assertEquals(6, jwtVcClaims.size());
                     {
                         Claim claim = jwtVcClaims.get(0);
-                        assertEquals("The jwt_vc-credential claim credentialSubject.given_name is present.",
-                                CREDENTIAL_SUBJECT,
-                                claim.getPath().get(0));
-                        assertEquals("The jwt_vc-credential claim credentialSubject.given_name is present.",
-                                "given_name",
-                                claim.getPath().get(1));
-                        assertFalse("The jwt_vc-credential claim credentialSubject.given_name is not mandatory.",
-                                claim.isMandatory());
-                        assertNotNull("The jwt_vc-credential claim credentialSubject.given_name has display configured",
-                                claim.getDisplay());
+                        assertEquals("Has credentialSubject.id", CREDENTIAL_SUBJECT, claim.getPath().get(0));
+                        assertEquals("credentialSubject.id mapped correctly","id", claim.getPath().get(1));
+                        assertFalse("credentialSubject.id is not mandatory", claim.isMandatory());
+                        assertNull("credentialSubject.id has no display", claim.getDisplay());
+                    }
+                    {
+                        Claim claim = jwtVcClaims.get(1);
+                        assertEquals("Has credentialSubject.given_name", CREDENTIAL_SUBJECT, claim.getPath().get(0));
+                        assertEquals("credentialSubject.given_name mapped correctly","given_name", claim.getPath().get(1));
+                        assertFalse("credentialSubject.given_name is not mandatory", claim.isMandatory());
+                        assertNotNull("credentialSubject.given_name has display", claim.getDisplay());
                         assertEquals(15, claim.getDisplay().size());
                         for (ClaimDisplay givenNameDisplay : claim.getDisplay()) {
                             assertNotNull(givenNameDisplay.getName());
@@ -732,17 +733,11 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                         }
                     }
                     {
-                        Claim claim = jwtVcClaims.get(1);
-                        assertEquals("The jwt_vc-credential claim credentialSubject.family_name is present.",
-                                CREDENTIAL_SUBJECT,
-                                claim.getPath().get(0));
-                        assertEquals("The jwt_vc-credential claim credentialSubject.family_name is present.",
-                                "family_name",
-                                claim.getPath().get(1));
-                        assertFalse("The jwt_vc-credential claim credentialSubject.family_name is not mandatory.",
-                                claim.isMandatory());
-                        assertNotNull("The jwt_vc-credential claim credentialSubject.family_name has display configured",
-                                claim.getDisplay());
+                        Claim claim = jwtVcClaims.get(2);
+                        assertEquals("Has credentialSubject.family_name", CREDENTIAL_SUBJECT, claim.getPath().get(0));
+                        assertEquals("credentialSubject.family_name mapped correctly","family_name", claim.getPath().get(1));
+                        assertFalse("credentialSubject.family_name is not mandatory", claim.isMandatory());
+                        assertNotNull("credentialSubject.family_name has display", claim.getDisplay());
                         assertEquals(15, claim.getDisplay().size());
                         for (ClaimDisplay familyNameDisplay : claim.getDisplay()) {
                             assertNotNull(familyNameDisplay.getName());
@@ -750,35 +745,11 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                         }
                     }
                     {
-                        Claim claim = jwtVcClaims.get(2);
-                        assertEquals("The jwt_vc-credential claim credentialSubject.birthdate is present.",
-                                CREDENTIAL_SUBJECT,
-                                claim.getPath().get(0));
-                        assertEquals("The jwt_vc-credential claim credentialSubject.birthdate is present.",
-                                "birthdate",
-                                claim.getPath().get(1));
-                        assertFalse("The jwt_vc-credential claim credentialSubject.birthdate is not mandatory.",
-                                claim.isMandatory());
-                        assertNotNull("The jwt_vc-credential claim credentialSubject.birthdate has display configured",
-                                claim.getDisplay());
-                        assertEquals(15, claim.getDisplay().size());
-                        for (ClaimDisplay birthDateDisplay : claim.getDisplay()) {
-                            assertNotNull(birthDateDisplay.getName());
-                            assertNotNull(birthDateDisplay.getLocale());
-                        }
-                    }
-                    {
                         Claim claim = jwtVcClaims.get(3);
-                        assertEquals("The jwt_vc-credential claim credentialSubject.email is present.",
-                                CREDENTIAL_SUBJECT,
-                                claim.getPath().get(0));
-                        assertEquals("The jwt_vc-credential claim credentialSubject.email is present.",
-                                "email",
-                                claim.getPath().get(1));
-                        assertFalse("The jwt_vc-credential claim credentialSubject.email is not mandatory.",
-                                claim.isMandatory());
-                        assertNotNull("The jwt_vc-credential claim credentialSubject.email has display configured",
-                                claim.getDisplay());
+                        assertEquals("Has credentialSubject.birthdate", CREDENTIAL_SUBJECT, claim.getPath().get(0));
+                        assertEquals("credentialSubject.birthdate mapped correctly","birthdate", claim.getPath().get(1));
+                        assertFalse("credentialSubject.birthdate is not mandatory", claim.isMandatory());
+                        assertNotNull("credentialSubject.birthdate has display", claim.getDisplay());
                         assertEquals(15, claim.getDisplay().size());
                         for (ClaimDisplay birthDateDisplay : claim.getDisplay()) {
                             assertNotNull(birthDateDisplay.getName());
@@ -787,16 +758,22 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     }
                     {
                         Claim claim = jwtVcClaims.get(4);
-                        assertEquals("The jwt_vc-credential claim credentialSubject.scope-name is present.",
-                                CREDENTIAL_SUBJECT,
-                                claim.getPath().get(0));
-                        assertEquals("The jwt_vc-credential claim credentialSubject.scope-name is present.",
-                                "scope-name",
-                                claim.getPath().get(1));
-                        assertFalse("The jwt_vc-credential claim credentialSubject.scope-name is not mandatory.",
-                                claim.isMandatory());
-                        assertNull("The jwt_vc-credential claim credentialSubject.scope-name has no display configured",
-                                claim.getDisplay());
+                        assertEquals("Has credentialSubject.email", CREDENTIAL_SUBJECT, claim.getPath().get(0));
+                        assertEquals("credentialSubject.email mapped correctly","email", claim.getPath().get(1));
+                        assertFalse("credentialSubject.email is not mandatory", claim.isMandatory());
+                        assertNotNull("credentialSubject.email has display", claim.getDisplay());
+                        assertEquals(15, claim.getDisplay().size());
+                        for (ClaimDisplay birthDateDisplay : claim.getDisplay()) {
+                            assertNotNull(birthDateDisplay.getName());
+                            assertNotNull(birthDateDisplay.getLocale());
+                        }
+                    }
+                    {
+                        Claim claim = jwtVcClaims.get(5);
+                        assertEquals("Has credentialSubject.scope-name", CREDENTIAL_SUBJECT, claim.getPath().get(0));
+                        assertEquals("credentialSubject.scope-name mapped correctly","scope-name", claim.getPath().get(1));
+                        assertFalse("credentialSubject.scope-name is not mandatory", claim.isMandatory());
+                        assertNull("credentialSubject.scope-name has no display", claim.getDisplay());
                     }
 
                     assertEquals("The jwt_vc-credential should offer vct",

--- a/testsuite/integration-arquillian/tests/base/src/test/resources/oid4vc/test-credential-mappers.json
+++ b/testsuite/integration-arquillian/tests/base/src/test/resources/oid4vc/test-credential-mappers.json
@@ -9,6 +9,16 @@
       }
     },
     {
+      "name": "subject-id",
+      "protocol": "oid4vc",
+      "protocolMapper": "oid4vc-subject-id-mapper",
+      "config": {
+        "claim.name": "id",
+        "userAttribute": "id",
+        "vc.mandatory": "false"
+      }
+    },
+    {
       "name": "givenName",
       "protocol": "oid4vc",
       "protocolMapper": "oid4vc-user-attribute-mapper",


### PR DESCRIPTION
closes #43854

This is the second attempt to fix the subject id issue. Unlike the previous attempt it is not concerned with SD JWT claim visibility nor does it introduce an additional 'did' user attribute.