### PR TITLE
fix(admin-ui): fix setFileUpload implementation to correctly display …

### DIFF
--- a/js/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
+++ b/js/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
@@ -59,19 +59,20 @@ export const FileUploadForm = ({
     modal: false,
   };
   const [fileUpload, setFileUpload] = useState<FileUploadType>(defaultUpload);
-  const removeDialog = () => setFileUpload(prev => ({ ...prev, modal: false }));
+  const removeDialog = () =>
+    setFileUpload((prev) => ({ ...prev, modal: false }));
 
   const handleFileInputChange = (_event: DropEvent, file: File) => {
-    setFileUpload(prev => ({ ...prev, filename: file.name }));
+    setFileUpload((prev) => ({ ...prev, filename: file.name }));
   };
 
   const handleTextOrDataChange = (value: string) => {
-    setFileUpload(prev => ({ ...prev, value }));
+    setFileUpload((prev) => ({ ...prev, value }));
     onChange(value);
   };
 
   const handleClear = () => {
-    setFileUpload(prev => ({ ...prev, modal: true }));
+    setFileUpload((prev) => ({ ...prev, modal: true }));
   };
 
   return (
@@ -119,10 +120,10 @@ export const FileUploadForm = ({
           onTextChange={(_, value) => handleTextOrDataChange(value)}
           onClearClick={handleClear}
           onReadStarted={() =>
-            setFileUpload(prev => ({ ...prev, isLoading: true }))
+            setFileUpload((prev) => ({ ...prev, isLoading: true }))
           }
           onReadFinished={() =>
-            setFileUpload(prev => ({ ...prev, isLoading: false }))
+            setFileUpload((prev) => ({ ...prev, isLoading: false }))
           }
           isLoading={fileUpload.isLoading}
           dropzoneProps={{
@@ -144,10 +145,10 @@ export const FileUploadForm = ({
             onTextChange={(_, value) => handleTextOrDataChange(value)}
             onClearClick={handleClear}
             onReadStarted={() =>
-              setFileUpload(prev => ({ ...prev, isLoading: true }))
+              setFileUpload((prev) => ({ ...prev, isLoading: true }))
             }
             onReadFinished={() =>
-              setFileUpload(prev => ({ ...prev, isLoading: false }))
+              setFileUpload((prev) => ({ ...prev, isLoading: false }))
             }
             isLoading={fileUpload.isLoading}
             hideDefaultPreview

--- a/js/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
+++ b/js/apps/admin-ui/src/components/json-file-upload/FileUploadForm.tsx
@@ -59,19 +59,19 @@ export const FileUploadForm = ({
     modal: false,
   };
   const [fileUpload, setFileUpload] = useState<FileUploadType>(defaultUpload);
-  const removeDialog = () => setFileUpload({ ...fileUpload, modal: false });
+  const removeDialog = () => setFileUpload(prev => ({ ...prev, modal: false }));
 
   const handleFileInputChange = (_event: DropEvent, file: File) => {
-    setFileUpload({ ...fileUpload, filename: file.name });
+    setFileUpload(prev => ({ ...prev, filename: file.name }));
   };
 
   const handleTextOrDataChange = (value: string) => {
-    setFileUpload({ ...fileUpload, value });
+    setFileUpload(prev => ({ ...prev, value }));
     onChange(value);
   };
 
   const handleClear = () => {
-    setFileUpload({ ...fileUpload, modal: true });
+    setFileUpload(prev => ({ ...prev, modal: true }));
   };
 
   return (
@@ -119,10 +119,10 @@ export const FileUploadForm = ({
           onTextChange={(_, value) => handleTextOrDataChange(value)}
           onClearClick={handleClear}
           onReadStarted={() =>
-            setFileUpload({ ...fileUpload, isLoading: true })
+            setFileUpload(prev => ({ ...prev, isLoading: true }))
           }
           onReadFinished={() =>
-            setFileUpload({ ...fileUpload, isLoading: false })
+            setFileUpload(prev => ({ ...prev, isLoading: false }))
           }
           isLoading={fileUpload.isLoading}
           dropzoneProps={{
@@ -144,10 +144,10 @@ export const FileUploadForm = ({
             onTextChange={(_, value) => handleTextOrDataChange(value)}
             onClearClick={handleClear}
             onReadStarted={() =>
-              setFileUpload({ ...fileUpload, isLoading: true })
+              setFileUpload(prev => ({ ...prev, isLoading: true }))
             }
             onReadFinished={() =>
-              setFileUpload({ ...fileUpload, isLoading: false })
+              setFileUpload(prev => ({ ...prev, isLoading: false }))
             }
             isLoading={fileUpload.isLoading}
             hideDefaultPreview


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/45488

The FileUploadForm component now correctly preserves the filename during file upload by using functional state updates throughout. Previously, rapid successive state changes (filename, loading status, file content) would overwrite each other due to stale state closures, causing the filename to be lost. 

All setState calls now use the functional update pattern prev => ({ ...prev, ... }) to ensure each update builds on the current state rather than captured state from closure creation.