### PR TITLE
OTEL: Add Telemetry options to Keycloak CR

### DIFF
--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -14,3 +14,10 @@ HTTP access logs can now be written to a dedicated file, separate from the serve
 This makes it easier to process and archive access logs independently for security auditing and compliance monitoring.
 
 For more information, see https://www.keycloak.org/server/logging#http-access-logging[Configuring HTTP access logging].
+
+= Telemetry configuration via Keycloak CR
+
+{project_name} now supports configuring the OpenTelemetry properties via Keycloak CR when using Operator.
+These properties are shared among the available OpenTelemetry components - logs, metrics, and traces.
+
+For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -44,7 +44,10 @@ Specific sensitive information is omitted from the HTTP Access log, such as the 
 
 The following sections provide details on deprecated features.
 
-=== <TODO>
+=== Deprecation of specific tracing properties in Keycloak CR
+
+The `tracing.serviceName`, and `tracing.resourceAttributes`, first-class citizens of the Keycloak CR, are now deprecated.
+You should use the new `telemetry.serviceName`, and `telemetry.resourceAttributes` first class citizens that are shared among all OpenTelemetry components - logs, metrics, and traces.
 
 // ------------------------ Removed features ------------------------ //
 == Removed features

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -46,8 +46,8 @@ The following sections provide details on deprecated features.
 
 === Deprecation of specific tracing properties in Keycloak CR
 
-The `tracing.serviceName`, and `tracing.resourceAttributes`, first-class citizens of the Keycloak CR, are now deprecated.
-You should use the new `telemetry.serviceName`, and `telemetry.resourceAttributes` first class citizens that are shared among all OpenTelemetry components - logs, metrics, and traces.
+The `tracing.serviceName`, and `tracing.resourceAttributes`, fields of the Keycloak CR, are now deprecated.
+You should use the new `telemetry.serviceName`, and `telemetry.resourceAttributes` fields citizens that are shared among all OpenTelemetry components - logs, metrics, and traces.
 
 // ------------------------ Removed features ------------------------ //
 == Removed features

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -46,7 +46,7 @@ The following sections provide details on deprecated features.
 
 === Deprecation of specific tracing properties in Keycloak CR
 
-The `tracing.serviceName`, and `tracing.resourceAttributes`, fields of the Keycloak CR, are now deprecated.
+The `tracing.serviceName`, and `tracing.resourceAttributes` fields of the Keycloak CR, are now deprecated.
 You should use the new `telemetry.serviceName`, and `telemetry.resourceAttributes` fields citizens that are shared among all OpenTelemetry components - logs, metrics, and traces.
 
 // ------------------------ Removed features ------------------------ //

--- a/docs/guides/observability/telemetry.adoc
+++ b/docs/guides/observability/telemetry.adoc
@@ -51,6 +51,26 @@ You can change the protocol via CLI as follows:
 
 <@kc.start parameters="--telemetry-protocol=http/protobuf"/>
 
+== Configuration via Keycloak CR (Operator)
+The Keycloak CR has first-class citizen configuration options for telemetry. These may be configured under the spec.telemtry stanza as follows:
+
+[source,yaml]
+----
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: example-kc
+spec:
+  telemetry:
+    endpoint: http://my-telemetry:4317          # default 'http://localhost:4317'
+    serviceName: my-best-keycloak-telemetry     # default 'keycloak'
+    protocol: http/protobuf                     # default 'grpc'
+    resourceAttributes:
+      service.namespace: keycloak-namespace-telemetry
+----
+
+These fields should reflect a 1:1 association with `telemetry-*` server options.
+
 == Traces
 
 See the https://www.keycloak.org/observability/tracing[Root cause analysis with tracing guide].

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -19,13 +19,17 @@ package org.keycloak.operator.controllers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -66,6 +70,7 @@ public class KeycloakDistConfigurator {
      */
     @SuppressWarnings("rawtypes")
     private final Map<String, org.keycloak.operator.controllers.KeycloakDistConfigurator.OptionMapper.Mapper> firstClassConfigOptions = new LinkedHashMap<>();
+    private final List<BiConsumer<Keycloak, KeycloakStatusAggregator>> validators = new ArrayList<>();
 
     public KeycloakDistConfigurator() {
         // register the configuration mappers for the various parts of the keycloak cr
@@ -89,6 +94,7 @@ public class KeycloakDistConfigurator {
      */
     public void validateOptions(Keycloak keycloakCR, KeycloakStatusAggregator status) {
         assumeFirstClassCitizens(keycloakCR, status);
+        executeCustomValidations(keycloakCR, status);
     }
 
     /* ---------- Configuration of first-class citizen fields ---------- */
@@ -134,7 +140,8 @@ public class KeycloakDistConfigurator {
                 .mapOption("telemetry-endpoint", TelemetrySpec::getEndpoint)
                 .mapOption("telemetry-service-name", TelemetrySpec::getServiceName)
                 .mapOption("telemetry-protocol", TelemetrySpec::getProtocol)
-                .mapOption("telemetry-resource-attributes", TelemetrySpec::getResourceAttributesString);
+                .mapOption("telemetry-resource-attributes", TelemetrySpec::getResourceAttributesString)
+                .validate((telemetry, status) -> validateResourceAttributes(telemetry.getResourceAttributes(), status));
     }
 
     void configureTracing() {
@@ -146,7 +153,8 @@ public class KeycloakDistConfigurator {
                 .mapOption("tracing-sampler-type", TracingSpec::getSamplerType)
                 .mapOption("tracing-sampler-ratio", TracingSpec::getSamplerRatio)
                 .mapOption("tracing-compression", TracingSpec::getCompression)
-                .mapOption("tracing-resource-attributes", TracingSpec::getResourceAttributesString);
+                .mapOption("tracing-resource-attributes", TracingSpec::getResourceAttributesString)
+                .validate((tracing, status) -> validateResourceAttributes(tracing.getResourceAttributes(), status));
     }
 
     void configureTransactions() {
@@ -194,6 +202,40 @@ public class KeycloakDistConfigurator {
     }
 
     /* ---------- END of configuration of first-class citizen fields ---------- */
+
+    private static void validateResourceAttributes(Map<String, String> resourceAttributes, KeycloakStatusAggregator status) {
+        Predicate<String> isInvalidResourceAttribute = (keyOrVal) -> (keyOrVal.contains("=") || keyOrVal.contains(","));
+        Set<String> invalidKeys = new HashSet<>();
+        Map<String, String> invalidValues = new HashMap<>();
+
+        resourceAttributes.forEach((key, val) -> {
+            if (isInvalidResourceAttribute.test(key)) {
+                invalidKeys.add(key);
+            }
+            if (isInvalidResourceAttribute.test(val)) {
+                invalidValues.put(key, val);
+            }
+        });
+
+        if (!invalidKeys.isEmpty()) {
+            var formattedKeys = invalidKeys.stream()
+                    .map("'%s'"::formatted)
+                    .collect(Collectors.toSet());
+            status.addErrorMessage("Resource attributes keys cannot contain characters '=' or ','. Invalid keys: %s".formatted(String.join(", ", formattedKeys)));
+        }
+
+        if (!invalidValues.isEmpty()) {
+            var formattedInvalidValues = invalidValues.entrySet()
+                    .stream()
+                    .map(entry -> "'%s'(key '%s')".formatted(entry.getValue(), entry.getKey()))
+                    .collect(Collectors.toSet());
+            status.addErrorMessage("Resource attributes values cannot contain characters '=' or ','. Invalid values: %s".formatted(String.join(", ", formattedInvalidValues)));
+        }
+    }
+
+    protected void executeCustomValidations(Keycloak keycloakCR, KeycloakStatusAggregator status) {
+        validators.forEach(validator -> validator.accept(keycloakCR, status));
+    }
 
     /**
      * Assume the specified first-class citizens are not included in the general server configuration
@@ -269,6 +311,18 @@ public class KeycloakDistConfigurator {
 
         public <R> OptionMapper<T> mapOption(String optionName, Function<T, R> optionValueSupplier) {
             firstClassConfigOptions.put(optionName, new Mapper<>(optionValueSupplier));
+            return this;
+        }
+
+        public <R> OptionMapper<T> validate(BiConsumer<T, KeycloakStatusAggregator> validator) {
+            validators.add((keycloakCR, status) -> {
+                T value = optionSpec.apply(keycloakCR);
+                if (value == null) {
+                    Log.debugf("Skipping validation of configuration as the parent is not specified in the CR");
+                    return;
+                }
+                validator.accept(value, status);
+            });
             return this;
         }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDistConfigurator.java
@@ -42,6 +42,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpManagementSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.ProxySpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.TelemetrySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TracingSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TransactionsSpec;
 
@@ -70,6 +71,7 @@ public class KeycloakDistConfigurator {
         // register the configuration mappers for the various parts of the keycloak cr
         configureHostname();
         configureFeatures();
+        configureTelemetry();
         configureTracing();
         configureTransactions();
         configureHttp();
@@ -125,6 +127,14 @@ public class KeycloakDistConfigurator {
         optionMapper(keycloakCR -> keycloakCR.getSpec().getFeatureSpec())
                 .mapOptionFromCollection("features", FeatureSpec::getEnabledFeatures)
                 .mapOptionFromCollection("features-disabled", FeatureSpec::getDisabledFeatures);
+    }
+
+    void configureTelemetry() {
+        optionMapper(keycloakCR -> keycloakCR.getSpec().getTelemetrySpec())
+                .mapOption("telemetry-endpoint", TelemetrySpec::getEndpoint)
+                .mapOption("telemetry-service-name", TelemetrySpec::getServiceName)
+                .mapOption("telemetry-protocol", TelemetrySpec::getProtocol)
+                .mapOption("telemetry-resource-attributes", TelemetrySpec::getResourceAttributesString);
     }
 
     void configureTracing() {

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/KeycloakSpec.java
@@ -35,6 +35,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.ProbeSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.ProxySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.SchedulingSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.ServiceMonitorSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.TelemetrySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TracingSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TransactionsSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.Truststore;
@@ -136,6 +137,10 @@ public class KeycloakSpec {
     @JsonProperty("networkPolicy")
     @JsonPropertyDescription("Controls the ingress traffic flow into Keycloak pods.")
     private NetworkPolicySpec networkPolicySpec;
+
+    @JsonProperty("telemetry")
+    @JsonPropertyDescription("In this section you can configure general shared OpenTelemetry settings for Keycloak.")
+    private TelemetrySpec telemetrySpec;
 
     @JsonProperty("tracing")
     @JsonPropertyDescription("In this section you can configure OpenTelemetry Tracing for Keycloak.")
@@ -337,6 +342,14 @@ public class KeycloakSpec {
 
     public void setNetworkPolicySpec(NetworkPolicySpec networkPolicySpec) {
         this.networkPolicySpec = networkPolicySpec;
+    }
+
+    public TelemetrySpec getTelemetrySpec() {
+        return telemetrySpec;
+    }
+
+    public void setTelemetrySpec(TelemetrySpec telemetrySpec) {
+        this.telemetrySpec = telemetrySpec;
     }
 
     public TracingSpec getTracingSpec() {

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TelemetrySpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TelemetrySpec.java
@@ -1,0 +1,76 @@
+package org.keycloak.operator.crds.v2alpha1.deployment.spec;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.sundr.builder.annotations.Buildable;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
+public class TelemetrySpec {
+
+    @JsonPropertyDescription("OpenTelemetry endpoint to connect to.")
+    private String endpoint;
+
+    @JsonPropertyDescription("OpenTelemetry service name. Takes precedence over 'service.name' defined in the 'resourceAttributes' map.")
+    private String serviceName;
+
+    @JsonPropertyDescription("OpenTelemetry protocol used for the telemetry data (default 'grpc'). For more information, check the OpenTelemetry guide.")
+    private String protocol;
+
+    @JsonPropertyDescription("OpenTelemetry resource attributes present in the exported telemetry data to characterize the telemetry producer.")
+    private Map<String, String> resourceAttributes;
+
+    public Map<String, String> getResourceAttributes() {
+        if (resourceAttributes == null) {
+            resourceAttributes = new LinkedHashMap<>();
+        }
+        return resourceAttributes;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    @JsonIgnore
+    public String getResourceAttributesString() {
+        return convertResourceAttributesToString(getResourceAttributes());
+    }
+
+    public void setResourceAttributes(Map<String, String> resourceAttributes) {
+        this.resourceAttributes = resourceAttributes;
+    }
+
+    /**
+     * Convert resource attributes in format key=val delimited by comma to string
+     */
+    public static String convertResourceAttributesToString(Map<String, String> attributes) {
+        return attributes.entrySet().stream()
+                .map(attr -> String.format("%s=%s", attr.getKey(), attr.getValue()))
+                .collect(Collectors.joining(","));
+    }
+}

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TracingSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/TracingSpec.java
@@ -19,12 +19,13 @@ package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import io.sundr.builder.annotations.Buildable;
+
+import static org.keycloak.operator.crds.v2alpha1.deployment.spec.TelemetrySpec.convertResourceAttributesToString;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Buildable(editableEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder")
@@ -36,7 +37,11 @@ public class TracingSpec {
     @JsonPropertyDescription("OpenTelemetry endpoint to connect to.")
     private String endpoint;
 
-    @JsonPropertyDescription("OpenTelemetry service name. Takes precedence over 'service.name' defined in the 'resourceAttributes' map.")
+    /**
+     * @deprecated Use {@link TelemetrySpec#getServiceName()}
+     */
+    @Deprecated
+    @JsonPropertyDescription("DEPRECATED - use the 'telemetry.serviceName' instead. OpenTelemetry service name. Takes precedence over 'service.name' defined in the 'resourceAttributes' map.")
     private String serviceName;
 
     @JsonPropertyDescription("OpenTelemetry protocol used for the telemetry data (default 'grpc'). For more information, check the Tracing guide.")
@@ -51,7 +56,11 @@ public class TracingSpec {
     @JsonPropertyDescription("OpenTelemetry compression method used to compress payloads. If unset, compression is disabled. Possible values are: gzip, none.")
     private String compression;
 
-    @JsonPropertyDescription("OpenTelemetry resource attributes present in the exported trace to characterize the telemetry producer.")
+    /**
+     * @deprecated Use {@link TelemetrySpec#getResourceAttributes()}
+     */
+    @Deprecated
+    @JsonPropertyDescription("DEPRECATED - use the 'telemetry.resourceAttributes' instead. OpenTelemetry resource attributes present in the exported trace to characterize the telemetry producer.")
     private Map<String, String> resourceAttributes;
 
     public Boolean getEnabled() {
@@ -120,19 +129,10 @@ public class TracingSpec {
     // resource attributes in format key=val delimited by comma
     @JsonIgnore
     public String getResourceAttributesString() {
-        return convertTracingAttributesToString(getResourceAttributes());
+        return convertResourceAttributesToString(getResourceAttributes());
     }
 
     public void setResourceAttributes(Map<String, String> resourceAttributes) {
         this.resourceAttributes = resourceAttributes;
-    }
-
-    /**
-     * Convert resource attributes in format key=val delimited by comma to string
-     */
-    public static String convertTracingAttributesToString(Map<String, String> attributes) {
-        return attributes.entrySet().stream()
-                .map(attr -> String.format("%s=%s", attr.getKey(), attr.getValue()))
-                .collect(Collectors.joining(","));
     }
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/ClusteringTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import static org.keycloak.operator.controllers.KeycloakDeploymentDependentResource.KC_TRACING_SERVICE_NAME;
+import static org.keycloak.operator.controllers.KeycloakDeploymentDependentResource.KC_TELEMETRY_SERVICE_NAME;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -95,7 +95,7 @@ public class ClusteringTest extends BaseOperatorTest {
         checkInstanceCount(1, Ingress.class, kc, kc1);
         checkInstanceCount(2, Service.class, kc, kc1);
 
-        // Tracing assertions
+        // Telemetry assertions
         var pods = k8sclient
                 .pods()
                 .inNamespace(namespace)
@@ -105,22 +105,22 @@ public class ClusteringTest extends BaseOperatorTest {
 
         assertThat(pods.size()).isEqualTo(2);
 
-        Function<Pod, String> getTracingServiceName = (pod) -> pod.getSpec().getContainers().get(0).getEnv().stream()
-                .filter(f -> f.getName().equals(KC_TRACING_SERVICE_NAME)).findAny().map(EnvVar::getValue).orElse(null);
+        Function<Pod, String> getTelemetryServiceName = (pod) -> pod.getSpec().getContainers().get(0).getEnv().stream()
+                .filter(f -> f.getName().equals(KC_TELEMETRY_SERVICE_NAME)).findAny().map(EnvVar::getValue).orElse(null);
 
         var kc1Pod = pods.stream().filter(f -> f.getMetadata().getName().startsWith("another-example-")).findAny().orElse(null);
         assertThat(kc1Pod).isNotNull();
 
-        var tracingServiceName1 = getTracingServiceName.apply(kc1Pod);
-        assertThat(tracingServiceName1).isNotNull();
-        assertThat(tracingServiceName1).isEqualTo("another-example");
+        var telemetryServiceName1 = getTelemetryServiceName.apply(kc1Pod);
+        assertThat(telemetryServiceName1).isNotNull();
+        assertThat(telemetryServiceName1).isEqualTo("another-example");
 
         var kcPod = pods.stream().filter(f -> !f.equals(kc1Pod)).findAny().orElse(null);
         assertThat(kcPod).isNotNull();
 
-        var tracingServiceName2 = getTracingServiceName.apply(kcPod);
-        assertThat(tracingServiceName2).isNotNull();
-        assertThat(tracingServiceName2).isEqualTo("example-kc");
+        var telemetryServiceName2 = getTelemetryServiceName.apply(kcPod);
+        assertThat(telemetryServiceName2).isNotNull();
+        assertThat(telemetryServiceName2).isEqualTo("example-kc");
 
         // ensure they don't see each other's pods
         assertThat(k8sclient.resource(kc).scale().getStatus().getReplicas()).isEqualTo(1);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -196,7 +196,7 @@ public class CRSerializationTest {
 
     @Test
     public void telemetrySpecification() {
-        Keycloak keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/test-serialization-keycloak-cr.yml"), Keycloak.class);
+        Keycloak keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/test-serialization-keycloak-cr-telemetry.yml"), Keycloak.class);
 
         TelemetrySpec telemetry = keycloak.getSpec().getTelemetrySpec();
         assertThat(telemetry, notNullValue());
@@ -215,7 +215,7 @@ public class CRSerializationTest {
 
     @Test
     public void tracingSpecification() {
-        Keycloak keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/test-serialization-keycloak-cr.yml"), Keycloak.class);
+        Keycloak keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/test-serialization-keycloak-cr-telemetry.yml"), Keycloak.class);
 
         TracingSpec tracing = keycloak.getSpec().getTracingSpec();
         assertThat(tracing, notNullValue());

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/CRSerializationTest.java
@@ -30,6 +30,7 @@ import org.keycloak.operator.crds.v2alpha1.deployment.spec.FeatureSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HostnameSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.HttpManagementSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.ServiceMonitorSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.TelemetrySpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TracingSpec;
 import org.keycloak.operator.crds.v2alpha1.deployment.spec.TransactionsSpec;
 import org.keycloak.operator.crds.v2alpha1.realmimport.KeycloakRealmImport;
@@ -191,6 +192,25 @@ public class CRSerializationTest {
         assertThat(limitMemQuantity, notNullValue());
         assertThat(limitMemQuantity.getAmount(), is("1500"));
         assertThat(limitMemQuantity.getFormat(), is("M"));
+    }
+
+    @Test
+    public void telemetrySpecification() {
+        Keycloak keycloak = Serialization.unmarshal(this.getClass().getResourceAsStream("/test-serialization-keycloak-cr.yml"), Keycloak.class);
+
+        TelemetrySpec telemetry = keycloak.getSpec().getTelemetrySpec();
+        assertThat(telemetry, notNullValue());
+
+        assertThat(telemetry.getEndpoint(), is("http://my-telemetry:4317"));
+        assertThat(telemetry.getServiceName(), is("my-best-keycloak-telemetry"));
+        assertThat(telemetry.getProtocol(), is("http/protobuf"));
+
+        var attributes = telemetry.getResourceAttributes();
+        assertThat(attributes, notNullValue());
+
+        assertThat(attributes.size(), is(2));
+        assertThat(attributes, hasEntry("service.namespace", "keycloak-namespace-telemetry"));
+        assertThat(attributes, hasEntry("service.name", "custom-service-name-telemetry"));
     }
 
     @Test

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -169,6 +169,18 @@ public class KeycloakDistConfiguratorTest {
     }
 
     @Test
+    public void telemetry() {
+        final Map<String, String> expectedValues = Map.of(
+                "telemetry-endpoint", "http://my-telemetry:4317",
+                "telemetry-service-name", "my-best-keycloak-telemetry",
+                "telemetry-protocol", "http/protobuf",
+                "telemetry-resource-attributes", "service.namespace=keycloak-namespace-telemetry,service.name=custom-service-name-telemetry"
+        );
+
+        testFirstClassCitizen(expectedValues);
+    }
+
+    @Test
     public void tracing() {
         final Map<String, String> expectedValues = Map.of(
                 "tracing-enabled", "true",

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/KeycloakDistConfiguratorTest.java
@@ -178,7 +178,7 @@ public class KeycloakDistConfiguratorTest {
                 "telemetry-resource-attributes", "service.namespace=keycloak-namespace-telemetry,service.name=custom-service-name-telemetry"
         );
 
-        testFirstClassCitizen(expectedValues);
+        testFirstClassCitizen("/test-serialization-keycloak-cr-telemetry.yml", expectedValues);
     }
 
     @Test
@@ -194,18 +194,18 @@ public class KeycloakDistConfiguratorTest {
                 "tracing-resource-attributes", "service.namespace=keycloak-namespace,service.name=custom-service-name"
         );
 
-        testFirstClassCitizen(expectedValues);
+        testFirstClassCitizen("/test-serialization-keycloak-cr-telemetry.yml", expectedValues);
     }
 
     @Test
     public void invalidTelemetryResourceAttributes() {
-        Keycloak keycloakCR = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr.yml", Keycloak.class);
+        Keycloak keycloakCR = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr-telemetry.yml", Keycloak.class);
         assertResourceAttributes(keycloakCR, keycloakCR.getSpec().getTelemetrySpec()::setResourceAttributes);
     }
 
     @Test
     public void invalidTracingResourceAttributes() {
-        Keycloak keycloakCR = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr.yml", Keycloak.class);
+        Keycloak keycloakCR = K8sUtils.getResourceFromFile("test-serialization-keycloak-cr-telemetry.yml", Keycloak.class);
         assertResourceAttributes(keycloakCR, keycloakCR.getSpec().getTracingSpec()::setResourceAttributes);
     }
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -482,8 +482,9 @@ public class PodTemplateTest {
 
         var envVars = container.getEnv();
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRUSTSTORE_PATHS));
-        assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRACING_SERVICE_NAME));
-        assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRACING_RESOURCE_ATTRIBUTES));
+        assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TELEMETRY_SERVICE_NAME));
+        assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TELEMETRY_RESOURCE_ATTRIBUTES));
+        assertThat(envVars.stream()).noneMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.KC_TRACING_RESOURCE_ATTRIBUTES));
         assertThat(envVars.stream()).anyMatch(envVar -> envVar.getName().equals(KeycloakDeploymentDependentResource.POD_IP));
 
         var readiness = container.getReadinessProbe().getHttpGet();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/CRAssert.java
@@ -85,6 +85,10 @@ public final class CRAssert {
         }
     }
 
+    public static void assertKeycloakStatusCondition(KeycloakStatus kcStatus, String condition, Boolean status) {
+        assertKeycloakStatusCondition(kcStatus, condition, status, null);
+    }
+
     public static void assertKeycloakStatusCondition(KeycloakStatus kcStatus, String condition, Boolean status, String containedMessage) {
         assertKeycloakStatusCondition(kcStatus, condition, status, containedMessage, null);
     }

--- a/operator/src/test/resources/test-serialization-keycloak-cr-telemetry.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr-telemetry.yml
@@ -1,0 +1,31 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: test-serialization-kc-telemetry
+spec:
+  instances: 3
+  tracing:
+    enabled: true
+    endpoint: http://my-tracing:4317
+    serviceName: my-best-keycloak
+    protocol: http/protobuf
+    samplerType: parentbased_traceidratio
+    samplerRatio: 0.01
+    compression: gzip
+    resourceAttributes:
+      service.namespace: keycloak-namespace
+      service.name: custom-service-name
+  telemetry:
+    endpoint: http://my-telemetry:4317
+    serviceName: my-best-keycloak-telemetry
+    protocol: http/protobuf
+    resourceAttributes:
+      service.namespace: keycloak-namespace-telemetry
+      service.name: custom-service-name-telemetry
+  additionalOptions:
+    - name: tracing-header-Authorization
+      secret:
+        name: tracing-secret
+        key: token
+    - name: tracing-header-X-Org-Id
+      value: my-org-id

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -10,12 +10,6 @@ spec:
       value: value1
     - name: features
       value: docker
-    - name: tracing-header-Authorization
-      secret:
-        name: tracing-secret
-        key: token
-    - name: tracing-header-X-Org-Id
-      value: my-org-id
   db:
     vendor: vendor
     usernameSecret:
@@ -107,24 +101,6 @@ spec:
       - step-up-authentication
   transaction:
     xaEnabled: false
-  telemetry:
-    endpoint: http://my-telemetry:4317
-    serviceName: my-best-keycloak-telemetry
-    protocol: http/protobuf
-    resourceAttributes:
-      service.namespace: keycloak-namespace-telemetry
-      service.name: custom-service-name-telemetry
-  tracing:
-    enabled: true
-    endpoint: http://my-tracing:4317
-    serviceName: my-best-keycloak
-    protocol: http/protobuf
-    samplerType: parentbased_traceidratio
-    samplerRatio: 0.01
-    compression: gzip
-    resourceAttributes:
-      service.namespace: keycloak-namespace
-      service.name: custom-service-name
   resources:
     requests:
       cpu: "500m"

--- a/operator/src/test/resources/test-serialization-keycloak-cr.yml
+++ b/operator/src/test/resources/test-serialization-keycloak-cr.yml
@@ -107,6 +107,13 @@ spec:
       - step-up-authentication
   transaction:
     xaEnabled: false
+  telemetry:
+    endpoint: http://my-telemetry:4317
+    serviceName: my-best-keycloak-telemetry
+    protocol: http/protobuf
+    resourceAttributes:
+      service.namespace: keycloak-namespace-telemetry
+      service.name: custom-service-name-telemetry
   tracing:
     enabled: true
     endpoint: http://my-tracing:4317


### PR DESCRIPTION
- Closes #45348
- Closes #45623
- Add the support for telemetry options in Keycloak CR
- Deprecate the `tracing.resourceAttributes` and `tracing.serviceName` in Keycloak CR
