### PR TITLE
Customization for JWTAuthorizationGrantType  to support ID-JAG

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -169,6 +169,8 @@ public class Profile {
 
         CIMD("OAuth Client ID Metadata Document", Type.EXPERIMENTAL),
 
+        IDENTITY_ASSERTION_JWT("Identity Assertion JWT", Type.EXPERIMENTAL),
+
         /**
          * @see <a href="https://github.com/keycloak/keycloak/issues/37967">Deprecate for removal the Instagram social broker</a>.
          */

--- a/core/src/main/java/org/keycloak/OAuth2Constants.java
+++ b/core/src/main/java/org/keycloak/OAuth2Constants.java
@@ -80,6 +80,10 @@ public interface OAuth2Constants {
     String JWT_AUTHORIZATION_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     String ASSERTION = "assertion";
 
+    // https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/
+    String IDENTITY_ASSERTION_JWT_HEADER_TYPE = "oauth-id-jag+jwt";
+
+
     // https://tools.ietf.org/html/draft-ietf-oauth-assertions-01#page-5
     String CLIENT_ASSERTION_TYPE = "client_assertion_type";
     String CLIENT_ASSERTION = "client_assertion";

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/DefaultJWTAuthorizationGrantValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/DefaultJWTAuthorizationGrantValidator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.protocol.oidc.grants;
+
+import java.util.Set;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.authenticators.client.AbstractBaseJWTValidator;
+import org.keycloak.authentication.authenticators.client.ClientAssertionState;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.representations.IDToken;
+import org.keycloak.representations.JsonWebToken;
+
+/**
+ * the default assertion validator for JWT Authorization grant that extends AbstractBaseJWTValidator and
+ * implements the JWTAuthorizationGrantValidator interface, which extends the JWTAuthorizationGrantValidationContext interface.
+ *
+ * @author rmartinc
+ */
+public class DefaultJWTAuthorizationGrantValidator extends AbstractBaseJWTValidator implements JWTAuthorizationGrantValidator {
+
+    private final String scope;
+    private Set<String> restrictedScopes;
+
+    public static DefaultJWTAuthorizationGrantValidator createValidator(KeycloakSession session, String scope, ClientAssertionState clientAssertionState) {
+        return new DefaultJWTAuthorizationGrantValidator(session, scope, clientAssertionState);
+    }
+
+    protected DefaultJWTAuthorizationGrantValidator(KeycloakSession session, String scope, ClientAssertionState clientAssertionState) {
+        super(session, clientAssertionState);
+        this.scope = scope;
+    }
+
+    public void validateClient() {
+        if (clientAssertionState.getClient().isPublicClient()) {
+            failureCallback("Public client not allowed to use authorization grant");
+        }
+
+        String val = clientAssertionState.getClient().getAttribute(OIDCConfigAttributes.JWT_AUTHORIZATION_GRANT_ENABLED);
+        if (!Boolean.parseBoolean(val)) {
+            throw new RuntimeException("JWT Authorization Grant is not supported for the requested client");
+        }
+    }
+
+    public void validateIssuer() {
+        if (getJWT().getIssuer() == null) {
+            failureCallback("Missing claim: " + OAuth2Constants.ISSUER);
+        }
+    }
+
+    public void validateSubject() {
+        if (getJWT().getSubject() == null) {
+            failureCallback("Missing claim: " + IDToken.SUBJECT);
+        }
+    }
+
+    @Override
+    public JsonWebToken getJWT() {
+        return clientAssertionState.getToken();
+    }
+
+    @Override
+    public String getAssertion() {
+        return clientAssertionState.getClientAssertion();
+    }
+
+    @Override
+    public String getScopeParam() {
+        return scope;
+    }
+
+    @Override
+    public Set<String> getRestrictedScopes() {
+        return restrictedScopes;
+    }
+
+    @Override
+    public void setRestrictedScopes(Set<String> restrictedScopes) {
+        this.restrictedScopes = restrictedScopes;
+    }
+
+    @Override
+    protected void failureCallback(String errorDescription) {
+        throw new RuntimeException(errorDescription);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/IDJWTAuthorizationGrantValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/IDJWTAuthorizationGrantValidator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.protocol.oidc.grants;
+
+
+import org.keycloak.authentication.authenticators.client.ClientAssertionState;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.representations.JsonWebToken;
+
+import org.jboss.logging.Logger;
+
+/**
+ * the assertion validator for Identity Assertion JWT Authorization Grant (ID-JAG).
+ * Identity Assertion JWT is a new type of JWT that can be used as an authorization grant per RFC 7523.
+ *  
+ * https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/
+ *
+ * @author <a href="mailto:yutaka.obuchi.sd@hitachi.com">Yutaka Obuchi</a>
+ */
+public class IDJWTAuthorizationGrantValidator extends DefaultJWTAuthorizationGrantValidator {
+
+    private static final Logger logger = Logger.getLogger(IDJWTAuthorizationGrantValidator.class);
+
+    public static IDJWTAuthorizationGrantValidator createValidator(KeycloakSession session, String scope, ClientAssertionState clientAssertionState) {
+        return new IDJWTAuthorizationGrantValidator(session, scope, clientAssertionState);
+    }
+
+    private IDJWTAuthorizationGrantValidator(KeycloakSession session, String scope, ClientAssertionState clientAssertionState) {
+        super(session, scope, clientAssertionState);
+    }
+
+    public void validateClient() {
+        super.validateClient();
+
+        JsonWebToken accessToken = clientAssertionState.getToken();
+        String clientIdInToken = (String) accessToken.getOtherClaims().get("client_id");
+        String clientIdInRequestHeaderOrBody = session.getContext().getClient().getClientId();
+        if (clientIdInToken == null || !clientIdInRequestHeaderOrBody.equals(clientIdInToken)) {
+                logger.warn("client id in assertion : " + clientIdInToken + " and client id in request header/body : " + clientIdInRequestHeaderOrBody);
+                failureCallback("client id in assertion : " + clientIdInToken + " and client id in request header/body : " + clientIdInRequestHeaderOrBody);
+                return;
+        }
+    }
+
+    public boolean validateTokenActive(int allowedClockSkew, int maxExp, boolean reusePermitted) {
+
+        JsonWebToken accessToken = clientAssertionState.getToken();
+        if (accessToken.getIat() == null) {
+            failureCallback("Token iat claim is required");
+            return false;
+        }
+
+        if (reusePermitted) {
+            logger.warn("Token reuse is not permitted. Token reuse permitted setting is ignored.");            
+        }
+
+        return super.validateTokenActive(allowedClockSkew, maxExp, false);
+
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
@@ -27,9 +27,12 @@ import org.keycloak.authentication.authenticators.client.ClientAssertionState;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.JWTAuthorizationGrantProvider;
 import org.keycloak.cache.AlternativeLookupProvider;
+import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.FederatedIdentityModel;
@@ -40,6 +43,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -60,8 +64,33 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
 
         try {
 
-            JWTAuthorizationGrantValidator authorizationGrantContext = JWTAuthorizationGrantValidator.createValidator(
-                    context.getSession(), client, assertion, formParams.getFirst(OAuth2Constants.SCOPE));
+            if (assertion == null) {
+                throw new IllegalArgumentException("Missing parameter:" + OAuth2Constants.ASSERTION);
+            }
+
+            JWSInput jws;
+            JsonWebToken jwt;
+            try {
+                jws = new JWSInput(assertion);
+                jwt = jws.readJsonContent(JsonWebToken.class);
+            } catch (JWSInputException e) {
+                throw new RuntimeException("The provided assertion is not a valid JWT");
+            }
+
+            String jwtTokenType = jws.getHeader().getType();
+            
+            ClientAssertionState clientAssertionState = new ClientAssertionState(OAuth2Constants.JWT_AUTHORIZATION_GRANT, assertion, jws, jwt);
+            clientAssertionState.setClient(context.getClient());
+
+            JWTAuthorizationGrantValidator authorizationGrantContext;
+            if (Profile.isFeatureEnabled(Profile.Feature.IDENTITY_ASSERTION_JWT) && jwtTokenType != null 
+                    && jwtTokenType.equals(OAuth2Constants.IDENTITY_ASSERTION_JWT_HEADER_TYPE)) {
+                authorizationGrantContext = IDJWTAuthorizationGrantValidator.createValidator(
+                    context.getSession(), formParams.getFirst(OAuth2Constants.SCOPE), clientAssertionState);
+            } else {
+                authorizationGrantContext = DefaultJWTAuthorizationGrantValidator.createValidator(
+                    context.getSession(), formParams.getFirst(OAuth2Constants.SCOPE), clientAssertionState);
+            }
             event.detail(Details.IDENTITY_PROVIDER_ISSUER, authorizationGrantContext.getIssuer());
             event.detail(Details.IDENTITY_PROVIDER_USER_ID, authorizationGrantContext.getSubject());
 
@@ -109,7 +138,7 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
 
             //user must exist in keycloak
             FederatedIdentityModel federatedIdentityModel = new FederatedIdentityModel(identityProviderModel.getAlias(), brokeredIdentityContext.getId(), brokeredIdentityContext.getUsername(), brokeredIdentityContext.getToken());
-            UserModel user = lookupUserByFederatedIdentity(federatedIdentityModel, authorizationGrantContext.getState());
+            UserModel user = lookupUserByFederatedIdentity(federatedIdentityModel, clientAssertionState);
             if (user == null) {
                 throw new RuntimeException("User not found");
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantValidator.java
@@ -1,119 +1,28 @@
-/*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- *  and other contributors as indicated by the @author tags.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
-
 package org.keycloak.protocol.oidc.grants;
 
-import java.util.Set;
+import java.util.List;
 
-import org.keycloak.OAuth2Constants;
-import org.keycloak.authentication.authenticators.client.AbstractBaseJWTValidator;
-import org.keycloak.authentication.authenticators.client.ClientAssertionState;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.jose.jws.JWSInputException;
-import org.keycloak.models.ClientModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.protocol.oidc.JWTAuthorizationGrantValidationContext;
-import org.keycloak.protocol.oidc.OIDCConfigAttributes;
-import org.keycloak.representations.IDToken;
-import org.keycloak.representations.JsonWebToken;
+import org.keycloak.protocol.oidc.JWTAuthorizationGrantValidationContext ;
+
 
 /**
- * Validator for JWT Authorization grant that extends AbstractBaseJWTValidator and
- * implements the JWTAuthorizationGrantValidationContext interface.
+ * Interface for the assertion validator of JWTAuthorizationGrant
  *
- * @author rmartinc
+ * @author <a href="mailto:yutaka.obuchi.sd@hitachi.com">Yutaka Obuchi</a>
  */
-public class JWTAuthorizationGrantValidator extends AbstractBaseJWTValidator implements JWTAuthorizationGrantValidationContext {
 
-    private final String scope;
-    private Set<String> restrictedScopes;
+public interface JWTAuthorizationGrantValidator extends JWTAuthorizationGrantValidationContext {
 
-    public static JWTAuthorizationGrantValidator createValidator(KeycloakSession session, ClientModel client, String assertion, String scope) {
-        if (assertion == null) {
-            throw new RuntimeException("Missing parameter:" + OAuth2Constants.ASSERTION);
-        }
-        try {
-            JWSInput jws = new JWSInput(assertion);
-            JsonWebToken jwt = jws.readJsonContent(JsonWebToken.class);
-            ClientAssertionState clientAssertionState = new ClientAssertionState(OAuth2Constants.JWT_AUTHORIZATION_GRANT, assertion, jws, jwt);
-            clientAssertionState.setClient(client);
-            return new JWTAuthorizationGrantValidator(session, scope, clientAssertionState);
-        } catch (JWSInputException e) {
-            throw new RuntimeException("The provided assertion is not a valid JWT");
-        }
-    }
-
-    private JWTAuthorizationGrantValidator(KeycloakSession session, String scope, ClientAssertionState clientAssertionState) {
-        super(session, clientAssertionState);
-        this.scope = scope;
-    }
-
-    public void validateClient() {
-        if (clientAssertionState.getClient().isPublicClient()) {
-            failureCallback("Public client not allowed to use authorization grant");
-        }
-
-        String val = clientAssertionState.getClient().getAttribute(OIDCConfigAttributes.JWT_AUTHORIZATION_GRANT_ENABLED);
-        if (!Boolean.parseBoolean(val)) {
-            throw new RuntimeException("JWT Authorization Grant is not supported for the requested client");
-        }
-    }
-
-    public void validateIssuer() {
-        if (getJWT().getIssuer() == null) {
-            failureCallback("Missing claim: " + OAuth2Constants.ISSUER);
-        }
-    }
-
-    public void validateSubject() {
-        if (getJWT().getSubject() == null) {
-            failureCallback("Missing claim: " + IDToken.SUBJECT);
-        }
-    }
-
-    @Override
-    public JsonWebToken getJWT() {
-        return clientAssertionState.getToken();
-    }
-
-    @Override
-    public String getAssertion() {
-        return clientAssertionState.getClientAssertion();
-    }
-
-    @Override
-    public String getScopeParam() {
-        return scope;
-    }
-
-    @Override
-    public Set<String> getRestrictedScopes() {
-        return restrictedScopes;
-    }
-
-    @Override
-    public void setRestrictedScopes(Set<String> restrictedScopes) {
-        this.restrictedScopes = restrictedScopes;
-    }
-
-    @Override
-    protected void failureCallback(String errorDescription) {
-        throw new RuntimeException(errorDescription);
-    }
+    void validateClient();
+    
+    void validateIssuer();
+    
+    void validateSubject();
+    
+    boolean validateTokenActive(int allowedClockSkew, int maxExp, boolean reusePermitted); 
+    
+    boolean validateSignatureAlgorithm(String expectedSignatureAlg);
+    
+    boolean validateTokenAudience(List<String> expectedAudiences, boolean multipleAudienceAllowed);
+    
 }

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthIdentityProvider.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthIdentityProvider.java
@@ -7,6 +7,7 @@ import java.security.KeyPair;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.common.crypto.CryptoIntegration;
 import org.keycloak.common.util.KeyUtils;
 import org.keycloak.crypto.Algorithm;
@@ -58,6 +59,10 @@ public class OAuthIdentityProvider {
 
     public String encodeToken(JsonWebToken token, OAuthIdentityProviderKeys keys) {
         return new JWSBuilder().type("JWT").jsonContent(token).sign(new ECDSASignatureSignerContext(keys.getKeyWrapper()));
+    }
+
+    public String encodeIDJAG(JsonWebToken token) {
+        return new JWSBuilder().type(OAuth2Constants.IDENTITY_ASSERTION_JWT_HEADER_TYPE).jsonContent(token).sign(new ECDSASignatureSignerContext(keys.getKeyWrapper()));
     }
 
     public OAuthIdentityProviderKeys createKeys() {

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/IDJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/IDJWTAuthorizationGrantTest.java
@@ -1,0 +1,220 @@
+package org.keycloak.tests.oauth;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.Time;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.IdentityProviderBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+@KeycloakIntegrationTest(config = IDJWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
+public class IDJWTAuthorizationGrantTest extends BaseAbstractJWTAuthorizationGrantTest {
+
+    @InjectRealm(config = IDJWTAuthorizationGrantTest.JWTAuthorizationGrantRealmConfig.class)
+    protected ManagedRealm realm;
+
+    @InjectUser(config = IDJWTAuthorizationGrantTest.FederatedUserConfiguration.class)
+    protected ManagedUser user;
+  
+    @Test
+    public void testNullIssInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        jwt.issuer(null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Missing claim: iss", response, events.poll());
+    }
+
+    @Test
+    public void testNullAudInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        jwt.audience(null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Invalid token audience", response, events.poll());
+    }
+
+    @Test
+    public void testNullSubInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        jwt.subject(null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Missing claim: sub", response, events.poll());
+    }
+    
+    @Test
+    public void testNullExpInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        jwt.exp(null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Token exp claim is required", response, events.poll());
+    }
+
+    @Test
+    public void testNullIatInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        jwt.iat(null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Token iat claim is required", response, events.poll());
+    }
+
+    @Test
+    public void testNullJtiInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        jwt.id(null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Token jti claim is required", response, events.poll());
+    }
+
+    @Test
+    public void testClientInTokenAndInRequestParameter() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("test-app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("client id in assertion : clientid_issued_by_resource_authz_to_client_app and client id in request header/body : test-app", response, events.poll());
+    }
+
+    @Test
+    public void testInvalidTokenAudience() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id","fake-audience",IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Invalid token audience", response, events.poll());
+    }
+
+    @Test
+    public void testNoClientInToken() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("test-app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("client id in assertion : null and client id in request header/body : test-app", response, events.poll());
+    }
+    
+    @Test
+    public void testNoAssertion() {
+        String jwtString = null;
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("Missing parameter:assertion", response, events.poll());
+    }
+    
+    @Test
+    public void testNoJWTAssertion() {
+        String jwtString = "no-jwt-string";
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertFailure("The provided assertion is not a valid JWT", response, events.poll());
+    }
+
+    @Test
+    public void testSuccessGrant() {
+        AccessToken jwt = createAuthorizationGrantToken("basic-user-id",oAuthClient.getEndpoints().getIssuer(),IDP_ISSUER,Time.currentTime() + 300L,(long) Time.currentTime(), null);
+        jwt.setOtherClaims("client_id","clientid_issued_by_resource_authz_to_client_app");
+        String jwtString = getIdentityProvider().encodeIDJAG(jwt);
+        AccessTokenResponse response = oAuthClient.client("clientid_issued_by_resource_authz_to_client_app", "test-secret").jwtAuthorizationGrantRequest(jwtString).send();
+        assertSuccess("clientid_issued_by_resource_authz_to_client_app", response);
+    }
+
+    protected AccessToken assertSuccess(String expectedClientId, AccessTokenResponse response) {
+        Assertions.assertTrue(response.isSuccess());
+        Assertions.assertNull(response.getRefreshToken());
+        AccessToken accessToken = oAuthClient.parseToken(response.getAccessToken(), AccessToken.class);
+        Assertions.assertNull(accessToken.getSessionId());
+        MatcherAssert.assertThat(accessToken.getId(), Matchers.startsWith("trrtag:"));
+        Assertions.assertEquals(expectedClientId, accessToken.getIssuedFor());
+        Assertions.assertEquals(user.getUsername(), accessToken.getPreferredUsername());
+        EventAssertion.assertSuccess(events.poll())
+                .type(EventType.JWT_AUTHORIZATION_GRANT)
+                .clientId(expectedClientId)
+                .sessionId(null)
+                .userId(user.getId())
+                .details(Details.GRANT_TYPE, OAuth2Constants.JWT_AUTHORIZATION_GRANT)
+                .details(Details.IDENTITY_PROVIDER, IDP_ALIAS)
+                .details(Details.IDENTITY_PROVIDER_ISSUER, IDP_ISSUER)
+                .details(Details.IDENTITY_PROVIDER_USER_ID, "basic-user-id")
+                .details(Details.USERNAME, user.getUsername());
+        return accessToken;
+    }
+
+    public static class JWTAuthorizationGrantRealmConfig extends AbstractJWTAuthorizationGrantTest.JWTAuthorizationGrantRealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.clients(ClientBuilder.create("clientid_issued_by_resource_authz_to_client_app")
+                .serviceAccountsEnabled(true)
+                .directAccessGrantsEnabled(true)
+                .publicClient(false)
+                .attribute(OIDCConfigAttributes.JWT_AUTHORIZATION_GRANT_ENABLED, "true")
+                .secret("test-secret")
+                .attribute(OIDCConfigAttributes.JWT_AUTHORIZATION_GRANT_IDP, IDP_ALIAS));
+            realm.identityProviders(
+                IdentityProviderBuilder.create()
+                            .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+                            .alias(IDP_ALIAS)
+                            .attribute(IdentityProviderModel.ISSUER, IDP_ISSUER)
+                            .attribute(OIDCIdentityProviderConfig.VALIDATE_SIGNATURE, Boolean.TRUE.toString())
+                            .attribute(OIDCIdentityProviderConfig.JWKS_URL, "http://127.0.0.1:8500/idp/jwks")
+                            .attribute(OIDCIdentityProviderConfig.USE_JWKS_URL, Boolean.TRUE.toString())
+                            .attribute(OIDCIdentityProviderConfig.JWT_AUTHORIZATION_GRANT_ENABLED, Boolean.TRUE.toString())
+                            .build());
+
+            return realm;
+        }
+    }
+
+    public static class FederatedUserConfiguration extends AbstractJWTAuthorizationGrantTest.FederatedUserConfiguration {
+
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            return user
+                    .username("basic-user")
+                    .password("password")
+                    .email("basic@localhost")
+                    .name("First", "Last")
+                    .federatedLink(IDP_ALIAS, "basic-user-id", "basic-user");
+        }
+    }
+
+    public static class JWTAuthorizationGrantServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.IDENTITY_ASSERTION_JWT);
+        }
+    }
+}


### PR DESCRIPTION
closes #49005 

This PR is for ID-JAG receiver, which receives ID-JAG and send back access token working as a part of token endpoint.

ID-JAG is one type of JWT, which can be used as Authorization Grant(https://www.rfc-editor.org/rfc/rfc7523.html#section-2.1).
AFAIK, the type for JWTAuthorizationGrant clearly mentioned in the standard specs or the draft of those  is only one, for now.
But in the future there could be more types coming.
So here in this PR, we make validators for every types of JWT pluggable  by introducing brand new SPI:JWTAuthorizationGrantValidatorSpi.


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
