### PR TITLE
Add Swedish translation for admin theme messages

### DIFF
--- a/themes/src/main/resources-community/theme/base/admin/messages/messages_sv.properties
+++ b/themes/src/main/resources-community/theme/base/admin/messages/messages_sv.properties
@@ -1,0 +1,82 @@
+invalidPasswordMinLengthMessage=Ogiltigt lösenord: minsta längd {0}.
+invalidPasswordMaxLengthMessage=Ogiltigt lösenord: maximal längd {0}.
+invalidPasswordMinLowerCaseCharsMessage=Ogiltigt lösenord: måste innehålla minst {0} gemener.
+invalidPasswordMinDigitsMessage=Ogiltigt lösenord: måste innehålla minst {0} siffror.
+invalidPasswordMinUpperCaseCharsMessage=Ogiltigt lösenord: måste innehålla minst {0} versaler.
+invalidPasswordMinSpecialCharsMessage=Ogiltigt lösenord: måste innehålla minst {0} specialtecken.
+invalidPasswordNotUsernameMessage=Ogiltigt lösenord: får inte vara samma som användarnamnet.
+invalidPasswordNotContainsUsernameMessage=Ogiltigt lösenord: kan inte innehålla användarnamnet.
+invalidPasswordNotEmailMessage=Ogiltigt lösenord: får inte vara samma som e-postadressen.
+invalidPasswordRegexPatternMessage=Ogiltigt lösenord: matchar inte regex-mönstret.
+invalidPasswordHistoryMessage=Ogiltigt lösenord: får inte vara samma som något av de senaste {0} lösenorden.
+invalidPasswordBlacklistedMessage=Ogiltigt lösenord: lösenordet finns på svartlistan.
+invalidPasswordGenericMessage=Ogiltigt lösenord: det nya lösenordet uppfyller inte lösenordspolicyn.
+
+ldapErrorEditModeMandatory=Redigeringsläge är obligatoriskt
+ldapErrorInvalidCustomFilter=Anpassat konfigurerat LDAP-filter börjar inte med "(" eller slutar inte med ")".
+ldapErrorConnectionTimeoutNotNumber=Anslutningstimeout måste vara ett tal
+ldapErrorReadTimeoutNotNumber=Lästimeout måste vara ett tal
+ldapErrorMissingClientId=Klient-ID måste anges i konfigurationen när Realm Roles Mapping inte används.
+ldapErrorCantPreserveGroupInheritanceWithUIDMembershipType=Det är inte möjligt att bevara grupparv och använda UID-medlemskapstyp samtidigt.
+ldapErrorCantWriteOnlyForReadOnlyLdap=Kan inte sätta write-only när LDAP-leverantörläget inte är WRITABLE
+ldapErrorCantWriteOnlyAndReadOnly=Kan inte sätta både write-only och read-only samtidigt
+ldapErrorCantEnableStartTlsAndConnectionPooling=Kan inte aktivera både StartTLS och connection pooling.
+ldapErrorCantEnableUnsyncedAndImportOff=Kan inte inaktivera import av användare när LDAP-leverantörläget är UNSYNCED
+ldapErrorMissingGroupsPathGroup=Gruppsökvägsgrupp existerar inte - vänligen skapa gruppen på angiven sökväg först
+ldapErrorValidatePasswordPolicyAvailableForWritableOnly=Validera lösenordspolicy är endast tillämplig med WRITABLE-redigeringsläge
+
+clientRedirectURIsFragmentError=Omdirigerings-URI:er får inte innehålla ett URI-fragment
+clientRootURLFragmentError=Rot-URL får inte innehålla ett URL-fragment
+clientRootURLIllegalSchemeError=Rot-URL använder ett otillåtet schema
+clientBaseURLIllegalSchemeError=Bas-URL använder ett otillåtet schema
+backchannelLogoutUrlIllegalSchemeError=Backchannel-utloggnings-URL använder ett otillåtet schema
+clientRedirectURIsIllegalSchemeError=En omdirigerings-URI använder ett otillåtet schema
+clientBaseURLInvalid=Bas-URL är inte en giltig URL
+clientRootURLInvalid=Rot-URL är inte en giltig URL
+clientRedirectURIsInvalid=En omdirigerings-URI är inte en giltig URI
+backchannelLogoutUrlIsInvalid=Backchannel-utloggnings-URL är inte en giltig URL
+
+
+pairwiseMalformedClientRedirectURI=Klienten innehöll en ogiltig omdirigerings-URI.
+pairwiseClientRedirectURIsMissingHost=Klientens omdirigerings-URI:er måste innehålla en giltig värdkomponent.
+pairwiseClientRedirectURIsMultipleHosts=Utan en konfigurerad Sector Identifier URI får klientens omdirigerings-URI:er inte innehålla flera värdkomponenter.
+pairwiseMalformedSectorIdentifierURI=Felaktig Sector Identifier URI.
+pairwiseFailedToGetRedirectURIs=Misslyckades med att hämta omdirigerings-URI:er från Sector Identifier URI.
+pairwiseRedirectURIsMismatch=Klientens omdirigerings-URI:er matchar inte omdirigerings-URI:erna hämtade från Sector Identifier URI.
+
+duplicatedJwksSettings=Knapparna "Använd JWKS" och "Använd JWKS URL" kan inte vara PÅ samtidigt.
+
+clientIdleExceedsRealmRememberMeIdle=Klientsessionens idle-timeout kan inte överskrida realm SSO-sessionens idle-timeout och RememberMe idle-timeout.
+clientSessionIdleTimeoutExceedsRealm=Klientsessionens idle-timeout kan inte överskrida realm SSO-sessionens idle-timeout.
+clientSessionMaxLifespanExceedsRealm=Klientsessionens maximala livslängd kan inte överskrida realm SSO-sessionens maximala livslängd.
+clientSessionMaxLifespanExceedsRealmRememberMeMaxSpan=Klientsessionens maximala livslängd kan inte överskrida realm SSO-sessionens maximala livslängd och RememberMe Max-spann.
+
+error-invalid-value=Ogiltigt värde.
+error-invalid-blank=Vänligen ange ett värde.
+error-empty=Vänligen ange ett värde.
+error-invalid-length=Attribut {0} måste ha en längd mellan {1} och {2}.
+error-invalid-length-too-short=Attribut {0} måste ha en minsta längd på {1}.
+error-invalid-length-too-long=Attribut {0} måste ha en maximal längd på {2}.
+error-invalid-email=Ogiltig e-postadress.
+error-invalid-number=Ogiltigt nummer.
+error-number-out-of-range=Attribut {0} måste vara ett tal mellan {1} och {2}.
+error-number-out-of-range-too-small=Attribut {0} måste ha ett minimivärde på {1}.
+error-number-out-of-range-too-big=Attribut {0} måste ha ett maximalt värde på {2}.
+error-pattern-no-match=Ogiltigt värde.
+error-invalid-uri=Ogiltig URL.
+error-invalid-uri-scheme=Ogiltigt URL-schema.
+error-invalid-uri-fragment=Ogiltigt URL-fragment.
+error-user-attribute-required=Vänligen ange attribut {0}.
+error-invalid-date=Attribut {0} är ett ogiltigt datum.
+error-user-attribute-read-only=Attribut {0} är skrivskyddat.
+error-username-invalid-character={0} innehåller ogiltiga tecken.
+error-person-name-invalid-character={0} innehåller ogiltiga tecken.
+error-invalid-multivalued-size=Attribut {0} måste ha minst {1} och högst {2} {2,choice,0#värden|1#värde|1<värden}.
+error-non-ascii-local-part-email=Den lokala delen av adressen får endast innehålla ASCII-tecken.
+
+client_account=Konto
+client_account-console=Kontokonsol
+client_security-admin-console=Säkerhetsadministratörskonsol
+client_admin-cli=Admin CLI
+client_realm-management=Realm-hantering
+client_broker=Broker


### PR DESCRIPTION
Adds messages_sv.properties to provide Swedish translations for all admin interface messages including password validation, LDAP errors, client URL validation, and error messages.

Closes #45281