### PR TITLE
[OID4VCI] Not able to find key for credential signature if client scope was sav…

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3665,7 +3665,7 @@ tokenJwsTypeHelp=The type value written into the typ header of the JWT. Defaults
 visibleClaims=Visible Claims
 visibleClaimsHelp=Comma-separated list of claims that are always disclosed in the SD-JWT body (e.g., "id,iat,nbf,exp,jti,given_name"). Defaults to "id,iat,nbf,exp,jti". Only applicable for SD-JWT format.
 signingKeyId=Signing Key ID
-signingKeyIdHelp=Optional. The ID of the realm key used to sign the credential. If not specified, the realm's active signing key will be used automatically.
+signingKeyIdHelp=Optional. The ID of the realm key used to sign the credential. If not specified, the realm's active signing key of the algorithm specified by 'Credential Signing Algorithm' (if set) will be used automatically. If this option is specified, it is highly recommended to specify also 'Credential Signing Algorithm' as the Signing Key ID must be of the algorithm specified by that option.
 useDefaultKey=Use default (realm's active signing key)
 # Workflows
 workflows=Workflows

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -126,5 +126,4 @@ public interface Details {
     String VERIFIABLE_CREDENTIAL_TARGET_USER_ID = "verifiable_credential_target_user_id";
     String VERIFIABLE_CREDENTIAL_FORMAT = "verifiable_credential_format";
     String VERIFIABLE_CREDENTIALS_ISSUED = "verifiable_credentials_issued";
-    String ERROR_TYPE = "error_type";
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/AbstractCredentialSigner.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/AbstractCredentialSigner.java
@@ -25,6 +25,7 @@ import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
+import org.keycloak.utils.StringUtil;
 
 public abstract class AbstractCredentialSigner<T> implements CredentialSigner<T> {
 
@@ -71,7 +72,7 @@ public abstract class AbstractCredentialSigner<T> implements CredentialSigner<T>
         KeyWrapper signingKey = getKey(keyId, algorithm);
         if (signingKey == null) {
             throw new CredentialSignerException(
-                    String.format("No key for id %s and algorithm %s available.", keyId, algorithm));
+                    String.format("No key for id '%s' and algorithm '%s' available.", keyId, algorithm));
         }
 
         if (keyIdSubstitute != null) {
@@ -91,7 +92,7 @@ public abstract class AbstractCredentialSigner<T> implements CredentialSigner<T>
         RealmModel realm = keycloakSession.getContext().getRealm();
         KeyManager keys = keycloakSession.keys();
 
-        if (keyId == null) {
+        if (StringUtil.isBlank(keyId)) {
             // Allow the signer to work with the active key if keyId is null
             // And we still have to figure out how to proceed with key rotation
             return keys.getActiveKey(realm, KeyUse.SIG, algorithm);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialBuildConfig.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialBuildConfig.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.utils.StringUtil;
 
 /**
  * Define credential-specific configurations for its builder.
@@ -91,14 +92,16 @@ public class CredentialBuildConfig {
         final String credentialIssuer = Optional.ofNullable(credentialModel.getIssuerDid()).orElse(
                 OID4VCIssuerWellKnownProvider.getIssuer(keycloakSession.getContext()));
 
+        String modelSigningAlg = credentialModel.getSigningAlg();
+        String signingAlg = StringUtil.isNotBlank(modelSigningAlg) ? modelSigningAlg : credentialConfiguration.getCredentialSigningAlgValuesSupported().get(0);
+
         return new CredentialBuildConfig().setCredentialIssuer(credentialIssuer)
                                           .setCredentialId(credentialConfiguration.getId())
                                           .setCredentialType(credentialConfiguration.getVct())
                                           .setTokenJwsType(credentialModel.getTokenJwsType())
                                           .setNumberOfDecoys(credentialModel.getSdJwtNumberOfDecoys())
                                           .setSigningKeyId(credentialModel.getSigningKeyId())
-                                          .setSigningAlgorithm(credentialConfiguration.getCredentialSigningAlgValuesSupported()
-                                                                                      .get(0))
+                                          .setSigningAlgorithm(signingAlg)
                                           .setHashAlgorithm(credentialModel.getHashAlgorithm())
                                           .setSdJwtVisibleClaims(credentialModel.getSdJwtVisibleClaims());
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
@@ -20,6 +20,7 @@ package org.keycloak.testsuite.oid4vc.issuance.signing;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +31,11 @@ import jakarta.ws.rs.core.HttpHeaders;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
+import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.models.oid4vci.Oid4vcProtocolMapperModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCAuthorizationDetailsResponse;
@@ -41,6 +44,7 @@ import org.keycloak.protocol.oid4vc.model.ClaimsDescription;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
@@ -66,6 +70,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.keycloak.OAuth2Constants.OPENID_CREDENTIAL;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.SIGNING_ALG;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.SIGNING_KEY_ID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -189,7 +195,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         HttpPost postCredential = getCredentialRequest(ctx, credRequestSupplier, tokenResponse, credentialConfigurationId, credentialIdentifier);
 
         try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
-            assertErrorCredentialResponse(credentialResponse);
+            assertErrorCredentialResponse_mandatoryClaimsMissing(credentialResponse);
             
             // Verify VERIFIABLE_CREDENTIAL_REQUEST_ERROR event was fired with details about missing mandatory claim
             events.expect(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
@@ -257,7 +263,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
             HttpPost postCredential = getCredentialRequest(ctx, credRequestSupplier, tokenResponse, credentialConfigurationId, credentialIdentifier);
 
             try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
-                assertErrorCredentialResponse(credentialResponse);
+                assertErrorCredentialResponse_mandatoryClaimsMissing(credentialResponse);
                 
                 // Verify VERIFIABLE_CREDENTIAL_REQUEST_ERROR event was fired with details about missing mandatory claim
                 events.expect(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
@@ -278,7 +284,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
             events.clear();
 
             try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
-                assertErrorCredentialResponse(credentialResponse);
+                assertErrorCredentialResponse_mandatoryClaimsMissing(credentialResponse);
                 
                 // Verify VERIFIABLE_CREDENTIAL_REQUEST_ERROR event was fired
                 events.expect(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
@@ -299,7 +305,7 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
             events.clear();
 
             try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
-                assertErrorCredentialResponse(credentialResponse);
+                assertErrorCredentialResponse_mandatoryClaimsMissing(credentialResponse);
                 
                 // Verify VERIFIABLE_CREDENTIAL_REQUEST_ERROR event was fired
                 events.expect(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
@@ -326,8 +332,88 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         }
     }
 
+    @Test
+    public void testCompleteFlowWithSigningAlgorithmAndKeyIdConfigured() throws Exception {
+        BiFunction<String, String, CredentialRequest> credRequestSupplier = (credentialConfigurationId, credentialIdentifier) -> {
+            CredentialRequest credentialRequest = new CredentialRequest();
+            credentialRequest.setCredentialIdentifier(credentialIdentifier);
+            return credentialRequest;
+        };
 
-    private void testCompleteFlowWithClaimsValidationAuthorizationCode(BiFunction<String, String, CredentialRequest> credentialRequestSupplier) throws Exception {
+        ClientScopeResource clientScope = ApiUtil.findClientScopeByName(testRealm(), getCredentialClientScope().getName());
+        ClientScopeRepresentation clientScopeRep = clientScope.toRepresentation();
+        Map<String, String> origAttributes = new HashMap<>(clientScopeRep.getAttributes());
+
+        try {
+            // 1 - Configure signature algorithm, but not keyId. Make sure that credential signed with the target algorithm
+            clientScopeRep.getAttributes().put(SIGNING_ALG, Algorithm.ES512);
+            clientScopeRep.getAttributes().put(SIGNING_KEY_ID, null);
+            clientScope.update(clientScopeRep);
+
+            Object credentialObj = testCompleteFlowWithClaimsValidationAuthorizationCode(credRequestSupplier);
+            JWSHeader jwsHeader = verifyCredentialSignature(credentialObj, Algorithm.ES512);
+            String es512keyId = jwsHeader.getKeyId();
+            logoutUser("john");
+
+            // 2 - Configure signature algorithm, and keyId with blank value "" (just to simulate what admin console was doing when clientScope was saved).
+            // Make sure that credential signed with the target algorithm and keyId is not considered
+            clientScopeRep.getAttributes().put(SIGNING_ALG, Algorithm.EdDSA);
+            clientScopeRep.getAttributes().put(SIGNING_KEY_ID, "");
+            clientScope.update(clientScopeRep);
+
+            credentialObj = testCompleteFlowWithClaimsValidationAuthorizationCode(credRequestSupplier);
+            verifyCredentialSignature(credentialObj, Algorithm.EdDSA);
+            logoutUser("john");
+
+            // 3 - Configure signature algorithm, and keyId with some value. Make sure that
+            // credential signed with the target algorithm and keyId as expected
+            clientScopeRep.getAttributes().put(SIGNING_ALG, Algorithm.ES512);
+            clientScopeRep.getAttributes().put(SIGNING_KEY_ID, es512keyId);
+            clientScope.update(clientScopeRep);
+
+            credentialObj = testCompleteFlowWithClaimsValidationAuthorizationCode(credRequestSupplier);
+            JWSHeader newJWSHeader = verifyCredentialSignature(credentialObj, Algorithm.ES512);
+            assertEquals(es512keyId, newJWSHeader.getKeyId());
+            logoutUser("john");
+
+            // 4 - Configure different signature algorithm not matching with key specified by keyId. Error is expected
+            clientScopeRep.getAttributes().put(SIGNING_ALG, Algorithm.EdDSA);
+            clientScopeRep.getAttributes().put(SIGNING_KEY_ID, es512keyId);
+            clientScope.update(clientScopeRep);
+
+            Oid4vcTestContext ctx = prepareOid4vcTestContext();
+            AccessTokenResponse tokenResponse = authzCodeFlow(ctx);
+            String credentialIdentifier = assertTokenResponse(tokenResponse);
+            String credentialConfigurationId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
+
+            // Clear events before credential request
+            events.clear();
+
+            HttpPost postCredential = getCredentialRequest(ctx, credRequestSupplier, tokenResponse, credentialConfigurationId, credentialIdentifier);
+
+            try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
+                String expectedError = "Signing of credential failed: No key for id '" + es512keyId + "' and algorithm 'EdDSA' available.";
+                assertErrorCredentialResponse(credentialResponse, ErrorType.INVALID_CREDENTIAL_REQUEST.name(), expectedError);
+
+                // Verify VERIFIABLE_CREDENTIAL_REQUEST_ERROR event was fired with details about missing mandatory claim
+                events.expect(EventType.VERIFIABLE_CREDENTIAL_REQUEST_ERROR)
+                        .client(client.getClientId())
+                        .user(AssertEvents.isUUID())
+                        .session(AssertEvents.isSessionId())
+                        .error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue())
+                        .detail(Details.REASON, expectedError)
+                        .assertEvent();
+            }
+
+        } finally {
+            // Revert clientScope config
+            clientScopeRep.setAttributes(origAttributes);
+            clientScope.update(clientScopeRep);
+        }
+    }
+
+    // Return VC credential object
+    private Object testCompleteFlowWithClaimsValidationAuthorizationCode(BiFunction<String, String, CredentialRequest> credentialRequestSupplier) throws Exception {
         Oid4vcTestContext ctx = prepareOid4vcTestContext();
 
         // Perform authorization code flow to get authorization code
@@ -335,11 +421,24 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         String credentialIdentifier = assertTokenResponse(tokenResponse);
         String credentialConfigurationId = getCredentialClientScope().getAttributes().get(CredentialScopeModel.CONFIGURATION_ID);
 
+        events.clear();
+
         // Request the actual credential using the identifier
         HttpPost postCredential = getCredentialRequest(ctx, credentialRequestSupplier, tokenResponse, credentialConfigurationId, credentialIdentifier);
 
         try (CloseableHttpResponse credentialResponse = httpClient.execute(postCredential)) {
-            assertSuccessfulCredentialResponse(credentialResponse);
+            Object credential = assertSuccessfulCredentialResponse(credentialResponse);
+
+            // Verify event
+            events.expect(EventType.VERIFIABLE_CREDENTIAL_REQUEST)
+                    .client(client.getClientId())
+                    .user(AssertEvents.isUUID())
+                    .session(AssertEvents.isSessionId())
+                    .detail(Details.USERNAME, "john")
+                    .detail(Details.CREDENTIAL_TYPE, credentialConfigurationId)
+                    .assertEvent();
+
+            return credential;
         }
     }
 
@@ -430,7 +529,8 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         return postCredential;
     }
 
-    private void assertSuccessfulCredentialResponse(CloseableHttpResponse credentialResponse) throws Exception {
+    // Test successful credential response and returns credential object
+    private Object assertSuccessfulCredentialResponse(CloseableHttpResponse credentialResponse) throws Exception {
         assertEquals(HttpStatus.SC_OK, credentialResponse.getStatusLine().getStatusCode());
         String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
 
@@ -450,13 +550,23 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
 
         // Verify the credential structure based on formatfix-authorization_details-processing
         verifyCredentialStructure(credentialObj);
+
+        return credentialObj;
     }
 
-    private void assertErrorCredentialResponse(CloseableHttpResponse credentialResponse) throws Exception {
+    private void assertErrorCredentialResponse_mandatoryClaimsMissing(CloseableHttpResponse credentialResponse) throws Exception {
         assertEquals(HttpStatus.SC_BAD_REQUEST, credentialResponse.getStatusLine().getStatusCode());
         String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
         OAuth2ErrorRepresentation error = JsonSerialization.readValue(responseBody, OAuth2ErrorRepresentation.class);
         assertEquals("Credential issuance failed: No elements selected after processing claims path pointer. The requested claims are not available in the user profile.", error.getError());
+    }
+
+    private void assertErrorCredentialResponse(CloseableHttpResponse credentialResponse, String expectedError, String expectedErrorDescription) throws Exception {
+        assertEquals(HttpStatus.SC_BAD_REQUEST, credentialResponse.getStatusLine().getStatusCode());
+        String responseBody = IOUtils.toString(credentialResponse.getEntity().getContent(), StandardCharsets.UTF_8);
+        OAuth2ErrorRepresentation error = JsonSerialization.readValue(responseBody, OAuth2ErrorRepresentation.class);
+        assertEquals(expectedError, error.getError());
+        assertEquals(expectedErrorDescription, error.getErrorDescription());
     }
 
     /**
@@ -467,6 +577,15 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         // Default implementation - subclasses should override
         assertNotNull("Credential object should not be null", credentialObj);
     }
+
+    /**
+     * Verify credential signature on VC credential is of expected algorithm and optionally expected keyId.
+     *
+     * @param vcCredential Verifiable credential
+     * @param expectedSignatureAlgorithm expected signature algorithm of the VC credential
+     * @return JWS header used for the VC credential. Can be used for further checks in the tests
+     */
+    protected abstract JWSHeader verifyCredentialSignature(Object vcCredential, String expectedSignatureAlgorithm) throws Exception;
 
     /**
      * Parse authorization details from the token response.

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCIssuerEndpointTest.java
@@ -374,7 +374,7 @@ public abstract class OID4VCIssuerEndpointTest extends OID4VCTest {
         clientResource.addOptionalClientScope(scopeId);
     }
 
-    private void logoutUser(String clientId, String username) {
+    protected void logoutUser(String username) {
         UserResource user = ApiUtil.findUserByUsernameId(adminClient.realm(TEST_REALM_NAME), username);
         user.logout();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJwtAuthorizationCodeFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJwtAuthorizationCodeFlowTest.java
@@ -17,8 +17,12 @@
 
 package org.keycloak.testsuite.oid4vc.issuance.signing;
 
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -62,5 +66,17 @@ public class OID4VCJwtAuthorizationCodeFlowTest extends OID4VCAuthorizationCodeF
 
         // Verify it looks like a JWT (contains dots)
         assertTrue("JWT should contain dots", jwtString.contains("."));
+    }
+
+    @Override
+    protected JWSHeader verifyCredentialSignature(Object vcCredential, String expectedSignatureAlgorithm) throws Exception {
+        String vcCredentialString = vcCredential.toString();
+        JWSInput jwsInput = new JWSInput(vcCredentialString);
+        JWSHeader header = jwsInput.getHeader();
+
+        assertEquals(expectedSignatureAlgorithm, header.getRawAlgorithm());
+        oauth.verifyToken(vcCredentialString, JsonWebToken.class);
+
+        return header;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtAuthorizationCodeFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCSdJwtAuthorizationCodeFlowTest.java
@@ -17,10 +17,15 @@
 
 package org.keycloak.testsuite.oid4vc.issuance.signing;
 
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.vp.SdJwtVP;
 
 import static org.keycloak.OID4VCConstants.SDJWT_DELIMITER;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -66,4 +71,17 @@ public class OID4VCSdJwtAuthorizationCodeFlowTest extends OID4VCAuthorizationCod
         assertTrue("SD-JWT should contain dots", sdJwtString.contains("."));
         assertTrue("SD-JWT should contain tilde", sdJwtString.contains(SDJWT_DELIMITER));
     }
+
+    @Override
+    protected JWSHeader verifyCredentialSignature(Object vcCredential, String expectedSignatureAlgorithm) {
+        IssuerSignedJWT issuerSignedJWT = SdJwtVP.of(vcCredential.toString())
+                .getIssuerSignedJWT();
+        JWSHeader header = issuerSignedJWT.getJwsHeader();
+
+        assertEquals(expectedSignatureAlgorithm, header.getRawAlgorithm());
+
+        oauth.verifyToken(issuerSignedJWT.getJws(), JsonWebToken.class);
+        return header;
+    }
+
 }


### PR DESCRIPTION
…ed from admin console

closes #44699

- Make it possible that `keyId` is considered just if it is not null or empty string (as admin-console can save this option as an empty string)

- Added automated tests for some combinations of "Signing key algorithm" and "Signing key ID" .

- Some changes done in the `OID4VCIssuerEndpoint` regarding exception handling, so that proper error is returned to the user and proper error event is triggered in case of some error (EG. Signing-key of configured KID is not available. Previously this was not catched and was just propagated as HTTP error 500 and no error event was triggered)

- I've also removed the `Details.ERROR_TYPE` in this PR and instead I've updated events to use `error` property instead. It seems to me there is no reason to have dedicated detail `error_type` as we can use proper type "error" for directly throwing the error event type.
