### PR TITLE
Drop `RuntimeConfigSetupCompleteBuildItem` from `KeycloakProcessor`

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -143,7 +143,6 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.HotDeploymentWatchedFileBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
-import io.quarkus.deployment.builditem.RuntimeConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.StaticInitConfigBuilderBuildItem;
 import io.quarkus.hibernate.orm.deployment.HibernateOrmConfig;
 import io.quarkus.hibernate.orm.deployment.PersistenceXmlDescriptorBuildItem;
@@ -245,15 +244,10 @@ class KeycloakProcessor {
     }
 
     /**
-     * Initialize configuration in runtime during the static initialization
-     * <p>
-     * We need to wait for the full configuration initialization on the Quarkus side (see {@link RuntimeConfigSetupCompleteBuildItem}).
-     * <p>
-     * It prevents issues like https://github.com/keycloak/keycloak/issues/45501
+     * Initialize configuration in runtime during the runtime initialization.
      */
     @Record(ExecutionTime.STATIC_INIT)
     @BuildStep
-    @Consume(RuntimeConfigSetupCompleteBuildItem.class)
     @Produce(ConfigBuildItem.class)
     void initConfig(KeycloakRecorder recorder) {
         // other buildsteps directly use the Config


### PR DESCRIPTION
https://github.com/keycloak/keycloak/pull/45612 bumped Quarkus version to 3.31 and the `RuntimeConfigSetupCompleteBuildItem` has no function in Quarkus 3.31. The item is deprecated and marked for removal because runtime config is always ready when runtime values are recorder. Almost shame to run CI for this PR. You can check https://github.com/quarkusio/quarkus/blob/main/core/deployment/src/main/java/io/quarkus/deployment/steps/RuntimeConfigSetupBuildStep.java for what the build item "does" (spoiler alert: nothing).

Code removed in this PR was added just few weeks ago in https://github.com/keycloak/keycloak/pull/45515.

By the above-mentioned explanation, I am not trying to say that the runtime config is ready when bytecode recorded by Keycloak's `initConfig` buildstep is executed, because it uses static init. If you look at the implementation https://github.com/quarkusio/quarkus/blob/33728ba54a7417a674c959daa1299fbb7cf4a0c1/core/deployment/src/main/java/io/quarkus/deployment/configuration/RunTimeConfigurationGenerator.java#L182 I think that runtime config is not ready, but everything around config generation and setup is complex, so I do not know how it is. I'll ask around on Quarkus Zulip: [#dev > Post RuntimeConfigSetupCompleteBuildItem deprecation world](https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/Post.20RuntimeConfigSetupCompleteBuildItem.20deprecation.20world/with/572023335).