### PR TITLE
fix: making cert lookup spi public

### DIFF
--- a/services/src/main/java/org/keycloak/services/x509/X509ClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/X509ClientCertificateLookup.java
@@ -35,6 +35,10 @@ public interface X509ClientCertificateLookup extends Provider {
     /**
      * Returns a client certificate, and optionally any certificates
      * in the certificate chain.
+     * <p>
+     * IMPORTANT: implementations should ensure that the source of the certificate is trusted.
+     * See for example the {@link HttpRequest#isProxyTrusted()} method.
+     *
      * @return
      */
     X509Certificate[] getCertificateChain(HttpRequest httpRequest) throws GeneralSecurityException;

--- a/services/src/main/java/org/keycloak/services/x509/X509ClientCertificateLookupSpi.java
+++ b/services/src/main/java/org/keycloak/services/x509/X509ClientCertificateLookupSpi.java
@@ -32,7 +32,7 @@ public class X509ClientCertificateLookupSpi implements Spi {
 
     @Override
     public boolean isInternal() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Rationale for this change:
- the api has been stable for years
- we have several examples of users creating their own cert providers, but that is not considered supported and they see warnings about this being an internal api.
- external contribution of new providers seems to take a long time #36161 

On timing, this is optional for 26.5.

closes: #33818

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
