### PR TITLE
Fix link to OpenTelemetry guide in logging

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -305,7 +305,7 @@ In this case, all calls to the `/realms/my-internal-realm/` and subsequent paths
 
 It is possible to export OpenTelemetry logs from your deployment to the OpenTelemetry collector for centralized log management.
 
-For more details, see the link:{telemetryguide_link}[{telemetryguide_name}] guide.
+For more details, see the <@links.observability id="telemetry"/> guide.
 
 <@opts.printRelevantOptions includedOptions="log log-*" excludedOptions="log-console-* log-file log-file-* log-syslog-* log-mdc* telemetry-logs-*">
 


### PR DESCRIPTION
- Closes keycloak/keycloak-web#692

Co-authored-by: Ryan Emerson <remerson@ibm.com>
Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit ab25c8e05991bbc827af68063c70eca1e7728ffb)
