### PR TITLE
Hot deploy custom providers from module to test server

### DIFF
--- a/test-framework/core/pom.xml
+++ b/test-framework/core/pom.xml
@@ -84,12 +84,10 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-            <version>${version.shrinkwrap}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <version>${version.shrinkwrap}</version>
         </dependency>
     </dependencies>
 

--- a/test-framework/core/pom.xml
+++ b/test-framework/core/pom.xml
@@ -81,6 +81,16 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-bootstrap-maven-resolver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <version>${version.shrinkwrap}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <version>${version.shrinkwrap}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/AuthenticationFlowConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/AuthenticationFlowConfigBuilder.java
@@ -2,6 +2,7 @@ package org.keycloak.testframework.realm;
 
 import org.keycloak.representations.idm.AuthenticationExecutionExportRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
+import org.keycloak.testframework.util.Collections;
 
 public class AuthenticationFlowConfigBuilder {
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/ClientConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/ClientConfigBuilder.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testframework.util.Collections;
 
 public class ClientConfigBuilder {
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/GroupConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/GroupConfigBuilder.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.testframework.util.Collections;
 
 public class GroupConfigBuilder {
     private final GroupRepresentation rep;

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/RealmConfigBuilder.java
@@ -18,6 +18,7 @@ import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.util.Collections;
 
 public class RealmConfigBuilder {
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/RoleConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/RoleConfigBuilder.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.testframework.util.Collections;
 
 public class RoleConfigBuilder {
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/realm/UserConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/realm/UserConfigBuilder.java
@@ -10,6 +10,7 @@ import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.FederatedIdentityRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.util.Collections;
 
 public class UserConfigBuilder {
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/EmbeddedKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/EmbeddedKeycloakServer.java
@@ -7,7 +7,6 @@ import org.keycloak.Keycloak;
 import org.keycloak.common.Version;
 import org.keycloak.it.utils.Maven;
 
-import io.quarkus.maven.dependency.Dependency;
 import org.eclipse.aether.artifact.Artifact;
 
 public class EmbeddedKeycloakServer implements KeycloakServer {
@@ -20,7 +19,7 @@ public class EmbeddedKeycloakServer implements KeycloakServer {
         Keycloak.Builder builder = Keycloak.builder().setVersion(Version.VERSION);
         this.tlsEnabled = tlsEnabled;
 
-        for(Dependency dependency : keycloakServerConfigBuilder.toDependencies()) {
+        for(KeycloakDependency dependency : keycloakServerConfigBuilder.toDependencies()) {
             var version = Optional.ofNullable(Maven.getArtifact(dependency.getGroupId(), dependency.getArtifactId()))
                     .map(Artifact::getVersion)
                     .orElse("");

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakDependency.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakDependency.java
@@ -1,0 +1,46 @@
+package org.keycloak.testframework.server;
+
+import io.quarkus.maven.dependency.ArtifactDependency;
+import io.quarkus.maven.dependency.DependencyBuilder;
+
+public class KeycloakDependency extends ArtifactDependency {
+
+    private final boolean hotDeployable;
+
+    private KeycloakDependency(Builder dependencyBuilder) {
+        super(dependencyBuilder);
+        this.hotDeployable = dependencyBuilder.hotDeployable;
+    }
+
+    public boolean isHotDeployable() {
+        return this.hotDeployable;
+    }
+
+    public static class Builder extends DependencyBuilder {
+
+        private boolean hotDeployable;
+
+        public Builder hotDeployable(boolean hotDeployable) {
+            this.hotDeployable = hotDeployable;
+            return this;
+        }
+
+        @Override
+        public Builder setGroupId(String groupId) {
+            super.setGroupId(groupId);
+            return this;
+        }
+
+        @Override
+        public Builder setArtifactId(String artifactId) {
+            super.setArtifactId(artifactId);
+            return this;
+        }
+
+        @Override
+        public KeycloakDependency build() {
+            return new KeycloakDependency(this);
+        }
+
+    }
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakDependency.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakDependency.java
@@ -6,22 +6,34 @@ import io.quarkus.maven.dependency.DependencyBuilder;
 public class KeycloakDependency extends ArtifactDependency {
 
     private final boolean hotDeployable;
+    private final boolean dependencyCurrentProject;
 
     private KeycloakDependency(Builder dependencyBuilder) {
         super(dependencyBuilder);
         this.hotDeployable = dependencyBuilder.hotDeployable;
+        this.dependencyCurrentProject = dependencyBuilder.dependencyCurrentProject;
     }
 
     public boolean isHotDeployable() {
         return this.hotDeployable;
     }
 
+    public boolean dependencyCurrentProject() {
+        return this.dependencyCurrentProject;
+    }
+
     public static class Builder extends DependencyBuilder {
 
-        private boolean hotDeployable;
+        private boolean hotDeployable = false;
+        private boolean dependencyCurrentProject = false;
 
         public Builder hotDeployable(boolean hotDeployable) {
             this.hotDeployable = hotDeployable;
+            return this;
+        }
+
+        public Builder dependencyCurrentProject(boolean dependencyCurrentProject) {
+            this.dependencyCurrentProject = dependencyCurrentProject;
             return this;
         }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServer.java
@@ -1,5 +1,7 @@
 package org.keycloak.testframework.server;
 
+import org.keycloak.testframework.config.Config;
+
 public interface KeycloakServer {
 
     void start(KeycloakServerConfigBuilder keycloakServerConfigBuilder, boolean tlsEnabled);
@@ -9,5 +11,9 @@ public interface KeycloakServer {
     String getBaseUrl();
 
     String getManagementBaseUrl();
+
+    static boolean getDependencyHotDeployEnabled() {
+        return Boolean.parseBoolean(Config.getValueTypeConfig(KeycloakServer.class, "hot.deploy", "false", String.class));
+    }
 
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
@@ -12,8 +12,6 @@ import java.util.stream.Collectors;
 import org.keycloak.common.Profile;
 import org.keycloak.testframework.infinispan.CacheType;
 
-import io.quarkus.maven.dependency.Dependency;
-import io.quarkus.maven.dependency.DependencyBuilder;
 import io.smallrye.config.SmallRyeConfig;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 
@@ -26,7 +24,7 @@ public class KeycloakServerConfigBuilder {
     private final Set<String> features = new HashSet<>();
     private final Set<String> featuresDisabled = new HashSet<>();
     private final LogBuilder log = new LogBuilder();
-    private final Set<Dependency> dependencies = new HashSet<>();
+    private final Set<KeycloakDependency> dependencies = new HashSet<>();
     private CacheType cacheType = CacheType.LOCAL;
     private boolean externalInfinispan = false;
 
@@ -172,7 +170,11 @@ public class KeycloakServerConfigBuilder {
      * @return
      */
     public KeycloakServerConfigBuilder dependency(String groupId, String artifactId) {
-        dependencies.add(new DependencyBuilder().setGroupId(groupId).setArtifactId(artifactId).build());
+        return dependency(groupId, artifactId, false);
+    }
+
+    public KeycloakServerConfigBuilder dependency(String groupId, String artifactId, boolean hotDeployable) {
+        dependencies.add(new KeycloakDependency.Builder().setGroupId(groupId).setArtifactId(artifactId).hotDeployable(hotDeployable).build());
         return this;
     }
 
@@ -288,7 +290,7 @@ public class KeycloakServerConfigBuilder {
         return args;
     }
 
-    Set<Dependency> toDependencies() {
+    Set<KeycloakDependency> toDependencies() {
         return dependencies;
     }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
@@ -170,12 +170,27 @@ public class KeycloakServerConfigBuilder {
      * @return
      */
     public KeycloakServerConfigBuilder dependency(String groupId, String artifactId) {
-        return dependency(groupId, artifactId, false);
+        return dependency(groupId, artifactId, false, false);
     }
 
     public KeycloakServerConfigBuilder dependency(String groupId, String artifactId, boolean hotDeployable) {
-        dependencies.add(new KeycloakDependency.Builder().setGroupId(groupId).setArtifactId(artifactId).hotDeployable(hotDeployable).build());
+        return dependency(groupId, artifactId, hotDeployable, false);
+    }
+
+    private KeycloakServerConfigBuilder dependency(String groupId, String artifactId, boolean hotDeployable, boolean dependencyCurrentProject) {
+        dependencies.add(
+                new KeycloakDependency.Builder()
+                        .setGroupId(groupId)
+                        .setArtifactId(artifactId)
+                        .hotDeployable(hotDeployable)
+                        .dependencyCurrentProject(dependencyCurrentProject)
+                        .build()
+        );
         return this;
+    }
+
+    public KeycloakServerConfigBuilder dependencyCurrentProject() {
+        return dependency("", "", false, true);
     }
 
     public class LogBuilder {

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/ProviderDeployer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/ProviderDeployer.java
@@ -1,0 +1,125 @@
+package org.keycloak.testframework.server;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.keycloak.it.utils.Maven;
+import org.keycloak.testframework.util.Collections;
+import org.keycloak.testframework.util.FileUtils;
+import org.keycloak.testframework.util.MavenProjectUtil;
+
+import io.quarkus.bootstrap.resolver.maven.workspace.LocalProject;
+import org.jboss.logging.Logger;
+
+public final class ProviderDeployer {
+
+    private final Logger log;
+
+    private final File providersDir;
+    private final Path providersPath;
+    private final boolean hotDeployEnabled;
+
+    private final Set<KeycloakDependency> requestedDependencies;
+    private final List<File> existingDependencies;
+
+    public ProviderDeployer(Logger log, File keycloakHomeDir, Set<KeycloakDependency> requestedDependencies) {
+        this.log = log;
+
+        this.providersDir = new File(keycloakHomeDir, "providers");
+        this.providersPath = providersDir.toPath();
+
+        this.requestedDependencies = requestedDependencies;
+        this.existingDependencies = listExistingDependencies();
+
+        this.hotDeployEnabled = KeycloakServer.getDependencyHotDeployEnabled();
+    }
+
+    public boolean areDependenciesCompatible() {
+        Set<String> requestedDependencies = this.requestedDependencies.stream().map(this::getDependencyJarName).collect(Collectors.toSet());
+        Set<String> startedWithDependencies = this.existingDependencies.stream().map(File::getName).collect(Collectors.toSet());
+        return Collections.equals(requestedDependencies, startedWithDependencies);
+    }
+
+    public void updateDependencies() throws IOException {
+        deleteNotRequestedDependencies();
+
+        for (KeycloakDependency d : requestedDependencies) {
+            boolean shouldPackageClasses = hotDeployEnabled && d.isHotDeployable();
+
+            String jarName = getDependencyJarName(d);
+            Path dependencyPath = getDependencyPath(d);
+            File dependencyFile = dependencyPath.toFile();
+            Path targetPath = providersPath.resolve(jarName);
+            File targetFile = targetPath.toFile();
+            File targetLastModified = new File(targetFile.getAbsolutePath() + ".lastModified");
+            long lastModified = targetLastModified.isFile() ? FileUtils.readLongFromFile(targetLastModified) : -1;
+
+            if (lastModified != dependencyPath.toFile().lastModified() || !targetFile.isFile()) {
+                log.trace("Adding or overwriting existing provider: " + targetPath.toFile().getAbsolutePath());
+
+                if (shouldPackageClasses || d.dependencyCurrentProject()) {
+                    MavenProjectUtil.buildJar(jarName, dependencyPath, targetPath);
+                } else {
+                    Files.copy(dependencyPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+                Files.writeString(targetLastModified.toPath(), Long.toString(dependencyFile.lastModified()));
+            }
+        }
+    }
+
+    private List<File> listExistingDependencies() {
+        if (providersDir.isDirectory()) {
+            File[] files = providersDir.listFiles(n -> n.getName().endsWith(".jar"));
+            if (files != null) {
+                return Arrays.stream(files).toList();
+            }
+        }
+        return List.of();
+    }
+
+    private String getDependencyJarName(KeycloakDependency dependency) {
+        String groupId = dependency.getGroupId();
+        String artifactId = dependency.getArtifactId();
+
+        if (dependency.dependencyCurrentProject()) {
+            LocalProject project = MavenProjectUtil.getCurrentModule();
+
+            groupId = project.getGroupId();
+            artifactId = project.getArtifactId();
+        }
+
+        return groupId + "__" + artifactId + ".jar";
+    }
+
+    private void deleteNotRequestedDependencies() {
+        existingDependencies.stream()
+                .filter(f -> {
+                    String fileName = f.getName();
+                    return requestedDependencies.stream().noneMatch(d -> fileName.equals(getDependencyJarName(d)));
+                }).forEach(f -> {
+                    log.trace("Deleted non-requested provider: " + f.getAbsolutePath());
+                    FileUtils.delete(f);
+                    FileUtils.delete(new File(f.getAbsolutePath() + ".lastModified"));
+                });
+    }
+
+    private Path getDependencyPath(KeycloakDependency d) {
+        if (d.dependencyCurrentProject()) {
+            return MavenProjectUtil.getCurrentModule().getClassesDir();
+        }
+
+        if (d.isHotDeployable() && hotDeployEnabled) {
+            return MavenProjectUtil.findLocalModule(d.getGroupId(), d.getArtifactId()).getClassesDir();
+        }
+
+        return Maven.resolveArtifact(d.getGroupId(), d.getArtifactId());
+    }
+
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/RemoteKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/RemoteKeycloakServer.java
@@ -10,8 +10,6 @@ import javax.net.ssl.SSLException;
 import org.keycloak.it.utils.Maven;
 import org.keycloak.testframework.config.Config;
 
-import io.quarkus.maven.dependency.Dependency;
-
 import static java.lang.System.out;
 
 public class RemoteKeycloakServer implements KeycloakServer {
@@ -62,10 +60,10 @@ public class RemoteKeycloakServer implements KeycloakServer {
         out.println(String.join(" \\\n", config.toArgs()));
         out.println();
 
-        Set<Dependency> dependencies = config.toDependencies();
+        Set<KeycloakDependency> dependencies = config.toDependencies();
         if (!dependencies.isEmpty()) {
             out.println("Requested providers:");
-            for (Dependency d : dependencies) {
+            for (KeycloakDependency d : dependencies) {
                 out.println("* " + d.getGroupId() + ":" + d.getArtifactId());
             }
             out.println();
@@ -76,7 +74,7 @@ public class RemoteKeycloakServer implements KeycloakServer {
         out.println("Remote Keycloak server is not running on " + getBaseUrl() + ", please start Keycloak with:");
         out.println();
 
-        Set<Dependency> dependencies = config.toDependencies();
+        Set<KeycloakDependency> dependencies = config.toDependencies();
         if (!dependencies.isEmpty()) {
             String dependencyPaths = dependencies.stream().map(d -> Maven.resolveArtifact(d.getGroupId(), d.getArtifactId()).toString()).collect(Collectors.joining(","));
             out.println("KCW_PROVIDERS=" + dependencyPaths + " \\");

--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/Collections.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/Collections.java
@@ -74,8 +74,4 @@ public class Collections {
         return combine(m1, Map.of(key, values.toList()));
     }
 
-    public static <T> boolean equals(Set<T> a, Set<T> b) {
-        return a.size() == b.size() && a.containsAll(b);
-    }
-
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/Collections.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/Collections.java
@@ -1,4 +1,4 @@
-package org.keycloak.testframework.realm;
+package org.keycloak.testframework.util;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -10,12 +10,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-class Collections {
+public class Collections {
 
     private Collections() {
     }
 
-    static <T> List<T> combine(List<T> l1, List<T> l2) {
+    public static <T> List<T> combine(List<T> l1, List<T> l2) {
         if (l1 == null) {
             return new LinkedList<>(l2);
         } else {
@@ -25,16 +25,16 @@ class Collections {
     }
 
     @SafeVarargs
-    static <T> List<T> combine(List<T> l1, T... items) {
+    public static <T> List<T> combine(List<T> l1, T... items) {
         return combine(l1, Arrays.asList(items));
     }
 
-    static <T> List<T> combine(List<T> l1, Stream<T> items) {
+    public static <T> List<T> combine(List<T> l1, Stream<T> items) {
         return combine(l1, items.toList());
     }
 
 
-    static <T> Set<T> combine(Set<T> s1, Set<T> s2) {
+    public static <T> Set<T> combine(Set<T> s1, Set<T> s2) {
         if (s1 == null) {
             return new HashSet<>(s2);
         } else {
@@ -44,16 +44,16 @@ class Collections {
     }
 
     @SafeVarargs
-    static <T> Set<T> combine(Set<T> s1, T... items) {
+    public static <T> Set<T> combine(Set<T> s1, T... items) {
         return combine(s1, Set.of(items));
     }
 
-    static <T> Set<T> combine(Set<T> s1, Stream<T> items) {
+    public static <T> Set<T> combine(Set<T> s1, Stream<T> items) {
         return combine(s1, items.collect(Collectors.toSet()));
     }
 
 
-    static <K, V> Map<K, List<V>> combine(Map<K, List<V>> m1, Map<K, List<V>> m2) {
+    public static <K, V> Map<K, List<V>> combine(Map<K, List<V>> m1, Map<K, List<V>> m2) {
         if (m1 == null) {
             m1 = new HashMap<>();
         }
@@ -66,12 +66,16 @@ class Collections {
     }
 
     @SafeVarargs
-    static <K, V> Map<K, List<V>> combine(Map<K, List<V>> m1, K key, V... values) {
+    public static <K, V> Map<K, List<V>> combine(Map<K, List<V>> m1, K key, V... values) {
         return combine(m1, Map.of(key, List.of(values)));
     }
 
-    static <K, V> Map<K, List<V>> combine(Map<K, List<V>> m1, K key, Stream<V> values) {
+    public static <K, V> Map<K, List<V>> combine(Map<K, List<V>> m1, K key, Stream<V> values) {
         return combine(m1, Map.of(key, values.toList()));
+    }
+
+    public static <T> boolean equals(Set<T> a, Set<T> b) {
+        return a.size() == b.size() && a.containsAll(b);
     }
 
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/JarUtil.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/JarUtil.java
@@ -1,0 +1,46 @@
+package org.keycloak.testframework.util;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+
+public class JarUtil {
+
+    /**
+     * Builds a JAR from already-compiled classes and resources.
+     *
+     * @param jarName the JAR filename
+     * @param classesPath path to compiled output directory ({@code target/classes})
+     * @param targetPath path where to export the JAR
+     */
+    public static void buildModuleJar(String jarName, Path classesPath, Path targetPath) {
+        JavaArchive providerJar = ShrinkWrap.create(JavaArchive.class, jarName);
+
+        try (Stream<Path> sourcePathStream = Files.walk(classesPath)) {
+            sourcePathStream.filter(Files::isRegularFile)
+                    .forEach(p -> {
+                        String relativeFilePath = classesPath.relativize(p).toString();
+
+                        if (relativeFilePath.endsWith(".class")) {
+                            String fullyQualifiedClassName = relativeFilePath.replace(File.separatorChar, '.').substring(0, relativeFilePath.lastIndexOf('.'));
+                            providerJar.addClass(fullyQualifiedClassName);
+                        } else {
+                            File resourceFile = p.toFile();
+                            providerJar.addAsResource(resourceFile, relativeFilePath);
+                        }
+                    });
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        providerJar.as(ZipExporter.class).exportTo(targetPath.toFile(), true);
+    }
+}

--- a/test-framework/examples/providers/pom.xml
+++ b/test-framework/examples/providers/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.keycloak.testframework</groupId>
             <artifactId>keycloak-test-framework-core</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test-framework/examples/providers/pom.xml
+++ b/test-framework/examples/providers/pom.xml
@@ -36,6 +36,12 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-core</artifactId>
+            <version>${version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/examples/providers/src/main/java/org/keycloak/providers/example/MyCustomRealmResourceProvider.java
+++ b/test-framework/examples/providers/src/main/java/org/keycloak/providers/example/MyCustomRealmResourceProvider.java
@@ -11,6 +11,8 @@ import org.keycloak.services.resource.RealmResourceProvider;
 
 /**
  *
+ * @see org.keycloak.providers.example.MyCustomProviderWithinSameModuleTest
+ * @see org.keycloak.test.examples.MyCustomProviderTest
  * @author <a href="mailto:svacek@redhat.com">Simon Vacek</a>
  */
 public class MyCustomRealmResourceProvider  implements RealmResourceProvider {

--- a/test-framework/examples/providers/src/test/java/org/keycloak/providers/example/MyCustomProviderWithinSameModuleTest.java
+++ b/test-framework/examples/providers/src/test/java/org/keycloak/providers/example/MyCustomProviderWithinSameModuleTest.java
@@ -1,19 +1,17 @@
 package org.keycloak.providers.example;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.net.URL;
 
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,18 +28,16 @@ public class MyCustomProviderWithinSameModuleTest {
     @InjectRealm
     ManagedRealm realm;
 
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
     @Test
-    public void httpGetTest() {
-        String url = realm.getBaseUrl();
+    public void httpGetTest() throws IOException {
+        URL url = KeycloakUriBuilder.fromUri(realm.getBaseUrl()).path("/custom-provider/hello").build().toURL();
 
-        HttpUriRequest request = new HttpGet(url + "/custom-provider/hello");
-        try {
-            HttpResponse response = HttpClientBuilder.create().build().execute(request);
-            Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+        String response = simpleHttp.doGet(url.toString()).header("Accept", "text/plain").asString();
 
-            String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-            Assertions.assertEquals("Hello World!", content);
-        } catch (IOException ignored) {}
+        Assertions.assertEquals("Hello World!", response);
     }
 
     public static class ServerConfig implements KeycloakServerConfig {

--- a/test-framework/examples/providers/src/test/java/org/keycloak/providers/example/MyCustomProviderWithinSameModuleTest.java
+++ b/test-framework/examples/providers/src/test/java/org/keycloak/providers/example/MyCustomProviderWithinSameModuleTest.java
@@ -1,4 +1,4 @@
-package org.keycloak.test.examples;
+package org.keycloak.providers.example;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -21,11 +21,11 @@ import org.junit.jupiter.api.Test;
 /**
  *
  * @see org.keycloak.providers.example.MyCustomRealmResourceProvider
- * @see org.keycloak.providers.example.MyCustomProviderWithinSameModuleTest
+ * @see org.keycloak.test.examples.MyCustomProviderTest
  * @author <a href="mailto:svacek@redhat.com">Simon Vacek</a>
  */
-@KeycloakIntegrationTest(config = MyCustomProviderTest.ServerConfig.class)
-public class MyCustomProviderTest {
+@KeycloakIntegrationTest(config = MyCustomProviderWithinSameModuleTest.ServerConfig.class)
+public class MyCustomProviderWithinSameModuleTest {
 
     @InjectRealm
     ManagedRealm realm;
@@ -48,7 +48,7 @@ public class MyCustomProviderTest {
 
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.dependency("org.keycloak.testframework", "keycloak-test-framework-example-providers", true);
+            return config.dependencyCurrentProject();
         }
 
     }

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/MyCustomProviderTest.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/MyCustomProviderTest.java
@@ -46,7 +46,7 @@ public class MyCustomProviderTest {
 
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.dependency("org.keycloak.testframework", "keycloak-test-framework-example-providers");
+            return config.dependency("org.keycloak.testframework", "keycloak-test-framework-example-providers", true);
         }
 
     }

--- a/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/MyCustomProviderTest.java
+++ b/test-framework/examples/tests/src/test/java/org/keycloak/test/examples/MyCustomProviderTest.java
@@ -1,19 +1,17 @@
 package org.keycloak.test.examples;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.net.URL;
 
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,18 +28,16 @@ public class MyCustomProviderTest {
     @InjectRealm
     ManagedRealm realm;
 
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
     @Test
-    public void httpGetTest() {
-        String url = realm.getBaseUrl();
+    public void httpGetTest() throws IOException {
+        URL url = KeycloakUriBuilder.fromUri(realm.getBaseUrl()).path("/custom-provider/hello").build().toURL();
 
-        HttpUriRequest request = new HttpGet(url + "/custom-provider/hello");
-        try {
-            HttpResponse response = HttpClientBuilder.create().build().execute(request);
-            Assertions.assertEquals(200, response.getStatusLine().getStatusCode());
+        String response = simpleHttp.doGet(url.toString()).header("Accept", "text/plain").asString();
 
-            String content = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
-            Assertions.assertEquals("Hello World!", content);
-        } catch (IOException ignored) {}
+        Assertions.assertEquals("Hello World!", response);
     }
 
     public static class ServerConfig implements KeycloakServerConfig {

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -80,6 +80,16 @@
                 <artifactId>testcontainers-postgresql</artifactId>
                 <version>${version.testcontainers}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-api</artifactId>
+                <version>${version.shrinkwrap}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-impl-base</artifactId>
+                <version>${version.shrinkwrap}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <version.testcontainers>2.0.3</version.testcontainers>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Closes #34188 

Adds the `KC_TEST_SERVER_HOT_DEPLOY=[true/false]` config option. It affects only the `distribution` Keycloak server.

If enabled, dependencies and providers marked as `hotDeployable` will be packaged into a JAR from the most recent compiled sources and deployed.

This eliminates the need to compile this dependency before running tests with the `distribution` Keycloak server.

Also adds the option to deploy a provider from the current module with `KeycloakServerConfigBuilder#dependencyCurrentProject()`