### PR TITLE
fix: updating owasp.html.sanitizer.version to addresss CVE-2025-66021

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <log4j2-api.version>2.25.1</log4j2-api.version> <!-- Odd name needs to align with Quarkus -->
         <resteasy.version>6.2.12.Final</resteasy.version>
         <resteasy.undertow.version>${resteasy.version}</resteasy.undertow.version>
-        <owasp.html.sanitizer.version>20240325.1</owasp.html.sanitizer.version>
+        <owasp.html.sanitizer.version>20260101.1</owasp.html.sanitizer.version>
         <slf4j.version>2.0.6</slf4j.version>
         <sun.istack.version>3.0.10</sun.istack.version>
         <sun.saaj.version>2.0.1</sun.saaj.version>


### PR DESCRIPTION
closes #45097

Marked as on hold until the productized jar is available. @ahus1 to double check does this mean that a 26.4.8 is not planned in the near-term.

Signed-off-by: Steve Hawkins <shawkins@redhat.com>
(cherry picked from commit 6dc2e269be651be112876b2242994429407f9ae6)
