### PR TITLE
Fix: Prevent brute force counter increment on session limit denial

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -174,9 +174,9 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
                         .map(f -> f.get(UserSessionLimitsAuthenticatorFactory.ERROR_MESSAGE))
                         .orElse(SESSION_LIMIT_EXCEEDED);
 
-                context.getEvent().error(Errors.GENERIC_AUTHENTICATION_ERROR);
+                context.getEvent().error(Errors.ACCESS_DENIED);
                 Response challenge = context.form().setError(errorMessage).createErrorPage(Response.Status.FORBIDDEN);
-                context.failure(AuthenticationFlowError.GENERIC_AUTHENTICATION_ERROR, challenge, eventDetails, errorMessage);
+                context.forceChallenge(challenge);
                 return Collections.emptyList();
 
             case UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION:

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -146,7 +146,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
         // Login the same user again and verify the configured error message is shown
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
-        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
         errorPage.assertCurrent();
         assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
     }
@@ -211,7 +211,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             // Login the same user again and verify the configured error message is shown
             loginPage.open();
             loginPage.login("test-user@localhost", "password");
-            events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
             errorPage.assertCurrent();
             assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
         } finally {
@@ -440,7 +440,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
             driver.navigate().to(changePasswordUrl.trim());
 
-            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.ACCESS_DENIED).assertEvent();
         } finally {
             testRealm().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).setDirectAccessGrantsEnabled(false);
             ApiUtil.resetUserPassword(testRealm().users().get(findUser("test-user@localhost").getId()), "password", false);
@@ -527,7 +527,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
             driver.navigate().to(changePasswordUrl.trim());
 
-            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.ACCESS_DENIED).assertEvent();
         } finally {
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "0");
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "1");
@@ -622,7 +622,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
         // New login should fail due the sessions limit
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
-        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
         errorPage.assertCurrent();
         assertEquals("There are too many sessions", errorPage.getError()); // Default error message
 


### PR DESCRIPTION
### Root Cause
 
Users with valid credentials were being locked out when hitting session limits because the system treated session denials as authentication failures, incrementing the brute force counter.

### Solution
 
Changed DENY_NEW_SESSION handling from context.failure() to context.forceChallenge()
Updated error event from GENERIC_AUTHENTICATION_ERROR to ACCESS_DENIED
Updated tests to match new error behavior
 
### Impact
 
Session limit denials no longer increment brute force counters, preventing legitimate users from being locked out due to session limits.
 
Fixes: #44474
