### PR TITLE
JWT Authorization Grant for Google idp

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityProviderTypeUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityProviderTypeUtil.java
@@ -49,7 +49,7 @@ public class IdentityProviderTypeUtil {
         KeycloakSessionFactory sf = session.getKeycloakSessionFactory();
 
         Stream<ProviderFactory> factories = sf.getProviderFactoriesStream(IdentityProvider.class);
-        if (types.contains(IdentityProviderType.ANY) || types.contains(IdentityProviderType.USER_AUTHENTICATION)) {
+        if (types.contains(IdentityProviderType.ANY) || types.contains(IdentityProviderType.USER_AUTHENTICATION) || types.contains(IdentityProviderType.JWT_AUTHORIZATION_GRANT)) {
             factories = Stream.concat(factories, sf.getProviderFactoriesStream(SocialIdentityProvider.class));
         }
 

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProvider.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.social.google;
 
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -43,15 +44,18 @@ import org.keycloak.services.ErrorResponseException;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class GoogleIdentityProvider extends OIDCIdentityProvider implements SocialIdentityProvider<OIDCIdentityProviderConfig> {
 
+    public static final String ISSUER_URL = "https://accounts.google.com";
     public static final String AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
     public static final String TOKEN_URL = "https://oauth2.googleapis.com/token";
     public static final String PROFILE_URL = "https://openidconnect.googleapis.com/v1/userinfo";
     public static final String TOKEN_INFO_URL = "https://oauth2.googleapis.com/tokeninfo";
+    public static final String JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
     public static final String DEFAULT_SCOPE = "openid profile email";
 
     private static final String OIDC_PARAMETER_HOSTED_DOMAINS = "hd";
@@ -63,6 +67,8 @@ public class GoogleIdentityProvider extends OIDCIdentityProvider implements Soci
         config.setAuthorizationUrl(AUTH_URL);
         config.setTokenUrl(TOKEN_URL);
         config.setUserInfoUrl(PROFILE_URL);
+        getConfig().setUseJwksUrl(true);
+        getConfig().setJwksUrl(JWKS_URL);
     }
 
     @Override
@@ -164,4 +170,14 @@ public class GoogleIdentityProvider extends OIDCIdentityProvider implements Soci
         throw new IdentityBrokerException("Hosted domain does not match.");
     }
 
+    @Override
+    public boolean isAssertionReuseAllowed() {
+        return true;
+    }
+
+    @Override
+    public List<String> getAllowedAudienceForJWTGrant() {
+        //google IDToken audience can only contain client-id, this is an exception compared to the RFC7523
+        return Collections.singletonList(getConfig().getClientId());
+    }
 }

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProvider.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.social.google;
 
-import java.util.Collections;
 import java.util.List;
 
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -69,6 +68,8 @@ public class GoogleIdentityProvider extends OIDCIdentityProvider implements Soci
         config.setUserInfoUrl(PROFILE_URL);
         getConfig().setUseJwksUrl(true);
         getConfig().setJwksUrl(JWKS_URL);
+        getConfig().setIssuer(ISSUER_URL);
+        getConfig().setAllowClientIdAsAudience(true);
     }
 
     @Override
@@ -173,11 +174,5 @@ public class GoogleIdentityProvider extends OIDCIdentityProvider implements Soci
     @Override
     public boolean isAssertionReuseAllowed() {
         return true;
-    }
-
-    @Override
-    public List<String> getAllowedAudienceForJWTGrant() {
-        //google IDToken audience can only contain client-id, this is an exception compared to the RFC7523
-        return Collections.singletonList(getConfig().getClientId());
     }
 }

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderConfig.java
@@ -16,13 +16,15 @@
  */
 package org.keycloak.social.google;
 
+import org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantConfig;
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.RealmModel;
 
 /**
  * @author Vlastimil Elias (velias at redhat dot com)
  */
-public class GoogleIdentityProviderConfig extends OIDCIdentityProviderConfig {
+public class GoogleIdentityProviderConfig extends OIDCIdentityProviderConfig implements JWTAuthorizationGrantConfig {
 
     public GoogleIdentityProviderConfig(IdentityProviderModel model) {
         super(model);
@@ -58,5 +60,12 @@ public class GoogleIdentityProviderConfig extends OIDCIdentityProviderConfig {
     
     public void setOfflineAccess(boolean offlineAccess) {
         getConfig().put("offlineAccess", String.valueOf(offlineAccess));
+    }
+
+    @Override
+    public void validate(RealmModel realm) {
+        if (!GoogleIdentityProvider.ISSUER_URL.equals(getConfig().get(ISSUER))) {
+           throw new IllegalArgumentException("The issuer url [" + getConfig().get(ISSUER) + "] is invalid");
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
@@ -18,8 +18,10 @@ package org.keycloak.social.google;
 
 import java.util.List;
 
+import org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantConfig;
 import org.keycloak.broker.provider.AbstractIdentityProviderFactory;
 import org.keycloak.broker.social.SocialIdentityProviderFactory;
+import org.keycloak.common.Profile;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -44,7 +46,9 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
 
     @Override
     public GoogleIdentityProviderConfig createConfig() {
-        return new GoogleIdentityProviderConfig();
+        GoogleIdentityProviderConfig config = new  GoogleIdentityProviderConfig();
+        config.getConfig().put(IdentityProviderModel.ISSUER, GoogleIdentityProvider.ISSUER_URL);
+        return config;
     }
 
     @Override
@@ -56,7 +60,7 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
     public List<ProviderConfigProperty> getConfigProperties() {
         // The supported authentication URI parameters can be found in the google identity documentation
         // See: https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters
-        return ProviderConfigurationBuilder.create()
+        List<ProviderConfigProperty> providerConfigProperties = ProviderConfigurationBuilder.create()
                 .property().name("prompt")
                 .label("Prompt")
                 .helpText("Set 'prompt' query parameter when logging in with Google. The allowed values are 'none', 'consent' and 'select_account'. " +
@@ -80,5 +84,18 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
                         "Google token to access Google APIs when the user is not at the browser.")
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .add().build();
+
+        if (Profile.isFeatureEnabled(Profile.Feature.JWT_AUTHORIZATION_GRANT)) {
+            //easier to add to previous builder when feature will be supported
+            providerConfigProperties.addAll(ProviderConfigurationBuilder.create()
+                    .property().name(JWTAuthorizationGrantConfig.JWT_AUTHORIZATION_GRANT_ENABLED)
+                    .label("JWT Authorization Grant")
+                    .helpText("Enable the Google identity provider to act as a trust provider to validate " +
+                            "authorization grant JWT assertions (Google ID Token) according to RFC 7523, " +
+                            "except for the audience claim that must contain the client id of the configured client")
+                    .type(ProviderConfigProperty.BOOLEAN_TYPE).add().build());
+        }
+
+        return providerConfigProperties;
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderTest.java
@@ -6,9 +6,11 @@ import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderStorageProvider;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.social.google.GoogleIdentityProvider;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.injection.LifeCycle;
@@ -134,4 +136,15 @@ public class IdentityProviderTest extends AbstractIdentityProviderTest {
         response = managedRealm.admin().identityProviders().getIdentityProviders("nonexistent");
         Assertions.assertEquals(400, response.getStatus(), "Status");
     }
+
+    @Test
+    public void testGoogleIDPConfiguration() {
+        Response response = managedRealm.admin().identityProviders().create(createRep("google", "google", false, Map.of(OIDCIdentityProviderConfig.ISSUER, "bad-issuer")));
+        Assertions.assertEquals(400, response.getStatus(), "Status");
+
+        create(createRep("google", "google"));
+        IdentityProviderRepresentation googleIdentityProvider = managedRealm.admin().identityProviders().get("google").toRepresentation();
+        Assertions.assertEquals(GoogleIdentityProvider.ISSUER_URL, googleIdentityProvider.getConfig().get(OIDCIdentityProviderConfig.ISSUER));
+    }
+
 }


### PR DESCRIPTION
Closes #45179

PR to add support for the JWT Authorization Grant for the Google Identity Provider.

- I added a switch on the Google IdP to enable the JWT Authorization Grant, and implemented the `getAllowedAudienceForJWTGrant` to accept only the client-id as audience.

- The `isAssertionReuseAllowed` is also always true because the `jti` is missing in the Google IDToken.
 - Google’s IDToken is a JWT and can be validated “offline” without calling the token info endpoint, because Google provides the JWKS endpoint: `https://www.googleapis.com/oauth2/v3/certs`.
- The `validateAuthorizationGrantAssertion` is the same of the `OIDCIdentityProvider`

- To use the `DefaultAlternativeLookupProvider.lookupIdentityProviderFromIssuer()` we need the Google issuer in the config map of the idp model.
I initialized the issuer value in `GoogleIdentityProviderConfig.createConfig()`, and when the IdP is saved from the Admin UI, the configuration is persisted with the correct issuer value.
The idea is that for the already configured idps to use the JWT Authorization Grant you must enable the switch, which updates the configuration and automatically persists the issuer as well. So the case where the JWT auth grant is enabled without the issuer in the configuration should never occur.
WDYT? Is this approach too weak? The alternative would be to somehow modify `DefaultAlternativeLookupProvider.lookupIdentityProviderFromIssuer() `to get the IdP.

- I tested everything manually, and I added a test only to validate the issuer configuration.



<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
