### PR TITLE
fix: adding admin role invalidation when a new realm is found

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -493,13 +493,16 @@ public class RealmCacheSession implements CacheRealmProvider {
                 return null;
             }
 
+            // to accommodate imports of new realms, check to see if the master admin role is up-to-date
             if (!model.getName().equals(Config.getAdminRealm())) {
                 RealmModel adminRealm = session.realms().getRealmByName(Config.getAdminRealm());
-                ClientModel clientModel = session.clients().getClientByClientId(adminRealm, model.getName() + "-realm");
-                if (clientModel != null) {
-                    RoleModel adminRole = adminRealm.getRole(AdminRoles.ADMIN);
-                    if (adminRole.getCompositesStream().noneMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())))) {
-                        invalidateRole(adminRole.getId());
+                if (adminRealm != null) {
+                    ClientModel clientModel = session.clients().getClientByClientId(adminRealm, model.getName() + "-realm");
+                    if (clientModel != null) {
+                        RoleModel adminRole = adminRealm.getRole(AdminRoles.ADMIN);
+                        if (adminRole.getCompositesStream().noneMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())))) {
+                            registerRoleInvalidation(adminRole.getId(), adminRole.getName(), adminRole.getContainerId());
+                        }
                     }
                 }
             }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -26,10 +26,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.keycloak.Config;
 import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.Profile;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientInitialAccessModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientProvider;
@@ -490,6 +492,15 @@ public class RealmCacheSession implements CacheRealmProvider {
             if (model == null) {
                 return null;
             }
+
+            if (!model.getName().equals(Config.getAdminRealm())) {
+                RealmModel adminRealm = session.realms().getRealmByName(Config.getAdminRealm());
+                RoleModel adminRole = adminRealm.getRole(AdminRoles.ADMIN);
+                if (!invalidations.contains(adminRole.getId())) {
+                    invalidateRole(adminRole.getId());
+                }
+            }
+
             cached = new CachedRealm(loaded, model);
             cache.addRevisioned(cached, startupRevision);
             adapter = new RealmAdapter(session, cached, this);
@@ -1057,6 +1068,7 @@ public class RealmCacheSession implements CacheRealmProvider {
         return list.stream().sorted(GroupModel.COMPARE_BY_NAME);
     }
 
+    @Override
     public Stream<GroupModel> getGroupsStream(RealmModel realm, Stream<String> ids, String search, Integer first, Integer max) {
         return getGroupDelegate().getGroupsStream(realm, ids, search, first, max);
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -495,9 +495,12 @@ public class RealmCacheSession implements CacheRealmProvider {
 
             if (!model.getName().equals(Config.getAdminRealm())) {
                 RealmModel adminRealm = session.realms().getRealmByName(Config.getAdminRealm());
-                RoleModel adminRole = adminRealm.getRole(AdminRoles.ADMIN);
-                if (!invalidations.contains(adminRole.getId())) {
-                    invalidateRole(adminRole.getId());
+                ClientModel clientModel = session.clients().getClientByClientId(adminRealm, model.getName() + "-realm");
+                if (clientModel != null) {
+                    RoleModel adminRole = adminRealm.getRole(AdminRoles.ADMIN);
+                    if (adminRole.getCompositesStream().noneMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())))) {
+                        invalidateRole(adminRole.getId());
+                    }
                 }
             }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
@@ -19,6 +19,7 @@ package org.keycloak.services.resources.admin.fgap;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.ws.rs.ForbiddenException;
 
@@ -165,16 +166,36 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
     public boolean hasOneAdminRole(RealmModel realm, String... adminRoles) {
         String clientId;
         RealmManager realmManager = new RealmManager(session);
+        boolean masterAdminRealm = false;
         if (RealmManager.isAdministrationRealm(adminsRealm)) {
             clientId = realm.getMasterAdminClient().getClientId();
+            masterAdminRealm = true;
         } else if (adminsRealm.equals(realm)) {
             clientId = realm.getClientByClientId(realmManager.getRealmAdminClientId(realm)).getClientId();
         } else {
             return false;
         }
-        return identity.hasOneClientRole(clientId, adminRoles);
+        boolean result = identity.hasOneClientRole(clientId, adminRoles);
+        if (!result && masterAdminRealm && !adminsRealm.equals(realm)
+                && hasNewAdminRoles(realm, clientId, adminRoles)) {
+            return true;
+        }
+        return result;
     }
 
+    private boolean hasNewAdminRoles(RealmModel realm, String clientId, String... adminRoles) {
+        RealmModel masterRealm = getMasterRealm();
+        UserModel admin = admin();
+        RoleModel masterAdminRole = masterRealm.getRole(AdminRoles.ADMIN);
+        if (!admin.hasRole(masterAdminRole)) {
+            return false;
+        }
+        Set<String> roleNames = Set.of(adminRoles);
+        ClientModel clientModel = masterRealm.getClientByClientId(clientId);
+        return clientModel != null && masterAdminRole.getCompositesStream()
+                .anyMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())
+                        && roleNames.contains(r.getName())));
+    }
 
     public boolean isAdminSameRealm() {
         return auth == null || realm.getId().equals(auth.getRealm().getId());

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
@@ -45,6 +45,7 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.services.managers.AuthenticationManager;
@@ -177,6 +178,7 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
         }
         boolean result = identity.hasOneClientRole(clientId, adminRoles);
         if (!result && masterAdminRealm && !adminsRealm.equals(realm)
+                && AbstractOIDCProtocolMapper.getShouldUseLightweightToken(session)
                 && hasNewAdminRoles(realm, clientId, adminRoles)) {
             return true;
         }


### PR DESCRIPTION
closes: #45966

In order to not require a restart on a new realm import there are two changes.

Whenever an admin performs an operation on the new realm, the new logic in RealmSessionCache will invalidate the master admin role if needed.

Then for that to be applicable to the current operation, it needs to also be taken into account for the MgmtPermissions role logic - the newly invalidated admin role is checked for new roles.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
