### PR TITLE
Provide HTTP access logs written to file with rotation

### DIFF
--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -6,4 +6,11 @@
 If you are using the HTTP Access logging capability, sensitive information is omitted.
 It means that tokens in the 'Authorization' HTTP header and specific sensitive Keycloak cookies are not shown.
 
-For more information, see https://www.keycloak.org/server/logging#http-access-logging[Configuring logging].
+For more information, see https://www.keycloak.org/server/logging#http-access-logging[Configuring HTTP access logging].
+
+= HTTP access logs in a dedicated file
+
+HTTP access logs can now be written to a dedicated file, separate from the server logs.
+This makes it easier to process and archive access logs independently for security auditing and compliance monitoring.
+
+For more information, see https://www.keycloak.org/server/logging#http-access-logging[Configuring HTTP access logging].

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -322,6 +322,39 @@ You can use regular expressions to exclude them, such as:
 
 In this case, all calls to the `/realms/my-internal-realm/` and subsequent paths will be excluded from the HTTP Access log.
 
+=== Log to dedicated file with rotation
+
+Instead of keeping the HTTP access logs in the normal server log, you can write them to a dedicated log file.
+This helps you separate HTTP access logs from the server logs and maintain audit trails.
+When file logging is enabled, HTTP access logs are not written to the console.
+
+==== Enable file logging
+
+You can enable file logging as follows:
+
+<@kc.start parameters="--http-access-log-enabled=true --http-access-log-file-enabled=true"/>
+
+This automatically creates a file called `keycloak-http-access.log` in the `/data` directory of your distribution.
+
+==== Change file name and suffix
+
+You can change the name of the log file using the `http-access-log-file-name` property.
+To change the file suffix (`.log` is the default), use the `http-access-log-file-suffix` property.
+
+For example, to write HTTP access logs to the file `my-http-logs.txt`:
+
+<@kc.start parameters="--http-access-log-enabled=true --http-access-log-file-enabled=true --http-access-log-file-name=my-http-logs --http-access-log-file-suffix=txt"/>
+
+==== File rotation
+
+By default, the HTTP access log file is rotated daily.
+
+When the daily rotation occurs, a date-based suffix '.+{yyyy-MM-dd}+' is added to the log file name from the previous day, keeping access logs separated by date (for example, `keycloak-http-access.2052-02-29.log`).
+
+To disable rotation, use the following configuration:
+
+<@kc.start parameters="--http-access-log-enabled=true --http-access-log-file-enabled=true --http-access-log-file-rotate=false"/>
+
 [[logs-export-opentelemetry]]
 == Telemetry Logs export (OpenTelemetry)
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpAccessLogOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpAccessLogOptions.java
@@ -47,4 +47,29 @@ public class HttpAccessLogOptions {
             .category(OptionCategory.HTTP_ACCESS_LOG)
             .description("Set of HTTP Cookie headers whose values must be masked when the 'long' pattern or '%{ALL_REQUEST_HEADERS}' format is enabled with the 'http-access-log-pattern' option. Selected security sensitive cookies are always masked.")
             .build();
+
+    // File
+    public static final Option<Boolean> HTTP_ACCESS_LOG_FILE_ENABLED = new OptionBuilder<>("http-access-log-file-enabled", Boolean.class)
+            .category(OptionCategory.HTTP_ACCESS_LOG)
+            .description("If HTTP access logging should be done to a separate file.")
+            .defaultValue(Boolean.FALSE)
+            .build();
+
+    public static final Option<String> HTTP_ACCESS_LOG_FILE_SUFFIX = new OptionBuilder<>("http-access-log-file-suffix", String.class)
+            .category(OptionCategory.HTTP_ACCESS_LOG)
+            .description("The HTTP access log file suffix. When rotation is enabled, a date-based suffix '.{yyyy-MM-dd}' is added before the specified suffix. If multiple rotations occur on the same day, an incremental index is appended to the date.")
+            .defaultValue(".log")
+            .build();
+
+    public static final Option<String> HTTP_ACCESS_LOG_FILE_NAME = new OptionBuilder<>("http-access-log-file-name", String.class)
+            .category(OptionCategory.HTTP_ACCESS_LOG)
+            .description("The HTTP access log file base name, which will create a log file name concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is located in the '/data' directory of the distribution.")
+            .defaultValue("keycloak-http-access")
+            .build();
+
+    public static final Option<Boolean> HTTP_ACCESS_LOG_FILE_ROTATE = new OptionBuilder<>("http-access-log-file-rotate", Boolean.class)
+            .category(OptionCategory.HTTP_ACCESS_LOG)
+            .description("If the HTTP Access log file should be rotated daily.")
+            .defaultValue(true)
+            .build();
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpAccessLogPropertyMappers.java
@@ -13,7 +13,8 @@ import io.smallrye.config.ConfigSourceInterceptorContext;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
-    public static final String ACCESS_LOG_ENABLED_MSG = "HTTP Access log is enabled";
+    private static final String ACCESS_LOG_ENABLED_MSG = "HTTP Access log is enabled";
+    private static final String ACCESS_LOG_FILE_ENABLED_MSG = "HTTP Access logging to file is enabled";
 
     @Override
     public List<PropertyMapper<?>> getPropertyMappers() {
@@ -42,6 +43,25 @@ public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
                         .paramLabel("<cookies>")
                         .to("quarkus.http.access-log.masked-cookies")
                         .transformer(HttpAccessLogPropertyMappers::transformMaskedCookies)
+                        .build(),
+                // file
+                fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_FILE_ENABLED)
+                        .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogEnabled, ACCESS_LOG_ENABLED_MSG)
+                        .to("quarkus.http.access-log.log-to-file")
+                        .build(),
+                fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_FILE_NAME)
+                        .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogFileEnabled, ACCESS_LOG_FILE_ENABLED_MSG)
+                        .paramLabel("<name>")
+                        .to("quarkus.http.access-log.base-file-name")
+                        .build(),
+                fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_FILE_SUFFIX)
+                        .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogFileEnabled, ACCESS_LOG_FILE_ENABLED_MSG)
+                        .paramLabel("<suffix>")
+                        .to("quarkus.http.access-log.log-suffix")
+                        .build(),
+                fromOption(HttpAccessLogOptions.HTTP_ACCESS_LOG_FILE_ROTATE)
+                        .isEnabled(HttpAccessLogPropertyMappers::isHttpAccessLogFileEnabled, ACCESS_LOG_FILE_ENABLED_MSG)
+                        .to("quarkus.http.access-log.rotate")
                         .build()
         );
     }
@@ -67,5 +87,9 @@ public class HttpAccessLogPropertyMappers implements PropertyMapperGrouping {
 
     static boolean isHttpAccessLogEnabled() {
         return Configuration.isTrue(HttpAccessLogOptions.HTTP_ACCESS_LOG_ENABLED);
+    }
+
+    static boolean isHttpAccessLogFileEnabled() {
+        return Configuration.isTrue(HttpAccessLogOptions.HTTP_ACCESS_LOG_FILE_ENABLED);
     }
 }

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -7,6 +7,7 @@ quarkus.banner.enabled=false
 
 # Set Keycloak category for HTTP access log
 quarkus.http.access-log.category=org.keycloak.http.access-log
+quarkus.http.access-log.log-directory=${kc.home.dir:default}${file.separator}data
 
 # Enables metrics from other extensions if metrics is enabled
 quarkus.datasource.metrics.enabled=${quarkus.micrometer.enabled:false}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -1002,6 +1002,59 @@ public class PicocliTest extends AbstractConfigurationTest {
         nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-masked-cookies=MY_CUSTOM_COOKIE," + CookieType.AUTH_SESSION_ID.getName());
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         assertExternalConfig("quarkus.http.access-log.masked-cookies", "AUTH_SESSION_ID,KC_AUTH_SESSION_HASH,KEYCLOAK_IDENTITY,KEYCLOAK_SESSION,AUTH_SESSION_ID_LEGACY,KEYCLOAK_IDENTITY_LEGACY,KEYCLOAK_SESSION_LEGACY,MY_CUSTOM_COOKIE");
+        onAfter();
+
+        // log to file
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-file-enabled=true");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Available only when HTTP Access log is enabled"));
+        assertExternalConfigNull("quarkus.http.access-log.log-to-file");
+        onAfter();
+
+        // log to file defaults
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-enabled=true");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfig(Map.of(
+                "quarkus.http.access-log.log-to-file", "true",
+                "quarkus.http.access-log.base-file-name", "keycloak-http-access",
+                "quarkus.http.access-log.log-suffix", ".log",
+                "quarkus.http.access-log.rotate", "true"
+        ));
+        onAfter();
+
+        // name - disabled
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-name=something");
+        assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
+        assertThat(nonRunningPicocli.getErrString(), containsString("Available only when HTTP Access logging to file is enabled"));
+        assertExternalConfig("quarkus.http.access-log.log-to-file", "false");
+        assertExternalConfigNull("quarkus.http.access-log.base-file-name");
+        onAfter();
+
+        // name
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-enabled=true", "--http-access-log-file-name=something");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfig(Map.of(
+                "quarkus.http.access-log.log-to-file", "true",
+                "quarkus.http.access-log.base-file-name", "something")
+        );
+        onAfter();
+
+        // suffix
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-enabled=true", "--http-access-log-file-suffix=.txt");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfig(Map.of(
+                "quarkus.http.access-log.log-to-file", "true",
+                "quarkus.http.access-log.log-suffix", ".txt")
+        );
+        onAfter();
+
+        // rotate
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-file-enabled=true", "--http-access-log-file-rotate=false");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfig(Map.of(
+                "quarkus.http.access-log.log-to-file", "true",
+                "quarkus.http.access-log.rotate", "false")
+        );
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -371,6 +371,23 @@ HTTP Access log:
                        instance, '/realms/my-realm/.*' will exclude all subsequent endpoints for
                        realm 'my-realm' from the log. Available only when HTTP Access log is
                        enabled.
+--http-access-log-file-enabled <true|false>
+                     If HTTP access logging should be done to a separate file. Default: false.
+                       Available only when HTTP Access log is enabled.
+--http-access-log-file-name <name>
+                     The HTTP access log file base name, which will create a log file name
+                       concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
+                       located in the '/data' directory of the distribution. Default:
+                       keycloak-http-access. Available only when HTTP Access logging to file is
+                       enabled.
+--http-access-log-file-rotate <true|false>
+                     If the HTTP Access log file should be rotated daily. Default: true. Available
+                       only when HTTP Access logging to file is enabled.
+--http-access-log-file-suffix <suffix>
+                     The HTTP access log file suffix. When rotation is enabled, a date-based suffix
+                       '.{yyyy-MM-dd}' is added before the specified suffix. If multiple rotations
+                       occur on the same day, an incremental index is appended to the date.
+                       Default: .log. Available only when HTTP Access logging to file is enabled.
 --http-access-log-masked-cookies <cookies>
                      Set of HTTP Cookie headers whose values must be masked when the 'long' pattern
                        or '%{ALL_REQUEST_HEADERS}' format is enabled with the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -372,6 +372,23 @@ HTTP Access log:
                        instance, '/realms/my-realm/.*' will exclude all subsequent endpoints for
                        realm 'my-realm' from the log. Available only when HTTP Access log is
                        enabled.
+--http-access-log-file-enabled <true|false>
+                     If HTTP access logging should be done to a separate file. Default: false.
+                       Available only when HTTP Access log is enabled.
+--http-access-log-file-name <name>
+                     The HTTP access log file base name, which will create a log file name
+                       concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
+                       located in the '/data' directory of the distribution. Default:
+                       keycloak-http-access. Available only when HTTP Access logging to file is
+                       enabled.
+--http-access-log-file-rotate <true|false>
+                     If the HTTP Access log file should be rotated daily. Default: true. Available
+                       only when HTTP Access logging to file is enabled.
+--http-access-log-file-suffix <suffix>
+                     The HTTP access log file suffix. When rotation is enabled, a date-based suffix
+                       '.{yyyy-MM-dd}' is added before the specified suffix. If multiple rotations
+                       occur on the same day, an incremental index is appended to the date.
+                       Default: .log. Available only when HTTP Access logging to file is enabled.
 --http-access-log-masked-cookies <cookies>
                      Set of HTTP Cookie headers whose values must be masked when the 'long' pattern
                        or '%{ALL_REQUEST_HEADERS}' format is enabled with the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -334,6 +334,23 @@ HTTP Access log:
                        instance, '/realms/my-realm/.*' will exclude all subsequent endpoints for
                        realm 'my-realm' from the log. Available only when HTTP Access log is
                        enabled.
+--http-access-log-file-enabled <true|false>
+                     If HTTP access logging should be done to a separate file. Default: false.
+                       Available only when HTTP Access log is enabled.
+--http-access-log-file-name <name>
+                     The HTTP access log file base name, which will create a log file name
+                       concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
+                       located in the '/data' directory of the distribution. Default:
+                       keycloak-http-access. Available only when HTTP Access logging to file is
+                       enabled.
+--http-access-log-file-rotate <true|false>
+                     If the HTTP Access log file should be rotated daily. Default: true. Available
+                       only when HTTP Access logging to file is enabled.
+--http-access-log-file-suffix <suffix>
+                     The HTTP access log file suffix. When rotation is enabled, a date-based suffix
+                       '.{yyyy-MM-dd}' is added before the specified suffix. If multiple rotations
+                       occur on the same day, an incremental index is appended to the date.
+                       Default: .log. Available only when HTTP Access logging to file is enabled.
 --http-access-log-masked-cookies <cookies>
                      Set of HTTP Cookie headers whose values must be masked when the 'long' pattern
                        or '%{ALL_REQUEST_HEADERS}' format is enabled with the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -371,6 +371,23 @@ HTTP Access log:
                        instance, '/realms/my-realm/.*' will exclude all subsequent endpoints for
                        realm 'my-realm' from the log. Available only when HTTP Access log is
                        enabled.
+--http-access-log-file-enabled <true|false>
+                     If HTTP access logging should be done to a separate file. Default: false.
+                       Available only when HTTP Access log is enabled.
+--http-access-log-file-name <name>
+                     The HTTP access log file base name, which will create a log file name
+                       concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
+                       located in the '/data' directory of the distribution. Default:
+                       keycloak-http-access. Available only when HTTP Access logging to file is
+                       enabled.
+--http-access-log-file-rotate <true|false>
+                     If the HTTP Access log file should be rotated daily. Default: true. Available
+                       only when HTTP Access logging to file is enabled.
+--http-access-log-file-suffix <suffix>
+                     The HTTP access log file suffix. When rotation is enabled, a date-based suffix
+                       '.{yyyy-MM-dd}' is added before the specified suffix. If multiple rotations
+                       occur on the same day, an incremental index is appended to the date.
+                       Default: .log. Available only when HTTP Access logging to file is enabled.
 --http-access-log-masked-cookies <cookies>
                      Set of HTTP Cookie headers whose values must be masked when the 'long' pattern
                        or '%{ALL_REQUEST_HEADERS}' format is enabled with the

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -369,6 +369,23 @@ HTTP Access log:
                        instance, '/realms/my-realm/.*' will exclude all subsequent endpoints for
                        realm 'my-realm' from the log. Available only when HTTP Access log is
                        enabled.
+--http-access-log-file-enabled <true|false>
+                     If HTTP access logging should be done to a separate file. Default: false.
+                       Available only when HTTP Access log is enabled.
+--http-access-log-file-name <name>
+                     The HTTP access log file base name, which will create a log file name
+                       concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
+                       located in the '/data' directory of the distribution. Default:
+                       keycloak-http-access. Available only when HTTP Access logging to file is
+                       enabled.
+--http-access-log-file-rotate <true|false>
+                     If the HTTP Access log file should be rotated daily. Default: true. Available
+                       only when HTTP Access logging to file is enabled.
+--http-access-log-file-suffix <suffix>
+                     The HTTP access log file suffix. When rotation is enabled, a date-based suffix
+                       '.{yyyy-MM-dd}' is added before the specified suffix. If multiple rotations
+                       occur on the same day, an incremental index is appended to the date.
+                       Default: .log. Available only when HTTP Access logging to file is enabled.
 --http-access-log-masked-cookies <cookies>
                      Set of HTTP Cookie headers whose values must be masked when the 'long' pattern
                        or '%{ALL_REQUEST_HEADERS}' format is enabled with the


### PR DESCRIPTION
- Closes #41353
- HTTP access logs written to a dedicated file in `/data/keycloak-http-access.log`