### PR TITLE
fix: ensuring that Keycloak test launch doesn't capture runtime defaults

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -39,6 +39,7 @@ public final class Environment {
 
     public static final String KC_CONFIG_REBUILD_CHECK = "kc.config.rebuild-check";
     public static final String KC_CONFIG_BUILT = "kc.config.built";
+    public static final String KC_TEST_REBUILD = "kc.test.rebuild";
     private static final String KC_HOME_DIR = "kc.home.dir";
     public static final String NON_SERVER_MODE = "nonserver";
     public static final String PROFILE ="kc.profile";

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -75,13 +75,13 @@ public final class PropertyMappers {
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
         PropertyMapper<?> mapper = getMapper(name);
 
-        // During re-aug do not resolve server runtime properties and avoid they included by quarkus in the default value config source.
+        // During re-aug do not resolve server runtime properties and avoid including in the quarkus default value config source.
         //
         // The special handling of log properties is because some logging runtime properties are requested during build time
         // and we need to resolve them. That should be fine as they are generally not considered security sensitive.
         // If however expressions are not enabled that means quarkus is specifically looking for runtime defaults, and we should not provide a value
         // See https://github.com/quarkusio/quarkus/pull/42157
-        if (isRebuild() && isKeycloakRuntime(name, mapper)
+        if ((isRebuild() || Boolean.getBoolean(Environment.KC_TEST_REBUILD)) && isKeycloakRuntime(name, mapper)
                 && (NestedPropertyMappingInterceptor.getResolvingRoot().or(() -> Optional.of(name))
                         .filter(n -> n.startsWith("quarkus.log.") || n.startsWith("quarkus.console.")).isEmpty()
                         || !Expressions.isEnabled())) {

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/Keycloak.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/Keycloak.java
@@ -205,7 +205,9 @@ public class Keycloak {
             AugmentAction action = curated.createAugmentor();
             Environment.setHomeDir(homeDir);
             ConfigArgsConfigSource.setCliArgs(args.toArray(new String[0]));
+            System.setProperty(Environment.KC_TEST_REBUILD, "true");
             StartupAction startupAction = action.createInitialRuntimeApplication();
+            System.getProperties().remove(Environment.KC_TEST_REBUILD);
 
             application = startupAction.runMainClass(args.toArray(new String[0]));
 


### PR DESCRIPTION
closes: #41630

The issue here is that the augmentation phase is capturing the raw runtime default values. For several logging options is the value "default", which is then converted to a boolean.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
