### PR TITLE
Login[v2]: Improve a11y for authenticator selector

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
@@ -14,7 +14,7 @@
                 <form id="kc-select-credential-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
                     <input type="hidden" name="authenticationExecution" value="${authenticationSelection.authExecId}">
                 </form>
-                <div class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].requestSubmit()">
+                <div role="button" class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].requestSubmit()" tabindex="0">
                     <div class="pf-v5-c-data-list__item-content">
                         <div class="${properties.kcSelectAuthListItemIconClass!}">
                             <i class="${properties['${authenticationSelection.iconCssClass}']!authenticationSelection.iconCssClass} ${properties.kcSelectAuthListItemIconPropertyClass!}"></i>


### PR DESCRIPTION
Clickable elements should be focusable and have interactive semantics. See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Guides/Understanding_WCAG/Keyboard?utm_source=devtools&utm_medium=a11y-panel-checks-keyboard#Interactive_elements_must_be_focusable

Closes #45227