### PR TITLE
Add SAML client model mapper for admin-v2 API

### DIFF
--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/SAMLClientModelMapper.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/SAMLClientModelMapper.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.mapper;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+
+/**
+ * Mapper for SAML clients between model and representation.
+ */
+public class SAMLClientModelMapper extends BaseClientModelMapper<SAMLClientRepresentation> {
+
+    // SAML attribute keys
+    private static final String SAML_NAME_ID_FORMAT = "saml_name_id_format";
+    private static final String SAML_FORCE_NAME_ID_FORMAT = "saml_force_name_id_format";
+    private static final String SAML_AUTHN_STATEMENT = "saml.authnstatement";
+    private static final String SAML_SERVER_SIGNATURE = "saml.server.signature";
+    private static final String SAML_ASSERTION_SIGNATURE = "saml.assertion.signature";
+    private static final String SAML_CLIENT_SIGNATURE = "saml.client.signature";
+    private static final String SAML_FORCE_POST_BINDING = "saml.force.post.binding";
+    private static final String SAML_SIGNATURE_ALGORITHM = "saml.signature.algorithm";
+    private static final String SAML_SIGNATURE_CANONICALIZATION = "saml_signature_canonicalization_method";
+    private static final String SAML_SIGNING_CERTIFICATE = "saml.signing.certificate";
+    private static final String SAML_ALLOW_ECP_FLOW = "saml.allow.ecp.flow";
+
+    public SAMLClientModelMapper(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    protected SAMLClientRepresentation createClientRepresentation() {
+        return new SAMLClientRepresentation();
+    }
+
+    @Override
+    protected void fromModelSpecific(ClientModel model, SAMLClientRepresentation rep) {
+        // Name ID settings
+        rep.setNameIdFormat(model.getAttribute(SAML_NAME_ID_FORMAT));
+        rep.setForceNameIdFormat(getBooleanAttribute(model, SAML_FORCE_NAME_ID_FORMAT));
+
+        // Signature settings
+        rep.setIncludeAuthnStatement(getBooleanAttribute(model, SAML_AUTHN_STATEMENT));
+        rep.setSignDocuments(getBooleanAttribute(model, SAML_SERVER_SIGNATURE));
+        rep.setSignAssertions(getBooleanAttribute(model, SAML_ASSERTION_SIGNATURE));
+        rep.setClientSignatureRequired(getBooleanAttribute(model, SAML_CLIENT_SIGNATURE));
+        rep.setSignatureAlgorithm(model.getAttribute(SAML_SIGNATURE_ALGORITHM));
+        rep.setSignatureCanonicalizationMethod(model.getAttribute(SAML_SIGNATURE_CANONICALIZATION));
+        rep.setSigningCertificate(model.getAttribute(SAML_SIGNING_CERTIFICATE));
+
+        // Binding and logout settings
+        rep.setForcePostBinding(getBooleanAttribute(model, SAML_FORCE_POST_BINDING));
+        rep.setFrontChannelLogout(model.isFrontchannelLogout());
+
+        // ECP flow
+        rep.setAllowEcpFlow(getBooleanAttribute(model, SAML_ALLOW_ECP_FLOW));
+    }
+
+    @Override
+    protected void toModelSpecific(SAMLClientRepresentation rep, ClientModel model) {
+        model.setProtocol(SAMLClientRepresentation.PROTOCOL);
+
+        // Name ID settings
+        setAttributeIfNotNull(model, SAML_NAME_ID_FORMAT, rep.getNameIdFormat());
+        setBooleanAttributeIfNotNull(model, SAML_FORCE_NAME_ID_FORMAT, rep.getForceNameIdFormat());
+
+        // Signature settings
+        setBooleanAttributeIfNotNull(model, SAML_AUTHN_STATEMENT, rep.getIncludeAuthnStatement());
+        setBooleanAttributeIfNotNull(model, SAML_SERVER_SIGNATURE, rep.getSignDocuments());
+        setBooleanAttributeIfNotNull(model, SAML_ASSERTION_SIGNATURE, rep.getSignAssertions());
+        setBooleanAttributeIfNotNull(model, SAML_CLIENT_SIGNATURE, rep.getClientSignatureRequired());
+        setAttributeIfNotNull(model, SAML_SIGNATURE_ALGORITHM, rep.getSignatureAlgorithm());
+        setAttributeIfNotNull(model, SAML_SIGNATURE_CANONICALIZATION, rep.getSignatureCanonicalizationMethod());
+        setAttributeIfNotNull(model, SAML_SIGNING_CERTIFICATE, rep.getSigningCertificate());
+
+        // Binding and logout settings
+        setBooleanAttributeIfNotNull(model, SAML_FORCE_POST_BINDING, rep.getForcePostBinding());
+        if (rep.getFrontChannelLogout() != null) {
+            model.setFrontchannelLogout(rep.getFrontChannelLogout());
+        }
+
+        // ECP flow
+        setBooleanAttributeIfNotNull(model, SAML_ALLOW_ECP_FLOW, rep.getAllowEcpFlow());
+    }
+
+    private Boolean getBooleanAttribute(ClientModel model, String key) {
+        String value = model.getAttribute(key);
+        return value != null ? Boolean.parseBoolean(value) : null;
+    }
+
+    private void setAttributeIfNotNull(ClientModel model, String key, String value) {
+        if (value != null) {
+            model.setAttribute(key, value);
+        }
+    }
+
+    private void setBooleanAttributeIfNotNull(ClientModel model, String key, Boolean value) {
+        if (value != null) {
+            model.setAttribute(key, value.toString());
+        }
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/SAMLClientModelMapperFactory.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/models/mapper/SAMLClientModelMapperFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.mapper;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+
+/**
+ * Factory for creating SAMLClientModelMapper instances.
+ */
+public class SAMLClientModelMapperFactory implements ClientModelMapperFactory {
+
+    @Override
+    public ClientModelMapper create(KeycloakSession session) {
+        return new SAMLClientModelMapper(session);
+    }
+
+    @Override
+    public String getId() {
+        return SAMLClientRepresentation.PROTOCOL;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/SAMLClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/SAMLClientRepresentation.java
@@ -1,16 +1,195 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.keycloak.representations.admin.v2;
 
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
+ * Representation of a SAML client.
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
  */
-@Schema
+@Schema(description = "SAML Client configuration")
 public class SAMLClientRepresentation extends BaseClientRepresentation {
     public static final String PROTOCOL = "saml";
+
+    @JsonPropertyDescription("Name ID format to use for the subject (e.g., 'username', 'email', 'transient', 'persistent')")
+    private String nameIdFormat;
+
+    @JsonPropertyDescription("Force the specified Name ID format even if the client requests a different one")
+    private Boolean forceNameIdFormat;
+
+    @JsonPropertyDescription("Include AuthnStatement in the SAML response")
+    private Boolean includeAuthnStatement;
+
+    @JsonPropertyDescription("Sign SAML documents on the server side")
+    private Boolean signDocuments;
+
+    @JsonPropertyDescription("Sign SAML assertions")
+    private Boolean signAssertions;
+
+    @JsonPropertyDescription("Require client to sign SAML requests")
+    private Boolean clientSignatureRequired;
+
+    @JsonPropertyDescription("Force POST binding for SAML responses")
+    private Boolean forcePostBinding;
+
+    @JsonPropertyDescription("Use front-channel logout (browser redirect)")
+    private Boolean frontChannelLogout;
+
+    @JsonPropertyDescription("Signature algorithm for signing SAML documents (e.g., 'RSA_SHA256', 'RSA_SHA512')")
+    private String signatureAlgorithm;
+
+    @JsonPropertyDescription("Canonicalization method for XML signatures")
+    private String signatureCanonicalizationMethod;
+
+    @JsonPropertyDescription("X.509 certificate for signing (PEM format, without headers)")
+    private String signingCertificate;
+
+    @JsonPropertyDescription("Allow ECP (Enhanced Client or Proxy) flow")
+    private Boolean allowEcpFlow;
 
     @Override
     public String getProtocol() {
         return PROTOCOL;
+    }
+
+    public String getNameIdFormat() {
+        return nameIdFormat;
+    }
+
+    public void setNameIdFormat(String nameIdFormat) {
+        this.nameIdFormat = nameIdFormat;
+    }
+
+    public Boolean getForceNameIdFormat() {
+        return forceNameIdFormat;
+    }
+
+    public void setForceNameIdFormat(Boolean forceNameIdFormat) {
+        this.forceNameIdFormat = forceNameIdFormat;
+    }
+
+    public Boolean getIncludeAuthnStatement() {
+        return includeAuthnStatement;
+    }
+
+    public void setIncludeAuthnStatement(Boolean includeAuthnStatement) {
+        this.includeAuthnStatement = includeAuthnStatement;
+    }
+
+    public Boolean getSignDocuments() {
+        return signDocuments;
+    }
+
+    public void setSignDocuments(Boolean signDocuments) {
+        this.signDocuments = signDocuments;
+    }
+
+    public Boolean getSignAssertions() {
+        return signAssertions;
+    }
+
+    public void setSignAssertions(Boolean signAssertions) {
+        this.signAssertions = signAssertions;
+    }
+
+    public Boolean getClientSignatureRequired() {
+        return clientSignatureRequired;
+    }
+
+    public void setClientSignatureRequired(Boolean clientSignatureRequired) {
+        this.clientSignatureRequired = clientSignatureRequired;
+    }
+
+    public Boolean getForcePostBinding() {
+        return forcePostBinding;
+    }
+
+    public void setForcePostBinding(Boolean forcePostBinding) {
+        this.forcePostBinding = forcePostBinding;
+    }
+
+    public Boolean getFrontChannelLogout() {
+        return frontChannelLogout;
+    }
+
+    public void setFrontChannelLogout(Boolean frontChannelLogout) {
+        this.frontChannelLogout = frontChannelLogout;
+    }
+
+    public String getSignatureAlgorithm() {
+        return signatureAlgorithm;
+    }
+
+    public void setSignatureAlgorithm(String signatureAlgorithm) {
+        this.signatureAlgorithm = signatureAlgorithm;
+    }
+
+    public String getSignatureCanonicalizationMethod() {
+        return signatureCanonicalizationMethod;
+    }
+
+    public void setSignatureCanonicalizationMethod(String signatureCanonicalizationMethod) {
+        this.signatureCanonicalizationMethod = signatureCanonicalizationMethod;
+    }
+
+    public String getSigningCertificate() {
+        return signingCertificate;
+    }
+
+    public void setSigningCertificate(String signingCertificate) {
+        this.signingCertificate = signingCertificate;
+    }
+
+    public Boolean getAllowEcpFlow() {
+        return allowEcpFlow;
+    }
+
+    public void setAllowEcpFlow(Boolean allowEcpFlow) {
+        this.allowEcpFlow = allowEcpFlow;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SAMLClientRepresentation that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(nameIdFormat, that.nameIdFormat) 
+                && Objects.equals(forceNameIdFormat, that.forceNameIdFormat) 
+                && Objects.equals(includeAuthnStatement, that.includeAuthnStatement) 
+                && Objects.equals(signDocuments, that.signDocuments) 
+                && Objects.equals(signAssertions, that.signAssertions) 
+                && Objects.equals(clientSignatureRequired, that.clientSignatureRequired) 
+                && Objects.equals(forcePostBinding, that.forcePostBinding) 
+                && Objects.equals(frontChannelLogout, that.frontChannelLogout) 
+                && Objects.equals(signatureAlgorithm, that.signatureAlgorithm) 
+                && Objects.equals(signatureCanonicalizationMethod, that.signatureCanonicalizationMethod) 
+                && Objects.equals(signingCertificate, that.signingCertificate) 
+                && Objects.equals(allowEcpFlow, that.allowEcpFlow);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), nameIdFormat, forceNameIdFormat, includeAuthnStatement, 
+                signDocuments, signAssertions, clientSignatureRequired, forcePostBinding, 
+                frontChannelLogout, signatureAlgorithm, signatureCanonicalizationMethod, 
+                signingCertificate, allowEcpFlow);
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -19,6 +19,7 @@ import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
 import org.keycloak.representations.admin.v2.validation.CreateClientDefault;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.services.ServiceException;
 import org.keycloak.services.resources.admin.ClientResource;
@@ -86,10 +87,17 @@ public class DefaultClientService implements ClientService {
             created = true;
             validator.validate(client, CreateClientDefault.class); // TODO improve it to avoid second validation when we know it is create and not update
 
-            model = mapper.toModel(client);
-            var rep = ModelToRepresentation.toRepresentation(model, session);
-            model = clientsResource.createClientModel(rep);
+            // First, create a basic v1 representation to persist the client in the database.
+            // We can't use mapper.toModel(client) directly for creation because the "detached model"
+            var basicRep = new ClientRepresentation();
+            basicRep.setClientId(client.getClientId());
+            basicRep.setProtocol(client.getProtocol());
+
+            // Create the client in the database
+            model = clientsResource.createClientModel(basicRep);
             clientResource = clientsResource.getClient(model.getId());
+
+            mapper.toModel(client, model);
         }
 
         handleRoles(client.getRoles());

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -60,7 +60,9 @@ public class DefaultClientService implements ClientService {
                                                    ClientSearchOptions searchOptions, ClientSortAndSliceOptions sortAndSliceOptions) {
         // TODO: is the access map on the representation needed
         return clientsResource.getClientModels(null, true, false, null, null, null)
-                .map(model -> session.getProvider(ClientModelMapper.class, model.getProtocol()).fromModel(model));
+                .filter(model -> model.getProtocol() != null) // Skip clients with null protocol
+                .map(model -> session.getProvider(ClientModelMapper.class, model.getProtocol()).fromModel(model))
+                .filter(java.util.Objects::nonNull);
     }
 
     @Override

--- a/rest/admin-v2/api/src/main/resources/META-INF/services/org.keycloak.models.mapper.ClientModelMapperFactory
+++ b/rest/admin-v2/api/src/main/resources/META-INF/services/org.keycloak.models.mapper.ClientModelMapperFactory
@@ -1,1 +1,2 @@
 org.keycloak.models.mapper.OIDCClientModelMapperFactory
+org.keycloak.models.mapper.SAMLClientModelMapperFactory

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.tests.admin.client.v2;
 
+import java.util.List;
 import java.util.Set;
 
 import jakarta.ws.rs.core.HttpHeaders;
@@ -25,7 +26,9 @@ import jakarta.ws.rs.core.MediaType;
 import org.keycloak.admin.api.client.ClientApi;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.common.Profile;
+import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
 import org.keycloak.services.error.ViolationExceptionResponse;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
@@ -37,6 +40,7 @@ import org.keycloak.testframework.realm.RealmConfigBuilder;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpMessage;
 import org.apache.http.client.methods.HttpDelete;
@@ -221,6 +225,86 @@ public class ClientApiV2Test {
 
         try (var response = client.execute(getRequest)) {
             assertEquals(404, response.getStatusLine().getStatusCode());
+        }
+    }
+
+    @Test
+    public void getClientsMixedProtocols() throws Exception {
+        // Create an OIDC client
+        HttpPost oidcRequest = new HttpPost(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        setAuthHeader(oidcRequest);
+        oidcRequest.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        OIDCClientRepresentation oidcRep = new OIDCClientRepresentation();
+        oidcRep.setEnabled(true);
+        oidcRep.setClientId("mixed-test-oidc");
+        oidcRep.setDescription("OIDC client for mixed protocol test");
+
+        oidcRequest.setEntity(new StringEntity(mapper.writeValueAsString(oidcRep)));
+
+        try (var response = client.execute(oidcRequest)) {
+            assertEquals(201, response.getStatusLine().getStatusCode());
+        }
+
+        // Create a SAML client
+        HttpPost samlRequest = new HttpPost(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        setAuthHeader(samlRequest);
+        samlRequest.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        SAMLClientRepresentation samlRep = new SAMLClientRepresentation();
+        samlRep.setEnabled(true);
+        samlRep.setClientId("mixed-test-saml");
+        samlRep.setDescription("SAML client for mixed protocol test");
+
+        samlRequest.setEntity(new StringEntity(mapper.writeValueAsString(samlRep)));
+
+        try (var response = client.execute(samlRequest)) {
+            assertEquals(201, response.getStatusLine().getStatusCode());
+        }
+
+        // Get all clients - this should work with mixed protocols
+        HttpGet getRequest = new HttpGet(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients");
+        setAuthHeader(getRequest);
+
+        try (var response = client.execute(getRequest)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+
+            List<BaseClientRepresentation> clients = mapper.readValue(response.getEntity().getContent(),
+                    new TypeReference<List<BaseClientRepresentation>>() {});
+
+            // Should contain both our created clients
+            boolean foundOidc = clients.stream()
+                    .anyMatch(c -> "mixed-test-oidc".equals(c.getClientId()) && c instanceof OIDCClientRepresentation);
+            boolean foundSaml = clients.stream()
+                    .anyMatch(c -> "mixed-test-saml".equals(c.getClientId()) && c instanceof SAMLClientRepresentation);
+
+            assertThat("OIDC client should be in the list", foundOidc, is(true));
+            assertThat("SAML client should be in the list", foundSaml, is(true));
+        }
+
+        // Get individual SAML client
+        HttpGet getSamlRequest = new HttpGet(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/mixed-test-saml");
+        setAuthHeader(getSamlRequest);
+
+        try (var response = client.execute(getSamlRequest)) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            SAMLClientRepresentation samlClient = mapper.createParser(response.getEntity().getContent())
+                    .readValueAs(SAMLClientRepresentation.class);
+            assertEquals("mixed-test-saml", samlClient.getClientId());
+            assertEquals("SAML client for mixed protocol test", samlClient.getDescription());
+        }
+
+        // Cleanup
+        HttpDelete deleteOidc = new HttpDelete(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/mixed-test-oidc");
+        setAuthHeader(deleteOidc);
+        try (var response = client.execute(deleteOidc)) {
+            assertEquals(204, response.getStatusLine().getStatusCode());
+        }
+
+        HttpDelete deleteSaml = new HttpDelete(HOSTNAME_LOCAL_ADMIN + "/realms/master/clients/mixed-test-saml");
+        setAuthHeader(deleteSaml);
+        try (var response = client.execute(deleteSaml)) {
+            assertEquals(204, response.getStatusLine().getStatusCode());
         }
     }
 


### PR DESCRIPTION
Add SAML client model mapper for admin-v2 API

Implements mapper and factory for converting between SAMLClientModel
and SAMLClientRepresentation, including support for SAML-specific
attributes like signature algorithms, name ID formats, and certificates.

Fixes #44853

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
