### PR TITLE
Check SubjectConfirmationData element for bearer type

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_3.adoc
@@ -1,0 +1,12 @@
+== Breaking changes
+
+Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
+In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
+
+=== The SAML broker and adapter now check the SubjectConfirmationData element for the bearer type
+
+Now {project_name}, when acting as a SAML Service Provider (SP) in identity brokering or in the adapter, validates the `SubjectConfirmationData` for the type `urn:oasis:names:tc:SAML:2.0:cm:bearer` defined in the standard. The elements `NotBefore`, `NotOnOrAfter` and `Recipient`, when present in the assertion, are checked to be in the valid time range and to be the correct destination URI respectively. Previously, similar values were checked for other parts of the SAML response (for example the `Conditions` element or the `destination` attribute).
+
+To prepare for the upgrade, verify that the Identity Provider or adapter configurations allow for a sufficient clock skew for the time attributes.
+
+If you see any issue after the upgrade related to this element, please configure the external IdP to set the correct values for the subject confirmation element.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -5,6 +5,10 @@
 
 include::changes-26_6_0.adoc[leveloffset=2]
 
+=== Migrating to 26.5.3
+
+include::changes-26_5_3.adoc[leveloffset=2]
+
 === Migrating to 26.5.0
 
 include::changes-26_5_0.adoc[leveloffset=2]

--- a/saml-core/src/main/java/org/keycloak/saml/validators/ConditionsValidator.java
+++ b/saml-core/src/main/java/org/keycloak/saml/validators/ConditionsValidator.java
@@ -164,13 +164,16 @@ public class ConditionsValidator {
     private Result validateExpiration() {
         XMLGregorianCalendar notBefore = conditions.getNotBefore();
         XMLGregorianCalendar notOnOrAfter = conditions.getNotOnOrAfter();
+        return validateExpiration(assertionId, notBefore, notOnOrAfter, now, clockSkewInMillis)? Result.VALID : Result.INVALID;
+    }
 
+    protected static boolean validateExpiration(String assertionId, XMLGregorianCalendar notBefore, XMLGregorianCalendar notOnOrAfter, XMLGregorianCalendar now, int clockSkewInMillis) {
         if (notBefore == null && notOnOrAfter == null) {
-            return Result.VALID;
+            return true;
         }
 
         if (notBefore != null && notOnOrAfter != null && notBefore.compare(notOnOrAfter) != DatatypeConstants.LESSER) {
-            return Result.INVALID;
+            return false;
         }
 
         XMLGregorianCalendar updatedNotBefore = XMLTimeUtil.subtract(notBefore, clockSkewInMillis);
@@ -183,7 +186,7 @@ public class ConditionsValidator {
             LOG.infof("Assertion %s expired.", assertionId);
         }
 
-        return valid ? Result.VALID : Result.INVALID;
+        return valid;
     }
 
     /**

--- a/saml-core/src/main/java/org/keycloak/saml/validators/SubjectConfirmationDataValidator.java
+++ b/saml-core/src/main/java/org/keycloak/saml/validators/SubjectConfirmationDataValidator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.saml.validators;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.keycloak.dom.saml.v2.assertion.SubjectConfirmationDataType;
+import org.keycloak.saml.processing.core.saml.v2.util.XMLTimeUtil;
+
+import org.jboss.logging.Logger;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class SubjectConfirmationDataValidator {
+
+    private static final Logger logger = Logger.getLogger(SubjectConfirmationDataValidator.class);
+    private final SubjectConfirmationDataType subjectConfirmationData;
+    private final String inResponseTo;
+    private final int clockSkewInMillis;
+    private final String assertionId;
+    private final XMLGregorianCalendar now = XMLTimeUtil.getIssueInstant();
+    private final Set<String> allowedRecipients;
+    private final DestinationValidator destinationValidator;
+
+    private SubjectConfirmationDataValidator(String assertionId, SubjectConfirmationDataType subjectConfirmationData, String inResponseTo,
+            int clockSkewInMillis, Set<String> allowedRecipients, DestinationValidator destinationValidator) {
+        this.assertionId = assertionId;
+        this.subjectConfirmationData = subjectConfirmationData;
+        this.inResponseTo = inResponseTo;
+        this.clockSkewInMillis = clockSkewInMillis;
+        this.allowedRecipients = allowedRecipients;
+        this.destinationValidator = destinationValidator;
+    }
+
+    public static class Builder {
+
+        private final String assertionId;
+        private final SubjectConfirmationDataType subjectConfirmationData;
+        private final DestinationValidator destinationValidator;
+        private int clockSkewInMillis = 0;
+        private final Set<String> allowedRecipients = new HashSet<>();
+        private String inResponseTo;
+
+        public Builder(String assertionId, SubjectConfirmationDataType subjectConfirmationData, DestinationValidator destinationValidator) {
+            this.assertionId = assertionId;
+            this.subjectConfirmationData = subjectConfirmationData;
+            this.destinationValidator = destinationValidator;
+        }
+
+        public Builder inResponseTo(String inResponseTo) {
+            this.inResponseTo = inResponseTo;
+            return this;
+        }
+
+        public Builder clockSkewInMillis(int clockSkewInMillis) {
+            this.clockSkewInMillis = clockSkewInMillis;
+            return this;
+        }
+
+        public Builder allowedRecipient(String... allowedRecipients) {
+            this.allowedRecipients.addAll(Arrays.asList(allowedRecipients));
+            return this;
+        }
+
+        public SubjectConfirmationDataValidator build() {
+            return new SubjectConfirmationDataValidator(assertionId, subjectConfirmationData, inResponseTo, clockSkewInMillis, allowedRecipients, destinationValidator);
+        }
+    }
+
+    public boolean isValid() {
+        if (subjectConfirmationData == null) {
+            return true;
+        }
+
+        if (!ConditionsValidator.validateExpiration(assertionId, subjectConfirmationData.getNotBefore(), subjectConfirmationData.getNotOnOrAfter(), now, clockSkewInMillis)) {
+            return false;
+        }
+
+        if (!validateRecipient()) {
+            return false;
+        }
+
+        return validateInResponseTo();
+    }
+
+    private boolean validateRecipient() {
+        if (subjectConfirmationData.getRecipient() == null || allowedRecipients.isEmpty()) {
+            return true;
+        }
+
+        for (String allowedRecipient : allowedRecipients) {
+            if (destinationValidator.validate(subjectConfirmationData.getRecipient(), allowedRecipient)) {
+                return true;
+            }
+        }
+
+        logger.tracef("Response Validation Error: SubjectConfirmationData invalid recipient '%s', not in %s",
+                subjectConfirmationData.getRecipient(), allowedRecipients);
+        return false;
+    }
+
+    private boolean validateInResponseTo() {
+        if (inResponseTo == null || subjectConfirmationData.getInResponseTo() == null) {
+            return true;
+        }
+
+        // Assertion > Subject > Confirmation > SubjectConfirmationData > InResponseTo does not match request ID
+        if (subjectConfirmationData.getInResponseTo().equals(inResponseTo)) {
+            return true;
+        }
+
+        logger.tracef("Response Validation Error: received SubjectConfirmationData InResponseTo '%s' does not match the expected request ID '%s'",
+                subjectConfirmationData.getInResponseTo(), inResponseTo);
+        return false;
+    }
+}

--- a/saml-core/src/test/java/org/keycloak/saml/validators/SubjectConfirmationDataValidatorTest.java
+++ b/saml-core/src/test/java/org/keycloak/saml/validators/SubjectConfirmationDataValidatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.saml.validators;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.keycloak.dom.saml.v2.assertion.SubjectConfirmationDataType;
+import org.keycloak.saml.processing.core.saml.v2.util.XMLTimeUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class SubjectConfirmationDataValidatorTest {
+
+    @Test
+    public void testNull() {
+        DestinationValidator destVal = DestinationValidator.forProtocolMap(null);
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", null, destVal).build().isValid());
+    }
+
+    @Test
+    public void testNotBefore() {
+        SubjectConfirmationDataType scd = new SubjectConfirmationDataTypeBuilder().notBefore(1000).build();
+        DestinationValidator destVal = DestinationValidator.forProtocolMap(null);
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).clockSkewInMillis(2000).build().isValid());
+        Assert.assertFalse(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).clockSkewInMillis(0).build().isValid());
+    }
+
+    @Test
+    public void testNotOnOrBefore() {
+        SubjectConfirmationDataType scd = new SubjectConfirmationDataTypeBuilder().notOnOrAfter(-1000).build();
+        DestinationValidator destVal = DestinationValidator.forProtocolMap(null);
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).clockSkewInMillis(2000).build().isValid());
+        Assert.assertFalse(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).clockSkewInMillis(0).build().isValid());
+    }
+
+    @Test
+    public void tesBothDates() {
+        SubjectConfirmationDataType scd = new SubjectConfirmationDataTypeBuilder().notBefore(-1000).notOnOrAfter(1000).build();
+        DestinationValidator destVal = DestinationValidator.forProtocolMap(null);
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).build().isValid());
+        scd = new SubjectConfirmationDataTypeBuilder().notBefore(1000).notOnOrAfter(-1000).build();
+        Assert.assertFalse(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).build().isValid());
+    }
+
+    @Test
+    public void testInResponseTo() {
+        SubjectConfirmationDataType scd = new SubjectConfirmationDataTypeBuilder().inResponseTo("id-123").build();
+        DestinationValidator destVal = DestinationValidator.forProtocolMap(null);
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).inResponseTo("id-123").build().isValid());
+        Assert.assertFalse(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).inResponseTo("id-567").build().isValid());
+        scd = new SubjectConfirmationDataTypeBuilder().recipient("https://keycloak.org").notOnOrAfter(1000).build();
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).inResponseTo("id-123").build().isValid());
+    }
+
+    @Test
+    public void testRecipient() {
+        SubjectConfirmationDataType scd = new SubjectConfirmationDataTypeBuilder().recipient("https://keycloak.org").build();
+        DestinationValidator destVal = DestinationValidator.forProtocolMap(null);
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).allowedRecipient("https://keycloak.org").build().isValid());
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).allowedRecipient("https://keycloak.com", "https://keycloak.org").build().isValid());
+        Assert.assertFalse(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).allowedRecipient("https://keycloak.com").build().isValid());
+        scd = new SubjectConfirmationDataTypeBuilder().inResponseTo("id-123").notOnOrAfter(1000).build();
+        Assert.assertTrue(new SubjectConfirmationDataValidator.Builder("id", scd, destVal).allowedRecipient("https://keycloak.org").build().isValid());
+    }
+
+    private static class SubjectConfirmationDataTypeBuilder {
+        private final SubjectConfirmationDataType scd;
+
+        public SubjectConfirmationDataTypeBuilder() {
+            scd = new SubjectConfirmationDataType();
+        }
+
+        public SubjectConfirmationDataTypeBuilder notBefore(long offsetMillis) {
+            XMLGregorianCalendar value = XMLTimeUtil.getIssueInstant();
+            value = XMLTimeUtil.add(value, offsetMillis);
+            scd.setNotBefore(value);
+            return this;
+        }
+
+        public SubjectConfirmationDataTypeBuilder notOnOrAfter(long offsetMillis) {
+            XMLGregorianCalendar value = XMLTimeUtil.getIssueInstant();
+            value = XMLTimeUtil.add(value, offsetMillis);
+            scd.setNotOnOrAfter(value);
+            return this;
+        }
+
+        public SubjectConfirmationDataTypeBuilder inResponseTo(String id) {
+            scd.setInResponseTo(id);
+            return this;
+        }
+
+        public SubjectConfirmationDataTypeBuilder recipient(String recipient) {
+            scd.setRecipient(recipient);
+            return this;
+        }
+
+        public SubjectConfirmationDataType build() {
+            return scd;
+        }
+    }
+
+}

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/SamlBackchannelArtifactResolveReceiver.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/saml/SamlBackchannelArtifactResolveReceiver.java
@@ -41,6 +41,7 @@ public class SamlBackchannelArtifactResolveReceiver implements AutoCloseable {
     private final ClientRepresentation samlClient;
     private final PublicKey publicKey;
     private final PrivateKey privateKey;
+    private String inResponseTo;
 
     public SamlBackchannelArtifactResolveReceiver(int port, ClientRepresentation samlClient, String publicKeyStr, String privateKeyStr) {
         this.samlClient = samlClient;
@@ -75,6 +76,10 @@ public class SamlBackchannelArtifactResolveReceiver implements AutoCloseable {
         return artifactResolve;
     }
 
+    public void setInResponseTo(String inResponseTo) {
+        this.inResponseTo = inResponseTo;
+    }
+
     @Override
     public void close() throws Exception {
         server.stop(0);
@@ -100,7 +105,10 @@ public class SamlBackchannelArtifactResolveReceiver implements AutoCloseable {
                 ResponseType loginResponse = loginResponseBuilder
                         .issuer(samlClient.getClientId())
                         .requestIssuer(artifactResolve.getIssuer().getValue())
-                        .requestID(artifactResolve.getID())
+                        .requestID(inResponseTo)
+                        .assertionExpiration(60)
+                        .subjectExpiration(60)
+                        .sessionExpiration(60)
                         .buildModel();
 
                 Document loginResponseBuilderAsDoc = loginResponseBuilder.buildDocument(loginResponse);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractAdvancedBrokerTest.java
@@ -538,12 +538,12 @@ public abstract class AbstractAdvancedBrokerTest extends AbstractBrokerTest {
             updateExecutions(AbstractBrokerTest::enableUpdateProfileOnFirstLogin);
             RealmRepresentation realm = adminClient.realm(bc.providerRealmName()).toRepresentation();
             assertNotNull(realm);
-            realm.setAccessTokenLifespan(1);
+            realm.setAccessTokenLifespan(5);
             adminClient.realm(bc.providerRealmName()).update(realm);
             IdentityProviderRepresentation idp = adminClient.realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias()).toRepresentation();
             idp.getConfig().put("backchannelSupported", "false");
             adminClient.realm(bc.consumerRealmName()).identityProviders().get(bc.getIDPAlias()).update(idp);
-            Time.setOffset(2);
+            Time.setOffset(10);
 
             oauth.clientId("broker-app");
             loginPage.open(bc.consumerRealmName());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/BrokerTest.java
@@ -481,6 +481,10 @@ public class BrokerTest extends AbstractSamlTest {
 
                 // simulate IdP response (artifact as query param)
                 samlClientBuilder.processSamlResponse(REDIRECT)
+                        .transformDocument(doc -> {
+                            samlBackchannelArtifactResolveReceiver.setInResponseTo(doc.getDocumentElement().getAttribute("ID"));
+                            return doc;
+                        })
                         .targetAttributeSamlArtifact()
                         .targetUri(getSamlBrokerUrl(REALM_NAME))
                         .build();


### PR DESCRIPTION
Closes #45646

The `SubjectConfirmationData` is now checked for the bearer type in all the attributes. There is a new class `SubjectConfirmationDataValidator` that validates the `notBefore`, `notOnOrAfter`, `inResponseTo` and `recipient` if they are present in the confirmation. Test added.
