### PR TITLE
Covering hiding username/email when brute force is enabled during identity-first login

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/LoginPage.java
@@ -155,6 +155,10 @@ public class LoginPage extends LanguageComboboxAwarePage {
         return !driver.findElements(By.id("username")).isEmpty();
     }
 
+    public boolean isEmailInputPresent() {
+        return !driver.findElements(By.id("email")).isEmpty();
+    }
+
     public boolean isRegisterLinkPresent() {
         return !driver.findElements(By.linkText("Register")).isEmpty();
     }


### PR DESCRIPTION
Closes #45685

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
