### PR TITLE
Make environment variables override values from .env.test

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/config/Config.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/config/Config.java
@@ -114,7 +114,7 @@ public class Config {
             Path envTestPath = currentPath.resolve(".env.test");
             if (Files.isRegularFile(envTestPath)) {
                 try {
-                    return new EnvConfigSource(ConfigSourceUtil.urlToMap(envTestPath.toUri().toURL()), 350);
+                    return new EnvConfigSource(ConfigSourceUtil.urlToMap(envTestPath.toUri().toURL()), 296);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
See https://smallrye.io/smallrye-config/Main/config/getting-started/ by default SmallRye uses `300` for environment variables, and `295` for `.env` file. Changing `.env.test` from 350 to 296 to match this.

Closes #45252

Signed-off-by: stianst <stianst@gmail.com>
