### PR TITLE
Add required attribute to mandatory login form fields

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -80,8 +80,10 @@ import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
 
 import static org.keycloak.common.Profile.Feature.DYNAMIC_SCOPES;
 import static org.keycloak.testsuite.admin.ApiUtil.findClientByClientId;
@@ -1111,4 +1113,15 @@ public class LoginTest extends AbstractChangeImportedUserPasswordsTest {
            Assert.assertNotNull(session.authenticationSessions().getRootAuthenticationSession(session.getContext().getRealm(), authSessionId));
         });
    }
+
+    @Test
+    public void testLoginFieldsHaveRequiredAttribute() {
+        loginPage.open();
+
+        WebElement usernameInput = driver.findElement(By.id("username"));
+        assertNotNull("Username field should have required attribute", usernameInput.getDomAttribute("required"));
+
+        WebElement passwordInput = driver.findElement(By.id("password"));
+        assertNotNull("Password field should have required attribute", passwordInput.getDomAttribute("required"));
+    }
 }

--- a/themes/src/main/resources/theme/keycloak.v2/login/field.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/field.ftl
@@ -46,6 +46,7 @@
     <span class="${properties.kcInputClass} <#if error?has_content>${properties.kcError}</#if>">
         <input id="${name}" name="${name}" value="${value}" type="text" autocomplete="${autocomplete}" <#if autofocus>autofocus</#if>
                 <#if autocomplete == "one-time-code">inputmode="numeric"</#if>
+                <#if required>required</#if>
                 aria-invalid="<#if error?has_content>true</#if>"/>
         <@errorIcon error=error/>
     </span>
@@ -58,6 +59,7 @@
       <div class="${properties.kcInputGroupItemClass} ${properties.kcFill}">
         <span class="${properties.kcInputClass} <#if error?has_content>${properties.kcError}</#if>">
           <input id="${name}" name="${name}" value="${value}" type="password" autocomplete="${autocomplete}" <#if autofocus>autofocus</#if>
+                  <#if required>required</#if>
                   aria-invalid="<#if error?has_content>true</#if>"/>
           <@errorIcon error=error/>
         </span>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-password.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-password.ftl
@@ -10,7 +10,7 @@
         <div id="kc-form">
             <div id="kc-form-wrapper">
                 <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-                    <@field.password name="password" label=msg("password") forgotPassword=realm.resetPasswordAllowed autofocus=true autocomplete="current-password" />
+                    <@field.password name="password" label=msg("password") forgotPassword=realm.resetPasswordAllowed autofocus=true autocomplete="current-password" required=true />
                     <@buttons.loginButton />
                 </form>
             </div>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-username.ftl
@@ -19,7 +19,7 @@
                                 <#assign label>
                                     <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
                                 </#assign>
-                                <@field.input name="username" label=label value=login.username!'' autofocus=true autocomplete="${(enableWebAuthnConditionalUI?has_content)?then('username webauthn', 'username')}" />
+                                <@field.input name="username" label=label value=login.username!'' autofocus=true autocomplete="${(enableWebAuthnConditionalUI?has_content)?then('username webauthn', 'username')}" required=true />
                             </div>
                         </#if>
 

--- a/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login.ftl
@@ -18,14 +18,14 @@
                             <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
                         </#assign>
                         <@field.input name="username" label=label error=kcSanitize(messagesPerField.getFirstError('username','password'))?no_esc
-                            autofocus=true autocomplete="${(enableWebAuthnConditionalUI?has_content)?then('username webauthn', 'username')}" value=login.username!'' />
-                        <@field.password name="password" label=msg("password") error="" forgotPassword=realm.resetPasswordAllowed autofocus=usernameHidden?? autocomplete="current-password">
+                            autofocus=true autocomplete="${(enableWebAuthnConditionalUI?has_content)?then('username webauthn', 'username')}" value=login.username!'' required=true />
+                        <@field.password name="password" label=msg("password") error="" forgotPassword=realm.resetPasswordAllowed autofocus=usernameHidden?? autocomplete="current-password" required=true>
                             <#if realm.rememberMe && !usernameHidden??>
                                 <@field.checkbox name="rememberMe" label=msg("rememberMe") value=login.rememberMe?? />
                             </#if>
                         </@field.password>
                     <#else>
-                        <@field.password name="password" label=msg("password") forgotPassword=realm.resetPasswordAllowed autofocus=usernameHidden?? autocomplete="current-password">
+                        <@field.password name="password" label=msg("password") forgotPassword=realm.resetPasswordAllowed autofocus=usernameHidden?? autocomplete="current-password" required=true>
                             <#if realm.rememberMe && !usernameHidden??>
                                 <@field.checkbox name="rememberMe" label=msg("rememberMe") value=login.rememberMe?? />
                             </#if>


### PR DESCRIPTION
Added the HTML `required` attribute to mandatory input fields in the Keycloak V2 login theme to improve accessibility for screen reader users.

### Changes
- Updated `field.ftl` macros to render `required` attribute when `required=true`
- Added `required=true` to username/password fields in login flows:
  - `login.ftl` (main login)
  - `login-username.ftl` (username-only login)
  - `login-password.ftl` (password-only login)
- Added integration test to verify required attribute is present

Closes #44912

### Screenshots

**1. Login Page**

<img src="https://github.com/user-attachments/assets/4fd2a460-d077-49cf-9da3-53bb1c68dee2" width="500">
<br/><br/><br/>

**2. Identity-First Login (Username → Password)**

<table>
  <tr>
    <td align="center"><b>Username-only Page</b></td>
    <td align="center"><b>Password-only Page</b></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/aea1aa91-a84a-48d4-9ddd-6a718250dd9a" width="400"></td>
    <td><img src="https://github.com/user-attachments/assets/5f295122-2fd0-45fe-ad3f-0903c0ea06e8" width="400"></td>
  </tr>
</table>