### PR TITLE
[OID4VCI] Make OID4VC credential offer storage cluster-aware and rename provider

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorageFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorageFactory.java
@@ -20,14 +20,21 @@ import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 
-public class InMemoryCredentialOfferStorageFactory implements CredentialOfferStorageFactory {
+/**
+ * Factory for {@link DefaultCredentialOfferStorage}.
+ * 
+ * <p>This factory provides the default cluster-aware implementation of credential offer storage.
+ * The storage uses Keycloak's distributed cache infrastructure, making it suitable for
+ * clustered and cross-DC deployments.
+ */
+public class DefaultCredentialOfferStorageFactory implements CredentialOfferStorageFactory {
 
     private static CredentialOfferStorage INSTANCE;
 
     @Override
     public CredentialOfferStorage create(KeycloakSession session) {
         if (INSTANCE == null) {
-            INSTANCE = new InMemoryCredentialOfferStorage();
+            INSTANCE = new DefaultCredentialOfferStorage();
         }
         return INSTANCE;
     }
@@ -42,6 +49,6 @@ public class InMemoryCredentialOfferStorageFactory implements CredentialOfferSto
 
     @Override
     public String getId() {
-        return "in_memory";
+        return "default";
     }
 }

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageFactory
@@ -1,1 +1,1 @@
-org.keycloak.protocol.oid4vc.issuance.credentialoffer.InMemoryCredentialOfferStorageFactory
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.DefaultCredentialOfferStorageFactory


### PR DESCRIPTION
This PR renames and improves `InMemoryCredentialOfferStorage` to reflect its true cluster-aware behavior. 

## Changes:

- Replace `InMemoryCredentialOfferStorage` with `DefaultCredentialOfferStorage` backed by singleUseObjects (Infinispan)
- Fix expiration handling by converting absolute expiration timestamps to lifespan seconds and skipping already-expired entries
- Rename factory to `DefaultCredentialOfferStorageFactory` and change provider id to default
- Update SPI service registration and add JavaDoc clarifying cluster/cross-DC behavior

Closes #44674
