### PR TITLE
fix: correct permission type redirect in resource details

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/DetailCell.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/DetailCell.tsx
@@ -1,4 +1,4 @@
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import { useFetch } from "@keycloak/keycloak-ui-shared";
 import { DescriptionList } from "@patternfly/react-core";
 import { useState } from "react";
@@ -24,8 +24,7 @@ export const DetailCell = ({ id, clientId, uris }: DetailCellProps) => {
 
   const { realm } = useRealm();
   const [scope, setScope] = useState<Scope>();
-  const [permissions, setPermissions] =
-    useState<ResourceServerRepresentation[]>();
+  const [permissions, setPermissions] = useState<PolicyRepresentation[]>();
 
   useFetch(
     () =>
@@ -70,7 +69,7 @@ export const DetailCell = ({ id, clientId, uris }: DetailCellProps) => {
             id: clientId,
             realm,
             permissionId: permission.id!,
-            permissionType: "resource",
+            permissionType: permission.type!,
           })
         }
       />

--- a/js/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx
@@ -1,6 +1,6 @@
 import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientRepresentation";
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import {
   HelpItem,
   TextControl,
@@ -52,8 +52,7 @@ export default function ResourceDetails() {
   const [client, setClient] = useState<ClientRepresentation>();
   const [resource, setResource] = useState<ResourceRepresentation>();
 
-  const [permissions, setPermission] =
-    useState<ResourceServerRepresentation[]>();
+  const [permissions, setPermission] = useState<PolicyRepresentation[]>();
 
   const { addAlert, addError } = useAlerts();
   const form = useForm<SubmittedResource>({

--- a/js/apps/admin-ui/src/clients/authorization/Resources.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Resources.tsx
@@ -1,5 +1,5 @@
+import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation";
 import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation";
-import type ResourceServerRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation";
 import {
   ListEmptyState,
   PaginatingTableToolbar,
@@ -67,8 +67,7 @@ export const AuthorizationResources = ({
     useState<ExpandableResourceRepresentation[]>();
   const [selectedResource, setSelectedResource] =
     useState<ResourceRepresentation>();
-  const [permissions, setPermission] =
-    useState<ResourceServerRepresentation[]>();
+  const [permissions, setPermission] = useState<PolicyRepresentation[]>();
 
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);

--- a/js/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/js/libs/keycloak-admin-client/src/resources/clients.ts
@@ -768,7 +768,7 @@ export class Clients extends Resource<{ realm?: string }> {
 
   public listPermissionsByResource = this.makeRequest<
     { id: string; resourceId: string },
-    ResourceServerRepresentation[]
+    PolicyRepresentation[]
   >({
     method: "GET",
     path: "/{id}/authz/resource-server/resource/{resourceId}/permissions",


### PR DESCRIPTION
Closes #45428

  ## Description

  Fixed wrong redirect for permissions accessed via resource details in the Admin UI authorization panel.

  When clicking on a permission from the Resources tab, the navigation was always treating it as a "resource" type
  permission, even for scope-based permissions.

  ## Changes

  1. **`js/libs/keycloak-admin-client/src/resources/clients.ts`**
     - Fixed `listPermissionsByResource` return type from `ResourceServerRepresentation[]` to
  `PolicyRepresentation[]` to match actual API response

  2. **`js/apps/admin-ui/src/clients/authorization/DetailCell.tsx`**
     - Changed hardcoded `permissionType: "resource"` to `permissionType: permission.type!`
     - Updated type imports to use `PolicyRepresentation`

  3. **`js/apps/admin-ui/src/clients/authorization/ResourceDetails.tsx`**
     - Updated type imports to use `PolicyRepresentation`

  4. **`js/apps/admin-ui/src/clients/authorization/Resources.tsx`**
     - Updated type imports to use `PolicyRepresentation`

## Fix Result

[kc-resource-navigate-fix.webm](https://github.com/user-attachments/assets/0559849f-653a-426c-a28b-7f2aaed42dd6)
