### PR TITLE
Fix unhandled IllegalArgumentException in SAMLRequestParser

### DIFF
--- a/saml-core/src/main/java/org/keycloak/saml/SAMLRequestParser.java
+++ b/saml-core/src/main/java/org/keycloak/saml/SAMLRequestParser.java
@@ -63,7 +63,13 @@ public class SAMLRequestParser {
 
     public static SAMLDocumentHolder parseRequestPostBinding(String samlMessage) {
         InputStream is;
-        byte[] samlBytes = PostBindingUtil.base64Decode(samlMessage);
+        byte[] samlBytes;
+        try {
+            samlBytes = PostBindingUtil.base64Decode(samlMessage);
+        } catch (IllegalArgumentException e) {
+            logger.samlBase64DecodingError(e);
+            return null;
+        }
         if (log.isDebugEnabled()) {
             String str = new String(samlBytes, GeneralConstants.SAML_CHARSET);
             log.debug("SAML POST Binding");
@@ -79,7 +85,13 @@ public class SAMLRequestParser {
     }
 
     public static SAMLDocumentHolder parseResponsePostBinding(String samlMessage) {
-        byte[] samlBytes = PostBindingUtil.base64Decode(samlMessage);
+        byte[] samlBytes;
+        try {
+            samlBytes = PostBindingUtil.base64Decode(samlMessage);
+        } catch (IllegalArgumentException e) {
+            logger.samlBase64DecodingError(e);
+            return null;
+        }
         log.debug("SAML POST Binding");
         return parseResponseDocument(samlBytes);
     }

--- a/saml-core/src/test/java/org/keycloak/saml/SAMLRequestParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/SAMLRequestParserTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.saml;
+
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link SAMLRequestParser}.
+ */
+public class SAMLRequestParserTest {
+
+    /**
+     * Tests that parseRequestPostBinding returns null instead of throwing
+     * IllegalArgumentException when given invalid Base64 input.
+     *
+     * @see <a href="https://github.com/keycloak/keycloak/issues/44803">Issue #44803</a>
+     */
+    @Test
+    public void testParseRequestPostBindingWithInvalidBase64ReturnsNull() {
+        // Invalid Base64 string containing '?' character (decimal 63)
+        String invalidBase64 = "SGVsbG8gV29ybGQ/InvalidBase64!@#$";
+
+        SAMLDocumentHolder result = SAMLRequestParser.parseRequestPostBinding(invalidBase64);
+
+        assertNull("parseRequestPostBinding should return null for invalid Base64 input", result);
+    }
+
+    /**
+     * Tests that parseResponsePostBinding returns null instead of throwing
+     * IllegalArgumentException when given invalid Base64 input.
+     *
+     * @see <a href="https://github.com/keycloak/keycloak/issues/44803">Issue #44803</a>
+     */
+    @Test
+    public void testParseResponsePostBindingWithInvalidBase64ReturnsNull() {
+        // Invalid Base64 string containing '?' character (decimal 63)
+        String invalidBase64 = "SGVsbG8gV29ybGQ/InvalidBase64!@#$";
+
+        SAMLDocumentHolder result = SAMLRequestParser.parseResponsePostBinding(invalidBase64);
+
+        assertNull("parseResponsePostBinding should return null for invalid Base64 input", result);
+    }
+
+    @Test
+    public void testParseRequestPostBindingWithNullReturnsNullArgumentException() {
+        try {
+            SAMLRequestParser.parseRequestPostBinding(null);
+            // If we get here, the method didn't throw an exception which is unexpected
+            // for null input based on PostBindingUtil.base64Decode behavior
+        } catch (IllegalArgumentException e) {
+            // Expected - null input throws IllegalArgumentException
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary
closes: #44803 - Handle invalid Base64 input in SAMLRequestParser to return proper 400 Bad Request instead of 500 Internal Server Error.

  ## Changes
  - Added try-catch for `IllegalArgumentException` in `parseRequestPostBinding()` and `parseResponsePostBinding()`
  - When Base64 decoding fails, methods now return `null` (matching the pattern used in redirect binding methods)
  - Added unit tests in `SAMLRequestParserTest`
  - Added integration test in `BasicSamlTest`

  ## Test plan
  - [x] Unit test: `SAMLRequestParserTest.testParseRequestPostBindingWithInvalidBase64ReturnsNull`
  - [x] Unit test: `SAMLRequestParserTest.testParseResponsePostBindingWithInvalidBase64ReturnsNull`
  - [x] Integration test: `BasicSamlTest.testInvalidBase64InSamlRequestReturnsBadRequest`

  ## How to verify
  ```bash
  curl -X POST "http://localhost:8080/realms/master/protocol/saml" \
  --data-urlencode "SAMLRequest=InvalidBase64!@#$"
  Should return 400 Bad Request instead of 500 Internal Server Error.
  ```
