### PR TITLE
Update Infinispan CRs in multi-cluster architecture to use InPlaceRolling upgrade strategy

### DIFF
--- a/docs/guides/high-availability/examples/generated/ispn-single.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-single.yaml
@@ -311,8 +311,8 @@ spec:
   expose:
     type: Route
   configMapName: "cluster-config"
-  image: quay.io/infinispan/server:15.0.19.Final
-  version: 15.0.19
+  image: quay.io/infinispan/server:16.0.5
+  version: 16.0.5
   configListener:
     enabled: false
   container:
@@ -331,4 +331,6 @@ spec:
     type: DataGrid
     # end::infinispan-single[]
     
+  upgrades:
+    type: InPlaceRolling
     # end::infinispan-crossdc[]

--- a/docs/guides/high-availability/examples/generated/ispn-site-a.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-site-a.yaml
@@ -346,7 +346,7 @@ spec:
     type: Route
   configMapName: "cluster-config"
   image: 
-  version: 15.0.19
+  version: 16.0.5
   configListener:
     enabled: false
   container:
@@ -394,6 +394,8 @@ spec:
           url: openshift://api.site-b # <13>
           secretName: xsite-token-secret # <14>
           
+  upgrades:
+    type: InPlaceRolling
     # end::infinispan-crossdc[]
 ---
 # Source: ispn-helm/templates/infinispan-alerts.yaml

--- a/docs/guides/high-availability/examples/generated/ispn-site-b.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-site-b.yaml
@@ -346,7 +346,7 @@ spec:
     type: Route
   configMapName: "cluster-config"
   image: 
-  version: 15.0.19
+  version: 16.0.5
   configListener:
     enabled: false
   container:
@@ -396,6 +396,8 @@ spec:
           url: openshift://api.site-a # <13>
           secretName: xsite-token-secret # <14>
           
+  upgrades:
+    type: InPlaceRolling
     # end::infinispan-crossdc[]
 ---
 # Source: ispn-helm/templates/infinispan-alerts.yaml

--- a/docs/guides/high-availability/examples/generated/ispn-volatile.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-volatile.yaml
@@ -514,7 +514,7 @@ spec:
     type: Route
   configMapName: "cluster-config"
   image: 
-  version: 15.0.19
+  version: 16.0.5
   configListener:
     enabled: false
   container:
@@ -564,6 +564,8 @@ spec:
           url: openshift://api.site-b # <13>
           secretName: xsite-token-secret # <14>
           
+  upgrades:
+    type: InPlaceRolling
     # end::infinispan-crossdc[]
 ---
 # Source: ispn-helm/templates/infinispan-alerts.yaml

--- a/docs/guides/high-availability/examples/generated/keycloak-ispn.yaml
+++ b/docs/guides/high-availability/examples/generated/keycloak-ispn.yaml
@@ -66,34 +66,6 @@ metadata:
 binaryData:
   keycloak-benchmark-dataset-999.0.0-SNAPSHOT.jar: ...
 ---
-# Source: keycloak/templates/postgres/postgres-exporter-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: postgres-exporter
-  namespace: keycloak
-data:
-  pgexporter-queries.yaml: |
-    # This is configuration file for postgres_exporter.
-    # Add custom metrics via SQL statements here as described here: https://github.com/prometheus-community/postgres_exporter#adding-new-metrics-via-a-config-file
-    # See https://github.com/prometheus-community/postgres_exporter/blob/master/queries.yaml for examples.
-    pg_locks_waiting:
-      # language=SQL
-      query: |
-        WITH q_locks AS (select * from pg_locks where granted = false and pid != pg_backend_pid())
-        SELECT (select current_database()) as datname, lower(lockmodes) AS mode, coalesce((select count(*) FROM q_locks WHERE mode = lockmodes), 0) AS count FROM
-        unnest('{AccessShareLock, ExclusiveLock, RowShareLock, RowExclusiveLock, ShareLock, ShareRowExclusiveLock, AccessExclusiveLock, ShareUpdateExclusiveLock}'::text[]) lockmodes;
-      metrics:
-        - datname:
-            usage: "LABEL"
-            description: "Database name"
-        - mode:
-            usage: "LABEL"
-            description: "Lock type"
-        - count:
-            usage: "GAUGE"
-            description: "Number of locks"
----
 # Source: keycloak/templates/keycloak-jvmdebug-service.yaml
 apiVersion: v1
 kind: Service
@@ -112,214 +84,6 @@ spec:
   selector:
     app: keycloak
   sessionAffinity: None
----
-# Source: keycloak/templates/postgres/postgres-deployment.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: postgres-headless
-  namespace: keycloak
-  labels:
-    app: postgres
-spec:
-  clusterIP: None
-  ports:
-    - name: postgres
-      port: 5432
-      targetPort: 5432
-      protocol: TCP
-  selector:
-    app: postgres
----
-# Source: keycloak/templates/postgres/postgres-exporter.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: postgres-exporter
-  name: postgres-exporter
-  namespace: keycloak
-spec:
-  ports:
-    - port: 9187
-      name: metrics
-      protocol: TCP
-      targetPort: 9187
-  selector:
-    app: postgres-exporter
-  sessionAffinity: None
-  type: ClusterIP
----
-# Source: keycloak/templates/postgres/postgres-nodeport.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: postgres-nodeport
-  namespace: keycloak
-  labels:
-    app: postgres
-spec:
-  type: NodePort
-  ports:
-    - protocol: TCP
-      port: 5432
-      nodePort: 30009
-  selector:
-    app: postgres
----
-# Source: keycloak/templates/postgres/postgres-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: postgres
-  name: postgres
-  namespace: keycloak
-spec:
-  ports:
-    - port: 5432
-      protocol: TCP
-      targetPort: 5432
-  selector:
-    app: postgres
-  sessionAffinity: None
-  type: ClusterIP
----
-# Source: keycloak/templates/postgres/postgres-exporter.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: postgres-exporter
-  name: postgres-exporter
-  namespace: keycloak
-spec:
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app: postgres-exporter
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app: postgres-exporter
-      annotations:
-        checksum: ea6be7f450cc15ae55e469caf5a789a1cfd67ff8612d737ec5d85c83d528ee52
-    spec:
-      containers:
-        - env:
-            - name: DATA_SOURCE_NAME
-              value: postgresql://keycloak:secret99@postgres:5432/keycloak?sslmode=disable
-            - name: PG_EXPORTER_EXTEND_QUERY_PATH
-              value: /conf/pgexporter-queries.yaml
-          image: quay.io/prometheuscommunity/postgres-exporter:v0.10.1
-          imagePullPolicy: Always
-          startupProbe:
-            httpGet:
-              path: /metrics
-              port: 9187
-            failureThreshold: 20
-            initialDelaySeconds: 10
-            periodSeconds: 2
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 9187
-            failureThreshold: 10
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 9187
-            failureThreshold: 10
-            periodSeconds: 10
-          name: postgres-exporter
-          ports:
-            - containerPort: 9187
-              name: metrics
-              protocol: TCP
-          volumeMounts:
-            - mountPath: /conf
-              name: config
-      restartPolicy: Always
-      volumes:
-        - name: config
-          configMap:
-            name: postgres-exporter
----
-# Source: keycloak/templates/postgres/postgres-deployment.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  labels:
-    app: postgres
-  name: postgres
-  namespace: keycloak
-spec:
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app: postgres
-  serviceName: postgres-headless
-  template:
-    metadata:
-      labels:
-        app: postgres
-    spec:
-      containers:
-        - imagePullPolicy: Always
-          env:
-            - name: POSTGRES_PASSWORD
-              value: secret99
-            - name: POSTGRES_USER
-              value: keycloak
-            - name: POSTGRES_DB
-              value: keycloak
-          image: mirror.gcr.io/postgres:15
-          volumeMounts:
-            - mountPath: /var/lib/postgresql/data
-              name: postgres-data
-          resources:
-            requests:
-              cpu: "0"
-          startupProbe:
-            tcpSocket:
-              port: 5432
-            failureThreshold: 20
-            initialDelaySeconds: 10
-            periodSeconds: 2
-          readinessProbe:
-            tcpSocket:
-              port: 5432
-            failureThreshold: 10
-            periodSeconds: 10
-          livenessProbe:
-            tcpSocket:
-              port: 5432
-            failureThreshold: 10
-            periodSeconds: 10
-          name: postgres
-          ports:
-            - containerPort: 5432
-              protocol: TCP
-      restartPolicy: Always
-      # The rhel9/postgresql-13 is known to take ~30 seconds to shut down
-      # As this is a deployment with ephemeral storage, there is no need to wait as the data will be gone anyway
-      terminationGracePeriodSeconds: 0
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Retain
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres-data
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 1Gi
 ---
 # Source: keycloak/templates/keycloak.yaml
 # There are several callouts in this YAML marked with `# <1>' etc. See 'running/keycloak-deployment.adoc` for the details.
@@ -355,8 +119,11 @@ spec:
       key: password
   image: <KEYCLOAK_IMAGE_HERE> # <3>
   startOptimized: false # <3>
+  update:
+    strategy: Auto
   features:
     enabled:
+      - rolling-updates:v2
       - multi-site # <4>
   # tag::keycloak-ispn[]
   additionalOptions:
@@ -412,7 +179,7 @@ spec:
     podTemplate:
       metadata:
         annotations:
-          checksum/config: ab21fb8e92d83105cdb82d375d7eba40bef80b0542bc0d594c5e46de50b07d34-723cd1a69cc6fc31fdb2f252e53786f0571d06efcc7fe1f8449e22e6c322f253-<KEYCLOAK_IMAGE_HERE>-01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+          checksum/config: fb7f978be22beed7f21f50fcaaa4d99f0938297281d6d76563012ae1b1a2e8d9-01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b-<KEYCLOAK_IMAGE_HERE>-01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       spec:
         containers:
           - env:
@@ -451,19 +218,3 @@ spec:
           - name: keycloak-providers
             configMap:
               name: keycloak-providers
----
-# Source: keycloak/templates/postgres/postgres-exporter.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    app: postgres-exporter
-  name: postgres-exporter
-  namespace: keycloak
-spec:
-  endpoints:
-    - port: metrics
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: postgres-exporter

--- a/docs/guides/high-availability/examples/generated/keycloak.yaml
+++ b/docs/guides/high-availability/examples/generated/keycloak.yaml
@@ -53,34 +53,6 @@ metadata:
 binaryData:
   keycloak-benchmark-dataset-999.0.0-SNAPSHOT.jar: ...
 ---
-# Source: keycloak/templates/postgres/postgres-exporter-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: postgres-exporter
-  namespace: keycloak
-data:
-  pgexporter-queries.yaml: |
-    # This is configuration file for postgres_exporter.
-    # Add custom metrics via SQL statements here as described here: https://github.com/prometheus-community/postgres_exporter#adding-new-metrics-via-a-config-file
-    # See https://github.com/prometheus-community/postgres_exporter/blob/master/queries.yaml for examples.
-    pg_locks_waiting:
-      # language=SQL
-      query: |
-        WITH q_locks AS (select * from pg_locks where granted = false and pid != pg_backend_pid())
-        SELECT (select current_database()) as datname, lower(lockmodes) AS mode, coalesce((select count(*) FROM q_locks WHERE mode = lockmodes), 0) AS count FROM
-        unnest('{AccessShareLock, ExclusiveLock, RowShareLock, RowExclusiveLock, ShareLock, ShareRowExclusiveLock, AccessExclusiveLock, ShareUpdateExclusiveLock}'::text[]) lockmodes;
-      metrics:
-        - datname:
-            usage: "LABEL"
-            description: "Database name"
-        - mode:
-            usage: "LABEL"
-            description: "Lock type"
-        - count:
-            usage: "GAUGE"
-            description: "Number of locks"
----
 # Source: keycloak/templates/keycloak-jvmdebug-service.yaml
 apiVersion: v1
 kind: Service
@@ -99,214 +71,6 @@ spec:
   selector:
     app: keycloak
   sessionAffinity: None
----
-# Source: keycloak/templates/postgres/postgres-deployment.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: postgres-headless
-  namespace: keycloak
-  labels:
-    app: postgres
-spec:
-  clusterIP: None
-  ports:
-    - name: postgres
-      port: 5432
-      targetPort: 5432
-      protocol: TCP
-  selector:
-    app: postgres
----
-# Source: keycloak/templates/postgres/postgres-exporter.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: postgres-exporter
-  name: postgres-exporter
-  namespace: keycloak
-spec:
-  ports:
-    - port: 9187
-      name: metrics
-      protocol: TCP
-      targetPort: 9187
-  selector:
-    app: postgres-exporter
-  sessionAffinity: None
-  type: ClusterIP
----
-# Source: keycloak/templates/postgres/postgres-nodeport.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: postgres-nodeport
-  namespace: keycloak
-  labels:
-    app: postgres
-spec:
-  type: NodePort
-  ports:
-    - protocol: TCP
-      port: 5432
-      nodePort: 30009
-  selector:
-    app: postgres
----
-# Source: keycloak/templates/postgres/postgres-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: postgres
-  name: postgres
-  namespace: keycloak
-spec:
-  ports:
-    - port: 5432
-      protocol: TCP
-      targetPort: 5432
-  selector:
-    app: postgres
-  sessionAffinity: None
-  type: ClusterIP
----
-# Source: keycloak/templates/postgres/postgres-exporter.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: postgres-exporter
-  name: postgres-exporter
-  namespace: keycloak
-spec:
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app: postgres-exporter
-  strategy:
-    type: Recreate
-  template:
-    metadata:
-      labels:
-        app: postgres-exporter
-      annotations:
-        checksum: ea6be7f450cc15ae55e469caf5a789a1cfd67ff8612d737ec5d85c83d528ee52
-    spec:
-      containers:
-        - env:
-            - name: DATA_SOURCE_NAME
-              value: postgresql://keycloak:secret99@postgres:5432/keycloak?sslmode=disable
-            - name: PG_EXPORTER_EXTEND_QUERY_PATH
-              value: /conf/pgexporter-queries.yaml
-          image: quay.io/prometheuscommunity/postgres-exporter:v0.10.1
-          imagePullPolicy: Always
-          startupProbe:
-            httpGet:
-              path: /metrics
-              port: 9187
-            failureThreshold: 20
-            initialDelaySeconds: 10
-            periodSeconds: 2
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 9187
-            failureThreshold: 10
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 9187
-            failureThreshold: 10
-            periodSeconds: 10
-          name: postgres-exporter
-          ports:
-            - containerPort: 9187
-              name: metrics
-              protocol: TCP
-          volumeMounts:
-            - mountPath: /conf
-              name: config
-      restartPolicy: Always
-      volumes:
-        - name: config
-          configMap:
-            name: postgres-exporter
----
-# Source: keycloak/templates/postgres/postgres-deployment.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  labels:
-    app: postgres
-  name: postgres
-  namespace: keycloak
-spec:
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app: postgres
-  serviceName: postgres-headless
-  template:
-    metadata:
-      labels:
-        app: postgres
-    spec:
-      containers:
-        - imagePullPolicy: Always
-          env:
-            - name: POSTGRES_PASSWORD
-              value: secret99
-            - name: POSTGRES_USER
-              value: keycloak
-            - name: POSTGRES_DB
-              value: keycloak
-          image: mirror.gcr.io/postgres:15
-          volumeMounts:
-            - mountPath: /var/lib/postgresql/data
-              name: postgres-data
-          resources:
-            requests:
-              cpu: "2"
-          startupProbe:
-            tcpSocket:
-              port: 5432
-            failureThreshold: 20
-            initialDelaySeconds: 10
-            periodSeconds: 2
-          readinessProbe:
-            tcpSocket:
-              port: 5432
-            failureThreshold: 10
-            periodSeconds: 10
-          livenessProbe:
-            tcpSocket:
-              port: 5432
-            failureThreshold: 10
-            periodSeconds: 10
-          name: postgres
-          ports:
-            - containerPort: 5432
-              protocol: TCP
-      restartPolicy: Always
-      # The rhel9/postgresql-13 is known to take ~30 seconds to shut down
-      # As this is a deployment with ephemeral storage, there is no need to wait as the data will be gone anyway
-      terminationGracePeriodSeconds: 0
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Retain
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres-data
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 1Gi
 ---
 # Source: keycloak/templates/keycloak.yaml
 # There are several callouts in this YAML marked with `# <1>' etc. See 'running/keycloak-deployment.adoc` for the details.
@@ -344,8 +108,11 @@ spec:
       key: password
   image: <KEYCLOAK_IMAGE_HERE> # <3>
   startOptimized: false # <3>
+  update:
+    strategy: Auto
   features:
     enabled:
+      - rolling-updates:v2
       - multi-site # <4>
   # tag::keycloak-ispn[]
   additionalOptions:
@@ -401,7 +168,7 @@ spec:
     podTemplate:
       metadata:
         annotations:
-          checksum/config: ab21fb8e92d83105cdb82d375d7eba40bef80b0542bc0d594c5e46de50b07d34-93971346f578300330ab5caf025f596730a3c95c08feb9ec53787b03b9f407b8-<KEYCLOAK_IMAGE_HERE>-01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+          checksum/config: fb7f978be22beed7f21f50fcaaa4d99f0938297281d6d76563012ae1b1a2e8d9-01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b-<KEYCLOAK_IMAGE_HERE>-01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
       spec:
         containers:
           - env:
@@ -440,19 +207,3 @@ spec:
           - name: keycloak-providers
             configMap:
               name: keycloak-providers
----
-# Source: keycloak/templates/postgres/postgres-exporter.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    app: postgres-exporter
-  name: postgres-exporter
-  namespace: keycloak
-spec:
-  endpoints:
-    - port: metrics
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: postgres-exporter


### PR DESCRIPTION
Closes #45424

The various postgres files removed in the diff are unneeded and are removed as a result of the fix for https://github.com/keycloak/keycloak-benchmark/issues/1270.