### PR TITLE
Add missing repeatHelp translation key

### DIFF
--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_tr.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_tr.properties
@@ -1114,6 +1114,7 @@ userGroupsRetrieveStrategyHelp=Kullanıcı gruplarının nasıl alınacağını 
 hour=Saat
 connectionTimeoutHelp=Milisaniye cinsinden LDAP bağlantı zaman aşımı
 repeat=Tekrarla
+repeatHelp=Politika zaman kısıtlamasının nasıl tanımlandığını belirtir. 'Tekrarlama' seçilirse, politika yalnızca başlangıç ve bitiş zamanları arasında geçerli olur. 'Tekrarla' seçilirse, politikayı ay, gün, saat ve dakika aralıkları gibi belirli tekrarlayan zaman dilimlerine ek olarak kısıtlayabilirsiniz.
 defaultSigAlgHelp=Realm için token'ları imzalamak için kullanılan varsayılan algoritma
 save-admin-eventsHelp=Etkinleştirilirse, yönetici olayları veritabanına kaydedilir ve olayları Yönetici UI'da kullanılabilir hale getirir.
 policyGroupsHelp=Bu politika tarafından hangi kullanıcı(lar)a izin verildiğini belirtir.

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -1150,6 +1150,7 @@ userGroupsRetrieveStrategyHelp=Specify how to retrieve groups of user. LOAD_GROU
 hour=Hour
 connectionTimeoutHelp=LDAP connection timeout in milliseconds
 repeat=Repeat
+repeatHelp=Specifies how the policy time restriction is defined. If 'Not Repeat', the policy is granted only between the start and expire times. If 'Repeat', you can additionally restrict the policy to specific recurring time periods such as month, day, hour, and minute ranges.
 defaultSigAlgHelp=Default algorithm used to sign tokens for the realm
 save-admin-eventsHelp=If enabled, admin events are saved to the database, which makes events available to the Admin UI.
 policyGroupsHelp=Specifies which user(s) are allowed by this policy.


### PR DESCRIPTION
## Summary
  - Added missing `repeatHelp` translation value for the Time policy form
  - Translations included: English and Turkish
  - Translation text was written based on existing Keycloak help text patterns and similar policy translations

## Note
  Other languages are missing this translation as well. I can add AI-generated translations for other languages if
  needed, though I can only personally verify English and Turkish. 

Closes #45085
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->