### PR TITLE
Fix link to OpenTelemetry guide in logging

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -305,7 +305,7 @@ In this case, all calls to the `/realms/my-internal-realm/` and subsequent paths
 
 It is possible to export OpenTelemetry logs from your deployment to the OpenTelemetry collector for centralized log management.
 
-For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.
+For more details, see the <@links.observability id="telemetry"/> guide.
 
 <@opts.printRelevantOptions includedOptions="log log-*" excludedOptions="log-console-* log-file log-file-* log-syslog-* log-mdc* telemetry-logs-*">
 


### PR DESCRIPTION
- Closes keycloak/keycloak-web#692

The variable is not available for guides, only for the main docs. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
