### PR TITLE
Hibernate Validator is enabled by default when not used (#45681)

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -100,6 +100,7 @@ import org.keycloak.quarkus.runtime.services.health.KeycloakClusterReadyHealthCh
 import org.keycloak.quarkus.runtime.services.health.KeycloakReadyHealthCheck;
 import org.keycloak.quarkus.runtime.storage.database.jpa.NamedJpaConnectionProviderFactory;
 import org.keycloak.quarkus.runtime.themes.FlatClasspathThemeResourceProviderFactory;
+import org.keycloak.quarkus.runtime.validation.HibernateValidatorFactoryCustomizer;
 import org.keycloak.representations.provider.ScriptProviderDescriptor;
 import org.keycloak.representations.provider.ScriptProviderMetadata;
 import org.keycloak.representations.userprofile.config.UPConfig;
@@ -130,6 +131,7 @@ import io.quarkus.bootstrap.logging.InitialConfigurator;
 import io.quarkus.datasource.deployment.spi.DevServicesDatasourceResultBuildItem;
 import io.quarkus.datasource.runtime.DataSourcesBuildTimeConfig;
 import io.quarkus.deployment.IsDevelopment;
+import io.quarkus.deployment.IsTest;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
@@ -849,6 +851,16 @@ class KeycloakProcessor {
     private static void disableReadyHealthCheck(BuildProducer<BuildTimeConditionBuildItem> removeBeans, CombinedIndexBuildItem index) {
         ClassInfo disabledBean = index.getIndex().getClassByName(DotName.createSimple(KeycloakReadyHealthCheck.class.getName()));
         removeBeans.produce(new BuildTimeConditionBuildItem(disabledBean.asClass(), false));
+    }
+
+    @BuildStep(onlyIfNot = IsTest.class) // needed for embedded Keycloak
+    void disableHibernateValidatorCustomizer(BuildProducer<BuildTimeConditionBuildItem> removeBeans, CombinedIndexBuildItem index) {
+        if (!Profile.isFeatureEnabled(Profile.Feature.CLIENT_ADMIN_API_V2)) {
+            // disables the filter
+            ClassInfo disabledBean = index.getIndex()
+                    .getClassByName(DotName.createSimple(HibernateValidatorFactoryCustomizer.class.getName()));
+            removeBeans.produce(new BuildTimeConditionBuildItem(disabledBean.asClass(), false));
+        }
     }
 
     @BuildStep

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -46,7 +46,8 @@ public class IgnoredArtifacts {
                         metrics(),
                         otelMetrics(),
                         openApi(),
-                        openApiSwagger()
+                        openApiSwagger(),
+                        hibernateValidator()
                 )
                 .flatMap(Collection::stream)
                 .collect(Collectors.toUnmodifiableSet());
@@ -211,5 +212,18 @@ public class IgnoredArtifacts {
     private static Set<String> openApiSwagger() {
         boolean isEnabled = Configuration.isTrue(OpenApiOptions.OPENAPI_UI_ENABLED);
         return !isEnabled ? OPENAPI_SWAGGER : emptySet();
+    }
+
+    // Hibernate Validator
+    public static Set<String> HIBERNATE_VALIDATOR = Set.of(
+            "io.quarkus:quarkus-hibernate-validator",
+            "io.quarkus:quarkus-hibernate-validator-deployment",
+            "io.quarkus:quarkus-hibernate-validator-spi",
+            "org.hibernate.validator:hibernate-validator"
+    );
+
+    private static Set<String> hibernateValidator() {
+        boolean isEnabled = Profile.isFeatureEnabled(Profile.Feature.CLIENT_ADMIN_API_V2);
+        return !isEnabled ? HIBERNATE_VALIDATOR : emptySet();
     }
 }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -82,11 +82,6 @@
             <artifactId>twitter4j-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate-validator.version}</version> <!--Not sure why we need to set it as it should be part of dependencyManagement-->
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>

--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -8,7 +8,6 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jakarta.validation.ValidationException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -102,8 +101,6 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
                 error.setErrorDescription("Cannot parse the JSON");
             } else if (isServerError) {
                 error.setErrorDescription("For more on this error consult the server log.");
-            } else if (throwable instanceof ValidationException) {
-                error.setErrorDescription(throwable.getMessage());
             }
 
             return Response.status(responseStatus)


### PR DESCRIPTION
Hibernate Validator is enabled by default when not used

Closes #45677

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit 44375e217880a64b21bfb13558d361502e1eea80)
