### PR TITLE
[quarkus-next] configureResteasy() missing Quarkus build step dependency

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -890,6 +890,7 @@ class KeycloakProcessor {
     }
 
     @BuildStep
+    @Consume(ConfigBuildItem.class)
     @Consume(ProfileBuildItem.class)
     void configureResteasy(CombinedIndexBuildItem index,
             BuildProducer<BuildTimeConditionBuildItem> buildTimeConditionBuildItemBuildProducer,


### PR DESCRIPTION
Closes: #46095

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This PR needs to be merged to main after the upgrade to Quarkus 3.32 and after the related Quarkus upstream fix https://github.com/quarkusio/quarkus/pull/52463.