### PR TITLE
CIMD - Persistent CIMD

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -159,6 +159,8 @@ public class Profile {
 
         OPENAPI("OpenAPI specification served at runtime", Type.EXPERIMENTAL, CLIENT_ADMIN_API_V2),
 
+        CIMD("OAuth Client ID Metadata Document", Type.EXPERIMENTAL),
+
         /**
          * @see <a href="https://github.com/keycloak/keycloak/issues/37967">Deprecate for removal the Instagram social broker</a>.
          */

--- a/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
+++ b/core/src/main/java/org/keycloak/protocol/oidc/representations/OIDCConfigurationRepresentation.java
@@ -205,6 +205,9 @@ public class OIDCConfigurationRepresentation {
     @JsonProperty("authorization_details_types_supported")
     private List<String> authorizationDetailsTypesSupported;
 
+    @JsonProperty("client_id_metadata_document_supported")
+    private Boolean clientIdMetadataDocumentSupported;
+
     protected Map<String, Object> otherClaims = new HashMap<String, Object>();
 
     public String getIssuer() {
@@ -675,5 +678,13 @@ public class OIDCConfigurationRepresentation {
 
     public void setAuthorizationDetailsTypesSupported(List<String> authorizationDetailsTypesSupported) {
         this.authorizationDetailsTypesSupported = authorizationDetailsTypesSupported;
+    }
+
+    public Boolean getClientIdMetadataDocumentSupported() {
+        return clientIdMetadataDocumentSupported;
+    }
+
+    public void setClientIdMetadataDocumentSupported(Boolean clientIdMetadataDocumentSupported) {
+        this.clientIdMetadataDocumentSupported = clientIdMetadataDocumentSupported;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeCondition.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeCondition.java
@@ -1,0 +1,86 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.condition;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.condition.AbstractClientPolicyConditionProvider;
+import org.keycloak.services.clientpolicy.context.PreAuthorizationRequestContext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * The class is a condition of client policies. On {@code PRE_AUTHORIZATION_REQUEST} event,
+ * it checks if the value of {@code client_id} parameter is URI and
+ * the scheme part of the URI is the one defined in its configuration.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientIdUriSchemeCondition extends AbstractClientPolicyConditionProvider<ClientIdUriSchemeCondition.Configuration> {
+
+    private static final Logger logger = Logger.getLogger(ClientIdUriSchemeCondition.class);
+
+    public ClientIdUriSchemeCondition(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public Class<ClientIdUriSchemeCondition.Configuration> getConditionConfigurationClass() {
+        return ClientIdUriSchemeCondition.Configuration.class;
+    }
+
+    public static class Configuration extends ClientPolicyConditionConfigurationRepresentation {
+        @JsonProperty(ClientIdUriSchemeConditionFactory.CLIENT_ID_URI_SCHEME)
+        protected List<String> clientIdUriSchemes = Collections.emptyList();
+
+        public List<String> getClientIdUriSchemes() {
+            return clientIdUriSchemes;
+        }
+
+        public void setClientIdUriSchemes(List<String> clientIdUriSchemes) {
+            this.clientIdUriSchemes = clientIdUriSchemes;
+        }
+    }
+
+    @Override
+    public String getProviderId() {
+        return ClientIdUriSchemeConditionFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
+        switch (context.getEvent()) {
+            case PRE_AUTHORIZATION_REQUEST:
+                PreAuthorizationRequestContext paContext = (PreAuthorizationRequestContext) context;
+                String clientId = ((PreAuthorizationRequestContext) context).getRequestParameters().getFirst(OAuth2Constants.CLIENT_ID);
+                if (isUriSchemeMatched(clientId)) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            default:
+                return ClientPolicyVote.ABSTAIN;
+        }
+    }
+
+    private boolean isUriSchemeMatched(String clientId) {
+        if (clientId == null || configuration.getClientIdUriSchemes() == null || configuration.getClientIdUriSchemes().isEmpty()) {
+            return false;
+        }
+
+        final URI uri;
+        try {
+            uri = new URI(clientId);
+        } catch (URISyntaxException e) {
+            logger.debugv("not URL: clientId = {0}", clientId);
+            return false;
+        }
+
+        return configuration.getClientIdUriSchemes().stream().anyMatch(uri.getScheme()::equals);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeCondition.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeCondition.java
@@ -81,6 +81,6 @@ public class ClientIdUriSchemeCondition extends AbstractClientPolicyConditionPro
             return false;
         }
 
-        return configuration.getClientIdUriSchemes().stream().anyMatch(uri.getScheme()::equals);
+        return configuration.getClientIdUriSchemes().stream().anyMatch(i->i.equals(uri.getScheme()));
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeConditionFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeConditionFactory.java
@@ -10,7 +10,7 @@ import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvide
 
 /**
  * The class is the factory class of {@link ClientIdUriSchemeCondition}.
- * It provides one configuration: Scheme part of the URI.
+ * It provides two configuration: Scheme part and host part of the URI.
  *
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
@@ -19,6 +19,7 @@ public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyCondi
     public static final String PROVIDER_ID = "client-id-uri";
 
     public static final String CLIENT_ID_URI_SCHEME = "client-id-uri-scheme";
+    public static final String TRUSTED_DOMAINS = "client-id-uri-allow-permitted-domains";
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
 
@@ -31,6 +32,20 @@ public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyCondi
                 "URI scheme",
                 "Scheme part of the URI",
                 ProviderConfigProperty.MULTIVALUED_STRING_TYPE, null);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty(
+                TRUSTED_DOMAINS,
+                "Trusted domains",
+                "If some domains are filled, The condition evaluates to true " +
+                        "if the host part of client_id parameter in an authorization request matches one of the filled domains. " +
+                        "Otherwise, the condition evaluates to false " +
+                        "The domains are checked by using regex. " +
+                        "If the domains not filled, the condition evaluate to false regardless of the client_id parameter value. " +
+                        "For example, use pattern like this '(.*)\\.example\\.org' if you want to accept the parameter / property whose domain is 'example.org'." +
+                        "Don't forget to use escaping of special characters like dots as otherwise dot is interpreted as any character in regex!",
+                ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+                null);
         configProperties.add(property);
     }
 
@@ -46,7 +61,8 @@ public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyCondi
 
     @Override
     public String getHelpText() {
-        return "The condition checks whether client_id is URI and its scheme.).";
+        return "The condition checks that the scheme part of client_id parameter matches one of the filled ones " +
+               "and the host part of the client_id matches one of the filled domains.";
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeConditionFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeConditionFactory.java
@@ -1,0 +1,56 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.condition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.clientpolicy.condition.AbstractClientPolicyConditionProviderFactory;
+import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider;
+
+/**
+ * The class is the factory class of {@link ClientIdUriSchemeCondition}.
+ * It provides one configuration: Scheme part of the URI.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyConditionProviderFactory {
+
+    public static final String PROVIDER_ID = "client-id-uri";
+
+    public static final String CLIENT_ID_URI_SCHEME = "client-id-uri-scheme";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    static {
+        addCommonConfigProperties(configProperties);
+
+        ProviderConfigProperty property;
+        property = new ProviderConfigProperty(
+                CLIENT_ID_URI_SCHEME,
+                "URI scheme",
+                "Scheme part of the URI",
+                ProviderConfigProperty.MULTIVALUED_STRING_TYPE, null);
+        configProperties.add(property);
+    }
+
+    @Override
+    public ClientPolicyConditionProvider create(KeycloakSession session) {
+        return new ClientIdUriSchemeCondition(session);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "The condition checks whether client_id is URI and its scheme.).";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeConditionFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/condition/ClientIdUriSchemeConditionFactory.java
@@ -3,7 +3,10 @@ package org.keycloak.protocol.oauth2.cimd.clientpolicy.condition;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.clientpolicy.condition.AbstractClientPolicyConditionProviderFactory;
 import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvider;
@@ -14,7 +17,8 @@ import org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProvide
  *
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyConditionProviderFactory {
+public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyConditionProviderFactory
+        implements EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = "client-id-uri";
 
@@ -68,5 +72,10 @@ public class ClientIdUriSchemeConditionFactory extends AbstractClientPolicyCondi
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         return configProperties;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.CIMD);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
@@ -105,10 +105,15 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
     protected CONFIG configuration;
     protected ClientIdMetadataDocumentProvider<CONFIG> provider;
 
+    // Factory Global Setting:
+    // Client ID Metadata Document Provider Name
+    protected String cimdProviderName; // non-null
+
     protected abstract Logger getLogger();
 
-    protected AbstractClientIdMetadataDocumentExecutor(KeycloakSession session) {
+    protected AbstractClientIdMetadataDocumentExecutor(KeycloakSession session, String cimdProviderName) {
         this.session = session;
+        this.cimdProviderName = cimdProviderName;
     }
 
     protected ClientIdMetadataDocumentProvider<CONFIG> getProvider() {
@@ -137,10 +142,6 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
         protected boolean restrictSameDomain = false;
         @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.REQUIRED_PROPERTIES)
         protected List<String> requiredProperties = null;
-
-        // Client ID Metadata Document Provider Name
-        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.CIMD_PROVIDER_NAME)
-        protected String cimdProviderName = PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID;
 
         public Configuration() {
         }
@@ -191,14 +192,6 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
 
         public void setRequiredProperties(List<String> requiredProperties) {
             this.requiredProperties = requiredProperties;
-        }
-
-        public String getCimdProviderName() {
-            return cimdProviderName;
-        }
-
-        public void setCimdProviderName(String cimdProviderName) {
-            this.cimdProviderName = cimdProviderName;
         }
     }
 
@@ -347,7 +340,7 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
     }
 
     private void process(PreAuthorizationRequestContext preAuthorizationRequestContext) throws ClientPolicyException {
-        provider = session.getProvider(ClientIdMetadataDocumentProvider.class, getConfiguration().getCimdProviderName());
+        provider = session.getProvider(ClientIdMetadataDocumentProvider.class, cimdProviderName);
         provider.setConfiguration(getConfiguration());
 
         String clientId = preAuthorizationRequestContext.getClientId();

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
@@ -1,0 +1,865 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.Time;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oauth2.cimd.provider.ClientIdMetadataDocumentProvider;
+import org.keycloak.protocol.oauth2.cimd.provider.PersistentClientIdMetadataDocumentProviderFactory;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.PreAuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.Header;
+import org.apache.http.NameValuePair;
+import org.jboss.logging.Logger;
+
+/**
+ * The abstract class implements OAuth Client ID Metadata Document specification (Internet Draft v00).
+ * @see <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-client-id-metadata-document-00">OAuth Client ID Metadata Document (CIMD) [Internet Draft]]</a>
+ *
+ * <p>Moreover, the abstract class implements Authorization part of Model Context Protocol (MCP) specification (version 2025-11-25).
+ * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization">Model Context Protocol (MCP) [2025-11-25]]</a>
+ *
+ * <p>The abstract class satisfies the following requirements of CIMD and MCP:
+ * <ul>
+ *     <li>Requirements whose requirement level is MUST or SHOULD.</li>
+ *     <li>Requirements in Security Consideration.</li>
+ * </ul>
+ *
+ * <p>The abstract class provides the following features:
+ * <ul>
+ *     <li>Client ID Verification: if {client_id} parameter satisfies the requirements of the specifications</li>
+ *     <li>Client ID Validation: if {{client_id} parameter is valid according to the policy.</li>
+ *     <li>Fetching Client Metadata: fetch a client metadata by accessing {client_id} URL.</li>
+ *     <li>Client Metadata Verification: if a client metadata satisfies the requirements of the specifications.</li>
+ *     <li>Client Metadata Validation: if a client metadata is valid according to the policy.</li>
+ *     <li>Client Metadata Augmentation in {@link OIDCClientRepresentation}: augment a fetched client metadata.</li>
+ * </ul>
+ *
+ * <p>Roles of the abstract class and its concrete class:
+ * The abstract class covers the basic checks and processes by following the CIMD and MCP specifications while
+ * the concrete class of the abstract class provides additional checks or processes.
+ *
+ * <p>For example, regarding Client ID Validation and Client Metadata Validation, the CIMD and MCP specifications allow
+ * an authorization server to implement policies that determine the valid {client_id} parameter value and client metadata.
+ * The CIMD and MCP specification show some examples of the policies roughly, but what policies are implemented in detail
+ * is up to the authorization server implementation.
+ * Therefore, the abstract class provides some of the examples and the concrete class can implement additional policies.
+ *
+ * <p>Client Metadata Caching:
+ * The abstract class does not treat the following processes. It delegates them to {@link ClientIdMetadataDocumentProvider}:
+ * <ul>
+ *     <li>determining if (re-)fetching a client metadata is needed</li>
+ *     <li>concrete process of caching a client metadata: create and update</li>
+ *     <li>update cache expiry time</li>
+ *     <li>augment a client metadata in {@code ClientRepresentation}</li>
+ * </ul>
+ * For example, {@code PersistentClientIdMetadataDocumentProvider} persists client metadata.
+ * In the future, the provider for non-persisting a client metadata can be provided.
+ *
+ * <p>Client Metadata Format:
+ * According to the CIMD specification, the client metadata format is the same as for Dynamic Client Registration except for {@code client_id} property.
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7591>OAuth 2.0 Dynamic Client Registration Protocol [RFC 7591]]</a>
+ * Therefore, {@link OIDCClientRepresentation} is used for the client metadata format.
+ * The CIMD specification allows the use of additional properties (MAY requirement level), but the class does not treat them.
+ *
+ * <p>Client Metadata Augmentation in {@code OIDCClientRepresentation}:
+ * To successfully convert a fetched client metadata to {@code ClientRepresentation}, intentionally augment it.
+ * The actual example is a public client. The CIMD and MCP specification allows a public client.
+ * {@code }DescriptionConverter.toInternal} recognize a client as a public client if token_endpoint_auth_method is "none"
+ * If a client metadata lacks token_endpoint_auth_method, it is converted to "none", meaning it is treated as a public client.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends AbstractClientIdMetadataDocumentExecutor.Configuration> implements ClientPolicyExecutorProvider<CONFIG> {
+
+    protected final KeycloakSession session;
+    protected CONFIG configuration;
+    protected ClientIdMetadataDocumentProvider<CONFIG> provider;
+
+    protected abstract Logger getLogger();
+
+    protected AbstractClientIdMetadataDocumentExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    protected ClientIdMetadataDocumentProvider<CONFIG> getProvider() {
+        return provider;
+    }
+
+    public CONFIG getConfiguration() {
+        return configuration;
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+        // Client ID Verification
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.ALLOW_PRIVATE_ADDRESS)
+        protected boolean allowPrivateAddress = false;
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.ALLOW_LOOPBACK_ADDRESS)
+        protected boolean allowLoopbackAddress = false;
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.ALLOW_HTTP_SCHEME)
+        protected boolean allowHttpScheme = false;
+
+        // Client ID Validation
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.ALLOW_PERMITTED_DOMAINS)
+        protected List<String> allowPermittedDomains = null;
+
+        // Client Metadata Validation
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.RESTRICT_SAME_DOMAIN)
+        protected boolean restrictSameDomain = false;
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.REQUIRED_PROPERTIES)
+        protected List<String> requiredProperties = null;
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.CONSENT_REQUIRED)
+        protected boolean consentRequired = true;
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.FULL_SCOPE_DISABLED)
+        protected boolean fullScopeDisabled = true;
+
+        // Client ID Metadata Document Provider Name
+        @JsonProperty(AbstractClientIdMetadataDocumentExecutorFactory.CIMD_PROVIDER_NAME)
+        protected String cimdProviderName = PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID;
+
+        public Configuration() {
+        }
+
+        public boolean isAllowPrivateAddress() {
+            return allowPrivateAddress;
+        }
+
+        public void setAllowPrivateAddress(boolean allowPrivateAddress) {
+            this.allowPrivateAddress = allowPrivateAddress;
+        }
+
+        public boolean isAllowLoopbackAddress() {
+            return allowLoopbackAddress;
+        }
+
+        public void setAllowLoopbackAddress(boolean allowLoopbackAddress) {
+            this.allowLoopbackAddress = allowLoopbackAddress;
+        }
+
+        public boolean isAllowHttpScheme() {
+            return allowHttpScheme;
+        }
+
+        public void setAllowHttpScheme(boolean allowHttpScheme) {
+            this.allowHttpScheme = allowHttpScheme;
+        }
+
+        public List<String> getAllowPermittedDomains() {
+            return allowPermittedDomains;
+        }
+
+        public void setAllowPermittedDomains(List<String> permittedDomains) {
+            this.allowPermittedDomains = permittedDomains;
+        }
+
+        public boolean isRestrictSameDomain() {
+            return restrictSameDomain;
+        }
+
+        public void setRestrictSameDomain(boolean restrictSameDomain) {
+            this.restrictSameDomain = restrictSameDomain;
+        }
+
+        public List<String> getRequiredProperties() {
+            return requiredProperties;
+        }
+
+        public void setRequiredProperties(List<String> requiredProperties) {
+            this.requiredProperties = requiredProperties;
+        }
+
+        public boolean isConsentRequired() {
+            return consentRequired;
+        }
+
+        public void setConsentRequired(boolean consentRequired) {
+            this.consentRequired = consentRequired;
+        }
+
+        public boolean isFullScopeDisabled() {
+            return fullScopeDisabled;
+        }
+
+        public void setFullScopeDisabled(boolean fullScopeDisabled) {
+            this.fullScopeDisabled = fullScopeDisabled;
+        }
+
+        public String getCimdProviderName() {
+            return cimdProviderName;
+        }
+
+        public void setCimdProviderName(String cimdProviderName) {
+            this.cimdProviderName = cimdProviderName;
+        }
+    }
+
+    /**
+     * The CIMD and MCP specification requires an authorization server to cache a client metadata.
+     * The inner class put together a client metadata and Cache-Control header's value.
+     */
+    public static class OIDCClientRepresentationWithCacheControl {
+        private final OIDCClientRepresentation oidcClientRepresentation;
+        private final ClientMetadataCacheControl clientMetadataCacheControl;
+
+        public OIDCClientRepresentationWithCacheControl(OIDCClientRepresentation oidcClientRepresentation, String rawCacheControlHeaderValue) {
+            this.oidcClientRepresentation = oidcClientRepresentation;
+            this.clientMetadataCacheControl = new ClientMetadataCacheControl(rawCacheControlHeaderValue);
+        }
+
+        public OIDCClientRepresentation getOidcClientRepresentation() {
+            return oidcClientRepresentation;
+        }
+
+        public ClientMetadataCacheControl getClientMetadataCacheControl() {
+            return clientMetadataCacheControl;
+        }
+    }
+
+    /**
+     * The CIMD and MCP specification requires an authorization server to cache a client metadata.
+     * The inner class covers the Cache-Control header's directives:
+     * <ul>
+     *     <li>only consider directives of a response.</li>
+     *     <li>do not consider whether private or public.</li>
+     *     <li>consider max-age and s-maxage directives showing the lifetime of client metadata.</li>
+     *     <li>s-maxage takes precedence over max-age</li>
+     *     <li>consider no-cache and no-store directives showing no caching client metadata.</li>
+     *     <li>do not consider other directives.</li>
+     * </ul>
+     */
+    public static class ClientMetadataCacheControl {
+        private boolean noCache = false;
+        private boolean noStore = false;
+        private int maxAgeValue = -1;
+        private int sMaxAgeValue = -1;
+        private final String normalizedCacheControlHeaderValue;
+
+        public ClientMetadataCacheControl(String rawCacheControlHeaderValue) {
+            if (rawCacheControlHeaderValue == null) {
+                normalizedCacheControlHeaderValue = null;
+            } else {
+                normalizedCacheControlHeaderValue = rawCacheControlHeaderValue.toLowerCase().replaceAll("\\s", "");
+                List<String> sList  = Arrays.asList(normalizedCacheControlHeaderValue.split(",", 0));
+                if (sList.contains("no-cache")) {
+                    noCache = true;
+                }
+                if (sList.contains("no-store")) {
+                    noStore = true;
+                }
+                if (sList.stream().filter(i->i.startsWith("max-age=")).count() == 1) {
+                    maxAgeValue = deriveExpiryValue("max-age", sList);
+                }
+                if (sList.stream().filter(i->i.startsWith("s-maxage=")).count() == 1) {
+                    sMaxAgeValue = deriveExpiryValue("s-maxage", sList);
+                }
+            }
+        }
+
+        public boolean isNoCache() {
+            return noCache;
+        }
+
+        public boolean isNoStore() {
+            return noStore;
+        }
+
+        public boolean isMaxAge() {
+            return maxAgeValue >= 0;
+        }
+
+        public int getMaxAgeValue() {
+            return maxAgeValue;
+        }
+
+        public boolean isSmaxAge() {
+            return sMaxAgeValue >= 0;
+        }
+
+        public int getSmaxAgeValue() {
+            return sMaxAgeValue;
+        }
+
+        public final String getNormalizedCacheControlHeaderValue() {
+            return normalizedCacheControlHeaderValue;
+        }
+
+        public int getCacheExpiryTimeInSec() {
+            if (isNoCache() || isNoStore()) {
+                return Time.currentTime();
+            }
+            if (isSmaxAge()) { // s-maxage takes precedence over max-age
+                return Time.currentTime() + getSmaxAgeValue();
+            }
+            if (isMaxAge()) {
+                return Time.currentTime() + getMaxAgeValue();
+            }
+            return Time.currentTime();
+        }
+
+        private int deriveExpiryValue(final String key, List<String> sList) {
+            String[] sAry = sList.stream().filter(i->i.startsWith(key + "=")).findFirst().get().split("=");
+            try {
+                if (sAry.length == 2) {
+                    return Integer.parseInt(sAry[1]);
+                }
+            } catch (NumberFormatException e) {
+                // no-op
+            }
+            return -1;
+        }
+    }
+
+    /**
+     * CREATE: a client metadata is not created, so fetching it creating it is needed.
+     * UPDATE: a client metadata has been already created but it has expired, so re-fetching it and updating it is needed.
+     * NO_UPDATE: a client metadata has been already created and it does not expire, so fetching it is not needed.
+     */
+    public enum FetchOperation {
+        CREATE,
+        UPDATE,
+        NO_UPDATE
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        if (!Profile.isFeatureEnabled(Profile.Feature.CIMD)) {
+            getLogger().warnf("CIMD executor is used, but CIMD feature is disabled. So CIMD is not enforced for the clients. " +
+                    "Please enable CIMD feature in order to be able to have CIMD applied.");
+            return;
+        }
+
+        switch (context.getEvent()) {
+            case PRE_AUTHORIZATION_REQUEST:
+                PreAuthorizationRequestContext preAuthorizationRequestContext = (PreAuthorizationRequestContext)context;
+                process(preAuthorizationRequestContext);
+                break;
+            default:
+        }
+    }
+
+    private void process(PreAuthorizationRequestContext preAuthorizationRequestContext) throws ClientPolicyException {
+        provider = session.getProvider(ClientIdMetadataDocumentProvider.class, getConfiguration().getCimdProviderName());
+        provider.setConfiguration(getConfiguration());
+
+        String clientId = preAuthorizationRequestContext.getClientId();
+
+        // Authorization Request verification
+        URI redirectUriURI = verifyAuthorizationRequest(preAuthorizationRequestContext);
+
+        // Client ID verification
+        URI clientIdURI = verifyClientId(clientId);
+
+        // Client ID validation
+        validateClientId(clientIdURI);
+
+        // determine if (re-)fetching a client metadata is needed
+        FetchOperation fetchOp = provider.determineFetchOperation(clientId);
+        if (fetchOp == FetchOperation.NO_UPDATE) {
+            // no update
+            return;
+        }
+
+        // fetch Client ID Metadata
+        OIDCClientRepresentationWithCacheControl clientOIDCWithCacheControl = fetchClientMetadata(clientIdURI, fetchOp == FetchOperation.UPDATE, provider);
+        if (clientOIDCWithCacheControl == null) {
+            // fetched but no update
+            return;
+        }
+
+        // Client Metadata verification
+        verifyClientMetadata(clientIdURI, redirectUriURI, clientOIDCWithCacheControl.getOidcClientRepresentation());
+
+        // Client Metadata validation
+        validateClientMetadata(clientIdURI, redirectUriURI, clientOIDCWithCacheControl.getOidcClientRepresentation());
+
+        if (fetchOp == FetchOperation.CREATE) {
+            // Update Client Metadata
+            provider.createClientMetadata(clientOIDCWithCacheControl);
+        } else if (fetchOp == FetchOperation.UPDATE) {
+            // Create Client Metadata
+            provider.updateClientMetadata(clientOIDCWithCacheControl);
+        }
+    }
+
+    // Authorization Request Verification Errors
+    public static final String ERR_INVALID_PARAMETER = "Invalid Authorization Request: it does not include redirect_uri parameter";
+
+    // Client ID Verification Errors
+    public static final String ERR_CLIENTID_MALFORMED_URL = "Invalid Client ID: malformed URL.";
+    public static final String ERR_CLIENTID_INVALID_SCHEME = "Invalid Client ID: invalid scheme.";
+    public static final String ERR_CLIENTID_EMPTY_PATH = "Invalid Client ID: empty path.";
+    public static final String ERR_CLIENTID_PATH_TRAVERSAL = "Invalid Client ID: path traverse segment included.";
+    public static final String ERR_CLIENTID_FRAGMENT = "Invalid Client ID: fragment included.";
+    public static final String ERR_CLIENTID_USERINFO = "Invalid Client ID: userinfo included.";
+    public static final String ERR_CLIENTID_QUERY = "Invalid Client ID: query included.";
+    public static final String ERR_CLIENTID_UNRESOLVED = "Invalid Client ID: host unresolved.";
+    public static final String ERR_CLIENTID_LOOPBACK_ADDRESS = "Invalid Client ID: loopback address is not allowed.";
+    public static final String ERR_CLIENTID_PRIVATE_ADDRESS = "Invalid Client ID: private address is not allowed.";
+    //public static final String ERR_CLIENTID_LINKLOCAL_ADDRESS = "Invalid Client ID: link local address is not allowed.";
+
+    // Client ID Validation Errors
+    public static final String ERR_NOTALLOWED_DOMAIN = "Invalid Client ID: domain not allowed.";
+
+    // Client Metadata Verification Errors
+    public static final String ERR_METADATA_NOCONTENT = "Invalid Client Metadata: no content.";
+    public static final String ERR_METADATA_NOCLIENTID = "Invalid Client Metadata: no client_id.";
+    public static final String ERR_METADATA_CLIENTID_UNMATCH = "Invalid Client Metadata: client_id property does not exactly match client_id parameter.";
+    public static final String ERR_METADATA_NOTALLOWED_CLIENTAUTH = "Invalid Client Metadata: token_endpoint_auth_method property in client metadata is not-allowed authentication method..";
+    public static final String ERR_METADATA_CLIENTSECRET = "Invalid Client Metadata: client_secret or client_secret_expires_at property in client metadata is must not included.";
+    public static final String ERR_METADATA_REDIRECTURI = "Invalid Client Metadata: redirect_uri parameter does not exactly match the one of redirect_uris property in client metadata.";
+    public static final String ERR_METADATA_MALFORMED_URL = "Invalid Client Metadata: malformed URL.";
+    public static final String ERR_METADATA_UNRESOLVED = "Invalid Client Metadata: URL unresolved.";
+    public static final String ERR_METADATA_LOOPBACK_ADDRESS = "Invalid Client Metadata: loopback address is not allowed.";
+    public static final String ERR_METADATA_PRIVATE_ADDRESS = "Invalid Client Metadata: private address is not allowed.";
+    //public static final String ERR_METADATA_LINKLOCAL_ADDRESS = "Invalid Clent Metadata: link local address is not allowed.";
+
+    // Client Metadata Validation Errors
+    public static final String ERR_METADATA_URIS_SAMEDOMAIN = "Invalid Client Metadata: client_id parameter, redirect_uri parameter and at least one of redirect_uris properties in client metadata should be under the same domain.";
+    public static final String ERR_METADATA_NO_REQUIRED_PROPERTIES = "Invalid Client Metadata: it does not include all required properties.";
+
+    // Implementation
+    // Fetch Client Metadata
+    public static final String ERR_METADATA_FETCH_FAILED = "Client Metadata fetch failed";
+
+    /**
+     * Verifies an authorization request to check if the request includes required parameters and follows the expected format.
+     *
+     * @param preAuthorizationRequestContext an authorization request
+     * @return {@code URI} {@code redirect_uri} parameter value as {@link URI}
+     * @throws ClientPolicyException when verification of an authorization request fails.
+     */
+    protected URI verifyAuthorizationRequest(PreAuthorizationRequestContext preAuthorizationRequestContext) throws ClientPolicyException {
+        if (preAuthorizationRequestContext.getRequestParameters() == null) {
+            getLogger().warn("authorization request does not include any parameter.");
+            throw invalidClientId(ERR_INVALID_PARAMETER);
+        }
+
+        if (preAuthorizationRequestContext.getRequestParameters().getFirst(OIDCLoginProtocol.CLIENT_ID_PARAM) == null) {
+            getLogger().warn("authorization request does not include client_id.");
+            throw invalidClientId(ERR_INVALID_PARAMETER);
+        }
+
+        String redirectUri = preAuthorizationRequestContext.getRequestParameters().getFirst(OIDCLoginProtocol.REDIRECT_URI_PARAM);
+        if (redirectUri == null) {
+            getLogger().warn("authorization request does not include redirect_uri parameter.");
+            throw invalidClientId(ERR_INVALID_PARAMETER);
+        }
+
+        final URI uri;
+        try {
+            uri = new URI(redirectUri);
+        } catch (URISyntaxException e) {
+            getLogger().warnv("Malformed URL: redirectUri = {0}", redirectUri);
+            throw invalidClientId(ERR_INVALID_PARAMETER);
+        }
+
+        return uri;
+    }
+
+    /**
+     * Verifies a value of {@code client_id} parameter of an authorization request
+     * to check if the value satisfies the requirements of the CIMD and MCP specifications.
+     *
+     * @param clientId a value of {@code client_id} parameter of an authorization request
+     * @return {@code URI} {@code client_uri} parameter value as {@link URI}
+     * @throws ClientPolicyException when verification of an authorization request fails.
+     */
+    protected URI verifyClientId(final String clientId) throws ClientPolicyException {
+        getLogger().debugv("verifyClientId: clientId = {0}", clientId);
+
+        // Client identifier MUST be a URL.
+        final URI uri;
+        try {
+            uri = new URI(clientId);
+        } catch (URISyntaxException e) {
+            getLogger().warnv("Malformed URL: clientId = {0}", clientId);
+            throw invalidClientId(ERR_CLIENTID_MALFORMED_URL);
+        }
+
+        // Client identifier URLs MUST have an "https" scheme.
+        if (!getConfiguration().isAllowHttpScheme() && !"https".equals(uri.getScheme())) {
+            getLogger().warnv("Invalid URL Scheme: scheme = {0}", uri.getScheme());
+            throw invalidClientId(ERR_CLIENTID_INVALID_SCHEME);
+        }
+
+        // Client identifier URLs MUST contain a path component.
+        if (uri.getPath() == null || uri.getPath().isEmpty()) {
+            getLogger().warn("Empty path:");
+            throw invalidClientId(ERR_CLIENTID_EMPTY_PATH);
+        }
+
+        // Client identifier URLs MUST NOT contain single-dot or double-dot path segments.
+        if (uri.getRawPath().contains("/./") || uri.getRawPath().contains("/../")) {
+            getLogger().warnv("traverse path segment: raw path = {0}", uri.getRawPath());
+            throw invalidClientId(ERR_CLIENTID_PATH_TRAVERSAL);
+        }
+
+        // Client identifier URLs MUST NOT contain a fragment component.
+        if (uri.getFragment() != null) {
+            getLogger().warnv("url fragment: fragment = {0}", uri.getFragment());
+            throw invalidClientId(ERR_CLIENTID_FRAGMENT);
+        }
+
+        // Client identifier URLs MUST NOT contain a username or password.
+        if (uri.getUserInfo() != null) {
+            getLogger().warnv("user information: userinfo = {0}", uri.getUserInfo());
+            throw invalidClientId(ERR_CLIENTID_USERINFO);
+        }
+
+        // Client identifier URLs SHOULD NOT include a query string component.
+        if (uri.getQuery() != null) {
+            getLogger().warnv("url query: query = {0}", uri.getQuery());
+            throw invalidClientId(ERR_CLIENTID_QUERY);
+        }
+
+        // Client identifier URLs MAY contain a port.
+        // -> no check, a port is allowed.
+
+        // A short Client identifier URL is RECOMMENDED.
+        // -> no check
+
+        // A stable URL that does not frequently change for the client is RECOMMENDED.
+        // -> no check
+
+        // SSRF attack countermeasure
+        // Client identifier is not a loopback address
+        // Client identifier is not a private address
+        // TODO for integration test, loopback address should be allowed, so its configuration is needed like SecureRedirectUrisEnforcerExecutor
+        InetAddress addr;
+        try {
+            addr = InetAddress.getByName(uri.getHost());
+        } catch (UnknownHostException e) {
+            getLogger().warnv("unknown host: host = {0}", uri.getHost());
+            throw invalidClientId(ERR_CLIENTID_UNRESOLVED);
+        }
+        if (!getConfiguration().isAllowLoopbackAddress() && addr.isLoopbackAddress()) {
+            getLogger().warnv("loopback address: host = {0}", uri.getHost());
+            throw invalidClientId(ERR_CLIENTID_LOOPBACK_ADDRESS);
+        }
+        if (!getConfiguration().isAllowPrivateAddress() && addr.isSiteLocalAddress()) {
+            getLogger().warnv("private address: address = {0}", addr.toString());
+            throw invalidClientId(ERR_CLIENTID_PRIVATE_ADDRESS);
+        }
+        //if (addr.isLinkLocalAddress()) {
+        //    getLogger().warnv("link local address: address = {0}", addr.toString());
+        //    throw invalidClientId(ERR_CLIENTIDLINKLOCAL_ADDRESS);
+        //}
+
+        return uri;
+    }
+
+    /**
+     * Validate a value of {@code client_id} parameter of an authorization request
+     * to check if the value meets the policies.
+     *
+     * @param clientIdURI a value of {@code client_id} parameter of an authorization request in {@link URI}
+     * @throws ClientPolicyException when validation of an authorization request fails.
+     */
+    protected void validateClientId(final URI clientIdURI) throws ClientPolicyException {
+        // The authorization server MAY choose to have its own heuristics and policies around the trust of domain names used as client IDs.
+
+        // allow trusted domain policy
+        List<String> allowList = convertContentFilledList(getConfiguration().getAllowPermittedDomains());
+        if (allowList != null && !allowList.isEmpty()) {
+            if (allowList.stream().noneMatch(i->checkTrustedDomain(clientIdURI.getHost(), i))) {
+                getLogger().warnv("not allowed domain: host = {0}", clientIdURI.getHost());
+                throw invalidClientId(ERR_NOTALLOWED_DOMAIN);
+            }
+        }
+    }
+
+    // apply the same logic in TrustedHostClientRegistrationPolicy.
+    protected boolean checkTrustedDomain(String hostname, String trustedDomain) {
+        if (trustedDomain.startsWith("*.")) {
+            String domain = trustedDomain.substring(2);
+            return hostname.equals(domain) || hostname.endsWith("." + domain);
+        }
+        return hostname.equals(trustedDomain);
+    }
+
+    /**
+     * fetch a client metadata and update cache expiry time if the client metadata has been already created.
+     *
+     * @param clientIdURI a value of {@code client_id} parameter of an authorization request in {@link URI}
+     * @param isUpdate indicates the client metadata has been already created
+     * @param provider {@link ClientIdMetadataDocumentProvider} for updating cache expiry time
+     * @return {@code OIDCClientRepresentationWithCacheControl} a combination of a client metadata and Cache-Control header value accompanied by the metadata response.
+     * {@code null} if a client metadata was re-fetched but the HTTP response status code is 307 Not Modified.
+     * @throws ClientPolicyException when fetching a client metadata fails.
+     */
+    protected OIDCClientRepresentationWithCacheControl fetchClientMetadata(final URI clientIdURI, final boolean isUpdate,
+                                                                           ClientIdMetadataDocumentProvider provider) throws ClientPolicyException {
+        String clientId = clientIdURI.toString();
+
+        SimpleHttpRequest simpleHttp = SimpleHttp.create(session).doGet(clientId);
+
+        OIDCClientRepresentation clientOIDC;
+        try (SimpleHttpResponse response = simpleHttp.asResponse()) {
+            if (!isUpdate && response.getStatus() != Response.Status.OK.getStatusCode()) {
+                getLogger().warnv("fetching client metadata for the first time failed: clientId = {0}", clientId);
+                throw invalidClientId(ERR_METADATA_FETCH_FAILED);
+            }
+            if (isUpdate && response.getStatus() != Response.Status.OK.getStatusCode() && response.getStatus() != Response.Status.NOT_MODIFIED.getStatusCode()) {
+                getLogger().warnv("fetching client metadata for updating failed: clientId = {0}", clientId);
+                throw invalidClientId(ERR_METADATA_FETCH_FAILED);
+            }
+
+            Header[] headers = response.getAllHeaders();
+            String headerKey = Arrays.stream(headers).map(NameValuePair::getName).filter(HttpHeaders.CACHE_CONTROL::equalsIgnoreCase).findFirst().orElse(null); // both header and value are case-insensitive
+            String cacheControlHeaderValue = headerKey != null ? Arrays.stream(headers).filter(i->headerKey.equals(i.getName())).findFirst().get().getValue() : null;
+            ClientMetadataCacheControl clientMetadataCacheControl = new ClientMetadataCacheControl(cacheControlHeaderValue);
+
+            if (isUpdate) {
+                // it is better to compare the fetched client metadata with the existing client metadata.
+                // however, it is difficult to do that because the existing client metadata included additional properties when it was registered.
+                // therefore, such the comparing is not executed.
+                if (response.getStatus() == Response.Status.NOT_MODIFIED.getStatusCode()) {
+                    ClientModel clientModel = session.getContext().getRealm().getClientByClientId(clientId);
+                    // update cache expiry time
+                    provider.setCacheExpiryTimeToClientMetadata(clientModel, clientMetadataCacheControl.getCacheExpiryTimeInSec());
+                    return null;
+                }
+            }
+
+            clientOIDC = response.asJson(OIDCClientRepresentation.class);
+
+            // to successfully convert it to Client Representation, intentionally augment it.
+            augmentClientOIDC(clientOIDC);
+
+            return new OIDCClientRepresentationWithCacheControl(clientOIDC, cacheControlHeaderValue);
+        } catch (IOException e) {
+            getLogger().warnv("HTTP connection failure: {0}", e);
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, ERR_METADATA_FETCH_FAILED);
+        }
+    }
+
+    /**
+     * Verify a client metadata to check if it satisfies the requirements of the CIMD and MCP specifications.
+     *
+     * @param clientIdURI a value of {client_id} parameter of an authorization request in {@link URI}
+     * @param redirectUriURI a value of {redirect_uri} parameter of an authorization request in {@link URI}
+     * @param clientOIDC a client metadata
+     * @return {@code URI} {@code client_id} property of a client metadata in {@link URI}
+     * @throws ClientPolicyException when verifying a client metadata fails.
+     */
+    protected URI verifyClientMetadata(final URI clientIdURI, final URI redirectUriURI, final OIDCClientRepresentation clientOIDC) throws ClientPolicyException {
+        String clientId = clientIdURI.toString();
+        String redirectUri = redirectUriURI.toString();
+
+        if (clientOIDC == null) {
+            getLogger().warn("client metadata does not have its content.");
+            throw invalidClientId(ERR_METADATA_NOCONTENT);
+        }
+
+        // The client metadata document MUST contain a client_id property.
+        if (clientOIDC.getClientId() == null) {
+            getLogger().warn("client metadata does not include client_id property.");
+            throw invalidClientId(ERR_METADATA_NOCLIENTID);
+        }
+
+        // The client_id property's value MUST match the URL of the document
+        // using simple string comparison as defined in [RFC3986] Section 6.2.1.
+        if (!clientOIDC.getClientId().equals(clientId)) {
+            getLogger().warnv("client_id property in client metadata does not exactly match client_id parameter in authorization request. property = {0}, parameter = {1}", clientOIDC.getClientId(), clientId);
+            throw invalidClientId(ERR_METADATA_CLIENTID_UNMATCH);
+        }
+
+        // The token_endpoint_auth_method property MUST NOT include
+        // client_secret_post, client_secret_basic, client_secret_jwt,
+        // or any other method based around a shared symmetric secret.
+        if (clientOIDC.getTokenEndpointAuthMethod() != null && NOTALLOWED_ALGORITHMS.contains(clientOIDC.getTokenEndpointAuthMethod())) {
+            getLogger().warnv("not allowed client auth method: token_endpoint_auth_method = {0}", clientOIDC.getTokenEndpointAuthMethod());
+            throw invalidClientId(ERR_METADATA_NOTALLOWED_CLIENTAUTH);
+        }
+
+        // The client_secret and client_secret_expires_at properties MUST NOT be used.
+        if (clientOIDC.getClientSecret() != null || clientOIDC.getClientSecretExpiresAt() != null) {
+            getLogger().warn("client metadata includes client_secret or client_secret_expires_at.");
+            throw invalidClientId(ERR_METADATA_CLIENTSECRET);
+        }
+
+        // An authorization server MUST validate redirect URIs presented in an authorization request
+        // against those in the metadata document.
+        if (clientOIDC.getRedirectUris() == null || !clientOIDC.getRedirectUris().contains(redirectUri)) {
+            getLogger().warnv("redirect_uri parameter does not exactly match the one of redirect_uris property in client metadata: redirectUri = {0}", redirectUri);
+            throw invalidClientId(ERR_METADATA_REDIRECTURI);
+        }
+
+        // SSRF attack countermeasure
+        // It checks if an address resolved from a property whose value is URI is loopback address.
+        // It checks if an address resolved from a property whose value is URI is private address.
+        // RFC 7591: logo_uri, client_uri, tos_uri, policy_uri, jwks_uri.
+        if (clientOIDC.getLogoUri() != null) {
+            verifyUri(clientOIDC.getLogoUri(), (error, logMessageTemplate) -> {
+                getLogger().warnv(logMessageTemplate, "logo_uri", clientOIDC.getLogoUri());
+                throw invalidClientId(error);
+            });
+        }
+        if (clientOIDC.getClientUri() != null) {
+            verifyUri(clientOIDC.getClientUri(), (error, logMessageTemplate) -> {
+                getLogger().warnv(logMessageTemplate, "client_uri", clientOIDC.getClientUri());
+                throw invalidClientId(error);
+            });
+        }
+        if (clientOIDC.getTosUri() != null) {
+            verifyUri(clientOIDC.getTosUri(), (error, logMessageTemplate) -> {
+                getLogger().warnv(logMessageTemplate, "tos_uri", clientOIDC.getTosUri());
+                throw invalidClientId(error);
+            });
+        }
+        if (clientOIDC.getPolicyUri() != null) {
+            verifyUri(clientOIDC.getPolicyUri(), (error, logMessageTemplate) -> {
+                getLogger().warnv(logMessageTemplate, "policy_uri", clientOIDC.getPolicyUri());
+                throw invalidClientId(error);
+            });
+        }
+        if (clientOIDC.getJwksUri() != null) {
+            verifyUri(clientOIDC.getJwksUri(), (error, logMessageTemplate) -> {
+                getLogger().warnv(logMessageTemplate, "jwks_uri", clientOIDC.getJwksUri());
+                throw invalidClientId(error);
+            });
+        }
+
+        URI clientIdURIfromMetadata;
+        try {
+            clientIdURIfromMetadata = new URI(clientOIDC.getClientId());
+        } catch (URISyntaxException e) {
+            // never reach here
+            getLogger().warnv("Malformed URL: clientId in metadata = {0}", clientOIDC.getClientId());
+            throw invalidClientId(ERR_CLIENTID_MALFORMED_URL);
+        }
+
+        return clientIdURIfromMetadata;
+    }
+
+    private void verifyUri(String uriString, ErrorHandler errorHandler) throws ClientPolicyException {
+        final URI uri;
+        try {
+            uri = new URI(uriString);
+        } catch (URISyntaxException e) {
+            errorHandler.onError(ERR_METADATA_MALFORMED_URL, "Malformed URL: {0} property in metadata = {1}");
+            return;
+        }
+        InetAddress addr;
+        try {
+            addr = InetAddress.getByName(uri.getHost());
+        } catch (UnknownHostException e) {
+            errorHandler.onError(ERR_METADATA_UNRESOLVED, "Unresolved URL: {0} property in metadata = {1}");
+            return;
+        }
+        if (!getConfiguration().isAllowLoopbackAddress() && addr.isLoopbackAddress()) {
+            errorHandler.onError(ERR_METADATA_LOOPBACK_ADDRESS, "loopback address: {0} property in metadata = {1}");
+            return;
+        }
+        if (!getConfiguration().isAllowPrivateAddress() && addr.isSiteLocalAddress()) {
+            errorHandler.onError(ERR_METADATA_PRIVATE_ADDRESS, "private address: {0} property in metadata = {1}");
+            return;
+        }
+        if (addr.isLinkLocalAddress()) {
+            errorHandler.onError(ERR_METADATA_PRIVATE_ADDRESS, "link local address: {0} property in metadata = {1}");
+        }
+    }
+
+    public interface ErrorHandler {
+        void onError(String error, String logMessageTemplate) throws ClientPolicyException;
+    }
+
+    /**
+     * Validate a client metadata to check if the value meets the policies.
+     *
+     * @param clientIdURI a value of {client_id} parameter of an authorization request in {@link URI}
+     * @param redirectUriURI a value of {redirect_uri} parameter of an authorization request in {@link URI}
+     * @param clientOIDC a client metadata
+     * @throws ClientPolicyException when validating a client metadata fails.
+     */
+    protected void validateClientMetadata(final URI clientIdURI, final URI redirectUriURI, final OIDCClientRepresentation clientOIDC) throws ClientPolicyException {
+        // An authorization server MAY impose restrictions or relationships
+        // between the redirect_uris and the client_id or client_uri properties
+
+        // same domain policy
+        List<String> trustedDomains = convertContentFilledList(getConfiguration().getAllowPermittedDomains());
+        if (getConfiguration().isRestrictSameDomain() && trustedDomains != null && !trustedDomains.isEmpty()) {
+            // Client Metadata verification ensures that
+            //  - client_id parameter value in an authorization request exactly matches client_id property in metadata
+            //  - redirect_uri parameter value in an authorization request exactly matches one of client_uris property in metadata
+            // Therefore, only considering domain parts of client_id parameter value, redirect_uri parameter value matches one of permitted domains configuration.
+            if (trustedDomains.stream().noneMatch(i->checkTrustedDomain(clientIdURI.getHost(), i) && checkTrustedDomain(redirectUriURI.getHost(), i))) {
+                getLogger().warnv("client_id and redirect_uri domain not match: client_id host part = {0}, redirect_uri host part = {1}", clientIdURI.getHost(), redirectUriURI.getHost());
+                throw invalidClientId(ERR_METADATA_URIS_SAMEDOMAIN);
+            }
+        }
+
+        // required properties policy
+        List<String> requiredProperties = convertContentFilledList(getConfiguration().getRequiredProperties());
+        if (requiredProperties != null && !requiredProperties.isEmpty()) {
+            JsonNode jn = JsonSerialization.writeValueAsNode(clientOIDC);
+            if (requiredProperties.stream().filter(i->!i.isBlank()).anyMatch(i->jn.get(i) == null)) {
+                getLogger().warn("metadata does not include required properties");
+                throw invalidClientId(ERR_METADATA_NO_REQUIRED_PROPERTIES);
+            }
+        }
+    }
+
+    // to accept a public client in CIMD, intentionally "none" is not included
+    protected static final Set<String> NOTALLOWED_ALGORITHMS = new LinkedHashSet<>(Arrays.asList(
+            OIDCLoginProtocol.CLIENT_SECRET_POST,
+            OIDCLoginProtocol.CLIENT_SECRET_BASIC,
+            OIDCLoginProtocol.CLIENT_SECRET_JWT
+    ));
+
+    protected List<String> convertContentFilledList(List<String> list) {
+        if (list == null) {
+            return Collections.emptyList();
+        }
+        return list.stream().filter(Objects::nonNull).filter(i->!i.isBlank()).distinct().toList();
+    }
+
+    // to successfully convert it to Client Representation, intentionally augment it.
+
+    /**
+     * Augments a re-fetched client metadata to successfully convert it to {@code ClientRepresentation}.
+     *
+     * @param oidcClient a fetched client metadata
+     */
+    protected void augmentClientOIDC(OIDCClientRepresentation oidcClient) {
+        // Allowing a public client:
+        // DescriptionConverter.toInternal recognize a client as a public client if token_endpoint_auth_method is "none"
+        // If a client metadata lacks token_endpoint_auth_method, it is converted to "none", meaning it is treated as a public client.
+        if (oidcClient.getTokenEndpointAuthMethod() == null) {
+            oidcClient.setTokenEndpointAuthMethod("none");
+        }
+    }
+
+    protected static ClientPolicyException invalidClientId(String errorDetail) {
+        return new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, errorDetail);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
@@ -267,7 +267,7 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
 
         public int getCacheExpiryTimeInSec() {
             if (isNoCache() || isNoStore()) {
-                return Time.currentTime();
+                return minCacheTime > 0 ? Time.currentTime() + minCacheTime : Time.currentTime();
             }
             if (isSmaxAge()) { // s-maxage takes precedence over max-age
                 return Time.currentTime() + getSmaxAgeValue();
@@ -275,7 +275,7 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
             if (isMaxAge()) {
                 return Time.currentTime() + getMaxAgeValue();
             }
-            return Time.currentTime();
+            return minCacheTime > 0 ? Time.currentTime() + minCacheTime : Time.currentTime();
         }
 
         private int deriveExpiryValue(final String key, List<String> sList) {

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutor.java
@@ -25,6 +25,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oauth2.cimd.provider.ClientIdMetadataDocumentProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
@@ -642,7 +643,7 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
 
         // An authorization server MUST validate redirect URIs presented in an authorization request
         // against those in the metadata document.
-        if (clientOIDC.getRedirectUris() == null || !clientOIDC.getRedirectUris().contains(redirectUri)) {
+        if (clientOIDC.getRedirectUris() == null || RedirectUtils.verifyRedirectUri(session, clientOIDC.getClientUri(), redirectUri, Set.copyOf(clientOIDC.getRedirectUris()), true) == null) {
             getLogger().warnv("redirect_uri parameter does not exactly match the one of redirect_uris property in client metadata: redirectUri = {0}", redirectUri);
             throw invalidClientIdMetadata(ERR_METADATA_REDIRECTURI);
         }
@@ -830,5 +831,4 @@ public abstract class AbstractClientIdMetadataDocumentExecutor<CONFIG extends Ab
     protected static ClientPolicyException invalidClientIdMetadata(String errorDetail) {
         return new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, errorDetail);
     }
-
 }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -14,8 +14,6 @@ import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderF
  * <ul>
  *     <li>Client ID Verification / Client Metadata Verification (URL related)</li>
  *     <ul>
- *         <li>Allow loopback address: allows IPv4/IPv6 loopback address (for development environment)</li>
- *         <li>Allow private address: allows private address (for development environment)</li>
  *         <li>Allow http scheme: allows http scheme of a URI (for development environment)<</li>
  *     </ul>
  *     <li>Client ID Validation</li>
@@ -34,8 +32,6 @@ import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderF
 public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements ClientPolicyExecutorProviderFactory {
 
     // Client ID Verification
-    public static final String ALLOW_LOOPBACK_ADDRESS = "cimd-allow-loopback-address";
-    public static final String ALLOW_PRIVATE_ADDRESS = "cimd-allow-private-address";
     public static final String ALLOW_HTTP_SCHEME = "cimd-allow-http-scheme";
 
     // Client ID Validation
@@ -74,24 +70,6 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
     static protected void addCommonConfigProperties(List<ProviderConfigProperty> configProperties) {
         // Client ID Verification / Client Metadata Verification (URL related)
         ProviderConfigProperty property = new ProviderConfigProperty(
-                ALLOW_LOOPBACK_ADDRESS,
-                "Allow loopback address",
-                "If ON, then the executor allows loopback address as a valid Client ID URL and property of Client Metadata whose value is URL: client_uri, logo_uri, tos_uri, policy_uri, jwks_uri. " +
-                        "It can be ON only for development environment. It must be OFF in production environment. ",
-                ProviderConfigProperty.BOOLEAN_TYPE,
-                false);
-        configProperties.add(property);
-
-        property = new ProviderConfigProperty(
-                ALLOW_PRIVATE_ADDRESS,
-                "Allow private address",
-                "If ON, then the executor allows private address as a valid Client ID URL and property of Client Metadata whose value is URL: client_uri, logo_uri, tos_uri, policy_uri, jwks_uri. " +
-                        "It can be ON only for development environment. It must be OFF in production environment. ",
-                ProviderConfigProperty.BOOLEAN_TYPE,
-                false);
-        configProperties.add(property);
-
-        property = new ProviderConfigProperty(
                 ALLOW_HTTP_SCHEME,
                 "Allow http scheme",
                 "If ON, then the executor allows http scheme as a valid Client ID URL and property of Client Metadata whose value is URL: client_uri, logo_uri, tos_uri, policy_uri, jwks_uri. " +

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -46,11 +46,16 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
     public static final String REQUIRED_PROPERTIES = "cimd-required-properties";
     public static final String RESTRICT_SAME_DOMAIN = "cimd-restrict-same-domain";
 
-    // Client ID Metadata Document Provider Name
-    public static final String CIMD_PROVIDER_NAME = "cimd-provider-name";
+    // Factory Global Setting: CIMD Provider Name
+    // Name in properties: spi-client-policy-executor-client-id-metadata-document-cimd-provider-name
+    protected String cimdProviderName;
 
     @Override
     public void init(Config.Scope config) {
+        cimdProviderName = config.get("cimdProviderName");
+        if (cimdProviderName == null || cimdProviderName.isBlank()) {
+            cimdProviderName = PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID; // default
+        }
     }
 
     @Override
@@ -124,15 +129,6 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
                 "If client metadata does not include all the properties, the executor does not accept the client metadata.",
                 ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
                 null);
-        configProperties.add(property);
-
-        // Client ID Metadata Document Provider Name
-        property = new ProviderConfigProperty(
-                CIMD_PROVIDER_NAME,
-                "Client ID Metadata Document Provider Name",
-                "Client ID Metadata Document Provider Name. The default is Persistent Client ID Metadata Document Provider",
-                ProviderConfigProperty.STRING_TYPE,
-                PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID);
         configProperties.add(property);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -119,9 +119,8 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
         property = new ProviderConfigProperty(
                 RESTRICT_SAME_DOMAIN,
                 "Restrict same domain",
-                "If ON, then the executor checks Client ID URL and Redirect URI of an authorization request are under the same one of allow permitted domains." +
-                        "Moreover, the executor checks if Redirect URIs in Client Metadata has at least one entry whose domain is the same as " +
-                        "Client ID URL and Redirect URI of the authorization request. ",
+                "If ON, then the executor checks Client ID URL and Redirect URI of an authorization request " +
+                "and properties of client metadata whose value is URI are under the same one of allow permitted domains.",
                 ProviderConfigProperty.BOOLEAN_TYPE,
                 false);
         configProperties.add(property);

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
 
 /**
@@ -112,4 +113,37 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
         configProperties.add(property);
     }
 
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(CONFIG_CIMD_PROVIDER_NAME)
+                .type("string")
+                .helpText("Provider to use for the CIMD")
+                .defaultValue(ClientIdMetadataDocumentExecutorFactoryProviderConfig.DEFAULT_CONFIG_CIMD_PROVIDER_NAME)
+                .add()
+
+                .property()
+                .name(CONFIG_MIN_CACHE_TIME)
+                .type("int")
+                .helpText("Min cache time of client metadata in seconds for the CIMD.")
+                .defaultValue(ClientIdMetadataDocumentExecutorFactoryProviderConfig.DEFAULT_CONFIG_MIN_CACHE_TIME)
+                .add()
+
+                .property()
+                .name(CONFIG_MAX_CACHE_TIME)
+                .type("int")
+                .helpText("Max cache time of client metadata in seconds for the CIMD.")
+                .defaultValue(ClientIdMetadataDocumentExecutorFactoryProviderConfig.DEFAULT_CONFIG_MAX_CACHE_TIME)
+                .add()
+
+                .property()
+                .name(CONFIG_UPPER_LIMIT_METADATA_BYTES)
+                .type("int")
+                .helpText("Client metadata upper limit in byte for the CIMD.")
+                .defaultValue(ClientIdMetadataDocumentExecutorFactoryProviderConfig.DEFAULT_CONFIG_UPPER_LIMIT_METADATA_BYTES)
+                .add()
+
+                .build();
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -1,0 +1,164 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.protocol.oauth2.cimd.provider.PersistentClientIdMetadataDocumentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
+
+/**
+ * The abstract class is the factory class of {@link AbstractClientIdMetadataDocumentExecutor}.
+ *
+ * <p>It provides the following configurations:
+ * <ul>
+ *     <li>Client ID Verification / Client Metadata Verification (URL related)</li>
+ *     <ul>
+ *         <li>Allow loopback address: allows IPv4/IPv6 loopback address (for development environment)</li>
+ *         <li>Allow private address: allows private address (for development environment)</li>
+ *         <li>Allow http scheme: allows http scheme of a URI (for development environment)<</li>
+ *     </ul>
+ *     <li>Client ID Validation</li>
+ *     <ul>
+ *         <li>Allow permitted domains: only allow a URI whose hostname is under the one of the permitted domain (wildcard * can be used)</li>
+ *     </ul>
+ *     <li>Client Metadata Validation</li>
+ *     <ul>
+ *         <li>Restrict same domain: only allow {client_id} and {redirect_uri} parameter of an authorization request whose hostname is under the one of the permitted domain (wildcard * can be used)</li>
+ *         <li>Required properties: only allow a client metadata that includes all required properties</li>
+ *     </ul>
+ *     <li>Client Metadata Augmentation by Client ID Metadata Document Provider</li>
+ *     <ul>
+ *         <li>Consent required</li>
+ *         <li>Full scope disabled</li>
+ *     </ul>
+ *     <li>Client ID Metadata Document Provider Name: defines CIMD provider</li>
+ * </ul>
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    // Client ID Verification
+    public static final String ALLOW_LOOPBACK_ADDRESS = "cimd-allow-loopback-address";
+    public static final String ALLOW_PRIVATE_ADDRESS = "cimd-allow-private-address";
+    public static final String ALLOW_HTTP_SCHEME = "cimd-allow-http-scheme";
+
+    // Client ID Validation
+    public static final String ALLOW_PERMITTED_DOMAINS = "cimd-allow-permitted-domains";
+
+    // Client Metadata Validation
+    public static final String REQUIRED_PROPERTIES = "cimd-required-properties";
+    public static final String RESTRICT_SAME_DOMAIN = "cimd-restrict-same-domain";
+    public static final String CONSENT_REQUIRED = "cimd-consent-required";
+    public static final String FULL_SCOPE_DISABLED = "cimd-full-scope-disabled";
+
+    // Client ID Metadata Document Provider Name
+    public static final String CIMD_PROVIDER_NAME = "cimd-provider-name";
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getHelpText() {
+        return "On receiving an authorization request, this executor process the request by following OAuth Client ID Metadata Document (Internet Draft).";
+    }
+
+    static protected void addCommonConfigProperties(List<ProviderConfigProperty> configProperties) {
+        // Client ID Verification / Client Metadata Verification (URL related)
+        ProviderConfigProperty property = new ProviderConfigProperty(
+                ALLOW_LOOPBACK_ADDRESS,
+                "Allow loopback address",
+                "If ON, then the executor allows loopback address as a valid Client ID URL and property of Client Metadata whose value is URL: client_uri, logo_uri, tos_uri, policy_uri, jwks_uri. " +
+                        "It can be ON only for development environment. It must be OFF in production environment. ",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                false);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty(
+                ALLOW_PRIVATE_ADDRESS,
+                "Allow private address",
+                "If ON, then the executor allows private address as a valid Client ID URL and property of Client Metadata whose value is URL: client_uri, logo_uri, tos_uri, policy_uri, jwks_uri. " +
+                        "It can be ON only for development environment. It must be OFF in production environment. ",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                false);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty(
+                ALLOW_HTTP_SCHEME,
+                "Allow http scheme",
+                "If ON, then the executor allows http scheme as a valid Client ID URL and property of Client Metadata whose value is URL: client_uri, logo_uri, tos_uri, policy_uri, jwks_uri. " +
+                        "It can be ON only for development environment. It must be OFF in production environment. ",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                false);
+        configProperties.add(property);
+
+        // Client ID Validation
+        property = new ProviderConfigProperty(
+                ALLOW_PERMITTED_DOMAINS,
+                "Allow permitted domains",
+                "If some domains are filled, then the executor only accept a Client ID URL whose host part exactly matches one of the filled domains." +
+                        "If not filled, then all domains are possible to use. The domains are checked by using regex. " +
+                        "For example use pattern like this '(.*)\\.example\\.org' if you want to accept the Client ID URL whose domain is 'example.org'." +
+                        "Don't forget to use escaping of special characters like dots as otherwise dot is interpreted as any character in regex!",
+                ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+                null);
+        configProperties.add(property);
+
+        // Client Metadata Validation
+        property = new ProviderConfigProperty(
+                RESTRICT_SAME_DOMAIN,
+                "Restrict same domain",
+                "If ON, then the executor checks Client ID URL and Redirect URI of an authorization request are under the same one of allow permitted domains." +
+                        "Moreover, the executor checks if Redirect URIs in Client Metadata has at least one entry whose domain is the same as " +
+                        "Client ID URL and Redirect URI of the authorization request. ",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                false);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty(
+                REQUIRED_PROPERTIES,
+                "Required properties",
+                "If client metadata does not include all the properties, the executor does not accept the client metadata.",
+                ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+                null);
+        configProperties.add(property);
+
+        // Client Metadata Augmentation by Client ID Metadata Document Provider
+        property = new ProviderConfigProperty(
+                CONSENT_REQUIRED,
+                "Consent required",
+                "If ON, then an end-user is always required to grant consent to the client.",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                true);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty(
+                FULL_SCOPE_DISABLED,
+                "Full scope disabled",
+                "If ON, then client is not allowed to use all the scopes.",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                true);
+        configProperties.add(property);
+
+        // Client ID Metadata Document Provider Name
+        property = new ProviderConfigProperty(
+                CIMD_PROVIDER_NAME,
+                "Client ID Metadata Document Provider Name",
+                "Client ID Metadata Document Provider Name. The default is Persistent Client ID Metadata Document Provider",
+                ProviderConfigProperty.STRING_TYPE,
+                PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID);
+        configProperties.add(property);
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSessionFactory;
-import org.keycloak.protocol.oauth2.cimd.provider.PersistentClientIdMetadataDocumentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
 
@@ -46,16 +45,17 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
     public static final String REQUIRED_PROPERTIES = "cimd-required-properties";
     public static final String RESTRICT_SAME_DOMAIN = "cimd-restrict-same-domain";
 
-    // Factory Global Setting: CIMD Provider Name
-    // Name in properties: spi-client-policy-executor-client-id-metadata-document-cimd-provider-name
-    protected String cimdProviderName;
+    // Factory Global Settings
+    public static final String CONFIG_CIMD_PROVIDER_NAME = "cimd-provider-name";
+    public static final String CONFIG_MIN_CACHE_TIME = "min-cache-time";
+    public static final String CONFIG_MAX_CACHE_TIME = "max-cache-time";
+    public static final String CONFIG_UPPER_LIMIT_METADATA_BYTES = "upper-limit-metadata-bytes";
+
+    protected ClientIdMetadataDocumentExecutorFactoryProviderConfig providerConfig;
 
     @Override
     public void init(Config.Scope config) {
-        cimdProviderName = config.get("cimdProviderName");
-        if (cimdProviderName == null || cimdProviderName.isBlank()) {
-            cimdProviderName = PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID; // default
-        }
+        providerConfig = new ClientIdMetadataDocumentExecutorFactoryProviderConfig(config);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -21,7 +21,7 @@ import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderF
  *     </ul>
  *     <li>Client ID Validation</li>
  *     <ul>
- *         <li>Allow permitted domains: only allow a URI whose hostname is under the one of the permitted domain (wildcard * can be used)</li>
+ *         <li>Trusted domains: only allow a URI whose hostname is under the one of the permitted domain (wildcard * can be used)</li>
  *     </ul>
  *     <li>Client Metadata Validation</li>
  *     <ul>
@@ -40,7 +40,7 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
     public static final String ALLOW_HTTP_SCHEME = "cimd-allow-http-scheme";
 
     // Client ID Validation
-    public static final String ALLOW_PERMITTED_DOMAINS = "cimd-allow-permitted-domains";
+    public static final String TRUSTED_DOMAINS = "cimd-allow-permitted-domains";
 
     // Client Metadata Validation
     public static final String REQUIRED_PROPERTIES = "cimd-required-properties";
@@ -102,11 +102,14 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
 
         // Client ID Validation
         property = new ProviderConfigProperty(
-                ALLOW_PERMITTED_DOMAINS,
-                "Allow permitted domains",
-                "If some domains are filled, then the executor only accept a Client ID URL whose host part exactly matches one of the filled domains." +
-                        "If not filled, then all domains are possible to use. The domains are checked by using regex. " +
-                        "For example use pattern like this '(.*)\\.example\\.org' if you want to accept the Client ID URL whose domain is 'example.org'." +
+                TRUSTED_DOMAINS,
+                "Trusted domains",
+                "If some domains are filled, the executor only accepts the following URL-formatted parameters whose host part matches one of the filled domains: " +
+                        "Authorization request parameters: client_id, redirect_uri, " +
+                        "Client metadata properties: client_id, redirect_uris, jwks_uri, logo_uri, policy_uri, tos_uri, client_uri. " +
+                        "The domains are checked by using regex. " +
+                        "If the domains not filled, the executor denies all such the parameters and properties. " +
+                        "For example, use pattern like this '(.*)\\.example\\.org' if you want to accept the parameter / property whose domain is 'example.org'." +
                         "Don't forget to use escaping of special characters like dots as otherwise dot is interpreted as any character in regex!",
                 ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
                 null);

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -28,12 +28,6 @@ import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderF
  *         <li>Restrict same domain: only allow {client_id} and {redirect_uri} parameter of an authorization request whose hostname is under the one of the permitted domain (wildcard * can be used)</li>
  *         <li>Required properties: only allow a client metadata that includes all required properties</li>
  *     </ul>
- *     <li>Client Metadata Augmentation by Client ID Metadata Document Provider</li>
- *     <ul>
- *         <li>Consent required</li>
- *         <li>Full scope disabled</li>
- *     </ul>
- *     <li>Client ID Metadata Document Provider Name: defines CIMD provider</li>
  * </ul>
  *
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
@@ -51,8 +45,6 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
     // Client Metadata Validation
     public static final String REQUIRED_PROPERTIES = "cimd-required-properties";
     public static final String RESTRICT_SAME_DOMAIN = "cimd-restrict-same-domain";
-    public static final String CONSENT_REQUIRED = "cimd-consent-required";
-    public static final String FULL_SCOPE_DISABLED = "cimd-full-scope-disabled";
 
     // Client ID Metadata Document Provider Name
     public static final String CIMD_PROVIDER_NAME = "cimd-provider-name";
@@ -132,23 +124,6 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
                 "If client metadata does not include all the properties, the executor does not accept the client metadata.",
                 ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
                 null);
-        configProperties.add(property);
-
-        // Client Metadata Augmentation by Client ID Metadata Document Provider
-        property = new ProviderConfigProperty(
-                CONSENT_REQUIRED,
-                "Consent required",
-                "If ON, then an end-user is always required to grant consent to the client.",
-                ProviderConfigProperty.BOOLEAN_TYPE,
-                true);
-        configProperties.add(property);
-
-        property = new ProviderConfigProperty(
-                FULL_SCOPE_DISABLED,
-                "Full scope disabled",
-                "If ON, then client is not allowed to use all the scopes.",
-                ProviderConfigProperty.BOOLEAN_TYPE,
-                true);
         configProperties.add(property);
 
         // Client ID Metadata Document Provider Name

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/AbstractClientIdMetadataDocumentExecutorFactory.java
@@ -3,7 +3,9 @@ package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
 import java.util.List;
 
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
@@ -30,7 +32,8 @@ import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderF
  *
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements ClientPolicyExecutorProviderFactory {
+public abstract class AbstractClientIdMetadataDocumentExecutorFactory
+        implements ClientPolicyExecutorProviderFactory, EnvironmentDependentProviderFactory {
 
     // Client ID Verification
     public static final String ALLOW_HTTP_SCHEME = "cimd-allow-http-scheme";
@@ -145,5 +148,10 @@ public abstract class AbstractClientIdMetadataDocumentExecutorFactory implements
                 .add()
 
                 .build();
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.CIMD);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
@@ -39,8 +39,8 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
         return logger;
     }
 
-    public ClientIdMetadataDocumentExecutor(KeycloakSession session) {
-        super(session);
+    public ClientIdMetadataDocumentExecutor(KeycloakSession session, String cimdProviderName) {
+        super(session, cimdProviderName);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
@@ -1,0 +1,144 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * The class is a concrete class of {@link AbstractClientIdMetadataDocumentExecutor}.
+ * The class provide additional checks and processes, which are not determined by the CIMD and MCP specifications so these are keycloak-specific ones.
+ *
+ * <p>Client Metadata Validation:
+ * The class provides the following policies:
+ * <ul>
+ *     <li>only accept a confidential client</li>
+ *     <li>under the same domain as Server-side request forgery(SSRF) countermeasure: client_id, redirect_uri, client_uri, logo_uri, tos_uri,policy_uri, jwks_uri</li>
+ * </ul>
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDocumentExecutor<ClientIdMetadataDocumentExecutor.Configuration> {
+
+    private static final Logger logger = Logger.getLogger(ClientIdMetadataDocumentExecutor.class);
+
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    public ClientIdMetadataDocumentExecutor(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public String getProviderId() {
+        return ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID;
+    }
+
+    @Override
+    public Class<ClientIdMetadataDocumentExecutor.Configuration> getExecutorConfigurationClass() {
+        return ClientIdMetadataDocumentExecutor.Configuration.class;
+    }
+
+    @Override
+    public void setupConfiguration(ClientIdMetadataDocumentExecutor.Configuration config) {
+        this.configuration = Optional.ofNullable(config).orElse(createDefaultConfiguration());
+    }
+
+    private ClientIdMetadataDocumentExecutor.Configuration createDefaultConfiguration() {
+        return new ClientIdMetadataDocumentExecutor.Configuration();
+    }
+
+    public static class Configuration extends AbstractClientIdMetadataDocumentExecutor.Configuration {
+        // additional settings
+        // Client Metadata Validation
+        @JsonProperty(ClientIdMetadataDocumentExecutorFactory.ONLY_ALLOW_CONFIDENTIAL_CLIENT)
+        protected boolean onlyAllowConfidentialClient = false;
+        @JsonProperty(ClientIdMetadataDocumentExecutorFactory.ALL_URIS_RESTRICT_SAME_DOMAIN)
+        protected boolean allUrisRestrictSameDomain = false;
+
+        public Configuration() {
+            super();
+        }
+
+        public boolean isOnlyAllowConfidentialClient() {
+            return onlyAllowConfidentialClient;
+        }
+
+        public void setOnlyAllowConfidentialClient(boolean onlyAllowConfidentialClient) {
+            this.onlyAllowConfidentialClient = onlyAllowConfidentialClient;
+        }
+
+        public boolean isAllUrisRestrictSameDomain() {
+            return allUrisRestrictSameDomain;
+        }
+
+        public void setAllUrisRestrictSameDomain(boolean allUrisRestrictSameDomain) {
+            this.allUrisRestrictSameDomain = allUrisRestrictSameDomain;
+        }
+    }
+
+    // Client Metadata Validation Errors
+    public static final String ERR_METADATA_NO_CONFIDENTIAL_CLIENT = "Invalid Client Metadata: confidential client is only allowed.";
+    public static final String ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS = "Invalid Client Metadata: ether jwks or jwks_uri property is required.";
+    public static final String ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN = "Invalid Client Metadata: some uri property is not under the same permitted domain";
+
+    @Override
+    protected void validateClientMetadata(final URI clientIdURI, final URI redirectUriURI, final OIDCClientRepresentation clientOIDC) throws ClientPolicyException {
+        super.validateClientMetadata(clientIdURI, redirectUriURI, clientOIDC);
+
+        // only accept a confidential client
+        if (configuration.isOnlyAllowConfidentialClient()) {
+            if (clientOIDC.getTokenEndpointAuthMethod() == null || !ALLOWED_ALGORITHMS.contains(clientOIDC.getTokenEndpointAuthMethod())) {
+                getLogger().warn("not confidential client");
+                throw invalidClientId(ERR_METADATA_NO_CONFIDENTIAL_CLIENT);
+            }
+            if (clientOIDC.getJwksUri() == null && clientOIDC.getJwks() == null) {
+                getLogger().warn("confidential client but jwks or jwks_uri properties is not included");
+                throw invalidClientId(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
+            }
+            if (clientOIDC.getJwksUri() != null && clientOIDC.getJwks() != null) {
+                getLogger().warn("confidential client but both jwks and jwks_uri properties are included");
+                throw invalidClientId(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
+            }
+        }
+
+        // same domain : client_id, redirect_uri, client_uri, logo_uri, tos_uri,, policy_uri, jwks_uri
+        List<String> trustedDomains = convertContentFilledList(getConfiguration().getAllowPermittedDomains());
+        if (getConfiguration().isAllUrisRestrictSameDomain() && trustedDomains != null && !trustedDomains.isEmpty()) {
+            List<String> l = Stream.of(clientOIDC.getClientId(), clientOIDC.getClientUri(), clientOIDC.getLogoUri(), clientOIDC.getTosUri(), clientOIDC.getPolicyUri(), clientOIDC.getJwksUri())
+                    .filter(Objects::nonNull).toList();
+            try {
+                for (String s : l) {
+                    URI u = new URI(s);
+                    if (trustedDomains.stream().filter(i->!i.isBlank()).noneMatch(i -> checkTrustedDomain(u.getHost(), i) && checkTrustedDomain(redirectUriURI.getHost(), i))) {
+                        getLogger().warnv("not under the same domain = {0}", u.getHost());
+                        throw invalidClientId(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
+                    }
+                }
+            } catch (URISyntaxException e) {
+                getLogger().warnv("URI not resolved {0}}", e);
+                throw invalidClientId(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
+            }
+        }
+
+    }
+
+    protected static final Set<String> ALLOWED_ALGORITHMS = new LinkedHashSet<>(Arrays.asList(
+            OIDCLoginProtocol.PRIVATE_KEY_JWT,
+            OIDCLoginProtocol.TLS_CLIENT_AUTH
+    ));
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
@@ -1,14 +1,10 @@
 package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -67,8 +63,6 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
         // Client Metadata Validation
         @JsonProperty(ClientIdMetadataDocumentExecutorFactory.ONLY_ALLOW_CONFIDENTIAL_CLIENT)
         protected boolean onlyAllowConfidentialClient = false;
-        @JsonProperty(ClientIdMetadataDocumentExecutorFactory.ALL_URIS_RESTRICT_SAME_DOMAIN)
-        protected boolean allUrisRestrictSameDomain = false;
 
         public Configuration() {
             super();
@@ -81,20 +75,11 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
         public void setOnlyAllowConfidentialClient(boolean onlyAllowConfidentialClient) {
             this.onlyAllowConfidentialClient = onlyAllowConfidentialClient;
         }
-
-        public boolean isAllUrisRestrictSameDomain() {
-            return allUrisRestrictSameDomain;
-        }
-
-        public void setAllUrisRestrictSameDomain(boolean allUrisRestrictSameDomain) {
-            this.allUrisRestrictSameDomain = allUrisRestrictSameDomain;
-        }
     }
 
     // Client Metadata Validation Errors
     public static final String ERR_METADATA_NO_CONFIDENTIAL_CLIENT = "Invalid Client Metadata: confidential client is only allowed.";
     public static final String ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS = "Invalid Client Metadata: ether jwks or jwks_uri property is required.";
-    public static final String ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN = "Invalid Client Metadata: some uri property is not under the same permitted domain";
 
     @Override
     protected void validateClientMetadata(final URI clientIdURI, final URI redirectUriURI, final OIDCClientRepresentation clientOIDC) throws ClientPolicyException {
@@ -113,25 +98,6 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
             if (clientOIDC.getJwksUri() != null && clientOIDC.getJwks() != null) {
                 getLogger().warn("confidential client but both jwks and jwks_uri properties are included");
                 throw invalidClientIdMetadata(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
-            }
-        }
-
-        // same domain : client_id, redirect_uri, client_uri, logo_uri, tos_uri,, policy_uri, jwks_uri
-        List<String> trustedDomains = convertContentFilledList(getConfiguration().getTrustedDomains());
-        if (getConfiguration().isAllUrisRestrictSameDomain() && trustedDomains != null && !trustedDomains.isEmpty()) {
-            List<String> l = Stream.of(clientOIDC.getClientId(), clientOIDC.getClientUri(), clientOIDC.getLogoUri(), clientOIDC.getTosUri(), clientOIDC.getPolicyUri(), clientOIDC.getJwksUri())
-                    .filter(Objects::nonNull).toList();
-            try {
-                for (String s : l) {
-                    URI u = new URI(s);
-                    if (trustedDomains.stream().filter(i->!i.isBlank()).noneMatch(i -> checkTrustedDomain(u.getHost(), i) && checkTrustedDomain(redirectUriURI.getHost(), i))) {
-                        getLogger().warnv("not under the same domain = {0}", u.getHost());
-                        throw invalidClientIdMetadata(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
-                    }
-                }
-            } catch (URISyntaxException e) {
-                getLogger().warnv("URI not resolved {0}}", e);
-                throw invalidClientIdMetadata(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
             }
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
@@ -35,8 +35,8 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
         return logger;
     }
 
-    public ClientIdMetadataDocumentExecutor(KeycloakSession session, String cimdProviderName) {
-        super(session, cimdProviderName);
+    public ClientIdMetadataDocumentExecutor(KeycloakSession session, ClientIdMetadataDocumentExecutorFactoryProviderConfig providerConfig) {
+        super(session, providerConfig);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutor.java
@@ -104,20 +104,20 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
         if (configuration.isOnlyAllowConfidentialClient()) {
             if (clientOIDC.getTokenEndpointAuthMethod() == null || !ALLOWED_ALGORITHMS.contains(clientOIDC.getTokenEndpointAuthMethod())) {
                 getLogger().warn("not confidential client");
-                throw invalidClientId(ERR_METADATA_NO_CONFIDENTIAL_CLIENT);
+                throw invalidClientIdMetadata(ERR_METADATA_NO_CONFIDENTIAL_CLIENT);
             }
             if (clientOIDC.getJwksUri() == null && clientOIDC.getJwks() == null) {
                 getLogger().warn("confidential client but jwks or jwks_uri properties is not included");
-                throw invalidClientId(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
+                throw invalidClientIdMetadata(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
             }
             if (clientOIDC.getJwksUri() != null && clientOIDC.getJwks() != null) {
                 getLogger().warn("confidential client but both jwks and jwks_uri properties are included");
-                throw invalidClientId(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
+                throw invalidClientIdMetadata(ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
             }
         }
 
         // same domain : client_id, redirect_uri, client_uri, logo_uri, tos_uri,, policy_uri, jwks_uri
-        List<String> trustedDomains = convertContentFilledList(getConfiguration().getAllowPermittedDomains());
+        List<String> trustedDomains = convertContentFilledList(getConfiguration().getTrustedDomains());
         if (getConfiguration().isAllUrisRestrictSameDomain() && trustedDomains != null && !trustedDomains.isEmpty()) {
             List<String> l = Stream.of(clientOIDC.getClientId(), clientOIDC.getClientUri(), clientOIDC.getLogoUri(), clientOIDC.getTosUri(), clientOIDC.getPolicyUri(), clientOIDC.getJwksUri())
                     .filter(Objects::nonNull).toList();
@@ -126,12 +126,12 @@ public class ClientIdMetadataDocumentExecutor extends AbstractClientIdMetadataDo
                     URI u = new URI(s);
                     if (trustedDomains.stream().filter(i->!i.isBlank()).noneMatch(i -> checkTrustedDomain(u.getHost(), i) && checkTrustedDomain(redirectUriURI.getHost(), i))) {
                         getLogger().warnv("not under the same domain = {0}", u.getHost());
-                        throw invalidClientId(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
+                        throw invalidClientIdMetadata(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
                     }
                 }
             } catch (URISyntaxException e) {
                 getLogger().warnv("URI not resolved {0}}", e);
-                throw invalidClientId(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
+                throw invalidClientIdMetadata(ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
             }
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
@@ -27,7 +27,6 @@ public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMet
     public static final String PROVIDER_ID = "client-id-metadata-document";
 
     public static final String ONLY_ALLOW_CONFIDENTIAL_CLIENT = "only-allow-confidential-client";
-    public static final String ALL_URIS_RESTRICT_SAME_DOMAIN = "cimd-all_uris-restrict-same-domain";
 
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
@@ -35,9 +34,7 @@ public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMet
         addCommonConfigProperties(configProperties);
 
         // additional settings
-
         // Client Metadata Validation
-
         ProviderConfigProperty property = new ProviderConfigProperty(
                 ONLY_ALLOW_CONFIDENTIAL_CLIENT,
                 "Only Allow Confidential Client",
@@ -49,7 +46,7 @@ public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMet
 
     @Override
     public ClientPolicyExecutorProvider<ClientIdMetadataDocumentExecutor.Configuration> create(KeycloakSession session) {
-        return new ClientIdMetadataDocumentExecutor(session, cimdProviderName);
+        return new ClientIdMetadataDocumentExecutor(session, providerConfig);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
@@ -29,7 +29,6 @@ public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMet
     public static final String ONLY_ALLOW_CONFIDENTIAL_CLIENT = "only-allow-confidential-client";
     public static final String ALL_URIS_RESTRICT_SAME_DOMAIN = "cimd-all_uris-restrict-same-domain";
 
-
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     static {
@@ -59,7 +58,7 @@ public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMet
 
     @Override
     public ClientPolicyExecutorProvider<ClientIdMetadataDocumentExecutor.Configuration> create(KeycloakSession session) {
-        return new ClientIdMetadataDocumentExecutor(session);
+        return new ClientIdMetadataDocumentExecutor(session, cimdProviderName);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
@@ -1,0 +1,74 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+
+/**
+ * The class is a factory class of {@link ClientIdMetadataDocumentExecutor}.
+ *
+ * <p>It provides the following configurations:
+ * <ul>
+ *     <li>Client Metadata Validation</li>
+ *     <ul>
+ *         <li>Only Allow Confidential Client: only accept a confidential client</li>
+ *         <li>All URIs Restrict same domain: a client metadata includes properties whose values are URIs and an authorization server might access them.
+ *         To prevent Server-side request forgery (SSRF), only allows these properties whose values are under the same domain of the permitted domains.</li>
+ *     </ul>
+ * </ul>
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMetadataDocumentExecutorFactory {
+
+    public static final String PROVIDER_ID = "client-id-metadata-document";
+
+    public static final String ONLY_ALLOW_CONFIDENTIAL_CLIENT = "only-allow-confidential-client";
+    public static final String ALL_URIS_RESTRICT_SAME_DOMAIN = "cimd-all_uris-restrict-same-domain";
+
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        addCommonConfigProperties(configProperties);
+
+        // additional settings
+
+        // Client Metadata Validation
+
+        ProviderConfigProperty property = new ProviderConfigProperty(
+                ONLY_ALLOW_CONFIDENTIAL_CLIENT,
+                "Only Allow Confidential Client",
+                "If ON, then the executor only accept a Client Metadata showing a confidential client.",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                false);
+        configProperties.add(property);
+
+        property = new ProviderConfigProperty(
+                ALL_URIS_RESTRICT_SAME_DOMAIN,
+                "All URIs Restrict same domain",
+                "If ON, then the executor checks client_id and redirect_uris of an authorization request " +
+                        "and properties of client metadata whose value is URI is under the same domain defined by permitted domains.",
+                ProviderConfigProperty.BOOLEAN_TYPE,
+                false);
+        configProperties.add(property);
+    }
+
+    @Override
+    public ClientPolicyExecutorProvider<ClientIdMetadataDocumentExecutor.Configuration> create(KeycloakSession session) {
+        return new ClientIdMetadataDocumentExecutor(session);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactory.java
@@ -45,15 +45,6 @@ public class ClientIdMetadataDocumentExecutorFactory extends AbstractClientIdMet
                 ProviderConfigProperty.BOOLEAN_TYPE,
                 false);
         configProperties.add(property);
-
-        property = new ProviderConfigProperty(
-                ALL_URIS_RESTRICT_SAME_DOMAIN,
-                "All URIs Restrict same domain",
-                "If ON, then the executor checks client_id and redirect_uris of an authorization request " +
-                        "and properties of client metadata whose value is URI is under the same domain defined by permitted domains.",
-                ProviderConfigProperty.BOOLEAN_TYPE,
-                false);
-        configProperties.add(property);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactoryProviderConfig.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/clientpolicy/executor/ClientIdMetadataDocumentExecutorFactoryProviderConfig.java
@@ -1,0 +1,79 @@
+package org.keycloak.protocol.oauth2.cimd.clientpolicy.executor;
+
+import org.keycloak.Config;
+import org.keycloak.protocol.oauth2.cimd.provider.PersistentClientIdMetadataDocumentProviderFactory;
+
+/**
+ * The factory provider configuration for {@link AbstractClientIdMetadataDocumentExecutorFactory} as global settings.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientIdMetadataDocumentExecutorFactoryProviderConfig {
+
+    private final Config.Scope config;
+
+    /**
+     * CIMD provider name
+     */
+    private final String cimdProviderName;
+
+    /**
+     *  Min Cache Time (sec)
+     */
+    private final int minCacheTime;
+
+    /**
+     * Max Cache Time (sec)
+     */
+    private final int maxCacheTime;
+
+    /**
+     * Upper Limit Metadata Bytes
+     */
+    private final long upperLimitMetadataBytes;
+
+    /**
+     * Default value for {@link #cimdProviderName} :
+     */
+    public static final String DEFAULT_CONFIG_CIMD_PROVIDER_NAME = PersistentClientIdMetadataDocumentProviderFactory.PROVIDER_ID;
+
+    /**
+     * Default value for {@link #minCacheTime} : 5min
+     */
+    public static final int DEFAULT_CONFIG_MIN_CACHE_TIME = 300;
+
+    /**
+     * Default value for {@link #maxCacheTime} : 30days
+     */
+    public static final int DEFAULT_CONFIG_MAX_CACHE_TIME = 259200; // 30days
+
+    /**
+     * Default value for {@link #upperLimitMetadataBytes} : 5KB
+     */
+    public static final long DEFAULT_CONFIG_UPPER_LIMIT_METADATA_BYTES = 5000;
+
+
+    public ClientIdMetadataDocumentExecutorFactoryProviderConfig(Config.Scope config) {
+        this.config = config;
+        cimdProviderName = config.get(AbstractClientIdMetadataDocumentExecutorFactory.CONFIG_CIMD_PROVIDER_NAME, DEFAULT_CONFIG_CIMD_PROVIDER_NAME);
+        minCacheTime = config.getInt(AbstractClientIdMetadataDocumentExecutorFactory.CONFIG_MIN_CACHE_TIME, DEFAULT_CONFIG_MIN_CACHE_TIME);
+        maxCacheTime = config.getInt(AbstractClientIdMetadataDocumentExecutorFactory.CONFIG_MAX_CACHE_TIME, DEFAULT_CONFIG_MAX_CACHE_TIME);
+        upperLimitMetadataBytes = config.getLong(AbstractClientIdMetadataDocumentExecutorFactory.CONFIG_UPPER_LIMIT_METADATA_BYTES, DEFAULT_CONFIG_UPPER_LIMIT_METADATA_BYTES);
+    }
+
+    public String getCimdProviderName() {
+        return cimdProviderName;
+    }
+
+    public int getMinCacheTime() {
+        return minCacheTime;
+    }
+
+    public int getMaxCacheTime() {
+        return maxCacheTime;
+    }
+
+    public long getUpperLimitMetadataBytes() {
+        return upperLimitMetadataBytes;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/AbstractPersistentClientIdMetadataDocumentProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/AbstractPersistentClientIdMetadataDocumentProvider.java
@@ -1,0 +1,352 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.util.Time;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.RepresentationToModel;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.AbstractClientIdMetadataDocumentExecutor;
+import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
+import org.keycloak.protocol.oidc.mappers.AbstractPairwiseSubMapper;
+import org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper;
+import org.keycloak.protocol.oidc.mappers.SHA256PairwiseSubMapper;
+import org.keycloak.protocol.oidc.utils.SubjectType;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientregistration.ErrorCodes;
+import org.keycloak.services.clientregistration.oidc.DescriptionConverter;
+import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
+import org.keycloak.services.resources.admin.ClientResource;
+import org.keycloak.validation.ClientValidationContext;
+import org.keycloak.validation.ClientValidationProvider;
+import org.keycloak.validation.ValidationContext;
+import org.keycloak.validation.ValidationResult;
+
+import org.jboss.logging.Logger;
+
+/**
+ * The abstract class persists client metadata.
+ *
+ * <p>Creating and updating a client metadata:
+ * The class does almost the same process in Dynamic Client Registration (DCR)in {@code OIDCClientRegistrationProvider}.
+ *
+ * <p>The reason is that a client sends its metadata to an authorization server in DCR by RFC 7591
+ * while an authorization server fetches a client metadata in CIMD,
+ * which means that only the method of getting a client metadata is different.
+ *
+ * <p>The reason why not directly calling methods of {@code OIDCClientRegistrationProvider} is as follows:
+ * <ul>
+ *     <li>{@code client_id} property is not allowed in DCR while it is mandatory in CIMD.
+ *     {@code OIDCClientRegistrationProvider} does not allow client metadata including {@code client_id}. </li>
+ *     <li>A registration access token is issued in DCR
+ *     (to say more precisely, RFC 7592 OAuth 2.0 Dynamic Client Registration Management Protocol) while it is not needed in CIMD.
+ *     {@code OIDCClientRegistrationProvider} issues the registration access token.</li>
+ * </ul>
+ *
+ * <p>Cache expiry time:
+ * The provider stores the cache expiry time in an attribute of {@link ClientRepresentation}/{@link ClientModel}.
+ *
+ * <p>Process when a cache expires</p>
+ * Do nothing. After keycloak supports workflow for clients, it would be used to delete a client metadata.
+ *
+ * <p>Roles of the abstract class and its concrete class:
+ * The abstract class itself covers all about persisting a client metadata while the concrete class can see
+ * a configuration of the concrete class of ({@link AbstractClientIdMetadataDocumentExecutor}) and augment a client metadata based on it.
+ * Moreover, the concrete class can add or modify the abstract class, which makes it easy to implement custom persistent CIMD provider.
+ *
+ * 
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public abstract class AbstractPersistentClientIdMetadataDocumentProvider<CONFIG extends AbstractClientIdMetadataDocumentExecutor.Configuration> implements ClientIdMetadataDocumentProvider<CONFIG> {
+
+    protected KeycloakSession session;
+    protected CONFIG configuration;
+
+    public static final String CIMD_CACHE_EXPIRY_TIME_IN_SEC = "cimd.cache.expiry.time.in.sec";
+
+    protected abstract Logger getLogger();
+
+    protected AbstractPersistentClientIdMetadataDocumentProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public void setCacheExpiryTimeToClientMetadata(ClientRepresentation clientRep, int cacheExpiryTimeInSec) {
+        clientRep.getAttributes().put(CIMD_CACHE_EXPIRY_TIME_IN_SEC, Integer.toString(cacheExpiryTimeInSec));
+    }
+
+    @Override
+    public void setCacheExpiryTimeToClientMetadata(ClientModel clientModel, int cacheExpiryTimeInSec) {
+        clientModel.setAttribute(CIMD_CACHE_EXPIRY_TIME_IN_SEC, Integer.toString(cacheExpiryTimeInSec));
+    }
+
+    @Override
+    public AbstractClientIdMetadataDocumentExecutor.FetchOperation determineFetchOperation(String clientId) {
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel existingClientModel = realm.getClientByClientId(clientId);
+        if (existingClientModel != null) {
+            getLogger().debugv("client already exist: clientId = {0}", clientId);
+            // Client Metadata Caching
+            // if the client metadata remains effective, return
+            // otherwise
+            //   fetch Client ID Metadata
+            //   Client Metadata verification
+            //   Client Metadata validation
+            //   Persist Client Metadata (overwrite)
+            //  TODO: if an error occurs, the client metadata should be removed or remain persisted?
+            //        -> it remains persisted. If client metadata removal by workflow is implemented, the client metadata is automatically removed.
+            //        -> therefore, only returns an error response.
+            if (existingClientModel.getAttribute(CIMD_CACHE_EXPIRY_TIME_IN_SEC) != null) {
+                int i = Integer.parseInt(existingClientModel.getAttribute(CIMD_CACHE_EXPIRY_TIME_IN_SEC));
+                if (Time.currentTime() > i) {
+                    getLogger().debugv("client need to update: clientId = {0}", clientId);
+                    return AbstractClientIdMetadataDocumentExecutor.FetchOperation.UPDATE;
+                } else {
+                    // persisted client metadata is still effective
+                    getLogger().debugv("client no need to update: clientId = {0}", clientId);
+                    return AbstractClientIdMetadataDocumentExecutor.FetchOperation.NO_UPDATE;
+                }
+            }
+        }
+        getLogger().debugv("client need to create: clientId = {0}", clientId);
+        return AbstractClientIdMetadataDocumentExecutor.FetchOperation.CREATE;
+    }
+
+    @Override
+    public ClientModel createClientMetadata(AbstractClientIdMetadataDocumentExecutor.OIDCClientRepresentationWithCacheControl clientOIDCWithCacheControl) throws ClientPolicyException {
+        // do the same thing as in dynamic client registration except for:
+        //   - not set client registration token
+        RealmModel realm = session.getContext().getRealm();
+        try {
+            OIDCClientRepresentation clientOIDC = clientOIDCWithCacheControl.getOidcClientRepresentation();
+            ClientRepresentation clientRep = DescriptionConverter.toInternal(session, clientOIDC);
+
+            // set cache expiry time
+            setCacheExpiryTimeToClientMetadata(clientRep, clientOIDCWithCacheControl.getClientMetadataCacheControl().getCacheExpiryTimeInSec());
+
+            // augment client depending on the configuration of the CIMD executor
+            augmentClientMetadata(clientRep);
+
+            if (clientRep.getOptionalClientScopes() != null && clientRep.getDefaultClientScopes() == null) {
+                clientRep.setDefaultClientScopes(List.of(OIDCLoginProtocolFactory.BASIC_SCOPE));
+            }
+
+            EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
+            event.event(EventType.CLIENT_REGISTER);
+
+            ClientModel clientModel = ClientManager.createClient(session, realm, clientRep);
+
+            if (clientRep.getDefaultRoles() != null) {
+                for (String name : clientRep.getDefaultRoles()) {
+                    addDefaultRole(clientModel, name);
+                }
+            }
+
+            if (clientModel.isServiceAccountsEnabled()) {
+                new ClientManager(new RealmManager(session)).enableServiceAccount(clientModel);
+            }
+
+            if (Boolean.TRUE.equals(clientRep.getAuthorizationServicesEnabled())) {
+                RepresentationToModel.createResourceServer(clientModel, session, true);
+            }
+
+            session.getContext().setClient(clientModel);
+
+            clientRep = ModelToRepresentation.toRepresentation(clientModel, session);
+
+            clientRep.setDirectAccessGrantsEnabled(clientModel.isDirectAccessGrantsEnabled());
+
+            Stream<String> defaultRolesNames = getDefaultRolesStream(clientModel);
+            if (defaultRolesNames != null) {
+                clientRep.setDefaultRoles(defaultRolesNames.toArray(String[]::new));
+            }
+
+            event.client(clientRep.getClientId()).success();
+
+            clientModel = realm.getClientByClientId(clientRep.getClientId());
+            updatePairwiseSubMappers(clientModel, SubjectType.parse(clientOIDC.getSubjectType()), clientOIDC.getSectorIdentifierUri());
+            updateClientRepWithProtocolMappers(clientModel, clientRep);
+
+            validateClient(clientModel, clientOIDC, true);
+
+            return clientModel;
+        } catch (ModelDuplicateException e) {
+            getLogger().warnv("ModelDuplicateException: {0}", e);
+            throw new ClientPolicyException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier in use");
+        } catch (ClientPolicyException e) {
+            throw e; // intentionally
+        } catch (Exception e) {
+            getLogger().warnv("Exception: {0}", e);
+            throw invalidClientMetadata("invalid request");
+        }
+    }
+
+    @Override
+    public ClientModel updateClientMetadata(AbstractClientIdMetadataDocumentExecutor.OIDCClientRepresentationWithCacheControl clientOIDCWithCacheControl) throws ClientPolicyException {
+        // do the same thing as in dynamic client registration except for:
+        //   - not set client registration token
+        RealmModel realm = session.getContext().getRealm();
+
+        try {
+            OIDCClientRepresentation clientOIDC = clientOIDCWithCacheControl.getOidcClientRepresentation();
+            ClientRepresentation clientRep = DescriptionConverter.toInternal(session, clientOIDC);
+            String clientId = clientOIDC.getClientId();
+
+            // set cache expiry time
+            setCacheExpiryTimeToClientMetadata(clientRep, clientOIDCWithCacheControl.getClientMetadataCacheControl().getCacheExpiryTimeInSec());
+
+            // augment client depending on configuration
+            augmentClientMetadata(clientRep);
+
+            if (clientOIDC.getScope() != null) {
+                ClientModel oldClient = realm.getClientByClientId(clientId);
+                Collection<String> defaultClientScopes = oldClient.getClientScopes(true).keySet();
+                clientRep.setDefaultClientScopes(new ArrayList<>(defaultClientScopes));
+            }
+
+            EventBuilder event = new EventBuilder(realm, session, session.getContext().getConnection());
+            event.event(EventType.CLIENT_UPDATE).client(clientId);
+
+            ClientModel clientModel = realm.getClientByClientId(clientId);
+
+            if (!clientModel.getClientId().equals(clientRep.getClientId())) {
+                throw invalidClientMetadata("Client Identifier modified");
+            }
+
+            ClientResource.updateClientServiceAccount(session, clientModel, clientRep.isServiceAccountsEnabled());
+            RepresentationToModel.updateClient(clientRep, clientModel, session);
+            RepresentationToModel.updateClientProtocolMappers(clientRep, clientModel);
+            RepresentationToModel.updateClientScopes(clientRep, clientModel);
+
+            clientRep = ModelToRepresentation.toRepresentation(clientModel, session);
+
+            Stream<String> defaultRolesNames = getDefaultRolesStream(clientModel);
+            if (defaultRolesNames != null) {
+                clientRep.setDefaultRoles(defaultRolesNames.toArray(String[]::new));
+            }
+
+            event.client(clientRep.getClientId()).success();
+
+            session.getContext().setClient(clientModel);
+
+            clientModel = realm.getClientByClientId(clientRep.getClientId());
+            updatePairwiseSubMappers(clientModel, SubjectType.parse(clientOIDC.getSubjectType()), clientOIDC.getSectorIdentifierUri());
+            updateClientRepWithProtocolMappers(clientModel, clientRep);
+
+            validateClient(clientModel, clientOIDC, false);
+
+            return clientModel;
+        } catch (ClientPolicyException e) {
+            throw e; // intentionally
+        } catch (Exception e) {
+            getLogger().warnv("Exception: {0}", e);
+            throw invalidClientMetadata("invalid request");
+        }
+    }
+
+    private static ClientPolicyException invalidClientMetadata(String errorDetail) {
+        return new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, errorDetail);
+    }
+
+    // the same as AbstractClientRegistrationProvider.addDefaultRole
+    private void addDefaultRole(ClientModel client, String name) {
+        client.getRealm().getDefaultRole().addCompositeRole(getOrAddRoleId(client, name));
+    }
+
+    // the same as AbstractClientRegistrationProvider.getOrAddRoleId
+    private RoleModel getOrAddRoleId(ClientModel client, String name) {
+        RoleModel role = client.getRole(name);
+        if (role == null) {
+            role = client.addRole(name);
+        }
+        return role;
+    }
+
+    // the same as AbstractClientRegistrationProvider.getDefaultRolesStream
+    private Stream<String> getDefaultRolesStream(ClientModel client) {
+        return client.getRealm().getDefaultRole().getCompositesStream()
+                .filter(role -> role.isClientRole() && Objects.equals(role.getContainerId(), client.getId()))
+                .map(RoleModel::getName);
+    }
+
+    // the same as OIDCClientRegistrationProvider.updatePairwiseSubMappers
+    private void updatePairwiseSubMappers(ClientModel clientModel, SubjectType subjectType, String sectorIdentifierUri) {
+        if (subjectType == SubjectType.PAIRWISE) {
+
+            // See if we have existing pairwise mapper and update it. Otherwise create new
+            AtomicBoolean foundPairwise = new AtomicBoolean(false);
+
+            clientModel.getProtocolMappersStream().filter((ProtocolMapperModel mapping) -> {
+                if (mapping.getProtocolMapper().endsWith(AbstractPairwiseSubMapper.PROVIDER_ID_SUFFIX)) {
+                    foundPairwise.set(true);
+                    return true;
+                } else {
+                    return false;
+                }
+            }).toList().forEach((ProtocolMapperModel mapping) -> {
+                PairwiseSubMapperHelper.setSectorIdentifierUri(mapping, sectorIdentifierUri);
+                clientModel.updateProtocolMapper(mapping);
+            });
+
+            // We don't have existing pairwise mapper. So create new
+            if (!foundPairwise.get()) {
+                ProtocolMapperRepresentation newPairwise = SHA256PairwiseSubMapper.createPairwiseMapper(sectorIdentifierUri, null);
+                clientModel.addProtocolMapper(RepresentationToModel.toModel(newPairwise));
+            }
+
+        } else {
+            // Rather find and remove all pairwise mappers
+            clientModel.getProtocolMappersStream()
+                    .filter(mapperRep -> mapperRep.getProtocolMapper().endsWith(AbstractPairwiseSubMapper.PROVIDER_ID_SUFFIX))
+                    .toList()
+                    .forEach(clientModel::removeProtocolMapper);
+        }
+    }
+
+    // the same as OIDCClientRegistrationProvider.updateClientRepWithProtocolMappers
+    private void updateClientRepWithProtocolMappers(ClientModel clientModel, ClientRepresentation rep) {
+        List<ProtocolMapperRepresentation> mappings =
+                clientModel.getProtocolMappersStream().map(ModelToRepresentation::toRepresentation).collect(Collectors.toList());
+        rep.setProtocolMappers(mappings);
+    }
+
+    // the same as AbstractClientRegistrationProvider.updateClientRepWithProtocolMappers except for error handling
+    private void validateClient(ClientModel client, OIDCClientRepresentation oidcClient, boolean create) throws ClientPolicyException{
+        ClientValidationProvider provider = session.getProvider(ClientValidationProvider.class);
+        if (provider != null) {
+            ValidationContext.Event event = create ? ValidationContext.Event.CREATE : ValidationContext.Event.UPDATE;
+            ValidationResult result;
+
+            if (oidcClient != null) {
+                result = provider.validate(new ClientValidationContext.OIDCContext(event, session, client, oidcClient));
+            }
+            else {
+                result = provider.validate(new ClientValidationContext(event, session, client));
+            }
+
+            if (!result.isValid()) {
+                getLogger().warnv("validateClient failed: {0}", result.getAllErrorsAsString());
+                session.getTransactionManager().setRollbackOnly();
+                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "invalid request");
+            }
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/AbstractPersistentClientIdMetadataDocumentProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/AbstractPersistentClientIdMetadataDocumentProviderFactory.java
@@ -1,0 +1,25 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * The abstract class is the factory class of {@link AbstractPersistentClientIdMetadataDocumentProvider}.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public abstract class AbstractPersistentClientIdMetadataDocumentProviderFactory implements ClientIdMetadataDocumentProviderFactory {
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/ClientIdMetadataDocumentProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/ClientIdMetadataDocumentProvider.java
@@ -1,0 +1,84 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.AbstractClientIdMetadataDocumentExecutor;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.AbstractClientIdMetadataDocumentExecutor.FetchOperation;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.AbstractClientIdMetadataDocumentExecutor.OIDCClientRepresentationWithCacheControl;
+import org.keycloak.provider.Provider;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+
+/**
+ * The interface provides the following features:
+ *
+ * <ul>
+ *     <li>Determining if (re-)fetching a client metadata is needed</li>
+ *     <li>Concrete process of caching a client metadata: create and update</li>
+ *     <li>Update cache expiry time</li>
+ *     <li>Augment a client metadata in {@code ClientRepresentation}</li>
+ * </ul>
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public interface ClientIdMetadataDocumentProvider<CONFIG extends AbstractClientIdMetadataDocumentExecutor.Configuration> extends Provider {
+
+    /**
+     * Gets a configuration of an executor for Client ID metadata document.
+     * @return {@code CONFIG extends AbstractClientIdMetadataDocumentExecutor.Configuration}
+     */
+    CONFIG getConfiguration();
+
+    /**
+     * Sets a configuration of an executor for Client ID metadata document.
+     * @param configuration a configuration of an executor for Client ID metadata document, not {@code null}
+     */
+    void setConfiguration(CONFIG configuration);
+
+    /**
+     * Sets a cache expiry time in sec to a client metadata.
+     * @param clientRep a client metadata in {@code ClientRepresentation}, not {@code null}
+     * @param cacheExpiryTimeInSec when a cache expires in sec
+     */
+    void setCacheExpiryTimeToClientMetadata(ClientRepresentation clientRep, int cacheExpiryTimeInSec);
+
+    /**
+     * Sets a cache expiry time in sec to a client metadata.
+     * @param clientModel a client metadata in {@code ClientModel}, not {@code null}
+     * @param cacheExpiryTimeInSec when a cache expires in sec
+     */
+    void setCacheExpiryTimeToClientMetadata(ClientModel clientModel, int cacheExpiryTimeInSec);
+
+    /**
+     * Returns if fetching a client metadata to newly create it is needed, or re-fetching a client metadata to update it is needed,
+     * or re-fetching is not needed because a client metadata does not expire.
+     * @param clientId {@code client_id} parameter of an authorization request, not {@code null}
+     * @return {@link FetchOperation}
+     */
+    FetchOperation determineFetchOperation(String clientId);
+
+    /**
+     * Creates a client metadata.
+     * @param clientOIDCWithCacheControl a combination of a fetched client metadata and Cache-Control header accompanied by it, not {@code null}
+     * @return {@link ClientModel} a created client metadata in {@link ClientModel}
+     * @throws ClientPolicyException when creating a client metadata fails
+     */
+    ClientModel createClientMetadata(OIDCClientRepresentationWithCacheControl clientOIDCWithCacheControl) throws ClientPolicyException;
+
+    /**
+     * Updates a client metadata.
+     * @param clientOIDCWithCacheControl a combination of a re-fetched client metadata and Cache-Control header accompanied by it, not {@code null}
+     * @return {@link ClientModel} an updated client metadata in {@link ClientModel}
+     * @throws ClientPolicyException when updating a client metadata fails
+     */
+    ClientModel updateClientMetadata(OIDCClientRepresentationWithCacheControl clientOIDCWithCacheControl) throws ClientPolicyException;
+
+    /**
+     * Augments a client metadata.
+     * @param clientRep a client metadata in {@link ClientRepresentation}, not {@code null}
+     */
+    void augmentClientMetadata(ClientRepresentation clientRep);
+
+    @Override
+    default void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/ClientIdMetadataDocumentProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/ClientIdMetadataDocumentProviderFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderFactory;
+
+/**
+ * The interface is a factory of {@link ClientIdMetadataDocumentProvider}.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public interface ClientIdMetadataDocumentProviderFactory extends ProviderFactory<ClientIdMetadataDocumentProvider>,
+        EnvironmentDependentProviderFactory {
+
+    @Override
+    default boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.CIMD);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/ClientIdMetadataDocumentProviderSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/ClientIdMetadataDocumentProviderSpi.java
@@ -1,0 +1,33 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+/**
+ * The class is the SPI for {@link ClientIdMetadataDocumentProvider} and {@link ClientIdMetadataDocumentProviderFactory}.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ClientIdMetadataDocumentProviderSpi implements Spi {
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return "cimd";
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return ClientIdMetadataDocumentProvider.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return ClientIdMetadataDocumentProviderFactory.class;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/PersistentClientIdMetadataDocumentProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/PersistentClientIdMetadataDocumentProvider.java
@@ -1,0 +1,69 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutor;
+import org.keycloak.representations.idm.ClientRepresentation;
+
+import org.jboss.logging.Logger;
+
+import static org.keycloak.models.ClientScopeModel.CONSENT_SCREEN_TEXT;
+import static org.keycloak.models.ClientScopeModel.DISPLAY_ON_CONSENT_SCREEN;
+
+/**
+ *  The class is a concrete class of {@link AbstractPersistentClientIdMetadataDocumentProvider}.
+ *
+ * <p>Client Metadata Augmentation in {@link ClientRepresentation}:
+ * The class provide the following policies:
+ * <ul>
+ *     <li>Consent required: to mitigate the risk of phishing,
+ *     the CIMD and MCP specification requires an authorization server to show information on a client on the consent screen.</li>
+ *     <li>Full scope allowed: to follow least-privilege principle, only required scopes are permitted to a client.</li>
+ * </ul>
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class PersistentClientIdMetadataDocumentProvider extends AbstractPersistentClientIdMetadataDocumentProvider<ClientIdMetadataDocumentExecutor.Configuration> {
+
+    protected Logger logger = Logger.getLogger(PersistentClientIdMetadataDocumentProvider.class);
+
+    public Logger getLogger() {
+        return logger;
+    }
+
+    public PersistentClientIdMetadataDocumentProvider(KeycloakSession session) {
+        super(session);
+    }
+
+    @Override
+    public ClientIdMetadataDocumentExecutor.Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void setConfiguration(ClientIdMetadataDocumentExecutor.Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void augmentClientMetadata(ClientRepresentation clientRep) {
+        clientRep.setConsentRequired(getConfiguration().isConsentRequired());
+        clientRep.setFullScopeAllowed(!getConfiguration().isFullScopeDisabled());
+
+        // to show information on a client on the consent screen.
+        clientRep.getAttributes().put(DISPLAY_ON_CONSENT_SCREEN, "true");
+        URI uri = null;
+        try {
+            uri = new URI(clientRep.getClientId());
+        } catch (URISyntaxException e) {
+            return;
+        }
+
+        // The authorization server SHOULD display the hostname of the client_id on the authorization interface,
+        // in addition to displaying the fetched client information if any.
+        // TODO: better show other information on a client but not determined what information should be shown.
+        clientRep.getAttributes().put(CONSENT_SCREEN_TEXT, "The client's hostname is " + uri.getHost());
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/PersistentClientIdMetadataDocumentProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/PersistentClientIdMetadataDocumentProvider.java
@@ -49,8 +49,8 @@ public class PersistentClientIdMetadataDocumentProvider extends AbstractPersiste
 
     @Override
     public void augmentClientMetadata(ClientRepresentation clientRep) {
-        clientRep.setConsentRequired(getConfiguration().isConsentRequired());
-        clientRep.setFullScopeAllowed(!getConfiguration().isFullScopeDisabled());
+        clientRep.setConsentRequired(true);
+        clientRep.setFullScopeAllowed(false);
 
         // to show information on a client on the consent screen.
         clientRep.getAttributes().put(DISPLAY_ON_CONSENT_SCREEN, "true");

--- a/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/PersistentClientIdMetadataDocumentProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/cimd/provider/PersistentClientIdMetadataDocumentProviderFactory.java
@@ -1,0 +1,24 @@
+package org.keycloak.protocol.oauth2.cimd.provider;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutor;
+
+/**
+ * The class is the factory class of {@link PersistentClientIdMetadataDocumentProvider}.
+ *
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class PersistentClientIdMetadataDocumentProviderFactory extends AbstractPersistentClientIdMetadataDocumentProviderFactory {
+
+    public static final String PROVIDER_ID = "persistent-cimd";
+
+    @Override
+    public ClientIdMetadataDocumentProvider<ClientIdMetadataDocumentExecutor.Configuration> create(KeycloakSession session) {
+        return new PersistentClientIdMetadataDocumentProvider(session);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -221,6 +221,12 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
             config.setAuthorizationDetailsTypesSupported(authorizationDetailsTypesSupported);
         }
 
+        if (Profile.isFeatureEnabled(Profile.Feature.CIMD)) {
+            config.setClientIdMetadataDocumentSupported(true);
+        } else {
+            config.setClientIdMetadataDocumentSupported(false);
+        }
+
         config = checkConfigOverride(config);
         return config;
     }

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oauth2.cimd.provider.ClientIdMetadataDocumentProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oauth2.cimd.provider.ClientIdMetadataDocumentProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.protocol.oauth2.cimd.provider.PersistentClientIdMetadataDocumentProviderFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -37,3 +37,4 @@ org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorSpi
 org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandlerSpi
 org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorSpi
+org.keycloak.protocol.oauth2.cimd.provider.ClientIdMetadataDocumentProviderSpi

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.condition.ClientPolicyConditionProviderFactory
@@ -11,3 +11,4 @@ org.keycloak.services.clientpolicy.condition.ClientAttributesConditionFactory
 org.keycloak.services.clientpolicy.condition.AcrConditionFactory
 org.keycloak.services.clientpolicy.condition.GrantTypeConditionFactory
 org.keycloak.services.clientpolicy.condition.IdentityProviderConditionFactory
+org.keycloak.protocol.oauth2.cimd.clientpolicy.condition.ClientIdUriSchemeConditionFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -33,3 +33,4 @@ org.keycloak.services.clientpolicy.executor.SecureClientAuthenticationAssertionE
 org.keycloak.services.clientpolicy.executor.DownscopeAssertionGrantEnforcerExecutorFactory
 org.keycloak.services.clientpolicy.executor.JWTClaimEnforcerExecutorFactory
 org.keycloak.services.clientpolicy.executor.JWTAuthorizationGrantAudienceExecutorFactory
+org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutorFactory

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProvider.java
@@ -46,6 +46,7 @@ import org.keycloak.representations.adapters.action.TestAvailabilityAction;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resources.RealmsResource;
 import org.keycloak.testsuite.rest.representation.TestAuthenticationChannelRequest;
+import org.keycloak.testsuite.rest.representation.TestClientIdMetadataDocumentRequest;
 import org.keycloak.testsuite.rest.resource.TestingOIDCEndpointsApplicationResource;
 import org.keycloak.utils.MediaType;
 
@@ -69,6 +70,7 @@ public class TestApplicationResourceProvider implements RealmResourceProvider {
     private final ConcurrentMap<String, TestAuthenticationChannelRequest> authenticationChannelRequests;
     private final ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications;
     private final ConcurrentMap<String, String> intentClientBindings;
+    private final ConcurrentMap<String, TestClientIdMetadataDocumentRequest> clientIdMetadataDocumentRequests;
 
     private final HttpRequest request;
 
@@ -80,7 +82,8 @@ public class TestApplicationResourceProvider implements RealmResourceProvider {
             TestApplicationResourceProviderFactory.OIDCClientData oidcClientData,
             ConcurrentMap<String, TestAuthenticationChannelRequest> authenticationChannelRequests,
             ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications,
-            ConcurrentMap<String, String> intentClientBindings) {
+            ConcurrentMap<String, String> intentClientBindings,
+            ConcurrentMap<String, TestClientIdMetadataDocumentRequest> clientIdMetadataDocumentRequests) {
         this.session = session;
         this.adminLogoutActions = adminLogoutActions;
         this.backChannelLogoutTokens = backChannelLogoutTokens;
@@ -91,6 +94,7 @@ public class TestApplicationResourceProvider implements RealmResourceProvider {
         this.authenticationChannelRequests = authenticationChannelRequests;
         this.cibaClientNotifications = cibaClientNotifications;
         this.intentClientBindings = intentClientBindings;
+        this.clientIdMetadataDocumentRequests = clientIdMetadataDocumentRequests;
         this.request = session.getContext().getHttpRequest();
     }
 
@@ -267,7 +271,7 @@ public class TestApplicationResourceProvider implements RealmResourceProvider {
 
     @Path("/oidc-client-endpoints")
     public TestingOIDCEndpointsApplicationResource getTestingOIDCClientEndpoints() {
-        return new TestingOIDCEndpointsApplicationResource(oidcClientData, authenticationChannelRequests, cibaClientNotifications, intentClientBindings);
+        return new TestingOIDCEndpointsApplicationResource(oidcClientData, authenticationChannelRequests, cibaClientNotifications, intentClientBindings, clientIdMetadataDocumentRequests);
     }
 
     @Override

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestApplicationResourceProviderFactory.java
@@ -38,6 +38,7 @@ import org.keycloak.representations.adapters.action.TestAvailabilityAction;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resource.RealmResourceProviderFactory;
 import org.keycloak.testsuite.rest.representation.TestAuthenticationChannelRequest;
+import org.keycloak.testsuite.rest.representation.TestClientIdMetadataDocumentRequest;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -54,11 +55,12 @@ public class TestApplicationResourceProviderFactory implements RealmResourceProv
     private ConcurrentMap<String, TestAuthenticationChannelRequest> authenticationChannelRequests = new ConcurrentHashMap<>();
     private ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications = new ConcurrentHashMap<>();
     private ConcurrentMap<String, String> intentClientBindings = new ConcurrentHashMap<>();
+    private ConcurrentMap<String, TestClientIdMetadataDocumentRequest> clientIdMetadataDocumentRequests = new ConcurrentHashMap<>();
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
         return new TestApplicationResourceProvider(session, adminLogoutActions,
-                backChannelLogoutTokens, frontChannelLogoutTokens, pushNotBeforeActions, testAvailabilityActions, oidcClientData, authenticationChannelRequests, cibaClientNotifications, intentClientBindings);
+                backChannelLogoutTokens, frontChannelLogoutTokens, pushNotBeforeActions, testAvailabilityActions, oidcClientData, authenticationChannelRequests, cibaClientNotifications, intentClientBindings, clientIdMetadataDocumentRequests);
     }
 
     @Override

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/representation/TestClientIdMetadataDocumentRequest.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/representation/TestClientIdMetadataDocumentRequest.java
@@ -1,0 +1,41 @@
+package org.keycloak.testsuite.rest.representation;
+
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+
+public class TestClientIdMetadataDocumentRequest {
+
+    private OIDCClientRepresentation oidcClientRepresentation;
+    private String rawCacheControlHeaderValue;
+    private String command;
+
+    public TestClientIdMetadataDocumentRequest(OIDCClientRepresentation oidcClientRepresentation, String rawCacheControlHeaderValue, String command) {
+        this.oidcClientRepresentation = oidcClientRepresentation;
+        this.rawCacheControlHeaderValue = rawCacheControlHeaderValue;
+        this.command = command;
+    }
+
+    public OIDCClientRepresentation getOidcClientRepresentation() {
+        return oidcClientRepresentation;
+    }
+
+    public void setOidcClientRepresentation(OIDCClientRepresentation oidcClientRepresentation) {
+        this.oidcClientRepresentation = oidcClientRepresentation;
+    }
+
+    public String getRawCacheControlHeaderValue() {
+        return rawCacheControlHeaderValue;
+    }
+
+    public void setRawCacheControlHeaderValue(String rawCacheControlHeaderValue) {
+        this.rawCacheControlHeaderValue = rawCacheControlHeaderValue;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/resource/TestingOIDCEndpointsApplicationResource.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
@@ -75,14 +76,19 @@ import org.keycloak.protocol.oidc.grants.ciba.channel.HttpAuthenticationChannelP
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.executor.IntentClientBindCheckExecutor;
 import org.keycloak.services.managers.AppAuthManager;
 import org.keycloak.testsuite.rest.TestApplicationResourceProviderFactory;
 import org.keycloak.testsuite.rest.representation.TestAuthenticationChannelRequest;
+import org.keycloak.testsuite.rest.representation.TestClientIdMetadataDocumentRequest;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.resteasy.reactive.NoCache;
 
 import static org.keycloak.common.crypto.CryptoConstants.EC_KEY_SECP256R1;
@@ -101,14 +107,17 @@ public class TestingOIDCEndpointsApplicationResource {
     private final ConcurrentMap<String, TestAuthenticationChannelRequest> authenticationChannelRequests;
     private final ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications;
     private final ConcurrentMap<String, String> intentClientBindings;
+    private final ConcurrentMap<String, TestClientIdMetadataDocumentRequest> clientIdMetadataDocumentRequests;
 
     public TestingOIDCEndpointsApplicationResource(TestApplicationResourceProviderFactory.OIDCClientData oidcClientData,
             ConcurrentMap<String, TestAuthenticationChannelRequest> authenticationChannelRequests, ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications,
-            ConcurrentMap<String, String> intentClientBindings) {
+            ConcurrentMap<String, String> intentClientBindings,
+            ConcurrentMap<String, TestClientIdMetadataDocumentRequest> clientIdMetadataDocumentRequests) {
         this.clientData = oidcClientData;
         this.authenticationChannelRequests = authenticationChannelRequests;
         this.cibaClientNotifications = cibaClientNotifications;
         this.intentClientBindings = intentClientBindings;
+        this.clientIdMetadataDocumentRequests = clientIdMetadataDocumentRequests;
     }
 
     @GET
@@ -780,5 +789,76 @@ public class TestingOIDCEndpointsApplicationResource {
             response.setIsBound(Boolean.TRUE);
         }
         return response;
+    }
+
+    @GET
+    @Path("/set-client-id-metadata")
+    @NoCache
+    public void setClientIdMetadata(@QueryParam("path") String path, @QueryParam("encodedClientMetadata") String encodedClientMetadata, @QueryParam("cacheControlHeaderValue") String cacheControlHeaderValue) {
+        System.out.println("::::: setClientIdMetadata: encodedClientMetadata = " + encodedClientMetadata);
+        System.out.println("::::: setClientIdMetadata: cacheControlHeaderValue = " + cacheControlHeaderValue);
+        if (cacheControlHeaderValue == null || cacheControlHeaderValue.isEmpty()) cacheControlHeaderValue = "no-cache"; // default
+        byte[] serializedRequestObject = Base64Url.decode(encodedClientMetadata);
+        OIDCClientRepresentation oidcClientRepresentation = null;
+        try {
+            oidcClientRepresentation = JsonSerialization.readValue(serializedRequestObject, OIDCClientRepresentation.class);
+        } catch (IOException e) {
+            throw new BadRequestException("deserialize client metadata failed : " + e.getMessage());
+        }
+        this.clientIdMetadataDocumentRequests.put(path, new TestClientIdMetadataDocumentRequest(oidcClientRepresentation, cacheControlHeaderValue, null));
+    }
+
+    @POST
+    @Path("/register-client-id-metadata")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    public OIDCClientRepresentation registerClientIdMetadata(OIDCClientRepresentation oidcClientRepresentation, @QueryParam("cacheControlHeaderValue") String cacheControlHeaderValue, @QueryParam("command") String command) {
+        String[] parts = oidcClientRepresentation.getClientId().split("/");
+        System.out.println("::::: registerClientIdMetadata: oidcClientRepresentation = " + oidcClientRepresentation);
+        System.out.println("::::: registerClientIdMetadata: path = " + parts[parts.length - 1]);
+        System.out.println("::::: registerClientIdMetadata: cacheControlHeaderValue = " + cacheControlHeaderValue);
+        if (cacheControlHeaderValue == null || cacheControlHeaderValue.isEmpty()) cacheControlHeaderValue = "no-cache"; // default
+        this.clientIdMetadataDocumentRequests.put(parts[parts.length - 1], new TestClientIdMetadataDocumentRequest(oidcClientRepresentation, cacheControlHeaderValue, command));
+        return oidcClientRepresentation;
+    }
+
+    @GET
+    @Path("/get-client-id-metadata/{path}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getClientIdMetadata(@PathParam("path") String path) {
+        TestClientIdMetadataDocumentRequest testClientIdMetadataDocumentRequest = this.clientIdMetadataDocumentRequests.get(path);
+        OIDCClientRepresentation oidcClientRepresentation = testClientIdMetadataDocumentRequest.getOidcClientRepresentation();
+        String rawCacheControlHeaderValue = testClientIdMetadataDocumentRequest.getRawCacheControlHeaderValue();
+        String command = testClientIdMetadataDocumentRequest.getCommand();
+
+        System.out.println("::::: getClientIdMetadata: this.oidcClientRepresentation = " + oidcClientRepresentation);
+        System.out.println("::::: getClientIdMetadata: this.oidcClientRepresentation client id = " + oidcClientRepresentation.getClientId());
+        System.out.println("::::: getClientIdMetadata: this.clientMetadataCacheControlHeaders cacheControlHeaderValue = " + rawCacheControlHeaderValue);
+
+        Response.ResponseBuilder builder;
+        if ("NotModified".equals(command)) {
+            builder = Response.status(Status.NOT_MODIFIED);
+        } else if ("NotFound".equals(command)) {
+            builder = Response.status(Status.NOT_FOUND);
+        } else if ("MalformedResponse".equals(command)) {
+            String json = "{\"nullone\":null, \"emptyone\":\"\", \"blankone\": \" \", \"withvalue\" : \"my value\", \"withbooleanvalue\" : true, \"withnumbervalue\" : 10}";
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode jsonNode;
+            try {
+                jsonNode = mapper.readTree(json);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+            builder = Response.status(Status.OK).entity(jsonNode);
+        } else {
+            builder = Response.status(Status.OK).entity(oidcClientRepresentation);
+        }
+
+        if (rawCacheControlHeaderValue != null) {
+            builder.header("Cache-Control", rawCacheControlHeaderValue);
+        }
+
+        return builder.build();
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestApplicationResourceUrls.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestApplicationResourceUrls.java
@@ -65,4 +65,12 @@ public class TestApplicationResourceUrls {
 
         return builder.build().toString();
     }
+
+    public static String getClientIdMetadataUri(String path) {
+        UriBuilder builder = oidcClientEndpoints()
+                .path(TestOIDCEndpointsApplicationResource.class, "getClientIdMetadata")
+                .resolveTemplate("path", path);
+
+        return builder.build().toString();
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/client/resources/TestOIDCEndpointsApplicationResource.java
@@ -24,6 +24,7 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
@@ -32,6 +33,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
 import org.keycloak.services.clientpolicy.executor.IntentClientBindCheckExecutor;
 import org.keycloak.testsuite.rest.representation.TestAuthenticationChannelRequest;
 
@@ -178,4 +180,21 @@ public interface TestOIDCEndpointsApplicationResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoCache
     IntentClientBindCheckExecutor.IntentBindCheckResponse checkIntentClientBound(IntentClientBindCheckExecutor.IntentBindCheckRequest request);
+
+    @GET
+    @Path("/set-client-id-metadata")
+    @NoCache
+    void setClientIdMetadata(@QueryParam("path") String path, @QueryParam("encodedClientMetadata") String encodedClientMetadata, @QueryParam("cacheControlHeaderValue") String cacheControlHeaderValue);
+
+    @POST
+    @Path("/register-client-id-metadata")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    OIDCClientRepresentation registerClientIdMetadata(OIDCClientRepresentation oidcClientRepresentation, @QueryParam("cacheControlHeaderValue") String cacheControlHeaderValue, @QueryParam("command") String command);
+
+    @GET
+    @Path("/get-client-id-metadata/{path}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response getClientIdMetadata(@PathParam("path") String path);
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -719,6 +719,10 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         return null;
     }
 
+    protected ClientRepresentation findByClientIdByAdmin(String clientId) throws ClientPolicyException {
+        return adminClient.realm(REALM_NAME).clients().findByClientId(clientId).iterator().next();
+    }
+
     protected void updateClientByAdmin(String cId, Consumer<ClientRepresentation> op) throws ClientPolicyException {
         ClientResource clientResource = adminClient.realm(REALM_NAME).clients().get(cId);
         ClientRepresentation clientRep = clientResource.toRepresentation();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
@@ -705,7 +705,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
 
         // Client ID Verification:
         // Client identifier URLs MUST have an "https" scheme.
-        assertLoginAndError("http://example.com/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_INVALID_SCHEME);
+        assertLoginAndError("http://mcp.example.co.jp/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_INVALID_SCHEME);
 
         // Client ID Verification:
         // Client identifier URLs MUST contain a path component.
@@ -1056,37 +1056,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
         assertLoginAndError(clientId, ClientIdMetadataDocumentExecutor.ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
 
-        // consent required
-        // default value = true -> false
-        // full scope disabled
-        // default value = true -> false
-        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
-                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
-                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
-                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
-                                    it.setConsentRequired(false);
-                                    it.setFullScopeDisabled(false);
-                                }))
-                        .toRepresentation()
-        ).toString();
-        updateProfiles(json);
-
-        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
-        clientMetadata = setupOIDCClientRepresentation(clientId, i->{});
-        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
-
-        // send an authorization request
-        loginUserAndGetCode(clientId, false);
-
-        // check the persisted client settings
-        ClientRepresentation clientRepresentation = findByClientIdByAdmin(clientId);
-        assertFalse(clientRepresentation.isConsentRequired());
-        assertTrue(clientRepresentation.isFullScopeAllowed());
-
-        // delete the persisted client
-        deleteClientByAdmin(clientRepresentation.getId());
-        assertThrows(jakarta.ws.rs.NotFoundException.class, ()->getClientByAdmin(clientRepresentation.getId()));
     }
 
     private String loginUserAndGetCode(String clientId, boolean isGrantRequred) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
@@ -96,10 +96,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
-                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
-                                    it.setTrustedDomains(List.of("example.com","mcp.example.com"));
-                                }))
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setTrustedDomains(List.of("localhost", "example.com","mcp.example.com"))))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -108,9 +106,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
-                                        it.setClientIdUriSchemes(List.of("spiffe"));
-                                }))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("spiffe"))))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -131,9 +128,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
-                                    it.setClientIdUriSchemes(List.of("http", "https"));
-                                }))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -178,7 +174,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
                                     it.setTrustedDomains(List.of("*.example.com","localhost"));
                                     it.setRestrictSameDomain(true);
                                     it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri", "jwks_uri"));}))
@@ -307,7 +302,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
                                     it.setTrustedDomains(List.of("*.example.com","localhost"));
                                     it.setRestrictSameDomain(true);
                                     it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri"));}))
@@ -401,7 +395,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
                                     it.setTrustedDomains(List.of("*.example.com","localhost"));
                                     it.setRestrictSameDomain(true);
                                     it.setRequiredProperties(List.of("logo_uri", "scope"));}))
@@ -554,10 +547,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
-                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it-> {
-                                    it.setAllowLoopbackAddress(true);
-                                    it.setTrustedDomains(List.of("*.example.com","localhost"));
-                                }))
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"))))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -690,9 +681,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
-                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
-                                    it.setTrustedDomains(List.of("*.example.com","localhost"));}))
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"))))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -759,9 +749,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
-                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
-                                    it.setTrustedDomains(List.of("*.example.com","localhost"));}))
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"))))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -782,9 +771,8 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         // set Client Metadata
         // CIMD Executor's client metadata upper limit byte length default value: 5000
         String clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
-        OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
-            i.setClientName("0123456789".repeat(465) + "0123456");
-        });
+        OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i->
+                i.setClientName("0123456789".repeat(465) + "0123456"));
         byte[] contentBytes = JsonSerialization.writeValueAsBytes(clientMetadata);
         assertEquals(5001, contentBytes.length);
         TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
@@ -801,7 +789,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
-                                        it.setAllowLoopbackAddress(true)))
+                                        it.setTrustedDomains(List.of("localhost"))))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -859,11 +847,11 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         updatePolicies(json);
 
         // Client ID Verification:
-        // Client identifier URLs MUST have an "https" scheme.
+        // Client identifier URLs MUST have a "https" scheme.
         assertLoginAndError("Malformed URL", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_MALFORMED_URL);
 
         // Client ID Verification:
-        // Client identifier URLs MUST have an "https" scheme.
+        // Client identifier URLs MUST have a "https" scheme.
         assertLoginAndError("http://mcp.example.co.jp/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_INVALID_SCHEME);
 
         // Client ID Verification:
@@ -887,52 +875,61 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         assertLoginAndError("https://example.com/mcp?p1=123&p2=abc", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_QUERY);
 
         // Client ID Verification:
-        // Client identifier is not a loopback address
-        assertLoginAndError("https://localhost:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_LOOPBACK_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a loopback address
-        assertLoginAndError("https://127.0.0.1:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_LOOPBACK_ADDRESS);
-
-        // Client ID Verification:
-        assertLoginAndError("https://example.co.jp/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_HOST_UNRESOLVED);
-
-        // Client ID Verification:
-        // Client identifier is not a loopback address
-        assertLoginAndError("https://[::1]:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_LOOPBACK_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a loopback address
-        assertLoginAndError("https://[0:0:0:0:0:0:0:1]/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_LOOPBACK_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a private address
-        assertLoginAndError("https://10.0.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a private address
-        assertLoginAndError("https://10.255.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a private address
-        assertLoginAndError("https://172.16.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a private address
-        assertLoginAndError("https://172.31.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a private address
-        assertLoginAndError("https://192.168.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
-
-        // Client ID Verification:
-        // Client identifier is not a private address
-        assertLoginAndError("https://192.168.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
+        assertLoginAndError("https://example.co.jp/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_FETCH_FAILED);
 
         // Client ID Verification:
         // Client identifier is not a valid IPv6 address
         assertLoginAndError("https://0:0:0:0:0:0:0:1/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_HOST_UNRESOLVED);
-        
+
+        // update profiles
+        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setTrustedDomains(List.of("*.example.com"))))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://localhost:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://127.0.0.1:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://[::1]:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://[0:0:0:0:0:0:0:1]/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://10.0.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://10.255.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://172.16.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://172.31.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://192.168.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://192.168.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
     }
 
     @Test
@@ -941,11 +938,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
-                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it-> {
-                                        it.setAllowLoopbackAddress(true);
-                                        it.setTrustedDomains(List.of("*.example.com", "localhost", "10.255.255.255",
-                                                "mcpclient.example.org", "www.example.org", "172.31.255.254",
-                                                "[::1]", "client.example.com", "127.0.0.1", "10.255.255.1"));}))
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setTrustedDomains(List.of("*.example.com", "localhost",
+                                        "mcpclient.example.org", "www.example.org",
+                                        "[::1]", "client.example.com"))))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -956,9 +952,9 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
                                 createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
                                         it.setClientIdUriSchemes(List.of("http", "https"));
-                                        it.setTrustedDomains(List.of("*.example.com", "localhost", "10.255.255.255",
-                                            "mcpclient.example.org", "www.example.org", "172.31.255.254",
-                                            "[::1]", "client.example.com", "127.0.0.1", "10.255.255.1"));
+                                        it.setTrustedDomains(List.of("*.example.com", "localhost",
+                                            "mcpclient.example.org", "www.example.org",
+                                            "[::1]", "client.example.com"));
                                 }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
@@ -1028,16 +1024,16 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
         clientMetadata = setupOIDCClientRepresentation(clientId, i-> i.setLogoUri("https://10.255.255.255:443/mcp"));
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
-        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
 
-        // client_uri : unresolved address
+        // client_uri : not allowed domain
         clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
         clientMetadata = setupOIDCClientRepresentation(clientId, i->{
             i.setLogoUri("https://localhost:8443/logo");
-            i.setClientUri("https://mcpclient.example.org/client");
+            i.setClientUri("https://mcpclient.example.or.jp/client");
         });
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
-        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_HOST_UNRESOLVED);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
 
         // tos_uri : private address
         clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
@@ -1047,18 +1043,18 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
             i.setTosUri("https://172.31.255.254:443/mcp");
         });
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
-        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
 
-        // policy_uri : unresolved address
+        // policy_uri : not allowed domain
         clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
         clientMetadata = setupOIDCClientRepresentation(clientId, i->{
             i.setLogoUri("https://localhost:8443/logo");
             i.setClientUri("https://www.example.org");
             i.setTosUri("https://[::1]:8443/mcp");
-            i.setPolicyUri("https://client.example.com");
+            i.setPolicyUri("https://client.example.co.de");
         });
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
-        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_HOST_UNRESOLVED);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
 
         // jwks_uri : private address
         clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
@@ -1066,11 +1062,11 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
             i.setLogoUri("https://localhost:8443/logo");
             i.setClientUri("https://www.example.org");
             i.setTosUri("https://[::1]:8443/mcp");
-            i.setPolicyUri("https://127.0.0.1:443/mcp");
+            i.setPolicyUri("https://localhost:8443/policy");
             i.setJwksUri("https://10.255.255.1:443/mcp");
         });
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
-        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
     }
 
     @Test
@@ -1080,7 +1076,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                        it.setAllowLoopbackAddress(true);
                                         it.setOnlyAllowConfidentialClient(true);
                                         it.setTrustedDomains(List.of("*.example.com", "localhost"));
                                 }))
@@ -1128,7 +1123,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
                                     it.setOnlyAllowConfidentialClient(false);
                                     it.setTrustedDomains(List.of("*.example.com", "localhost", "www.example.co.jp"));
                                     it.setRestrictSameDomain(true);
@@ -1150,7 +1144,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
                                     it.setRequiredProperties(List.of("client_uri", "logo_uri"));
                                     it.setTrustedDomains(List.of("*.example.com", "[::1]", "localhost", "127.0.0.1"));
                                 }))
@@ -1168,7 +1161,6 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
-                                    it.setAllowLoopbackAddress(true);
                                     it.setRestrictSameDomain(true);
                                     it.setTrustedDomains(List.of("*.example.org", "localhost", "[::1]", "127.0.0.1"));
                                 }))

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
@@ -1,0 +1,1171 @@
+package org.keycloak.testsuite.client.policies;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.condition.ClientIdUriSchemeCondition;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.condition.ClientIdUriSchemeConditionFactory;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.AbstractClientIdMetadataDocumentExecutor;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutor;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutorFactory;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.client.resources.TestApplicationResourceUrls;
+import org.keycloak.testsuite.client.resources.TestOIDCEndpointsApplicationResource;
+import org.keycloak.testsuite.pages.AppPage;
+import org.keycloak.testsuite.pages.ErrorPage;
+import org.keycloak.testsuite.pages.LogoutConfirmPage;
+import org.keycloak.testsuite.pages.OAuthGrantPage;
+import org.keycloak.testsuite.util.ClientPoliciesUtil;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
+import org.keycloak.testsuite.util.oauth.TokenRevocationResponse;
+import org.keycloak.util.JsonSerialization;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.jboss.arquillian.graphene.page.Page;
+import org.junit.Test;
+
+import static org.keycloak.testsuite.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createExecutorConfig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This test class is for testing an executor of client policies.
+ * 
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+@EnableFeature(value = Profile.Feature.CIMD)
+public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
+
+    @Page
+    protected OAuthGrantPage grantPage;
+
+    @Page
+    protected AppPage appPage;
+
+    @Page
+    protected ErrorPage errorPage;
+
+    @Page
+    protected LogoutConfirmPage logoutConfirmPage;
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation realm = loadJson(getClass().getResourceAsStream("/testrealm.json"), RealmRepresentation.class);
+        testRealms.add(realm);
+    }
+
+    @Test
+    public void testClientIdUriSchemeCondition() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setAllowPermittedDomains(List.of("example.com","mcp.example.com"));
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("spiffe"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        String clientId;
+
+        // CIMD executor is not executed, so we expect the error showing that client is not found.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        oauth.client(clientId);
+        oauth.openLoginForm();
+        assertTrue(errorPage.isCurrent());
+        assertEquals("Client not found.", errorPage.getError());
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorForConfidentialClient() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setAllowPermittedDomains(List.of("*.example.com","localhost"));
+                                    it.setRestrictSameDomain(true);
+                                    it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri", "jwks_uri"));
+                                    it.setAllUrisRestrictSameDomain(true);}))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // Get keys of client. Will be used for client authentication
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        oidcClientEndpointsResource.generateKeys(Algorithm.PS256);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.getKeysAsBase64();
+        KeyPair keyPair = getKeyPairFromGeneratedBase64(generatedKeys, Algorithm.PS256);
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        // set Client Metadata
+        String clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
+            i.setLogoUri("https://localhost:8543/");
+            i.setClientUri("https://localhost:8543/client");
+            i.setTosUri("https://localhost:8543/tos");
+            i.setPolicyUri("https://localhost:8543/policy");
+            i.setScope("address phone");
+        });
+        String cacheControlHeaderValue = "must-revalidate, max-age=3600, public, s-maxage=20";
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, null);
+
+        // send an authorization request
+        String code = loginUserAndGetCode(clientId, true);
+
+        // get an access token
+        String signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        AccessTokenResponse tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // check the persisted client settings
+        ClientRepresentation clientRepresentation = findByClientIdByAdmin(clientId);
+        assertTrue(clientRepresentation.isConsentRequired()); // default
+        assertFalse(clientRepresentation.isFullScopeAllowed()); // default
+        assertFalse(clientRepresentation.isPublicClient());
+        assertEquals("client-jwt", clientRepresentation.getClientAuthenticatorType());
+
+        // logout
+        oauth.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+
+        // change the client metadata
+        clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
+            i.setLogoUri("https://localhost:8543/logo");
+            i.setClientUri("https://localhost:8543/client");
+            i.setTosUri("https://localhost:8543/tos");
+            i.setPolicyUri("https://localhost:8543/policy");
+            i.setScope("profile");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, null);
+
+        // do authorization code flow again, but registered client metadata is still effective
+        code = loginUserAndGetCode(clientId, false);
+        signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // therefore, keycloak does not fetch the client metadata.
+        // the registered client metadata remains the same
+        clientRepresentation = findByClientIdByAdmin(clientId);
+        Map<String, String> m = clientRepresentation.getAttributes();
+        List<String> optionalScopeList = clientRepresentation.getOptionalClientScopes();
+        assertEquals("https://localhost:8543/", m.get("logoUri"));
+        assertEquals(2, optionalScopeList.size());
+        assertTrue(optionalScopeList.contains("phone"));
+        assertTrue(optionalScopeList.contains("address"));
+        assertFalse(clientRepresentation.isPublicClient());
+        assertEquals("client-jwt", clientRepresentation.getClientAuthenticatorType());
+
+        // logout
+        oauth.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+
+        // do authorization code flow again, and registered client metadata is not effective
+        Thread.sleep(1000 * 25);
+        code = loginUserAndGetCode(clientId, false);
+        signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // therefore, keycloak re-fetch the client metadata.
+        // the registered client metadata changed
+        clientRepresentation = findByClientIdByAdmin(clientId);
+        m = clientRepresentation.getAttributes();
+        optionalScopeList = clientRepresentation.getOptionalClientScopes();
+        assertEquals("https://localhost:8543/logo", m.get("logoUri"));
+        assertEquals(1, optionalScopeList.size());
+        assertTrue(optionalScopeList.contains("profile"));
+
+        // delete the persisted client
+        String cid = clientRepresentation.getId();
+        deleteClientByAdmin(cid);
+        assertThrows(jakarta.ws.rs.NotFoundException.class, ()->getClientByAdmin(cid));
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorForPublicClient() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setAllowPermittedDomains(List.of("*.example.com","localhost"));
+                                    it.setRestrictSameDomain(true);
+                                    it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri"));
+                                    it.setAllUrisRestrictSameDomain(true);}))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // set Client Metadata
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        String clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
+            i.setLogoUri("https://localhost:8543/");
+            i.setClientUri("https://localhost:8543/client");
+            i.setTosUri("https://localhost:8543/tos");
+            i.setPolicyUri("https://localhost:8543/policy");
+            i.setScope("address phone");
+            i.setTokenEndpointAuthMethod(null); // public client
+            i.setJwksUri(null);
+        });
+        String cacheControlHeaderValue = "must-revalidate, max-age=3600, public, s-maxage=20";
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, null);
+
+        // send an authorization request
+        String code = loginUserAndGetCode(clientId, true);
+
+        // get an access token
+        AccessTokenResponse tokenResponse = oauth.
+                client(clientId).accessTokenRequest(code).send();
+        assertEquals(200, tokenResponse.getStatusCode());
+        AccessToken accessToken = oauth.verifyToken(tokenResponse.getAccessToken());
+        assertEquals(clientId, accessToken.getIssuedFor());
+
+        // check the persisted client settings
+        ClientRepresentation clientRepresentation = findByClientIdByAdmin(clientId);
+        assertTrue(clientRepresentation.isConsentRequired()); // default
+        assertFalse(clientRepresentation.isFullScopeAllowed()); // default
+        assertTrue(clientRepresentation.isPublicClient());
+        assertEquals("none", clientRepresentation.getClientAuthenticatorType());
+
+        // introspect
+        IntrospectionResponse introspectionResponse = oauth.client(TEST_CLIENT, TEST_CLIENT_SECRET).doIntrospectionAccessTokenRequest(tokenResponse.getAccessToken());
+        assertEquals(200, introspectionResponse.getStatusCode());
+        assertEquals(clientId, introspectionResponse.asTokenMetadata().getClientId());
+
+        // refresh
+        tokenResponse = oauth.client(clientId).doRefreshTokenRequest(tokenResponse.getRefreshToken());
+        assertEquals(200, tokenResponse.getStatusCode());
+        accessToken = oauth.verifyToken(tokenResponse.getAccessToken());
+        assertEquals(clientId, accessToken.getIssuedFor());
+
+        // revoke
+        TokenRevocationResponse revokeResponse = oauth.client(clientId).doTokenRevoke(tokenResponse.getAccessToken());
+        assertEquals(200, revokeResponse.getStatusCode());
+        introspectionResponse = oauth.client(TEST_CLIENT, TEST_CLIENT_SECRET).doIntrospectionAccessTokenRequest(tokenResponse.getAccessToken());
+        assertEquals(200, introspectionResponse.getStatusCode());
+        assertFalse(introspectionResponse.asTokenMetadata().isActive());
+
+        // get another token
+        oauth.scope("phone");
+        code = ssoLoginUserAndGetCode(clientId, OAuthGrantPage.PHONE_CONSENT_TEXT);
+        tokenResponse = oauth.client(clientId).accessTokenRequest(code).send();
+        assertEquals(200, tokenResponse.getStatusCode());
+        accessToken = oauth.verifyToken(tokenResponse.getAccessToken());
+        assertEquals(clientId, accessToken.getIssuedFor());
+        assertTrue(Arrays.asList(accessToken.getScope().split(" ")).contains("phone"));
+
+        // delete the persisted client
+        clientRepresentation = findByClientIdByAdmin(clientId);
+        String cid = clientRepresentation.getId();
+        deleteClientByAdmin(cid);
+        assertThrows(jakarta.ws.rs.NotFoundException.class, ()->getClientByAdmin(cid));
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorNotModifiedClientMetadata() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setAllowPermittedDomains(List.of("*.example.com","localhost"));
+                                    it.setRestrictSameDomain(true);
+                                    it.setRequiredProperties(List.of("logo_uri", "scope"));}))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // Get keys of client. Will be used for client authentication
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        oidcClientEndpointsResource.generateKeys(Algorithm.PS256);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.getKeysAsBase64();
+        KeyPair keyPair = getKeyPairFromGeneratedBase64(generatedKeys, Algorithm.PS256);
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        // set Client Metadata
+        // clientId = https://localhost:8543/auth/realms/master/app/oidc-client-endpoints/get-client-id-metadata
+        // clientUri = https://localhost:8543/auth/realms/master/app/auth
+        // jwksUri = https://localhost:8543/auth/realms/master/app/oidc-client-endpoints/get-jwks
+        String clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
+            i.setLogoUri("https://www.example.com");
+            i.setScope("address phone");
+        });
+        String cacheControlHeaderValue = "must-revalidate, max-age=3600, public, s-maxage=20";
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, null);
+
+        // send an authorization request
+        String code = loginUserAndGetCode(clientId, true);
+
+        // get an access token
+        String signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        AccessTokenResponse tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // check the persisted client settings
+        ClientRepresentation clientRepresentation = findByClientIdByAdmin(clientId);
+        assertTrue(clientRepresentation.isConsentRequired()); // default
+        assertFalse(clientRepresentation.isFullScopeAllowed()); // default
+
+        // logout
+        oauth.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+
+        // change the client metadata
+        // however, the client returns 304 Not Modified
+        clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
+            i.setLogoUri("https://www.example.com/logo");
+            i.setScope("profile");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, "NotModified");
+
+        // do authorization code flow again, but registered client metadata is still effective
+        code = loginUserAndGetCode(clientId, false);
+        signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // therefore, keycloak does not fetch the client metadata.
+        // the registered client metadata remains the same
+        clientRepresentation = findByClientIdByAdmin(clientId);
+        Map<String, String> m = clientRepresentation.getAttributes();
+        List<String> optionalScopeList = clientRepresentation.getOptionalClientScopes();
+        assertEquals("https://www.example.com", m.get("logoUri"));
+        assertEquals(2, optionalScopeList.size());
+        assertTrue(optionalScopeList.contains("phone"));
+        assertTrue(optionalScopeList.contains("address"));
+
+        // logout
+        oauth.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+
+        // do authorization code flow again, and registered client metadata is not effective
+        Thread.sleep(1000 * 20);
+        code = loginUserAndGetCode(clientId, false);
+        signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // therefore, keycloak re-fetch the client metadata.
+        // however, the client returns 304 Not Modified.
+        // therefore, the client metadata remains the same.
+        clientRepresentation = findByClientIdByAdmin(clientId);
+        m = clientRepresentation.getAttributes();
+        optionalScopeList = clientRepresentation.getOptionalClientScopes();
+        assertEquals("https://www.example.com", m.get("logoUri"));
+        assertEquals(2, optionalScopeList.size());
+        assertTrue(optionalScopeList.contains("phone"));
+        assertTrue(optionalScopeList.contains("address"));
+
+        // delete the persisted client
+        String cid = clientRepresentation.getId();
+        deleteClientByAdmin(cid);
+        assertThrows(jakarta.ws.rs.NotFoundException.class, ()->getClientByAdmin(cid));
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorFetchClientMetadataFailed() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it-> it.setAllowLoopbackAddress(true)))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        String clientId;
+        OIDCClientRepresentation clientMetadata;
+
+        // 404 Not Found returns
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i-> {});
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, "NotFound");
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_FETCH_FAILED);
+
+        // 200 OK but malformed client metadata
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i-> {});
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, "MalformedResponse");
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_FETCH_FAILED);
+    }
+
+    private void testClientIdMetadataDocumentExecutorCacheControl(String cacheControlHeaderValue, int expectedExpiry, TestOIDCEndpointsApplicationResource oidcClientEndpointsResource, PrivateKey privateKey, PublicKey publicKey) throws Exception {
+        // set Client Metadata
+        String clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
+            i.setLogoUri("https://www.example.com");
+            i.setScope("address phone");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, null);
+
+        // send an authorization request
+        String code = loginUserAndGetCode(clientId, true);
+
+        // get an access token
+        String signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        AccessTokenResponse tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // check the persisted client settings
+        ClientRepresentation clientRepresentation = findByClientIdByAdmin(clientId);
+        assertTrue(clientRepresentation.isConsentRequired()); // default
+        assertFalse(clientRepresentation.isFullScopeAllowed()); // default
+
+        // logout
+        oauth.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+
+        // change the client metadata
+        clientMetadata = setupOIDCClientRepresentation(clientId, i -> {
+            i.setLogoUri("https://www.example.com/logo");
+            i.setScope("profile");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, null);
+        Thread.sleep(1000 * 3);
+
+        Map<String, String> m;
+        List<String> optionalScopeList;
+        if (expectedExpiry > 0) {
+            // do authorization code flow again, but registered client metadata is still effective
+            code = loginUserAndGetCode(clientId, false);
+            signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+            tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+            oauth.verifyToken(tokenResponse.getAccessToken());
+
+            // therefore, keycloak does not fetch the client metadata.
+            // the registered client metadata remains the same
+            clientRepresentation = findByClientIdByAdmin(clientId);
+            m = clientRepresentation.getAttributes();
+            optionalScopeList = clientRepresentation.getOptionalClientScopes();
+            assertEquals("https://www.example.com", m.get("logoUri"));
+            assertEquals(2, optionalScopeList.size());
+            assertTrue(optionalScopeList.contains("phone"));
+            assertTrue(optionalScopeList.contains("address"));
+
+            // logout
+            oauth.openLogoutForm();
+            logoutConfirmPage.assertCurrent();
+            logoutConfirmPage.confirmLogout();
+
+            // wait
+            Thread.sleep(1000 * expectedExpiry);
+        }
+
+        // do authorization code flow again, and registered client metadata is not effective
+        code = loginUserAndGetCode(clientId, false);
+        signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.PS256);
+        tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
+        oauth.verifyToken(tokenResponse.getAccessToken());
+
+        // therefore, keycloak re-fetch the client metadata.
+        // the registered client metadata changed
+        clientRepresentation = findByClientIdByAdmin(clientId);
+        m = clientRepresentation.getAttributes();
+        optionalScopeList = clientRepresentation.getOptionalClientScopes();
+        assertEquals("https://www.example.com/logo", m.get("logoUri"));
+        assertEquals(1, optionalScopeList.size());
+        assertTrue(optionalScopeList.contains("profile"));
+
+        // logout
+        oauth.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+
+        // delete the persisted client
+        String cid = clientRepresentation.getId();
+        deleteClientByAdmin(cid);
+        assertThrows(jakarta.ws.rs.NotFoundException.class, ()->getClientByAdmin(cid));
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorCacheControl() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it-> it.setAllowLoopbackAddress(true)))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // Get keys of client. Will be used for client authentication
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        oidcClientEndpointsResource.generateKeys(Algorithm.PS256);
+        Map<String, String> generatedKeys = oidcClientEndpointsResource.getKeysAsBase64();
+        KeyPair keyPair = getKeyPairFromGeneratedBase64(generatedKeys, Algorithm.PS256);
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        // no Cache-Control header : not cached
+        testClientIdMetadataDocumentExecutorCacheControl(null, -1, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // empty Cache-Control header : not cached
+        testClientIdMetadataDocumentExecutorCacheControl("", -1, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // max-age : max-age considered
+        testClientIdMetadataDocumentExecutorCacheControl("max-age=20,    private", 20, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // s-maxage : s-maxage considered
+        testClientIdMetadataDocumentExecutorCacheControl("private,S-MAXAGE=15,  no-transform", 15, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // max-age and s-maxage : s-maxage considered
+        testClientIdMetadataDocumentExecutorCacheControl(" Max-Age=3600,public,S-MaxAge=12", 12, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // max-age and no-cache : not cached
+        testClientIdMetadataDocumentExecutorCacheControl("max-age=20, NO-CACHE  ", -1, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // s-maxage and no-store : not cached
+        testClientIdMetadataDocumentExecutorCacheControl("S-MAXAGE=20,no-store", -1, oidcClientEndpointsResource, privateKey, publicKey);
+
+        // unknown values only : not cached
+        // min-age=20, CACHE
+        testClientIdMetadataDocumentExecutorCacheControl("min-age=20,CACHE ", -1, oidcClientEndpointsResource, privateKey, publicKey);
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorVerifyAuthorizationRequest() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setAllowLoopbackAddress(true)))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        String clientId;
+        OIDCClientRepresentation clientMetadata;
+
+        // Authorization Request Verification:
+        // The authorization server MAY choose to have its own heuristics and policies
+        // around the trust of domain names used as client IDs.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i-> {});
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        oauth.redirectUri(null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_INVALID_PARAMETER);
+
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorVerifyClientId() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{}))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(AnyClientConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientPolicyConditionConfigurationRepresentation(), it->{}))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // Client ID Verification:
+        // Client identifier URLs MUST have an "https" scheme.
+        assertLoginAndError("Malformed URL", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_MALFORMED_URL);
+
+        // Client ID Verification:
+        // Client identifier URLs MUST have an "https" scheme.
+        assertLoginAndError("http://example.com/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_INVALID_SCHEME);
+
+        // Client ID Verification:
+        // Client identifier URLs MUST contain a path component.
+        assertLoginAndError("https://example.com", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_EMPTY_PATH);
+
+        // Client ID Verification:
+        // Client identifier URLs MUST NOT contain single-dot or double-dot path segments.
+        assertLoginAndError("https://example.com/mcp/.././index.html", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PATH_TRAVERSAL);
+
+        // Client ID Verification:
+        // Client identifier URLs MUST NOT contain a fragment component.
+        assertLoginAndError("https://example.com/mcp#prompts", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_FRAGMENT);
+
+        // Client ID Verification:
+        // Client identifier URLs MUST NOT contain a username or password.
+        assertLoginAndError("https://alice:wonderland@example.com/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_USERINFO);
+
+        // Client ID Verification:
+        // Client identifier URLs SHOULD NOT include a query string component.
+        assertLoginAndError("https://example.com/mcp?p1=123&p2=abc", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_QUERY);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://localhost:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_LOOPBACK_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://127.0.0.1:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_LOOPBACK_ADDRESS);
+
+        // Client ID Verification:
+        assertLoginAndError("https://example.co.jp/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_UNRESOLVED);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://::1:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_LOOPBACK_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://[::1]:8443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_LOOPBACK_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://0:0:0:0:0:0:0:1/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_LOOPBACK_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://10.0.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PRIVATE_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://10.255.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PRIVATE_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://172.16.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PRIVATE_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://172.31.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PRIVATE_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://192.168.0.0:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PRIVATE_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a private address
+        assertLoginAndError("https://192.168.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_PRIVATE_ADDRESS);
+
+        // Client ID Verification:
+        // Client identifier is not a loopback address
+        assertLoginAndError("https://fe12:3456:789a:1:::443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_CLIENTID_LOOPBACK_ADDRESS);
+    }
+
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorValidateClientId() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setAllowPermittedDomains(List.of("*.example.com","mcp.example.co.jp"));
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        String clientId;
+
+        // Client ID Validation:
+        // The authorization server MAY choose to have its own heuristics and policies
+        // around the trust of domain names used as client IDs.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_NOTALLOWED_DOMAIN);
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorVerifyClientMetadata() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->
+                                        it.setAllowLoopbackAddress(true)))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        String clientIdPath;
+        String clientId;
+        OIDCClientRepresentation clientMetadata;
+
+        // Client Metadata Verification:
+        // The client metadata document MUST contain a client_id property.
+        // clientId = not set
+        // clientUri = https://localhost:8543/auth/realms/master/app/auth
+        // jwksUri = https://localhost:8543/auth/realms/master/app/oidc-client-endpoints/get-jwks
+        clientIdPath = generateSuffixedName("CIMD");
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(clientIdPath);
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setClientId(null));
+        byte[] contentBytes = JsonSerialization.writeValueAsBytes(clientMetadata);
+        String encodedClientMetadata = Base64Url.encode(contentBytes);
+        oidcClientEndpointsResource.setClientIdMetadata(clientIdPath, encodedClientMetadata, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_NOCLIENTID);
+
+        // Client Metadata Verification:
+        // The client_id property's value MUST match the URL of the document
+        // using simple string comparison as defined in [RFC3986] Section 6.2.1.
+        clientIdPath = generateSuffixedName("CIMD");
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(clientIdPath);
+        final String differentClientId = clientId + "/different_path/" + clientIdPath;
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setClientId(differentClientId));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_CLIENTID_UNMATCH);
+
+        // Client Metadata Verification:
+        // The token_endpoint_auth_method property MUST NOT include
+        // client_secret_post, client_secret_basic, client_secret_jwt,
+        // or any other method based around a shared symmetric secret.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setTokenEndpointAuthMethod(OIDCLoginProtocol.CLIENT_SECRET_JWT));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_NOTALLOWED_CLIENTAUTH);
+
+        // Client Metadata Verification:
+        // The client_secret and client_secret_expires_at properties MUST NOT be used.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setClientSecret("ClientSecretNotAllowed"));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_CLIENTSECRET);
+
+        // Client Metadata Verification:
+        // An authorization server MUST validate redirect URIs presented in an authorization request
+        // against those in the metadata document.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setRedirectUris(Collections.singletonList("https://mcp.example.com/mcp/123abc")));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_REDIRECTURI);
+
+        // SSRF attack countermeasure
+        // It checks if an address resolved from a property whose value is URI is loopback address.
+        //  -> difficult to check because allowing loopback address is needed to fetch client metadata from loop-back addressed test-provider server
+        //  -> also jwks_uri is hosted by also the loop-back addressed test-provider server.
+        // It checks if an address resolved from a property whose value is URI is private address.
+        // RFC 7591: logo_uri, client_uri, tos_uri, policy_uri, jwks_uri.
+
+        // logo_uri : private address
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i-> i.setLogoUri("https://10.255.255.255:443/mcp"));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_PRIVATE_ADDRESS);
+
+        // client_uri : unresolved address
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->{
+            i.setLogoUri("https://localhost:8443/logo");
+            i.setClientUri("https://mcpclient.example.org/client");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_UNRESOLVED);
+
+        // tos_uri : private address
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->{
+            i.setLogoUri("https://localhost:8443/logo");
+            i.setClientUri("https://www.example.org");
+            i.setTosUri("https://172.31.255.254:443/mcp");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_PRIVATE_ADDRESS);
+
+        // policy_uri : unresolved address
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->{
+            i.setLogoUri("https://localhost:8443/logo");
+            i.setClientUri("https://www.example.org");
+            i.setTosUri("https://[::1]:8443/mcp");
+            i.setPolicyUri("https://client.example.com");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_UNRESOLVED);
+
+        // jwks_uri : private address
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->{
+            i.setLogoUri("https://localhost:8443/logo");
+            i.setClientUri("https://www.example.org");
+            i.setTosUri("https://[::1]:8443/mcp");
+            i.setPolicyUri("https://127.0.0.1:443/mcp");
+            i.setJwksUri("https://10.255.255.1:443/mcp");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, AbstractClientIdMetadataDocumentExecutor.ERR_METADATA_PRIVATE_ADDRESS);
+
+    }
+
+    @Test
+    public void testClientIdMetadataDocumentExecutorValidateClientMetadata() throws Exception {
+        // register profiles
+        String  json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                        it.setAllowLoopbackAddress(true);
+                                        it.setOnlyAllowConfidentialClient(true);
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
+                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        TestOIDCEndpointsApplicationResource oidcClientEndpointsResource = testingClient.testApp().oidcClientEndpoints();
+        String clientId;
+        OIDCClientRepresentation clientMetadata;
+
+        // Client Metadata Validation:
+        // Only a confidential client is allowed.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setTokenEndpointAuthMethod(null));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, ClientIdMetadataDocumentExecutor.ERR_METADATA_NO_CONFIDENTIAL_CLIENT);
+
+        // Client Metadata Validation:
+        // ether jwks or jwks_uri is required.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setJwksUri(null));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, ClientIdMetadataDocumentExecutor.ERR_METADATA_NO_CONFIDENTIAL_CLIENT_JWKS);
+
+        // Client Metadata Validation:
+        // An authorization server MAY impose restrictions or relationships
+        // between the redirect_uris and the client_id or client_uri properties
+        //
+        // same domain
+        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setOnlyAllowConfidentialClient(false);
+                                    it.setAllowPermittedDomains(List.of("*.example.com", "mcp.example.co.jp", "localhost"));
+                                    it.setRestrictSameDomain(true);
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        String originalRedirectUri = oauth.getRedirectUri();
+        oauth.redirectUri("https://mcp.example.co.jp/callback");
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setRedirectUris(List.of("https://mcp.example.co.jp/callback", "https://mcp.example.com/callback")));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, ClientIdMetadataDocumentExecutor.ERR_METADATA_URIS_SAMEDOMAIN);
+        oauth.redirectUri(originalRedirectUri);
+
+        // required properties
+        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setRequiredProperties(List.of("client_uri", "logo_uri"));
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->i.setClientUri("https://www.example.com"));
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, ClientIdMetadataDocumentExecutor.ERR_METADATA_NO_REQUIRED_PROPERTIES);
+
+        // All URIs under the same domain of permitted domains
+        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setAllUrisRestrictSameDomain(true);
+                                    it.setAllowPermittedDomains(List.of("*.example.com", "localhost"));
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->{
+            i.setLogoUri("https://localhost:8443/logo");
+            i.setClientUri("https://www.example.org");
+            i.setTosUri("https://[::1]:8443/mcp");
+            i.setPolicyUri("https://localhost/mcp");
+            i.setJwksUri("https://127.0.0.1:443/mcp");
+        });
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+        assertLoginAndError(clientId, ClientIdMetadataDocumentExecutor.ERR_METADATA_NO_ALL_URIS_SAMEDOMAIN);
+
+        // consent required
+        // default value = true -> false
+        // full scope disabled
+        // default value = true -> false
+        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
+                                createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
+                                    it.setAllowLoopbackAddress(true);
+                                    it.setConsentRequired(false);
+                                    it.setFullScopeDisabled(false);
+                                }))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        clientMetadata = setupOIDCClientRepresentation(clientId, i->{});
+        oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, null, null);
+
+        // send an authorization request
+        loginUserAndGetCode(clientId, false);
+
+        // check the persisted client settings
+        ClientRepresentation clientRepresentation = findByClientIdByAdmin(clientId);
+        assertFalse(clientRepresentation.isConsentRequired());
+        assertTrue(clientRepresentation.isFullScopeAllowed());
+
+        // delete the persisted client
+        deleteClientByAdmin(clientRepresentation.getId());
+        assertThrows(jakarta.ws.rs.NotFoundException.class, ()->getClientByAdmin(clientRepresentation.getId()));
+    }
+
+    private String loginUserAndGetCode(String clientId, boolean isGrantRequred) {
+        oauth.client(clientId);
+        oauth.loginForm().codeChallenge(null).doLogin(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        if (isGrantRequred) {
+            grantPage.assertCurrent();
+            grantPage.assertGrants("The client's hostname is localhost");
+            grantPage.accept();
+        }
+
+        String code = oauth.parseLoginResponse().getCode();
+        org.keycloak.testsuite.Assert.assertNotNull(code);
+        return code;
+    }
+
+    private String ssoLoginUserAndGetCode(String clientId, String expectedGrant) {
+        oauth.client(clientId);
+        oauth.loginForm().codeChallenge(null).open();
+
+        if (expectedGrant != null) {
+            grantPage.assertCurrent();
+            grantPage.assertGrants(expectedGrant);
+            grantPage.accept();
+        }
+
+        String code = oauth.parseLoginResponse().getCode();
+        org.keycloak.testsuite.Assert.assertNotNull(code);
+        return code;
+    }
+
+    private AccessTokenResponse doAccessTokenRequestWithClientSignedJWT(String code, String signedJwt, Supplier<CloseableHttpClient> httpClientSupplier) {
+        try {
+            List<NameValuePair> parameters = new LinkedList<>();
+            parameters.add(new BasicNameValuePair(OAuth2Constants.GRANT_TYPE, OAuth2Constants.AUTHORIZATION_CODE));
+            parameters.add(new BasicNameValuePair(OAuth2Constants.CODE, code));
+
+            parameters.add(new BasicNameValuePair(OAuth2Constants.REDIRECT_URI, oauth.getRedirectUri()));
+            parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ASSERTION_TYPE, OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT));
+            parameters.add(new BasicNameValuePair(OAuth2Constants.CLIENT_ASSERTION, signedJwt));
+
+            CloseableHttpResponse response = sendRequest(oauth.getEndpoints().getToken(), parameters, httpClientSupplier);
+            return new AccessTokenResponse(response);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private CloseableHttpResponse sendRequest(String requestUrl, List<NameValuePair> parameters, Supplier<CloseableHttpClient> httpClientSupplier) throws Exception {
+        try (CloseableHttpClient client = httpClientSupplier.get()) {
+            HttpPost post = new HttpPost(requestUrl);
+            UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+            post.setEntity(formEntity);
+            return client.execute(post);
+        }
+    }
+
+    private void assertLoginAndError(String clientId, String errorMessage) {
+        oauth.client(clientId);
+        oauth.openLoginForm();
+        assertTrue(errorPage.isCurrent());
+        assertEquals(errorMessage, errorPage.getError());
+        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST,
+                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST,
+                        errorMessage).client((String) null)
+                .user((String) null).assertEvent();
+    }
+
+    private OIDCClientRepresentation setupOIDCClientRepresentation(
+            String clientId, Consumer<OIDCClientRepresentation> apply) {
+        OIDCClientRepresentation clientMetadata = new OIDCClientRepresentation();
+        clientMetadata.setClientId(clientId);
+        clientMetadata.setRedirectUris(Collections.singletonList(oauth.getRedirectUri()));
+        clientMetadata.setTokenEndpointAuthMethod(OIDCLoginProtocol.PRIVATE_KEY_JWT);
+        clientMetadata.setJwksUri(TestApplicationResourceUrls.clientJwksUri());
+        if (apply != null) {
+            apply.accept(clientMetadata);
+        }
+        return clientMetadata;
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
@@ -134,8 +134,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                                     it.setAllowLoopbackAddress(true);
                                     it.setTrustedDomains(List.of("*.example.com","localhost"));
                                     it.setRestrictSameDomain(true);
-                                    it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri", "jwks_uri"));
-                                    it.setAllUrisRestrictSameDomain(true);}))
+                                    it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri", "jwks_uri"));}))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -256,8 +255,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                                     it.setAllowLoopbackAddress(true);
                                     it.setTrustedDomains(List.of("*.example.com","localhost"));
                                     it.setRestrictSameDomain(true);
-                                    it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri"));
-                                    it.setAllUrisRestrictSameDomain(true);}))
+                                    it.setRequiredProperties(List.of("scope", "logo_uri", "client_uri", "tos_uri", "policy_uri"));}))
                         .toRepresentation()
         ).toString();
         updateProfiles(json);
@@ -379,7 +377,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         // jwksUri = https://localhost:8543/auth/realms/master/app/oidc-client-endpoints/get-jwks
         String clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
         OIDCClientRepresentation clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
-            i.setLogoUri("https://www.example.com");
+            i.setLogoUri("https://localhost:8443/logo");
             i.setScope("address phone");
         });
         String cacheControlHeaderValue = "must-revalidate, max-age=3600, public, s-maxage=20";
@@ -406,7 +404,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         // change the client metadata
         // however, the client returns 304 Not Modified
         clientMetadata = setupOIDCClientRepresentation(clientId, i-> {
-            i.setLogoUri("https://www.example.com/logo");
+            i.setLogoUri("https://localhost:443/logo/v3");
             i.setScope("profile");
         });
         oidcClientEndpointsResource.registerClientIdMetadata(clientMetadata, cacheControlHeaderValue, "NotModified");
@@ -422,7 +420,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         clientRepresentation = findByClientIdByAdmin(clientId);
         Map<String, String> m = clientRepresentation.getAttributes();
         List<String> optionalScopeList = clientRepresentation.getOptionalClientScopes();
-        assertEquals("https://www.example.com", m.get("logoUri"));
+        assertEquals("https://localhost:8443/logo", m.get("logoUri"));
         assertEquals(2, optionalScopeList.size());
         assertTrue(optionalScopeList.contains("phone"));
         assertTrue(optionalScopeList.contains("address"));
@@ -445,7 +443,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         clientRepresentation = findByClientIdByAdmin(clientId);
         m = clientRepresentation.getAttributes();
         optionalScopeList = clientRepresentation.getOptionalClientScopes();
-        assertEquals("https://www.example.com", m.get("logoUri"));
+        assertEquals("https://localhost:8443/logo", m.get("logoUri"));
         assertEquals(2, optionalScopeList.size());
         assertTrue(optionalScopeList.contains("phone"));
         assertTrue(optionalScopeList.contains("address"));
@@ -812,9 +810,9 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         assertLoginAndError("https://192.168.255.255:443/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_PRIVATE_ADDRESS);
 
         // Client ID Verification:
-        // Client identifier is not a loopback address
-        // -> java.net.URI does not follow RFC 3986 so it cannot parse the following IPv6 address, resulting getHost() == null
+        // Client identifier is not a valid IPv6 address
         assertLoginAndError("https://0:0:0:0:0:0:0:1/mcp", AbstractClientIdMetadataDocumentExecutor.ERR_HOST_UNRESOLVED);
+        
     }
 
     @Test
@@ -1045,7 +1043,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                         .addExecutor(ClientIdMetadataDocumentExecutorFactory.PROVIDER_ID,
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
                                     it.setAllowLoopbackAddress(true);
-                                    it.setAllUrisRestrictSameDomain(true);
+                                    it.setRestrictSameDomain(true);
                                     it.setTrustedDomains(List.of("*.example.org", "localhost", "[::1]", "127.0.0.1"));
                                 }))
                         .toRepresentation()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientIdMetadataDocumentTest.java
@@ -104,12 +104,13 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         ).toString();
         updateProfiles(json);
 
-        // register policies
+        // register policies : no trusted domain
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("spiffe"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("spiffe"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -117,7 +118,52 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
 
         String clientId;
 
-        // CIMD executor is not executed, so we expect the error showing that client is not found.
+        // allowed scheme: spiffe
+        // actual scheme: https
+        // -> CIMD executor is not executed, so we expect the error showing that client is not found.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        oauth.client(clientId);
+        oauth.openLoginForm();
+        assertTrue(errorPage.isCurrent());
+        assertEquals("Client not found.", errorPage.getError());
+
+        // update policies: trusted domain vacant
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                    it.setClientIdUriSchemes(List.of("http", "https"));
+                                }))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // trusted domains: vacant
+        // host: localhost
+        // -> CIMD executor is not executed, so we expect the error showing that client is not found.
+        clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
+        oauth.client(clientId);
+        oauth.openLoginForm();
+        assertTrue(errorPage.isCurrent());
+        assertEquals("Client not found.", errorPage.getError());
+
+        // update policies: trusted domain filled
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                    it.setClientIdUriSchemes(List.of("http", "https"));
+                                    it.setTrustedDomains(List.of("example.com","mcp.example.com"));
+                                }))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // trusted domains: example.com, mcp.example.com
+        // host: localhost
+        // -> CIMD executor is not executed, so we expect the error showing that client is not found.
         clientId = TestApplicationResourceUrls.getClientIdMetadataUri(generateSuffixedName("CIMD"));
         oauth.client(clientId);
         oauth.openLoginForm();
@@ -144,8 +190,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -271,8 +319,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -363,8 +413,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -476,8 +528,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -512,8 +566,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -645,8 +701,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -712,8 +770,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com","localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -750,8 +810,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -892,8 +954,12 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com", "localhost", "10.255.255.255",
+                                            "mcpclient.example.org", "www.example.org", "172.31.255.254",
+                                            "[::1]", "client.example.com", "127.0.0.1", "10.255.255.1"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();
@@ -1016,7 +1082,7 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
                                 createExecutorConfig(new ClientIdMetadataDocumentExecutor.Configuration(), it->{
                                         it.setAllowLoopbackAddress(true);
                                         it.setOnlyAllowConfidentialClient(true);
-                                    it.setTrustedDomains(List.of("*.example.com", "localhost"));
+                                        it.setTrustedDomains(List.of("*.example.com", "localhost"));
                                 }))
                         .toRepresentation()
         ).toString();
@@ -1026,8 +1092,10 @@ public class ClientIdMetadataDocumentTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
                         .addCondition(ClientIdUriSchemeConditionFactory.PROVIDER_ID,
-                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->
-                                        it.setClientIdUriSchemes(List.of("http", "https"))))
+                                createConditionConfig(new ClientIdUriSchemeCondition.Configuration(), it->{
+                                        it.setClientIdUriSchemes(List.of("http", "https"));
+                                        it.setTrustedDomains(List.of("*.example.com", "localhost"));
+                                }))
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -38,6 +38,8 @@ import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.models.utils.MapperTypeSerializer;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.condition.ClientIdUriSchemeCondition;
+import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutor;
 import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor.SecureCibaAuthenticationRequestSigningAlgorithmExecutor;
 import org.keycloak.representations.idm.ClientPoliciesRepresentation;
 import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
@@ -276,6 +278,40 @@ public final class ClientPoliciesUtil {
     public static SecureRedirectUrisEnforcerExecutor.Configuration createSecureRedirectUrisEnforcerExecutorConfig(
             Consumer<SecureRedirectUrisEnforcerExecutor.Configuration> apply) {
         SecureRedirectUrisEnforcerExecutor.Configuration config = new SecureRedirectUrisEnforcerExecutor.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static ClientIdMetadataDocumentExecutor.Configuration createClientIdMetadataDocumentExecutorConfig(
+            Consumer<ClientIdMetadataDocumentExecutor.Configuration> apply) {
+        ClientIdMetadataDocumentExecutor.Configuration config = new ClientIdMetadataDocumentExecutor.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static ClientIdUriSchemeCondition.Configuration createClientIdUriSchemeConditionConfig(
+            Consumer<ClientIdUriSchemeCondition.Configuration> apply) {
+        ClientIdUriSchemeCondition.Configuration config = new ClientIdUriSchemeCondition.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static <CONFIG extends ClientPolicyExecutorConfigurationRepresentation> CONFIG createExecutorConfig(
+            CONFIG config, Consumer<CONFIG> apply) {
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static <CONFIG extends ClientPolicyConditionConfigurationRepresentation> CONFIG createConditionConfig(
+            CONFIG config, Consumer<CONFIG> apply) {
         if (apply != null) {
             apply.accept(config);
         }


### PR DESCRIPTION
closes #45284

## Class structure

Mainly there are two components:
- Processing CIMD/MCP specification
  - `AbstractClientIdMetadataDocumentExecutor` / `AbstractClientIdMetadataDocumentExecutorFactory` : can provide basic features regarding specifications.
  - `ClientIdMetadataDocumentExecutor` / `ClientIdMetadataDocumentExecutorFactory` : can extends the basic abstract class.
- Storing and managing client metadata
  - `ClientIdMetadataDocumentProviderSpi` / `ClientIdMetadataDocumentProvide` / `ClientIdMetadataDocumentProvideFactory` : SPI
  - `AbstractPersistentClientIdMetadataDocumentProvider` / `AbstractPersistentClientIdMetadataDocumentProviderFactory`: can provide basic basic features regarding persisting client metadata.
  - `PersistentClientIdMetadataDocumentProvider` / `PersistentClientIdMetadataDocumentProviderFactory`: can extends the basic abstract class.

The size of the PR is large, but about 1.2k of the PR codes are test codes and the codes includes a lot of code comments.

## Implementation patterns
Both adopt Factory pattern to make it easy to custom/extend the features.

### Processing CIMD/MCP specification component
Client policies are used. Its advantage is that we can construct client policy profile for each version of MCP. To apply the profile, the following condition is also added:
- `ClientIdUriSchemeCondition` / `ClientIdUriSchemeConditionFactory` : filter the request whose `client_id` starts with http/https.

### Regarding Storing and managing a client metadata component
To make it easy to implement non-persistenting client metadata, new SPI is introduced. 

### Displaying information on client metadata on the grant screen
Augmentation of client metadata in `PersistentClientIdMetadataDocumentProvider`, the information of fetched client metadata is shown on the existing grant screen.

### Integration tests
`TestingOIDCEndpointsApplicationResource` simulates the server hosting client metadata.

## Enchancement and customization:
- If we want to add keycloak-specific policies for Client ID validation and/or Client Metadata: modify `ClientIdMetadataDocumentExecutor` / `ClientIdMetadataDocumentExecutorFactory`.
- If keycloak users want to add their own Client ID validation and/or Client Metadata: extend `ClientIdMetadataDocumentExecutor` / `ClientIdMetadataDocumentExecutorFactory`.
- If we want to add keycloak-specific features/augmentation to client metadata: modify  `PersistentClientIdMetadataDocumentProvider` / `PersistentClientIdMetadataDocumentProviderFactory`
- If keycloak users want to add their own features/augmentation to client metadata: extend `PersistentClientIdMetadataDocumentProvider` / `PersistentClientIdMetadataDocumentProviderFactory`
- If we want to support non-persisting client metadata: implement `ClientIdMetadataDocumentExecutor` / `ClientIdMetadataDocumentExecutorFactory`
