### PR TITLE
Move HTTP access logs to data/log directory

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -334,7 +334,7 @@ You can enable file logging as follows:
 
 <@kc.start parameters="--http-access-log-enabled=true --http-access-log-file-enabled=true"/>
 
-This automatically creates a file called `keycloak-http-access.log` in the `/data` directory of your distribution.
+This automatically creates a file called `keycloak-http-access.log` in the `/data/log` directory of your distribution.
 
 ==== Change file name and suffix
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/HttpAccessLogOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/HttpAccessLogOptions.java
@@ -63,7 +63,7 @@ public class HttpAccessLogOptions {
 
     public static final Option<String> HTTP_ACCESS_LOG_FILE_NAME = new OptionBuilder<>("http-access-log-file-name", String.class)
             .category(OptionCategory.HTTP_ACCESS_LOG)
-            .description("The HTTP access log file base name, which will create a log file name concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is located in the '/data' directory of the distribution.")
+            .description("The HTTP access log file base name, which will create a log file name concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is located in the '/data/log' directory of the distribution.")
             .defaultValue("keycloak-http-access")
             .build();
 

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -250,11 +250,15 @@ class KeycloakProcessor {
     @BuildStep
     @Produce(ConfigBuildItem.class)
     void initConfig(KeycloakRecorder recorder) {
-        // other buildsteps directly use the Config
-        // so directly init it
         Config.init(new MicroProfileConfigProvider());
-        // also init in byte code for the actual server start
         recorder.initConfig();
+    }
+
+    @Record(ExecutionTime.RUNTIME_INIT)
+    @BuildStep
+    @Consume(ConfigBuildItem.class)
+    void createHttpAccessLogDirectory(KeycloakRecorder recorder) {
+        recorder.createHttpAccessLogDirectory();
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -254,7 +254,7 @@ class KeycloakProcessor {
         recorder.initConfig();
     }
 
-    @Record(ExecutionTime.RUNTIME_INIT)
+    @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
     @Consume(ConfigBuildItem.class)
     void createHttpAccessLogDirectory(KeycloakRecorder recorder) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -71,6 +71,15 @@ public class KeycloakRecorder {
         Config.init(new MicroProfileConfigProvider());
     }
 
+    public void createHttpAccessLogDirectory() {
+        Environment.getHomeDir().ifPresent(homeDir -> {
+            File logDir = new File(homeDir, "data" + File.separator + "log");
+            if (!logDir.exists()) {
+                logDir.mkdirs();
+            }
+        });
+    }
+
     public void configureProfile(Profile.ProfileName profileName, Map<Profile.Feature, Boolean> features) {
         Profile.init(profileName, features);
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -33,6 +33,7 @@ import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.common.crypto.FipsMode;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.HealthOptions;
+import org.keycloak.config.HttpAccessLogOptions;
 import org.keycloak.config.HttpOptions;
 import org.keycloak.config.MetricsOptions;
 import org.keycloak.config.OpenApiOptions;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakRecorder.java
@@ -72,12 +72,14 @@ public class KeycloakRecorder {
     }
 
     public void createHttpAccessLogDirectory() {
-        Environment.getHomeDir().ifPresent(homeDir -> {
-            File logDir = new File(homeDir, "data" + File.separator + "log");
-            if (!logDir.exists()) {
-                logDir.mkdirs();
-            }
-        });
+        if (Configuration.isTrue(HttpAccessLogOptions.HTTP_ACCESS_LOG_FILE_ENABLED)) {
+            Environment.getHomeDir().ifPresent(homeDir -> {
+                File logDir = new File(homeDir, "data" + File.separator + "log");
+                if (!logDir.exists() && !logDir.mkdirs() && !logDir.exists()) {
+                    throw new RuntimeException("Failed to create HTTP Access log directory");
+                }
+            });
+        }
     }
 
     public void configureProfile(Profile.ProfileName profileName, Map<Profile.Feature, Boolean> features) {

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.banner.enabled=false
 
 # Set Keycloak category for HTTP access log
 quarkus.http.access-log.category=org.keycloak.http.access-log
-quarkus.http.access-log.log-directory=${kc.home.dir:default}${file.separator}data
+quarkus.http.access-log.log-directory=${kc.home.dir:default}${file.separator}data${file.separator}log
 
 # Enables metrics from other extensions if metrics is enabled
 quarkus.datasource.metrics.enabled=${quarkus.micrometer.enabled:false}

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -296,7 +296,7 @@ public class LoggingDistTest {
     }
 
     protected static String readHttpAccessLogFile(RawDistRootPath path, String logName) {
-        return readFile(path.getDistRootPath() + File.separator + "data" + File.separator + logName, "HTTP Access log");
+        return readFile(path.getDistRootPath() + File.separator + "data" + File.separator + "log" + File.separator + logName, "HTTP Access log");
     }
 
     protected static String readFile(String path, String fileType) {
@@ -338,7 +338,7 @@ public class LoggingDistTest {
                 .statusCode(200);
         fileCliResult.assertNoMessage("127.0.0.1 GET /realms/master/clients/account/redirect");
 
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             String data = readHttpAccessLogFile(path, "keycloak-http-access.log");
             assertNotNull(data);
             assertThat(data, containsString("127.0.0.1 GET /realms/master/.well-known/openid-configuration"));
@@ -358,10 +358,12 @@ public class LoggingDistTest {
                 .statusCode(200);
         cliResult.assertNoMessage("http://127.0.0.1:8080/realms/master/clients/account/redirect");
 
-        String data = readHttpAccessLogFile(path, "my-custom-http-access.txt");
-        assertNotNull(data);
-        assertThat(data, containsString("GET /realms/master/.well-known/openid-configuration HTTP/1.1"));
-        assertThat(data, containsString("GET /realms/master/clients/account/redirect"));
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
+            String data = readHttpAccessLogFile(path, "my-custom-http-access.txt");
+            assertNotNull(data);
+            assertThat(data, containsString("GET /realms/master/.well-known/openid-configuration HTTP/1.1"));
+            assertThat(data, containsString("GET /realms/master/clients/account/redirect"));
+        });
     }
 
     // Telemetry Logs

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -378,7 +378,7 @@ HTTP Access log:
 --http-access-log-file-name <name>
                      The HTTP access log file base name, which will create a log file name
                        concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
-                       located in the '/data' directory of the distribution. Default:
+                       located in the '/data/log' directory of the distribution. Default:
                        keycloak-http-access. Available only when HTTP Access logging to file is
                        enabled.
 --http-access-log-file-rotate <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -379,7 +379,7 @@ HTTP Access log:
 --http-access-log-file-name <name>
                      The HTTP access log file base name, which will create a log file name
                        concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
-                       located in the '/data' directory of the distribution. Default:
+                       located in the '/data/log' directory of the distribution. Default:
                        keycloak-http-access. Available only when HTTP Access logging to file is
                        enabled.
 --http-access-log-file-rotate <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -341,7 +341,7 @@ HTTP Access log:
 --http-access-log-file-name <name>
                      The HTTP access log file base name, which will create a log file name
                        concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
-                       located in the '/data' directory of the distribution. Default:
+                       located in the '/data/log' directory of the distribution. Default:
                        keycloak-http-access. Available only when HTTP Access logging to file is
                        enabled.
 --http-access-log-file-rotate <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -378,7 +378,7 @@ HTTP Access log:
 --http-access-log-file-name <name>
                      The HTTP access log file base name, which will create a log file name
                        concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
-                       located in the '/data' directory of the distribution. Default:
+                       located in the '/data/log' directory of the distribution. Default:
                        keycloak-http-access. Available only when HTTP Access logging to file is
                        enabled.
 --http-access-log-file-rotate <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -376,7 +376,7 @@ HTTP Access log:
 --http-access-log-file-name <name>
                      The HTTP access log file base name, which will create a log file name
                        concatenating base and suffix (e.g. 'keycloak-http-access.log'). The file is
-                       located in the '/data' directory of the distribution. Default:
+                       located in the '/data/log' directory of the distribution. Default:
                        keycloak-http-access. Available only when HTTP Access logging to file is
                        enabled.
 --http-access-log-file-rotate <true|false>


### PR DESCRIPTION
- Closes #45629

This pull request makes a minor adjustment to the HTTP access log configuration. The log directory path now includes an additional `log` subdirectory, which helps organize log files more clearly.

- Updated the `quarkus.http.access-log.log-directory` property in `application.properties` to append a `log` folder to the log directory path, ensuring logs are stored in a dedicated subdirectory.Separate HTTP access logs to the /data/log directory alongside server logs for consistency. Both log types remain distinguishable by their file names.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
