### PR TITLE
Unable to find contextual data of type: org.keycloak.models.KeycloakSession #44574

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/storage/StoreSyncEvent.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/StoreSyncEvent.java
@@ -32,11 +32,11 @@ public class StoreSyncEvent implements ProviderEvent {
     private final boolean removed;
     private final ComponentModel model;
 
-    private StoreSyncEvent(KeycloakSession session, RealmModel realm, boolean removed) {
+    public StoreSyncEvent(KeycloakSession session, RealmModel realm, boolean removed) {
         this(session, realm, null, removed);
     }
 
-    private StoreSyncEvent(KeycloakSession session, RealmModel realm, ComponentModel model, boolean removed) {
+    public StoreSyncEvent(KeycloakSession session, RealmModel realm, ComponentModel model, boolean removed) {
         this.session = session;
         this.realm = realm;
         this.model = model;


### PR DESCRIPTION
This pull request refactors how `StoreSyncEvent` is fired and handled, improving transaction safety and making event publication more explicit. The main changes involve switching from a static `fire` method to directly publishing the event using the `KeycloakSessionFactory`, and updating the event listener logic to ensure correct realm context management within a transaction.

**Event Publication Refactor**

* Replaced the static `StoreSyncEvent.fire(session, realm, removed)` calls in `RealmManager` with explicit creation and publishing of a `StoreSyncEvent` using `sessionFactory.publish(new StoreSyncEvent(session, realm, removed))` in both the `removeRealm` and `importRealm` methods. This makes event publication more explicit and consistent. [[1]](diffhunk://#diff-d76b745a8ab9f786f735e87ba7dd2642f25d76c595d9f894db496d4fe0e0e58fR315-R320) [[2]](diffhunk://#diff-d76b745a8ab9f786f735e87ba7dd2642f25d76c595d9f894db496d4fe0e0e58fR689-R695)
* Changed the constructors of `StoreSyncEvent` from private to public to allow direct instantiation outside the class.

**Event Listener Transaction Handling**

* Updated `UserStorageEventListener.onEvent` to wrap the `StoreSyncEvent` handling logic in a `runJobInTransaction` block, ensuring the realm context is correctly set and restored within a transaction. The realm is now looked up by ID inside the transaction, and unnecessary context restoration code was removed. [[1]](diffhunk://#diff-7ca18c3f4a3b6ca1769802d131433058c875cfb87f049009e51bfd318bdca42eL72-R79) [[2]](diffhunk://#diff-7ca18c3f4a3b6ca1769802d131433058c875cfb87f049009e51bfd318bdca42eL89-R91)

**Imports and Minor Cleanups**

* Added missing imports for `KeycloakSessionFactory` in `RealmManager.java` to support the new event publication approach.…nt publishing

Closes #44574

