### PR TITLE
Add backchannel logout on user deletion

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/DeleteAccount.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/DeleteAccount.java
@@ -46,6 +46,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.messages.Messages;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import org.jboss.logging.Logger;
@@ -90,6 +91,9 @@ public class DeleteAccount implements RequiredActionProvider, RequiredActionFact
       if(!clientHasDeleteAccountRole(context)) {
         throw new ForbiddenException();
       }
+
+      UserSessionUtil.logoutAllUserSessions(session, realm, user);
+
       boolean removed = new UserManager(session).removeUser(realm, user);
 
       if (removed) {

--- a/services/src/main/java/org/keycloak/models/workflow/DeleteUserStepProvider.java
+++ b/services/src/main/java/org/keycloak/models/workflow/DeleteUserStepProvider.java
@@ -23,6 +23,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.UserCache;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageUtil;
 
@@ -53,6 +54,8 @@ public class DeleteUserStepProvider implements WorkflowStepProvider {
         if (user == null) {
             return;
         }
+
+        UserSessionUtil.logoutAllUserSessions(session, realm, user);
 
         UserManager userManager = new UserManager(session);
         if (!user.isFederated() || stepModel.get(PROPAGATE_TO_SP, false)) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -114,6 +114,7 @@ import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.storage.ReadOnlyException;
 import org.keycloak.userprofile.UserProfile;
@@ -709,6 +710,8 @@ public class UserResource {
         UserRepresentation userRepresentation = new UserRepresentation();
         userRepresentation.setId(user.getId());
         userRepresentation.setUsername(user.getUsername());
+
+        UserSessionUtil.logoutAllUserSessions(session, realm, user);
 
         boolean removed = new UserManager(session).removeUser(realm, user);
         if (removed) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -113,6 +113,7 @@ import org.keycloak.services.messages.Messages;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.services.validation.Validation;
 import org.keycloak.storage.ReadOnlyException;
 import org.keycloak.userprofile.UserProfile;
@@ -725,6 +726,8 @@ public class UserResource {
         UserRepresentation userRepresentation = new UserRepresentation();
         userRepresentation.setId(user.getId());
         userRepresentation.setUsername(user.getUsername());
+
+        UserSessionUtil.logoutAllUserSessions(session, realm, user);
 
         boolean removed = new UserManager(session).removeUser(realm, user);
         if (removed) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/DeleteAccountActionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/DeleteAccountActionTest.java
@@ -4,11 +4,14 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.ClientsResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.requiredactions.DeleteAccount;
 import org.keycloak.cookie.CookieType;
 import org.keycloak.events.EventType;
 import org.keycloak.models.AccountRoles;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
@@ -125,6 +128,51 @@ public class DeleteAccountActionTest extends AbstractTestRealmKeycloakTest {
     errorPage.assertCurrent();
 
     Assertions.assertEquals(errorPage.getError(), "You do not have enough permissions to delete your own account, contact admin.");
+  }
+
+  @Test
+  public void deleteAccountTriggersBackchannelLogout() {
+    String username = "backchannel-delete-user";
+    UserRepresentation userRep = UserBuilder.create()
+            .username(username)
+            .password("password")
+            .enabled(true)
+            .build();
+    managedRealm.admin().users().create(userRep).close();
+    addDeleteAccountRoleToUserClientRoles(username);
+
+    ClientsResource clients = managedRealm.admin().clients();
+    ClientRepresentation clientRep = clients.findByClientId("test-app").get(0);
+    clientRep.setDirectAccessGrantsEnabled(true);
+    clientRep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL,
+            oauth.APP_ROOT + "/admin/backchannelLogout");
+    ClientResource clientResource = clients.get(clientRep.getId());
+    clientResource.update(clientRep);
+
+    try {
+      oauth.doPasswordGrantRequest(username, "password");
+
+      UserRepresentation user = ActionUtil.findUserWithAdminClient(adminClient, username);
+      UserBuilder.update(user).requiredActions(DeleteAccount.PROVIDER_ID);
+      managedRealm.admin().users().get(user.getId()).update(user);
+
+      oauth.openLoginForm();
+      loginPage.login(username, "password");
+
+      Assertions.assertTrue(deleteAccountPage.isCurrent());
+      deleteAccountPage.clickConfirmAction();
+
+      events.expect(EventType.DELETE_ACCOUNT);
+
+      String rawLogoutToken = testingClient.testApp().getBackChannelRawLogoutToken();
+      Assertions.assertNotNull(rawLogoutToken, "Backchannel logout token should be received when user deletes account");
+
+      List<UserRepresentation> users = managedRealm.admin().users().search(username);
+      Assertions.assertEquals(0, users.size());
+    } finally {
+      clientRep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "");
+      clientResource.update(clientRep);
+    }
   }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.admin.client.resource.ClientResource;
@@ -533,5 +534,45 @@ public class LogoutTest extends AbstractKeycloakTest {
         loginPage.assertCurrent();
 
         return tokenResponse;
+    }
+
+    @Test
+    public void backchannelLogoutOnUserDeletion() throws Exception {
+        String testUserName = "backchannel-deletion-test-user";
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(testUserName);
+        user.setEmail(testUserName + "@localhost");
+        user.setEnabled(true);
+        Response response = adminClient.realm("test").users().create(user);
+        String testUserId = ApiUtil.getCreatedId(response);
+        response.close();
+        ApiUtil.resetUserPassword(adminClient.realm("test").users().get(testUserId), "password", false);
+
+        ClientsResource clients = adminClient.realm("test").clients();
+        ClientRepresentation clientRep = clients.findByClientId("test-app").get(0);
+        clientRep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, oauth.APP_ROOT + "/admin/backchannelLogout");
+        ClientResource clientResource = clients.get(clientRep.getId());
+        clientResource.update(clientRep);
+
+        try {
+            oauth.doLogin(testUserName, "password");
+            String code = oauth.parseLoginResponse().getCode();
+            AccessTokenResponse tokenResponse = oauth.accessTokenRequest(code)
+                    .param(AdapterConstants.CLIENT_SESSION_STATE, "client-session")
+                    .send();
+            assertNotNull(tokenResponse.getAccessToken());
+
+            adminClient.realm("test").users().get(testUserId).remove();
+
+            String rawLogoutToken = testingClient.testApp().getBackChannelRawLogoutToken();
+            assertNotNull("Backchannel logout token should be received when user is deleted", rawLogoutToken);
+
+            JWSInput jwsInput = new JWSInput(rawLogoutToken);
+            LogoutToken logoutToken = jwsInput.readJsonContent(LogoutToken.class);
+            validateLogoutToken(logoutToken);
+        } finally {
+            clientRep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "");
+            clientResource.update(clientRep);
+        }
     }
 }


### PR DESCRIPTION
Centralize logout logic in UserSessionUtil.logoutAllUserSessions(). Add setNotBeforeForUser to invalidate tokens before deletion. Skip setNotBeforeForUser for lightweight users (they don't persist). Trigger backchannel logout for all user sessions (online and offline). Apply to all three deletion paths:
- Admin API deletion (UserResource.deleteUser)
- Self-service deletion (DeleteAccount.processAction)
- Workflow deletion (DeleteUserStepProvider.run)

This ensures that when a user is deleted, all clients with backchannel logout URLs configured are notified via backchannel logout requests.

Closes #45120