### PR TITLE
Fix organization invitation redirect to respect account client base URL

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/ClientAttributeUpdater.java
@@ -155,6 +155,11 @@ public class ClientAttributeUpdater extends ServerResourceUpdater<ClientAttribut
         return this;
     }
 
+    public ClientAttributeUpdater setBaseUrl(String baseUrl) {
+        rep.setBaseUrl(baseUrl);
+        return this;
+    }
+
     public ClientAttributeUpdater addDefaultClientScope(String clientScope) {
         rep.getDefaultClientScopes().add(clientScope);
         return this;


### PR DESCRIPTION
## Description

When an organization's redirect URL is left empty, Keycloak currently defaults to the account console URL, ignoring the account client's configured Home URL (base URL). 

This fix checks the account client's base URL before falling back to the default account console URL.

## Changes

- Added `resolveAccountClientBaseUrl()` helper method in `OrganizationInvitationResource`
- Added `setBaseUrl()` method to `ClientAttributeUpdater` test utility  
- Added integration tests for the new behavior

Closes https://github.com/keycloak/keycloak/issues/45052
