### PR TITLE
wip: test with QOSDK 7.5.0.CR1

### DIFF
--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -26,10 +26,15 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.quarkus.platform</groupId>
+          <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-client-registration-api</artifactId>
+            <version>999.0.0-SNAPSHOT</version>
+          </dependency>
+          <dependency>
+                <groupId>io.quarkiverse.operatorsdk</groupId>
                 <artifactId>quarkus-operator-sdk-bom</artifactId>
-                <version>${quarkus.version}</version>
+                <version>7.5.0.CR1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <h2.version>2.4.240</h2.version>
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
         <hibernate.c3p0.version>6.2.13.Final</hibernate.c3p0.version>
+        <microprofile-metrics-api.version>5.1.2</microprofile-metrics-api.version>
         <hibernate-validator.version>9.0.1.Final</hibernate-validator.version>
         <infinispan.version>16.0.5</infinispan.version>
         <protostream.version>6.0.3</protostream.version> <!-- For the annotation processor: keep in sync with the version shipped with Infinispan -->
@@ -1336,6 +1337,12 @@
                 <artifactId>infinispan-core</artifactId>
                 <type>test-jar</type>
                 <version>${infinispan.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile.metrics</groupId>
+                <artifactId>microprofile-metrics-api</artifactId>
+                <scope>test</scope>
+                <version>${microprofile-metrics-api.version}</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.30.5</quarkus.version>
-        <quarkus.build.version>3.30.5</quarkus.build.version>
+        <quarkus.version>3.31.0.CR1</quarkus.version>
+        <quarkus.build.version>3.31.0.CR1</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -58,6 +58,12 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>testcontainers-infinispan</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -79,31 +85,31 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>cockroachdb</artifactId>
+            <artifactId>testcontainers-cockroachdb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mariadb</artifactId>
+            <artifactId>testcontainers-mariadb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mssqlserver</artifactId>
+            <artifactId>testcontainers-mssqlserver</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>tidb</artifactId>
+            <artifactId>testcontainers-tidb</artifactId>
         </dependency>
 
         <!-- JDBC Drivers -->

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -126,6 +126,12 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer</artifactId>
             <scope>provided</scope>
+            <exclusions>
+            	<exclusion>
+            		<groupId>io.quarkus</groupId>
+            		<artifactId>quarkus-bootstrap-runner</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/test-framework/db-tidb/pom.xml
+++ b/test-framework/db-tidb/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>tidb</artifactId>
+            <artifactId>testcontainers-tidb</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
- **fix: updating to quarkus 3.31.0.CR1**
- **updating test containers for 3.31.0.CR1**
- **excluding quarkus-bootstrap-runner to prevent trace logging**
- **wip: test with QOSDK 7.5.0.CR1**
