### PR TITLE
Wrap required indicators with "required" span

### DIFF
--- a/themes/src/main/resources/theme/base/login/register.ftl
+++ b/themes/src/main/resources/theme/base/login/register.ftl
@@ -17,7 +17,8 @@
                     <#if passwordRequired?? && (attribute.name == 'username' || (attribute.name == 'email' && realm.registrationEmailAsUsername))>
                         <div class="${properties.kcFormGroupClass!}">
                             <div class="${properties.kcLabelWrapperClass!}">
-                                <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label> *
+                                <label for="password" class="${properties.kcLabelClass!}">${msg("password")}</label>
+                                <span class="required">*</span>
                             </div>
                             <div class="${properties.kcInputWrapperClass!}">
                                 <div class="${properties.kcInputGroup!}" dir="ltr">
@@ -44,7 +45,8 @@
                         <div class="${properties.kcFormGroupClass!}">
                             <div class="${properties.kcLabelWrapperClass!}">
                                 <label for="password-confirm"
-                                       class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label> *
+                                       class="${properties.kcLabelClass!}">${msg("passwordConfirm")}</label>
+                                <span class="required">*</span>
                             </div>
                             <div class="${properties.kcInputWrapperClass!}">
                                 <div class="${properties.kcInputGroup!}" dir="ltr">

--- a/themes/src/main/resources/theme/base/login/user-profile-commons.ftl
+++ b/themes/src/main/resources/theme/base/login/user-profile-commons.ftl
@@ -42,7 +42,7 @@
 			<div class="${properties.kcFormGroupClass!}">
 				<div class="${properties.kcLabelWrapperClass!}">
 					<label for="${attribute.name}" class="${properties.kcLabelClass!}">${advancedMsg(attribute.displayName!'')}</label>
-					<#if attribute.required>*</#if>
+					<#if attribute.required><span class="required">*</span></#if>
 				</div>
 				<div class="${properties.kcInputWrapperClass!}">
 					<#if attribute.annotations.inputHelperTextBefore??>


### PR DESCRIPTION
Some asterisks indicating required fields in `user-profile-commons.ftl`
and `register.ftl` are not wrapped in a `<span class="required">` tag.

This caused incorrect styling in custom themes that inherit the base theme.

Update the markup to wrap required field indicators with
`<span class="required">`, matching the rest of the theme and ensuring
consistent styling.

Closes #45058

Signed-off-by: Geremia Taglialatela <tagliala.dev@gmail.com>

---

## Screenshots

### Reference

The current implementation in config-totp template:

<img width="497" height="70" alt="image" src="https://github.com/user-attachments/assets/53a16214-5f34-48bd-ab3e-fe5e8b1e2dfe" />

### Before (Register)

<img width="500" height="542" alt="image" src="https://github.com/user-attachments/assets/a20b1558-6c1f-41db-9659-163f212f85f9" />

### After (Register)

<img width="500" height="542" alt="image" src="https://github.com/user-attachments/assets/bc6a0175-4956-46c4-938d-828ae2e8bff6" />

### Note

the "laquo" issue appears even when I eject the default template without changes, so it should not be related to this change
