### PR TITLE
Fix: Persist refreshed external IDP tokens in DB

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -264,6 +264,12 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
                         newResponse.setAccessTokenExpiration(accessTokenExpiration);
                     }
                     identity.setToken(JsonSerialization.writeValueAsString(newResponse));
+
+                    if (getConfig().isStoreToken()) {
+                        RealmModel realm = session.getContext().getRealm();
+                        UserModel user = session.users().getUserById(realm, identity.getUserId());
+                        session.users().updateFederatedIdentity(realm, user, identity);
+                    }
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
When retrieving an external IDP token via `retrieveToken`, if the token is expired and successfully refreshed, the new token was updated in the `FederatedIdentityModel` in memory but not persisted to the database. This caused subsequent requests to fail or use old tokens.

This change ensures that `updateFederatedIdentity` is called to persist the refreshed token if `storeToken` is enabled configuration.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
