### PR TITLE
ConcurrentModificationException in KeycloakProcessor#configureProfile

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -242,6 +242,13 @@ class KeycloakProcessor {
         return new FeatureBuildItem("keycloak");
     }
 
+    /**
+     * Initialize configuration in runtime during the static initialization
+     * <p>
+     * We need to wait for the full configuration initialization on the Quarkus side (see {@link RuntimeConfigSetupCompleteBuildItem}).
+     * <p>
+     * It prevents issues like https://github.com/keycloak/keycloak/issues/45501
+     */
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     @Consume(RuntimeConfigSetupCompleteBuildItem.class)

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -141,6 +141,7 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
@@ -243,6 +244,7 @@ class KeycloakProcessor {
 
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
+    @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Produce(ConfigBuildItem.class)
     void initConfig(KeycloakRecorder recorder) {
         // other buildsteps directly use the Config


### PR DESCRIPTION
- Closes #45501

I was not able to reproduce the issue on my local machine, so this might be considered rather as an educated guess.

The `ConcurrentModificationException` for the `Configuration.getPropertyNames()` happens in the `QuarkusSingleProfileConfigResolver` during initializing profile. However, the iterator/stream over all the property streams seems to be modified somewhere. The property names object is an aggregated store of property names from individual config sources, which should be immutable. That may mean that we call the iterator when the runtime config is not fully initialized yet -> **We just wait for the runtime config completion on the Quarkus side.** But not sure why it started to fail now as recent changes do not uncover anything suspicious. 

Alternative issue -> AFAIK, the `SmallRyeConfig.getPropertyNames()` calls the interceptor chain via `iterateNames()` including our config interceptors. On the SmallRye side, they claim going over the property names should be thread safe and can be done concurrently. However, there might be some issues in our config interceptors that might provoke the CoModEx. 

@shawkins WDYT? 



