### PR TITLE
Fix mixed-cluster-compatibility-tests version matrix

### DIFF
--- a/.github/scripts/version-compatibility.sh
+++ b/.github/scripts/version-compatibility.sh
@@ -26,5 +26,5 @@ MAJOR_MINOR_RELEASES=$(echo "${ALL_RELEASES}" | (grep "${MAJOR_MINOR}" || true))
 if [[ -z "${MAJOR_MINOR_RELEASES}" ]]; then
   echo "skip"
 else
-  echo -n "${MAJOR_MINOR_RELEASES}" | jq -cnR '[inputs] | map({version: .})'
+  echo -n "${MAJOR_MINOR_RELEASES}" | jq -cnMR '[inputs] | map({version: .})'
 fi


### PR DESCRIPTION
Fixes #45708

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

The output of `jq` changed. A successful build will print `[{"version":"26.5.0"}]` but currently is printted as `[***"version":"26.5.1"***,***"version":"26.5.0"***]`
I'm enabling `--monochrome-output / -M` to prevent an invalid JSON output.

Run in my fork: https://github.com/pruivo/keycloak/actions/runs/21284395001/job/61261874680