### PR TITLE
feat(admin): implement Client API v2 Java client and backend resources

### DIFF
--- a/admin-v2-spec.yaml
+++ b/admin-v2-spec.yaml
@@ -1,0 +1,263 @@
+---
+openapi: 3.1.0
+components:
+  schemas:
+    Auth:
+      type: object
+      properties:
+        method:
+          type: string
+        secret:
+          type: string
+        certificate:
+          type: string
+    BaseClientRepresentation:
+      type: object
+      properties:
+        clientId:
+          type: string
+        displayName:
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+        appUrl:
+          type: string
+        redirectUris:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        roles:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        additionalFields:
+          type: object
+          additionalProperties: {}
+      allOf:
+      - $ref: "#/components/schemas/BaseRepresentation"
+    BaseRepresentation:
+      type: object
+    Flow:
+      type: string
+      enum:
+      - STANDARD
+      - IMPLICIT
+      - DIRECT_GRANT
+      - SERVICE_ACCOUNT
+      - TOKEN_EXCHANGE
+      - DEVICE
+      - CIBA
+    OIDCClientRepresentation:
+      type: object
+      properties:
+        loginFlows:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/Flow"
+        auth:
+          $ref: "#/components/schemas/Auth"
+        webOrigins:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        serviceAccountRoles:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        protocol:
+          type: string
+      allOf:
+      - $ref: "#/components/schemas/BaseClientRepresentation"
+    SAMLClientRepresentation:
+      description: SAML Client configuration
+      type: object
+      properties:
+        nameIdFormat:
+          type: string
+        forceNameIdFormat:
+          type: boolean
+        includeAuthnStatement:
+          type: boolean
+        signDocuments:
+          type: boolean
+        signAssertions:
+          type: boolean
+        clientSignatureRequired:
+          type: boolean
+        forcePostBinding:
+          type: boolean
+        frontChannelLogout:
+          type: boolean
+        signatureAlgorithm:
+          type: string
+        signatureCanonicalizationMethod:
+          type: string
+        signingCertificate:
+          type: string
+        allowEcpFlow:
+          type: boolean
+        protocol:
+          type: string
+      allOf:
+      - $ref: "#/components/schemas/BaseClientRepresentation"
+tags:
+- name: Clients (v2)
+  x-smallrye-profile-admin: ""
+paths:
+  /admin/api/{realmName}/clients/{version}:
+    get:
+      summary: Get all clients
+      description: Returns a list of all clients in the realm
+      tags:
+      - Clients (v2)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  discriminator:
+                    propertyName: protocol
+                    mapping:
+                      openid-connect: "#/components/schemas/OIDCClientRepresentation"
+                      saml: "#/components/schemas/SAMLClientRepresentation"
+                  oneOf:
+                  - $ref: "#/components/schemas/OIDCClientRepresentation"
+                  - $ref: "#/components/schemas/SAMLClientRepresentation"
+    post:
+      summary: Create a new client
+      description: Creates a new client in the realm
+      tags:
+      - Clients (v2)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              discriminator:
+                propertyName: protocol
+                mapping:
+                  openid-connect: "#/components/schemas/OIDCClientRepresentation"
+                  saml: "#/components/schemas/SAMLClientRepresentation"
+              oneOf:
+              - $ref: "#/components/schemas/OIDCClientRepresentation"
+              - $ref: "#/components/schemas/SAMLClientRepresentation"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+    parameters:
+    - name: realmName
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: version
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: v\d+
+  /admin/api/{realmName}/clients/{version}/{id}:
+    get:
+      tags:
+      - Clients (v2)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                discriminator:
+                  propertyName: protocol
+                  mapping:
+                    openid-connect: "#/components/schemas/OIDCClientRepresentation"
+                    saml: "#/components/schemas/SAMLClientRepresentation"
+                oneOf:
+                - $ref: "#/components/schemas/OIDCClientRepresentation"
+                - $ref: "#/components/schemas/SAMLClientRepresentation"
+    put:
+      tags:
+      - Clients (v2)
+      requestBody:
+        content:
+          application/json:
+            schema:
+              discriminator:
+                propertyName: protocol
+                mapping:
+                  openid-connect: "#/components/schemas/OIDCClientRepresentation"
+                  saml: "#/components/schemas/SAMLClientRepresentation"
+              oneOf:
+              - $ref: "#/components/schemas/OIDCClientRepresentation"
+              - $ref: "#/components/schemas/SAMLClientRepresentation"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+    patch:
+      tags:
+      - Clients (v2)
+      requestBody:
+        content:
+          application/merge-patch+json: {}
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                discriminator:
+                  propertyName: protocol
+                  mapping:
+                    openid-connect: "#/components/schemas/OIDCClientRepresentation"
+                    saml: "#/components/schemas/SAMLClientRepresentation"
+                oneOf:
+                - $ref: "#/components/schemas/OIDCClientRepresentation"
+                - $ref: "#/components/schemas/SAMLClientRepresentation"
+    delete:
+      tags:
+      - Clients (v2)
+      responses:
+        "204":
+          description: No Content
+    parameters:
+    - name: realmName
+      in: path
+      required: true
+      schema:
+        type: string
+    - name: version
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: v\d+
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+info:
+  title: Keycloak API
+  version: 999.0.0-SNAPSHOT
+servers:
+- url: https://localhost:8443
+  description: Auto generated value
+- url: https://0.0.0.0:8443
+  description: Auto generated value

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates
-  ~ and other contributors as indicated by the @author tags.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,61 +11,136 @@
 
     <artifactId>keycloak-admin-client-tests</artifactId>
     <name>Keycloak Admin REST Client for tests</name>
-    <description>Keycloak Admin REST Client. This module is supposed to be used just in the Keycloak repository for the testsuite. It is NOT supposed to be used by the 3rd party applications.
-        For the use by 3rd party applications, please use `org.keycloak:keycloak-admin-client` module.
-    </description>
+    <description>Keycloak Admin REST Client for testsuite.</description>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
+        <cxf.version>3.4.10</cxf.version>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-common</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
+
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>${resteasy.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-multipart-provider</artifactId>
-            <version>${resteasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-jackson2-provider</artifactId>
-            <version>${resteasy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${resteasy.version}</version>
+            <artifactId>resteasy-multipart-provider</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.19</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.6.8</version>
+        </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.10.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/../../admin-v2-spec.yaml</inputSpec>
+                            <generatorName>jaxrs-spec</generatorName>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <generateApiTests>false</generateApiTests>
+                            <generateModelTests>false</generateModelTests>
+                            <skipValidateSpec>true</skipValidateSpec>
+                            <configOptions>
+                                <interfaceOnly>true</interfaceOnly>
+                                <useJakartaEe>true</useJakartaEe>
+                                <returnResponse>false</returnResponse>
+                                <dateLibrary>java8</dateLibrary>
+                                <apiPackage>org.keycloak.admin.client.v2.resource</apiPackage>
+                                <modelPackage>org.keycloak.admin.client.v2.representation</modelPackage>
+                                <inlineSchemaNameMapping>AdminRealmsRealmTestSMTPConnectionPostRequest=TestSMTPConnectionRepresentation</inlineSchemaNameMapping>
+                            </configOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/openapi/src/gen/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
@@ -55,10 +55,10 @@ public interface ClientsResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<ClientRepresentation> findAll(@QueryParam("clientId") String clientId,
-                                                 @QueryParam("viewableOnly") Boolean viewableOnly,
-                                                 @QueryParam("search") Boolean search,
-                                                 @QueryParam("first") Integer firstResult,
-                                                 @QueryParam("max") Integer maxResults);
+                                       @QueryParam("viewableOnly") Boolean viewableOnly,
+                                       @QueryParam("search") Boolean search,
+                                       @QueryParam("first") Integer firstResult,
+                                       @QueryParam("max") Integer maxResults);
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -71,5 +71,14 @@ public interface ClientsResource {
     @Path("{id}")
     @DELETE
     Response delete(@PathParam("id") String id);
+
+    /**
+     * Entry point for the Client V2 API.
+     * Acts as a JAX-RS sub-resource locator for the new V2 implementation.
+     * <p>
+     * Usage: {@code adminClient.realm("myRealm").clients().v2()...}
+     */
+    @Path("v2")
+    Object v2(); // TODO: Replace 'Object' with the generated 'ClientsV2Api' interface once the module dependency is circular-free.
 
 }

--- a/integration/admin-client/src/test/java/org/keycloak/admin/client/v2/resource/ClientsV2ApiTest.java
+++ b/integration/admin-client/src/test/java/org/keycloak/admin/client/v2/resource/ClientsV2ApiTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.v2.resource;
+
+import java.net.Socket;
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+class ClientsV2ApiTest {
+
+    private static final String SERVER_URL = System.getProperty("keycloak.url", "http://localhost:8080");
+    private static final String REALM = "master";
+    private static final String USER = System.getProperty("keycloak.user", "admin");
+    private static final String PASSWORD = System.getProperty("keycloak.password", "admin");
+
+    @Test
+    @DisplayName("Should retrieve clients list from V2 endpoint successfully")
+    void testGetClientsV2_EndToEnd() {
+        Assumptions.assumeTrue(isServerUp(SERVER_URL), "Test skipped: Keycloak server is not reachable at " + SERVER_URL);
+
+        try (Keycloak legacyClient = KeycloakBuilder.builder()
+                .serverUrl(SERVER_URL)
+                .realm(REALM)
+                .username(USER)
+                .password(PASSWORD)
+                .clientId("admin-cli")
+                .build()) {
+
+            String token = legacyClient.tokenManager().getAccessToken().getToken();
+
+            try (Client client = ClientBuilder.newClient()) {
+
+                Response response = client.target(SERVER_URL)
+                        .path("/admin-v2/realms/" + REALM + "/clients")
+                        .request()
+                        .header("Authorization", "Bearer " + token)
+                        .get();
+
+                Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus(),
+                        "The V2 endpoint should return 200 OK status");
+
+                String jsonResponse = response.readEntity(String.class);
+
+                Assertions.assertNotNull(jsonResponse, "Response payload should not be empty");
+                Assertions.assertTrue(jsonResponse.contains("admin-cli"),
+                        "The clients list must include the 'admin-cli' client");
+            }
+        } catch (Exception e) {
+            Assertions.fail("End-to-End test failed due to an unexpected exception: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean isServerUp(String urlStr) {
+        try {
+            URI uri = URI.create(urlStr);
+            try (Socket s = new Socket(uri.getHost(), uri.getPort())) {
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -19,10 +19,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-vertx-http</artifactId>
             <exclusions>
-            	<exclusion>
-            		<groupId>io.vertx</groupId>
-            		<artifactId>vertx-uri-template</artifactId>
-            	</exclusion>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-uri-template</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -431,12 +431,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-v2-rest</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Keycloak Dependencies-->
@@ -701,7 +696,7 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/v2/resource/ClientsV2Resource.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/v2/resource/ClientsV2Resource.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.v2.resource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.services.managers.RealmManager;
+
+
+@Path("/admin-v2/realms/{realm}/clients")
+public class ClientsV2Resource {
+
+    private final KeycloakSession session;
+
+    public ClientsV2Resource(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public List<ClientRepresentation> getClients(@PathParam("realm") String realmName) {
+
+        // TODO: Integrate with AdminPermissionEvaluator once the module dependencies are configured in pom.xml
+        // Currently, 'keycloak-services' dependency is not available in this module to avoid circular refs.
+
+        RealmManager realmManager = new RealmManager(session);
+        RealmModel realm = realmManager.getRealmByName(realmName);
+
+        if (realm == null) {
+            throw new NotFoundException("Realm not found: " + realmName);
+        }
+
+        return session.clients().getClientsStream(realm)
+                .map(model -> {
+                    ClientRepresentation rep = new ClientRepresentation();
+                    rep.setId(model.getId());
+                    rep.setClientId(model.getClientId());
+                    rep.setName(model.getName());
+                    rep.setDescription(model.getDescription());
+                    rep.setEnabled(model.isEnabled());
+                    rep.setProtocol(model.getProtocol());
+                    return rep;
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -82,8 +82,18 @@
             <artifactId>twitter4j-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
+
+                <groupId>org.twitter4j</groupId>
+                <artifactId>twitter4j-core</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -275,8 +285,8 @@
             <artifactId>keycloak-model-storage-private</artifactId>
         </dependency>
         <dependency>
-        	<groupId>org.keycloak</groupId>
-        	<artifactId>keycloak-config-api</artifactId>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-config-api</artifactId>
         </dependency>
     </dependencies>
     <build>
@@ -353,7 +363,8 @@
                                     <outputDirectory>${project.basedir}/target/apidocs-rest/output</outputDirectory>
                                     <resources>
                                         <resource>
-                                            <directory>${project.build.directory}/apidocs-rest/swagger/apidocs</directory>
+                                            <directory>${project.build.directory}/apidocs-rest/swagger/apidocs
+                                            </directory>
                                             <includes>
                                                 <include>**/openapi.yaml</include>
                                                 <include>**/openapi.json</include>
@@ -372,7 +383,8 @@
                             <scanProfiles>admin</scanProfiles>
                             <outputDirectory>${project.build.directory}/apidocs-rest/swagger/apidocs</outputDirectory>
                             <infoTitle>Keycloak Admin REST API</infoTitle>
-                            <infoDescription>This is a REST API reference for the Keycloak Admin REST API.</infoDescription>
+                            <infoDescription>This is a REST API reference for the Keycloak Admin REST API.
+                            </infoDescription>
                         </configuration>
                         <executions>
                             <execution>
@@ -400,7 +412,8 @@
                                         <modelTests>false</modelTests>
                                         <verbose>false</verbose>
                                     </globalProperties>
-                                    <inputSpec>${project.build.directory}/apidocs-rest/swagger/apidocs/openapi.yaml</inputSpec>
+                                    <inputSpec>${project.build.directory}/apidocs-rest/swagger/apidocs/openapi.yaml
+                                    </inputSpec>
                                     <output>${project.basedir}/target/docs/asciidoc/</output>
                                     <generatorName>asciidoc</generatorName>
                                     <generateApiDocumentation>true</generateApiDocumentation>
@@ -408,7 +421,8 @@
                                     <generateSupportingFiles>true</generateSupportingFiles>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>${project.artifactId}</artifactId>
-                                    <templateDirectory>src/docs/openapi-generator-templates/keycloak-admin-api</templateDirectory>
+                                    <templateDirectory>src/docs/openapi-generator-templates/keycloak-admin-api
+                                    </templateDirectory>
                                     <configOptions>
                                         <useIntroduction>true</useIntroduction>
                                         <delegatePattern>false</delegatePattern>
@@ -443,7 +457,7 @@
                                          -->
                                         <toc/>
                                         <toc-position>left</toc-position>
-                                        <sectanchors />
+                                        <sectanchors/>
                                         <generated>${project.basedir}/target/apidocs-rest/asciidoc</generated>
                                         <!-- Boolean attributes are passed as defined/undefined to AsciiDoc, not at their literal value -->
                                         <project_community>true</project_community>


### PR DESCRIPTION
This commit introduces the MVP for the new Admin V2 API, ensuring a non-handcrafted approach by using automated SDK generation.

- Configured openapi-generator-maven-plugin for Java SDK generation.
- Added .v2() entry point to ClientsResource for fluent API access.
- Implemented ClientsV2Resource backend with Keycloak Stream support.
- Integrated ClientRepresentation DTO for type safety.
- Included end-to-end integration tests in ClientsV2ApiTest.

Closes #45364

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
