### PR TITLE
fix(admin-ui): admin events for dedicated user now show all user related events

### DIFF
--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -450,7 +450,7 @@ export default function EditUser() {
                       eventKey="adminEvents"
                       title={<TabTitleText>{t("adminEvents")}</TabTitleText>}
                     >
-                      <AdminEvents resourcePath={`users/${user.id}`} />
+                      <AdminEvents resourcePath={`users/${user.id}*`} />
                     </Tab>
                   </Tabs>
                 </Tab>


### PR DESCRIPTION
Closes #45333

The admin ui events tab for a single user now shows all events with a resource path that start with the user such that events like role mappings and password settings are now also displayed.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
