### PR TITLE
Allow mapped user attributes to be reset when broker claims are removed

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractUserAttributeMapperTest.java
@@ -1,5 +1,6 @@
 package org.keycloak.testsuite.broker;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,13 +43,13 @@ public abstract class AbstractUserAttributeMapperTest extends AbstractIdentityPr
       .put(KcOidcBrokerConfiguration.ATTRIBUTE_TO_MAP_NAME, MAPPED_ATTRIBUTE_NAME)
       .build();
 
-    protected abstract Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers(IdentityProviderMapperSyncMode syncMode);
+    protected abstract Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers(IdentityProviderMapperSyncMode syncMode, boolean nullable);
 
-    public void addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode syncMode) {
+    public void addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode syncMode, boolean nullable) {
         IdentityProviderRepresentation idp = setupIdentityProvider();
 
         IdentityProviderResource idpResource = realm.identityProviders().get(idp.getAlias());
-        for (IdentityProviderMapperRepresentation mapper : createIdentityProviderMappers(syncMode)) {
+        for (IdentityProviderMapperRepresentation mapper : createIdentityProviderMappers(syncMode, nullable)) {
             mapper.setIdentityProviderAlias(bc.getIDPAlias());
             idpResource.addMapper(mapper).close();
         }
@@ -87,17 +88,17 @@ public abstract class AbstractUserAttributeMapperTest extends AbstractIdentityPr
     }
 
     private void testValueMappingForImportSyncMode(Map<String, List<String>> initialUserAttributes, Map<String, List<String>> modifiedUserAttributes) {
-        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.IMPORT);
+        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.IMPORT, false);
         testValueMapping(initialUserAttributes, modifiedUserAttributes, initialUserAttributes);
     }
 
     private void testValueMappingForForceSyncMode(Map<String, List<String>> initialUserAttributes, Map<String, List<String>> modifiedUserAttributes) {
-        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.FORCE);
+        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.FORCE, false);
         testValueMapping(initialUserAttributes, modifiedUserAttributes, modifiedUserAttributes);
     }
 
     private void testValueMappingForLegacySyncMode(Map<String, List<String>> initialUserAttributes, Map<String, List<String>> modifiedUserAttributes) {
-        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.LEGACY);
+        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.LEGACY, false);
         testValueMapping(initialUserAttributes, modifiedUserAttributes, modifiedUserAttributes);
     }
 
@@ -145,6 +146,36 @@ public abstract class AbstractUserAttributeMapperTest extends AbstractIdentityPr
           .build(),
           ImmutableMap.<String, List<String>>builder()
           .put(KcOidcBrokerConfiguration.ATTRIBUTE_TO_MAP_NAME, ImmutableList.<String>builder().add("second value").build())
+          .build()
+        );
+    }
+
+    @Test
+    public void testProtectedAttributesAreSetNullInLegacySyncModeWhenNullable() {
+        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.LEGACY, true);
+        testValueMapping(ImmutableMap.<String, List<String>>builder()
+          .put("email",  ImmutableList.<String>builder().add(bc.getUserEmail()).build())
+          .build(),
+          ImmutableMap.<String, List<String>>builder()
+          .put("email", Collections.singletonList((String) null))
+          .build(),
+          ImmutableMap.<String, List<String>>builder()
+          .put("email", Collections.singletonList((String) null))
+          .build()
+        );
+    }
+
+    @Test
+    public void testProtectedAttributesAreSetNullInForceSyncModeWhenNullable() {
+        addIdentityProviderToConsumerRealm(IdentityProviderMapperSyncMode.FORCE, true);
+        testValueMapping(ImmutableMap.<String, List<String>>builder()
+          .put("email",  ImmutableList.<String>builder().add(bc.getUserEmail()).build())
+          .build(),
+          ImmutableMap.<String, List<String>>builder()
+          .put("email", Collections.singletonList((String) null))
+          .build(),
+          ImmutableMap.<String, List<String>>builder()
+          .put("email", Collections.singletonList((String) null))
           .build()
         );
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcUserAttributeMapperTest.java
@@ -16,7 +16,7 @@ public class OidcUserAttributeMapperTest extends AbstractUserAttributeMapperTest
     }
 
     @Override
-    protected Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers(IdentityProviderMapperSyncMode syncMode) {
+    protected Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers(IdentityProviderMapperSyncMode syncMode, boolean nullable) {
         IdentityProviderMapperRepresentation attrMapper1 = new IdentityProviderMapperRepresentation();
         attrMapper1.setName("attribute-mapper");
         attrMapper1.setIdentityProviderMapper(UserAttributeMapper.PROVIDER_ID);
@@ -31,6 +31,7 @@ public class OidcUserAttributeMapperTest extends AbstractUserAttributeMapperTest
         emailAttrMapper.setIdentityProviderMapper(UserAttributeMapper.PROVIDER_ID);
         emailAttrMapper.setConfig(ImmutableMap.<String,String>builder()
           .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+          .put(UserAttributeMapper.ALLOW_NULLABLE, Boolean.toString(nullable))
           .put(UserAttributeMapper.CLAIM, "email")
           .put(UserAttributeMapper.USER_ATTRIBUTE, "email")
           .build());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/SamlUserAttributeMapperTest.java
@@ -18,12 +18,13 @@ public class SamlUserAttributeMapperTest extends AbstractUserAttributeMapperTest
     }
 
     @Override
-    protected Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers(IdentityProviderMapperSyncMode syncMode) {
+    protected Iterable<IdentityProviderMapperRepresentation> createIdentityProviderMappers(IdentityProviderMapperSyncMode syncMode, boolean nullable) {
         IdentityProviderMapperRepresentation attrMapperEmail = new IdentityProviderMapperRepresentation();
         attrMapperEmail.setName("attribute-mapper-email");
         attrMapperEmail.setIdentityProviderMapper(UserAttributeMapper.PROVIDER_ID);
         attrMapperEmail.setConfig(ImmutableMap.<String,String>builder()
           .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+          .put(UserAttributeMapper.ALLOW_NULLABLE, Boolean.toString(nullable))
           .put(UserAttributeMapper.ATTRIBUTE_FRIENDLY_NAME, "email")
           .put(UserAttributeMapper.USER_ATTRIBUTE, "email")
           .build());


### PR DESCRIPTION
Adds a toggle on the OIDC/SAML attribute importer to allow firstname, lastname and email properties to be reset when no longer in broker response. Defaults to existing behaviour.

Closes #44824

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
