### PR TITLE
Unable to find contextual data of type: org.keycloak.models.KeycloakSession

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/AuthServerTestEnricher.java
@@ -728,6 +728,11 @@ public class AuthServerTestEnricher {
                     realms.append(testRealm.getRealm()).append(", ");
                 } catch (NotFoundException e) {
                     // Ignore
+                } catch (Exception e) {
+                    // [#44574] Unable to find contextual data of type: org.keycloak.models.KeycloakSession
+                    // https://github.com/keycloak/keycloak/issues/44574
+                    log.errorf("Failed to remove test realm: %s - %s", testRealm.getRealm(), e);
+                    // Ignore
                 }
             }
             log.info("removed realms: " + realms);


### PR DESCRIPTION
closes #44574

Providing a workaround rather than a deep dive fix in Keycloak/Arquillian.
With this change I can build and run the test like this

`mvn clean test -Dtest='org.keycloak.testsuite.oid4vc.**`

without breaking the build that works in IntelliJ (i.e. taking quarkus out of the equation for local dev work)