### PR TITLE
enforce `LF` line endings on `*.tsx` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 *.html text eol=lf
 *.java text eol=lf
 *.js text eol=lf
+*.tsx text eol=lf
 *.json text eol=lf
 *.jsp text eol=lf
 *.md text eol=lf


### PR DESCRIPTION
add `eol=lf` for `*.tsx` files declaration in `.gitattributes`

Closes #45996