### PR TITLE
Clarify documentation of OS-level dependencies for Kerberos

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/kerberos.adoc
+++ b/docs/documentation/server_admin/topics/authentication/kerberos.adoc
@@ -58,10 +58,10 @@ Ensure the keytab file `/tmp/http.keytab` is accessible on the host where {proje
 
 [[_server_setup]]
 
-Install a Kerberos client on your machine.
+Configure a Kerberos client on your machine.
 
 .Procedure
-. Install a Kerberos client. If your machine runs Fedora, Ubuntu, or RHEL, install the link:https://www.freeipa.org/page/Downloads[freeipa-client] package, containing a Kerberos client and other utilities.
+. Optionally, install a Kerberos client. If your machine runs Fedora, Ubuntu, or RHEL, install the link:https://www.freeipa.org/page/Downloads[freeipa-client] package, containing a Kerberos client and other utilities. Installing this package will supply you with tools and sensible defaults, but it is not required for JGSS Kerberos to function within {project_name}.
 . Configure the Kerberos client (on Linux, the configuration settings are in the link:https://web.mit.edu/kerberos/krb5-1.21/doc/admin/conf_files/krb5_conf.html[/etc/krb5.conf] file ).
 +
 Add your Kerberos realm to the configuration and configure the HTTP domains your server runs on.

--- a/docs/guides/migration/migrating-to-quarkus.adoc
+++ b/docs/guides/migration/migrating-to-quarkus.adoc
@@ -75,6 +75,11 @@ While the WildFly distribution automatically discovered custom providers, even s
 
 Depending on what APIs your providers use you may also need to make some changes to the providers. If you only leveraged classes from Keycloak SPIs you shouldn't need to, but if you used other APIs from WildFly you may need to make some changes. In addition, JavaEE APIs like session/stateless beans are no longer supported.
 
+== Migrating containers
+
+The container images for the Quarkus distribution derive from UBI Micro instead of UBI Minimal. This means that some binaries or configuration files (those not necessary for Keycloak's main functionality) may be missing. The solution is to add these files in as part of the container customization process explained in the https://www.keycloak.org/server/containers[Container guide].
+
+For example, for the Kerberos authentication features you will need to add `/etc/krb5.conf`. The `krb5-libs` RPM previously supplied this file, but was removed in the switch to UBI Micro. Note that binaries from `krb5-libs` are not required for Keycloak's Kerberos authentication features to work.
 
 == Migrating using the Operator
 

--- a/docs/guides/server/containers.adoc
+++ b/docs/guides/server/containers.adoc
@@ -105,6 +105,7 @@ First, consider if your use case can be implemented in a different way, and so a
 * A `+RUN curl+` instruction in your Containerfile can be replaced with `+ADD+`, since that instruction natively supports remote URLs.
 * Some common CLI tools can be replaced by creative use of the Linux filesystem. For example, `+ip addr show tap0+` becomes `+cat /sys/class/net/tap0/address+`
 * Tasks that need RPMs can be moved to a former stage of an image build, and the results copied across instead.
+* The Kerberos features of {project_name} do not require the binary parts of `krb5-libs` to be installed. Instead you can `+ADD+` just the relevant text configuration files, e.g. `/etc/krb5.conf`.
 
 Here is an example. Running `+update-ca-trust+` in a former build stage, then copying the result forward:
 


### PR DESCRIPTION
Closes #32527

For a long time the Kerberos authentication documentation has implied that freeipa or krb5-libs packages are a necessary dependency. This isn't actually the case. This causes concern and confusion in the case of the container deployment, which doesn't have these packages installed by default due to security hardening.

As evidenced by [the use of the `org.ietf.jgss` package](https://github.com/keycloak/keycloak/blob/77704a91b6067a41bdbf2a5b74fda1260adcedb2/common/src/main/java/org/keycloak/common/util/KerberosJdkProvider.java#L39-L42), Keycloak uses the [Java Generic Security Services API (JGSS)](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/jgss-api-mechanism.html) for kerberos, not krb5-libs via JNA. JGSS by default has no native dependencies. It will use a pure Java implementation[ unless `sun.security.jgss.native` is set to true](https://docs.oracle.com/en/java/javase/11/security/accessing-native-gss-api.html)

Unless overridden by the `java.security.krb5.conf` property, JGSS will look for the kerberos configuration in the same place that krb5-libs puts it, i.e. `/etc/krb5.conf`. This file seems to be the only actual dependency of Keycloak.

This PR updates the migration, container, and server admin guides to make this distinction more apparent.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
