### PR TITLE
Fix realm import failure when OID4VCI credential-offer-create role exists

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -138,7 +138,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         // Process authorization_details using provider discovery
         List<AuthorizationDetailsResponse> authorizationDetailsResponses = processAuthorizationDetails(userSession, sessionContext);
-        LOGGER.infof("Initial authorization_details processing result: %s", authorizationDetailsResponses);
+        LOGGER.debugf("Initial authorization_details processing result: %s", authorizationDetailsResponses);
 
         // If no authorization_details were processed from the request, try to generate them from credential offer
         if (authorizationDetailsResponses == null || authorizationDetailsResponses.isEmpty()) {

--- a/services/src/main/java/org/keycloak/services/managers/RealmManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/RealmManager.java
@@ -257,6 +257,10 @@ public class RealmManager {
     }
 
     protected void setupRealmDefaults(RealmModel realm) {
+        setupRealmDefaults(realm, null);
+    }
+
+    protected void setupRealmDefaults(RealmModel realm, RealmRepresentation realmRep) {
         realm.setBrowserSecurityHeaders(BrowserSecurityHeaders.realmDefaultHeaders);
 
         // brute force
@@ -275,7 +279,10 @@ public class RealmManager {
         realm.setLoginWithEmailAllowed(true);
 
         if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI)) {
-            if (realm.getRole(CREDENTIAL_OFFER_CREATE.getName()) == null) {
+            // Only create the role if it doesn't exist in the realm representation (during import)
+            // or if it doesn't exist in the realm model (during fresh creation)
+            if ((realmRep == null || !hasRealmRole(realmRep, CREDENTIAL_OFFER_CREATE.getName())) 
+                    && realm.getRole(CREDENTIAL_OFFER_CREATE.getName()) == null) {
                 RoleModel roleModel = realm.addRole(CREDENTIAL_OFFER_CREATE.getName());
                 roleModel.setDescription(CREDENTIAL_OFFER_CREATE.getDescription());
             }
@@ -591,7 +598,7 @@ public class RealmManager {
 
             // setup defaults
 
-            setupRealmDefaults(realm);
+            setupRealmDefaults(realm, rep);
 
             if (rep.getDefaultRole() == null) {
                 KeycloakModelUtils.setupDefaultRole(realm, determineDefaultRoleName(rep));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -31,7 +31,9 @@ import java.util.Set;
 
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authentication.requiredactions.WebAuthnRegisterFactory;
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.Strategy;
 import org.keycloak.exportimport.dir.DirExportProvider;
@@ -46,10 +48,12 @@ import org.keycloak.representations.idm.KeysMetadataRepresentation;
 import org.keycloak.representations.idm.RealmEventsConfigRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.testsuite.AbstractKeycloakTest;
 import org.keycloak.testsuite.Assert;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
 import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
 import org.keycloak.testsuite.client.resources.TestingExportImportResource;
 import org.keycloak.testsuite.runonserver.RunHelpers;
@@ -318,6 +322,62 @@ public class ExportImportTest extends AbstractKeycloakTest {
         assertThat(config, notNullValue());
         assertThat(config.size(), equalTo(1));
         JsonTestUtils.assertJsonEquals(config.getFirst(DeclarativeUserProfileProvider.UP_COMPONENT_CONFIG_KEY), JsonSerialization.writeValueAsString(persistedConfig), UPConfig.class);
+    }
+
+    @Test
+    @EnableFeature(value = Profile.Feature.OID4VC_VCI, skipRestart = true)
+    public void testRealmImportWithOID4VCICredentialOfferCreateRole() throws Throwable {
+        String testRealmName = "oid4vci-import-test";
+        
+        // Create a realm with OID4VCI enabled - credential-offer-create role will be created automatically
+        RealmRepresentation realmRep = new RealmRepresentation();
+        realmRep.setRealm(testRealmName);
+        realmRep.setEnabled(true);
+        adminClient.realms().create(realmRep);
+        
+        // Verify the role exists after creation
+        RealmResource realmResource = adminClient.realm(testRealmName);
+        RoleRepresentation credentialOfferCreateRole = realmResource.roles().get(OID4VCIConstants.CREDENTIAL_OFFER_CREATE.getName()).toRepresentation();
+        assertNotNull("credential-offer-create role should exist after realm creation", credentialOfferCreateRole);
+        assertEquals("Role name should match", OID4VCIConstants.CREDENTIAL_OFFER_CREATE.getName(), credentialOfferCreateRole.getName());
+        
+        // Export the realm
+        TestingExportImportResource exportImport = testingClient.testing().exportImport();
+        exportImport.setProvider(SingleFileExportProviderFactory.PROVIDER_ID);
+        exportImport.setAction(ExportImportConfig.ACTION_EXPORT);
+        exportImport.setRealmName(testRealmName);
+        String targetFilePath = exportImport.getExportImportTestDirectory() + File.separator + "oid4vci-realm-export.json";
+        exportImport.setFile(targetFilePath);
+        exportImport.runExport();
+        
+        // Verify the exported file contains the role
+        Map<String, RealmRepresentation> exportedRealms = ImportUtils.getRealmsFromStream(JsonSerialization.mapper, new FileInputStream(targetFilePath));
+        RealmRepresentation exportedRealm = exportedRealms.get(testRealmName);
+        assertNotNull("Exported realm should exist", exportedRealm);
+        assertTrue("Exported realm should contain credential-offer-create role",
+                exportedRealm.getRoles() != null && 
+                exportedRealm.getRoles().getRealm() != null &&
+                exportedRealm.getRoles().getRealm().stream()
+                    .anyMatch(role -> OID4VCIConstants.CREDENTIAL_OFFER_CREATE.getName().equals(role.getName())));
+        
+        // Remove the realm
+        removeRealm(testRealmName);
+        
+        // Import the realm back - this should succeed without ModelDuplicateException
+        exportImport.setAction(ExportImportConfig.ACTION_IMPORT);
+        exportImport.runImport();
+        
+        // Verify the realm was imported successfully
+        RealmResource importedRealmResource = adminClient.realm(testRealmName);
+        assertNotNull("Imported realm should exist", importedRealmResource);
+        
+        // Verify the role still exists after import
+        RoleRepresentation importedRole = importedRealmResource.roles().get(OID4VCIConstants.CREDENTIAL_OFFER_CREATE.getName()).toRepresentation();
+        assertNotNull("credential-offer-create role should exist after import", importedRole);
+        assertEquals("Role name should match", OID4VCIConstants.CREDENTIAL_OFFER_CREATE.getName(), importedRole.getName());
+
+        // Cleanup
+        removeRealm(testRealmName);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/exportimport/ExportImportTest.java
@@ -225,7 +225,10 @@ public class ExportImportTest extends AbstractKeycloakTest {
     private static void assertExportContainsGoogleClientSecret(String targetFilePath) throws IOException {
         assertTrue("Expected an export file to exist", new File(targetFilePath).exists());
 
-        Map<String, RealmRepresentation> realms = ImportUtils.getRealmsFromStream(JsonSerialization.mapper, new FileInputStream(new File(targetFilePath)));
+        Map<String, RealmRepresentation> realms;
+        try (FileInputStream fis = new FileInputStream(targetFilePath)) {
+            realms = ImportUtils.getRealmsFromStream(JsonSerialization.mapper, fis);
+        }
         List<IdentityProviderRepresentation> idps = realms.get("test-realm").getIdentityProviders();
         IdentityProviderRepresentation googleIdp = idps.stream().filter(idp -> idp.getAlias().equals("google1")).findFirst().get();
         assertNotNull(googleIdp);
@@ -351,7 +354,10 @@ public class ExportImportTest extends AbstractKeycloakTest {
         exportImport.runExport();
         
         // Verify the exported file contains the role
-        Map<String, RealmRepresentation> exportedRealms = ImportUtils.getRealmsFromStream(JsonSerialization.mapper, new FileInputStream(targetFilePath));
+        Map<String, RealmRepresentation> exportedRealms;
+        try (FileInputStream fis = new FileInputStream(targetFilePath)) {
+            exportedRealms = ImportUtils.getRealmsFromStream(JsonSerialization.mapper, fis);
+        }
         RealmRepresentation exportedRealm = exportedRealms.get(testRealmName);
         assertNotNull("Exported realm should exist", exportedRealm);
         assertTrue("Exported realm should contain credential-offer-create role",

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAttestationProofTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAttestationProofTest.java
@@ -197,8 +197,6 @@ public class OID4VCAttestationProofTest extends OID4VCIssuerEndpointTest {
                         jsonWebToken.getOtherClaims().get("vc"), VerifiableCredential.class);
                 assertNotNull("VerifiableCredential should not be null", vc);
                 assertNotNull("Credential subject should not be null", vc.getCredentialSubject());
-
-                LOGGER.infof("Successfully issued credential with attestation proof");
             } catch (Exception e) {
                 LOGGER.error("Test failed with exception", e);
                 fail("Test should not throw exception: " + e.getMessage());


### PR DESCRIPTION
This PR modifies setupRealmDefaults() to check for credential-offer-create role in the realm representation before creating it during import. This prevents ModelDuplicateException when importing a realm that already contains the built-in OID4VCI role.

The fix follows the same pattern used for offline_access role handling:
- Added overloaded setupRealmDefaults() method that accepts optional RealmRepresentation parameter
- Check hasRealmRole() before creating credential-offer-create role
- Updated importRealm() to pass realm representation to setupRealmDefaults()
- Preserves backward compatibility for fresh realm creation

Added testRealmImportWithOID4VCICredentialOfferCreateRole() to verify that realm import succeeds when the role is present in exported JSON.

Closes #44637
