### PR TITLE
[test-framework] Dependency download error with embedded server

### DIFF
--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/Maven.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/Maven.java
@@ -46,6 +46,10 @@ import org.eclipse.aether.resolution.DependencyResolutionException;
 public final class Maven {
 
     public static Path resolveArtifact(String groupId, String artifactId) {
+        return getArtifact(groupId, artifactId).getFile().toPath();
+    }
+
+    public static Artifact getArtifact(String groupId, String artifactId) {
         try {
             BootstrapMavenContext ctx = bootstrapCurrentMavenContext();
             LocalProject project = ctx.getCurrentProject();
@@ -72,7 +76,7 @@ public final class Maven {
                             ctx.getRepositorySystemSession(),
                             new ArtifactRequest().setArtifact(artifact)
                                     .setRepositories(remoteRepositories))
-                    .getArtifact().getFile().toPath();
+                    .getArtifact();
         } catch (Exception cause) {
             throw new RuntimeException("Failed to resolve artifact: " + groupId + ":" + artifactId, cause);
         }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/EmbeddedKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/EmbeddedKeycloakServer.java
@@ -1,11 +1,14 @@
 package org.keycloak.testframework.server;
 
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
 import org.keycloak.Keycloak;
 import org.keycloak.common.Version;
+import org.keycloak.it.utils.Maven;
 
 import io.quarkus.maven.dependency.Dependency;
+import org.eclipse.aether.artifact.Artifact;
 
 public class EmbeddedKeycloakServer implements KeycloakServer {
 
@@ -18,7 +21,10 @@ public class EmbeddedKeycloakServer implements KeycloakServer {
         this.tlsEnabled = tlsEnabled;
 
         for(Dependency dependency : keycloakServerConfigBuilder.toDependencies()) {
-            builder.addDependency(dependency.getGroupId(), dependency.getArtifactId(), "");
+            var version = Optional.ofNullable(Maven.getArtifact(dependency.getGroupId(), dependency.getArtifactId()))
+                    .map(Artifact::getVersion)
+                    .orElse("");
+            builder.addDependency(dependency.getGroupId(), dependency.getArtifactId(), version);
         }
 
         keycloak = builder.start(keycloakServerConfigBuilder.toArgs());


### PR DESCRIPTION
- Closes #38991
- We need the version for the dependency specified because of how the WorkspaceModule and included maven artifact resolver in the `quarkus/junit5/Keycloak.java` works
- We are already using the Maven utility class to get the info about these artifacts/JARs, so we can use it here as well
- I was able to reproduce the issue and confirm that it works

@stianst @lhanusov @vaceksimon Can you check it? Thanks!