### PR TITLE
Creating IdentityProvider with latest java admin-client may fail against Keycloak server 26.4 or older

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/IdentityProviderRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/IdentityProviderRepresentation.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.representations.idm;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +60,7 @@ public class IdentityProviderRepresentation {
     protected String postBrokerLoginFlowAlias;
     protected String organizationId;
     protected Map<String, String> config = new HashMap<>();
-    protected List<String> types = new ArrayList<>();
+    protected List<String> types; // Null by default for the compatibility with older versions of Keycloak server (26.4 and older)
 
     public String getInternalId() {
         return this.internalId;


### PR DESCRIPTION
closes #45257

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 29c15d8e8a363b976ec80aac1d2f9c1a8a4a655d)
