### PR TITLE
Correct Standard Token Exchange with Dynamic Scopes feature enabled

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -187,6 +187,7 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
 
         boolean validScopes;
         if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
+            session.getContext().setClient(client);
             AuthorizationRequestContext authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, scope);
             validScopes = TokenManager.isValidScope(session, scope, authorizationRequestContext, client, null);
         } else {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2WithDynamicScopesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/tokenexchange/StandardTokenExchangeV2WithDynamicScopesTest.java
@@ -1,0 +1,19 @@
+package org.keycloak.testsuite.oauth.tokenexchange;
+
+import org.keycloak.common.Profile;
+import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
+import org.keycloak.testsuite.arquillian.annotation.UncaughtServerErrorExpected;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+@EnableFeature(value = Profile.Feature.DYNAMIC_SCOPES, skipRestart = true)
+public class StandardTokenExchangeV2WithDynamicScopesTest extends StandardTokenExchangeV2Test {
+
+    @Override
+    @Test
+    @UncaughtServerErrorExpected
+    @Ignore
+    public void testExchangeWithDynamicScopesEnabled(){
+    }
+}


### PR DESCRIPTION
Closes #45716

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This draft PR solves a basic problem for working the Token Exchange with dynamic scopes.
However, two tests are keeping failing. I don't know why. Any help?