### PR TITLE
Fix duplicate header in VERIFY_EMAIL flow

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1088,6 +1088,7 @@ public class AuthenticationManager {
 
         if (authSession.getAuthNote(END_AFTER_REQUIRED_ACTIONS) != null) {
             LoginFormsProvider infoPage = session.getProvider(LoginFormsProvider.class).setAuthenticationSession(authSession)
+                    .setAttribute("messageHeader", Messages.ACCOUNT_UPDATED_TITLE)
                     .setSuccess(Messages.ACCOUNT_UPDATED);
             if (authSession.getAuthNote(SET_REDIRECT_URI_AFTER_REQUIRED_ACTIONS) != null) {
                 if (authSession.getRedirectUri() != null) {

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -140,6 +140,8 @@ public class Messages {
 
     public static final String ACCOUNT_UPDATED = "accountUpdatedMessage";
 
+    public static final String ACCOUNT_UPDATED_TITLE = "accountUpdatedTitle";
+
     public static final String ACCOUNT_PASSWORD_UPDATED = "accountPasswordUpdatedMessage";
 
     public static final String NO_ACCESS = "noAccessMessage";

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserEmailTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserEmailTest.java
@@ -614,7 +614,7 @@ public class UserEmailTest extends AbstractUserTest {
 
         passwordUpdatePage.changePassword("new-pass", "new-pass");
 
-        assertEquals("Your account has been updated.", driver.findElement(By.id("kc-page-title")).getText());
+        assertEquals("Account updated", driver.findElement(By.id("kc-page-title")).getText());
 
         String pageSource = driver.page().getPageSource();
 
@@ -696,7 +696,7 @@ public class UserEmailTest extends AbstractUserTest {
 
         passwordUpdatePage.changePassword("new-pass", "new-pass");
 
-        assertEquals("Your account has been updated.", driver.findElement(By.id("kc-page-title")).getText());
+        assertEquals("Account updated", driver.findElement(By.id("kc-page-title")).getText());
 
         String pageSource = driver.page().getPageSource();
 

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -311,6 +311,7 @@ linkIdpMessage=You need to verify your email address to link your account with {
 emailSentMessage=You should receive an email shortly with further instructions.
 emailSendErrorMessage=Failed to send email, please try again later.
 
+accountUpdatedTitle=Account updated
 accountUpdatedMessage=Your account has been updated.
 accountPasswordUpdatedMessage=Your password has been updated.
 


### PR DESCRIPTION
When executing the VERIFY_EMAIL action (for example via the admin API), the confirmation page showed "Your account has been updated." twice, once as the page header and once as the body.

The root cause is that `AuthenticationManager.finishedRequiredActions()` rendered the `ACCOUNT_UPDATED` info page without setting a messageHeader attribute.

The `info.ftl` template falls back to `message.summary` when `messageHeader` is not set, which produced the duplicated message.

Change summary:
- Add a new message key `accountUpdatedTitle` with value "Account Updated".
- Add a Messages constant (`ACCOUNT_UPDATED_TITLE`) for the new key.
- Update `AuthenticationManager` to set the `messageHeader` attribute to the message key (`ACCOUNT_UPDATED_TITLE`) instead of passing a resolved message string. Passing the key lets the template render a distinct header (localized via the message key) and keeps the body message separate.

Result:
- Header now reads "Account Updated"
- Body now reads "Your account has been updated."
- Prevents the same message appearing both in the header and the body.

Notes:
- This addresses the same underlying issue reported in #41701

Fix #46105

### Before

<img width="2532" height="1170" alt="image" src="https://github.com/user-attachments/assets/daaf36b4-8d08-4177-8003-2e736118b587" />


### After

<img width="2532" height="1170" alt="image" src="https://github.com/user-attachments/assets/00756988-b69b-431c-8d17-afe2dd326c45" />
