### PR TITLE
Mark Token Exchange v1 as deprecated but in preview

### DIFF
--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -66,11 +66,19 @@ public class ProfileTest {
         Profile profile = Profile.defaults();
 
         Assert.assertTrue(Profile.isFeatureEnabled(DEFAULT_FEATURE));
+        Assert.assertFalse(DEFAULT_FEATURE.isDeprecated());
+        MatcherAssert.assertThat(profile.getPreviewFeatures(), Matchers.not(Matchers.hasItem(DEFAULT_FEATURE)));
         Assert.assertFalse(Profile.isFeatureEnabled(DISABLED_BY_DEFAULT_FEATURE));
+        Assert.assertFalse(DISABLED_BY_DEFAULT_FEATURE.isDeprecated());
+        MatcherAssert.assertThat(profile.getPreviewFeatures(), Matchers.not(Matchers.hasItem(DISABLED_BY_DEFAULT_FEATURE)));
         Assert.assertFalse(Profile.isFeatureEnabled(PREVIEW_FEATURE));
         Assert.assertFalse(Profile.isFeatureEnabled(EXPERIMENTAL_FEATURE));
+        Assert.assertFalse(EXPERIMENTAL_FEATURE.isDeprecated());
+        MatcherAssert.assertThat(profile.getPreviewFeatures(), Matchers.not(Matchers.hasItem(EXPERIMENTAL_FEATURE)));
         if (DEPRECATED_FEATURE != null) {
             Assert.assertFalse(Profile.isFeatureEnabled(DEPRECATED_FEATURE));
+            MatcherAssert.assertThat(profile.getDeprecatedFeatures(), Matchers.hasItem(DEPRECATED_FEATURE));
+            Assert.assertTrue(DEPRECATED_FEATURE.isDeprecated());
         } else {
             MatcherAssert.assertThat(profile.getDeprecatedFeatures(), Matchers.empty());
         }
@@ -79,6 +87,8 @@ public class ProfileTest {
 
         MatcherAssert.assertThat(profile.getDisabledFeatures(), Matchers.hasItem(DISABLED_BY_DEFAULT_FEATURE));
         MatcherAssert.assertThat(profile.getPreviewFeatures(), Matchers.hasItem(PREVIEW_FEATURE));
+        Assert.assertTrue(Profile.Feature.TOKEN_EXCHANGE.isDeprecated());
+        Assert.assertEquals(Profile.Feature.Type.PREVIEW, Profile.Feature.TOKEN_EXCHANGE.getType());
     }
 
     @Test

--- a/core/src/main/java/org/keycloak/representations/info/FeatureRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/info/FeatureRepresentation.java
@@ -7,6 +7,7 @@ public class FeatureRepresentation {
     private String label;
     private FeatureType type;
     private boolean isEnabled;
+    private Boolean deprecated;
     private Set<String> dependencies;
 
     public FeatureRepresentation() {
@@ -34,6 +35,14 @@ public class FeatureRepresentation {
 
     public void setType(FeatureType type) {
         this.type = type;
+    }
+
+    public Boolean isDeprecated() {
+        return deprecated;
+    }
+
+    public void setDeprecated(Boolean deprecated) {
+        this.deprecated = Boolean.TRUE.equals(deprecated) ? deprecated : null;
     }
 
     public boolean isEnabled() {

--- a/js/apps/admin-ui/src/dashboard/Dashboard.tsx
+++ b/js/apps/admin-ui/src/dashboard/Dashboard.tsx
@@ -77,26 +77,27 @@ type FeatureItemProps = {
 
 const FeatureItem = ({ feature }: FeatureItemProps) => {
   const { t } = useTranslation();
+  const color =
+    feature.type === FeatureType.Default ||
+    feature.type === FeatureType.DisabledByDefault
+      ? "green"
+      : feature.type === FeatureType.Preview ||
+          feature.type === FeatureType.PreviewDisabledByDefault
+        ? "blue"
+        : feature.type === FeatureType.Experimental
+          ? "orange"
+          : feature.type === FeatureType.Deprecated
+            ? "grey"
+            : "red";
   return (
     <ListItem className="pf-v5-u-mb-sm">
       {feature.name}&nbsp;
-      {feature.type === FeatureType.Experimental && (
-        <Label color="orange">{t("experimental")}</Label>
-      )}
-      {feature.type === FeatureType.Preview && (
-        <Label color="blue">{t("preview")}</Label>
-      )}
-      {feature.type === FeatureType.PreviewDisabledByDefault && (
-        <Label color="blue">{t("preview")}</Label>
-      )}
-      {feature.type === FeatureType.Default && (
-        <Label color="green">{t("supported")}</Label>
-      )}
-      {feature.type === FeatureType.DisabledByDefault && (
-        <Label color="green">{t("supported")}</Label>
-      )}
-      {feature.type === FeatureType.Deprecated && (
-        <Label color="grey">{t("deprecated")}</Label>
+      <Label color={color}>{t(feature.type.toLowerCase())}</Label>
+      {feature.deprecated && feature.type !== FeatureType.Deprecated && (
+        <>
+          &nbsp;
+          <Label color="grey">{t("deprecated")}</Label>
+        </>
       )}
     </ListItem>
   );

--- a/js/libs/keycloak-admin-client/src/defs/featureRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/featureRepresentation.ts
@@ -3,6 +3,7 @@ export default interface FeatureRepresentation {
   label: string;
   type: FeatureType;
   enabled: boolean;
+  deprecated?: boolean;
   dependencies: string[];
 }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -445,6 +445,7 @@ public class ServerInfoAdminResource {
         featureRep.setLabel(feature.getLabel());
         featureRep.setType(FeatureType.valueOf(feature.getType().name()));
         featureRep.setEnabled(isEnabled);
+        featureRep.setDeprecated(feature.isDeprecated());
         featureRep.setDependencies(feature.getDependencies() != null ?
                 feature.getDependencies().stream().map(Enum::name).collect(Collectors.toSet()) : Collections.emptySet());
         return featureRep;


### PR DESCRIPTION
Closes #45791

I followed the first idea in the issue. In the admin console the label remains like `Preview` but I changed the color to grey. If you think that maybe we should change also  the label (adding deprecated) or we should add an icon or similar, just let me know. 
