### PR TITLE
Align user count to user search

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -450,7 +450,8 @@ public class UsersResource {
                     return session.users().getUsersCount(realm, parameters);
                 }
             }
-        } else if (last != null || first != null || email != null || username != null || emailVerified != null || enabled != null || !searchAttributes.isEmpty()) {
+        } else if (last != null || first != null || email != null || username != null || emailVerified != null
+            || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()) {
             Map<String, String> parameters = new HashMap<>();
             if (last != null) {
                 parameters.put(UserModel.LAST_NAME, last);


### PR DESCRIPTION
Closes #45219

Aligns the behaviour of the user count and user search admin REST API. Null checks on `exact`, `idpAlias` and `idpUserId` are consistents between the search and the count API.

Linked to https://github.com/keycloak/keycloak/pull/41980

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
