### PR TITLE
Add missing icons for keycloak.v2 login theme

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
@@ -68,6 +68,11 @@ kcLoginClass=pf-v5-c-login__main
 kcFormClass=pf-v5-c-form pf-v5-u-w-100
 kcFormCardClass=card-pf
 
+kcFeedbackErrorIcon=fa fa-fw fa-exclamation-circle
+kcFeedbackWarningIcon=fa fa-fw fa-exclamation-triangle
+kcFeedbackSuccessIcon=fa fa-fw fa-check-circle
+kcFeedbackInfoIcon=fa fa-fw fa-info-circle
+
 kcResetFlowIcon=pf-icon fas fa-share-square
 
 kcSelectAuthListClass=pf-v5-c-data-list select-auth-container
@@ -78,6 +83,7 @@ kcSelectAuthListItemBodyClass=pf-v5-c-data-list__cell pf-m-no-fill pf-v5-u-pt-md
 kcSelectAuthListItemIconClass=pf-v5-c-data-list__cell pf-m-icon pf-v5-u-display-flex pf-v5-u-pt-0 pf-v5-u-align-items-center 
 kcSelectAuthListItemFillClass=pf-v5-c-data-list__item-action
 kcSelectAuthListItemDescriptionClass=pf-v5-c-data-list__cell pf-m-no-fill select-auth-box-desc
+kcSelectAuthListItemArrowIconClass=fa fa-angle-right fa-lg
 
 kcRecoveryCodesWarning=pf-v5-c-alert pf-m-warning pf-m-inline pf-v5-u-mb-md kc-recovery-codes-warning
 kcLogin=pf-v5-c-login
@@ -91,6 +97,14 @@ kcLoginMainFooterHelperText=pf-v5-u-font-size-sm pf-v5-u-color-200
 kcLoginMainTitle=pf-v5-c-title pf-m-3xl
 kcLoginMainHeaderUtilities=pf-v5-c-login__main-header-utilities
 kcLoginMainBody=pf-v5-c-login__main-body
+
+##### css classes for the authenticators
+kcAuthenticatorDefaultClass=fa fa-list list-view-pf-icon-lg
+kcAuthenticatorRecoveryAuthnCodesClass=fa fa-list list-view-pf-icon-lg
+kcAuthenticatorPasswordClass=fa fa-unlock list-view-pf-icon-lg
+kcAuthenticatorOTPClass=fa fa-mobile list-view-pf-icon-lg
+kcAuthenticatorWebAuthnClass=fa fa-key list-view-pf-icon-lg
+kcAuthenticatorWebAuthnPasswordlessClass=fa fa-key list-view-pf-icon-lg
 
 kcContentWrapperClass=pf-v5-u-mb-md-on-md
 kcWebAuthnDefaultIcon=pf-v5-c-icon pf-m-lg

--- a/themes/src/main/resources/theme/keycloak.v2/login/webauthn-register.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/webauthn-register.ftl
@@ -6,7 +6,6 @@
     <#if section = "title">
         title
     <#elseif section = "header">
-        <span class="${properties.kcWebAuthnKeyIcon!}"></span>
         ${msg("webauthn-registration-title")}
     <#elseif section = "form">
     <div class="${properties.kcFormClass!}">

--- a/themes/src/main/resources/theme/keycloak/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/login/theme.properties
@@ -121,6 +121,7 @@ kcSelectAuthListItemTitle=select-auth-box-paragraph
 
 ##### css classes for the authenticators
 kcAuthenticatorDefaultClass=fa fa-list list-view-pf-icon-lg
+kcAuthenticatorRecoveryAuthnCodesClass=fa fa-list list-view-pf-icon-lg
 kcAuthenticatorPasswordClass=fa fa-unlock list-view-pf-icon-lg
 kcAuthenticatorOTPClass=fa fa-mobile list-view-pf-icon-lg
 kcAuthenticatorWebAuthnClass=fa fa-key list-view-pf-icon-lg


### PR DESCRIPTION
Closes #45162

Just adding the icons that were not added when creating login v2. The changes are the following:

* The warning/info/success/error icons properties were not defined. With this PR the icon is displayer, for example when sending the email for the forgot password.

<img width="943" height="806" alt="Screenshot From 2026-01-12 14-36-40" src="https://github.com/user-attachments/assets/40eb1f7e-3b1d-41f6-81e1-f22ac298a910" />

* The `select-authenticator.ftl` was missing the authenticator icons.

<img width="890" height="950" alt="Screenshot From 2026-01-12 14-35-48" src="https://github.com/user-attachments/assets/8e2f3f2f-87c2-444a-ba74-4aa0f3dca2b5" />

* The `webauthn-register.ftl` in v1 presented a key icon in the title. But for this one I decided to remove the icon completely. All the other pages never show an icon (otp, recovery-codes,...), so I think we better remove the icon in the title.

@fbieler Check if this is OK for you. We don't need to create all classes that are defined in v1. The idea is those classes can be overridden by extensions but don't needed to be defined if they are not needed.