### PR TITLE
Extend documentation on ServiceMonitor creation

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -544,6 +544,21 @@ The {project_name} Operator automatically generates a `ServiceMonitor` resource 
 `ServiceMonitor` resource to be created, the `monitoring.coreos.com/v1:ServiceMonitor` Custom Resource Definition (CRD)
 must be installed on your {kubernetes} cluster.
 
+A ServiceMonitor is only created if the `metrics-enabled` option is set.
+
+.Enable Keycloak metrics
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  additionalOptions:
+    - name: metrics-enabled
+      value: "true"
+----
+
 The Operator generates a `ServiceMonitor` with the following spec:
 
 .Default ServiceMonitor


### PR DESCRIPTION
The documentation so far only mentions how to disable the ServiceMonitor, leading to the assumption that it is enabled by default.

Getting a service monitor created also requires enabling metrics in keycloak, though:

https://github.com/keycloak/keycloak/blob/658faf210f2ff91ee254ff9fcc62ddfbcbcd9e42/operator/src/main/java/org/keycloak/operator/controllers/KeycloakServiceMonitorDependentResource.java#L50

While the missing setting creates a warning, the administrator should already have this information before applying the configuration.

Closes #45070

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
