### PR TITLE
Maven plugin to clear the test database

### DIFF
--- a/.github/scripts/aws/rds/aurora_clear.sql
+++ b/.github/scripts/aws/rds/aurora_clear.sql
@@ -1,0 +1,3 @@
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO public;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,6 +576,15 @@ jobs:
           name: aurora-integration-tests-mvn-logs
           path: .github/scripts/ansible/files
 
+      - name: Clear Aurora DB schema
+        id: aurora-clear-db-schema
+        run: |
+         EC2_CLUSTER_NAME=${{ steps.ec2-create.outputs.ec2_cluster }}
+         AWS_REGION=${{ steps.aurora-init.outputs.region }}
+         
+         cd .github/scripts/ansible
+         ./mvn_remote_runner.sh ${AWS_REGION} ${EC2_CLUSTER_NAME} "-Pexecute-sql -f tests/base/pom.xml sql:execute@clear-schema -Dautocommit=true -Ddriver=software.amazon.jdbc.Driver -Durl=\"jdbc:aws-wrapper:postgresql://${{ steps.aurora-create.outputs.endpoint }}/keycloak${{ steps.aurora-init.outputs.jdbc_params }}\" -Dusername=keycloak -Dpassword=${{ steps.aurora-init.outputs.aurora-cluster-password }}"
+
       - name: Run Aurora new database tests on EC2
         id: aurora-new-integration-tests
         run: |
@@ -588,10 +597,6 @@ jobs:
           PROPS+=" -Dkc.test.database.url=\"jdbc:aws-wrapper:postgresql://${{ steps.aurora-create.outputs.endpoint }}/keycloak${{ steps.aurora-init.outputs.jdbc_params }}\""
           PROPS+=" -Dkc.test.database.driver=software.amazon.jdbc.Driver"
           PROPS+=" -Dkc.test.database.driver.artifact=software.amazon.jdbc:aws-advanced-jdbc-wrapper"
-
-          PROPS+=" -Dkc.test.server.bootstrap=user"
-          PROPS+=" -Dkc.test.server.bootstrap.user.create=false -Dkc.test.server.bootstrap.username=admin -Dkc.test.server.bootstrap.password=admin"
-          PROPS+=" -Dkc.test.server.bootstrap.client.create=false -Dkc.test.server.bootstrap.client.id=admin-cli"
 
           cd .github/scripts/ansible
           ./mvn_remote_runner.sh ${AWS_REGION} ${EC2_CLUSTER_NAME} "$PROPS package -f tests/pom.xml -Dtest=DatabaseTestSuite"

--- a/test-framework/core/src/main/java/org/keycloak/testframework/admin/AdminClientSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/admin/AdminClientSupplier.java
@@ -27,16 +27,7 @@ public class AdminClientSupplier implements Supplier<Keycloak, InjectAdminClient
                 .grantType(OAuth2Constants.CLIENT_CREDENTIALS);
 
         if (mode.equals(InjectAdminClient.Mode.BOOTSTRAP)) {
-            adminBuilder.realm("master").clientId(Config.getAdminClientId());
-
-            String bootstrapGrantType = Config.getAdminClientGrantType();
-            if ("client".equals(bootstrapGrantType)) {
-                adminBuilder.clientSecret(Config.getAdminClientSecret());
-            } else if ("user".equals(bootstrapGrantType)) {
-                adminBuilder.username(Config.getAdminUsername()).password(Config.getAdminPassword()).grantType(OAuth2Constants.PASSWORD);
-            } else {
-                throw new TestFrameworkException("Invalid bootstrap grant type");
-            }
+            adminBuilder.realm("master").clientId(Config.getAdminClientId()).clientSecret(Config.getAdminClientSecret());
         } else if (mode.equals(InjectAdminClient.Mode.MANAGED_REALM)) {
             ManagedRealm managedRealm = instanceContext.getDependency(ManagedRealm.class);
             adminBuilder.realm(managedRealm.getName());

--- a/test-framework/core/src/main/java/org/keycloak/testframework/config/Config.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/config/Config.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 import org.keycloak.testframework.injection.ValueTypeAlias;
-import org.keycloak.testframework.server.KeycloakServer;
 
 import io.quarkus.runtime.configuration.CharsetConverter;
 import io.quarkus.runtime.configuration.InetSocketAddressConverter;
@@ -68,32 +67,20 @@ public class Config {
         return config;
     }
 
-    public static String getAdminClientGrantType() {
-        return getValueTypeConfig(KeycloakServer.class, "bootstrap", "client", String.class);
-    }
-
-    public static boolean getCreateBootstrapClient() {
-        return Boolean.parseBoolean(getValueTypeConfig(KeycloakServer.class, "bootstrap.client.create", "true", String.class));
-    }
-
-    public static boolean getCreateBootstrapUser() {
-        return Boolean.parseBoolean(getValueTypeConfig(KeycloakServer.class, "bootstrap.user.create", "true", String.class));
-    }
-
     public static String getAdminClientId() {
-        return getValueTypeConfig(KeycloakServer.class, "bootstrap.client.id", "temp-admin", String.class);
+        return "temp-admin";
     }
 
     public static String getAdminClientSecret() {
-        return getValueTypeConfig(KeycloakServer.class, "bootstrap.client.secret", "mysecret", String.class);
+        return "mysecret";
     }
 
     public static String getAdminUsername() {
-        return getValueTypeConfig(KeycloakServer.class, "bootstrap.username", "admin", String.class);
+        return "admin";
     }
 
     public static String getAdminPassword() {
-        return getValueTypeConfig(KeycloakServer.class, "bootstrap.password", "admin", String.class);
+        return "admin";
     }
 
     public static SmallRyeConfig initConfig() {

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/AbstractKeycloakServerSupplier.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/AbstractKeycloakServerSupplier.java
@@ -24,13 +24,9 @@ public abstract class AbstractKeycloakServerSupplier implements Supplier<Keycloa
         KeycloakIntegrationTest annotation = instanceContext.getAnnotation();
         KeycloakServerConfig serverConfig = SupplierHelpers.getInstance(annotation.config());
 
-        KeycloakServerConfigBuilder command = KeycloakServerConfigBuilder.startDev();
-        if (Config.getCreateBootstrapClient()) {
-            command.bootstrapAdminClient(Config.getAdminClientId(), Config.getAdminClientSecret());
-        }
-        if (Config.getCreateBootstrapUser()) {
-            command.bootstrapAdminUser(Config.getAdminUsername(), Config.getAdminPassword());
-        }
+        KeycloakServerConfigBuilder command = KeycloakServerConfigBuilder.startDev()
+                .bootstrapAdminClient(Config.getAdminClientId(), Config.getAdminClientSecret())
+                .bootstrapAdminUser(Config.getAdminUsername(), Config.getAdminPassword());
 
         command.log().handlers(KeycloakServerConfigBuilder.LogHandlers.CONSOLE);
 

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -159,4 +159,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>execute-sql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>sql-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>software.amazon.jdbc</groupId>
+                                <artifactId>aws-advanced-jdbc-wrapper</artifactId>
+                                <version>${aws-jdbc-wrapper.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>clear-schema</id>
+                                <configuration>
+                                    <srcFiles>
+                                        <srcFile>../../.github/scripts/aws/rds/aurora_clear.sql</srcFile>
+                                    </srcFiles>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
Adds Maven SQL Maven plugin configuration to create a fresh database. Tests failed previously because the integration test suite and the migration suite left some noise.

Reverts the last commit's changes. Configuring the bootsrap admin client is no longer needed.