### PR TITLE
Distribution server sometimes uses wrong pid for started Keycloak server.

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
@@ -108,6 +108,9 @@ public class DistributionKeycloakServer implements KeycloakServer {
 
             waitForStart(outputHandler);
 
+            if (!Environment.isWindows()) {
+                FileUtils.writeToFile(getPidFile(), ProcessUtils.getKeycloakPid(keycloakProcess));
+            }
             FileUtils.writeToFile(getServerArgsFile(), String.join(" ", args));
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -164,9 +167,6 @@ public class DistributionKeycloakServer implements KeycloakServer {
             keycloakProcess = pb.start();
             outputHandler = new OutputHandler(keycloakProcess);
             new Thread(outputHandler).start();
-
-            ProcessHandle descendent = ProcessUtils.waitForDescendent(keycloakProcess);
-            FileUtils.writeToFile(getPidFile(), descendent.pid());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This happens due to the behaviour of re-augmentation in `kc.sh`. This PR fixes two things:

* Wait for Keycloak to start before deciding on the actual `pid`
* Get the descendant pid, which is the case when re-augmentation was not needed (java was not started with exec, so will have a different pid to kc.sh), or get the process pid directly, which is the case when re-augmentation was done (and java was started with exec, which results in kc.sh and java having the same pid)

Closes #46110

Signed-off-by: stianst <stianst@gmail.com>
