### PR TITLE
[OID4VCI] Inconsistencies in well-known OID4VC metadata (Same metadata for all formats) #45485

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/CredentialBuilder.java
@@ -17,7 +17,9 @@
 
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.provider.Provider;
 
@@ -48,4 +50,24 @@ public interface CredentialBuilder extends Provider {
             VerifiableCredential verifiableCredential,
             CredentialBuildConfig credentialBuildConfig
     ) throws CredentialBuilderException;
+
+    /**
+     * Allows the credential builder to contribute format-specific metadata
+     * to the OID4VCI well-known credential issuer metadata.
+     *
+     * <p>
+     * Implementations should add only the metadata fields required by the
+     * supported credential format (for example {@code vct} for {@code dc+sd-jwt}
+     * or {@code credential_definition} for {@code jwt_vc_json}).
+     * </p>
+     *
+     * <p>
+     * The default implementation is a no-op to preserve backward compatibility.
+     * </p>
+     *
+     * @param credentialConfig the credential configuration to populate with format-specific metadata
+     * @param credentialScope  the credential scope model containing the source data
+     */
+    default void contributeToMetadata(SupportedCredentialConfiguration credentialConfig, CredentialScopeModel credentialScope) {
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
@@ -24,11 +24,14 @@ import java.util.function.UnaryOperator;
 
 import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
 import org.keycloak.protocol.oid4vc.issuance.TimeProvider;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
+import org.keycloak.protocol.oid4vc.model.CredentialDefinition;
 import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.Format;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 
@@ -103,5 +106,11 @@ public class JwtCredentialBuilder implements CredentialBuilder {
                 .jsonContent(jsonWebToken);
 
         return new JwtCredentialBody(jwsBuilder);
+    }
+
+    @Override
+    public void contributeToMetadata(SupportedCredentialConfiguration credentialConfig, CredentialScopeModel credentialScope) {
+        CredentialDefinition credentialDefinition = CredentialDefinition.parse(credentialScope);
+        credentialConfig.setCredentialDefinition(credentialDefinition);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilder.java
@@ -26,9 +26,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
 import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.Format;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.sdjwt.DisclosureSpec;
 import org.keycloak.sdjwt.IssuerSignedJWT;
@@ -133,5 +135,11 @@ public class SdJwtCredentialBuilder implements CredentialBuilder {
         SdJwt.Builder sdJwtBuilder = SdJwt.builder();
 
         return new SdJwtCredentialBody(sdJwtBuilder, issuerSignedJWT);
+    }
+
+    @Override
+    public void contributeToMetadata(SupportedCredentialConfiguration credentialConfig, CredentialScopeModel credentialScope) {
+        String vct = Optional.ofNullable(credentialScope.getVct()).orElse(credentialScope.getName());
+        credentialConfig.setVct(vct);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialBuildConfig.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialBuildConfig.java
@@ -97,7 +97,7 @@ public class CredentialBuildConfig {
 
         return new CredentialBuildConfig().setCredentialIssuer(credentialIssuer)
                                           .setCredentialConfigId(credentialConfiguration.getId())
-                                          .setCredentialType(credentialConfiguration.getVct())
+                                          .setCredentialType(credentialModel.getVct())
                                           .setTokenJwsType(credentialModel.getTokenJwsType())
                                           .setNumberOfDecoys(credentialModel.getSdJwtNumberOfDecoys())
                                           .setSigningKeyId(credentialModel.getSigningKeyId())

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/SupportedCredentialConfiguration.java
@@ -109,12 +109,6 @@ public class SupportedCredentialConfiguration {
         String format = Optional.ofNullable(credentialScope.getFormat()).orElse(Format.SD_JWT_VC);
         credentialConfiguration.setFormat(format);
 
-        String vct = Optional.ofNullable(credentialScope.getVct()).orElse(credentialScope.getName());
-        credentialConfiguration.setVct(vct);
-
-        CredentialDefinition credentialDefinition = CredentialDefinition.parse(credentialScope);
-        credentialConfiguration.setCredentialDefinition(credentialDefinition);
-
         KeyAttestationsRequired keyAttestationsRequired = KeyAttestationsRequired.parse(credentialScope);
         ProofTypesSupported proofTypesSupported = ProofTypesSupported.parse(keycloakSession,
                                                                             keyAttestationsRequired,

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCJWTIssuerEndpointTest.java
@@ -771,9 +771,9 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                         assertNull("credentialSubject.scope-name has no display", claim.getDisplay());
                     }
 
-                    assertEquals("The jwt_vc-credential should offer vct",
-                            verifiableCredentialType,
-                            jwtVcConfig.getVct());
+                    assertNotNull("The jwt_vc-credential should offer credential_definition",
+                            jwtVcConfig.getCredentialDefinition());
+                    assertNull("JWT_VC credentials should not have vct", jwtVcConfig.getVct());
 
                     // We are offering key binding only for identity credential
                     assertTrue("The jwt_vc-credential should contain a cryptographic binding method supported named jwk",


### PR DESCRIPTION
This pull request enhances the flexibility and correctness of the OID4VC issuer metadata by allowing credential builders to contribute format-specific metadata to the well-known endpoint. It introduces a new extension point in the `CredentialBuilder` interface, updates the issuer provider to use it, and adds targeted tests to ensure correct metadata exposure for different credential formats.

**Format-specific metadata contribution:**

* Added a new `contributeToMetadata` method to the `CredentialBuilder` interface, enabling each credential format to customize the metadata it exposes in the well-known endpoint. Default implementation is a no-op for backward compatibility.
* Implemented `contributeToMetadata` in `JwtCredentialBuilder` and `SdJwtCredentialBuilder` to ensure only relevant fields (`credential_definition` or `vct`) are present in the metadata for each format. [[1]](diffhunk://#diff-b3e591246d66e1bdc3fe6c9c5a553775fe0f13aa53cac68611d0ca10683bda25R108-R112) [[2]](diffhunk://#diff-ca6ba74d48a4c052114721df71fe13346ea8b92dfa0fa9bcb834cf2fe5b93280R137-R141)

**Provider logic updates:**

* Updated `OID4VCIssuerWellKnownProvider` to invoke `contributeToMetadata` for each supported credential configuration, using the factory pattern to obtain the correct builder for each format. This ensures that only format-appropriate metadata fields are included. [[1]](diffhunk://#diff-a8598fb792303a2cce62c2affdaede4d96ff4c324ee3b6b9d65ab342ae76edc9R50) [[2]](diffhunk://#diff-a8598fb792303a2cce62c2affdaede4d96ff4c324ee3b6b9d65ab342ae76edc9L463-R515)

**Testing:**

* Added `CredentialMetadataWellKnownTest` to verify that the well-known endpoint exposes the correct metadata for SD-JWT and JWT-VC credential types, ensuring that only the appropriate fields are present for each format.

These changes improve extensibility, ensure compliance with OID4VCI metadata requirements, and prevent leaking irrelevant metadata fields for unsupported formats.

Closes #45485