### PR TITLE
Fix ClientBean BaseURL returning null

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/ClientBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/ClientBean.java
@@ -50,6 +50,10 @@ public class ClientBean {
     }
 
     public String getBaseUrl() {
+        String configuredBaseUrl = client.getBaseUrl();
+        if ((configuredBaseUrl == null || configuredBaseUrl.isBlank()) && client.getRootUrl() != null) {
+            configuredBaseUrl = "/";
+        }
         return ResolveRelative.resolveRelativeUri(session, client.getRootUrl(), client.getBaseUrl());
     }
 


### PR DESCRIPTION
When RootURL is set, and BaseURL is null/empty, it should resolve back to RootURL to prevent FTL errors.

Closes #45746 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
