### PR TITLE
Use MIME decoder instead of the default one to replace deprecated Base64 class (26.5)

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/config/PemUtils.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/config/PemUtils.java
@@ -125,7 +125,7 @@ public class PemUtils {
     private static byte[] pemToDer(String pem) {
         try {
             pem = removeBeginEnd(pem);
-            return Base64.getDecoder().decode(pem);
+            return Base64.getMimeDecoder().decode(pem);
         } catch (IllegalArgumentException e) {
             throw new PemException(e);
         }

--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/profile/AbstractSamlAuthenticationHandler.java
@@ -691,7 +691,7 @@ public abstract class AbstractSamlAuthenticationHandler implements SamlAuthentic
 
         try {
             //byte[] decodedSignature = RedirectBindingUtil.urlBase64Decode(signature);
-            byte[] decodedSignature = Base64.getDecoder().decode(signature);
+            byte[] decodedSignature = Base64.getMimeDecoder().decode(signature);
             byte[] rawQueryBytes = rawQuery.getBytes(StandardCharsets.UTF_8);
 
             SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.getFromXmlMethod(decodedAlgorithm);

--- a/common/src/main/java/org/keycloak/common/crypto/PemUtilsProvider.java
+++ b/common/src/main/java/org/keycloak/common/crypto/PemUtilsProvider.java
@@ -128,7 +128,7 @@ public abstract class PemUtilsProvider {
     public byte[] pemToDer(String pem) {
         try {
             pem = removeBeginEnd(pem);
-            return Base64.getDecoder().decode(pem);
+            return Base64.getMimeDecoder().decode(pem);
         } catch (IllegalArgumentException e) {
             throw new PemException(e);
         }

--- a/common/src/main/java/org/keycloak/common/util/KerberosSerializationUtils.java
+++ b/common/src/main/java/org/keycloak/common/util/KerberosSerializationUtils.java
@@ -108,7 +108,7 @@ public class KerberosSerializationUtils {
     }
 
     private static Object deserialize(String serialized) throws ClassNotFoundException, IOException {
-        byte[] bytes = java.util.Base64.getDecoder().decode(serialized);
+        byte[] bytes = java.util.Base64.getMimeDecoder().decode(serialized);
         ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
         ObjectInputStream in = null;
         try {

--- a/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
+++ b/core/src/main/java/org/keycloak/util/BasicAuthHelper.java
@@ -44,7 +44,7 @@ public class BasicAuthHelper {
 
         String val;
         try {
-            val = new String(Base64.getDecoder().decode(header.substring(6)));
+            val = new String(Base64.getMimeDecoder().decode(header.substring(6)));
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/impl/SPNEGOAuthenticator.java
+++ b/federation/kerberos/src/main/java/org/keycloak/federation/kerberos/impl/SPNEGOAuthenticator.java
@@ -164,7 +164,7 @@ public class SPNEGOAuthenticator {
         GSSCredential gssCredential = manager.createCredential(null, GSSCredential.INDEFINITE_LIFETIME, supportedMechs, GSSCredential.ACCEPT_ONLY);
         GSSContext gssContext = manager.createContext(gssCredential);
 
-        byte[] inputToken = Base64.getDecoder().decode(spnegoToken);
+        byte[] inputToken = Base64.getMimeDecoder().decode(spnegoToken);
         byte[] respToken = gssContext.acceptSecContext(inputToken, 0, inputToken.length);
         responseToken = Base64.getEncoder().encodeToString(respToken);
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPIdentityStore.java
@@ -597,7 +597,7 @@ public class LDAPIdentityStore implements IdentityStore {
             }
 
             try {
-                byte[] bytes = Base64.getDecoder().decode(value);
+                byte[] bytes = Base64.getMimeDecoder().decode(value);
                 attr.add(bytes);
             } catch (IllegalArgumentException iae) {
                 logger.warnf("Wasn't able to Base64 decode the attribute value. Ignoring attribute update. Attribute: %s, Attribute value: %s", attrName, attrValue);

--- a/saml-core-api/src/main/java/org/keycloak/dom/xmlsec/w3/xmldsig/DSAKeyValueType.java
+++ b/saml-core-api/src/main/java/org/keycloak/dom/xmlsec/w3/xmldsig/DSAKeyValueType.java
@@ -203,10 +203,10 @@ public class DSAKeyValueType implements KeyValueType {
     public DSAPublicKey convertToPublicKey() throws ProcessingException {
 
         try {
-            BigInteger BigY = new BigInteger(1, massage(Base64.getDecoder().decode(new String(y))));
-            BigInteger BigP = new BigInteger(1, massage(Base64.getDecoder().decode(new String(p))));
-            BigInteger BigQ = new BigInteger(1, massage(Base64.getDecoder().decode(new String(q))));
-            BigInteger BigG = new BigInteger(1, massage(Base64.getDecoder().decode(new String(g))));
+            BigInteger BigY = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(y))));
+            BigInteger BigP = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(p))));
+            BigInteger BigQ = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(q))));
+            BigInteger BigG = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(g))));
 
             KeyFactory dsaKeyFactory = KeyFactory.getInstance("dsa");
             DSAPublicKeySpec kspec = new DSAPublicKeySpec(BigY, BigP, BigQ, BigG);
@@ -226,10 +226,10 @@ public class DSAKeyValueType implements KeyValueType {
     public DSAPrivateKey convertToPrivateKey() throws ProcessingException {
 
         try {
-            BigInteger BigY = new BigInteger(1, massage(Base64.getDecoder().decode(new String(y))));
-            BigInteger BigP = new BigInteger(1, massage(Base64.getDecoder().decode(new String(p))));
-            BigInteger BigQ = new BigInteger(1, massage(Base64.getDecoder().decode(new String(q))));
-            BigInteger BigG = new BigInteger(1, massage(Base64.getDecoder().decode(new String(g))));
+            BigInteger BigY = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(y))));
+            BigInteger BigP = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(p))));
+            BigInteger BigQ = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(q))));
+            BigInteger BigG = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(g))));
 
             KeyFactory dsaKeyFactory = KeyFactory.getInstance("dsa");
             DSAPrivateKeySpec kspec = new DSAPrivateKeySpec(BigY, BigP, BigQ, BigG);

--- a/saml-core-api/src/main/java/org/keycloak/dom/xmlsec/w3/xmldsig/RSAKeyValueType.java
+++ b/saml-core-api/src/main/java/org/keycloak/dom/xmlsec/w3/xmldsig/RSAKeyValueType.java
@@ -98,8 +98,8 @@ public class RSAKeyValueType implements KeyValueType {
      */
     public RSAPublicKey convertToPublicKey() throws ProcessingException {
         try {
-            BigInteger bigModulus = new BigInteger(1, massage(Base64.getDecoder().decode(new String(modulus))));
-            BigInteger bigEx = new BigInteger(1, massage(Base64.getDecoder().decode(new String(exponent))));
+            BigInteger bigModulus = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(modulus))));
+            BigInteger bigEx = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(exponent))));
             KeyFactory rsaKeyFactory = KeyFactory.getInstance("rsa");
             RSAPublicKeySpec kspec = new RSAPublicKeySpec(bigModulus, bigEx);
             return (RSAPublicKey) rsaKeyFactory.generatePublic(kspec);
@@ -117,8 +117,8 @@ public class RSAKeyValueType implements KeyValueType {
      */
     public RSAPrivateKey convertToPrivateKey() throws ProcessingException {
         try {
-            BigInteger bigModulus = new BigInteger(1, massage(Base64.getDecoder().decode(new String(modulus))));
-            BigInteger bigEx = new BigInteger(1, massage(Base64.getDecoder().decode(new String(exponent))));
+            BigInteger bigModulus = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(modulus))));
+            BigInteger bigEx = new BigInteger(1, massage(Base64.getMimeDecoder().decode(new String(exponent))));
             KeyFactory rsaKeyFactory = KeyFactory.getInstance("rsa");
             RSAPrivateKeySpec kspec = new RSAPrivateKeySpec(bigModulus, bigEx);
             return (RSAPrivateKey) rsaKeyFactory.generatePrivate(kspec);

--- a/saml-core/src/main/java/org/keycloak/saml/processing/web/util/PostBindingUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/web/util/PostBindingUtil.java
@@ -58,7 +58,7 @@ public class PostBindingUtil {
             throw logger.nullArgumentError("encodedString");
 
         try {
-            return Base64.getDecoder().decode(encodedString);
+            return Base64.getMimeDecoder().decode(encodedString);
         } catch (Exception e) {
             logger.error(e);
             throw logger.invalidArgumentError("base64 decode failed: " + e.getMessage());

--- a/saml-core/src/main/java/org/keycloak/saml/processing/web/util/RedirectBindingUtil.java
+++ b/saml-core/src/main/java/org/keycloak/saml/processing/web/util/RedirectBindingUtil.java
@@ -98,7 +98,7 @@ public class RedirectBindingUtil {
      */
     public static byte[] urlBase64Decode(String encodedString) throws IOException {
         String decodedString = urlDecode(encodedString);
-        return Base64.getDecoder().decode(decodedString);
+        return Base64.getMimeDecoder().decode(decodedString);
     }
 
     /**
@@ -166,7 +166,7 @@ public class RedirectBindingUtil {
      * @throws IOException
      */
     public static InputStream base64DeflateDecode(String encodedString) throws IOException {
-        byte[] base64decodedMsg = Base64.getDecoder().decode(encodedString);
+        byte[] base64decodedMsg = Base64.getMimeDecoder().decode(encodedString);
         return DeflateUtil.decode(base64decodedMsg);
     }
 

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParserTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/parsers/saml/SAMLParserTest.java
@@ -218,7 +218,7 @@ public class SAMLParserTest {
         assertNull(rtChoiceType.getAssertion());
         assertNotNull(rtChoiceType.getEncryptedAssertion());
 
-        PrivateKey privateKey = DerUtils.decodePrivateKey(Base64.getDecoder().decode(PRIVATE_KEY));
+        PrivateKey privateKey = DerUtils.decodePrivateKey(Base64.getMimeDecoder().decode(PRIVATE_KEY));
         AssertionUtil.decryptAssertion(resp, privateKey);
 
         rtChoiceType = resp.getAssertions().get(0);

--- a/saml-core/src/test/java/org/keycloak/saml/processing/core/saml/v2/util/AssertionUtilTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/processing/core/saml/v2/util/AssertionUtilTest.java
@@ -49,7 +49,7 @@ public class AssertionUtilTest {
     @Test
     public void testSaml20Signed() throws Exception {
 
-        X509Certificate decodeCertificate = DerUtils.decodeCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(PUBLIC_CERT)));
+        X509Certificate decodeCertificate = DerUtils.decodeCertificate(new ByteArrayInputStream(Base64.getMimeDecoder().decode(PUBLIC_CERT)));
 
         try (InputStream st = AssertionUtilTest.class.getResourceAsStream("saml20-signed-response.xml")) {
             Document document = DocumentUtil.getDocument(st);
@@ -61,7 +61,7 @@ public class AssertionUtilTest {
             // test manipulation of signature
             Element signatureElement = AssertionUtil.getSignature(assertion);
             Element signatureValue = (Element) signatureElement.getElementsByTagNameNS("http://www.w3.org/2000/09/xmldsig#", "SignatureValue").item(0);
-            byte[] validSignature = Base64.getDecoder().decode(signatureValue.getTextContent());
+            byte[] validSignature = Base64.getMimeDecoder().decode(signatureValue.getTextContent());
 
             // change the signature value slightly
             byte[] invalidSignature =  Arrays.copyOf(validSignature, validSignature.length);

--- a/server-spi-private/src/main/java/org/keycloak/credential/hash/Pbkdf2PasswordHashProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/credential/hash/Pbkdf2PasswordHashProvider.java
@@ -99,7 +99,7 @@ public class Pbkdf2PasswordHashProvider implements PasswordHashProvider {
 
     private int keySize(PasswordCredentialModel credential) {
         try {
-            byte[] bytes = Base64.getDecoder().decode(credential.getPasswordSecretData().getValue());
+            byte[] bytes = Base64.getMimeDecoder().decode(credential.getPasswordSecretData().getValue());
             return bytes.length * 8;
         } catch (IllegalArgumentException e) {
             throw new RuntimeException("Credential could not be decoded", e);

--- a/server-spi-private/src/main/java/org/keycloak/device/DeviceActivityManager.java
+++ b/server-spi-private/src/main/java/org/keycloak/device/DeviceActivityManager.java
@@ -48,7 +48,7 @@ public class DeviceActivityManager {
         }
 
         try {
-            return JsonSerialization.readValue(Base64.getDecoder().decode(deviceInfo), DeviceRepresentation.class);
+            return JsonSerialization.readValue(Base64.getMimeDecoder().decode(deviceInfo), DeviceRepresentation.class);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server-spi/src/main/java/org/keycloak/credential/CredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/credential/CredentialModel.java
@@ -176,7 +176,7 @@ public class CredentialModel implements Serializable {
     @JsonIgnore
     public byte[] getSalt() {
         String saltStr = readString("salt", true);
-        return saltStr == null ? null : Base64.getDecoder().decode(saltStr);
+        return saltStr == null ? null : Base64.getMimeDecoder().decode(saltStr);
     }
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/DefaultActionTokenKey.java
+++ b/server-spi/src/main/java/org/keycloak/models/DefaultActionTokenKey.java
@@ -80,7 +80,7 @@ public class DefaultActionTokenKey extends JsonWebToken implements SingleUseObje
 
         String userId;
         try {
-            userId = new String(Base64.getDecoder().decode(parsed[0]), StandardCharsets.UTF_8);
+            userId = new String(Base64.getMimeDecoder().decode(parsed[0]), StandardCharsets.UTF_8);
         } catch (IllegalArgumentException ex) {
             userId = parsed[0];
         }

--- a/server-spi/src/main/java/org/keycloak/models/credential/dto/PasswordSecretData.java
+++ b/server-spi/src/main/java/org/keycloak/models/credential/dto/PasswordSecretData.java
@@ -37,7 +37,7 @@ public class PasswordSecretData {
         }
         else {
             this.value = value;
-            this.salt = Base64.getDecoder().decode(salt);
+            this.salt = Base64.getMimeDecoder().decode(salt);
         }
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/utils/RecoveryAuthnCodesUtils.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/RecoveryAuthnCodesUtils.java
@@ -42,7 +42,7 @@ public class RecoveryAuthnCodesUtils {
     public static boolean verifyRecoveryCodeInput(String rawInputRecoveryCode, String hashedSavedRecoveryCode) {
         byte[] hashedInputBackupCode = hashRawCode(rawInputRecoveryCode);
         try {
-            byte[] savedCode = Base64.getDecoder().decode(hashedSavedRecoveryCode);
+            byte[] savedCode = Base64.getMimeDecoder().decode(hashedSavedRecoveryCode);
             return MessageDigest.isEqual(hashedInputBackupCode, savedCode);
         } catch (IllegalArgumentException iae) {
             logger.warnf("Error when decoding saved recovery code", iae);

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -166,7 +166,7 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
 
         byte[] credentialId = null;
         try {
-            credentialId = Base64.getDecoder().decode(credData.getCredentialId());
+            credentialId = Base64.getMimeDecoder().decode(credData.getCredentialId());
         } catch (IllegalArgumentException ex) {
             // NOP
         }

--- a/services/src/main/java/org/keycloak/keys/AbstractGeneratedEcKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/AbstractGeneratedEcKeyProviderFactory.java
@@ -115,7 +115,7 @@ public abstract class AbstractGeneratedEcKeyProviderFactory<T extends KeyProvide
     protected String getCurveFromPublicKey(String publicEcKeyBase64Encoded) {
         try {
             KeyFactory kf = KeyFactory.getInstance("EC");
-            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEcKeyBase64Encoded));
+            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEcKeyBase64Encoded));
             ECPublicKey ecKey = (ECPublicKey) kf.generatePublic(publicKeySpec);
             return "P-" + ecKey.getParams().getCurve().getField().getFieldSize();
         } catch (Throwable t) {

--- a/services/src/main/java/org/keycloak/keys/GeneratedEcdhKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedEcdhKeyProvider.java
@@ -54,11 +54,11 @@ public class GeneratedEcdhKeyProvider extends AbstractEcKeyProvider {
                                               .orElse(false);
 
         try {
-            PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateEcdhKeyBase64Encoded));
+            PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getMimeDecoder().decode(privateEcdhKeyBase64Encoded));
             KeyFactory kf = KeyFactory.getInstance("EC");
             PrivateKey decodedPrivateKey = kf.generatePrivate(privateKeySpec);
 
-            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEcdhKeyBase64Encoded));
+            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEcdhKeyBase64Encoded));
             PublicKey decodedPublicKey = kf.generatePublic(publicKeySpec);
 
             KeyPair keyPair = new KeyPair(decodedPublicKey, decodedPrivateKey);

--- a/services/src/main/java/org/keycloak/keys/GeneratedEcdsaKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedEcdsaKeyProvider.java
@@ -54,11 +54,11 @@ public class GeneratedEcdsaKeyProvider extends AbstractEcKeyProvider {
                                                                .orElse(false);
 
         try {
-            PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateEcdsaKeyBase64Encoded));
+            PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getMimeDecoder().decode(privateEcdsaKeyBase64Encoded));
             KeyFactory kf = KeyFactory.getInstance("EC");
             PrivateKey decodedPrivateKey = kf.generatePrivate(privateKeySpec);
 
-            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEcdsaKeyBase64Encoded));
+            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEcdsaKeyBase64Encoded));
             PublicKey decodedPublicKey = kf.generatePublic(publicKeySpec);
 
             KeyPair keyPair = new KeyPair(decodedPublicKey, decodedPrivateKey);

--- a/services/src/main/java/org/keycloak/keys/GeneratedEddsaKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedEddsaKeyProvider.java
@@ -47,11 +47,11 @@ public class GeneratedEddsaKeyProvider extends AbstractEddsaKeyProvider {
         String curveName = model.getConfig().getFirst(GeneratedEddsaKeyProviderFactory.EDDSA_ELLIPTIC_CURVE_KEY);
 
         try {
-            PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(privateEddsaKeyBase64Encoded));
+            PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getMimeDecoder().decode(privateEddsaKeyBase64Encoded));
             KeyFactory kf = KeyFactory.getInstance("EdDSA");
             PrivateKey decodedPrivateKey = kf.generatePrivate(privateKeySpec);
 
-            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEddsaKeyBase64Encoded));
+            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEddsaKeyBase64Encoded));
             PublicKey decodedPublicKey = kf.generatePublic(publicKeySpec);
 
             KeyPair keyPair = new KeyPair(decodedPublicKey, decodedPrivateKey);

--- a/services/src/main/java/org/keycloak/keys/GeneratedEddsaKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/GeneratedEddsaKeyProviderFactory.java
@@ -133,7 +133,7 @@ public class GeneratedEddsaKeyProviderFactory extends AbstractEddsaKeyProviderFa
     private String getCurveFromPublicKey(String publicEddsaKeyBase64Encoded) {
         try {
             KeyFactory kf = KeyFactory.getInstance("EdDSA");
-            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEddsaKeyBase64Encoded));
+            X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEddsaKeyBase64Encoded));
             EdECPublicKey edEcKey = (EdECPublicKey) kf.generatePublic(publicKeySpec);
             return edEcKey.getParams().getName();
         } catch (Throwable t) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
@@ -320,7 +320,7 @@ public class AttestationValidatorUtil {
 
             for (String certBase64 : x5cList) {
                 // Use Keycloak's Base64 implementation for decoding x5c certificates
-                byte[] certBytes = Base64.getDecoder().decode(certBase64);
+                byte[] certBytes = Base64.getMimeDecoder().decode(certBase64);
                 try (InputStream in = new ByteArrayInputStream(certBytes)) {
                     certChain.add((X509Certificate) cf.generateCertificate(in));
                 }

--- a/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/profile/ecp/authenticator/HttpBasicAuthenticator.java
@@ -111,7 +111,7 @@ public class HttpBasicAuthenticator implements Authenticator {
         }
 
         try {
-            String val = new String(Base64.getDecoder().decode(credentials));
+            String val = new String(Base64.getMimeDecoder().decode(credentials));
             int seperatorIndex = val.indexOf(":");
             if(seperatorIndex == -1) return new String[]{val};
             String user = val.substring(0, seperatorIndex);

--- a/services/src/main/java/org/keycloak/services/x509/Rfc9440ClientCertificateLookup.java
+++ b/services/src/main/java/org/keycloak/services/x509/Rfc9440ClientCertificateLookup.java
@@ -1,17 +1,16 @@
 package org.keycloak.services.x509;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.keycloak.common.util.Base64;
 import org.keycloak.common.util.DerUtils;
 import org.keycloak.http.HttpRequest;
 
@@ -168,8 +167,8 @@ public class Rfc9440ClientCertificateLookup implements X509ClientCertificateLook
 
         byte[] certificateBytes;
         try {
-            certificateBytes = Base64.decode(base64EncodedByteSequence);
-        } catch (IOException e) {
+            certificateBytes = Base64.getMimeDecoder().decode(base64EncodedByteSequence);
+        } catch (IllegalArgumentException e) {
             throw new Rfc9440ViolationException("2.1", "value does not contain base64 encoded content", e);
         }
 

--- a/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/twitter/TwitterIdentityProvider.java
@@ -107,7 +107,7 @@ public class TwitterIdentityProvider extends AbstractIdentityProvider<OAuth2Iden
     }
 
     protected static RequestToken base64DecodeRequestToken(String serialized) throws IOException, ClassNotFoundException {
-        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(serialized)))) {
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(Base64.getMimeDecoder().decode(serialized)))) {
             return (RequestToken) in.readObject();
         }
     }

--- a/services/src/test/java/org/keycloak/test/broker/saml/SAMLParsingTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/saml/SAMLParsingTest.java
@@ -17,7 +17,10 @@
 
 package org.keycloak.test.broker.saml;
 
+import java.util.Base64;
+
 import org.keycloak.saml.SAMLRequestParser;
+import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
 import org.keycloak.saml.processing.web.util.PostBindingUtil;
 
@@ -31,11 +34,20 @@ import org.junit.Test;
  */
 public class SAMLParsingTest {
 
-    private static final String SAML_RESPONSE = "PHNhbWxwOkxvZ291dFJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiIHhtbG5zPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIiBEZXN0aW5hdGlvbj0iaHR0cDovL2xvY2FsaG9zdDo4MDgxL2F1dGgvcmVhbG1zL3JlYWxtLXdpdGgtYnJva2VyL2Jyb2tlci9rYy1zYW1sLWlkcC1iYXNpYy9lbmRwb2ludCIgSUQ9IklEXzlhMTcxZDIzLWM0MTctNDJmNS05YmNhLWMwOTMxMjNmZDY4YyIgSW5SZXNwb25zZVRvPSJJRF9iYzczMDcxMS0yMDM3LTQzZjMtYWQ3Ni03YmMzMzg0MmZiODciIElzc3VlSW5zdGFudD0iMjAxNi0wMi0yOVQxMjowMDoxNC4wNDRaIiBWZXJzaW9uPSIyLjAiPjxzYW1sOklzc3VlciB4bWxuczpzYW1sPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6YXNzZXJ0aW9uIj5odHRwOi8vbG9jYWxob3N0OjgwODIvYXV0aC9yZWFsbXMvcmVhbG0td2l0aC1zYW1sLWlkcC1iYXNpYzwvc2FtbDpJc3N1ZXI+PHNhbWxwOlN0YXR1cz48c2FtbHA6U3RhdHVzQ29kZSBWYWx1ZT0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOnN0YXR1czpTdWNjZXNzIi8+PC9zYW1scDpTdGF0dXM+PC9zYW1scDpMb2dvdXRSZXNwb25zZT4=";
+    private static final String SAML_RESPONSE = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" Destination=\"http://localhost:8081/auth/realms/realm-with-broker/broker/kc-saml-idp-basic/endpoint\" ID=\"ID_9a171d23-c417-42f5-9bca-c093123fd68c\" InResponseTo=\"ID_bc730711-2037-43f3-ad76-7bc33842fb87\" IssueInstant=\"2016-02-29T12:00:14.044Z\" Version=\"2.0\"><saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8082/auth/realms/realm-with-saml-idp-basic</saml:Issuer><samlp:Status><samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/></samlp:Status></samlp:LogoutResponse>";
 
     @Test
     public void parseTest() {
-        byte[] samlBytes = PostBindingUtil.base64Decode(SAML_RESPONSE);
+        String base64 = Base64.getEncoder().encodeToString(SAML_RESPONSE.getBytes(GeneralConstants.SAML_CHARSET));
+        byte[] samlBytes = PostBindingUtil.base64Decode(base64);
+        SAMLDocumentHolder holder = SAMLRequestParser.parseResponseDocument(samlBytes);
+        Assert.assertNotNull(holder);
+    }
+
+    @Test
+    public void parseMimeTest() {
+        String base64 = Base64.getMimeEncoder().encodeToString(SAML_RESPONSE.getBytes(GeneralConstants.SAML_CHARSET));
+        byte[] samlBytes = PostBindingUtil.base64Decode(base64);
         SAMLDocumentHolder holder = SAMLRequestParser.parseResponseDocument(samlBytes);
         Assert.assertNotNull(holder);
     }

--- a/test-framework/remote-providers/src/main/java/org/keycloak/testframework/remote/providers/runonserver/SerializationUtil.java
+++ b/test-framework/remote-providers/src/main/java/org/keycloak/testframework/remote/providers/runonserver/SerializationUtil.java
@@ -29,7 +29,7 @@ public class SerializationUtil {
 
     public static Object decode(String encoded, ClassLoader classLoader) {
         try {
-            byte[] bytes = Base64.getDecoder().decode(encoded);
+            byte[] bytes = Base64.getMimeDecoder().decode(encoded);
             ByteArrayInputStream is = new ByteArrayInputStream(bytes);
             ObjectInputStream ois = new ObjectInputStream(is) {
                 @Override
@@ -63,7 +63,7 @@ public class SerializationUtil {
     public static Throwable decodeException(String result) {
         try {
             result = result.substring("EXCEPTION:".length());
-            byte[] bytes = Base64.getDecoder().decode(result);
+            byte[] bytes = Base64.getMimeDecoder().decode(result);
             ByteArrayInputStream is = new ByteArrayInputStream(bytes);
             ObjectInputStream ois = new ObjectInputStream(is);
             return (Throwable) ois.readObject();

--- a/tests/base/src/test/java/org/keycloak/tests/keys/GeneratedEcdhKeyProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/keys/GeneratedEcdhKeyProviderTest.java
@@ -309,7 +309,7 @@ public class GeneratedEcdhKeyProviderTest {
 
     private String getCurveFromPublicKey(String publicEcKeyBase64Encoded) throws Exception {
         KeyFactory kf = KeyFactory.getInstance("EC");
-        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEcKeyBase64Encoded));
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEcKeyBase64Encoded));
         ECPublicKey ecKey = (ECPublicKey) kf.generatePublic(publicKeySpec);
         return "P-" + ecKey.getParams().getCurve().getField().getFieldSize();
     }

--- a/tests/base/src/test/java/org/keycloak/tests/keys/GeneratedEcdsaKeyProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/keys/GeneratedEcdsaKeyProviderTest.java
@@ -237,7 +237,7 @@ public class GeneratedEcdsaKeyProviderTest {
 
     private String getCurveFromPublicKey(String publicEcdsaKeyBase64Encoded) throws Exception {
         KeyFactory kf = KeyFactory.getInstance("EC");
-        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(publicEcdsaKeyBase64Encoded));
+        X509EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(publicEcdsaKeyBase64Encoded));
         ECPublicKey ecKey = (ECPublicKey) kf.generatePublic(publicKeySpec);
         return "P-" + ecKey.getParams().getCurve().getField().getFieldSize();
     }

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/runonserver/SerializationUtil.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/runonserver/SerializationUtil.java
@@ -30,7 +30,7 @@ public class SerializationUtil {
 
     public static Object decode(String encoded, ClassLoader classLoader) {
         try {
-            byte[] bytes = Base64.getDecoder().decode(encoded);
+            byte[] bytes = Base64.getMimeDecoder().decode(encoded);
             ByteArrayInputStream is = new ByteArrayInputStream(bytes);
             ObjectInputStream ois = new ObjectInputStream(is) {
                 @Override
@@ -68,7 +68,7 @@ public class SerializationUtil {
     public static Throwable decodeException(String result) {
         try {
             result = result.substring("EXCEPTION:".length());
-            byte[] bytes = Base64.getDecoder().decode(result);
+            byte[] bytes = Base64.getMimeDecoder().decode(result);
             ByteArrayInputStream is = new ByteArrayInputStream(bytes);
             ObjectInputStream ois = new ObjectInputStream(is);
             return (Throwable) ois.readObject();

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/TokenSignatureUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/TokenSignatureUtil.java
@@ -171,7 +171,7 @@ public class TokenSignatureUtil {
             if (rep.getKid().equals(activeKid)) {
                 X509EncodedKeySpec publicKeySpec = null;
                 try {
-                    publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(rep.getPublicKey()));
+                    publicKeySpec = new X509EncodedKeySpec(Base64.getMimeDecoder().decode(rep.getPublicKey()));
                 } catch (IllegalArgumentException e1) {
                     e1.printStackTrace();
                 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/adapter/servlet/SAMLServletAdapterTest.java
@@ -1502,7 +1502,7 @@ public class SAMLServletAdapterTest extends AbstractSAMLServletAdapterTest {
         Document doc = DocumentUtil.getDocument(new StringReader(xml));
         String certBase64 = DocumentUtil.getElement(doc, new QName("http://www.w3.org/2000/09/xmldsig#", "X509Certificate")).getTextContent();
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(certBase64)));
+        Certificate cert = cf.generateCertificate(new ByteArrayInputStream(Base64.getMimeDecoder().decode(certBase64)));
         PublicKey pubkey = cert.getPublicKey();
         Assert.assertTrue(AssertionUtil.isSignatureValid(doc.getDocumentElement(), pubkey));
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -456,8 +456,8 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
         // It seems that PemUtils.decodePrivateKey, decodePublicKey can only treat RSA type keys, not EC type keys. Therefore, these are not used.
         String privateKeyBase64 = generatedKeys.get(TestingOIDCEndpointsApplicationResource.PRIVATE_KEY);
         String publicKeyBase64 =  generatedKeys.get(TestingOIDCEndpointsApplicationResource.PUBLIC_KEY);
-        PrivateKey privateKey = decodePrivateKey(Base64.getDecoder().decode(privateKeyBase64), algorithm);
-        PublicKey publicKey = decodePublicKey(Base64.getDecoder().decode(publicKeyBase64), algorithm);
+        PrivateKey privateKey = decodePrivateKey(Base64.getMimeDecoder().decode(privateKeyBase64), algorithm);
+        PublicKey publicKey = decodePublicKey(Base64.getMimeDecoder().decode(publicKeyBase64), algorithm);
         return new KeyPair(publicKey, privateKey);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AbstractClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AbstractClientAuthSignedJWTTest.java
@@ -962,8 +962,8 @@ public abstract class AbstractClientAuthSignedJWTTest extends AbstractKeycloakTe
         // It seems that PemUtils.decodePrivateKey, decodePublicKey can only treat RSA type keys, not EC type keys. Therefore, these are not used.
         String privateKeyBase64 = generatedKeys.get(TestingOIDCEndpointsApplicationResource.PRIVATE_KEY);
         String publicKeyBase64 =  generatedKeys.get(TestingOIDCEndpointsApplicationResource.PUBLIC_KEY);
-        PrivateKey privateKey = decodePrivateKey(Base64.getDecoder().decode(privateKeyBase64), algorithm, curve);
-        PublicKey publicKey = decodePublicKey(Base64.getDecoder().decode(publicKeyBase64), algorithm, curve);
+        PrivateKey privateKey = decodePrivateKey(Base64.getMimeDecoder().decode(privateKeyBase64), algorithm, curve);
+        PublicKey publicKey = decodePublicKey(Base64.getMimeDecoder().decode(publicKeyBase64), algorithm, curve);
         return new KeyPair(publicKey, privateKey);
     }
 


### PR DESCRIPTION
Closes #45226

PR:             https://github.com/keycloak/keycloak/pull/45279
Commit:         https://github.com/keycloak/keycloak/commit/1aa1621eaa950d957d64f5f7c5aa6392329f83cb
PR branch:      backport-45279-26.5
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.5

