### PR TITLE
Sync client scope state between tabs in dedicated scopes

### DIFF
--- a/js/apps/admin-ui/src/clients/scopes/DedicatedScope.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/DedicatedScope.tsx
@@ -7,7 +7,6 @@ import {
   PageSection,
   Switch,
 } from "@patternfly/react-core";
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { HelpItem } from "@keycloak/keycloak-ui-shared";
 import { useAdminClient } from "../../admin-client";
@@ -18,17 +17,14 @@ import { useAccess } from "../../context/access/Access";
 
 type DedicatedScopeProps = {
   client: ClientRepresentation;
+  onChange?: (client: ClientRepresentation) => void;
 };
 
-export const DedicatedScope = ({
-  client: initialClient,
-}: DedicatedScopeProps) => {
+export const DedicatedScope = ({ client, onChange }: DedicatedScopeProps) => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
   const { addAlert, addError } = useAlerts();
-
-  const [client, setClient] = useState<ClientRepresentation>(initialClient);
 
   const { hasAccess } = useAccess();
   const isManager = hasAccess("manage-clients") || client.access?.manage;
@@ -70,7 +66,7 @@ export const DedicatedScope = ({
     try {
       await adminClient.clients.update({ id: client.id! }, newClient);
       addAlert(t("clientScopeSuccess"), AlertVariant.success);
-      setClient(newClient);
+      onChange?.(newClient);
     } catch (error) {
       addError("clientScopeError", error);
     }

--- a/js/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/DedicatedScopes.tsx
@@ -132,7 +132,7 @@ export default function DedicatedScopes() {
             data-testid="scopeTab"
             {...scopeTab}
           >
-            <DedicatedScope client={client} />
+            <DedicatedScope client={client} onChange={setClient} />
           </Tab>
         </RoutableTabs>
       </PageSection>


### PR DESCRIPTION
# Issue

Closes #46083

# Summary

  - Fix stale state when switching between "Mappers" and "Scope" tabs in dedicated scopes
  - Lift client state management from DedicatedScope child component to DedicatedScopes parent

# Description

## Problem

  When a user toggles the "Full Scope Allowed" switch in the Scope tab and then switches to the Mappers tab and
  back, the switch state would reset to its original value. This happened because DedicatedScope was managing its
  own internal state initialized from props, which became out of sync with the parent component.

## Solution

  Remove internal state from DedicatedScope and add an onChange callback prop to notify the parent when the client
  is updated. The parent DedicatedScopes now maintains the single source of truth for client state across all tabs.

## Changes

  - DedicatedScope.tsx: Remove useState for client, add optional onChange prop, call onChange?.() after successful
  API update
  - DedicatedScopes.tsx: Pass onChange={setClient} to sync state updates

# Test plan

  - Navigate to a client's dedicated scopes page (Clients → [Client] → Client scopes → Dedicated scopes link)
  - Go to the "Scope" tab
  - Toggle the "Full Scope Allowed" switch
  - Switch to the "Mappers" tab
  - Switch back to the "Scope" tab
  - Verify the switch state is preserved correctly

# Result Video

[client-switch-fix.webm](https://github.com/user-attachments/assets/79c46c33-92b5-4922-a6a4-9ee885c72c99)

