### PR TITLE
fix: allow the same vm to run a keycloak instance multiple times

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -18,17 +18,21 @@
 package org.keycloak.quarkus.runtime;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ForkJoinPool;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
+import org.keycloak.common.Profile;
 import org.keycloak.common.Version;
 import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
 import org.keycloak.quarkus.runtime.cli.Picocli;
 import org.keycloak.quarkus.runtime.cli.command.AbstractNonServerCommand;
 import org.keycloak.quarkus.runtime.cli.command.DryRunMixin;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 import org.keycloak.quarkus.runtime.integration.jaxrs.QuarkusKeycloakApplication;
 
 import io.quarkus.arc.Arc;
@@ -75,6 +79,15 @@ public class KeycloakMain implements QuarkusApplication {
             picocli = new Picocli();
         }
         main(args, picocli);
+    }
+
+    public static void reset(Properties systemProperties) {
+        System.setProperties((Properties) systemProperties.clone());
+        PropertyMappers.reset();
+        PersistedConfigSource.getInstance().getConfigValueProperties().clear();
+        Profile.reset();
+        Configuration.resetConfig();
+        ExecutionExceptionHandler.resetExceptionTransformers();
     }
 
     public static void main(String[] args, Picocli picocli) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/AbstractConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/AbstractConfigurationTest.java
@@ -23,10 +23,8 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import org.keycloak.Config;
-import org.keycloak.common.Profile;
 import org.keycloak.quarkus.runtime.Environment;
-import org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler;
-import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
+import org.keycloak.quarkus.runtime.KeycloakMain;
 
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.ConfigValue.ConfigValueBuilder;
@@ -71,17 +69,9 @@ public abstract class AbstractConfigurationTest {
 
     @BeforeClass
     public static void resetConfiguration() {
-        System.setProperties((Properties) SYSTEM_PROPERTIES.clone());
+        KeycloakMain.reset(SYSTEM_PROPERTIES);
         Environment.setHomeDir(Paths.get("src/test/resources/"));
-
         KcEnvConfigSource.ENV_OVERRIDE.clear();
-
-        PropertyMappers.reset();
-        ConfigArgsConfigSource.setCliArgs();
-        PersistedConfigSource.getInstance().getConfigValueProperties().clear();
-        Profile.reset();
-        Configuration.resetConfig();
-        ExecutionExceptionHandler.resetExceptionTransformers();
     }
 
     @After


### PR DESCRIPTION
closes: #45921

Reuses the test logic we already have for resetting the system state between runs.

This assumes that the Keycloak instance takes responsibility for restoring the state of the system properties. That can be tweaked if needed - in particular we can try to track specifically what we / quarkus can manipulate and just clear that.

Finally the alternative to this whole approach would be to fork the test execution instead.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
