### PR TITLE
Remove VERIFY_EMAIL action and publish event in ExecuteActionsActionTokenHandler

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
@@ -31,6 +31,7 @@ import org.keycloak.authentication.actiontoken.AbstractActionTokenHandler;
 import org.keycloak.authentication.actiontoken.ActionTokenContext;
 import org.keycloak.authentication.actiontoken.TokenUtils;
 import org.keycloak.authentication.requiredactions.util.RequiredActionsValidator;
+import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.forms.login.LoginFormsProvider;
@@ -119,7 +120,15 @@ public class ExecuteActionsActionTokenHandler extends AbstractActionTokenHandler
 
         UserModel user = tokenContext.getAuthenticationSession().getAuthenticatedUser();
         // verify user email as we know it is valid as this entry point would never have gotten here.
-        user.setEmailVerified(true);
+        if (!user.isEmailVerified()) {
+            user.setEmailVerified(true);
+            user.removeRequiredAction(UserModel.RequiredAction.VERIFY_EMAIL);
+            authSession.removeRequiredAction(UserModel.RequiredAction.VERIFY_EMAIL);
+            tokenContext.getEvent().clone()
+                    .event(EventType.VERIFY_EMAIL)
+                    .detail(Details.EMAIL, user.getEmail())
+                    .success();
+        }
 
         String nextAction = AuthenticationManager.nextRequiredAction(tokenContext.getSession(), authSession, tokenContext.getRequest(), tokenContext.getEvent());
         return AuthenticationManager.redirectToRequiredActions(tokenContext.getSession(), tokenContext.getRealm(), authSession, tokenContext.getUriInfo(), nextAction);


### PR DESCRIPTION
When processing execute-actions token, the email was marked as verified but the VERIFY_EMAIL required action was not removed and no event was published. This led to inconsistent state.

Now properly:
- Removes VERIFY_EMAIL from user and auth session
- Publishes VERIFY_EMAIL event for audit trail
- Only performs these actions if email was not already verified

Closes #42875
