### PR TITLE
Keycloak should not allow matrix parameters in URLs as we don't use them

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_9.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_9.adoc
@@ -15,3 +15,14 @@ If you are running on PostgreSQL as a database for {project_name}, ensure that t
 
 This is used during upgrades of {project_name} to determine an estimated number of rows in a table.
 If {project_name} does not have permissions to access these tables, it will log a warning and proceed with the less efficient `+SELECT COUNT(*) ...+` operation during the upgrade to determine the number of rows in tables affected by schema changes.
+
+=== Accepting URL paths without a semicolon
+
+Previously {project_name} accepted HTTP requests with paths containing a semicolon (`;`).
+When processing them, it handled them as of RFC 3986 as a separator for matrix parameters, which basically ignored those parts.
+As this has led to a hard-to-configure URL filtering, for example, in reverse proxies, this is now disabled, and {project_name} responds with an HTTP 400 response code.
+
+To analyze rejected requests in the server log, enable debug logging for `org.keycloak.quarkus.runtime.services.RejectNonNormalizedPathFilter`.
+
+To revert to the previous behavior and to accept matrix parameters set the option `http-accept-non-normalized-paths` to `true`.
+With this configuration, enable and review the HTTP access log to identify problematic requests.

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpOptions.java
@@ -153,7 +153,7 @@ public class HttpOptions {
 
     public static final Option<Boolean> HTTP_ACCEPT_NON_NORMALIZED_PATHS = new OptionBuilder<>("http-accept-non-normalized-paths", Boolean.class)
             .category(OptionCategory.HTTP)
-            .description("If the server should accept paths that are not normalized according to RFC3986 or that contain a double slash ('//'). While accepting those requests might be relevant for legacy applications, it is recommended to disable it to allow for more concise URL filtering.")
+            .description("If the server should accept paths that are not normalized according to RFC3986 or that contain a double slash ('//') or semicolon (';'). While accepting those requests might be relevant for legacy applications, it is recommended to disable it to allow for more concise URL filtering.")
             .deprecated()
             .defaultValue(Boolean.FALSE)
             .build();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/RejectNonNormalizedPathFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/RejectNonNormalizedPathFilter.java
@@ -50,6 +50,21 @@ public class RejectNonNormalizedPathFilter implements Handler<RoutingContext> {
                 jsonString = "";
             }
             routingContext.response().setStatusCode(400).end(jsonString);
+        } else if (routingContext.request().path().contains(";")) {
+            // RFC 6570 defines matrix parameters that are separated with a semicolon in each path segment.
+            // Keycloak does not use @MatrixParam, therefore any URL containing a semicolon is treated as invalid.
+            // Once Keycloak starts using them in any of its APIs, consider enabling them only for specific paths,
+            // as URL filtering would otherwise be quite hard for reverse proxies.
+            LOGGER.debugf("Invalid character ';' found in the request path", routingContext.request().path());
+            OAuth2ErrorRepresentation error = new OAuth2ErrorRepresentation("invalidCharacter", "Request path contains invalid character ';'");
+            routingContext.response().headers().add("Content-Type", "application/json; charset=UTF-8");
+            String jsonString;
+            try {
+                jsonString = MAPPER.writeValueAsString(error);
+            } catch (JsonProcessingException e) {
+                jsonString = "";
+            }
+            routingContext.response().setStatusCode(400).end(jsonString);
         } else {
             routingContext.next();
         }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
@@ -65,6 +66,8 @@ public class HttpDistTest {
     public void preventNonNormalizedURLs() {
         when().get("/realms/master").then().statusCode(200);
         when().get("/realms/xxx/../master").then().statusCode(400);
+        given().urlEncodingEnabled(false)
+                .when().get("/realms/master;xxx").then().statusCode(400);
     }
 
     @Test
@@ -72,6 +75,8 @@ public class HttpDistTest {
     public void allowNonNormalizedURLs() {
         when().get("/realms/master").then().statusCode(200);
         when().get("/realms/xxx/../master").then().statusCode(200);
+        given().urlEncodingEnabled(false)
+                .when().get("/realms/master;xxx").then().statusCode(200);
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -217,9 +217,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -287,9 +287,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -265,9 +265,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -288,9 +288,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -237,9 +237,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -260,9 +260,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -264,9 +264,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -287,9 +287,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -262,9 +262,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -285,9 +285,10 @@ HTTP(S):
 
 --http-accept-non-normalized-paths <true|false>
                      DEPRECATED. If the server should accept paths that are not normalized
-                       according to RFC3986 or that contain a double slash ('//'). While accepting
-                       those requests might be relevant for legacy applications, it is recommended
-                       to disable it to allow for more concise URL filtering. Default: false.
+                       according to RFC3986 or that contain a double slash ('//') or semicolon
+                       (';'). While accepting those requests might be relevant for legacy
+                       applications, it is recommended to disable it to allow for more concise URL
+                       filtering. Default: false.
 --http-enabled <true|false>
                      Enables the HTTP listener. Enabled by default in development mode. Typically
                        not enabled in production unless the server is fronted by a TLS termination


### PR DESCRIPTION
Closes #45533

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
