### PR TITLE
Wrap form buttons in `kcFormButtonsClass` div

### DIFF
--- a/themes/src/main/resources/theme/base/login/login-config-totp.ftl
+++ b/themes/src/main/resources/theme/base/login/login-config-totp.ftl
@@ -93,23 +93,25 @@
 
             <div class="${properties.kcFormGroupClass!}">
                 <@passwordCommons.logoutOtherSessions/>
-            </div>
 
-            <#if isAppInitiatedAction??>
-                <input type="submit"
-                       class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                       id="saveTOTPBtn" value="${msg("doSubmit")}"
-                />
-                <button type="submit"
-                        class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!} ${properties.kcButtonLargeClass!}"
-                        id="cancelTOTPBtn" name="cancel-aia" value="true" />${msg("doCancel")}
-                </button>
-            <#else>
-                <input type="submit"
-                       class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
-                       id="saveTOTPBtn" value="${msg("doSubmit")}"
-                />
-            </#if>
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <#if isAppInitiatedAction??>
+                        <input type="submit"
+                               class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
+                               id="saveTOTPBtn" value="${msg("doSubmit")}"
+                        />
+                        <button type="submit"
+                                class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!} ${properties.kcButtonLargeClass!}"
+                                id="cancelTOTPBtn" name="cancel-aia" value="true" />${msg("doCancel")}
+                        </button>
+                    <#else>
+                        <input type="submit"
+                               class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"
+                               id="saveTOTPBtn" value="${msg("doSubmit")}"
+                        />
+                    </#if>
+                </div>
+            </div>
         </form>
     </#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
- Closes #45164

Previously, the buttons in `login-config-totp.ftl` were not enclosed in a `<div>` with the `${properties.kcFormButtonsClass!}` class.

This resulted in inconsistent margins and alignment compared to other base theme templates, especially affecting button groups.

Update the markup to wrap the buttons in a `kc-form-buttons` div with the appropriate class. This aligns the template with the styling standards used elsewhere and ensures margin consistency across the UI.

Related to: #45164

---

### Notes for review

1. I've preserved `id="kc-form-buttons"` for uniformity with other templates
2. This may affect other templates
3. The implementation is mimicking `login-update-password.ftl`: 
    https://github.com/keycloak/keycloak/blob/1aa1621eaa950d957d64f5f7c5aa6392329f83cb/themes/src/main/resources/theme/base/login/login-update-password.ftl#L65-L72
5. Please review with "hide whitespace" turned on, because this is a very simple change but default diff is bigger than it should be
    <img width="301" height="289" alt="image" src="https://github.com/user-attachments/assets/439bb85e-132d-4141-b53e-6cd1acaf9cf7" />
