### PR TITLE
Fix missing validation error labels when editing a user

### DIFF
--- a/js/apps/admin-ui/src/user/EditUser.tsx
+++ b/js/apps/admin-ui/src/user/EditUser.tsx
@@ -59,6 +59,7 @@ import {
 import { UserParams, UserTab, toUser } from "./routes/User";
 import { toUsers } from "./routes/Users";
 import { isLightweightUser } from "./utils";
+import { extractUserProfileErrorMessages } from "./utils/user-profile";
 
 import "./user-section.css";
 import { AdminEvents } from "../events/AdminEvents";
@@ -193,14 +194,19 @@ export default function EditUser() {
             (field, params) => {
               if (field.startsWith("attributes.")) {
                 const attributeName = field.substring("attributes.".length);
+                let isUnmanagedAttribute = false;
                 (data.unmanagedAttributes as KeyValueType[]).forEach(
                   (attr, index) => {
                     if (attr.key === attributeName) {
                       unmanagedAttributeErrors[index] = params;
                       someUnmanagedAttributeError = true;
+                      isUnmanagedAttribute = true;
                     }
                   },
                 );
+                if (!isUnmanagedAttribute) {
+                  form.setError(field, params);
+                }
               } else {
                 form.setError(field, params);
               }
@@ -219,7 +225,8 @@ export default function EditUser() {
             param,
           ) => t(key as string, param as any)) as TFunction);
         }
-        addError("userNotSaved", "");
+        const errorMessage = extractUserProfileErrorMessages(error, t);
+        addError("userNotSaved", errorMessage);
       } else {
         addError("userCreateError", error);
       }

--- a/js/apps/admin-ui/src/user/utils/user-profile.ts
+++ b/js/apps/admin-ui/src/user/utils/user-profile.ts
@@ -1,4 +1,6 @@
 import { UserProfileAttributeMetadata } from "@keycloak/keycloak-admin-client/lib/defs/userProfileMetadata";
+import { isUserProfileError } from "@keycloak/keycloak-ui-shared";
+import { TFunction } from "i18next";
 
 export function isRequiredAttribute({
   required,
@@ -6,6 +8,46 @@ export function isRequiredAttribute({
 }: UserProfileAttributeMetadata): boolean {
   // Check if required is true or if the validators include a validation that would make the attribute implicitly required.
   return required || hasRequiredValidators(validators);
+}
+
+/**
+ * Extracts error messages from a UserProfileError and formats them as a single string.
+ * Handles both single error and multiple errors in the responseData structure.
+ *
+ * @param error - The error object (should be a UserProfileError)
+ * @param t - Translation function
+ * @returns Formatted error message string with all errors joined by semicolons
+ */
+export function extractUserProfileErrorMessages(
+  error: unknown,
+  t: TFunction,
+): string {
+  if (!isUserProfileError(error)) {
+    return "";
+  }
+
+  const responseData = error.responseData as
+    | { errors?: { errorMessage?: string; params?: string[] }[] }
+    | { errorMessage?: string; params?: string[] };
+
+  const errors =
+    "errors" in responseData && responseData.errors
+      ? responseData.errors
+      : [responseData as { errorMessage?: string; params?: string[] }];
+
+  const errorMessages = errors
+    .map((e) => {
+      const params = e.params
+        ? Object.fromEntries(e.params.map((v, i) => [i.toString(), v]))
+        : {};
+      return t(e.errorMessage || "", {
+        ...params,
+        defaultValue: e.errorMessage,
+      });
+    })
+    .filter((msg) => msg && msg.trim() !== "");
+
+  return errorMessages.length > 0 ? errorMessages.join("; ") : "";
 }
 
 /**


### PR DESCRIPTION
When editing a user and validation errors occur:
- Toast notification now shows actual error messages instead of empty string
- Inline errors now appear below custom User Profile attributes
- Errors are properly extracted and displayed for both single and multiple errors

The fix ensures that custom User Profile attributes (with 'attributes.' prefix) are handled correctly even when unmanaged attributes are enabled.

### 1. Toast notification with error message
**Before**: 
- Toast showed an empty message ("The user has not been saved: ") when validation errors occurred.
-  Inline validation errors did not appear below custom User Profile attributes when editing a user, even though they worked for standard fields like email.

**After the fix**: 
- Toast displays the actual error message extracted from the server response, making it clear why the save failed.
- Inline errors now appear below custom User Profile attributes (e.g., customRequired), providing immediate feedback when required fields are empty or validation fails. This matches the behavior seen when creating a new user.

<img src="https://github.com/user-attachments/assets/c666c003-dab9-48f9-a654-f8a3d9434381" width="600" height="400" alt="UserAttributes1">

### 2. Toast notification with multiple error messages

<img src="https://github.com/user-attachments/assets/e31af3d0-d548-4842-b890-180f4600864c" width="600" height="400" alt="UserAttributes1">

### 3. Attributes Section 
**Before**: 
- Toast showed an empty message ("The user has not been saved: ") when validation errors occurred.
**After the fix**: 
- Toast displays the actual error message extracted from the server response, making it clear why the save failed.

<img src="https://github.com/user-attachments/assets/3b5f047c-88fc-410a-a448-5b4434f17d7f" width="600" height="400" alt="UserAttributes1">



Closes #44819


