### PR TITLE
introduced related colors to the theme tab

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/themes/ColorControl.tsx
+++ b/js/apps/admin-ui/src/realm-settings/themes/ColorControl.tsx
@@ -1,0 +1,50 @@
+import {
+  TextInputProps,
+  InputGroup,
+  InputGroupItem,
+} from "@patternfly/react-core";
+import { TextControl } from "@keycloak/keycloak-ui-shared";
+import { useFormContext, useWatch } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+export type ColorControlProps = TextInputProps & {
+  name: string;
+  label: string;
+  color: string;
+  onUserChange?: () => void;
+};
+
+export const ColorControl = ({
+  name,
+  color,
+  label,
+  onUserChange,
+  ...props
+}: ColorControlProps) => {
+  const { t } = useTranslation();
+  const { control, setValue } = useFormContext();
+  const currentValue = useWatch({
+    control,
+    name,
+  });
+
+  const handleChange = (value: string) => {
+    setValue(name, value);
+    if (onUserChange) {
+      onUserChange();
+    }
+  };
+
+  return (
+    <InputGroup>
+      <InputGroupItem isFill>
+        <TextControl {...props} name={name} label={t(label)} />
+      </InputGroupItem>
+      <input
+        type="color"
+        value={currentValue || color}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </InputGroup>
+  );
+};

--- a/js/apps/admin-ui/src/realm-settings/themes/DefaultColorAccordion.tsx
+++ b/js/apps/admin-ui/src/realm-settings/themes/DefaultColorAccordion.tsx
@@ -1,0 +1,48 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionToggle,
+} from "@patternfly/react-core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { resolveColorToHex } from "./PatternflyVars";
+import { ColorControl, ColorControlProps } from "./ColorControl";
+
+type DefaultColorAccordionProps = ColorControlProps & {
+  colorName?: string;
+  onOverride?: (colorName: string) => void;
+};
+
+export const DefaultColorAccordion = (props: DefaultColorAccordionProps) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const { color, colorName, onOverride, ...rest } = props;
+
+  const handleOverride = () => {
+    if (colorName && onOverride) {
+      onOverride(colorName);
+    }
+  };
+
+  return (
+    <Accordion asDefinitionList={false} isBordered togglePosition="start">
+      <AccordionItem>
+        <AccordionToggle
+          onClick={() => setExpanded(!expanded)}
+          isExpanded={expanded}
+          id="default-color-toggle"
+        >
+          {t(props.label || "defaultColor")}
+        </AccordionToggle>
+        <AccordionContent id="default-color-content" isHidden={!expanded}>
+          <ColorControl
+            {...rest}
+            color={resolveColorToHex(color)}
+            onUserChange={handleOverride}
+          />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/js/apps/admin-ui/src/realm-settings/themes/PatternflyVars.ts
+++ b/js/apps/admin-ui/src/realm-settings/themes/PatternflyVars.ts
@@ -56,14 +56,16 @@ const variables: VariableDefinition[] = [
         },
         variable: "active-color--100",
       },
-      {
-        name: "secondaryColor",
-        defaultValue: {
-          light: "{{color}}",
-          dark: "color-mix(in srgb, {{color}} 78%, white)",
-        },
-        variable: "primary-color--100",
-      },
+      // TODO in patternfly atm secondary buttons don't have a secondaryColor
+      // see: https://github.com/patternfly/patternfly-react/issues/12238
+      // {
+      //   name: "secondaryColor",
+      //   defaultValue: {
+      //     light: "{{color}}",
+      //     dark: "color-mix(in srgb, {{color}} 78%, white)",
+      //   },
+      //   variable: "primary-color--100",
+      // },
     ],
   },
   {

--- a/js/apps/admin-ui/src/realm-settings/themes/PatternflyVars.ts
+++ b/js/apps/admin-ui/src/realm-settings/themes/PatternflyVars.ts
@@ -1,5 +1,28 @@
 // variable is the PF5 variable with the --pf-v5-global-- prefix removed
-const variables = [
+// Dependencies use {{color}} token which gets replaced with parent's current value
+type Value = { light?: string; dark?: string };
+export type DefaultValueType = string | Value;
+
+type DependencyVariable = {
+  name: string;
+  defaultValue: DefaultValueType;
+  variable: string | Value;
+};
+
+type FlattenedDependencyVariable = {
+  name: string;
+  defaultValue: DefaultValueType;
+  variable: string;
+};
+
+type VariableDefinition = {
+  name: string;
+  defaultValue: string | Value;
+  variable: string | Value;
+  dependencies?: DependencyVariable[];
+};
+
+const variables: VariableDefinition[] = [
   {
     name: "font",
     defaultValue: '"RedHatText", helvetica, arial, sans-serif',
@@ -16,102 +39,212 @@ const variables = [
     variable: "success-color--100",
   },
   {
-    name: "activeColor",
-    defaultValue: { light: "#0066cc", dark: "#1fa7f8" },
-    variable: "active-color--100",
-  },
-  {
     name: "primaryColor",
     defaultValue: "#0066cc",
     variable: { light: "primary-color--100", dark: "primary-color--300" },
-  },
-  {
-    name: "primaryColorHover",
-    defaultValue: "#004080",
-    variable: "primary-color--200",
-  },
-  {
-    name: "secondaryColor",
-    defaultValue: { light: "#0066cc", dark: "#1fa7f8" },
-    variable: "primary-color--100",
+    dependencies: [
+      {
+        name: "primaryColorHover",
+        defaultValue: "color-mix(in srgb, {{color}} 63%, black)",
+        variable: "primary-color--200",
+      },
+      {
+        name: "activeColor",
+        defaultValue: {
+          light: "{{color}}",
+          dark: "color-mix(in srgb, {{color}} 78%, white)",
+        },
+        variable: "active-color--100",
+      },
+      {
+        name: "secondaryColor",
+        defaultValue: {
+          light: "{{color}}",
+          dark: "color-mix(in srgb, {{color}} 78%, white)",
+        },
+        variable: "primary-color--100",
+      },
+    ],
   },
   {
     name: "linkColor",
     defaultValue: { light: "#0066cc", dark: "#1fa7f8" },
     variable: "link--Color",
-  },
-  {
-    name: "linkColorHover",
-    defaultValue: { light: "#004080", dark: "#73bcf7" },
-    variable: "link--Color--hover",
+    dependencies: [
+      {
+        name: "linkColorHover",
+        defaultValue: {
+          light: "color-mix(in srgb, {{color}} 63%, black)",
+          dark: "color-mix(in srgb, {{color}} 63%, white)",
+        },
+        variable: "link--Color--hover",
+      },
+    ],
   },
   {
     name: "backgroundColor",
     defaultValue: { light: "#ffffff", dark: "#1b1d21" },
     variable: "BackgroundColor--light-100",
-  },
-  {
-    name: "backgroundColorAccent",
-    defaultValue: "#26292d",
-    variable: { dark: "BackgroundColor--300" },
-  },
-  {
-    name: "backgroundColorNav",
-    defaultValue: { light: "#212427", dark: "#1b1d21" },
-    variable: {
-      light: "BackgroundColor--dark-300",
-      dark: "BackgroundColor--100",
-    },
-  },
-  {
-    name: "backgroundColorHeader",
-    defaultValue: { light: "#151515", dark: "#030303" },
-    variable: {
-      light: "BackgroundColor--dark-100",
-      dark: "palette--black-1000",
-    },
+    dependencies: [
+      {
+        name: "backgroundColorAccent",
+        defaultValue: "color-mix(in srgb, {{color}} 95%, white)",
+        variable: { dark: "BackgroundColor--300" },
+      },
+      {
+        name: "backgroundColorNav",
+        defaultValue: {
+          light: "color-mix(in srgb, {{color}} 14%, black)",
+          dark: "color-mix(in srgb, {{color}} 99%, black)",
+        },
+        variable: {
+          light: "BackgroundColor--dark-300",
+          dark: "BackgroundColor--100",
+        },
+      },
+      {
+        name: "backgroundColorHeader",
+        defaultValue: {
+          light: "color-mix(in srgb, {{color}} 8%, black)",
+          dark: "color-mix(in srgb, {{color}} 10%, black)",
+        },
+        variable: {
+          light: "BackgroundColor--dark-100",
+          dark: "palette--black-1000",
+        },
+      },
+    ],
   },
   { name: "iconColor", defaultValue: "#f0f0f0", variable: "Color--light-200" },
   {
     name: "textColor",
     defaultValue: { light: "#151515", dark: "#e0e0e0" },
     variable: "Color--100",
-  },
-  {
-    name: "lightTextColor",
-    defaultValue: { light: "#ffffff", dark: "#e0e0e0" },
-    variable: "Color--light-100",
+    dependencies: [
+      {
+        name: "lightTextColor",
+        defaultValue: { light: "#ffffff", dark: "{{color}}" },
+        variable: "Color--light-100",
+      },
+      {
+        name: "inputTextColor",
+        defaultValue: { light: "{{color}}", dark: "{{color}}" },
+        variable: "Color--dark-100",
+      },
+    ],
   },
   {
     name: "inputBackgroundColor",
     defaultValue: "#36373a",
     variable: { dark: "BackgroundColor--400" },
   },
-  {
-    name: "inputTextColor",
-    defaultValue: { light: "#151515", dark: "#e0e0e0" },
-    variable: "Color--dark-100",
-  },
 ];
 
-type Value = { light?: string; dark: string };
 type ThemeType = keyof Value;
 
-const convert = (v: string | Value, theme: ThemeType) =>
-  typeof v === "string" ? v : v[theme];
+export type FlattenedVariable = Omit<VariableDefinition, "dependencies"> & {
+  parentName?: string;
+  dependencies?: FlattenedDependencyVariable[];
+};
 
-export const lightTheme = () =>
-  variables
-    .filter((v) => typeof v.defaultValue !== "string")
-    .map((v) => ({
+const convert = (v: string | Value | undefined, theme: ThemeType) =>
+  typeof v === "string" ? v : v?.[theme];
+
+const flattenVariables = (theme: ThemeType): FlattenedVariable[] => {
+  const result: FlattenedVariable[] = [];
+
+  variables.forEach((v) => {
+    const defaultValue = convert(v.defaultValue, theme);
+    const variable = convert(v.variable, theme);
+
+    // Skip variables that don't have a value for this theme
+    if (defaultValue === undefined && variable === undefined) return;
+
+    const flattenedVar: FlattenedVariable = {
       name: v.name,
-      defaultValue: convert(v.defaultValue, "light"),
-      variable: convert(v.variable, "light"),
-    }));
+      defaultValue: defaultValue!,
+      variable: variable!,
+    };
 
-export const darkTheme = () =>
-  variables.map((v) => ({
-    name: v.name,
-    defaultValue: convert(v.defaultValue, "dark"),
-    variable: convert(v.variable, "dark"),
-  }));
+    if (v.dependencies && v.dependencies.length > 0) {
+      flattenedVar.dependencies = v.dependencies
+        .map((dep) => {
+          const depVariable = convert(dep.variable, theme);
+          if (!depVariable) return null;
+          return {
+            name: dep.name,
+            variable: depVariable,
+            defaultValue: dep.defaultValue,
+          };
+        })
+        .filter((dep): dep is FlattenedDependencyVariable => dep !== null);
+    }
+
+    result.push(flattenedVar);
+
+    if (v.dependencies) {
+      v.dependencies.forEach((dep) => {
+        const depVariable = convert(dep.variable, theme);
+        if (!depVariable) return;
+        result.push({
+          name: dep.name,
+          defaultValue: dep.defaultValue,
+          variable: depVariable,
+          parentName: v.name,
+        });
+      });
+    }
+  });
+
+  return result;
+};
+
+export const lightTheme = (): FlattenedVariable[] =>
+  flattenVariables("light").filter(
+    (v) => v.defaultValue !== undefined || v.parentName !== undefined,
+  );
+
+export const darkTheme = (): FlattenedVariable[] => flattenVariables("dark");
+
+export function resolveColorToHex(colorValue: string) {
+  // If already a valid hex color, return it directly
+  if (/^#[0-9a-fA-F]{6}$/i.test(colorValue)) {
+    return colorValue.toLowerCase();
+  }
+
+  const el = document.createElement("div");
+  el.style.cssText = `position:absolute;left:-9999px;color:${colorValue}`;
+  document.body.appendChild(el);
+  const computed = getComputedStyle(el).color;
+  el.remove();
+
+  let r = 0,
+    g = 0,
+    b = 0;
+
+  // Parse color(srgb 0 0.252 0.504) format (0-1 range)
+  let matches = /color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/.exec(
+    computed || "",
+  );
+  if (matches) {
+    [, r, g, b] = matches.map(Number);
+    r = Math.round(r * 255);
+    g = Math.round(g * 255);
+    b = Math.round(b * 255);
+  } else {
+    // Parse rgb(r, g, b) or rgba(r, g, b, a) format
+    matches = /rgba?\(\s*(\d+),\s*(\d+),\s*(\d+)/.exec(computed || "");
+    if (matches) {
+      [, r, g, b] = matches.map(Number);
+    }
+  }
+  return "#" + [r, g, b].map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+export function resolveColorReferences(
+  colorValue: DefaultValueType,
+  parentValue: string,
+  theme: ThemeType,
+): string {
+  return convert(colorValue, theme)!.replace(/\{\{color\}\}/g, parentValue);
+}

--- a/js/apps/admin-ui/src/realm-settings/themes/ThemeColors.tsx
+++ b/js/apps/admin-ui/src/realm-settings/themes/ThemeColors.tsx
@@ -1,28 +1,19 @@
 import RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
-import { TextControl } from "@keycloak/keycloak-ui-shared";
 import {
   Alert,
   Flex,
   FlexItem,
   FormGroup,
-  InputGroup,
-  InputGroupItem,
   PageSection,
   Tab,
   Tabs,
   Text,
   TextContent,
-  TextInputProps,
   ToggleGroup,
   ToggleGroupItem,
 } from "@patternfly/react-core";
-import { useEffect, useMemo, useState } from "react";
-import {
-  FormProvider,
-  useForm,
-  useFormContext,
-  useWatch,
-} from "react-hook-form";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { FixedButtonsGroup } from "../../components/form/FixedButtonGroup";
 import { FormAccess } from "../../components/form/FormAccess";
@@ -33,39 +24,20 @@ import { ImageUpload } from "./ImageUpload";
 import { LoginPreviewWindow } from "./LoginPreviewWindow";
 import { usePreviewLogo } from "./LogoContext";
 import { usePreviewBackground } from "./BackgroundContext";
-import { darkTheme, lightTheme } from "./PatternflyVars";
+import {
+  darkTheme,
+  lightTheme,
+  resolveColorToHex,
+  resolveColorReferences,
+  DefaultValueType,
+} from "./PatternflyVars";
 import { PreviewWindow } from "./PreviewWindow";
 import { ThemeRealmRepresentation } from "./ThemesTab";
 import { UploadJar } from "./UploadJar";
+import { DefaultColorAccordion } from "./DefaultColorAccordion";
+import { ColorControl } from "./ColorControl";
 
 type ThemeType = "light" | "dark";
-
-type ColorControlProps = TextInputProps & {
-  name: string;
-  label: string;
-  color: string;
-};
-
-const ColorControl = ({ name, color, label, ...props }: ColorControlProps) => {
-  const { t } = useTranslation();
-  const { control, setValue } = useFormContext();
-  const currentValue = useWatch({
-    control,
-    name,
-  });
-  return (
-    <InputGroup>
-      <InputGroupItem isFill>
-        <TextControl {...props} name={name} label={t(label)} />
-      </InputGroupItem>
-      <input
-        type="color"
-        value={currentValue || color}
-        onChange={(e) => setValue(name, e.target.value)}
-      />
-    </InputGroup>
-  );
-};
 
 const switchTheme = (theme: ThemeType) => {
   if (theme === "light") {
@@ -91,12 +63,15 @@ export const ThemeColors = ({
 }: ThemeColorsProps) => {
   const { t } = useTranslation();
   const form = useForm();
-  const { handleSubmit, watch } = form;
+  const { handleSubmit, watch, control, setValue } = form;
   const style = watch();
   const contextLogo = usePreviewLogo();
   const contextBackground = usePreviewBackground();
   const [open, toggle, setOpen] = useToggle();
   const [previewTab, setPreviewTab] = useState(0);
+  const [overriddenColors, setOverriddenColors] = useState<Set<string>>(
+    new Set(),
+  );
 
   const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
   const getDarkModeFromRealm = () => {
@@ -112,15 +87,90 @@ export const ThemeColors = ({
     [theme],
   );
 
+  const parentColors = useMemo(
+    () => mapping.filter((m) => m.dependencies && m.dependencies.length > 0),
+    [mapping],
+  );
+
+  const parentWatchNames = useMemo(
+    () =>
+      parentColors
+        .map((p) => (p.variable ? `${theme}.${p.variable}` : null))
+        .filter((name): name is string => name !== null),
+    [parentColors, theme],
+  );
+
+  const parentColorValues = useWatch({
+    control,
+    name: parentWatchNames,
+  });
+
+  const prevParentValues = useRef<(string | undefined)[]>([]);
+
+  // Mark a color as overridden by user
+  const markAsOverridden = useCallback((colorName: string) => {
+    setOverriddenColors((prev) => new Set(prev).add(colorName));
+  }, []);
+
+  // Recalculate derived colors when any parent color changes
+  useEffect(() => {
+    if (!parentColorValues || parentColorValues.length === 0) return;
+
+    // Find which parent colors changed and update their dependents
+    parentColors.forEach((parent, index) => {
+      const currentValue = parentColorValues[index];
+      const prevValue = prevParentValues.current[index];
+
+      if (currentValue && currentValue !== prevValue && parent.dependencies) {
+        // Update each dependent that hasn't been manually overridden
+        parent.dependencies.forEach((dep) => {
+          if (!overriddenColors.has(dep.name)) {
+            const resolved = resolveColorReferences(
+              dep.defaultValue,
+              currentValue,
+              theme,
+            );
+            const hexValue = resolveColorToHex(resolved);
+            setValue(`${theme}.${dep.variable}`, hexValue);
+          }
+        });
+      }
+    });
+
+    prevParentValues.current = [...parentColorValues];
+  }, [parentColorValues, parentColors, overriddenColors, theme, setValue]);
+
+  const defaultValue = (v: DefaultValueType | undefined, theme: ThemeType) =>
+    typeof v === "string" ? v : v?.[theme];
+
   const reset = () => {
+    setOverriddenColors(new Set());
+
+    const parentDefaults: Record<string, string> = {};
+    mapping.forEach((m) => {
+      if (m.defaultValue && !m.parentName) {
+        parentDefaults[m.name] = defaultValue(m.defaultValue, theme)!;
+      }
+    });
+
     form.reset({
-      [theme]: mapping.reduce(
-        (acc, m) => ({
-          ...acc,
-          [m.variable!]: m.defaultValue,
-        }),
-        {},
-      ),
+      [theme]: mapping.reduce<Record<string, string>>((acc, m) => {
+        if (!m.variable) return acc;
+
+        let value = defaultValue(m.defaultValue, theme);
+        if (m.parentName && value?.includes("{{")) {
+          const parentValue = parentDefaults[m.parentName];
+          if (parentValue) {
+            const resolved = resolveColorReferences(value, parentValue, theme);
+            value = resolveColorToHex(resolved);
+          }
+        }
+
+        if (value !== undefined) {
+          acc[defaultValue(m.variable, theme)!] = value;
+        }
+        return acc;
+      }, {}),
     });
   };
 
@@ -240,14 +290,25 @@ export const ThemeColors = ({
                     onChange={(bg) => contextBackground?.setBackground(bg)}
                   />
                 </FormGroup>
-                {mapping.map((m) => (
-                  <ColorControl
-                    key={m.name}
-                    color={m.defaultValue!}
-                    name={`${theme}.${m.variable!}`}
-                    label={m.name}
-                  />
-                ))}
+                {mapping.map((m) =>
+                  m.parentName ? (
+                    <DefaultColorAccordion
+                      label={m.name}
+                      color={defaultValue(m.defaultValue, theme)!}
+                      key={m.name}
+                      name={`${theme}.${m.variable}`}
+                      colorName={m.name}
+                      onOverride={markAsOverridden}
+                    />
+                  ) : (
+                    <ColorControl
+                      key={m.name}
+                      color={defaultValue(m.defaultValue, theme)!}
+                      name={`${theme}.${m.variable!}`}
+                      label={m.name}
+                    />
+                  ),
+                )}
               </FormProvider>
             </FormAccess>
           </FlexItem>

--- a/js/apps/admin-ui/src/realm-settings/themes/ThemeColors.tsx
+++ b/js/apps/admin-ui/src/realm-settings/themes/ThemeColors.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { TextControl } from "@keycloak/keycloak-ui-shared";
 import { FixedButtonsGroup } from "../../components/form/FixedButtonGroup";
 import { FormAccess } from "../../components/form/FormAccess";
 import useToggle from "../../utils/useToggle";


### PR DESCRIPTION
This reduces the number of colors that the user has to set to make his
own theme, by having hover and or other colors be derived from a parent
color

fixes: #45527

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
