### PR TITLE
[OID4VCI] Fix OID4VCI credential requests to restrict Default client scopes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol;
 
 import java.util.Map;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.WebApplicationException;
 
 import org.keycloak.events.EventBuilder;
@@ -84,5 +85,20 @@ public interface LoginProtocolFactory extends ProviderFactory<LoginProtocol> {
      */
     default boolean isValidClientScope(KeycloakSession session, ClientModel client, ClientScopeModel clientScope) {
         return true;
+    }
+
+    /**
+     * Validates whether a client scope can be assigned as Default or Optional to a client or realm.
+     * This method is called before assigning a client scope to ensure protocol-specific restrictions are enforced.
+     *
+     * @param session      the Keycloak session
+     * @param clientScope  the client scope to be assigned
+     * @param defaultScope true if assigning as Default scope, false if Optional
+     * @param realm        the realm where the assignment is happening
+     * @throws BadRequestException if the assignment is not allowed
+     */
+    default void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope, boolean defaultScope, RealmModel realm) {
+        // Default implementation: no validation (allows all assignments)
+        // Protocol-specific implementations can override to enforce restrictions
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -137,7 +137,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
             naturalPersonScope.addProtocolMapper(builtins.get(FIRST_NAME_MAPPER));
             naturalPersonScope.addProtocolMapper(builtins.get(LAST_NAME_MAPPER));
             addClientScopeDefaults(naturalPersonScope);
-            newRealm.addDefaultClientScope(naturalPersonScope, true);
+            newRealm.addDefaultClientScope(naturalPersonScope, false);
         }
     }
 
@@ -202,6 +202,25 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
     @Override
     public int order() {
         return OIDCLoginProtocolFactory.UI_ORDER - 20;
+    }
+
+    @Override
+    public void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope, boolean defaultScope, RealmModel realm) {
+        if (!OID4VC_PROTOCOL.equals(clientScope.getProtocol())) {
+            return;
+        }
+
+        if (!realm.isVerifiableCredentialsEnabled()) {
+            throw new ErrorResponseException("invalid_request",
+                    "OID4VCI client scopes cannot be assigned when Verifiable Credentials is disabled for the realm",
+                    Response.Status.BAD_REQUEST);
+        }
+
+        if (defaultScope) {
+            throw new ErrorResponseException("invalid_request",
+                    "OID4VCI client scopes cannot be assigned as Default scopes. Only Optional scope assignment is supported.",
+                    Response.Status.BAD_REQUEST);
+        }
     }
 
     // Private ---------------------------------------------------------------------------------------------------------

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -852,8 +852,7 @@ public class OID4VCIssuerEndpoint {
             }
 
             // Find the configured scope in the login client
-            // Check both Default and Optional client scopes
-            ClientScopeModel clientScope = getOid4vciClientScopes(clientModel).get(credConfig.getScope());
+            ClientScopeModel clientScope = clientModel.getClientScopes(false).get(credConfig.getScope());
             if (clientScope == null) {
                 var errorMessage = String.format("Client scope not found: %s", credConfig.getScope());
                 eventBuilder.detail(Details.REASON, errorMessage).error(Errors.INVALID_REQUEST);
@@ -1487,8 +1486,7 @@ public class OID4VCIssuerEndpoint {
         ClientModel clientModel = session.getContext().getClient();
 
         // Get the client scope that matches the credentialConfig scope
-        // Check both Default and Optional client scopes
-        Map<String, ClientScopeModel> clientScopes = getOid4vciClientScopes(clientModel);
+        Map<String, ClientScopeModel> clientScopes = clientModel.getClientScopes(false);
         ClientScopeModel clientScopeModel = clientScopes.get(credentialConfig.getScope());
 
         if (clientScopeModel == null) {
@@ -1496,34 +1494,6 @@ public class OID4VCIssuerEndpoint {
         }
 
         return new CredentialScopeModel(clientScopeModel);
-    }
-
-    /**
-     * Returns all OID4VCI client scopes (both Default and Optional) assigned to the client.
-     * This combines scopes from both getClientScopes(true) for Default scopes
-     * and getClientScopes(false) for Optional scopes, filtering to only include
-     * scopes with the OID4VC protocol.
-     *
-     * @param clientModel the client model
-     * @return a map of OID4VCI client scopes (scope name -> ClientScopeModel)
-     */
-    private Map<String, ClientScopeModel> getOid4vciClientScopes(ClientModel clientModel) {
-        Map<String, ClientScopeModel> allScopes = new HashMap<>();
-
-        if (clientModel == null) {
-            return allScopes;
-        }
-
-        clientModel.getClientScopes(true).values().stream()
-                .filter(scope -> OID4VC_PROTOCOL.equals(scope.getProtocol()))
-                .forEach(scope -> allScopes.put(scope.getName(), scope));
-
-        // Optional scopes override defaults
-        clientModel.getClientScopes(false).values().stream()
-                .filter(scope -> OID4VC_PROTOCOL.equals(scope.getProtocol()))
-                .forEach(scope -> allScopes.put(scope.getName(), scope));
-
-        return allScopes;
     }
 
     private Response getErrorResponse(ErrorType errorType) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -62,6 +62,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.protocol.ClientInstallationProvider;
+import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.LoginProtocolFactory;
 import org.keycloak.protocol.oidc.OIDCClientSecretConfigWrapper;
 import org.keycloak.representations.adapters.action.GlobalRequestResult;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -424,6 +426,9 @@ public class ClientResource {
         if (defaultScope && clientScope.isDynamicScope()) {
             throw new ErrorResponseException("invalid_request", "Can't assign a Dynamic Scope to a Client as a Default Scope", Response.Status.BAD_REQUEST);
         }
+
+        validateClientScopeAssignment(session, clientScope, defaultScope, realm);
+        
         client.addClientScope(clientScope, defaultScope);
 
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE_CLIENT_MAPPING).resourcePath(session.getContext().getUri()).success();
@@ -843,6 +848,23 @@ public class ClientResource {
         RepresentationToModel.updateClient(rep, client, session);
         RepresentationToModel.updateClientProtocolMappers(rep, client);
         updateAuthorizationSettings(rep);
+    }
+
+    /**
+     * Validates client scope assignment using protocol-specific validation if available.
+     *
+     * @param session      the Keycloak session
+     * @param clientScope  the client scope to be assigned
+     * @param defaultScope true if assigning as Default scope, false if Optional
+     * @param realm        the realm where the assignment is happening
+     */
+    public static void validateClientScopeAssignment(KeycloakSession session, ClientScopeModel clientScope,
+                                                     boolean defaultScope, RealmModel realm) {
+        LoginProtocolFactory loginProtocolFactory = (LoginProtocolFactory) session.getKeycloakSessionFactory()
+                .getProviderFactory(LoginProtocol.class, clientScope.getProtocol());
+        if (loginProtocolFactory != null) {
+            loginProtocolFactory.validateClientScopeAssignment(session, clientScope, defaultScope, realm);
+        }
     }
 
     public static void updateClientServiceAccount(KeycloakSession session, ClientModel client, Boolean isServiceAccountEnabled) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -292,6 +292,9 @@ public class RealmAdminResource {
         if (clientScope == null) {
             throw new NotFoundException("Client scope not found");
         }
+        
+        ClientResource.validateClientScopeAssignment(session, clientScope, defaultScope, realm);
+        
         realm.addDefaultClientScope(clientScope, defaultScope);
 
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE).resourcePath(session.getContext().getUri()).success();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -212,27 +212,27 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         // Lookup the pre-installed oid4vc_natural_person client scope
         sdJwtTypeNaturalPersonClientScope = requireExistingClientScope(sdJwtTypeNaturalPersonScopeName);
 
-        // Register the optional client scopes
-        sdJwtTypeCredentialClientScope = registerOptionalClientScope(sdJwtTypeCredentialScopeName,
-                                                                     null,
-                                                                     sdJwtTypeCredentialConfigurationIdName,
+        // Register the client scopes
+        sdJwtTypeCredentialClientScope = registerClientScope(sdJwtTypeCredentialScopeName,
+                                                             null,
+                                                             sdJwtTypeCredentialConfigurationIdName,
                                                                      sdJwtTypeCredentialScopeName,
                                                                      sdJwtCredentialVct,
                                                                      Format.SD_JWT_VC,
                                                                      null,
                                                                      List.of(KeyAttestationResistanceLevels.HIGH,
                                                                              KeyAttestationResistanceLevels.MODERATE));
-        jwtTypeCredentialClientScope = registerOptionalClientScope(jwtTypeCredentialScopeName,
-                                                                   TEST_DID.toString(),
-                                                                   jwtTypeCredentialConfigurationIdName,
+        jwtTypeCredentialClientScope = registerClientScope(jwtTypeCredentialScopeName,
+                                                           TEST_DID.toString(),
+                                                           jwtTypeCredentialConfigurationIdName,
                                                                    jwtTypeCredentialScopeName,
                                                                    null,
                                                                    Format.JWT_VC,
                                                                    TEST_CREDENTIAL_MAPPERS_FILE,
                                                                    Collections.emptyList());
-        minimalJwtTypeCredentialClientScope = registerOptionalClientScope("vc-with-minimal-config",
-                                                                          null,
-                                                                          null,
+        minimalJwtTypeCredentialClientScope = registerClientScope("vc-with-minimal-config",
+                                                                  null,
+                                                                  null,
                                                                           null,
                                                                           null,
                                                                           null,
@@ -266,14 +266,29 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         return null;
     }
 
-    private ClientScopeRepresentation registerOptionalClientScope(String scopeName,
-                                                                  String issuerDid,
-                                                                  String credentialConfigurationId,
-                                                                  String credentialIdentifier,
-                                                                  String vct,
-                                                                  String format,
-                                                                  String protocolMapperReferenceFile,
-                                                                  List<String> acceptedKeyAttestationValues) {
+    /**
+     * Registers a client scope in the realm. This method creates and registers the scope
+     * but does NOT assign it to any client. Assignment as Default or Optional must be done
+     * separately by the test.
+     *
+     * @param scopeName the name of the client scope
+     * @param issuerDid the issuer DID
+     * @param credentialConfigurationId the credential configuration ID
+     * @param credentialIdentifier the credential identifier
+     * @param vct the verifiable credential type
+     * @param format the credential format
+     * @param protocolMapperReferenceFile reference to protocol mapper file
+     * @param acceptedKeyAttestationValues accepted key attestation values
+     * @return the registered ClientScopeRepresentation
+     */
+    protected ClientScopeRepresentation registerClientScope(String scopeName,
+                                                            String issuerDid,
+                                                            String credentialConfigurationId,
+                                                            String credentialIdentifier,
+                                                            String vct,
+                                                            String format,
+                                                            String protocolMapperReferenceFile,
+                                                            List<String> acceptedKeyAttestationValues) {
         // Check if the client scope already exists
         List<ClientScopeRepresentation> existingScopes = testRealm().clientScopes().findAll();
         for (ClientScopeRepresentation existingScope : existingScopes) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -31,8 +31,10 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
@@ -60,6 +62,7 @@ import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentatio
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.managers.AppAuthManager.BearerTokenAuthenticator;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
@@ -948,8 +951,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
      */
     @Test
     public void testCredentialRequestWithOptionalClientScope() {
-        // Create and register scope, then assign as Optional
-        ClientScopeRepresentation optionalScope = registerClientScope(
+        ClientScopeRepresentation optionalScope = registerOptionalClientScope(
                 "optional-jwt-credential",
                 TEST_DID.toString(),
                 "optional-jwt-credential-config-id",
@@ -989,47 +991,86 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     }
 
     /**
-     * Test that credential requests work when the client scope is assigned as Default.
+     * Test that OID4VCI client scopes cannot be assigned as Default to a client.
      */
     @Test
-    public void testCredentialRequestWithDefaultClientScope() {
-        // Create and register scope, then assign as Default
-        ClientScopeRepresentation defaultScope = registerClientScope(
-                "default-jwt-credential",
+    public void testCannotAssignOid4vciScopeAsDefaultToClient() {
+        ClientScopeRepresentation oid4vciScope = registerOptionalClientScope(
+                "test-oid4vci-scope",
                 TEST_DID.toString(),
-                "default-jwt-credential-config-id",
+                "test-oid4vci-config-id",
                 null, null,
                 Format.JWT_VC,
                 null, null);
         
         ClientRepresentation testClient = testRealm().clients().findByClientId(client.getClientId()).get(0);
-        testRealm().clients().get(testClient.getId()).addDefaultClientScope(defaultScope.getId());
+        ClientResource clientResource = testRealm().clients().get(testClient.getId());
+        
+        try {
+            clientResource.addDefaultClientScope(oid4vciScope.getId());
+            Assert.fail("Expected BadRequestException when trying to assign OID4VCI scope as Default");
+        } catch (BadRequestException e) {
+            OAuth2ErrorRepresentation error = e.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("OID4VCI client scopes cannot be assigned as Default scopes. Only Optional scope assignment is supported.",
+                    error.getErrorDescription());
+        }
+    }
 
-        // Extract serializable data before lambda
-        final String scopeName = defaultScope.getName();
-        final String configId = defaultScope.getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
-        String token = getBearerToken(oauth, client, scopeName);
+    @Test
+    public void testCannotAssignOid4vciScopeAsDefaultToRealm() {
+        ClientScopeRepresentation oid4vciScope = registerOptionalClientScope(
+                "test-oid4vci-realm-scope",
+                TEST_DID.toString(),
+                "test-oid4vci-realm-config-id",
+                null, null,
+                Format.JWT_VC,
+                null, null);
+        
+        try {
+            testRealm().addDefaultDefaultClientScope(oid4vciScope.getId());
+            Assert.fail("Expected BadRequestException when trying to assign OID4VCI scope as realm Default");
+        } catch (BadRequestException e) {
+            OAuth2ErrorRepresentation error = e.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("OID4VCI client scopes cannot be assigned as Default scopes. Only Optional scope assignment is supported.",
+                    error.getErrorDescription());
+        }
+    }
+
+    /**
+     * Test that OID4VCI client scopes cannot be assigned even as Optional when OID4VCI is disabled at realm level.
+     */
+    @Test
+    public void testCannotAssignOid4vciScopeWhenRealmDisabled() {
+        ClientScopeRepresentation oid4vciScope = registerOptionalClientScope(
+                "test-oid4vci-disabled-scope",
+                TEST_DID.toString(),
+                "test-oid4vci-disabled-config-id",
+                null, null,
+                Format.JWT_VC,
+                null, null);
 
         testingClient.server(TEST_REALM_NAME).run(session -> {
-            BearerTokenAuthenticator authenticator = new BearerTokenAuthenticator(session);
-            authenticator.setTokenString(token);
-            OID4VCIssuerEndpoint issuerEndpoint = prepareIssuerEndpoint(session, authenticator);
-
-            CredentialRequest credentialRequest = new CredentialRequest()
-                    .setCredentialConfigurationId(configId);
-
-            String requestPayload = JsonSerialization.writeValueAsString(credentialRequest);
-            Response credentialResponse = issuerEndpoint.requestCredential(requestPayload);
-
-            assertEquals("The credential request should succeed for Default client scope",
-                    HttpStatus.SC_OK, credentialResponse.getStatus());
-            assertNotNull("A credential should be returned", credentialResponse.getEntity());
-
-            CredentialResponse credentialResponseVO = JsonSerialization.mapper
-                    .convertValue(credentialResponse.getEntity(), CredentialResponse.class);
-
-            assertNotNull("Credentials array should not be null", credentialResponseVO.getCredentials());
-            assertFalse("Credentials array should not be empty", credentialResponseVO.getCredentials().isEmpty());
+            RealmModel realm = session.getContext().getRealm();
+            realm.setVerifiableCredentialsEnabled(false);
         });
+
+        try {
+            ClientRepresentation testClient = testRealm().clients().findByClientId(client.getClientId()).get(0);
+            ClientResource clientResource = testRealm().clients().get(testClient.getId());
+            
+            try {
+                clientResource.addOptionalClientScope(oid4vciScope.getId());
+                Assert.fail("Expected BadRequestException when OID4VCI is disabled at realm level");
+            } catch (BadRequestException e) {
+                OAuth2ErrorRepresentation error = e.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+                assertEquals("OID4VCI client scopes cannot be assigned when Verifiable Credentials is disabled for the realm",
+                        error.getErrorDescription());
+            }
+        } finally {
+            testingClient.server(TEST_REALM_NAME).run(session -> {
+                RealmModel realm = session.getContext().getRealm();
+                realm.setVerifiableCredentialsEnabled(true);
+            });
+        }
     }
 }


### PR DESCRIPTION
This PR implements backend validation to restrict OID4VCI client scope assignments as default:

Changes:
- OID4VCI scopes can only be assigned as Optional scopes (not Default)
- OID4VCI scopes cannot be assigned when the Verifiable Credentials feature is disabled at the realm level
- The pre-created `oid4vc_natural_person` scope is now assigned as Optional by default

Closes #44737