### PR TITLE
[OID4VCI] Fix `authorization_details` being returned in subsequent SSO logins after OID4VCI flow

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -109,6 +109,7 @@ import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.protocol.oid4vc.utils.ClaimsPathPointer;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantType;
 import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantTypeFactory;
+import org.keycloak.protocol.oidc.rar.AuthorizationDetailsResponse;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.saml.processing.api.util.DeflateUtil;
@@ -775,8 +776,8 @@ public class OID4VCIssuerEndpoint {
 
         if (credentialIdentifier != null) {
 
-            // Retrieve the associated credential offer state
-            //
+            // First check if the credential identifier exists
+            // This allows proper error reporting for unknown identifiers
             CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
             CredentialOfferState offerState = offerStorage.findOfferStateByCredentialId(session, credentialIdentifier);
             if (offerState == null) {
@@ -786,8 +787,39 @@ public class OID4VCIssuerEndpoint {
             }
 
             // Get the credential_configuration_id from AuthorizationDetails
-            //
+            // First check if offer state has authorization_details (for pre-authorized flows)
             OID4VCAuthorizationDetailsResponse authDetails = offerState.getAuthorizationDetails();
+
+            // Validate authorization_details: either in token or in offer state
+            // For pre-authorized flows, offer state is the source of truth
+            // For authorization code flows, token must contain authorization_details
+            AccessToken accessToken = authResult.token();
+            Object tokenAuthDetails = accessToken.getOtherClaims().get(OAuth2Constants.AUTHORIZATION_DETAILS);
+            if (tokenAuthDetails == null && authDetails == null) {
+                var errorMessage = "Access token does not contain authorization_details and offer state has no authorization_details. " +
+                        "Only tokens issued with authorization_details can be used for credential requests with credential_identifier.";
+                LOGGER.debugf(errorMessage);
+                throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+            }
+
+            // Use authorization_details from offer state if available, otherwise from token
+            // For pre-authorized flows, offer state is authoritative
+            if (authDetails == null) {
+                // Extract from token if offer state doesn't have it
+                // This should be rare but handle it for robustness
+                if (tokenAuthDetails instanceof List) {
+                    List<AuthorizationDetailsResponse> tokenAuthDetailsList = (List<AuthorizationDetailsResponse>) tokenAuthDetails;
+                    if (!tokenAuthDetailsList.isEmpty() && tokenAuthDetailsList.get(0) instanceof OID4VCAuthorizationDetailsResponse) {
+                        authDetails = (OID4VCAuthorizationDetailsResponse) tokenAuthDetailsList.get(0);
+                    }
+                }
+            }
+
+            if (authDetails == null) {
+                var errorMessage = "No authorization_details found in offer state or token";
+                throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_REQUEST, errorMessage));
+            }
+            
             String credConfigId = authDetails.getCredentialConfigurationId();
             if (credConfigId == null) {
                 var errorMessage = "No credential_configuration_id in AuthorizationDetails";

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
@@ -69,6 +69,8 @@ import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Base class for authorization code flow tests with authorization details and claims validation.
@@ -132,6 +134,78 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         }
 
         return ctx;
+    }
+
+    /**
+     * Test that verifies that a second regular SSO login should NOT return authorization_details
+     * from a previous OID4VCI login.
+     */
+    @Test
+    public void testSecondSSOLoginDoesNotReturnAuthorizationDetails() throws Exception {
+        Oid4vcTestContext ctx = prepareOid4vcTestContext();
+
+        // ===== STEP 1: First login with OID4VCI (should return authorization_details) =====
+        AccessTokenResponse firstTokenResponse = authzCodeFlow(ctx);
+        String credentialIdentifier = assertTokenResponse(firstTokenResponse);
+        assertNotNull("Credential identifier should be present in first token", credentialIdentifier);
+
+        // ===== STEP 2: Second login - Regular SSO (should NOT return authorization_details) =====
+        // Second login WITHOUT OID4VCI scope and WITHOUT authorization_details.
+        oauth.client(client.getClientId());
+        oauth.scope(OAuth2Constants.SCOPE_OPENID);
+        oauth.openLoginForm();
+
+        String secondCode = oauth.parseLoginResponse().getCode();
+        assertNotNull("Second authorization code should not be null", secondCode);
+
+        // Exchange second code for tokens WITHOUT authorization_details
+        HttpPost postSecondToken = new HttpPost(ctx.openidConfig.getTokenEndpoint());
+        List<NameValuePair> secondTokenParameters = new LinkedList<>();
+        secondTokenParameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.AUTHORIZATION_CODE));
+        secondTokenParameters.add(new BasicNameValuePair(OAuth2Constants.CODE, secondCode));
+        secondTokenParameters.add(new BasicNameValuePair(OAuth2Constants.REDIRECT_URI, oauth.getRedirectUri()));
+        secondTokenParameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ID, oauth.getClientId()));
+        secondTokenParameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_SECRET, "password"));
+        // NOTE: NO authorization_details parameter in this request
+
+        UrlEncodedFormEntity secondTokenFormEntity = new UrlEncodedFormEntity(secondTokenParameters, StandardCharsets.UTF_8);
+        postSecondToken.setEntity(secondTokenFormEntity);
+
+        AccessTokenResponse secondTokenResponse;
+        try (CloseableHttpResponse tokenHttpResponse = httpClient.execute(postSecondToken)) {
+            assertEquals("Second token exchange should succeed", HttpStatus.SC_OK, tokenHttpResponse.getStatusLine().getStatusCode());
+            String tokenResponseBody = IOUtils.toString(tokenHttpResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+            secondTokenResponse = JsonSerialization.readValue(tokenResponseBody, AccessTokenResponse.class);
+        }
+
+        // ===== STEP 3: Verify second token does NOT have authorization_details =====
+        Map<String, Object> secondTokenMap = JsonSerialization.readValue(JsonSerialization.writeValueAsString(secondTokenResponse), Map.class);
+        Object secondAuthDetailsObj = secondTokenMap.get(OAuth2Constants.AUTHORIZATION_DETAILS);
+
+        assertNull("Second token (regular SSO) should NOT have authorization_details", secondAuthDetailsObj);
+
+        // ===== STEP 4: Verify second token cannot be used for credential requests =====
+        String credentialConfigurationId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
+        CredentialRequest credentialRequest = new CredentialRequest();
+        credentialRequest.setCredentialIdentifier(credentialIdentifier);
+
+        HttpPost postCredential = new HttpPost(ctx.credentialIssuer.getCredentialEndpoint());
+        postCredential.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + secondTokenResponse.getToken());
+        postCredential.addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        postCredential.setEntity(new StringEntity(JsonSerialization.writeValueAsString(credentialRequest), StandardCharsets.UTF_8));
+
+        // Credential request with second token should fail
+        // The second token doesn't have the OID4VCI scope, so it should fail at scope check
+        try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
+            assertEquals("Credential request with token without OID4VCI scope should fail",
+                    HttpStatus.SC_BAD_REQUEST, credentialResponse.getStatusLine().getStatusCode());
+
+            String errorBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+
+            assertTrue("Error should indicate scope check failure. Actual error: " + errorBody,
+                    errorBody.contains("Scope check failure"));
+        }
+
     }
 
     // Test for the whole authorization_code flow with the credentialRequest using credential_configuration_id


### PR DESCRIPTION
## Problem

When a user performs an OIDC login with OID4VCI scope and `authorization_details`, the token correctly includes `authorization_details`. However, if the same user performs a subsequent regular SSO login (without OID4VCI scope or authorization_details), the token response incorrectly included `authorization_details` from the previous login.

This occurred because `authorization_details` were stored in the user session, which persisted across multiple authentication flows in the same browser session.

## Solution

- Store `authorization_details` as claims in access tokens and refresh tokens instead of in the user session
- Only generate `authorization_details` from credential offers when:
  - No `authorization_details` were processed from the request, AND
  - A credential offer note exists in the client session (indicating an OID4VCI flow)

This ensures that `authorization_details` are only included in tokens that were explicitly issued with OID4VCI scope and `authorization_details` parameter.

closes #44961
