### PR TITLE
Remove empty labels from keycloak_user_events_total metric (#45583)

### DIFF
--- a/docs/guides/observability/metrics-for-troubleshooting-keycloak.adoc
+++ b/docs/guides/observability/metrics-for-troubleshooting-keycloak.adoc
@@ -41,10 +41,10 @@ The snippet below is an example of a response provided by the metric endpoint:
 ----
 # HELP keycloak_user_events_total Keycloak user events
 # TYPE keycloak_user_events_total counter
-keycloak_user_events_total{client_id="security-admin-console",error="",event="code_to_token",idp="",realm="master",} 1.0
-keycloak_user_events_total{client_id="security-admin-console",error="",event="login",idp="",realm="master",} 1.0
-keycloak_user_events_total{client_id="security-admin-console",error="",event="logout",idp="",realm="master",} 1.0
-keycloak_user_events_total{client_id="security-admin-console",error="invalid_user_credentials",event="login",idp="",realm="master",} 1.0
+keycloak_user_events_total{client_id="security-admin-console",event="code_to_token",realm="master"} 1.0
+keycloak_user_events_total{client_id="security-admin-console",event="login",realm="master"} 1.0
+keycloak_user_events_total{client_id="security-admin-console",event="logout",realm="master"} 1.0
+keycloak_user_events_total{client_id="security-admin-console",error="invalid_user_credentials",event="login",realm="master"} 1.0
 ----
 
 === Password hashing
@@ -82,7 +82,7 @@ The snippet below is an example of a response provided by the metric endpoint:
 ----
 # HELP keycloak_credentials_password_hashing_validations_total Password validations
 # TYPE keycloak_credentials_password_hashing_validations_total counter
-keycloak_credentials_password_hashing_validations_total{algorithm="argon2",hashing_strength="Argon2id-1.3[m=7168,t=5,p=1]",outcome="valid",realm="realm-0",} 39949.0
+keycloak_credentials_password_hashing_validations_total{algorithm="argon2",hashing_strength="Argon2id-1.3[m=7168,t=5,p=1]",outcome="valid",realm="realm-0"} 39949.0
 ----
 
 == Next steps

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventMetricsProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventMetricsProviderTest.java
@@ -111,7 +111,7 @@ public class EventMetricsProviderTest extends AbstractKeycloakTest {
 
         testingClient.server().run(session -> {
             MatcherAssert.assertThat("Searching for metrics match in " + Metrics.globalRegistry.find("keycloak.user").meters(),
-                    Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "", "realm", TEST).count() == 1);
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "login", "realm", TEST).count() == 1);
         });
 
         // Show all labels, but filter out events like logout@
@@ -149,7 +149,7 @@ public class EventMetricsProviderTest extends AbstractKeycloakTest {
             MatcherAssert.assertThat("Searching for login error metric",
                     Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "ERROR", "realm", TEST, "client.id", CLIENT_ID, "idp", "IDENTITY_PROVIDER").count() == 1);
             MatcherAssert.assertThat("Searching for refresh with unknown client",
-                    Metrics.globalRegistry.counter("keycloak.user", "event", "refresh_token", "error", "client_not_found", "realm", TEST, "client.id", "unknown", "idp", "").count() == 1);
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "refresh_token", "error", "client_not_found", "realm", TEST, "client.id", "unknown").count() == 1);
         });
 
     }


### PR DESCRIPTION
Closes #45582

Signed-off-by: Luca Tronchin <ltronky@gmail.com>
(cherry picked from commit a351784c336630bee021ab1c57b51e49340e1f81)

@pruivo Could you please check this backport to 26.5.x?

@ltronky JFYI, this is a backport for 26.5.x