### PR TITLE
fix: clear all filters when resetting attribute search

### DIFF
--- a/js/apps/admin-ui/src/components/users/UserDataTableAttributeSearchForm.tsx
+++ b/js/apps/admin-ui/src/components/users/UserDataTableAttributeSearchForm.tsx
@@ -33,6 +33,7 @@ type UserDataTableAttributeSearchFormProps = {
   profile: UserProfileConfig;
   createAttributeSearchChips: () => ReactNode;
   searchUserWithAttributes: () => void;
+  clearAllFilters: () => void;
 };
 
 type UserFilterForm = UserAttribute & { exact: boolean };
@@ -43,6 +44,7 @@ export function UserDataTableAttributeSearchForm({
   profile,
   createAttributeSearchChips,
   searchUserWithAttributes,
+  clearAllFilters,
 }: UserDataTableAttributeSearchFormProps) {
   const { t } = useTranslation();
   const { addAlert } = useAlerts();
@@ -134,6 +136,7 @@ export function UserDataTableAttributeSearchForm({
       (chip) => chip.name !== chip.name,
     );
     setActiveFilters({ ...activeFilters, userAttribute: filtered });
+    clearAllFilters();
   };
 
   const createAttributeKeyInputField = () => {

--- a/js/apps/admin-ui/src/components/users/UserDataTableToolbarItems.tsx
+++ b/js/apps/admin-ui/src/components/users/UserDataTableToolbarItems.tsx
@@ -137,6 +137,7 @@ export function UserDataTableToolbarItems({
             setActiveFilters={setActiveFilters}
             profile={profile}
             createAttributeSearchChips={createAttributeSearchChips}
+            clearAllFilters={clearAllFilters}
             searchUserWithAttributes={() => {
               searchUserWithAttributes();
               setSearchDropdownOpen(false);


### PR DESCRIPTION
Closes #45108

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
## Summary

Pass `clearAllFilters` callback to `UserDataTableAttributeSearchForm` and call it in `clearActiveFilters` to trigger UI refresh on reset.

Fixes bug where reset cleared filter state but didn't refresh the user list.

### Demo Video

[kc-user-attr-search-bug-fix.webm](https://github.com/user-attachments/assets/a7ba716d-198d-436a-a057-7a38293e0c27)
