### PR TITLE
Add `operationId` to OpenAPI spec for Client v2

### DIFF
--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -100,6 +100,8 @@ quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.filter=true
 mp.openapi.scan.packages=org.keycloak.representations.admin.v2,org.keycloak.admin.api,org.keycloak.quarkus.runtime.oas,io.quarkus.smallrye.openapi
 mp.openapi.extensions.smallrye.auto-inheritance=PARENT_ONLY
+mp.openapi.extensions.smallrye.operationIdStrategy=METHOD
+mp.openapi.extensions.smallrye.duplicateOperationIdBehavior=FAIL
 
 # Disable Error messages from smallrye.openapi
 # related issue: https://github.com/keycloak/keycloak/issues/41871


### PR DESCRIPTION
Closes #45573

Currently it generates the following operationids:
```
  /admin/api/{realmName}/clients/{version}:
    get:
      operationId: getClients
    post:
      operationId: createClient
```
```
  /admin/api/{realmName}/clients/{version}/{id}:
    get:
      operationId: getClient
    put:
      operationId: createOrUpdateClient
    patch:
      operationId: patchClient
    delete:
      operationId: deleteClient
```

The source is the method name and it can be overridden using the `@Operation` annotation.

Potential problem are conflicts as operationid needs to be unique. This might be a problem especially if multiple API groups will be contained in a single OpenAPI spec where same method names can have different meanings in different contexts/groups. I'm starting to think if we should perhaps even have separate OpenAPI specs for different API groups.