### PR TITLE
Fix SearchDropdown clear button and URI search in Authorization tabs

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/SearchDropdown.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/SearchDropdown.tsx
@@ -30,6 +30,15 @@ type SearchDropdownProps = {
   type: "resource" | "policy" | "permission";
 };
 
+const defaultValues: SearchForm = {
+  name: "",
+  type: "",
+  uri: "",
+  owner: "",
+  scope: "",
+  resource: "",
+};
+
 export const SearchDropdown = ({
   types,
   search,
@@ -37,7 +46,7 @@ export const SearchDropdown = ({
   type,
 }: SearchDropdownProps) => {
   const { t } = useTranslation();
-  const form = useForm<SearchForm>({ mode: "onChange" });
+  const form = useForm<SearchForm>({ mode: "onChange", defaultValues });
   const {
     reset,
     formState: { isDirty },
@@ -51,7 +60,7 @@ export const SearchDropdown = ({
     onSearch(form);
   };
 
-  useEffect(() => reset(search), [search]);
+  useEffect(() => reset(search), [search, reset]);
 
   return (
     <Dropdown
@@ -80,7 +89,7 @@ export const SearchDropdown = ({
           {type === "resource" && (
             <>
               <TextControl name="type" label={t("type")} />
-              <TextControl name="uris" label={t("uris")} />
+              <TextControl name="uri" label={t("uris")} />
               <TextControl name="owner" label={t("owner")} />
             </>
           )}
@@ -116,7 +125,10 @@ export const SearchDropdown = ({
             <Button
               variant="link"
               data-testid="revert-btn"
-              onClick={() => onSearch({})}
+              onClick={() => {
+                reset(defaultValues);
+                onSearch({});
+              }}
             >
               {t("clear")}
             </Button>


### PR DESCRIPTION
## Summary

Fixes two issues in the SearchDropdown component used in Authorization tabs (Resources, Policies, Permissions):

1. **Clear button doesn't visually reset form fields** - Form inputs retain their values after clicking Clear
2. **URI search doesn't work** - Form used `name="uris"` but API expects `uri` parameter

## Changes

- Add `defaultValues` to `useForm` for proper form reset
- Call `reset(defaultValues)` in Clear button handler
- Fix form field name from `uris` to `uri` to match API parameter
- Add missing `reset` dependency to useEffect

## Test plan

- [ ] Navigate to Clients → Authorization → Resources/Policies/Permissions
- [ ] Open search dropdown, enter values, close and reopen - values should persist (existing behavior)
- [ ] Click Clear button - all form fields should be empty
- [ ] Search by URI in Resources tab - matching resources should be found

Closes #45406


https://github.com/user-attachments/assets/67227289-47c8-412d-ab70-a7033917f8a1

