### PR TITLE
[quarkus-next] DatasourcesDistTest fails due to Quarkus stdout/stderr…

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatasourcesDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/dist/DatasourcesDistTest.java
@@ -18,7 +18,6 @@ public class DatasourcesDistTest {
     @Test
     @Launch({"start-dev", "--db-kind-users=postgres", "--db-kind-clients=postgres", "--transaction-xa-enabled-users=false"})
     public void multipleNonXaDatasources(CLIResult result) {
-        result.assertNoMessage("Multiple datasources are specified:"); // log handlers are not initialized yet, so only the error should be visible
         result.assertExitCode(CommandLine.ExitCode.SOFTWARE);
         result.assertError("Multiple datasources are configured but more than 1 (<default>, users) is using non-XA transactions.");
     }


### PR DESCRIPTION
… capture changes

Closes: #46084

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This PR needs to be merged to main after the upgrade to Quarkus 3.32.