### PR TITLE
Max expiration for Google IDToken

### DIFF
--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderConfig.java
@@ -63,6 +63,11 @@ public class GoogleIdentityProviderConfig extends OIDCIdentityProviderConfig imp
     }
 
     @Override
+    public int getJWTAuthorizationGrantMaxAllowedAssertionExpiration() {
+        return Integer.parseInt(getConfig().getOrDefault(JWT_AUTHORIZATION_GRANT_MAX_ALLOWED_ASSERTION_EXPIRATION, "3600"));
+    }
+
+    @Override
     public void validate(RealmModel realm) {
         if (!GoogleIdentityProvider.ISSUER_URL.equals(getConfig().get(ISSUER))) {
            throw new IllegalArgumentException("The issuer url [" + getConfig().get(ISSUER) + "] is invalid");

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderFactory.java
@@ -94,6 +94,15 @@ public class GoogleIdentityProviderFactory extends AbstractIdentityProviderFacto
                             "authorization grant JWT assertions (Google ID Token) according to RFC 7523, " +
                             "except for the audience claim that must contain the client id of the configured client")
                     .type(ProviderConfigProperty.BOOLEAN_TYPE).add().build());
+
+            providerConfigProperties.addAll(ProviderConfigurationBuilder.create()
+                    .property().name(JWTAuthorizationGrantConfig.JWT_AUTHORIZATION_GRANT_MAX_ALLOWED_ASSERTION_EXPIRATION)
+                    .label("Max allowed assertion expiration")
+                            .defaultValue("3600")
+                    .helpText("This property is used only for JWT Authorization Grant" +
+                            " to set the max accepted duration limit for the assertion. " +
+                            "Note that the Google ID Token expires after 1 hour, so this property can be used to limit the time during which the assertion can be used.")
+                    .type(ProviderConfigProperty.NUMBER_TYPE).add().build());
         }
 
         return providerConfigProperties;


### PR DESCRIPTION
Closes #45725

Added a configurable property to set the max allowed expiration for Google ID Token when used with the JWT authorization grant.

For social providers, configuration properties are defined dynamically via the `getConfigProperties`, so it is not possible to hide this new property when the JWT authorization grant is disabled without changing how the UI for social provider is rendered. I added a note in the tooltip to say that this property is used only for the JWT authorization grant.

I also set the default value to 1 hour, same as the default lifetime of Google ID Tokens.


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
