### PR TITLE
MCP requirement - Audience Mapper and Checker referring RFC 8707 resource parameter

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -162,6 +162,8 @@ public class Profile {
 
         CIMD("OAuth Client ID Metadata Document", Type.EXPERIMENTAL),
 
+        RESOURCE_INDICATOR("Resource Indicators for OAuth 2.0", Type.EXPERIMENTAL),
+
         /**
          * @see <a href="https://github.com/keycloak/keycloak/issues/37967">Deprecate for removal the Instagram social broker</a>.
          */

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -146,6 +146,9 @@ public class OIDCLoginProtocol implements LoginProtocol {
     // https://datatracker.ietf.org/doc/html/rfc9449#section-12.3
     public static final String DPOP_JKT = "dpop_jkt";
 
+    // https://datatracker.ietf.org/doc/html/rfc8707
+    public static final String RESOURCE_PARAM = "resource";
+
     private static final Logger logger = Logger.getLogger(OIDCLoginProtocol.class);
 
     protected KeycloakSession session;

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -586,6 +586,9 @@ public class TokenManager {
         for (Map.Entry<String, String> entry : transferredNotes.entrySet()) {
             clientSession.setNote(entry.getKey(), entry.getValue());
         }
+        if (authSession.getClientNote(OAuth2Constants.RESOURCE) == null && clientSession.getNote(OAuth2Constants.RESOURCE) != null) {
+            clientSession.removeNote(OAuth2Constants.RESOURCE);
+        }
 
         Map<String, String> transferredUserSessionNotes = authSession.getUserSessionNotes();
         for (Map.Entry<String, String> entry : transferredUserSessionNotes.entrySet()) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -455,5 +455,6 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         paramAction.accept(OIDCLoginProtocol.SCOPE_PARAM, request.getScope());
         paramAction.accept(OIDCLoginProtocol.STATE_PARAM, request.getState());
         paramAction.accept(OIDCLoginProtocol.DPOP_JKT, request.getDpopJkt());
+        paramAction.accept(OIDCLoginProtocol.RESOURCE_PARAM, request.getResource());
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequest.java
@@ -55,10 +55,16 @@ public class AuthorizationEndpointRequest {
 
     String acr;
 
+    String resource;
+
     AuthorizationRequestContext authorizationRequestContext;
 
     public String getAcr() {
         return acr;
+    }
+
+    public String getResource() {
+        return resource;
     }
 
     public String getClientId() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
@@ -102,6 +102,9 @@ public abstract class AuthzEndpointRequestParser {
         KNOWN_REQ_PARAMS.add(OAuth2Constants.CLIENT_ASSERTION_TYPE);
         KNOWN_REQ_PARAMS.add(OAuth2Constants.CLIENT_ASSERTION);
         KNOWN_REQ_PARAMS.add(OAuth2Constants.CLIENT_SECRET);
+
+        // https://datatracker.ietf.org/doc/html/rfc8707
+        KNOWN_REQ_PARAMS.add(OIDCLoginProtocol.RESOURCE_PARAM);
     }
 
     protected AuthzEndpointRequestParser(KeycloakSession keycloakSession) {
@@ -148,6 +151,8 @@ public abstract class AuthzEndpointRequestParser {
         request.codeChallengeMethod = replaceIfNotNull(request.codeChallengeMethod, getAndValidateParameter(OIDCLoginProtocol.CODE_CHALLENGE_METHOD_PARAM));
 
         request.dpopJkt = replaceIfNotNull(request.dpopJkt, getAndValidateParameter(OIDCLoginProtocol.DPOP_JKT));
+
+        request.resource = replaceIfNotNull(request.resource, getAndValidateParameter(OIDCLoginProtocol.RESOURCE_PARAM));
 
         extractAdditionalReqParams(request.additionalReqParams);
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ResourceIndicatorMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ResourceIndicatorMapper.java
@@ -1,0 +1,93 @@
+package org.keycloak.protocol.oidc.mappers;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.Config;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.common.Profile;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class ResourceIndicatorMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, TokenIntrospectionTokenMapper, EnvironmentDependentProviderFactory {
+
+    public static final String PROVIDER_ID = "oidc-resource-indicator-mapper";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    private static final Logger logger = Logger.getLogger(ResourceIndicatorMapper.class);
+
+    static {
+        OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, ResourceIndicatorMapper.class);
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Resource Indicators";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Adds requested OAuth2 Resource Indicators to audience claim.";
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.RESOURCE_INDICATOR);
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession, KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
+        if (clientSessionCtx == null || clientSessionCtx.getClientSession() == null) {
+            return;
+        }
+        String resourceInAuthorizationRequest = clientSessionCtx.getClientSession().getNote(OAuth2Constants.RESOURCE);
+        if (resourceInAuthorizationRequest != null && !resourceInAuthorizationRequest.isBlank()) {
+            logger.debugv(" mapper: resource in authorization request = {0}", resourceInAuthorizationRequest);
+            token.addAudience(resourceInAuthorizationRequest);
+        }
+    }
+
+    public static ProtocolMapperModel create(String name, boolean accessToken, boolean introspectionEndpoint) {
+        ProtocolMapperModel mapper = new ProtocolMapperModel();
+        mapper.setName(name);
+        mapper.setProtocolMapper(PROVIDER_ID);
+        mapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        Map<String, String> config = new HashMap<>();
+        if (accessToken) {
+            config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
+        }
+        if (introspectionEndpoint) {
+            config.put(OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION, "true");
+        }
+        mapper.setConfig(config);
+        return mapper;
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResourceIndicatorExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResourceIndicatorExecutor.java
@@ -1,0 +1,133 @@
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.context.TokenRequestContext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class SecureResourceIndicatorExecutor implements ClientPolicyExecutorProvider<SecureResourceIndicatorExecutor.Configuration> {
+
+    protected final KeycloakSession session;
+    protected Configuration configuration;
+
+    private static final Logger logger = Logger.getLogger(SecureResourceIndicatorExecutor.class);
+
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void setupConfiguration(Configuration config) {
+        this.configuration = config;
+    }
+
+    @Override
+    public Class<Configuration> getExecutorConfigurationClass() {
+        return Configuration.class;
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+        @JsonProperty(SecureResourceIndicatorExecutorFactory.PERMITTED_RESOURCES)
+        protected List<String> allowPermittedResources = null;
+
+        public Configuration() {
+        }
+
+        public List<String> getAllowPermittedResources() {
+            return allowPermittedResources;
+        }
+
+        public void setAllowPermittedResources(List<String> allowPermittedResources) {
+            this.allowPermittedResources = allowPermittedResources;
+        }
+    }
+
+    public static final String ERR_NOT_PERMITTED_RESOURCE = "not allowed resource parameter value";
+    public static final String ERR_NO_RESOURCE_IN_TOKEN_REQUEST = "resource parameter value in token request does not exist.";
+    public static final String ERR_DIFFERENT_RESOURCE = "resource parameter value in token request does not match the one in authorization request.";
+
+    public SecureResourceIndicatorExecutor(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public String getProviderId() {
+        return SecureResourceIndicatorExecutorFactory.PROVIDER_ID;
+    }
+
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        if (!Profile.isFeatureEnabled(Profile.Feature.RESOURCE_INDICATOR)) {
+            logger.warnf("RESOURCE_INDICATOR feature is disabled. So the executor does not work. " +
+                    "Please enable RESOURCE_INDICATOR feature in order to be able to have token audience binding with resource parameter applied.");
+            return;
+        }
+
+        switch (context.getEvent()) {
+            case AUTHORIZATION_REQUEST:
+                AuthorizationRequestContext authzRequestContext = (AuthorizationRequestContext) context;
+                String resourceParam = authzRequestContext.getAuthorizationEndpointRequest().getResource();
+                logger.debugv(" on authz request: resourceParam = {0}", resourceParam);
+                List<String> allowResourceList = convertContentFilledList(configuration.getAllowPermittedResources());
+                if (allowResourceList != null && !allowResourceList.isEmpty() && !allowResourceList.contains(resourceParam)) {
+                        logger.warnv("not allowed resource parameter value: resource = {0}", resourceParam);
+                        throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, ERR_NOT_PERMITTED_RESOURCE);
+                }
+                return;
+            case TOKEN_REQUEST:
+                checkResourceParameterValue((TokenRequestContext) context);
+                return;
+            default:
+        }
+    }
+
+    /**
+     * When the authorization request does not include resource parameter but the token request includes that,
+     * the resource parameter in the token request is ignored, not set to audience claim in an access token.
+     */
+    private void checkResourceParameterValue(TokenRequestContext context) throws ClientPolicyException {
+        String resourceInTokenRequest = context.getParams().getFirst(OAuth2Constants.RESOURCE);
+        AuthenticatedClientSessionModel clientSession = context.getParseResult().getClientSession();
+        if (clientSession == null) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "client session is null");
+        }
+        String resourceInAuthorizationRequest = clientSession.getNote(OAuth2Constants.RESOURCE);
+
+        logger.debugv(" on token request: resourceInAuthorizationRequest = {0}", resourceInAuthorizationRequest);
+
+        if (resourceInAuthorizationRequest == null) {
+            return;
+        }
+
+        if (resourceInTokenRequest == null) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, ERR_NO_RESOURCE_IN_TOKEN_REQUEST);
+        }
+
+        if (!resourceInTokenRequest.equals(resourceInAuthorizationRequest)) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, ERR_DIFFERENT_RESOURCE);
+        }
+    }
+
+    protected List<String> convertContentFilledList(List<String> list) {
+        if (list == null) {
+            return Collections.emptyList();
+        }
+        return list.stream().filter(Objects::nonNull).filter(i->!i.isBlank()).distinct().toList();
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResourceIndicatorExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureResourceIndicatorExecutorFactory.java
@@ -1,0 +1,69 @@
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
+ */
+public class SecureResourceIndicatorExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "secure-resource-indicator-check";
+
+    public static final String PERMITTED_RESOURCES = "allow-permitted-resources";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new SecureResourceIndicatorExecutor(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "On the authorization endpoint, this executor validates the resource parameter in the authorization request, "
+                + "and on the token endpoint it checks that the resource parameter in the token request matches the one sent in the authorization request. "
+                + "If validation fails, it denies the request.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    static {
+        addCommonConfigProperties(configProperties);
+    }
+
+    static protected void addCommonConfigProperties(List<ProviderConfigProperty> configProperties) {
+        ProviderConfigProperty property = new ProviderConfigProperty(
+                PERMITTED_RESOURCES,
+                "Permitted resources",
+                "If filled, then the executor only accepts resource parameters whose values exactly match one of the permitted resources.",
+                ProviderConfigProperty.MULTIVALUED_STRING_TYPE,
+                null);
+        configProperties.add(property);
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -62,3 +62,4 @@ org.keycloak.protocol.oidc.mappers.SubMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationGroupMembershipMapper
 org.keycloak.protocol.saml.mappers.AuthnContextClassRefMapper
+org.keycloak.protocol.oidc.mappers.ResourceIndicatorMapper

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -35,3 +35,4 @@ org.keycloak.services.clientpolicy.executor.DownscopeAssertionGrantEnforcerExecu
 org.keycloak.services.clientpolicy.executor.JWTClaimEnforcerExecutorFactory
 org.keycloak.services.clientpolicy.executor.JWTAuthorizationGrantAudienceExecutorFactory
 org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutorFactory
+org.keycloak.services.clientpolicy.executor.SecureResourceIndicatorExecutorFactory

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ResourceIndicatorMapperTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ResourceIndicatorMapperTest.java
@@ -1,0 +1,468 @@
+package org.keycloak.tests.oauth;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.ws.rs.BadRequestException;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.ResourceIndicatorMapper;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
+import org.keycloak.services.clientpolicy.executor.SecureResourceIndicatorExecutorFactory;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.LogoutConfirmPage;
+import org.keycloak.testsuite.util.ClientPoliciesUtil;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
+import org.keycloak.testsuite.util.oauth.TokenRevocationResponse;
+import org.keycloak.util.JsonSerialization;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static org.keycloak.services.clientpolicy.executor.SecureResourceIndicatorExecutor.ERR_DIFFERENT_RESOURCE;
+import static org.keycloak.services.clientpolicy.executor.SecureResourceIndicatorExecutor.ERR_NOT_PERMITTED_RESOURCE;
+import static org.keycloak.services.clientpolicy.executor.SecureResourceIndicatorExecutor.ERR_NO_RESOURCE_IN_TOKEN_REQUEST;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createAnyClientConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createResourceAudienceBindExecutorConfig;
+
+
+@KeycloakIntegrationTest(config = ResourceIndicatorMapperTest.ResourceIndicatorMapperServerConfig.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class ResourceIndicatorMapperTest {
+
+    @InjectRealm(config = ResourceIndicatorMapperRealmConfig.class)
+    ManagedRealm testRealm;
+
+    @InjectOAuthClient
+    OAuthClient oAuthClient;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @InjectPage
+    protected LogoutConfirmPage logoutConfirmPage;
+
+    private static final String TEST_REALM = "MyTestRealm";
+    private static final String TEST_CLIENT = "MyTestClient";
+    private static final String TEST_CLIENT_SECRET = "secret";
+    private static final String TEST_USER = "MyTestUser";
+    private static final String TEST_USER_PASSWORD = "password";
+    private static final String TEST_MAPPER = "resource-indicator";
+
+    private static final String POLICY_NAME = "MyPolicy";
+    private static final String PROFILE_NAME = "MyProfile";
+
+    @BeforeEach
+    public void setup() {
+        // It is enough to be executed only once before start testing.
+        // However, static method annotated @BeforeAll cannot refer to the member runOnServer, so it is executed here.
+        // It is better to do that in ResourceIndicatorMapperRealmConfig.configure, but no way to do that in that method.
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName(TEST_REALM);
+            ClientModel target = realm.getClientByClientId(TEST_CLIENT);
+            if (target.getProtocolMapperByName(OIDCLoginProtocol.LOGIN_PROTOCOL, TEST_MAPPER) == null) {
+                target.addProtocolMapper(ResourceIndicatorMapper.create(TEST_MAPPER, true, true));
+                target.setServiceAccountsEnabled(true);
+            }
+
+            // disable verify profile required action
+            RequiredActionProviderModel model = realm.getRequiredActionProviderByAlias(UserModel.RequiredAction.VERIFY_PROFILE.name());
+            if (model.isEnabled()) {
+                model.setDefaultAction(false);
+                model.setEnabled(false);
+                realm.updateRequiredActionProvider(model);
+            }
+        });
+    }
+
+    @AfterEach
+    public void cleanup() {
+        // logout
+        oAuthClient.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+    }
+
+    @Test
+    public void testSuccessfulBindMapper() throws IOException {
+        // authorization code grant
+        //  resource specified in an authorization request
+        //  resource not specified in a token request
+        //  -> bind with resource specified in an authorization request
+        String resourceInAuthorizationRequest = "https://resource.example.com/v1";
+        String resourceInTokenRequest = null;
+        String code = loginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        AccessTokenResponse tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenValidResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // introspect
+        //  -> bind with resource specified in an authorization request
+        IntrospectionResponse introspectionResponse = oAuthClient.doIntrospectionAccessTokenRequest(tokenResponse.getAccessToken());
+        assertIntrospectValidResponse(introspectionResponse, resourceInAuthorizationRequest);
+
+        // refresh
+        //  resource not specified in a token refresh request
+        //  -> bind with resource specified in an authorization request
+        tokenResponse = oAuthClient.doRefreshTokenRequest(tokenResponse.getRefreshToken());
+        assertRefreshTokenResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // revoke
+        TokenRevocationResponse revokeResponse = oAuthClient.doTokenRevoke(tokenResponse.getAccessToken());
+        assertRevokeValidResponse(revokeResponse, tokenResponse);
+
+        // authorization code grant
+        //  resource not specified in an authorization request
+        //  resource not specified in a token request
+        //  -> not bind
+        resourceInAuthorizationRequest = null;
+        resourceInTokenRequest = null;
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertNotBindTokenValidResponse(tokenResponse);
+
+        // authorization code grant
+        //  resource specified in an authorization request
+        //  resource specified in a token request
+        //  -> bind with resource specified in an authorization request
+        resourceInAuthorizationRequest = "https://resource.example.com/v1";
+        resourceInTokenRequest = "https://different.resource.example.com/";
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenValidResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // authorization code grant
+        // resource specified in an authorization request
+        // resource specified in a token request
+        // -> bind with resource specified in an authorization request
+        resourceInAuthorizationRequest = "https://resource.example.com/v1";
+        resourceInTokenRequest = resourceInAuthorizationRequest;
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenValidResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // refresh
+        //  resource specified in a token refresh request, but it is different from the one in the authorization request
+        //  -> bind with resource specified in an authorization request
+        tokenResponse = oAuthClient.refreshRequest(tokenResponse.getRefreshToken()).resource("https://different.resource.example.com/").send();
+        assertRefreshTokenResponse(tokenResponse, resourceInAuthorizationRequest);
+    }
+
+    @Test
+    public void testNotBindMapper() {
+        // setup realm
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName(TEST_REALM);
+            ClientModel target = realm.getClientByClientId(TEST_CLIENT);
+            ProtocolMapperModel model = target.getProtocolMapperByName(OIDCLoginProtocol.LOGIN_PROTOCOL, TEST_MAPPER);
+            if (model != null) {
+                target.removeProtocolMapper(model);
+            }
+        });
+
+        // resource specified in an authorization request but no mapper applied - not bind
+        String resource = "https://resource.example.com/v1";
+        String code = loginUserAndGetCode(TEST_CLIENT, resource);
+        AccessTokenResponse tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resource).send();
+        assertNotBindTokenValidResponse(tokenResponse);
+    }
+
+    @Test
+    public void testSuccessfulBindMapperWithExecutor() throws Exception {
+        // register profiles
+        String json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "O Primeiro Perfil")
+                        .addExecutor(SecureResourceIndicatorExecutorFactory.PROVIDER_ID, null)
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(AnyClientConditionFactory.PROVIDER_ID,
+                                createAnyClientConditionConfig())
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // authorization code grant
+        //  resource specified in an authorization request
+        //  resource specified in a token request, and it is the same as the one in the authorization request
+        //  -> bind with resource specified in an authorization request
+        String resourceInAuthorizationRequest = "https://resource.example.com/v1";
+        String resourceInTokenRequest = resourceInAuthorizationRequest;
+        String code = loginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        AccessTokenResponse tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenValidResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // introspect
+        //  -> bind with resource specified in an authorization request
+        IntrospectionResponse introspectionResponse = oAuthClient.doIntrospectionAccessTokenRequest(tokenResponse.getAccessToken());
+        assertIntrospectValidResponse(introspectionResponse, resourceInAuthorizationRequest);
+
+        // refresh
+        //  resource specified in a token refresh request, but it is different from the one in the authorization request
+        //  -> bind with resource specified in an authorization request
+        tokenResponse = oAuthClient.refreshRequest(tokenResponse.getRefreshToken()).resource("https://different.resource.example.com/").send();
+        assertRefreshTokenResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // refresh
+        //  resource not specified in a token refresh request
+        //  -> bind with resource specified in an authorization request
+        tokenResponse = oAuthClient.refreshRequest(tokenResponse.getRefreshToken()).resource(null).send();
+        assertRefreshTokenResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // revoke
+        TokenRevocationResponse revokeResponse = oAuthClient.doTokenRevoke(tokenResponse.getAccessToken());
+        assertRevokeValidResponse(revokeResponse, tokenResponse);
+
+        // authorization code grant
+        //  resource not specified in an authorization request
+        //  resource not specified in a token request
+        //  -> not bind
+        resourceInAuthorizationRequest = null;
+        resourceInTokenRequest = null;
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, null);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(null).send();
+        assertNotBindTokenValidResponse(tokenResponse);
+
+        // authorization code grant
+        //  resource not specified in an authorization request
+        //  resource specified in a token request
+        //  -> not bind
+        resourceInAuthorizationRequest = null;
+        resourceInTokenRequest = "https://resource.example.com/v3";
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertNotBindTokenValidResponse(tokenResponse);
+
+        // authorization code grant
+        //  resource specified in an authorization request
+        //  resource not specified in a token request
+        //  -> error
+        resourceInAuthorizationRequest = null;
+        resourceInTokenRequest = "https://resource.example.com/v3";
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertNotBindTokenValidResponse(tokenResponse);
+
+        // authorization code grant
+        //  resource specified in an authorization request
+        //  resource specified in a token request, but it is different from the one in the authorization request
+        //  -> error
+        resourceInAuthorizationRequest = "https://mcp.example.com/mcp";
+        resourceInTokenRequest = "https://resource.example.com/v3";
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenInvalidResponse(tokenResponse, ERR_DIFFERENT_RESOURCE);
+
+        // add permitted resources
+        List<String> permittedResources = List.of("https://example.com/resource", "https://www.example.com/res");
+        json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "O Primeiro Perfil")
+                        .addExecutor(SecureResourceIndicatorExecutorFactory.PROVIDER_ID, createResourceAudienceBindExecutorConfig(permittedResources))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // authorization code grant
+        //  resource specified in an authorization request, and it is included in the permitted resources
+        //  resource specified in a token request, and it is the same one in the authorization request
+        //  -> bind with resource specified in an authorization request
+        resourceInAuthorizationRequest = permittedResources.get(0);
+        resourceInTokenRequest = resourceInAuthorizationRequest;
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenValidResponse(tokenResponse, resourceInAuthorizationRequest);
+
+        // authorization code grant
+        //  resource is not specified in an authorization request
+        //  -> error
+        assertLoginError(TEST_CLIENT, null, OAuthErrorException.INVALID_REQUEST, ERR_NOT_PERMITTED_RESOURCE);
+
+        // authorization code grant
+        //  resource specified in an authorization request, but it is not included in the permitted resources
+        //  -> error
+        assertLoginError(TEST_CLIENT, "https://different.resource.example.com/", OAuthErrorException.INVALID_REQUEST, ERR_NOT_PERMITTED_RESOURCE);
+
+        // authorization code grant
+        //  resource specified in an authorization request, and it is included in the permitted resources
+        //  resource specified in a token request, and it is included in the permitted resources, but it is different from the same one in the authorization request
+        //  -> error
+        resourceInAuthorizationRequest = permittedResources.get(1);
+        resourceInTokenRequest = permittedResources.get(0);
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenInvalidResponse(tokenResponse, ERR_DIFFERENT_RESOURCE);
+
+        // authorization code grant
+        //  resource specified in an authorization request, and it is included in the permitted resources
+        //  resource not specified in a token request
+        //  -> error
+        resourceInAuthorizationRequest = permittedResources.get(1);
+        resourceInTokenRequest = null;
+        code = ssoLoginUserAndGetCode(TEST_CLIENT, resourceInAuthorizationRequest);
+        tokenResponse = oAuthClient.
+                client(TEST_CLIENT, TEST_CLIENT_SECRET).accessTokenRequest(code).resource(resourceInTokenRequest).send();
+        assertTokenInvalidResponse(tokenResponse, ERR_NO_RESOURCE_IN_TOKEN_REQUEST);
+
+        // logout
+        oAuthClient.openLogoutForm();
+        logoutConfirmPage.assertCurrent();
+        logoutConfirmPage.confirmLogout();
+    }
+
+    public static class ResourceIndicatorMapperRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmConfigBuilder configure(RealmConfigBuilder realm) {
+            realm.name(TEST_REALM);
+            realm.addClient(TEST_CLIENT).secret(TEST_CLIENT_SECRET).redirectUris("http://127.0.0.1:8500/callback/oauth");
+            realm.addUser(TEST_USER).password(TEST_USER_PASSWORD);
+            return realm;
+        }
+    }
+
+    public static class ResourceIndicatorMapperServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.RESOURCE_INDICATOR);
+        }
+    }
+
+    private String loginUserAndGetCode(String clientId, String resource) {
+        oAuthClient.client(clientId);
+        oAuthClient.loginForm().resource(resource).doLogin(TEST_USER, TEST_USER_PASSWORD);
+
+        String code = oAuthClient.parseLoginResponse().getCode();
+        Assertions.assertNotNull(code);
+        return code;
+    }
+
+    private String ssoLoginUserAndGetCode(String clientId, String resource) {
+        oAuthClient.client(clientId);
+        oAuthClient.loginForm().resource(resource).open();
+
+        String code = oAuthClient.parseLoginResponse().getCode();
+        Assertions.assertNotNull(code);
+        return code;
+    }
+
+    private void assertTokenValidResponse(AccessTokenResponse tokenResponse, String resource) {
+        Assertions.assertEquals(200, tokenResponse.getStatusCode());
+        AccessToken accessToken = oAuthClient.verifyToken(tokenResponse.getAccessToken());
+        Assertions.assertEquals(1, accessToken.getAudience().length);
+        Assertions.assertEquals(resource, accessToken.getAudience()[0]);
+        IDToken idToken = oAuthClient.verifyIDToken(tokenResponse.getIdToken());
+        Assertions.assertEquals(1, idToken.getAudience().length);
+        Assertions.assertEquals(TEST_CLIENT, idToken.getAudience()[0]);
+    }
+
+    private void assertIntrospectValidResponse(IntrospectionResponse introspectionResponse, String resource) throws IOException {
+        Assertions.assertEquals(200, introspectionResponse.getStatusCode());
+        Assertions.assertEquals(1, introspectionResponse.asTokenMetadata().getAudience().length);
+        Assertions.assertEquals(resource, introspectionResponse.asTokenMetadata().getAudience()[0]);
+    }
+
+    private void assertRefreshTokenResponse(AccessTokenResponse tokenResponse, String resource) {
+        Assertions.assertEquals(200, tokenResponse.getStatusCode());
+        AccessToken accessToken = oAuthClient.verifyToken(tokenResponse.getAccessToken());
+        Assertions.assertEquals(1, accessToken.getAudience().length);
+        Assertions.assertEquals(resource, accessToken.getAudience()[0]);
+    }
+
+    private void assertRevokeValidResponse(TokenRevocationResponse revokeResponse, AccessTokenResponse tokenResponse) throws IOException {
+        Assertions.assertEquals(200, revokeResponse.getStatusCode());
+        IntrospectionResponse introspectionResponse = oAuthClient.doIntrospectionAccessTokenRequest(tokenResponse.getAccessToken());
+        Assertions.assertEquals(200, introspectionResponse.getStatusCode());
+        Assertions.assertFalse(introspectionResponse.asTokenMetadata().isActive());
+    }
+
+    private void assertNotBindTokenValidResponse(AccessTokenResponse tokenResponse) {
+        Assertions.assertEquals(200, tokenResponse.getStatusCode());
+        AccessToken accessToken = oAuthClient.verifyToken(tokenResponse.getAccessToken());
+        Assertions.assertNull(accessToken.getAudience());
+    }
+
+    private void assertTokenInvalidResponse(AccessTokenResponse tokenResponse, String errorDescription) {
+        Assertions.assertEquals(400, tokenResponse.getStatusCode());
+        Assertions.assertEquals(OAuthErrorException.INVALID_GRANT, tokenResponse.getError());
+        Assertions.assertEquals(errorDescription, tokenResponse.getErrorDescription());
+    }
+
+    private void assertLoginError(String clientId, String resource, String error, String errorDescription) {
+        oAuthClient.client(clientId);
+        oAuthClient.loginForm().resource(resource).open();
+
+        AuthorizationEndpointResponse authorizationEndpointResponse = oAuthClient.parseLoginResponse();
+        Assertions.assertEquals(error, authorizationEndpointResponse.getError());
+        Assertions.assertEquals(errorDescription, authorizationEndpointResponse.getErrorDescription());
+    }
+
+    // Client Policies Operations
+
+    private void updateProfiles(String json) throws ClientPolicyException {
+        try {
+            ClientProfilesRepresentation clientProfiles = JsonSerialization.readValue(json, ClientProfilesRepresentation.class);
+            testRealm.admin().clientPoliciesProfilesResource().updateProfiles(clientProfiles);
+        } catch (BadRequestException e) {
+            throw new ClientPolicyException("update profiles failed", e.getResponse().getStatusInfo().toString());
+        } catch (Exception e) {
+            throw new ClientPolicyException("update profiles failed", e.getMessage());
+        }
+    }
+
+    private void updatePolicies(String json) throws ClientPolicyException {
+        try {
+            ClientPoliciesRepresentation clientPolicies = json==null ? null : JsonSerialization.readValue(json, ClientPoliciesRepresentation.class);
+            testRealm.admin().clientPoliciesPoliciesResource().updatePolicies(clientPolicies);
+        } catch (BadRequestException e) {
+            throw new ClientPolicyException("update policies failed", e.getResponse().getStatusInfo().toString());
+        } catch (IOException e) {
+            throw new ClientPolicyException("update policies failed", e.getMessage());
+        }
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -1,0 +1,460 @@
+package org.keycloak.testsuite.util;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.MultivaluedMap;
+import org.keycloak.crypto.KeyType;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.jose.jwk.ECPublicJWK;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jws.Algorithm;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.models.utils.MapperTypeSerializer;
+import org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor.SecureCibaAuthenticationRequestSigningAlgorithmExecutor;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyConditionRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorRepresentation;
+import org.keycloak.representations.idm.ClientPolicyRepresentation;
+import org.keycloak.representations.idm.ClientProfileRepresentation;
+import org.keycloak.representations.idm.ClientProfilesRepresentation;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
+import org.keycloak.services.clientpolicy.condition.ClientAttributesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientRolesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceGroupsCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceHostsCondition;
+import org.keycloak.services.clientpolicy.condition.ClientUpdaterSourceRolesCondition;
+import org.keycloak.services.clientpolicy.condition.GrantTypeCondition;
+import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutor;
+import org.keycloak.services.clientpolicy.executor.DPoPBindEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutor;
+import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.IntentClientBindCheckExecutor;
+import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.RejectImplicitGrantExecutor;
+import org.keycloak.services.clientpolicy.executor.RejectResourceOwnerPasswordCredentialsGrantExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureResourceIndicatorExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureResponseTypeExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmExecutor;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtExecutor;
+import org.keycloak.util.DPoPGenerator;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static org.keycloak.jose.jwk.JWKUtil.toIntegerBytes;
+
+public final class ClientPoliciesUtil {
+
+    public static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Client Profiles CRUD Operations
+
+    public static class ClientProfilesBuilder {
+        private final ClientProfilesRepresentation profilesRep;
+
+        public ClientProfilesBuilder() {
+            profilesRep = new ClientProfilesRepresentation();
+            profilesRep.setProfiles(new ArrayList<>());
+        }
+
+        // Create client profile from existing representation
+        public ClientProfilesBuilder(ClientProfilesRepresentation existingRep) {
+            this.profilesRep = existingRep;
+        }
+
+        public ClientProfilesBuilder addProfile(ClientProfileRepresentation rep) {
+            profilesRep.getProfiles().add(rep);
+            return this;
+        }
+
+        public ClientProfilesRepresentation toRepresentation() {
+            return profilesRep;
+        }
+
+        public String toString() {
+            String profilesJson = null;
+            try {
+                profilesJson = objectMapper.writeValueAsString(profilesRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+            return profilesJson;
+        }
+    }
+
+    public static class ClientProfileBuilder {
+
+        private final ClientProfileRepresentation profileRep;
+
+        public ClientProfileBuilder() {
+            profileRep = new ClientProfileRepresentation();
+        }
+
+        public ClientProfileBuilder createProfile(String name, String description) {
+            if (name != null) {
+                profileRep.setName(name);
+            }
+            if (description != null) {
+                profileRep.setDescription(description);
+            }
+            profileRep.setExecutors(new ArrayList<>());
+
+            return this;
+        }
+
+        public ClientProfileBuilder addExecutor(String providerId, ClientPolicyExecutorConfigurationRepresentation config) throws Exception {
+            if (config == null) {
+                config = new ClientPolicyExecutorConfigurationRepresentation();
+            }
+            ClientPolicyExecutorRepresentation executor = new ClientPolicyExecutorRepresentation();
+            executor.setExecutorProviderId(providerId);
+            executor.setConfiguration(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class));
+            profileRep.getExecutors().add(executor);
+            return this;
+        }
+
+        public ClientProfileRepresentation toRepresentation() {
+            return profileRep;
+        }
+
+        public String toString() {
+            String profileJson = null;
+            try {
+                profileJson = objectMapper.writeValueAsString(profileRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+            return profileJson;
+        }
+    }
+
+    // Client Profiles - Executor CRUD Operations
+
+    public static HolderOfKeyEnforcerExecutor.Configuration createHolderOfKeyEnforceExecutorConfig(Boolean autoConfigure) {
+        HolderOfKeyEnforcerExecutor.Configuration config = new HolderOfKeyEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static PKCEEnforcerExecutor.Configuration createPKCEEnforceExecutorConfig(Boolean autoConfigure) {
+        PKCEEnforcerExecutor.Configuration config = new PKCEEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static FullScopeDisabledExecutor.Configuration createFullScopeDisabledExecutorConfig(Boolean autoConfigure) {
+        FullScopeDisabledExecutor.Configuration config = new FullScopeDisabledExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static ConsentRequiredExecutor.Configuration createConsentRequiredExecutorConfig(Boolean autoConfigure) {
+        ConsentRequiredExecutor.Configuration config = new ConsentRequiredExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static SecureClientAuthenticatorExecutor.Configuration createSecureClientAuthenticatorExecutorConfig(List<String> allowedClientAuthenticators, String defaultClientAuthenticator) {
+        SecureClientAuthenticatorExecutor.Configuration config = new SecureClientAuthenticatorExecutor.Configuration();
+        config.setAllowedClientAuthenticators(allowedClientAuthenticators);
+        config.setDefaultClientAuthenticator(defaultClientAuthenticator);
+        return config;
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf) {
+        return createSecureRequestObjectExecutorConfig(availablePeriod, verifyNbf, false);
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf, Boolean encryptionRequired) {
+        return createSecureRequestObjectExecutorConfig(availablePeriod, verifyNbf, encryptionRequired, null);
+    }
+
+    public static SecureRequestObjectExecutor.Configuration createSecureRequestObjectExecutorConfig(Integer availablePeriod, Boolean verifyNbf, Boolean encryptionRequired, Integer allowedClockSkew) {
+        SecureRequestObjectExecutor.Configuration config = new SecureRequestObjectExecutor.Configuration();
+        if (availablePeriod != null) config.setAvailablePeriod(availablePeriod);
+        if (verifyNbf != null) config.setVerifyNbf(verifyNbf);
+        if (encryptionRequired != null) config.setEncryptionRequired(encryptionRequired);
+        if (allowedClockSkew != null) config.setAllowedClockSkew(allowedClockSkew);
+        return config;
+    }
+
+    public static SecureResponseTypeExecutor.Configuration createSecureResponseTypeExecutor(Boolean autoConfigure, Boolean allowTokenResponseType) {
+        SecureResponseTypeExecutor.Configuration config = new SecureResponseTypeExecutor.Configuration();
+        if (autoConfigure != null) config.setAutoConfigure(autoConfigure);
+        if (allowTokenResponseType != null) config.setAllowTokenResponseType(allowTokenResponseType);
+        return config;
+    }
+
+    public static SecureSigningAlgorithmForSignedJwtExecutor.Configuration createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig(Boolean requireClientAssertion) {
+        SecureSigningAlgorithmForSignedJwtExecutor.Configuration config = new SecureSigningAlgorithmForSignedJwtExecutor.Configuration();
+        config.setRequireClientAssertion(requireClientAssertion);
+        return config;
+    }
+
+    public static SecureSigningAlgorithmExecutor.Configuration createSecureSigningAlgorithmEnforceExecutorConfig(String defaultAlgorithm) {
+        SecureSigningAlgorithmExecutor.Configuration config = new SecureSigningAlgorithmExecutor.Configuration();
+        config.setDefaultAlgorithm(defaultAlgorithm);
+        return config;
+    }
+
+    public static SecureCibaAuthenticationRequestSigningAlgorithmExecutor.Configuration createSecureCibaAuthenticationRequestSigningAlgorithmExecutorConfig(String defaultAlgorithm) {
+        SecureCibaAuthenticationRequestSigningAlgorithmExecutor.Configuration config = new SecureCibaAuthenticationRequestSigningAlgorithmExecutor.Configuration();
+        config.setDefaultAlgorithm(defaultAlgorithm);
+        return config;
+    }
+
+    public static RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean autoConfigure) {
+        RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration config = new RejectResourceOwnerPasswordCredentialsGrantExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static RejectImplicitGrantExecutor.Configuration createRejectImplicitGrantExecutorConfig(Boolean autoConfigure) {
+        RejectImplicitGrantExecutor.Configuration config = new RejectImplicitGrantExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        return config;
+    }
+
+    public static IntentClientBindCheckExecutor.Configuration createIntentClientBindCheckExecutorConfig(String intentName, String endpoint) {
+        IntentClientBindCheckExecutor.Configuration config = new IntentClientBindCheckExecutor.Configuration();
+        config.setIntentName(intentName);
+        config.setIntentClientBindCheckEndpoint(endpoint);
+        return config;
+    }
+
+    public static DPoPBindEnforcerExecutor.Configuration createDPoPBindEnforcerExecutorConfig(Boolean autoConfigure, Boolean enforceAuthorizationCodeBindingToDpop, Boolean bindRefreshToken) {
+        DPoPBindEnforcerExecutor.Configuration config = new DPoPBindEnforcerExecutor.Configuration();
+        config.setAutoConfigure(autoConfigure);
+        config.setEnforceAuthorizationCodeBindingToDpop(enforceAuthorizationCodeBindingToDpop);
+        config.setAllowOnlyRefreshTokenBinding(bindRefreshToken);
+        return config;
+    }
+
+    public static SecureRedirectUrisEnforcerExecutor.Configuration createSecureRedirectUrisEnforcerExecutorConfig(
+            Consumer<SecureRedirectUrisEnforcerExecutor.Configuration> apply) {
+        SecureRedirectUrisEnforcerExecutor.Configuration config = new SecureRedirectUrisEnforcerExecutor.Configuration();
+        if (apply != null) {
+            apply.accept(config);
+        }
+        return config;
+    }
+
+    public static SecureResourceIndicatorExecutor.Configuration createResourceAudienceBindExecutorConfig(List<String> permittedResources) {
+        SecureResourceIndicatorExecutor.Configuration config = new SecureResourceIndicatorExecutor.Configuration();
+        config.setAllowPermittedResources(permittedResources);
+        return config;
+    }
+
+    public static class ClientPoliciesBuilder {
+        private final ClientPoliciesRepresentation policiesRep;
+
+        public ClientPoliciesBuilder() {
+            policiesRep = new ClientPoliciesRepresentation();
+            policiesRep.setPolicies(new ArrayList<>());
+        }
+
+        public ClientPoliciesBuilder addPolicy(ClientPolicyRepresentation rep) {
+            policiesRep.getPolicies().add(rep);
+            return this;
+        }
+
+        public ClientPoliciesRepresentation toRepresentation() {
+            return policiesRep;
+        }
+
+        public String toString() {
+            String policiesJson = null;
+            try {
+                policiesJson = objectMapper.writeValueAsString(policiesRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+            return policiesJson;
+        }
+    }
+
+    public static class ClientPolicyBuilder {
+
+        private final ClientPolicyRepresentation policyRep;
+
+        public ClientPolicyBuilder() {
+            policyRep = new ClientPolicyRepresentation();
+        }
+
+        public ClientPolicyBuilder createPolicy(String name, String description, Boolean isEnabled) {
+            policyRep.setName(name);
+            if (description != null) {
+                policyRep.setDescription(description);
+            }
+            if (isEnabled != null) {
+                policyRep.setEnabled(isEnabled);
+            } else {
+                policyRep.setEnabled(Boolean.FALSE);
+            }
+
+            policyRep.setConditions(new ArrayList<>());
+            policyRep.setProfiles(new ArrayList<>());
+
+            return this;
+        }
+
+        public ClientPolicyBuilder addCondition(String providerId, ClientPolicyConditionConfigurationRepresentation config) throws Exception {
+            if (config == null) {
+                config = new ClientPolicyConditionConfigurationRepresentation();
+            }
+            ClientPolicyConditionRepresentation condition = new ClientPolicyConditionRepresentation();
+            condition.setConditionProviderId(providerId);
+            condition.setConfiguration(JsonSerialization.mapper.readValue(JsonSerialization.mapper.writeValueAsBytes(config), JsonNode.class));
+            policyRep.getConditions().add(condition);
+            return this;
+        }
+
+        public ClientPolicyBuilder addProfile(String profileName) {
+            policyRep.getProfiles().add(profileName);
+            return this;
+        }
+
+        public ClientPolicyRepresentation toRepresentation() {
+            return policyRep;
+        }
+
+        public String toString() {
+            String policyJson = null;
+            try {
+                policyJson = objectMapper.writeValueAsString(policyRep);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+            return policyJson;
+        }
+    }
+
+    // Client Policies - Condition CRUD Operations
+
+    public static ClientPolicyConditionConfigurationRepresentation createAnyClientConditionConfig() {
+        return new ClientPolicyConditionConfigurationRepresentation();
+    }
+
+    public static ClientPolicyConditionConfigurationRepresentation createAnyClientConditionConfig(Boolean isNegativeLogic) {
+        ClientPolicyConditionConfigurationRepresentation config = new ClientPolicyConditionConfigurationRepresentation();
+        config.setNegativeLogic(isNegativeLogic);
+        return config;
+    }
+
+    public static ClientAccessTypeCondition.Configuration createClientAccessTypeConditionConfig(List<String> types) {
+        ClientAccessTypeCondition.Configuration config = new ClientAccessTypeCondition.Configuration();
+        config.setType(types);
+        return config;
+    }
+
+    public static ClientRolesCondition.Configuration createClientRolesConditionConfig(List<String> roles) {
+        ClientRolesCondition.Configuration config = new ClientRolesCondition.Configuration();
+        config.setRoles(roles);
+        return config;
+    }
+
+    public static ClientScopesCondition.Configuration createClientScopesConditionConfig(String type, List<String> scopes) {
+        ClientScopesCondition.Configuration config = new ClientScopesCondition.Configuration();
+        config.setType(type);
+        config.setScopes(scopes);
+        return config;
+    }
+
+    public static ClientAttributesCondition.Configuration createClientAttributesConditionConfig(MultivaluedMap<String, String> attributes) {
+        ClientAttributesCondition.Configuration config = new ClientAttributesCondition.Configuration();
+        String attrsAsString = MapperTypeSerializer.serialize(attributes);
+        config.setAttributes(attrsAsString);
+        return config;
+    }
+
+    public static ClientUpdaterContextCondition.Configuration createClientUpdateContextConditionConfig(List<String> updateClientSource) {
+        ClientUpdaterContextCondition.Configuration config = new ClientUpdaterContextCondition.Configuration();
+        config.setUpdateClientSource(updateClientSource);
+        return config;
+    }
+
+    public static ClientUpdaterSourceGroupsCondition.Configuration createClientUpdateSourceGroupsConditionConfig(List<String> groups) {
+        ClientUpdaterSourceGroupsCondition.Configuration config = new ClientUpdaterSourceGroupsCondition.Configuration();
+        config.setGroups(groups);
+        return config;
+    }
+
+    public static ClientUpdaterSourceHostsCondition.Configuration createClientUpdateSourceHostsConditionConfig(List<String> trustedHosts) {
+        ClientUpdaterSourceHostsCondition.Configuration config = new ClientUpdaterSourceHostsCondition.Configuration();
+        config.setTrustedHosts(trustedHosts);
+        return config;
+    }
+
+    public static ClientUpdaterSourceRolesCondition.Configuration createClientUpdateSourceRolesConditionConfig(List<String> roles) {
+        ClientUpdaterSourceRolesCondition.Configuration config = new ClientUpdaterSourceRolesCondition.Configuration();
+        config.setRoles(roles);
+        return config;
+    }
+
+    public static GrantTypeCondition.Configuration createGrantTypeConditionConfig(List<String> grantTypes) {
+        GrantTypeCondition.Configuration config = new GrantTypeCondition.Configuration();
+        config.setGrantTypes(grantTypes);
+        return config;
+    }
+
+    // DPoP
+    public static JWK createRsaJwk(Key publicKey) {
+        return JWKBuilder.create()
+                .rsa(publicKey, KeyUse.SIG);
+    }
+
+    public static JWK createEcJwk(Key publicKey) {
+        ECPublicKey ecKey = (ECPublicKey) publicKey;
+
+        int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+        ECPublicJWK k = new ECPublicJWK();
+        k.setKeyType(KeyType.EC);
+        k.setCrv("P-" + fieldSize);
+        k.setX(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+
+        return k;
+    }
+
+    public static KeyPair generateEcdsaKey(String ecDomainParamName) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        return org.keycloak.common.util.KeyUtils.generateEcKeyPair(ecDomainParamName);
+    }
+
+    public static String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, String algorithm, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken) throws IOException {
+        return generateSignedDPoPProof(jti, htm, htu, iat, algorithm, jwsHeader, privateKey, accessToken, new DPoPGenerator());
+    }
+
+    public static String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, String algorithm, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken, DPoPGenerator dpopGenerator) throws IOException {
+        if (algorithm.equals(jwsHeader.getAlgorithm().toString())) {
+            return dpopGenerator.generateSignedDPoPProof(jti, htm, htu, iat, jwsHeader, privateKey, accessToken);
+        } else {
+            // Ability to test failure scenarios when different algorithms are used for the JWSHeader and for the actual key
+            JWSHeader updatedHeader = new JWSHeader(Algorithm.valueOf(algorithm), jwsHeader.getType(), jwsHeader.getKeyId(), jwsHeader.getKey());
+            String dpop = dpopGenerator.generateSignedDPoPProof(jti, htm, htu, iat, updatedHeader, privateKey, accessToken);
+            String dpopOrigHeader = Base64Url.encode(JsonSerialization.writeValueAsBytes(jwsHeader));
+            // Replace header with the original algorithm
+            String updatedAlgorithmHeader = dpop.substring(0, dpop.indexOf('.'));
+            return dpop.replace(updatedAlgorithmHeader, dpopOrigHeader);
+        }
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenRequest.java
@@ -56,6 +56,11 @@ public class AccessTokenRequest extends AbstractHttpPostRequest<AccessTokenReque
         parameter(OAuth2Constants.REDIRECT_URI, redirectUri);
         return this;
     }
+    
+    public AccessTokenRequest resource(String resource) {
+        parameter(OAuth2Constants.RESOURCE, resource);
+        return this;
+    }
 
     public AccessTokenRequest param(String name, String value) {
         parameter(name, value);

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
@@ -97,6 +97,11 @@ public class LoginUrlBuilder extends AbstractUrlBuilder {
         return this;
     }
 
+    public LoginUrlBuilder resource(String resource) {
+        parameter(OIDCLoginProtocol.RESOURCE_PARAM, resource);
+        return this;
+    }
+
     @Override
     protected void initRequest() {
         parameter(OAuth2Constants.RESPONSE_TYPE, client.config().getResponseType());

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RefreshRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RefreshRequest.java
@@ -26,6 +26,11 @@ public class RefreshRequest extends AbstractHttpPostRequest<RefreshRequest, Acce
         return this;
     }
 
+    public RefreshRequest resource(String resource) {
+        parameter(OAuth2Constants.RESOURCE, resource);
+        return this;
+    }
+
     protected void initRequest() {
         parameter(OAuth2Constants.GRANT_TYPE, OAuth2Constants.REFRESH_TOKEN);
         parameter(OAuth2Constants.REFRESH_TOKEN, refreshToken);


### PR DESCRIPTION
closes #41527

The PR's code size is large, but half of them are for testing.

## Class structure
 - `ResourceIndicatorMapper` : adds the value of `resource` parameter in an authorization request to an access token's "aud" claim.
 - `SecureResourceIndicatorExecutor` / `SecureResourceIndicatorExecutorFactory`:  checks if `resource` parameter value in an authorization request and token request are valid. If not, returns an error.

## The way of adding `resource` parameter value to an access token's `aud` claim
1. `AuthorizationEndpoint.updateAuthenticationSession` stores the `resource` parameter value in an authorization request to an `AuthenticationSession`.
2. `TokenManager.attachAuthenticationSession` copies the `resource` parameter value of the `AuthenticationSession` to `AuthenticatedClientSession`.
3. `ResourceIndicatorMapper` and `SecureResourceIndicatorExecutor` can see it from `AuthenticatedClientSession.getNote`.

