### PR TITLE
Use RawSqlStatement instead of RawParameterizedSqlStatement for Saml encryption update

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_4_0_SamlEncryptionAttributes.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_4_0_SamlEncryptionAttributes.java
@@ -18,7 +18,7 @@ package org.keycloak.connections.jpa.updater.liquibase.custom;
 
 import liquibase.exception.CustomChangeException;
 import liquibase.statement.SqlStatement;
-import liquibase.statement.core.RawParameterizedSqlStatement;
+import liquibase.statement.core.RawSqlStatement;
 
 /**
  *
@@ -41,11 +41,13 @@ public class JpaUpdate26_4_0_SamlEncryptionAttributes extends CustomKeycloakTask
     private SqlStatement createInsertQueryForAttribute(String attribute, String value) {
         final String clientTable = getTableName("CLIENT");
         final String clientAttributesTable = getTableName("CLIENT_ATTRIBUTES");
-        return new RawParameterizedSqlStatement(
-                "INSERT INTO " + clientAttributesTable + " (CLIENT_ID,NAME,VALUE) " +
-                "SELECT ID, ?, ? FROM " + clientTable + " WHERE PROTOCOL = ? AND ID NOT IN " +
-                "(SELECT CLIENT_ID FROM " + clientAttributesTable + " WHERE NAME = ?)",
-                attribute, value, "saml", attribute
+        return new RawSqlStatement(
+                String.format(
+                        "INSERT INTO %s (CLIENT_ID,NAME,VALUE) " +
+                        "SELECT ID, '%s', '%s' FROM %s WHERE PROTOCOL = 'saml' AND ID NOT IN " +
+                        "(SELECT CLIENT_ID FROM %s WHERE NAME = '%s')",
+                        clientAttributesTable, attribute, value, clientTable, clientAttributesTable, attribute
+                )
         );
     }
 }


### PR DESCRIPTION
Closes #45107

It seems that `RawParameterizedSqlStatement` is not logged OK when exporting to a file and should be substituted by `RawSqlStatement`. It wa smy falt because I used the parametrized version because the other one was deprecated. It seems that there is an issue and that one is not exported OK when using the file (I suppose because the parameters are not created).

I tested that all migrations work OK and tested the export to file with Oracle.