### PR TITLE
Improve error message when organization name cannot be used as alias

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -103,7 +103,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
             try {
                 ReservedCharValidator.validateNoSpace(name);
             } catch (ReservedCharValidator.ReservedCharException e) {
-                throw new ModelValidationException("Name contains a reserved character and cannot be used as alias");
+                throw new ModelValidationException("Name cannot be used as alias: " + e.getMessage());
             }
             alias = name;
         }


### PR DESCRIPTION
## Summary
- Include the original validation message from `ReservedCharValidator` in the error response
- Users now see descriptive messages like "Name cannot be used as alias: Empty Space not allowed." instead of generic "Name contains a reserved character and cannot be used as alias"

## Test plan
- [ ] Create organization with name containing spaces (e.g., "Test Organization") and leave alias empty
- [ ] Verify error message shows: "Name cannot be used as alias: Empty Space not allowed."

[organization-create-error-msg.webm](https://github.com/user-attachments/assets/6fe81ed8-28cf-4829-9cc4-667d14b7b175)

Closes #45718