### PR TITLE
Distribution server sometimes uses wrong pid for started Keycloak server.

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
@@ -108,6 +108,12 @@ public class DistributionKeycloakServer implements KeycloakServer {
 
             waitForStart(outputHandler);
 
+            List<ProcessHandle> descendants = keycloakProcess.descendants().toList();
+            if (descendants.size() != 1) {
+                throw new RuntimeException("Started process does not have a single descendant, unable to identify running process");
+            }
+
+            FileUtils.writeToFile(getPidFile(), descendants.get(0).pid());
             FileUtils.writeToFile(getServerArgsFile(), String.join(" ", args));
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -164,9 +170,6 @@ public class DistributionKeycloakServer implements KeycloakServer {
             keycloakProcess = pb.start();
             outputHandler = new OutputHandler(keycloakProcess);
             new Thread(outputHandler).start();
-
-            ProcessHandle descendent = ProcessUtils.waitForDescendent(keycloakProcess);
-            FileUtils.writeToFile(getPidFile(), descendent.pid());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/ProcessUtils.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/ProcessUtils.java
@@ -1,29 +1,12 @@
 package org.keycloak.testframework.util;
 
 import java.util.Iterator;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.keycloak.quarkus.runtime.Environment;
 
 public class ProcessUtils {
-
-    public static ProcessHandle waitForDescendent(Process process) {
-        long timeout = System.currentTimeMillis() + 5000;
-        while (System.currentTimeMillis() < timeout) {
-            Optional<ProcessHandle> descendent = process.descendants().findFirst();
-            if (descendent.isPresent()) {
-                return descendent.get();
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        throw new RuntimeException("Descendent process not started within timeout");
-    }
 
     public static boolean killProcess(String pid) {
         try {


### PR DESCRIPTION
Changing to waiting for Keycloak to start before getting the descendant pid as then `kc.sh` will for sure have reached the last step (starting java).

Closes #46110

Signed-off-by: stianst <stianst@gmail.com>
