### PR TITLE
Keycloak should not allow matrix parameters in URLs as we don't use them

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_2.adoc
@@ -8,3 +8,14 @@ It also lists significant changes to internal APIs.
 Previously virtual threads were used when at least two CPU cores were available.
 Starting with this version, virtual threads are only used when at least four CPU cores are available.
 This change should prevent deadlocks due to pinned virtual threads.
+
+=== Accepting URL paths without a semicolon
+
+Previously {project_name} accepted HTTP requests with paths containing a semicolon (`;`).
+When processing them, it handled them as of RFC 3986 as a separator for matrix parameters, which basically ignored those parts.
+As this has led to a hard-to-configure URL filtering, for example, in reverse proxies, this is now disabled, and {project_name} responds with an HTTP 400 response code.
+
+To analyze rejected requests in the server log, enable debug logging for `org.keycloak.quarkus.runtime.services.RejectNonNormalizedPathFilter`.
+
+To revert to the previous behavior and to accept matrix parameters set the option `http-accept-non-normalized-paths` to `true`.
+With this configuration, enable and review the HTTP access log to identify problematic requests.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -146,7 +146,7 @@ public class HttpOptions {
 
     public static final Option<Boolean> HTTP_ACCEPT_NON_NORMALIZED_PATHS = new OptionBuilder<>("http-accept-non-normalized-paths", Boolean.class)
             .category(OptionCategory.HTTP)
-            .description("If the server should accept paths that are not normalized according to RFC3986 or that contain a double slash ('//'). While accepting those requests might be relevant for legacy applications, it is recommended to disable it to allow for more concise URL filtering.")
+            .description("If the server should accept paths that are not normalized according to RFC3986 or that contain a double slash ('//') or semicolon (';'). While accepting those requests might be relevant for legacy applications, it is recommended to disable it to allow for more concise URL filtering.")
             .deprecated()
             .defaultValue(Boolean.FALSE)
             .build();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -33,6 +33,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 import io.quarkus.test.junit.main.Launch;
 import org.junit.jupiter.api.Test;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
@@ -66,6 +67,8 @@ public class HttpDistTest {
     public void preventNonNormalizedURLs() {
         when().get("/realms/master").then().statusCode(200);
         when().get("/realms/xxx/../master").then().statusCode(400);
+        given().urlEncodingEnabled(false)
+                .when().get("/realms/master;xxx").then().statusCode(400);
     }
 
     @Test
@@ -73,6 +76,8 @@ public class HttpDistTest {
     public void allowNonNormalizedURLs() {
         when().get("/realms/master").then().statusCode(200);
         when().get("/realms/xxx/../master").then().statusCode(200);
+        given().urlEncodingEnabled(false)
+                .when().get("/realms/master;xxx").then().statusCode(200);
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -221,9 +221,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -291,9 +291,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -269,9 +269,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -292,9 +292,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -237,9 +237,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -260,9 +260,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -268,9 +268,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -291,9 +291,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -266,9 +266,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -289,9 +289,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination


### PR DESCRIPTION
Closes #45533

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
