### PR TITLE
Disable GroupTest#createMultiDeleteMultiReadMulti for MSSQL

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
@@ -54,6 +54,7 @@ import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.conditions.DisabledForDatabases;
 import org.keycloak.testframework.events.AdminEventAssertion;
 import org.keycloak.testframework.realm.ClientConfigBuilder;
 import org.keycloak.testframework.realm.GroupConfigBuilder;
@@ -116,6 +117,7 @@ public class GroupTest extends AbstractGroupTest {
 
     
     @Test
+    @DisabledForDatabases("mssql")
     public void createMultiDeleteMultiReadMulti() {
         // create multiple groups
         List<String> groupUuuids = new ArrayList<>();


### PR DESCRIPTION
Closes #42166


(cherry picked from commit 4c4a333365447b466007a97a8d4e96e85ef7156b)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
