### PR TITLE
[26.2] Set explicit version for Docker API and upgrade Minikube to solve registry issue

### DIFF
--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -62,6 +62,8 @@ jobs:
   test-local:
     name: Test local
     runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: 1.43 # Workaround to have compatible Docker client with engine in GHA agents
     needs: [build]
     strategy:
       matrix:
@@ -113,6 +115,8 @@ jobs:
   test-remote:
     name: Test remote
     runs-on: ubuntu-latest
+    env:
+      DOCKER_API_VERSION: 1.43 # Workaround to have compatible Docker client with engine in GHA agents
     needs: [build]
     strategy:
           matrix:
@@ -167,6 +171,9 @@ jobs:
   test-olm:
     name: Test OLM installation
     runs-on: ubuntu-latest
+    env:
+      MINIKUBE_VERSION: v1.38.0 # Upgrade minikube to fix the issue with unstable registry
+      KUBERNETES_VERSION: v1.35.0
     needs: [build]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/45892
- Explicitly set the Docker API version to have it work with the minikube/k8s versions - we just simulate the same environment as before the GHA runners docker upgrade
- Upgrade minikube/k8s only for OLM testing to solve an issue with the unstable registry addon

**More details:** 
When the minikube/k8s is upgraded for the whole Operator CI, there are some failures with the Ingress tests. For the 26.4/26.5/main releases, there are no issues with the upgrade as it's already done. The 26.2.x testsuite might miss some tweaks that were done along the way to the latest release and I'd like to have changes for this branch minimal. When I changed the CNI to calico, the KC instance is not accessible in the remote tests mode with the ingress - local test mode is ok. When kept the CNI cilium, even the local mode test failed. There might be some issues with the network policies, or we just have outdated testsuite to deal with it for 26.2. I think it's ok to go this way. If we want to ensure the 26.2 Operator works with the latest k8s API, it should be done as a follow-up (if it's necessary). 

