### PR TITLE
OTEL: Ability to specify headers for exporters

### DIFF
--- a/docs/documentation/release_notes/index.adoc
+++ b/docs/documentation/release_notes/index.adoc
@@ -13,6 +13,9 @@ include::topics/templates/document-attributes.adoc[]
 :release_header_latest_link: {releasenotes_link_latest}
 include::topics/templates/release-header.adoc[]
 
+== {project_name_full} 26.6.0
+include::topics/26_6_0.adoc[leveloffset=2]
+
 == {project_name_full} 26.5.0
 include::topics/26_5_0.adoc[leveloffset=2]
 

--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -21,3 +21,13 @@ For more information, see https://www.keycloak.org/server/logging#http-access-lo
 These properties are shared among the available OpenTelemetry components - logs, metrics, and traces.
 
 For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.
+
+= Custom request headers for OpenTelemetry
+
+It is now possible to set request headers for exporting telemetry via OpenTelemetry Protocol (OTLP).
+It is mainly useful for providing tokens in the request.
+
+You can specify these headers via the general parent option `telemetry-header-<header>` wildcard option, accepting any custom header name.
+Or you can use the `telemetry-logs-header-<header>` for OpenTelemetry Logs, or `telemetry-metrics-header-<header>` for OpenTelemetry Metrics.
+
+For more details, see the  link:{telemetryguide_link}[{telemetryguide_name}] guide.

--- a/docs/guides/observability/telemetry.adoc
+++ b/docs/guides/observability/telemetry.adoc
@@ -51,6 +51,18 @@ You can change the protocol via CLI as follows:
 
 <@kc.start parameters="--telemetry-protocol=http/protobuf"/>
 
+=== Request headers
+You can configure custom request headers that will be sent when exporting telemetry data to the OpenTelemetry collector.
+This is useful for providing authentication tokens or other custom headers required by your telemetry backend.
+
+Use the `telemetry-header-<header>` option to set headers for all telemetry components (logs, metrics, and traces).
+
+Replace `<header>` with your custom header name in the option name.
+
+<@kc.start parameters="--telemetry-header-Authorization='Bearer my-token' --telemetry-header-X-Custom-Header=custom-value"/>
+
+NOTE: Component-specific headers take precedence over general headers for their respective components.
+
 == Configuration via Keycloak CR (Operator)
 The Keycloak CR has first-class citizen configuration options for telemetry. These may be configured under the spec.telemtry stanza as follows:
 
@@ -100,6 +112,11 @@ For example, if you want only to export `WARN` and `ERROR` logs, you can change 
 
 <@kc.start parameters="--telemetry-logs-level=WARN"/>
 
+=== Request headers
+As stated for the general configuration of headers, you can configure custom request headers that will be used when exporting logs.
+
+<@kc.start parameters="--telemetry-logs-header-Authorization='Bearer logs-token'"/>
+
 == Metrics
 
 WARNING: The OpenTelemetry Metrics feature is currently experimental, and it is not recommended for use in production.
@@ -120,6 +137,11 @@ You can enable the OpenTelemetry Metrics via CLI as follows:
 NOTE: Metrics (`metrics-enabled`) needs to be enabled as well
 
 For more information on how to set up metrics, see the configuration options below or visit the https://www.keycloak.org/observability/configuration-metrics[Gaining insights with metrics guide].
+
+=== Request headers
+As stated for the general configuration of headers, you can configure custom request headers that will be used when exporting metrics.
+
+<@kc.start parameters="--telemetry-metrics-header-Authorization='Bearer metrics-token'"/>
 
 <@profile.ifCommunity>
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/TelemetryDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/TelemetryDeploymentTest.java
@@ -1,0 +1,86 @@
+package org.keycloak.operator.testsuite.integration;
+
+import java.util.List;
+
+import org.keycloak.operator.Constants;
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.deployment.ValueOrSecret;
+import org.keycloak.operator.testsuite.apiserver.DisabledIfApiServerTest;
+import org.keycloak.operator.testsuite.utils.K8sUtils;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.operator.testsuite.utils.K8sUtils.deployKeycloak;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisabledIfApiServerTest
+@QuarkusTest
+public class TelemetryDeploymentTest extends BaseOperatorTest {
+
+    @Test
+    public void telemetryHeaders() {
+        var kc = getTestKeycloakDeployment(false);
+        kc.getSpec().setImage(null); // doesn't seem to become ready with the custom image
+
+        // telemetry
+        K8sUtils.set(k8sclient, createSecret("telemetry-secret"));
+        addHeaderWithSecret(kc, "telemetry-header-Authorization", "telemetry-secret");
+
+        // telemetry logs
+        K8sUtils.set(k8sclient, createSecret("telemetry-logs-secret"));
+        addHeaderWithSecret(kc, "telemetry-logs-header-Authorization", "telemetry-logs-secret");
+
+        // telemetry metrics
+        K8sUtils.set(k8sclient, createSecret("telemetry-metrics-secret"));
+        addHeaderWithSecret(kc, "telemetry-metrics-header-Authorization", "telemetry-metrics-secret");
+
+        deployKeycloak(k8sclient, kc, true);
+
+        var envVars = k8sclient
+                .pods()
+                .inNamespace(namespace)
+                .withLabels(Constants.DEFAULT_LABELS)
+                .list()
+                .getItems()
+                .get(0)
+                .getSpec()
+                .getContainers()
+                .get(0)
+                .getEnv();
+
+        assertHeader(envVars, "KC_TELEMETRY_HEADER_AUTHORIZATION", "telemetry-secret");
+        assertHeader(envVars, "KC_TELEMETRY_LOGS_HEADER_AUTHORIZATION", "telemetry-logs-secret");
+        assertHeader(envVars, "KC_TELEMETRY_METRICS_HEADER_AUTHORIZATION", "telemetry-metrics-secret");
+    }
+
+    protected void assertHeader(List<EnvVar> envVars, String headerEnvVar, String secretName) {
+        assertTrue(envVars.stream().anyMatch(
+                e -> e.getName().equals(headerEnvVar) && e.getValueFrom() != null
+                        && e.getValueFrom().getSecretKeyRef().getName().equals(secretName) && e.getValueFrom().getSecretKeyRef().getKey().equals("token")));
+
+    }
+
+    protected Secret createSecret(String secretName) {
+        return new SecretBuilder()
+                .withNewMetadata()
+                .withName(secretName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .addToStringData("token", "<not-empty>")
+                .build();
+    }
+
+    protected void addHeaderWithSecret(Keycloak kc, String optionName, String secretName) {
+        kc.getSpec().getAdditionalOptions().add(new ValueOrSecret(optionName,
+                new SecretKeySelectorBuilder()
+                        .withName(secretName)
+                        .withKey("token")
+                        .build()));
+    }
+}

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -243,6 +243,27 @@ public class CRSerializationTest {
     }
 
     @Test
+    public void telemetryHeaders(){
+        Keycloak keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/test-serialization-keycloak-cr-telemetry.yml"), Keycloak.class);
+        assertThat(keycloak, notNullValue());
+        var additionalOptions = keycloak.getSpec().getAdditionalOptions().stream().collect(Collectors.toMap(ValueOrSecret::getName, e -> e));
+        assertNotNull(additionalOptions);
+        assertThat(additionalOptions.isEmpty(), is(false));
+
+        assertThat(additionalOptions, hasEntry("tracing-header-Authorization", new ValueOrSecret("tracing-header-Authorization", new SecretKeySelector("tracing-secret", "token", false))));
+        assertThat(additionalOptions, hasEntry("tracing-header-X-Org-Id", new ValueOrSecret("tracing-header-X-Org-Id", "my-org-id")));
+
+        assertThat(additionalOptions, hasEntry("telemetry-header-Some-key", new ValueOrSecret("telemetry-header-Some-key", new SecretKeySelector("telemetry-header-secret", "token", false))));
+        assertThat(additionalOptions, hasEntry("telemetry-header-Org-name", new ValueOrSecret("telemetry-header-Org-name", "Keycloak123")));
+
+        assertThat(additionalOptions, hasEntry("telemetry-logs-header-Authorization", new ValueOrSecret("telemetry-logs-header-Authorization", new SecretKeySelector("telemetry-logs-secret", "token", false))));
+        assertThat(additionalOptions, hasEntry("telemetry-logs-header-X-Org-Id", new ValueOrSecret("telemetry-logs-header-X-Org-Id", "my-org-id-logs")));
+
+        assertThat(additionalOptions, hasEntry("telemetry-metrics-header-Authorization", new ValueOrSecret("telemetry-metrics-header-Authorization", new SecretKeySelector("telemetry-metrics-secret", "token", false))));
+        assertThat(additionalOptions, hasEntry("telemetry-metrics-header-X-Org-Id", new ValueOrSecret("telemetry-metrics-header-X-Org-Id", "my-org-id-metrics")));
+    }
+
+    @Test
     public void resourcesSpecificationOnlyLimit() {
         final Keycloak keycloak = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr-with-empty-list.yml", Keycloak.class);
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -566,7 +566,13 @@ public class PodTemplateTest {
         var additionalOptions = List.of(
                 new ValueOrSecret("log-level-org.package.some_class", "debug"),
                 new ValueOrSecret("tracing-header-Authorization", "Bearer aldskfjqweoiruzxcv"),
-                new ValueOrSecret("tracing-header-My-BEST_$header", "api-asdflkqjwer-key")
+                new ValueOrSecret("tracing-header-My-BEST_$header", "api-asdflkqjwer-key"),
+                new ValueOrSecret("telemetry-header-Authorization", "Bearer aldskfjqweoiruzxcv-telemetry"),
+                new ValueOrSecret("telemetry-header-My-BEST_$header", "api-asdflkqjwer-key-telemetry"),
+                new ValueOrSecret("telemetry-logs-header-Authorization", "Bearer aldskfjqweoiruzxcv-logs"),
+                new ValueOrSecret("telemetry-logs-header-My-BEST_$header", "api-asdflkqjwer-key-logs"),
+                new ValueOrSecret("telemetry-metrics-header-Authorization", "Bearer aldskfjqweoiruzxcv-metrics"),
+                new ValueOrSecret("telemetry-metrics-header-My-BEST_$header", "api-asdflkqjwer-key-metrics")
         );
 
         // Act
@@ -583,11 +589,33 @@ public class PodTemplateTest {
                 "KCKEY_TRACING_HEADER_MY_BEST__HEADER", "tracing-header-My-BEST_$header",
                 "KC_TRACING_HEADER_MY_BEST__HEADER", "api-asdflkqjwer-key"
         );
+        var assertEnvVarKeysTelemetry = Map.of(
+                "KCKEY_TELEMETRY_HEADER_MY_BEST__HEADER", "telemetry-header-My-BEST_$header",
+                "KC_TELEMETRY_HEADER_MY_BEST__HEADER", "api-asdflkqjwer-key-telemetry",
+                "KCKEY_TELEMETRY_HEADER_AUTHORIZATION", "telemetry-header-Authorization",
+                "KC_TELEMETRY_HEADER_AUTHORIZATION", "Bearer aldskfjqweoiruzxcv-telemetry"
+        );
+        var assertEnvVarKeysTelemetryLogs = Map.of(
+                "KCKEY_TELEMETRY_LOGS_HEADER_MY_BEST__HEADER", "telemetry-logs-header-My-BEST_$header",
+                "KC_TELEMETRY_LOGS_HEADER_MY_BEST__HEADER", "api-asdflkqjwer-key-logs",
+                "KCKEY_TELEMETRY_LOGS_HEADER_AUTHORIZATION", "telemetry-logs-header-Authorization",
+                "KC_TELEMETRY_LOGS_HEADER_AUTHORIZATION", "Bearer aldskfjqweoiruzxcv-logs"
+        );
+        var assertEnvVarKeysTelemetryMetrics = Map.of(
+                "KCKEY_TELEMETRY_METRICS_HEADER_MY_BEST__HEADER", "telemetry-metrics-header-My-BEST_$header",
+                "KC_TELEMETRY_METRICS_HEADER_MY_BEST__HEADER", "api-asdflkqjwer-key-metrics",
+                "KCKEY_TELEMETRY_METRICS_HEADER_AUTHORIZATION", "telemetry-metrics-header-Authorization",
+                "KC_TELEMETRY_METRICS_HEADER_AUTHORIZATION", "Bearer aldskfjqweoiruzxcv-metrics"
+        );
 
         var envVars = podTemplate.getSpec().getContainers().get(0).getEnv().stream()
                 .filter(e -> e.getValue() != null)
                 .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
         assertThat(envVars).containsAllEntriesOf(assertEnvVarKeys);
+        assertThat(envVars).containsAllEntriesOf(assertEnvVarKeysTelemetry);
+        assertThat(envVars).containsAllEntriesOf(assertEnvVarKeysTelemetryLogs);
+        assertThat(envVars).containsAllEntriesOf(assertEnvVarKeysTelemetryMetrics);
     }
 
     @Test

--- a/operator/src/test/resources/test-serialization-keycloak-cr-telemetry.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr-telemetry.yml
@@ -29,3 +29,23 @@ spec:
         key: token
     - name: tracing-header-X-Org-Id
       value: my-org-id
+    - name: telemetry-header-Some-key
+      secret:
+        name: telemetry-header-secret
+        key: token
+    - name: telemetry-header-Org-name
+      value: Keycloak123
+    # OTel Logs
+    - name: telemetry-logs-header-Authorization
+      secret:
+        name: telemetry-logs-secret
+        key: token
+    - name: telemetry-logs-header-X-Org-Id
+      value: my-org-id-logs
+    # OTel Metrics
+    - name: telemetry-metrics-header-Authorization
+      secret:
+        name: telemetry-metrics-secret
+        key: token
+    - name: telemetry-metrics-header-X-Org-Id
+      value: my-org-id-metrics

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
@@ -34,6 +34,11 @@ public class TelemetryOptions {
             .description("OpenTelemetry resource attributes characterize the telemetry producer. Values in format 'key1=val1,key2=val2'.")
             .build();
 
+    public static final Option<String> TELEMETRY_HEADER = new OptionBuilder<>("telemetry-header-<header>", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("General OpenTelemetry header that will be part of the exporter request (mainly useful for providing Authorization header). Check the documentation on how to set environment variables for headers containing special characters or custom case-sensitive headers.")
+            .build();
+
     // Telemetry Logs
     public static final Option<Boolean> TELEMETRY_LOGS_ENABLED = new OptionBuilder<>("telemetry-logs-enabled", Boolean.class)
             .category(OptionCategory.TELEMETRY)
@@ -60,6 +65,17 @@ public class TelemetryOptions {
             .caseInsensitiveExpectedValues(true)
             .build();
 
+    public static final Option<String> TELEMETRY_LOGS_HEADER = new OptionBuilder<>("telemetry-logs-header-<header>", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("OpenTelemetry header that will be part of the log exporter request (mainly useful for providing Authorization header). Check the documentation on how to set environment variables for headers containing special characters or custom case-sensitive headers.")
+            .build();
+
+    public static final Option<List<String>> TELEMETRY_LOGS_HEADERS = OptionBuilder.listOptionBuilder("telemetry-logs-headers", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .hidden()
+            .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'telemetry-logs-header-<header>' options.")
+            .build();
+
     // Telemetry Metrics
     public static final Option<Boolean> TELEMETRY_METRICS_ENABLED = new OptionBuilder<>("telemetry-metrics-enabled", Boolean.class)
             .category(OptionCategory.TELEMETRY)
@@ -83,5 +99,16 @@ public class TelemetryOptions {
             .category(OptionCategory.TELEMETRY)
             .description("The interval between the start of two metric export attempts to the destination handling OpenTelemetry metrics data. It accepts simplified format for time units as java.time.Duration (like 5000ms, 30s, 5m, 1h). If the value is only a number, it represents time in seconds.")
             .defaultValue("60s")
+            .build();
+
+    public static final Option<String> TELEMETRY_METRICS_HEADER = new OptionBuilder<>("telemetry-metrics-header-<header>", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .description("OpenTelemetry header that will be part of the metrics exporter request (mainly useful for providing Authorization header). Check the documentation on how to set environment variables for headers containing special characters or custom case-sensitive headers.")
+            .build();
+
+    public static final Option<List<String>> TELEMETRY_METRICS_HEADERS = OptionBuilder.listOptionBuilder("telemetry-metrics-headers", String.class)
+            .category(OptionCategory.TELEMETRY)
+            .hidden()
+            .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'telemetry-metrics-header-<header>' options.")
             .build();
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -315,12 +315,24 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling OpenTelemetry logs. Default:
                        false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -340,6 +352,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -315,12 +315,24 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling OpenTelemetry logs. Default:
                        false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -340,6 +352,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -670,12 +670,24 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling OpenTelemetry logs. Default:
                        false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -695,6 +707,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -671,12 +671,24 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling OpenTelemetry logs. Default:
                        false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -696,6 +708,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -597,9 +597,21 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -615,6 +627,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -670,12 +670,24 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling OpenTelemetry logs. Default:
                        false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -695,6 +707,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -668,12 +668,24 @@ Telemetry (OpenTelemetry):
                      OpenTelemetry endpoint to connect to. Default: http://localhost:4317.
                        Available only when any of available OpenTelemetry components (Logs,
                        Metrics, Traces) is turned on.
+--telemetry-header-<header> <value>
+                     General OpenTelemetry header that will be part of the exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when any of available
+                       OpenTelemetry components (Logs, Metrics, Traces) is turned on.
 --telemetry-logs-enabled <true|false>
                      Enables exporting logs to a destination handling OpenTelemetry logs. Default:
                        false. Available only when feature 'opentelemetry-logs:v1' is enabled.
 --telemetry-logs-endpoint <url>
                      OpenTelemetry endpoint to export logs to. If not given, the value is inherited
                        from the 'telemetry-endpoint' option. Available only when Telemetry Logs
+                       functionality ('telemetry-logs-enabled') is enabled.
+--telemetry-logs-header-<header> <value>
+                     OpenTelemetry header that will be part of the log exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when Telemetry Logs
                        functionality ('telemetry-logs-enabled') is enabled.
 --telemetry-logs-level <level>
                      The most verbose log level exported to the telemetry endpoint. For more
@@ -693,6 +705,13 @@ Telemetry (OpenTelemetry):
 --telemetry-metrics-endpoint <url>
                      OpenTelemetry endpoint to connect to for Metrics. If not given, the value is
                        inherited from the 'telemetry-endpoint' option. Available only when metrics
+                       ('metrics-enabled') and Telemetry Metrics functionality
+                       ('telemetry-metrics-enabled') are enabled.
+--telemetry-metrics-header-<header> <value>
+                     OpenTelemetry header that will be part of the metrics exporter request (mainly
+                       useful for providing Authorization header). Check the documentation on how
+                       to set environment variables for headers containing special characters or
+                       custom case-sensitive headers. Available only when metrics
                        ('metrics-enabled') and Telemetry Metrics functionality
                        ('telemetry-metrics-enabled') are enabled.
 --telemetry-metrics-interval <duration>


### PR DESCRIPTION
- Closes #45220

-------------------
- We already have the `tracing-header-<header>` option with the same functionality, so this PR just adds the missing pieces for OTEL logs+metrics, and adds the general parent option for all of them 
- Created the `telemetry-header-<header>` parent option
- Created the `telemetry-logs-header-<header>` option for OTel Logs
- Created the `telemetry-metrics-header-<header>` option for OTel Metrics
