### PR TITLE
Fix no error throw if Keycloak is configured wrongly, and add support to setting timeout from testsuite

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
@@ -22,16 +22,24 @@ public class DistributionKeycloakServer implements KeycloakServer {
     private RawKeycloakDistribution keycloak;
 
     private final boolean debug;
+    private final long startTimeout;
     private boolean tlsEnabled = false;
 
-    public DistributionKeycloakServer(boolean debug) {
+    public DistributionKeycloakServer(boolean debug, long startTimeout) {
         this.debug = debug;
+        this.startTimeout = startTimeout;
     }
 
     @Override
     public void start(KeycloakServerConfigBuilder keycloakServerConfigBuilder, boolean tlsEnabled) {
         this.tlsEnabled = tlsEnabled;
-        keycloak = new RawKeycloakDistribution(false, MANUAL_STOP, false, RE_CREATE, REMOVE_BUILD_OPTIONS_AFTER_BUILD, REQUEST_PORT, new LoggingOutputConsumer());
+        keycloak = new RawKeycloakDistribution(false, MANUAL_STOP, false, RE_CREATE, REMOVE_BUILD_OPTIONS_AFTER_BUILD, REQUEST_PORT, new LoggingOutputConsumer())
+                .withThreadDump(false)
+                .withThrowErrorIfFailedToStart(true);
+
+        if (startTimeout > 0) {
+            keycloak.withStartTimeout(startTimeout);
+        }
 
         // RawKeycloakDistribution sets "DEBUG_SUSPEND", not "DEBUG" when debug is passed to constructor
         if (debug) {

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServerSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServerSupplier.java
@@ -7,12 +7,15 @@ public class DistributionKeycloakServerSupplier extends AbstractKeycloakServerSu
 
     private static final Logger LOGGER = Logger.getLogger(DistributionKeycloakServerSupplier.class);
 
+    @ConfigProperty(name = "start.timeout", defaultValue = "-1")
+    long startTimeout;
+
     @ConfigProperty(name = "debug", defaultValue = "false")
-    boolean debug = false;
+    boolean debug;
 
     @Override
     public KeycloakServer getServer() {
-        return new DistributionKeycloakServer(debug);
+        return new DistributionKeycloakServer(debug, startTimeout);
     }
 
     @Override


### PR DESCRIPTION
Closes #44100, Closes #39168

Signed-off-by: stianst <stianst@gmail.com>
