### PR TITLE
[BACKPORT] 45417 fixed unmanaged attributes to not allow writing when only admin can view policy is enabled

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
+++ b/server-spi-private/src/main/java/org/keycloak/userprofile/DefaultAttributes.java
@@ -261,20 +261,16 @@ public class DefaultAttributes extends HashMap<String, List<String>> implements 
         Map<String, List<String>> attributes = new HashMap<>(this);
 
         for (String name : nameSet()) {
-            AttributeMetadata metadata = getMetadata(name);
             RealmModel realm = session.getContext().getRealm();
 
-            if ((UserModel.USERNAME.equals(name) && realm.isRegistrationEmailAsUsername())
-                || isReadableOrWritableDuringRegistration(name)
-                || !isManagedAttribute(name)) {
+            if ((UserModel.USERNAME.equals(name) && realm.isRegistrationEmailAsUsername())) {
                 continue;
             }
 
-            if (metadata == null || !metadata.canEdit(createAttributeContext(metadata))) {
+            if (isReadOnly(name)) {
                 attributes.remove(name);
             }
         }
-
         return attributes;
     }
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/userprofile/UserProfileUtil.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/userprofile/UserProfileUtil.java
@@ -59,8 +59,16 @@ public class UserProfileUtil {
     }
 
     public static UPConfig enableUnmanagedAttributes(UserProfileResource upResource) {
+        return setUnmanagedAttributesPolicy(upResource, UPConfig.UnmanagedAttributePolicy.ENABLED);
+    }
+
+    public static UPConfig disableUnmanagedAttributes(UserProfileResource upResource) {
+        return setUnmanagedAttributesPolicy(upResource, null);
+    }
+
+    public static UPConfig setUnmanagedAttributesPolicy(UserProfileResource upResource, UPConfig.UnmanagedAttributePolicy policy) {
         UPConfig cfg = upResource.getConfiguration();
-        cfg.setUnmanagedAttributePolicy(UPConfig.UnmanagedAttributePolicy.ENABLED);
+        cfg.setUnmanagedAttributePolicy(policy);
         upResource.update(cfg);
         return cfg;
     }


### PR DESCRIPTION
Closes https://github.com/keycloak/keycloak/issues/45417

Cherry-pick of https://github.com/keycloak/keycloak/commit/9d0f679ecea405958f167fcd0f4a6db6ae32c3fa and https://github.com/keycloak/keycloak/commit/c5c83d6604d4c73139f38fce3ed7b7c4c38c09f2 squashed.