### PR TITLE
Fix duplicate client-uuid path parameter in OpenAPI spec

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -424,7 +424,7 @@ public class RoleContainerResource extends RoleResource {
      * @param clientUuid
      * @return
      */
-    @Path("{role-name}/composites/clients/{client-uuid}")
+    @Path("{role-name}/composites/clients/{targetClientUuid}")
     @GET
     @NoCache
     @Produces(MediaType.APPLICATION_JSON)
@@ -436,7 +436,7 @@ public class RoleContainerResource extends RoleResource {
         @APIResponse(responseCode = "404", description = "Not Found")
     })
     public Stream<RoleRepresentation> getClientRoleComposites(final @Parameter(description = "role's name (not id!)") @PathParam("role-name") String roleName,
-                                                                final @PathParam("client-uuid") String clientUuid) {
+                                                                final @PathParam("targetClientUuid") String clientUuid) {
         auth.roles().requireView(roleContainer);
         RoleModel role = roleContainer.getRole(roleName);
         if (role == null) {


### PR DESCRIPTION
Closes #46015

The endpoint `GET /admin/realms/{realm}/clients/{client-uuid}/roles/{role-name}/composites/clients/{client-uuid}` contains two path parameters with the same name `{client-uuid}`, which produces an invalid OpenAPI specification.

This breaks OpenAPI code generators like [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) that rely on unique parameter names per path.

## Solution

Rename `{client-uuid}` to `{targetClientUuid}` in `RoleContainerResource.java`.

`{clientUuid}` is not sufficient because most code generators normalise `{client-uuid}` (from the parent path) to `clientUuid` as well, which would still produce a collision. `{targetClientUuid}` makes the semantics clear: it refers to the client whose roles are being queried as composites, not the client that owns the role.

## Impact

This is a non-breaking change:
- The actual URL path segment value doesn't change
- Only the OpenAPI parameter name changes, making the spec valid
