### PR TITLE
Show jwks, certificate or publicKey for the key information

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -1941,6 +1941,7 @@ fullSyncPeriod=Full sync period
 clientsExplain=Clients are applications and services that can request authentication of a user.
 addNode=Add node
 jwksUrl=JWKS URL
+jwks=JSON Web Key Set
 policy-description=A description for this policy.
 defaultPasswordLabel=My password
 mapperUserAttributeName=User Attribute Name

--- a/js/apps/admin-ui/src/clients/keys/Certificate.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Certificate.tsx
@@ -11,25 +11,31 @@ type CertificateProps = Omit<CertificateDisplayProps, "id"> & {
 type CertificateDisplayProps = {
   id: string;
   helpTextKey?: string;
+  type?: "jwks" | "certificate" | "publicKey";
   keyInfo?: CertificateRepresentation;
 };
 
-const CertificateDisplay = ({ id, keyInfo }: CertificateDisplayProps) => {
+const CertificateDisplay = ({
+  id,
+  type = "certificate",
+  keyInfo,
+}: CertificateDisplayProps) => {
   const { t } = useTranslation();
   return (
     <TextArea
       readOnly
       rows={5}
       id={id}
-      data-testid="certificate"
-      value={keyInfo?.certificate}
-      aria-label={t("certificate")}
+      data-testid={type}
+      value={keyInfo?.[type]}
+      aria-label={t(type)}
     />
   );
 };
 
 export const Certificate = ({
-  helpTextKey = "certificateHelp",
+  helpTextKey,
+  type = "certificate",
   keyInfo,
   plain = false,
 }: CertificateProps) => {
@@ -37,14 +43,29 @@ export const Certificate = ({
   const id = useId();
 
   return plain ? (
-    <CertificateDisplay id={id} keyInfo={keyInfo} />
+    <CertificateDisplay id={id} type={type} keyInfo={keyInfo} />
   ) : (
     <FormGroup
-      label={t("certificate")}
+      label={t(type)}
       fieldId={id}
-      labelIcon={<HelpItem helpText={t(helpTextKey)} fieldLabelId={id} />}
+      labelIcon={
+        helpTextKey ? (
+          <HelpItem helpText={t(helpTextKey)} fieldLabelId={id} />
+        ) : undefined
+      }
     >
-      <CertificateDisplay id={id} keyInfo={keyInfo} />
+      <CertificateDisplay id={id} type={type} keyInfo={keyInfo} />
     </FormGroup>
   );
+};
+
+export const KeyInfoArea = ({ type, keyInfo, ...rest }: CertificateProps) => {
+  const myType = type
+    ? type
+    : keyInfo?.jwks
+      ? "jwks"
+      : keyInfo?.certificate
+        ? "certificate"
+        : "publicKey";
+  return <Certificate type={myType} keyInfo={keyInfo} {...rest} />;
 };

--- a/js/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -23,7 +23,7 @@ import { DefaultSwitchControl } from "../../components/SwitchControl";
 import { convertAttributeNameToForm } from "../../util";
 import useToggle from "../../utils/useToggle";
 import { FormFields } from "../ClientDetails";
-import { Certificate } from "./Certificate";
+import { KeyInfoArea } from "./Certificate";
 import { GenerateKeyDialog, getFileExtension } from "./GenerateKeyDialog";
 import { ImportFile, ImportKeyDialog } from "./ImportKeyDialog";
 
@@ -157,9 +157,9 @@ export const Keys = ({
             />
             {useJwksUrl !== "true" &&
               (keyInfo ? (
-                <Certificate plain keyInfo={keyInfo} />
+                <KeyInfoArea keyInfo={keyInfo} />
               ) : (
-                "No client certificate configured"
+                "No public key configured"
               ))}
             {useJwksUrl === "true" && (
               <TextControl


### PR DESCRIPTION
Closes #44284

Just a little PR to show the certificate information for OIDC clients using the three possible formats (jwks, certificate or public ket). Previously the certificate was fixed and it could be empty. The `Certificate.tsx` is modified to allow passing the `type` to show in the display. There is a new element `KeyInfoArea` that, if no `type` is passed, selects the first option that is defined in the order jws, certificate, public key.
