### PR TITLE
[client-v2] Extend client policies tests to check exact events

### DIFF
--- a/rest/admin-v2/tests/pom.xml
+++ b/rest/admin-v2/tests/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-v2-rest</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak.tests</groupId>
+            <artifactId>keycloak-tests-custom-providers</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/custom-providers/src/main/java/org/keycloak/testsuite/client/policies/TrackEventsClientPolicyExecutor.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/testsuite/client/policies/TrackEventsClientPolicyExecutor.java
@@ -1,0 +1,85 @@
+package org.keycloak.testsuite.client.policies;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyEvent;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProvider;
+import org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory;
+
+import org.jboss.logging.Logger;
+
+public class TrackEventsClientPolicyExecutor implements ClientPolicyExecutorProviderFactory, ClientPolicyExecutorProvider<TrackEventsClientPolicyExecutor.Configuration> {
+    public static final String PROVIDER_ID = "track-events-client-policy-executor";
+
+    private static final Logger log = Logger.getLogger(TrackEventsClientPolicyExecutor.class);
+    private static final TrackEventsClientPolicyExecutor SINGLETON = new TrackEventsClientPolicyExecutor();
+    private final List<ClientPolicyEvent> events;
+
+    public TrackEventsClientPolicyExecutor() {
+        this.events = new ArrayList<>();
+    }
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) {
+        log.warnf("Executor with type: %s", context.getEvent());
+        events.add(context.getEvent());
+    }
+
+    public List<ClientPolicyEvent> getEvents() {
+        return events;
+    }
+
+    public void clearEventResult() {
+        events.clear();
+    }
+
+    @Override
+    public TrackEventsClientPolicyExecutor create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getProviderId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Test Client Policy executor that checks if only specific policies with certain ClientPolicyEvent types are executed.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+    }
+}

--- a/tests/custom-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/tests/custom-providers/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.testsuite.client.policies.TrackEventsClientPolicyExecutor


### PR DESCRIPTION
- Closes https://github.com/keycloak/keycloak/issues/46114
- Extended tests for the client policies in the https://github.com/keycloak/keycloak/pull/46029
- Create `TestClientPolicyExecutor` executor that just observes all client policy types and stores them inan  ordered list
- Created the `YesClientPolicyCondition` policy condition that always returns YES, and the wanted client policy is always evaluated/executed
- Based on the analysis in: https://github.com/keycloak/keycloak/issues/45940#issuecomment-3840875460

@edewit @vmuzikar Can you check it? Thanks!