### PR TITLE
Fix German translation placeholder for organization membership title

### DIFF
--- a/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
+++ b/themes/src/main/resources-community/theme/base/login/messages/messages_de.properties
@@ -474,7 +474,7 @@ auth-x509-client-username-form-help-text=Melden Sie sich mit einem X509 Client-Z
 organization.member.register.title=Erstellen Sie ein Konto, um der Organization ${kc.org.name} beizutreten
 auth-x509-client-username-form-display-name=X509 Zertifikat
 passkey-unsupported-browser-text=Passkey wird von diesem Browser nicht unterstützt. Probieren Sie einen anderen oder kontaktieren Sie Ihren Administrator.
-organization.confirm-membership.title=Sie sind dabei, der Organization ${kc.org} beizutreten
+organization.confirm-membership.title=Sie sind dabei, der Organization ${kc.org.name} beizutreten
 
 # Passkey
 passkey-login-title=Anmeldung mit Passkey


### PR DESCRIPTION
Closes #45020

Fixes a wrong placeholder in the German translation for
`organization.confirm-membership.title`.
`${kc.org}` was not resolved and is replaced with `${kc.org.name}`.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
