### PR TITLE
Check if requested user is enabled for impersonation in TE v1

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/V1TokenExchangeProvider.java
@@ -140,7 +140,7 @@ public class V1TokenExchangeProvider extends AbstractTokenExchangeProvider {
                 requestedUser = session.users().getUserById(realm, requestedSubject);
             }
 
-            if (requestedUser == null) {
+            if (requestedUser == null || !requestedUser.isEnabled()) {
                 // We always returned access denied to avoid username fishing
                 event.detail(Details.REASON, "requested_subject not found");
                 event.error(Errors.NOT_ALLOWED);

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/UserAttributeUpdater.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/updaters/UserAttributeUpdater.java
@@ -106,6 +106,11 @@ public class UserAttributeUpdater extends ServerResourceUpdater<UserAttributeUpd
         return this;
     }
 
+    public UserAttributeUpdater setEnabled(Boolean enabled) {
+        rep.setEnabled(enabled);
+        return this;
+    }
+
     public UserAttributeUpdater setRequiredActions(UserModel.RequiredAction... requiredAction) {
         rep.setRequiredActions(Arrays.stream(requiredAction)
                 .map(action -> action.name())


### PR DESCRIPTION
Closes #45651

Just checking if the impersonated user is enabled. I suppose we allow impersonating users that are temporarily disabled (locked by failed attempts). Tests added.