### PR TITLE
Implement Java client MVP for Client API v2

### DIFF
--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -83,6 +83,47 @@
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.19</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/../../services/target/apidocs-rest/swagger/apidocs/openapi.yaml</inputSpec>
+                            <generatorName>java</generatorName>
+                            <library>microprofile</library> <output>${project.build.directory}/generated-sources/openapi</output>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <configOptions>
+                                <useJakartaEe>true</useJakartaEe>
+                                <dateLibrary>java8</dateLibrary>
+                                <apiPackage>org.keycloak.admin.client.v2.resource</apiPackage>
+                                <modelPackage>org.keycloak.admin.client.v2.representation</modelPackage>
+                                <inlineSchemaNameMapping>AdminRealmsRealmTestSMTPConnectionPostRequest=TestSMTPConnectionRepresentation</inlineSchemaNameMapping>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -84,7 +84,8 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate-validator.version}</version> <!--Not sure why we need to set it as it should be part of dependencyManagement-->
+            <version>${hibernate-validator.version}
+            </version> <!--Not sure why we need to set it as it should be part of dependencyManagement-->
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -280,8 +281,8 @@
             <artifactId>keycloak-model-storage-private</artifactId>
         </dependency>
         <dependency>
-        	<groupId>org.keycloak</groupId>
-        	<artifactId>keycloak-config-api</artifactId>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-config-api</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -358,7 +359,8 @@
                                     <outputDirectory>${project.basedir}/target/apidocs-rest/output</outputDirectory>
                                     <resources>
                                         <resource>
-                                            <directory>${project.build.directory}/apidocs-rest/swagger/apidocs</directory>
+                                            <directory>${project.build.directory}/apidocs-rest/swagger/apidocs
+                                            </directory>
                                             <includes>
                                                 <include>**/openapi.yaml</include>
                                                 <include>**/openapi.json</include>
@@ -377,7 +379,8 @@
                             <scanProfiles>admin</scanProfiles>
                             <outputDirectory>${project.build.directory}/apidocs-rest/swagger/apidocs</outputDirectory>
                             <infoTitle>Keycloak Admin REST API</infoTitle>
-                            <infoDescription>This is a REST API reference for the Keycloak Admin REST API.</infoDescription>
+                            <infoDescription>This is a REST API reference for the Keycloak Admin REST API.
+                            </infoDescription>
                         </configuration>
                         <executions>
                             <execution>
@@ -405,7 +408,8 @@
                                         <modelTests>false</modelTests>
                                         <verbose>false</verbose>
                                     </globalProperties>
-                                    <inputSpec>${project.build.directory}/apidocs-rest/swagger/apidocs/openapi.yaml</inputSpec>
+                                    <inputSpec>${project.build.directory}/apidocs-rest/swagger/apidocs/openapi.yaml
+                                    </inputSpec>
                                     <output>${project.basedir}/target/docs/asciidoc/</output>
                                     <generatorName>asciidoc</generatorName>
                                     <generateApiDocumentation>true</generateApiDocumentation>
@@ -413,7 +417,8 @@
                                     <generateSupportingFiles>true</generateSupportingFiles>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>${project.artifactId}</artifactId>
-                                    <templateDirectory>src/docs/openapi-generator-templates/keycloak-admin-api</templateDirectory>
+                                    <templateDirectory>src/docs/openapi-generator-templates/keycloak-admin-api
+                                    </templateDirectory>
                                     <configOptions>
                                         <useIntroduction>true</useIntroduction>
                                         <delegatePattern>false</delegatePattern>
@@ -448,7 +453,7 @@
                                          -->
                                         <toc/>
                                         <toc-position>left</toc-position>
-                                        <sectanchors />
+                                        <sectanchors/>
                                         <generated>${project.basedir}/target/apidocs-rest/asciidoc</generated>
                                         <!-- Boolean attributes are passed as defined/undefined to AsciiDoc, not at their literal value -->
                                         <project_community>true</project_community>


### PR DESCRIPTION

- Configured openapi-generator-maven-plugin in keycloak-admin-client-tests.
- Used MicroProfile library to ensure compatibility with Quarkus and Jakarta EE.
- Automated SDK generation to follow the 'NOT handcrafted' requirement.

Closes #45364
