### PR TITLE
Keycloak User Session Count Limiter - Per Flow Counting 

### DIFF
--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Adapters</name>

--- a/adapters/saml/core-public/pom.xml
+++ b/adapters/saml/core-public/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/saml/core/pom.xml
+++ b/adapters/saml/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/saml/pom.xml
+++ b/adapters/saml/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Keycloak SAML Client Adapter Modules</name>

--- a/adapters/saml/wildfly-elytron/pom.xml
+++ b/adapters/saml/wildfly-elytron/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/saml/wildfly/pom.xml
+++ b/adapters/saml/wildfly/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Keycloak SAML Wildfly Integration</name>

--- a/adapters/saml/wildfly/wildfly-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/adapters/spi/adapter-spi/pom.xml
+++ b/adapters/spi/adapter-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/spi/jboss-adapter-core/pom.xml
+++ b/adapters/spi/jboss-adapter-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/adapters/spi/pom.xml
+++ b/adapters/spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <name>Keycloak Client Adapter SPI Modules</name>

--- a/authz/client/pom.xml
+++ b/authz/client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz/policy/common/pom.xml
+++ b/authz/policy/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-provider-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz/policy/pom.xml
+++ b/authz/policy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-authz-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/authz/pom.xml
+++ b/authz/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.keycloak.bom</groupId>
     <artifactId>keycloak-bom-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.3.2</version>
 
     <packaging>pom</packaging>
 

--- a/boms/spi/pom.xml
+++ b/boms/spi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.keycloak.bom</groupId>
         <artifactId>keycloak-bom-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <groupId>org.keycloak.bom</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/default/pom.xml
+++ b/crypto/default/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-crypto-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/elytron/pom.xml
+++ b/crypto/elytron/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-crypto-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/fips1402/pom.xml
+++ b/crypto/fips1402/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-crypto-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Crypto Parent</name>

--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/dependencies/server-all/pom.xml
+++ b/dependencies/server-all/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>keycloak-dependencies-parent</artifactId>
 		<groupId>org.keycloak</groupId>
-		<version>999.0.0-SNAPSHOT</version>
+		<version>26.3.2</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/dependencies/server-min/pom.xml
+++ b/dependencies/server-min/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<artifactId>keycloak-dependencies-parent</artifactId>
 		<groupId>org.keycloak</groupId>
-		<version>999.0.0-SNAPSHOT</version>
+		<version>26.3.2</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-api-docs-dist</artifactId>

--- a/distribution/downloads/pom.xml
+++ b/distribution/downloads/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-dist-downloads</artifactId>

--- a/distribution/galleon-feature-packs/pom.xml
+++ b/distribution/galleon-feature-packs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <name>Galleon Feature Pack Builds</name>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack-layer-metadata-tests/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>galleon-feature-packs-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
+++ b/distribution/galleon-feature-packs/saml-adapter-galleon-pack/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>galleon-feature-packs-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/distribution/licenses-common/pom.xml
+++ b/distribution/licenses-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-distribution-licenses-common</artifactId>

--- a/distribution/maven-plugins/licenses-processor/pom.xml
+++ b/distribution/maven-plugins/licenses-processor/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-maven-plugins-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-distribution-licenses-maven-plugin</artifactId>

--- a/distribution/maven-plugins/pom.xml
+++ b/distribution/maven-plugins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-distribution-maven-plugins-parent</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/saml-adapters/pom.xml
+++ b/distribution/saml-adapters/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-distribution-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <name>SAML Adapters Distribution Parent</name>

--- a/distribution/saml-adapters/wildfly-adapter/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <name>Keycloak Wildfly SAML Adapter</name>

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-adapter-zip/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
+++ b/distribution/saml-adapters/wildfly-adapter/wildfly-modules/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/aggregation/pom.xml
+++ b/docs/documentation/aggregation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/api_documentation/pom.xml
+++ b/docs/documentation/api_documentation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/authorization_services/pom.xml
+++ b/docs/documentation/authorization_services/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/dist/pom.xml
+++ b/docs/documentation/dist/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/header-maven-plugin/pom.xml
+++ b/docs/documentation/header-maven-plugin/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>documentation-parent</artifactId>
         <groupId>org.keycloak.documentation</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>header-maven-plugin</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.3.2</version>
     <packaging>maven-plugin</packaging>
 
     <name>header-maven-plugin</name>

--- a/docs/documentation/pom.xml
+++ b/docs/documentation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-docs-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -14,7 +14,7 @@
 
     <groupId>org.keycloak.documentation</groupId>
     <artifactId>documentation-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.3.2</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/docs/documentation/release_notes/pom.xml
+++ b/docs/documentation/release_notes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/server_admin/pom.xml
+++ b/docs/documentation/server_admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/server_development/pom.xml
+++ b/docs/documentation/server_development/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/tests/pom.xml
+++ b/docs/documentation/tests/pom.xml
@@ -60,7 +60,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -2,10 +2,10 @@
 :project_name_full: Keycloak
 :project_community: true
 :project_product: false
-:project_version: DEV
-:project_versionMvn: 999.0.0-SNAPSHOT
-:project_versionNpm: 999.0.0-SNAPSHOT
-:project_versionDoc: DEV
+:project_version: 26.3.2
+:project_versionMvn: 26.3.2
+:project_versionNpm: 26.3.2
+:project_versionDoc: 26.3.2
 
 :archivebasename: keycloak
 :archivedownloadurl: https://github.com/keycloak/keycloak/releases/download/{project_version}/keycloak-{project_version}.zip

--- a/docs/documentation/upgrading/pom.xml
+++ b/docs/documentation/upgrading/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.documentation</groupId>
         <artifactId>documentation-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/guides/pom.xml
+++ b/docs/guides/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-docs-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/maven-plugin/pom.xml
+++ b/docs/maven-plugin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-docs-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Docs Parent</name>

--- a/federation/ipatuura/pom.xml
+++ b/federation/ipatuura/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/kerberos/pom.xml
+++ b/federation/kerberos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/ldap/pom.xml
+++ b/federation/ldap/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/federation/sssd/pom.xml
+++ b/federation/sssd/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration/client-cli/admin-cli/pom.xml
+++ b/integration/client-cli/admin-cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-client-cli-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration/client-cli/client-cli-dist/pom.xml
+++ b/integration/client-cli/client-cli-dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-client-cli-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-client-cli-dist</artifactId>

--- a/integration/client-cli/pom.xml
+++ b/integration/client-cli/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <name>Keycloak Client CLI</name>

--- a/integration/client-registration/pom.xml
+++ b/integration/client-registration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-integration-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Integration</name>

--- a/js/apps/account-ui/package.json
+++ b/js/apps/account-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-account-ui",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.3.2",
   "type": "module",
   "main": "lib/keycloak-account-ui.js",
   "types": "./lib/keycloak-account-ui.d.ts",

--- a/js/apps/account-ui/pom.xml
+++ b/js/apps/account-ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/apps/admin-ui/package.json
+++ b/js/apps/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-admin-ui",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.3.2",
   "type": "module",
   "main": "lib/keycloak-admin-ui.js",
   "types": "./lib/keycloak-admin-ui.d.ts",

--- a/js/apps/admin-ui/pom.xml
+++ b/js/apps/admin-ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-admin-client",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.3.2",
   "description": "A client to interact with Keycloak's Administration API",
   "type": "module",
   "main": "lib/index.js",

--- a/js/libs/keycloak-admin-client/pom.xml
+++ b/js/libs/keycloak-admin-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/libs/ui-shared/package.json
+++ b/js/libs/ui-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keycloak/keycloak-ui-shared",
-  "version": "999.0.0-SNAPSHOT",
+  "version": "26.3.2",
   "type": "module",
   "main": "./dist/keycloak-ui-shared.js",
   "types": "./dist/keycloak-ui-shared.d.ts",

--- a/js/libs/ui-shared/pom.xml
+++ b/js/libs/ui-shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/js/themes-vendor/pom.xml
+++ b/js/themes-vendor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-js-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/misc/theme-verifier/pom.xml
+++ b/misc/theme-verifier/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>org.keycloak</groupId>
     <artifactId>theme-verifier-maven-plugin</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.3.2</version>
 
     <name>Keycloak Theme verifier</name>
     <description>Keycloak Theme verifier</description>

--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/model/jpa/pom.xml
+++ b/model/jpa/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Model Parent</name>

--- a/model/storage-private/pom.xml
+++ b/model/storage-private/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/storage-services/pom.xml
+++ b/model/storage-services/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/model/storage/pom.xml
+++ b/model/storage/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-model-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/operator/pom.xml
+++ b/operator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     </description>
     <groupId>org.keycloak</groupId>
     <artifactId>keycloak-parent</artifactId>
-    <version>999.0.0-SNAPSHOT</version>
+    <version>26.3.2</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -41,7 +41,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <project.version.npm>999.0.0-SNAPSHOT</project.version.npm>
+        <project.version.npm>26.3.2</project.version.npm>
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 

--- a/quarkus/config-api/pom.xml
+++ b/quarkus/config-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/quarkus/dist/pom.xml
+++ b/quarkus/dist/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-quarkus-dist</artifactId>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <name>Keycloak Quarkus Parent</name>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/quarkus/server/pom.xml
+++ b/quarkus/server/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/quarkus/tests/integration/pom.xml
+++ b/quarkus/tests/integration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>keycloak-quarkus-test-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quarkus/tests/junit5/pom.xml
+++ b/quarkus/tests/junit5/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>keycloak-quarkus-test-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/quarkus/tests/pom.xml
+++ b/quarkus/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>keycloak-quarkus-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/rest/admin-ui-ext/pom.xml
+++ b/rest/admin-ui-ext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-rest-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>keycloak-rest-admin-ui-ext</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <name>Keycloak Administration UI</name>

--- a/saml-core-api/pom.xml
+++ b/saml-core-api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/saml-core/pom.xml
+++ b/saml-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/server-spi/pom.xml
+++ b/server-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -26,6 +26,7 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
 
     private static final Logger logger = Logger.getLogger(UserSessionLimitsAuthenticator.class);
     public static final String SESSION_LIMIT_EXCEEDED = "sessionLimitExceeded";
+    public static final String FLOW_PATH_NOTE = "AUTH_FLOW_PATH";
     protected final KeycloakSession session;
 
     String behavior;
@@ -57,20 +58,35 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
         behavior = config.get(UserSessionLimitsAuthenticatorFactory.BEHAVIOR);
         int userRealmLimit = getIntConfigProperty(UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, config);
         int userClientLimit = getIntConfigProperty(UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, config);
+        String sessionCountingScope = config.getOrDefault(
+                UserSessionLimitsAuthenticatorFactory.SESSION_COUNTING_SCOPE,
+                UserSessionLimitsAuthenticatorFactory.SCOPE_ALL_FLOWS);
+
+        // Tag the session with the flow path BEFORE counting if scope is set to "This Authentication Flow"
+        // This ensures the session being created can be tracked properly
+        if (UserSessionLimitsAuthenticatorFactory.SCOPE_THIS_FLOW.equals(sessionCountingScope)) {
+            context.getAuthenticationSession().setUserSessionNote(FLOW_PATH_NOTE, context.getFlowPath());
+        }
 
         if (context.getRealm() != null && context.getUser() != null) {
 
-            // Get the session count in this realm for this specific user
-            List<UserSessionModel> userSessionsForRealm = session.sessions()
+            // Get all user sessions for this realm
+            List<UserSessionModel> allUserSessionsForRealm = session.sessions()
                     .getUserSessionsStream(context.getRealm(), context.getUser())
                     .collect(Collectors.toList());
+
+            // Filter sessions based on counting scope
+            List<UserSessionModel> userSessionsForRealm = filterSessionsByScope(
+                    allUserSessionsForRealm, context.getFlowPath(), sessionCountingScope);
+            
             int userSessionCountForRealm = userSessionsForRealm.size();
 
             // Get the session count related to the current client for this user
             List<UserSessionModel> userSessionsForClient = getUserSessionsForClientIfEnabled(userSessionsForRealm, currentClient, userClientLimit);
-            int userSessionCountForClient = userSessionsForClient.size();
+            int userSessionCountForClient = userSessionsForClient.size();           
             logger.debugf("session-limiter's configured realm session limit: %s", userRealmLimit);
             logger.debugf("session-limiter's configured client session limit: %s", userClientLimit);
+            logger.debugf("session-limiter's session counting scope: %s", sessionCountingScope);
             logger.debugf("session-limiter's count of total user sessions for the entire realm (could be apps other than web apps): %s", userSessionCountForRealm);
             logger.debugf("session-limiter's count of total user sessions for this keycloak client: %s", userSessionCountForClient);
 
@@ -92,6 +108,21 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
         } else {
             context.success();
         }
+    }
+
+    private List<UserSessionModel> filterSessionsByScope(
+            List<UserSessionModel> allSessions,
+            String currentFlowPath,
+            String sessionCountingScope) {
+
+        if (UserSessionLimitsAuthenticatorFactory.SCOPE_THIS_FLOW.equals(sessionCountingScope)) {
+            // Count only sessions from this specific flow
+            return allSessions.stream()
+                    .filter(s -> currentFlowPath.equals(s.getNote(FLOW_PATH_NOTE)))
+                    .collect(Collectors.toList());
+        }
+        // Default: count all sessions (SCOPE_ALL_FLOWS)
+        return allSessions;
     }
 
     private boolean exceedsLimit(long count, long limit) {
@@ -157,9 +188,9 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
                         .map(f -> f.get(UserSessionLimitsAuthenticatorFactory.ERROR_MESSAGE))
                         .orElse(SESSION_LIMIT_EXCEEDED);
 
-                context.getEvent().error(Errors.GENERIC_AUTHENTICATION_ERROR);
+                context.getEvent().error(Errors.ACCESS_DENIED);
                 Response challenge = context.form().setError(errorMessage).createErrorPage(Response.Status.FORBIDDEN);
-                context.failure(AuthenticationFlowError.GENERIC_AUTHENTICATION_ERROR, challenge, eventDetails, errorMessage);
+                context.forceChallenge(challenge);
                 break;
 
             case UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION:

--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticatorFactory.java
@@ -19,6 +19,9 @@ public class UserSessionLimitsAuthenticatorFactory implements AuthenticatorFacto
     public static final String TERMINATE_OLDEST_SESSION = "Terminate oldest session";
     public static final String USER_SESSION_LIMITS = "user-session-limits";
     public static final String ERROR_MESSAGE = "errorMessage";
+    public static final String SESSION_COUNTING_SCOPE = "sessionCountingScope";
+    public static final String SCOPE_THIS_FLOW = "This Authentication Flow";
+    public static final String SCOPE_ALL_FLOWS = "All Authentication Flows";
 
     private static AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
             AuthenticationExecutionModel.Requirement.REQUIRED,
@@ -84,7 +87,15 @@ public class UserSessionLimitsAuthenticatorFactory implements AuthenticatorFacto
         customErrorMessage.setHelpText("If left empty a default error message is shown");
         customErrorMessage.setType(ProviderConfigProperty.STRING_TYPE);
 
-        return Arrays.asList(userRealmLimit, userClientLimit, behaviourProperty, customErrorMessage);
+        ProviderConfigProperty sessionCountingScope = new ProviderConfigProperty();
+        sessionCountingScope.setName(SESSION_COUNTING_SCOPE);
+        sessionCountingScope.setLabel("Session Counting Scope");
+        sessionCountingScope.setHelpText("Determines how sessions are counted. 'This Authentication Flow' counts only sessions created through this specific flow. 'All Authentication Flows' counts all user sessions across all flows..");
+        sessionCountingScope.setType(ProviderConfigProperty.LIST_TYPE);
+        sessionCountingScope.setDefaultValue(SCOPE_ALL_FLOWS);
+        sessionCountingScope.setOptions(Arrays.asList(SCOPE_THIS_FLOW, SCOPE_ALL_FLOWS));
+
+        return Arrays.asList(userRealmLimit, userClientLimit, behaviourProperty, customErrorMessage, sessionCountingScope);
     }
 
     @Override

--- a/test-framework/bom/pom.xml
+++ b/test-framework/bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/clustering/pom.xml
+++ b/test-framework/clustering/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.testframework</groupId>
         <artifactId>keycloak-test-framework-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/core/pom.xml
+++ b/test-framework/core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-mariadb/pom.xml
+++ b/test-framework/db-mariadb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-mssql/pom.xml
+++ b/test-framework/db-mssql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-mysql/pom.xml
+++ b/test-framework/db-mysql/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-oracle/pom.xml
+++ b/test-framework/db-oracle/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/db-postgres/pom.xml
+++ b/test-framework/db-postgres/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/email-server/pom.xml
+++ b/test-framework/email-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/examples/pom.xml
+++ b/test-framework/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/examples/providers/pom.xml
+++ b/test-framework/examples/providers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>keycloak-test-framework-examples</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-framework/examples/tests/pom.xml
+++ b/test-framework/examples/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-examples</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/junit5-config/pom.xml
+++ b/test-framework/junit5-config/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/oauth/pom.xml
+++ b/test-framework/oauth/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/pom.xml
+++ b/test-framework/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/remote-providers/pom.xml
+++ b/test-framework/remote-providers/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/remote/pom.xml
+++ b/test-framework/remote/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/test-framework/ui/pom.xml
+++ b/test-framework/ui/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-test-framework-parent</artifactId>
         <groupId>org.keycloak.testframework</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/base/pom.xml
+++ b/tests/base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/clustering/pom.xml
+++ b/tests/clustering/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.keycloak.tests</groupId>
         <artifactId>keycloak-tests-parent</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/custom-providers/pom.xml
+++ b/tests/custom-providers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/migration-util/pom.xml
+++ b/tests/migration-util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/utils-shared/pom.xml
+++ b/tests/utils-shared/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/tests/utils/pom.xml
+++ b/tests/utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-tests-parent</artifactId>
         <groupId>org.keycloak.tests</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-testsuite-pom</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/testsuite/integration-arquillian/servers/app-server/app-server-spi/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/app-server-spi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/galleon/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/galleon/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server-jboss</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-app-server-jboss</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/app-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/quarkus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-servers-auth-server</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers-deployment/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server-services</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>integration-arquillian-testsuite-providers-deployment</artifactId>

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server-services</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>integration-arquillian-testsuite-providers</artifactId>

--- a/testsuite/integration-arquillian/servers/auth-server/undertow/pom.xml
+++ b/testsuite/integration-arquillian/servers/auth-server/undertow/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-auth-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/infinispan/datagrid/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/infinispan/datagrid/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-infinispan</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/infinispan/infinispan/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/infinispan/infinispan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-infinispan</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/infinispan/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/infinispan/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/testsuite/integration-arquillian/servers/cache-server/legacy/datagrid/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/legacy/datagrid/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-legacy</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/legacy/infinispan/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/legacy/infinispan/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server-legacy</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/legacy/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/legacy/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers-cache-server</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/cache-server/pom.xml
+++ b/testsuite/integration-arquillian/servers/cache-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/migration/pom.xml
+++ b/testsuite/integration-arquillian/servers/migration/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-servers</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/servers/pom.xml
+++ b/testsuite/integration-arquillian/servers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/test-apps/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/test-apps/servlets/pom.xml
+++ b/testsuite/integration-arquillian/test-apps/servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-test-apps</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -130,7 +130,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
         // Login the same user again and verify the configured error message is shown
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
-        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
         errorPage.assertCurrent();
         assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
     }
@@ -185,7 +185,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             // Login the same user again and verify the configured error message is shown
             loginPage.open();
             loginPage.login("test-user@localhost", "password");
-            events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
             errorPage.assertCurrent();
             assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
         } finally {
@@ -320,7 +320,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
             driver.navigate().to(changePasswordUrl.trim());
 
-            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.ACCESS_DENIED).assertEvent();
         } finally {
             testRealm().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).setDirectAccessGrantsEnabled(false);
             ApiUtil.resetUserPassword(testRealm().users().get(findUser("test-user@localhost").getId()), "password", false);
@@ -407,7 +407,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
             driver.navigate().to(changePasswordUrl.trim());
 
-            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.ACCESS_DENIED).assertEvent();
         } finally {
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "0");
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "1");
@@ -502,7 +502,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
         // New login should fail due the sessions limit
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
-        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
         errorPage.assertCurrent();
         assertEquals("There are too many sessions", errorPage.getError()); // Default error message
 

--- a/testsuite/integration-arquillian/tests/other/jpa-performance/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/jpa-performance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests-other</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-jpa-performance</artifactId>

--- a/testsuite/integration-arquillian/tests/other/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian-tests</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <artifactId>integration-arquillian-tests-other</artifactId>

--- a/testsuite/integration-arquillian/tests/other/sssd/pom.xml
+++ b/testsuite/integration-arquillian/tests/other/sssd/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-tests-other</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/integration-arquillian/tests/pom.xml
+++ b/testsuite/integration-arquillian/tests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/testsuite/integration-arquillian/util/pom.xml
+++ b/testsuite/integration-arquillian/util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.keycloak.testsuite</groupId>
         <artifactId>integration-arquillian</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-testsuite-pom</artifactId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/utils/pom.xml
+++ b/testsuite/utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-testsuite-pom</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/themes/pom.xml
+++ b/themes/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/util/embedded-ldap/pom.xml
+++ b/util/embedded-ldap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>keycloak-parent</artifactId>
         <groupId>org.keycloak</groupId>
-        <version>999.0.0-SNAPSHOT</version>
+        <version>26.3.2</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This fix introduces an optional flow-aware session filtering mechanism to the existing User Session Count Limiter authenticator.

Previously, the authenticator counted all active user sessions together, regardless of how those sessions were created (for example, browser login vs. direct grant). This caused sessions created via one authentication flow to block logins through a different flow.
<img width="1862" height="917" alt="image" src="https://github.com/user-attachments/assets/ed087306-f52f-43f8-a5e4-ab7334013890" />
<img width="1862" height="917" alt="image" src="https://github.com/user-attachments/assets/ea835777-362b-4f72-a31e-d097fd3229d0" />
<img width="1862" height="917" alt="image" src="https://github.com/user-attachments/assets/78f9e685-0d31-44cb-a340-164c5cdd4c38" />

