### PR TITLE
Fix label class in config-totp template

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -53,7 +53,7 @@
         <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-totp-settings-form" method="post">
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="totp" class="control-label">${msg("authenticatorCode")}</label> <span class="required">*</span>
+                    <label for="totp" class="${properties.kcLabelClass!}">${msg("authenticatorCode")}</label> <span class="required">*</span>
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
                     <input type="text" id="totp" name="totp" autocomplete="one-time-code" class="${properties.kcInputClass!}"
@@ -75,7 +75,7 @@
 
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="userLabel" class="control-label">${msg("loginTotpDeviceName")}</label> <#if totp.otpCredentials?size gte 1><span class="required">*</span></#if>
+                    <label for="userLabel" class="${properties.kcLabelClass!}">${msg("loginTotpDeviceName")}</label> <#if totp.otpCredentials?size gte 1><span class="required">*</span></#if>
                 </div>
 
                 <div class="${properties.kcInputWrapperClass!}">


### PR DESCRIPTION
The labels in `login-config-totp.ftl` were statically styled with a `form-control` class instead of the intended dynamic `kcLabelClass ` property.

This caused incorrect styling in custom themes inheriting the base theme.

Update the markup to use `kcLabelClass`, matching the rest of the theme and ensuring consistent label styling.

Closes #45069

---

## Screenshots

### Reference

This is how labels look like:

<img width="499" height="142" alt="image" src="https://github.com/user-attachments/assets/f03f2fbb-4036-4597-ae82-022ab79fec3c" />

### Before

<img width="500" height="328" alt="image" src="https://github.com/user-attachments/assets/441a5852-2867-413c-9624-73e7c424a1b0" />

### After

<img width="500" height="321" alt="image" src="https://github.com/user-attachments/assets/3958f967-daf1-46ec-acd0-1cb111b6a38d" />

## Potential breaking changes

This may be considered a potential breaking change for themes based on `base` or `keycloak`.

`keycloak.v2` is not affected because it uses a different template:

https://github.com/keycloak/keycloak/blob/c6b13cb2ec30d94ed149b61203a3df6d51fda396/themes/src/main/resources/theme/keycloak.v2/login/login-config-totp.ftl#L58-L60