### PR TITLE
Fix label wrapper class in config-totp template

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -52,7 +52,7 @@
 
         <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-totp-settings-form" method="post">
             <div class="${properties.kcFormGroupClass!}">
-                <div class="${properties.kcInputWrapperClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
                     <label for="totp" class="control-label">${msg("authenticatorCode")}</label> <span class="required">*</span>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
@@ -74,7 +74,7 @@
             </div>
 
             <div class="${properties.kcFormGroupClass!}">
-                <div class="${properties.kcInputWrapperClass!}">
+                <div class="${properties.kcLabelWrapperClass!}">
                     <label for="userLabel" class="control-label">${msg("loginTotpDeviceName")}</label> <#if totp.otpCredentials?size gte 1><span class="required">*</span></#if>
                 </div>
 


### PR DESCRIPTION
The labels in `login-config-totp.ftl` were wrapped with the `kcInputWrapperClass` instead of the intended `kcLabelWrapperClass`.

This caused incorrect styling in custom themes inheriting the base theme.

Update the markup to use `kcLabelWrapperClass`, matching the rest of the theme and ensuring consistent label styling.

Close #45053

---

### Caveats
- 👋🏼 Hello, first contribution here
- I did not run tests locally, not a Java developer (just ran `./mvnw spotless:*`)
- This may break custom themes based on the assumption that the wrapper class there is `kcInputWrapperClass`