### PR TITLE
Keycloak User Session Count Limiter - Per Flow Counting

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticatorFactory.java
@@ -19,6 +19,9 @@ public class UserSessionLimitsAuthenticatorFactory implements AuthenticatorFacto
     public static final String TERMINATE_OLDEST_SESSION = "Terminate oldest session";
     public static final String USER_SESSION_LIMITS = "user-session-limits";
     public static final String ERROR_MESSAGE = "errorMessage";
+    public static final String SESSION_COUNTING_SCOPE = "sessionCountingScope";
+    public static final String SCOPE_THIS_FLOW = "This Authentication Flow";
+    public static final String SCOPE_ALL_FLOWS = "All Authentication Flows";
 
     private static AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
             AuthenticationExecutionModel.Requirement.REQUIRED,
@@ -84,7 +87,15 @@ public class UserSessionLimitsAuthenticatorFactory implements AuthenticatorFacto
         customErrorMessage.setHelpText("If left empty a default error message is shown");
         customErrorMessage.setType(ProviderConfigProperty.STRING_TYPE);
 
-        return Arrays.asList(userRealmLimit, userClientLimit, behaviourProperty, customErrorMessage);
+        ProviderConfigProperty sessionCountingScope = new ProviderConfigProperty();
+        sessionCountingScope.setName(SESSION_COUNTING_SCOPE);
+        sessionCountingScope.setLabel("Session Counting Scope");
+        sessionCountingScope.setHelpText("Determines how sessions are counted. 'This Authentication Flow' counts only sessions created through this specific flow. 'All Authentication Flows' counts all user sessions across all flows..");
+        sessionCountingScope.setType(ProviderConfigProperty.LIST_TYPE);
+        sessionCountingScope.setDefaultValue(SCOPE_ALL_FLOWS);
+        sessionCountingScope.setOptions(Arrays.asList(SCOPE_THIS_FLOW, SCOPE_ALL_FLOWS));
+
+        return Arrays.asList(userRealmLimit, userClientLimit, behaviourProperty, customErrorMessage, sessionCountingScope);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -146,7 +146,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
         // Login the same user again and verify the configured error message is shown
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
-        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
         errorPage.assertCurrent();
         assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
     }
@@ -211,7 +211,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             // Login the same user again and verify the configured error message is shown
             loginPage.open();
             loginPage.login("test-user@localhost", "password");
-            events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
             errorPage.assertCurrent();
             assertEquals(ERROR_TO_DISPLAY, errorPage.getError());
         } finally {
@@ -440,7 +440,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
             driver.navigate().to(changePasswordUrl.trim());
 
-            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.ACCESS_DENIED).assertEvent();
         } finally {
             testRealm().clients().findByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).get(0).setDirectAccessGrantsEnabled(false);
             ApiUtil.resetUserPassword(testRealm().users().get(findUser("test-user@localhost").getId()), "password", false);
@@ -527,7 +527,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
             String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
             driver.navigate().to(changePasswordUrl.trim());
 
-            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+            events.expect(EventType.RESET_PASSWORD_ERROR).client("account").error(Errors.ACCESS_DENIED).assertEvent();
         } finally {
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "0");
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.RESET_CREDENTIALS_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "1");
@@ -622,7 +622,7 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
         // New login should fail due the sessions limit
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
-        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.GENERIC_AUTHENTICATION_ERROR).assertEvent();
+        events.expect(EventType.LOGIN_ERROR).user((String) null).error(Errors.ACCESS_DENIED).assertEvent();
         errorPage.assertCurrent();
         assertEquals("There are too many sessions", errorPage.getError()); // Default error message
 


### PR DESCRIPTION
This fix introduces an optional flow-aware session filtering mechanism to the existing User Session Count Limiter authenticator.

Previously, the authenticator counted all active user sessions together, regardless of how those sessions were created (for example, browser login vs. direct grant). This caused sessions created via one authentication flow to block logins through a different flow.
<img width="1862" height="917" alt="image" src="https://github.com/user-attachments/assets/ed087306-f52f-43f8-a5e4-ab7334013890" />
<img width="1862" height="917" alt="image" src="https://github.com/user-attachments/assets/ea835777-362b-4f72-a31e-d097fd3229d0" />
<img width="1862" height="917" alt="image" src="https://github.com/user-attachments/assets/78f9e685-0d31-44cb-a340-164c5cdd4c38" />

