### PR TITLE
Remove unnecessary closing div in webauthn-authenticate template

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/webauthn-authenticate.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/webauthn-authenticate.ftl
@@ -91,7 +91,6 @@
                                                 <i>${authenticator.createdAt}</i>
                                             </span>
                                         </div>
-                                        </div>
                                         <div class="${properties.kcSelectAuthListItemFillClass!}"></div>
                                     </div>
                                 </li>


### PR DESCRIPTION
closes keycloak/keycloak#45307

(cherry picked from commit 316f893d193b3eac28189d77aa4535a17839ddcb)
