### PR TITLE
Allow authentication steps after IDP redirect with browser flow conti…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/AuthenticationFlowHierarchyHelper.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationFlowHierarchyHelper.java
@@ -1,0 +1,241 @@
+package org.keycloak.authentication;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.RealmModel;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Utility class for analyzing authentication flow hierarchies.
+ *
+ * <p>This class provides methods to navigate and analyze complex nested
+ * authentication flow structures, including:</p>
+ * <ul>
+ *   <li>Finding parent flows of subflows</li>
+ *   <li>Detecting executions after a subflow at parent level</li>
+ *   <li>Recursive traversal of nested flow hierarchies</li>
+ * </ul>
+ *
+ * <p>Used primarily for browser flow continuation after IDP redirect,
+ * where we need to determine if additional authenticators follow
+ * the IDP authentication.</p>
+ *
+ * <h3>Example Flow Structure:</h3>
+ * <pre>
+ * BrowserFlow (FLOW)
+ *   ├─ Cookie (ALTERNATIVE)
+ *   ├─ AuthSubflow (ALTERNATIVE)
+ *   │   ├─ ConditionalSubflow (CONDITIONAL)
+ *   │   │   ├─ Condition (condition)
+ *   │   │   └─ IdpOtpSubflow (REQUIRED)
+ *   │   │       ├─ IDP Redirector (REQUIRED)
+ *   │   │       └─ OTP Form (REQUIRED)  ← Current subflow
+ *   │   └─ Username/Password (ALTERNATIVE)  ← Found recursively!
+ *   └─ Browser Forms (ALTERNATIVE)
+ * </pre>
+ *
+ * @author Keycloak Team
+ */
+public class AuthenticationFlowHierarchyHelper {
+
+    private static final Logger logger = Logger.getLogger(AuthenticationFlowHierarchyHelper.class);
+
+    private final RealmModel realm;
+
+    /**
+     * Creates a new helper for the given realm.
+     *
+     * @param realm The realm containing the authentication flows
+     */
+    public AuthenticationFlowHierarchyHelper(RealmModel realm) {
+        this.realm = realm;
+    }
+
+    /**
+     * Checks if there are more executions after a subflow at parent level.
+     *
+     * <p>This method recursively traverses the flow hierarchy to determine
+     * if any authenticators follow the given subflow, either:</p>
+     * <ol>
+     *   <li>Directly in the parent flow after the subflow</li>
+     *   <li>In any ancestor flow after the parent flow</li>
+     * </ol>
+     *
+     * <h3>Example Flow Structure:</h3>
+     * <pre>
+     * TopFlow (FLOW)
+     *   ├─ Cookie (ALTERNATIVE)
+     *   ├─ ParentSubflow (ALTERNATIVE)
+     *   │   ├─ IDP Redirector (REQUIRED)
+     *   │   └─ OTP Form (REQUIRED)      ← subFlowId
+     *   └─ Username/Password (ALTERNATIVE) ← Returns TRUE (found!)
+     * </pre>
+     *
+     * <h3>Algorithm:</h3>
+     * <ol>
+     *   <li>Find the direct parent flow of the subflow</li>
+     *   <li>Check if there are executions after the subflow in the parent</li>
+     *   <li>If not, recursively check after the parent flow itself</li>
+     *   <li>Continue until top flow is reached or executions are found</li>
+     * </ol>
+     *
+     * @param topFlow The top-level flow (usually browser flow)
+     * @param subFlowId The ID of the subflow to check after
+     * @return {@code true} if there are more executions after the subflow,
+     *         {@code false} otherwise
+     */
+    public boolean hasMoreExecutionsAfterParentFlow(AuthenticationFlowModel topFlow, String subFlowId) {
+        // If the subflow is the top flow, there are no parent-level executions
+        if (topFlow.getId().equals(subFlowId)) {
+            return false;
+        }
+
+        // Find the direct parent flow of the subflow
+        FlowContext parentContext = findParentFlowContext(topFlow, subFlowId);
+        if (parentContext == null) {
+            logger.debugf("Could not find parent flow for subFlowId=%s", subFlowId);
+            return false;
+        }
+
+        logger.debugf("Found parent flow '%s' for subFlow '%s'",
+            parentContext.getParentFlow().getAlias(), subFlowId);
+
+        // Check if there are more executions in the parent flow after the subflow
+        boolean hasMoreInParent = hasMoreExecutionsInFlowAfterSubFlow(
+            parentContext.getParentFlow().getId(), subFlowId);
+
+        if (hasMoreInParent) {
+            logger.debugf("Found more executions in parent flow '%s' after subFlow",
+                parentContext.getParentFlow().getAlias());
+            return true;
+        }
+
+        // If not, check recursively if there are more executions after the parent flow
+        // (only if the parent is not the top flow)
+        if (!parentContext.getParentFlow().getId().equals(topFlow.getId())) {
+            logger.debugf("No more executions in parent flow, checking recursively after parent flow '%s'",
+                parentContext.getParentFlow().getAlias());
+            return hasMoreExecutionsAfterParentFlow(topFlow, parentContext.getParentFlow().getId());
+        }
+
+        return false;
+    }
+
+    /**
+     * Finds the direct parent flow context of a subflow.
+     *
+     * <p>This method recursively searches through the flow hierarchy to find
+     * the parent flow that directly contains the target subflow.</p>
+     *
+     * <h3>Example:</h3>
+     * <pre>
+     * TopFlow
+     *   └─ ParentFlow           ← This will be returned
+     *       └─ TargetSubflow    ← Looking for this
+     * </pre>
+     *
+     * @param currentFlow The flow to start searching from
+     * @param targetSubFlowId The ID of the subflow to find the parent for
+     * @return {@link FlowContext} containing parent flow and execution,
+     *         or {@code null} if not found
+     */
+    public FlowContext findParentFlowContext(AuthenticationFlowModel currentFlow, String targetSubFlowId) {
+        List<AuthenticationExecutionModel> executions =
+            realm.getAuthenticationExecutionsStream(currentFlow.getId()).collect(Collectors.toList());
+
+        for (AuthenticationExecutionModel execution : executions) {
+            if (execution.isAuthenticatorFlow()) {
+                // Direct match found
+                if (execution.getFlowId().equals(targetSubFlowId)) {
+                    return new FlowContext(currentFlow, execution);
+                }
+
+                // Search recursively in this subflow
+                AuthenticationFlowModel subFlow = realm.getAuthenticationFlowById(execution.getFlowId());
+                if (subFlow != null) {
+                    FlowContext found = findParentFlowContext(subFlow, targetSubFlowId);
+                    if (found != null) {
+                        return found;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if there are more executions in a flow after a specific subflow.
+     *
+     * <p>This method checks only the direct children of the given flow,
+     * not recursively in nested subflows.</p>
+     *
+     * @param flowId The ID of the flow to check
+     * @param subFlowId The ID of the subflow
+     * @return {@code true} if there are executions after the subflow in this flow,
+     *         {@code false} otherwise
+     */
+    private boolean hasMoreExecutionsInFlowAfterSubFlow(String flowId, String subFlowId) {
+        List<AuthenticationExecutionModel> executions =
+            realm.getAuthenticationExecutionsStream(flowId).collect(Collectors.toList());
+
+        boolean foundSubFlow = false;
+        for (AuthenticationExecutionModel execution : executions) {
+            if (foundSubFlow) {
+                // Check if execution is active (not disabled) and is an authenticator
+                if (!execution.isDisabled() &&
+                    (execution.isAuthenticatorFlow() || execution.getAuthenticator() != null)) {
+                    return true;
+                }
+            }
+            if (execution.isAuthenticatorFlow() && execution.getFlowId().equals(subFlowId)) {
+                foundSubFlow = true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Context class holding parent flow and the execution that references the subflow.
+     *
+     * <p>This class provides access to both the parent flow and the execution
+     * model that represents the subflow reference within the parent.</p>
+     */
+    public static class FlowContext {
+        private final AuthenticationFlowModel parentFlow;
+        private final AuthenticationExecutionModel subFlowExecution;
+
+        /**
+         * Creates a new flow context.
+         *
+         * @param parentFlow The parent flow containing the subflow
+         * @param subFlowExecution The execution in the parent that references the subflow
+         */
+        public FlowContext(AuthenticationFlowModel parentFlow,
+                          AuthenticationExecutionModel subFlowExecution) {
+            this.parentFlow = parentFlow;
+            this.subFlowExecution = subFlowExecution;
+        }
+
+        /**
+         * Gets the parent flow.
+         *
+         * @return The parent flow model
+         */
+        public AuthenticationFlowModel getParentFlow() {
+            return parentFlow;
+        }
+
+        /**
+         * Gets the subflow execution.
+         *
+         * @return The execution model representing the subflow in the parent
+         */
+        public AuthenticationExecutionModel getSubFlowExecution() {
+            return subFlowExecution;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -31,9 +31,12 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.authentication.authenticators.broker.util.PostBrokerLoginConstants;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.authentication.authenticators.client.ClientAuthUtil;
 import org.keycloak.authentication.authenticators.util.AcrStore;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
@@ -95,6 +98,10 @@ public class AuthenticationProcessor {
 
     public static final String BROKER_SESSION_ID = "broker.session.id";
     public static final String BROKER_USER_ID = "broker.user.id";
+    public static final String BROKER_PENDING_USER_ID = "BROKER_PENDING_USER_ID";
+    public static final String BROKER_PENDING_CONTEXT = "BROKER_PENDING_CONTEXT";
+    public static final String BROKER_TOKENS_PENDING = "BROKER_TOKENS_PENDING";
+    public static final String BROKER_CONTINUATION_PBL_PENDING = "BROKER_CONTINUATION_PBL_PENDING";
     public static final String FORWARDED_PASSIVE_LOGIN = "forwarded.passive.login";
 
     // Boolean flag, which is true when authentication-selector screen should be rendered (typically displayed when user clicked on 'try another way' link)
@@ -993,10 +1000,17 @@ public class AuthenticationProcessor {
 
     public static void resetFlow(AuthenticationSessionModel authSession, String flowPath) {
         logger.debug("RESET FLOW");
+
         authSession.getParentSession().setTimestamp(Time.currentTime());
         authSession.setAuthenticatedUser(null);
         authSession.clearExecutionStatus();
+
+        // Preserve broker-related session notes during reset
+        Map<String, String> brokerNotes = preserveBrokerSessionNotes(authSession);
+
         authSession.clearUserSessionNotes();
+        restoreBrokerSessionNotes(authSession, brokerNotes);
+
         authSession.clearAuthNotes();
 
         Set<String> requiredActions = authSession.getRequiredActions();
@@ -1007,6 +1021,54 @@ public class AuthenticationProcessor {
         authSession.setAction(CommonClientSessionModel.Action.AUTHENTICATE.name());
 
         authSession.setAuthNote(CURRENT_FLOW_PATH, flowPath);
+    }
+
+    /**
+     * Preserves broker-related session notes that must survive flow resets.
+     * These notes contain critical broker state including tokens and identity provider info.
+     *
+     * @param authSession The authentication session
+     * @return Map of preserved notes
+     */
+    private static Map<String, String> preserveBrokerSessionNotes(AuthenticationSessionModel authSession) {
+        Map<String, String> preserved = new HashMap<>();
+        Map<String, String> currentNotes = authSession.getUserSessionNotes();
+
+        // Keys to preserve - using string constants to avoid broker package dependencies
+        String[] preservedKeys = {
+            "IDENTITY_PROVIDER",                  // Details.IDENTITY_PROVIDER
+            "IDENTITY_PROVIDER_USERNAME",         // Details.IDENTITY_PROVIDER_USERNAME
+            "FEDERATED_ID_TOKEN",                 // OIDCIdentityProvider.FEDERATED_ID_TOKEN
+            "FEDERATED_ACCESS_TOKEN",             // OIDCIdentityProvider.FEDERATED_ACCESS_TOKEN
+            "FEDERATED_ACCESS_TOKEN_RESPONSE",    // OIDCIdentityProvider.FEDERATED_ACCESS_TOKEN_RESPONSE
+            "FEDERATED_REFRESH_TOKEN",            // AbstractOAuth2IdentityProvider.FEDERATED_REFRESH_TOKEN
+            "FEDERATED_TOKEN_EXPIRATION",         // AbstractOAuth2IdentityProvider.FEDERATED_TOKEN_EXPIRATION
+            "SAML_FEDERATED_SUBJECT_NAMEID"      // SAMLEndpoint.SAML_FEDERATED_SUBJECT_NAMEID
+        };
+
+        for (String key : preservedKeys) {
+            String value = currentNotes.get(key);
+            if (value != null) {
+                preserved.put(key, value);
+                logger.debugf("Preserving broker note '%s' during resetFlow()", key);
+            }
+        }
+
+        return preserved;
+    }
+
+    /**
+     * Restores broker-related session notes after clearing.
+     *
+     * @param authSession The authentication session
+     * @param brokerNotes The notes to restore
+     */
+    private static void restoreBrokerSessionNotes(AuthenticationSessionModel authSession,
+                                                   Map<String, String> brokerNotes) {
+        for (Map.Entry<String, String> entry : brokerNotes.entrySet()) {
+            authSession.setUserSessionNote(entry.getKey(), entry.getValue());
+            logger.debugf("Restored broker note '%s' after resetFlow()", entry.getKey());
+        }
     }
 
     // Recreate new root auth session and new auth session from the given auth session.
@@ -1118,12 +1180,16 @@ public class AuthenticationProcessor {
         Response challenge = authenticationFlow.processFlow();
         if (challenge != null) return challenge;
         if (authenticationSession.getAuthenticatedUser() == null) {
-            if (this.forwardedErrorMessageStore.getForwardedMessage() != null) {
-                LoginFormsProvider forms = session.getProvider(LoginFormsProvider.class).setAuthenticationSession(authenticationSession);
-                forms.addError(this.forwardedErrorMessageStore.getForwardedMessage());
-                return forms.createErrorPage(Response.Status.BAD_REQUEST);
-            } else
-                throw new AuthenticationFlowException(AuthenticationFlowError.UNKNOWN_USER);
+            // Check if there is a pending broker user that should be set
+            String brokerPendingUserId = authenticationSession.getAuthNote(BROKER_PENDING_USER_ID);
+            if (brokerPendingUserId == null) {
+                if (this.forwardedErrorMessageStore.getForwardedMessage() != null) {
+                    LoginFormsProvider forms = session.getProvider(LoginFormsProvider.class).setAuthenticationSession(authenticationSession);
+                    forms.addError(this.forwardedErrorMessageStore.getForwardedMessage());
+                    return forms.createErrorPage(Response.Status.BAD_REQUEST);
+                } else
+                    throw new AuthenticationFlowException(AuthenticationFlowError.UNKNOWN_USER);
+            }
         }
         if (!authenticationFlow.isSuccessful()) {
             throw new AuthenticationFlowException(authenticationFlow.getFlowExceptions());
@@ -1232,6 +1298,63 @@ public class AuthenticationProcessor {
     }
 
     protected Response authenticationComplete() {
+        // Finalize pending broker authentication if needed.
+        // Note: When finalizePendingBrokerAuthenticationInFlow() was called during flow processing
+        // (e.g., when an authenticator like OTP requires a user), BROKER_PENDING_USER_ID will already
+        // be cleaned up. In that case, we skip this block - the broker finalization and PBL setup
+        // were already handled there.
+        String brokerPendingUserId = authenticationSession.getAuthNote(BROKER_PENDING_USER_ID);
+        if (brokerPendingUserId != null) {
+            logger.debugf("Finalizing pending broker authentication for user ID %s", brokerPendingUserId);
+
+            // Set authenticated user if not already set
+            if (authenticationSession.getAuthenticatedUser() == null) {
+                UserModel federatedUser = session.users().getUserById(realm, brokerPendingUserId);
+                if (federatedUser == null) {
+                    throw new AuthenticationFlowException(AuthenticationFlowError.UNKNOWN_USER);
+                }
+                authenticationSession.setAuthenticatedUser(federatedUser);
+            }
+
+            SerializedBrokeredIdentityContext serializedCtx =
+                SerializedBrokeredIdentityContext.readFromAuthenticationSession(
+                    authenticationSession, BROKER_PENDING_CONTEXT);
+
+            if (serializedCtx != null) {
+                try {
+                    BrokeredIdentityContext context = serializedCtx.deserialize(session, authenticationSession);
+                    String providerAlias = context.getIdpConfig().getAlias();
+
+                    authenticationSession.setAuthNote(BROKER_SESSION_ID, context.getBrokerSessionId());
+                    authenticationSession.setAuthNote(BROKER_USER_ID, context.getBrokerUserId());
+
+                    context.getIdp().authenticationFinished(authenticationSession, context);
+
+                    authenticationSession.setUserSessionNote(Details.IDENTITY_PROVIDER, providerAlias);
+                    authenticationSession.setUserSessionNote(Details.IDENTITY_PROVIDER_USERNAME,
+                        context.getUsername());
+
+                    // Check if post-broker-login flow needs to run after browser flow continuation.
+                    org.keycloak.models.IdentityProviderModel currentIdpConfig = session.identityProviders().getByAlias(providerAlias);
+                    String postBrokerLoginFlowId = currentIdpConfig != null ? currentIdpConfig.getPostBrokerLoginFlowId() : null;
+                    if (postBrokerLoginFlowId != null) {
+                        logger.debugf("Post-broker-login flow configured for provider '%s', setting PBL pending flag", providerAlias);
+                        serializedCtx.saveToAuthenticationSession(authenticationSession,
+                            PostBrokerLoginConstants.PBL_BROKERED_IDENTITY_CONTEXT);
+                        authenticationSession.setAuthNote(PostBrokerLoginConstants.PBL_AFTER_FIRST_BROKER_LOGIN, "false");
+                        authenticationSession.setAuthNote(BROKER_CONTINUATION_PBL_PENDING, "true");
+                    }
+
+                } catch (Exception e) {
+                    logger.error("Failed to finalize pending broker authentication", e);
+                }
+            }
+
+            // Cleanup
+            authenticationSession.removeAuthNote(BROKER_PENDING_USER_ID);
+            authenticationSession.removeAuthNote(BROKER_PENDING_CONTEXT);
+        }
+
         new AcrStore(session, authenticationSession).setAuthFlowLevelAuthenticatedToCurrentRequest();
 
         // attachSession(); // Session will be attached after requiredActions + consents are finished.
@@ -1240,10 +1363,26 @@ public class AuthenticationProcessor {
         String nextRequiredAction = nextRequiredAction();
         if (nextRequiredAction != null) {
             return AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
-        } else {
-            event.detail(Details.CODE_ID, authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
-            return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
         }
+
+        // After all required actions are done, check if post-broker-login flow needs to run.
+        // This flag may have been set either above (when BROKER_PENDING_USER_ID was still present)
+        // or by finalizePendingBrokerAuthenticationInFlow() in DefaultAuthenticationFlow
+        // (when the broker state was consumed during flow processing).
+        if ("true".equals(authenticationSession.getAuthNote(BROKER_CONTINUATION_PBL_PENDING))) {
+            authenticationSession.removeAuthNote(BROKER_CONTINUATION_PBL_PENDING);
+            authenticationSession.getParentSession().setTimestamp(Time.currentTime());
+            URI redirect = LoginActionsService.postBrokerLoginProcessor(uriInfo)
+                    .queryParam(Constants.CLIENT_ID, authenticationSession.getClient().getClientId())
+                    .queryParam(Constants.TAB_ID, authenticationSession.getTabId())
+                    .queryParam(Constants.CLIENT_DATA, AuthenticationProcessor.getClientData(session, authenticationSession))
+                    .build(realm.getName());
+            logger.debugf("Redirecting to post-broker-login flow after browser flow continuation");
+            return Response.status(302).location(redirect).build();
+        }
+
+        event.detail(Details.CODE_ID, authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
+        return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
     }
 
     public String nextRequiredAction() {

--- a/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
+++ b/services/src/main/java/org/keycloak/authentication/DefaultAuthenticationFlow.java
@@ -31,11 +31,16 @@ import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.authentication.authenticators.broker.util.PostBrokerLoginConstants;
+import org.keycloak.authentication.authenticators.broker.util.SerializedBrokeredIdentityContext;
 import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
 import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.events.Details;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -426,6 +431,26 @@ public class DefaultAuthenticationFlow implements AuthenticationFlow {
         logger.debugv("authenticator: {0}", factory.getId());
         UserModel authUser = processor.getAuthenticationSession().getAuthenticatedUser();
 
+        // If Authenticator requires a user but none is set, check pending broker user
+        String brokerPendingUserId = processor.getAuthenticationSession().getAuthNote(AuthenticationProcessor.BROKER_PENDING_USER_ID);
+        if (authenticator.requiresUser() && authUser == null) {
+            if (brokerPendingUserId != null) {
+                logger.debugf("Authenticator requires user, setting pending broker authenticated user now");
+
+                UserModel federatedUser = processor.getSession().users().getUserById(
+                    processor.getRealm(), brokerPendingUserId);
+                if (federatedUser == null) {
+                    throw new AuthenticationFlowException("Broker authenticated user not found",
+                        AuthenticationFlowError.UNKNOWN_USER);
+                }
+
+                processor.getAuthenticationSession().setAuthenticatedUser(federatedUser);
+                authUser = federatedUser;
+
+                finalizePendingBrokerAuthenticationInFlow(processor);
+            }
+        }
+
         //If executions are alternative, get the actual execution to show based on user preference
         List<AuthenticationSelectionOption> selectionOptions = createAuthenticationSelectionList(model);
         if (!selectionOptions.isEmpty() && calledFromFlow) {
@@ -617,5 +642,60 @@ public class DefaultAuthenticationFlow implements AuthenticationFlow {
                 .filter(AuthenticationFlowCallback.class::isInstance)
                 .map(AuthenticationFlowCallback.class::cast)
                 .forEach(callback -> callback.onTopFlowSuccess(flow));
+    }
+
+    /**
+     * Finalizes a pending broker authentication by deserializing the context and calling authenticationFinished().
+     * This is called when an authenticator requires a user and a pending broker user needs to be set.
+     *
+     * @param processor The authentication processor
+     */
+    private void finalizePendingBrokerAuthenticationInFlow(AuthenticationProcessor processor) {
+        AuthenticationSessionModel authSession = processor.getAuthenticationSession();
+        KeycloakSession session = processor.getSession();
+
+        SerializedBrokeredIdentityContext serializedCtx =
+            SerializedBrokeredIdentityContext.readFromAuthenticationSession(
+                authSession, AuthenticationProcessor.BROKER_PENDING_CONTEXT);
+
+        if (serializedCtx == null) {
+            logger.debugf("No pending broker context found - cannot finalize");
+            return;
+        }
+
+        try {
+            BrokeredIdentityContext context = serializedCtx.deserialize(session, authSession);
+            String providerAlias = context.getIdpConfig().getAlias();
+
+            authSession.setAuthNote(AuthenticationProcessor.BROKER_SESSION_ID, context.getBrokerSessionId());
+            authSession.setAuthNote(AuthenticationProcessor.BROKER_USER_ID, context.getBrokerUserId());
+
+            logger.debugf("Calling authenticationFinished() to store tokens for provider '%s'", providerAlias);
+            context.getIdp().authenticationFinished(authSession, context);
+
+            authSession.setUserSessionNote(Details.IDENTITY_PROVIDER, providerAlias);
+            authSession.setUserSessionNote(Details.IDENTITY_PROVIDER_USERNAME, context.getUsername());
+
+            // Check if post-broker-login flow needs to run after browser flow continuation.
+            // Save PBL context now; the actual redirect happens in authenticationComplete().
+            org.keycloak.models.IdentityProviderModel currentIdpConfig = session.identityProviders().getByAlias(providerAlias);
+            String postBrokerLoginFlowId = currentIdpConfig != null ? currentIdpConfig.getPostBrokerLoginFlowId() : null;
+            if (postBrokerLoginFlowId != null) {
+                logger.debugf("Post-broker-login flow configured for provider '%s', setting PBL pending flag", providerAlias);
+                serializedCtx.saveToAuthenticationSession(authSession,
+                    PostBrokerLoginConstants.PBL_BROKERED_IDENTITY_CONTEXT);
+                authSession.setAuthNote(PostBrokerLoginConstants.PBL_AFTER_FIRST_BROKER_LOGIN, "false");
+                authSession.setAuthNote(AuthenticationProcessor.BROKER_CONTINUATION_PBL_PENDING, "true");
+            }
+
+        } catch (Exception e) {
+            logger.error("Failed to finalize pending broker authentication", e);
+            throw new AuthenticationFlowException("Failed to finalize broker authentication",
+                AuthenticationFlowError.INTERNAL_ERROR);
+        } finally {
+            // Cleanup
+            authSession.removeAuthNote(AuthenticationProcessor.BROKER_PENDING_USER_ID);
+            authSession.removeAuthNote(AuthenticationProcessor.BROKER_PENDING_CONTEXT);
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/IdentityProviderAuthenticator.java
@@ -18,6 +18,7 @@
 package org.keycloak.authentication.authenticators.browser;
 
 import java.net.URI;
+import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
 
@@ -32,6 +33,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.Urls;
 import org.keycloak.services.managers.ClientSessionCode;
+import org.keycloak.sessions.AuthenticationSessionModel;
 
 import org.jboss.logging.Logger;
 
@@ -46,6 +48,35 @@ public class IdentityProviderAuthenticator implements Authenticator {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
+        // CRITICAL: Check for pending broker authentication and set user early
+        // This ensures the user is available for subsequent authenticators
+        setUserFromPendingBrokerAuthentication(context);
+
+        // Check if this authenticator was already executed successfully (e.g., after broker login flow continuation)
+        // This prevents re-execution and redirect loops when returning from broker authentication
+        if (context.getExecution() != null) {
+            Map<String, AuthenticationSessionModel.ExecutionStatus> executionStatuses =
+                context.getAuthenticationSession().getExecutionStatus();
+
+            if (executionStatuses != null) {
+                AuthenticationSessionModel.ExecutionStatus currentStatus =
+                    executionStatuses.get(context.getExecution().getId());
+
+                if (currentStatus == AuthenticationSessionModel.ExecutionStatus.SUCCESS) {
+                    LOG.infof("IdentityProviderAuthenticator was already executed successfully " +
+                        "(execution ID: %s), marking as success and continuing to next authenticator. User=%s",
+                        context.getExecution().getId(),
+                        context.getUser() != null ? context.getUser().getUsername() : "null");
+
+                    context.success();
+                    return;
+                }
+
+                LOG.debugf("IdentityProviderAuthenticator current status: %s (execution ID: %s)",
+                    currentStatus, context.getExecution().getId());
+            }
+        }
+
         if (context.getUriInfo().getQueryParameters().containsKey(AdapterConstants.KC_IDP_HINT)) {
             String providerId = context.getUriInfo().getQueryParameters().getFirst(AdapterConstants.KC_IDP_HINT);
             if (providerId == null || providerId.equals("")) {
@@ -99,6 +130,40 @@ public class IdentityProviderAuthenticator implements Authenticator {
 
         LOG.warnf("Provider not found or not enabled for realm %s", providerId);
         context.attempted();
+    }
+
+    /**
+     * Sets the authenticated user from pending broker authentication if available.
+     * This is called when the IDP redirector is marked as SUCCESS and we're continuing
+     * the browser flow with additional authenticators.
+     *
+     * @param context The authentication flow context
+     */
+    private void setUserFromPendingBrokerAuthentication(AuthenticationFlowContext context) {
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        String brokerPendingUserId = authSession.getAuthNote(AuthenticationProcessor.BROKER_PENDING_USER_ID);
+
+        LOG.infof("setUserFromPendingBrokerAuthentication: brokerPendingUserId=%s, currentUser=%s",
+            brokerPendingUserId, context.getUser() != null ? context.getUser().getUsername() : "null");
+
+        if (brokerPendingUserId != null && context.getUser() == null) {
+            LOG.infof("Found pending broker user ID '%s', setting user in authentication context", brokerPendingUserId);
+
+            UserModel federatedUser = context.getSession().users().getUserById(
+                context.getRealm(), brokerPendingUserId);
+
+            if (federatedUser != null) {
+                authSession.setAuthenticatedUser(federatedUser);
+                context.setUser(federatedUser);
+                LOG.infof("Successfully set user '%s' from pending broker authentication", federatedUser.getUsername());
+            } else {
+                LOG.warnf("Pending broker user ID '%s' not found in realm", brokerPendingUserId);
+            }
+        } else if (brokerPendingUserId == null) {
+            LOG.infof("No pending broker user ID found - skipping user setup");
+        } else {
+            LOG.infof("User already set - skipping");
+        }
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -1105,6 +1105,24 @@ public class AuthenticationManager {
 
             return response;
         }
+
+        // After required actions complete, check if post-broker-login flow needs to run
+        // (deferred from browser flow continuation to allow required actions like CONFIGURE_TOTP first)
+        if ("true".equals(authSession.getAuthNote(AuthenticationProcessor.BROKER_CONTINUATION_PBL_PENDING))) {
+            authSession.removeAuthNote(AuthenticationProcessor.BROKER_CONTINUATION_PBL_PENDING);
+            // Reset session state so the post-broker-login endpoint accepts this session
+            authSession.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
+            authSession.setAuthNote(AuthenticationProcessor.CURRENT_FLOW_PATH, LoginActionsService.POST_BROKER_LOGIN_PATH);
+            authSession.removeAuthNote(AuthenticationProcessor.CURRENT_AUTHENTICATION_EXECUTION);
+            authSession.getParentSession().setTimestamp(Time.currentTime());
+            URI redirect = LoginActionsService.postBrokerLoginProcessor(uriInfo)
+                    .queryParam(Constants.CLIENT_ID, authSession.getClient().getClientId())
+                    .queryParam(Constants.TAB_ID, authSession.getTabId())
+                    .queryParam(Constants.CLIENT_DATA, AuthenticationProcessor.getClientData(session, authSession))
+                    .build(authSession.getRealm().getName());
+            return Response.status(302).location(redirect).build();
+        }
+
         RealmModel realm = authSession.getRealm();
 
         ClientSessionContext clientSessionCtx = AuthenticationProcessor.attachSession(authSession, userSession, session, realm, clientConnection, event);

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -45,6 +46,7 @@ import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;
 
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.AuthenticationFlowHierarchyHelper;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.RequiredActionContext;
 import org.keycloak.authentication.authenticators.broker.AbstractIdpAuthenticator;
@@ -78,6 +80,7 @@ import org.keycloak.http.HttpRequest;
 import org.keycloak.locale.LocaleSelectorProvider;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
@@ -670,9 +673,23 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
             if (shouldMigrateId) {
                 migrateFederatedIdentityId(context, federatedUser);
             }
-            authenticationSession.setAuthenticatedUser(federatedUser);
 
-            return finishOrRedirectToPostBrokerLogin(authenticationSession, context, false);
+            boolean hasMore = hasMoreAuthenticatorsAfterCurrent(authenticationSession);
+            boolean firstBrokerLoginInProgress = authenticationSession.getAuthNote(AbstractIdpAuthenticator.BROKERED_CONTEXT_NOTE) != null;
+
+            if (hasMore && !firstBrokerLoginInProgress) {
+                prepareBrokerTokenStorage(authenticationSession, context);
+
+                SerializedBrokeredIdentityContext ctx = SerializedBrokeredIdentityContext.serialize(context);
+                ctx.saveToAuthenticationSession(authenticationSession, AuthenticationProcessor.BROKER_PENDING_CONTEXT);
+
+                authenticationSession.setAuthNote(AuthenticationProcessor.BROKER_PENDING_USER_ID, federatedUser.getId());
+
+                return returnToBrowserFlow(authenticationSession);
+            } else {
+                authenticationSession.setAuthenticatedUser(federatedUser);
+                return finishOrRedirectToPostBrokerLogin(authenticationSession, context, false);
+            }
         }
     }
 
@@ -789,7 +806,23 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
                 updateFederatedIdentity(context, federatedUser);
             }
 
-            return finishOrRedirectToPostBrokerLogin(authSession, context, true);
+            // Prüfe ob weitere Authenticators folgen
+            boolean hasMore = hasMoreAuthenticatorsAfterCurrent(authSession);
+
+            if (hasMore) {
+                // Prepare broker token storage before continuing flow
+                prepareBrokerTokenStorage(authSession, context);
+
+                // Serialisiere Context
+                SerializedBrokeredIdentityContext ctx = SerializedBrokeredIdentityContext.serialize(context);
+                ctx.saveToAuthenticationSession(authSession, AuthenticationProcessor.BROKER_PENDING_CONTEXT);
+                authSession.setAuthNote(AuthenticationProcessor.BROKER_PENDING_USER_ID, federatedUser.getId());
+
+                return returnToBrowserFlow(authSession);
+            } else {
+                authSession.setAuthenticatedUser(federatedUser);
+                return finishOrRedirectToPostBrokerLogin(authSession, context, true);
+            }
         }  catch (Exception e) {
             return redirectToErrorPage(authSession, Response.Status.INTERNAL_SERVER_ERROR, Messages.IDENTITY_PROVIDER_UNEXPECTED_ERROR, e);
         }
@@ -1438,6 +1471,150 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
         if (this.session.getTransactionManager().isActive()) {
             this.session.getTransactionManager().rollback();
         }
+    }
+
+    /**
+     * Checks if there are more authenticators configured in the browser flow after the identity-provider-redirector.
+     * This includes authenticators in the same subflow (for REQUIRED) or in subsequent flows.
+     *
+     * @param authSession The authentication session
+     * @return true if more authenticators follow, false otherwise
+     */
+    private boolean hasMoreAuthenticatorsAfterCurrent(AuthenticationSessionModel authSession) {
+        AuthenticationFlowModel browserFlow = AuthenticationFlowResolver.resolveBrowserFlow(authSession);
+        if (browserFlow == null) {
+            logger.debugf("No browser flow found");
+            return false;
+        }
+
+        AuthenticationExecutionModel idpExecution = findIdpRedirectorExecution(browserFlow);
+        if (idpExecution == null) {
+            logger.debugf("IDP Redirector execution not found in browser flow");
+            return false;
+        }
+
+        authSession.setAuthNote("IDP_EXECUTION_ID", idpExecution.getId());
+
+        // Only check for more executions in the same flow when the IDP redirector is REQUIRED.
+        // When it is ALTERNATIVE (e.g., in the default browser flow or inside a CONDITIONAL subflow),
+        // executions at the same level are alternative paths, not sequential steps.
+        boolean moreInSameFlow = false;
+        if (idpExecution.getRequirement() == AuthenticationExecutionModel.Requirement.REQUIRED) {
+            moreInSameFlow = hasMoreExecutionsInFlow(idpExecution.getParentFlow(), idpExecution.getId());
+        }
+
+        // Always check for more executions after the parent flow in the hierarchy.
+        // This handles cases like CONDITIONAL subflows containing an ALTERNATIVE IDP redirector
+        // followed by REQUIRED authenticators in the parent flow (e.g., OTP after conditional IDP).
+        AuthenticationFlowHierarchyHelper flowHelper = new AuthenticationFlowHierarchyHelper(realmModel);
+        boolean moreAfterParentFlow = flowHelper.hasMoreExecutionsAfterParentFlow(browserFlow, idpExecution.getParentFlow());
+
+        logger.debugf("hasMoreAuthenticators: idpRequirement=%s, moreInSameFlow=%s, moreAfterParentFlow=%s",
+            idpExecution.getRequirement(), moreInSameFlow, moreAfterParentFlow);
+
+        return moreInSameFlow || moreAfterParentFlow;
+    }
+
+    /**
+     * Finds the IDP Redirector Execution recursively in all flows.
+     */
+    private AuthenticationExecutionModel findIdpRedirectorExecution(AuthenticationFlowModel flow) {
+        List<AuthenticationExecutionModel> executions =
+            realmModel.getAuthenticationExecutionsStream(flow.getId()).collect(Collectors.toList());
+
+        for (AuthenticationExecutionModel execution : executions) {
+            if ("identity-provider-redirector".equals(execution.getAuthenticator())) {
+                return execution;
+            }
+            if (execution.isAuthenticatorFlow()) {
+                AuthenticationFlowModel subFlow = realmModel.getAuthenticationFlowById(execution.getFlowId());
+                if (subFlow != null) {
+                    AuthenticationExecutionModel found = findIdpRedirectorExecution(subFlow);
+                    if (found != null) {
+                        return found;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks whether there are further non-disabled executions in the same flow after a specific execution.
+     */
+    private boolean hasMoreExecutionsInFlow(String flowId, String afterExecutionId) {
+        List<AuthenticationExecutionModel> executions =
+            realmModel.getAuthenticationExecutionsStream(flowId).collect(Collectors.toList());
+
+        boolean foundExecution = false;
+        for (AuthenticationExecutionModel execution : executions) {
+            if (foundExecution) {
+                if (!execution.isDisabled() &&
+                    (execution.isAuthenticatorFlow() || execution.getAuthenticator() != null)) {
+                    return true;
+                }
+            }
+            if (execution.getId().equals(afterExecutionId)) {
+                foundExecution = true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Creates a redirect response back to the browser flow to continue authentication.
+     *
+     * @param authSession The authentication session
+     * @return Response with 302 redirect to browser flow
+     */
+    private Response returnToBrowserFlow(AuthenticationSessionModel authSession) {
+        // Mark IDP Redirector as SUCCESS so that it is not executed again
+        String idpExecutionId = authSession.getAuthNote("IDP_EXECUTION_ID");
+        if (idpExecutionId != null) {
+            authSession.setExecutionStatus(idpExecutionId, AuthenticationSessionModel.ExecutionStatus.SUCCESS);
+            authSession.removeAuthNote("IDP_EXECUTION_ID");
+            logger.debugf("Marked IDP execution %s as SUCCESS", idpExecutionId);
+        }
+
+        // Reset flow path back to browser authentication path
+        authSession.setAuthNote(AuthenticationProcessor.CURRENT_FLOW_PATH, LoginActionsService.AUTHENTICATE_PATH);
+
+        String clientData = AuthenticationProcessor.getClientData(session, authSession);
+
+        URI redirect = LoginActionsService.loginActionsBaseUrl(session.getContext().getUri())
+            .path(LoginActionsService.AUTHENTICATE_PATH)
+            .queryParam(Constants.CLIENT_ID, authSession.getClient().getClientId())
+            .queryParam(Constants.TAB_ID, authSession.getTabId())
+            .queryParam(Constants.CLIENT_DATA, clientData)
+            .build(realmModel.getName());
+
+        return Response.status(302).location(redirect).build();
+    }
+
+    /**
+     * Prepares IDP tokens for later storage by setting broker session IDs early.
+     * The actual token storage happens later via authenticationFinished().
+     * This is called early in the authentication flow to ensure broker session info
+     * is available when browser flow continuation is used.
+     *
+     * @param authSession The authentication session
+     * @param context The brokered identity context containing tokens
+     */
+    private void prepareBrokerTokenStorage(AuthenticationSessionModel authSession,
+                                           BrokeredIdentityContext context) {
+        // Set broker session IDs early so they're available throughout the flow
+        authSession.setAuthNote(AuthenticationProcessor.BROKER_SESSION_ID, context.getBrokerSessionId());
+        authSession.setAuthNote(AuthenticationProcessor.BROKER_USER_ID, context.getBrokerUserId());
+
+        // Set provider info as user session notes (will be transferred to user session later)
+        authSession.setUserSessionNote(Details.IDENTITY_PROVIDER, context.getIdpConfig().getAlias());
+        authSession.setUserSessionNote(Details.IDENTITY_PROVIDER_USERNAME, context.getUsername());
+
+        // Mark that tokens should be stored after user is set
+        authSession.setAuthNote(AuthenticationProcessor.BROKER_TOKENS_PENDING, "true");
+
+        logger.debugf("Prepared broker token storage for provider '%s' and user '%s'",
+            context.getIdpConfig().getAlias(), context.getUsername());
     }
 
 }

--- a/services/src/test/java/org/keycloak/authentication/AuthenticationFlowHierarchyHelperTest.java
+++ b/services/src/test/java/org/keycloak/authentication/AuthenticationFlowHierarchyHelperTest.java
@@ -1,0 +1,491 @@
+package org.keycloak.authentication;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.RealmModel;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link AuthenticationFlowHierarchyHelper}.
+ *
+ * <p>These tests verify the correct behavior of flow hierarchy analysis,
+ * including flat flows, nested subflows, and deeply nested structures.</p>
+ *
+ * @author Keycloak Team
+ */
+public class AuthenticationFlowHierarchyHelperTest {
+
+    private TestRealmModel realm;
+    private AuthenticationFlowHierarchyHelper helper;
+
+    @Before
+    public void setup() {
+        TestRealmModel testRealm = new TestRealmModel();
+        realm = testRealm;
+        helper = new AuthenticationFlowHierarchyHelper(testRealm.getProxy());
+    }
+
+    /**
+     * Test: Flat flow with no executions after subflow
+     *
+     * <pre>
+     * TopFlow
+     *   ├─ Cookie (ALTERNATIVE)
+     *   └─ SubFlow (ALTERNATIVE)  ← No executions after this
+     * </pre>
+     *
+     * Expected: false (no more executions)
+     */
+    @Test
+    public void testFlatFlow_NoMoreExecutions() {
+        // Setup flow structure
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel subFlow = createFlow("sub-flow", "SubFlow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(subFlow);
+
+        realm.addExecution("top-flow", createAuthenticatorExecution("cookie", "top-flow"));
+        realm.addExecution("top-flow", createFlowExecution("sub-flow", "top-flow"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "sub-flow");
+
+        // Verify
+        assertFalse("Should return false when no executions after subflow", result);
+    }
+
+    /**
+     * Test: Flat flow with executions after subflow
+     *
+     * <pre>
+     * TopFlow
+     *   ├─ Cookie (ALTERNATIVE)
+     *   ├─ SubFlow (ALTERNATIVE)         ← Checking after this
+     *   └─ Username/Password (ALTERNATIVE) ← Found!
+     * </pre>
+     *
+     * Expected: true (execution found after subflow)
+     */
+    @Test
+    public void testFlatFlow_WithExecutionsAfter() {
+        // Setup flow structure
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel subFlow = createFlow("sub-flow", "SubFlow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(subFlow);
+
+        realm.addExecution("top-flow", createAuthenticatorExecution("cookie", "top-flow"));
+        realm.addExecution("top-flow", createFlowExecution("sub-flow", "top-flow"));
+        realm.addExecution("top-flow", createAuthenticatorExecution("username-password", "top-flow"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "sub-flow");
+
+        // Verify
+        assertTrue("Should return true when execution found after subflow", result);
+    }
+
+    /**
+     * Test: Single-level nested subflow with execution after parent
+     *
+     * <pre>
+     * TopFlow
+     *   ├─ Cookie (ALTERNATIVE)
+     *   ├─ ParentSubflow (ALTERNATIVE)
+     *   │   └─ TargetSubflow (REQUIRED)  ← Checking after this
+     *   └─ Username/Password (ALTERNATIVE) ← Found at parent level!
+     * </pre>
+     *
+     * Expected: true (execution found at parent level)
+     */
+    @Test
+    public void testNestedFlow_OneLevel_WithExecutionAfterParent() {
+        // Setup flow structure
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel parentSubflow = createFlow("parent-subflow", "ParentSubflow");
+        AuthenticationFlowModel targetSubflow = createFlow("target-subflow", "TargetSubflow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(parentSubflow);
+        realm.addFlow(targetSubflow);
+
+        realm.addExecution("top-flow", createAuthenticatorExecution("cookie", "top-flow"));
+        realm.addExecution("top-flow", createFlowExecution("parent-subflow", "top-flow"));
+        realm.addExecution("top-flow", createAuthenticatorExecution("username-password", "top-flow"));
+
+        realm.addExecution("parent-subflow", createFlowExecution("target-subflow", "parent-subflow"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "target-subflow");
+
+        // Verify
+        assertTrue("Should return true when execution found at parent level", result);
+    }
+
+    /**
+     * Test: Two-level nested subflow with execution after grandparent
+     *
+     * <pre>
+     * TopFlow
+     *   ├─ Cookie (ALTERNATIVE)
+     *   ├─ Level1Subflow (ALTERNATIVE)
+     *   │   └─ Level2Subflow (REQUIRED)
+     *   │       └─ TargetSubflow (REQUIRED)  ← Checking after this
+     *   └─ Username/Password (ALTERNATIVE)    ← Found at grandparent level!
+     * </pre>
+     *
+     * Expected: true (execution found at grandparent level through recursion)
+     */
+    @Test
+    public void testNestedFlow_TwoLevels_WithExecutionAfterGrandparent() {
+        // Setup flow structure
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel level1Subflow = createFlow("level1-subflow", "Level1Subflow");
+        AuthenticationFlowModel level2Subflow = createFlow("level2-subflow", "Level2Subflow");
+        AuthenticationFlowModel targetSubflow = createFlow("target-subflow", "TargetSubflow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(level1Subflow);
+        realm.addFlow(level2Subflow);
+        realm.addFlow(targetSubflow);
+
+        realm.addExecution("top-flow", createAuthenticatorExecution("cookie", "top-flow"));
+        realm.addExecution("top-flow", createFlowExecution("level1-subflow", "top-flow"));
+        realm.addExecution("top-flow", createAuthenticatorExecution("username-password", "top-flow"));
+
+        realm.addExecution("level1-subflow", createFlowExecution("level2-subflow", "level1-subflow"));
+        realm.addExecution("level2-subflow", createFlowExecution("target-subflow", "level2-subflow"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "target-subflow");
+
+        // Verify
+        assertTrue("Should return true when execution found at grandparent level through recursion", result);
+    }
+
+    /**
+     * Test: Three-level nested subflow (deep nesting)
+     *
+     * <pre>
+     * TopFlow
+     *   └─ L1 → L2 → L3 → TargetSubflow  ← No executions after any level
+     * </pre>
+     *
+     * Expected: false (no executions at any level)
+     */
+    @Test
+    public void testNestedFlow_ThreeLevels_NoExecutionsAfter() {
+        // Setup flow structure
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel l1 = createFlow("l1", "L1");
+        AuthenticationFlowModel l2 = createFlow("l2", "L2");
+        AuthenticationFlowModel l3 = createFlow("l3", "L3");
+        AuthenticationFlowModel target = createFlow("target", "Target");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(l1);
+        realm.addFlow(l2);
+        realm.addFlow(l3);
+        realm.addFlow(target);
+
+        realm.addExecution("top-flow", createFlowExecution("l1", "top-flow"));
+        realm.addExecution("l1", createFlowExecution("l2", "l1"));
+        realm.addExecution("l2", createFlowExecution("l3", "l2"));
+        realm.addExecution("l3", createFlowExecution("target", "l3"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "target");
+
+        // Verify
+        assertFalse("Should return false when no executions at any level", result);
+    }
+
+    /**
+     * Test: Conditional flow with execution after
+     *
+     * <pre>
+     * TopFlow
+     *   ├─ AuthSubflow (ALTERNATIVE)
+     *   │   └─ ConditionalSubflow (CONDITIONAL)
+     *   │       ├─ Condition
+     *   │       └─ IdpOtpSubflow (REQUIRED)  ← Checking after this
+     *   └─ BrowserForms (ALTERNATIVE)         ← Found!
+     * </pre>
+     *
+     * Expected: true (execution found after conditional flow)
+     */
+    @Test
+    public void testConditionalFlow_WithExecutionsAfter() {
+        // Setup flow structure
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel authSubflow = createFlow("auth-subflow", "AuthSubflow");
+        AuthenticationFlowModel conditionalSubflow = createFlow("conditional-subflow", "ConditionalSubflow");
+        AuthenticationFlowModel idpOtpSubflow = createFlow("idp-otp-subflow", "IdpOtpSubflow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(authSubflow);
+        realm.addFlow(conditionalSubflow);
+        realm.addFlow(idpOtpSubflow);
+
+        realm.addExecution("top-flow", createFlowExecution("auth-subflow", "top-flow"));
+        realm.addExecution("top-flow", createAuthenticatorExecution("browser-forms", "top-flow"));
+
+        realm.addExecution("auth-subflow", createFlowExecution("conditional-subflow", "auth-subflow"));
+
+        realm.addExecution("conditional-subflow", createAuthenticatorExecution("condition", "conditional-subflow"));
+        realm.addExecution("conditional-subflow", createFlowExecution("idp-otp-subflow", "conditional-subflow"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "idp-otp-subflow");
+
+        // Verify
+        assertTrue("Should return true when execution found after conditional flow", result);
+    }
+
+    /**
+     * Test: Edge case where subFlowId equals topFlowId
+     *
+     * Expected: false (no parent level for top flow)
+     */
+    @Test
+    public void testSubFlowIsTopFlow_ReturnsFalse() {
+        // Setup
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        realm.addFlow(topFlow);
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "top-flow");
+
+        // Verify
+        assertFalse("Should return false when subFlowId equals topFlowId", result);
+    }
+
+    /**
+     * Test: Edge case where parent cannot be found
+     *
+     * Expected: false (parent not found)
+     */
+    @Test
+    public void testParentNotFound_ReturnsFalse() {
+        // Setup
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        realm.addFlow(topFlow);
+        realm.addExecution("top-flow", createAuthenticatorExecution("cookie", "top-flow"));
+
+        // Test with non-existent subflow ID
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "non-existent-subflow");
+
+        // Verify
+        assertFalse("Should return false when parent flow cannot be found", result);
+    }
+
+    /**
+     * Test: Finding parent context for direct child
+     *
+     * <pre>
+     * TopFlow
+     *   └─ ChildSubflow  ← Find parent of this
+     * </pre>
+     *
+     * Expected: FlowContext with topFlow as parent
+     */
+    @Test
+    public void testFindParentFlowContext_DirectChild() {
+        // Setup
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel childSubflow = createFlow("child-subflow", "ChildSubflow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(childSubflow);
+
+        realm.addExecution("top-flow", createFlowExecution("child-subflow", "top-flow"));
+
+        // Test
+        AuthenticationFlowHierarchyHelper.FlowContext context =
+            helper.findParentFlowContext(topFlow, "child-subflow");
+
+        // Verify
+        assertNotNull("Should find parent context", context);
+        assertEquals("Parent should be topFlow", "top-flow", context.getParentFlow().getId());
+        assertEquals("Execution should reference child subflow", "child-subflow",
+            context.getSubFlowExecution().getFlowId());
+    }
+
+    /**
+     * Test: Finding parent context for nested child (2 levels)
+     *
+     * <pre>
+     * TopFlow
+     *   └─ Level1
+     *       └─ Level2  ← Find parent of this
+     * </pre>
+     *
+     * Expected: FlowContext with level1 as parent
+     */
+    @Test
+    public void testFindParentFlowContext_NestedChild() {
+        // Setup
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel level1 = createFlow("level1", "Level1");
+        AuthenticationFlowModel level2 = createFlow("level2", "Level2");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(level1);
+        realm.addFlow(level2);
+
+        realm.addExecution("top-flow", createFlowExecution("level1", "top-flow"));
+        realm.addExecution("level1", createFlowExecution("level2", "level1"));
+
+        // Test
+        AuthenticationFlowHierarchyHelper.FlowContext context =
+            helper.findParentFlowContext(topFlow, "level2");
+
+        // Verify
+        assertNotNull("Should find parent context", context);
+        assertEquals("Parent should be level1", "level1", context.getParentFlow().getId());
+        assertEquals("Execution should reference level2", "level2",
+            context.getSubFlowExecution().getFlowId());
+    }
+
+    /**
+     * Test: Finding parent context when child does not exist
+     *
+     * Expected: null (not found)
+     */
+    @Test
+    public void testFindParentFlowContext_NotFound() {
+        // Setup
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        realm.addFlow(topFlow);
+        realm.addExecution("top-flow", createAuthenticatorExecution("cookie", "top-flow"));
+
+        // Test
+        AuthenticationFlowHierarchyHelper.FlowContext context =
+            helper.findParentFlowContext(topFlow, "non-existent");
+
+        // Verify
+        assertNull("Should return null when child not found", context);
+    }
+
+    /**
+     * Test: Disabled execution should be ignored
+     *
+     * <pre>
+     * TopFlow
+     *   ├─ SubFlow
+     *   ├─ DisabledAuth (DISABLED) ← Should be ignored
+     *   └─ EnabledAuth              ← Should be found
+     * </pre>
+     *
+     * Expected: true (enabled execution found, disabled ignored)
+     */
+    @Test
+    public void testDisabledExecution_ShouldBeIgnored() {
+        // Setup
+        AuthenticationFlowModel topFlow = createFlow("top-flow", "TopFlow");
+        AuthenticationFlowModel subFlow = createFlow("sub-flow", "SubFlow");
+
+        realm.addFlow(topFlow);
+        realm.addFlow(subFlow);
+
+        realm.addExecution("top-flow", createFlowExecution("sub-flow", "top-flow"));
+
+        AuthenticationExecutionModel disabledExec = createAuthenticatorExecution("disabled-auth", "top-flow");
+        disabledExec.setRequirement(AuthenticationExecutionModel.Requirement.DISABLED);
+        realm.addExecution("top-flow", disabledExec);
+
+        realm.addExecution("top-flow", createAuthenticatorExecution("enabled-auth", "top-flow"));
+
+        // Test
+        boolean result = helper.hasMoreExecutionsAfterParentFlow(topFlow, "sub-flow");
+
+        // Verify
+        assertTrue("Should return true, skipping disabled execution", result);
+    }
+
+    // Helper methods for creating test data
+
+    private AuthenticationFlowModel createFlow(String id, String alias) {
+        AuthenticationFlowModel flow = new AuthenticationFlowModel();
+        flow.setId(id);
+        flow.setAlias(alias);
+        return flow;
+    }
+
+    private AuthenticationExecutionModel createAuthenticatorExecution(String authenticator, String parentFlowId) {
+        AuthenticationExecutionModel execution = new AuthenticationExecutionModel();
+        execution.setId(authenticator + "-exec-id");
+        execution.setAuthenticator(authenticator);
+        execution.setParentFlow(parentFlowId);
+        execution.setAuthenticatorFlow(false);
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
+        return execution;
+    }
+
+    private AuthenticationExecutionModel createFlowExecution(String flowId, String parentFlowId) {
+        AuthenticationExecutionModel execution = new AuthenticationExecutionModel();
+        execution.setId(flowId + "-exec-id");
+        execution.setFlowId(flowId);
+        execution.setParentFlow(parentFlowId);
+        execution.setAuthenticatorFlow(true);
+        execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
+        return execution;
+    }
+
+    /**
+     * Simple test double for RealmModel that stores flows and executions in memory.
+     * Uses dynamic proxy to avoid implementing all RealmModel methods.
+     */
+    private static class TestRealmModel {
+        private final Map<String, AuthenticationFlowModel> flows = new HashMap<>();
+        private final Map<String, List<AuthenticationExecutionModel>> executions = new HashMap<>();
+        private final RealmModel proxy;
+
+        TestRealmModel() {
+            this.proxy = (RealmModel) java.lang.reflect.Proxy.newProxyInstance(
+                RealmModel.class.getClassLoader(),
+                new Class<?>[]{RealmModel.class},
+                (proxy, method, args) -> {
+                    // Handle getAuthenticationFlowById
+                    if (method.getName().equals("getAuthenticationFlowById") && args != null && args.length == 1) {
+                        return flows.get(args[0]);
+                    }
+                    // Handle getAuthenticationExecutionsStream
+                    if (method.getName().equals("getAuthenticationExecutionsStream") && args != null && args.length == 1) {
+                        return executions.getOrDefault(args[0], new ArrayList<>()).stream();
+                    }
+                    // All other methods throw UnsupportedOperationException
+                    throw new UnsupportedOperationException("Method " + method.getName() + " not implemented in test double");
+                }
+            );
+        }
+
+        RealmModel getProxy() {
+            return proxy;
+        }
+
+        void addFlow(AuthenticationFlowModel flow) {
+            flows.put(flow.getId(), flow);
+            executions.putIfAbsent(flow.getId(), new ArrayList<>());
+        }
+
+        void addExecution(String flowId, AuthenticationExecutionModel execution) {
+            executions.computeIfAbsent(flowId, k -> new ArrayList<>()).add(execution);
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFlowContinuationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerFlowContinuationTest.java
@@ -1,0 +1,1163 @@
+package org.keycloak.testsuite.broker;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authentication.AuthenticationFlow;
+import org.keycloak.authentication.authenticators.browser.IdentityProviderAuthenticatorFactory;
+import org.keycloak.authentication.authenticators.conditional.ConditionalUserConfiguredAuthenticatorFactory;
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.events.Details;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.DefaultAuthenticationFlows;
+import org.keycloak.models.utils.TimeBasedOTP;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
+import org.keycloak.testsuite.util.AccountHelper;
+import org.keycloak.testsuite.util.FlowUtil;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.keycloak.models.utils.TimeBasedOTP.DEFAULT_INTERVAL_SECONDS;
+import static org.keycloak.testsuite.admin.ApiUtil.removeUserByUsername;
+import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.configurePostBrokerLoginWithOTP;
+import static org.keycloak.testsuite.broker.BrokerRunOnServerUtil.disablePostBrokerLoginFlow;
+import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
+import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for Browser Flow Continuation after Broker Login.
+ *
+ * Tests the functionality where additional authenticators in the browser flow
+ * are executed after a successful broker login, before finalizing authentication.
+ * This is different from post-broker flows which are separate flows executed after
+ * the broker login flow completes.
+ *
+ * @author Keycloak Team
+ */
+public class KcOidcBrokerFlowContinuationTest extends AbstractInitializedBaseBrokerTest {
+
+    private static final KcOidcBrokerConfiguration BROKER_CONFIG_INSTANCE = new KcOidcBrokerConfiguration();
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
+
+    private TimeBasedOTP totp;
+
+    @Override
+    protected BrokerConfiguration getBrokerConfiguration() {
+        return BROKER_CONFIG_INSTANCE;
+    }
+
+    @Before
+    public void setUpTotp() {
+        totp = new TimeBasedOTP();
+    }
+
+    @After
+    public void cleanupFlows() {
+        // Reset time offset (may have been changed by OTP tests)
+        setTimeOffset(0);
+
+        // Reset post-broker-login flow on IDP (if set by combined test)
+        testingClient.server(bc.consumerRealmName()).run(disablePostBrokerLoginFlow(bc.getIDPAlias()));
+
+        // Reset to default browser flow
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            AuthenticationFlowModel defaultFlow =
+                realm.getFlowByAlias(DefaultAuthenticationFlows.BROWSER_FLOW);
+            if (defaultFlow != null) {
+                realm.setBrowserFlow(defaultFlow);
+            }
+        });
+    }
+
+    /**
+     * Core Test: Broker Login WITH OTP Continuation
+     *
+     * Tests the main use case where an IDP redirector is followed by an OTP
+     * authenticator in the same browser flow. After successful broker login,
+     * the user should be prompted for OTP before authentication is finalized.
+     */
+    @Test
+    public void testBrokerLoginWithOtpContinuation() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        configureBrowserFlowWithIdpAndOtp("browser-with-idp-and-otp", bc.getIDPAlias());
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        // User should be redirected to IDP automatically
+        waitForPage(driver, "sign in to", false);
+        assertTrue("Should be redirected to provider realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+        // Login at provider
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // After broker login, OTP configuration page should appear
+        totpPage.assertCurrent();
+        String totpSecret = totpPage.getTotpSecret();
+        totpPage.configure(totp.generateTOTP(totpSecret));
+
+        // Should now be logged in
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify broker session notes and tokens
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+        assertAuthNotesCleanedUp(bc.getUserLogin());
+
+        // Logout and test second login with existing federated identity
+        AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), bc.getUserLogin());
+        AccountHelper.logout(adminClient.realm(bc.providerRealmName()), bc.getUserLogin());
+
+        setOtpTimeOffset(DEFAULT_INTERVAL_SECONDS, totp);
+
+        // Second login - should still go through OTP
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // OTP should be required again
+        loginTotpPage.assertCurrent();
+        loginTotpPage.login(totp.generateTOTP(totpSecret));
+
+        // Wait and navigate to account page
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify broker session notes and tokens
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+    }
+
+
+    /**
+     * Regression Test: Broker Login WITHOUT additional authenticators
+     *
+     * Ensures that the existing behavior still works when there are no
+     * authenticators following the IDP redirector. User should be logged in
+     * immediately after broker authentication.
+     */
+    @Test
+    public void testBrokerLoginWithoutAdditionalAuthenticators() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // Configure browser flow: Cookie (ALT) -> IDP Redirector (ALT) only
+        configureBrowserFlowWithIdpOnly("browser-with-idp-only", bc.getIDPAlias());
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        // User should be redirected to IDP automatically
+        waitForPage(driver, "sign in to", false);
+        assertTrue("Should be redirected to provider realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+        // Login at provider
+        log.debug("Logging in to provider realm");
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // After broker login, check if update profile page appears (first login)
+        if (updateAccountInformationPage.isCurrent()) {
+            log.debug("Update profile page appeared, updating account info");
+            updateAccountInformationPage.updateAccountInformation(bc.getUserLogin(), bc.getUserEmail(), "Firstname", "Lastname");
+        }
+
+        // Wait a bit for redirect
+        log.debug("Waiting for redirect back to consumer realm, current URL: " + driver.getCurrentUrl());
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            // ignore
+        }
+        log.debug("After wait, current URL: " + driver.getCurrentUrl());
+
+        // Should be logged in - try to get the account page
+        driver.navigate().to(getConsumerRoot() + "/realms/" + bc.consumerRealmName() + "/account");
+        log.debug("Navigated to account page, current URL: " + driver.getCurrentUrl());
+
+        // Verify we're logged in
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify broker session notes and tokens
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+        assertAuthNotesCleanedUp(bc.getUserLogin());
+    }
+
+    /**
+     * First Broker Login with OTP Continuation
+     *
+     * Tests flow continuation with a new user. Ensures that user creation
+     * works correctly in combination with flow continuation.
+     */
+    @Test
+    public void testFirstBrokerLoginWithOtpContinuation() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // Configure browser flow with IDP and OTP
+        configureBrowserFlowWithIdpAndOtp("browser-with-idp-and-otp", bc.getIDPAlias());
+
+        // Create a new user in provider realm that doesn't exist in consumer
+        String newUsername = "newuser-" + System.currentTimeMillis();
+        String newUserEmail = newUsername + "@test.com";
+        createUserInRealm(bc.providerRealmName(), newUsername, "password", "NewFirst", "NewLast", newUserEmail);
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        loginPage.login(newUsername, "password");
+
+        // OTP configuration should be shown for new user
+        totpPage.assertCurrent();
+        String totpSecret = totpPage.getTotpSecret();
+        totpPage.configure(totp.generateTOTP(totpSecret));
+
+        // Wait and navigate to account page
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(newUsername);
+
+        // Verify user was created in consumer realm
+        RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
+        List<UserRepresentation> users = consumerRealm.users().search(newUsername);
+        assertEquals("User should be created", 1, users.size());
+
+        // Verify federated identity link exists
+        String username = newUsername;  // Capture in local variable for lambda
+        String idpAlias = bc.getIDPAlias();
+        Boolean federatedIdentityExists = testingClient.server(bc.consumerRealmName()).fetch(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            UserModel user = session.users().getUserByUsername(realm, username);
+            if (user == null) return false;
+
+            FederatedIdentityModel federatedIdentity = session.users()
+                .getFederatedIdentity(realm, user, idpAlias);
+            return federatedIdentity != null;
+        }, Boolean.class);
+
+        assertTrue("Federated identity should exist", federatedIdentityExists);
+
+        // Verify broker session notes
+        assertBrokerSessionNotes(newUsername, bc.getIDPAlias());
+
+        // Cleanup
+        removeUserByUsername(consumerRealm, newUsername);
+        removeUserByUsername(adminClient.realm(bc.providerRealmName()), newUsername);
+    }
+
+    /**
+     * Nested Flows: IDP in Conditional Subflow
+     *
+     * Tests that flow continuation works correctly when the IDP redirector
+     * is inside a conditional subflow, and there are authenticators after
+     * the parent subflow.
+     */
+    @Test
+    public void testBrokerLoginInConditionalSubflow() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // Configure complex nested flow
+        configureBrowserFlowWithConditionalIdpAndOtp("browser-conditional-idp", bc.getIDPAlias());
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        assertTrue("Should be redirected to provider realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // OTP should appear after broker login (from parent flow)
+        totpPage.assertCurrent();
+        String totpSecret = totpPage.getTotpSecret();
+        totpPage.configure(totp.generateTOTP(totpSecret));
+
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify correct flow execution
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+    }
+
+    /**
+     * SAML Provider Test
+     *
+     * Ensures that flow continuation works with SAML providers, not just OIDC.
+     * Tests that SAML-specific session notes are correctly stored.
+     */
+    @Test
+    public void testSamlBrokerLoginWithOtpContinuation() {
+        KcSamlBrokerConfiguration samlBrokerConfig = KcSamlBrokerConfiguration.INSTANCE;
+        RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
+
+        try {
+            // Set up SAML broker
+            updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+            adminClient.realm(bc.providerRealmName()).clients()
+                .create(samlBrokerConfig.createProviderClients().get(0));
+            consumerRealm.identityProviders().create(samlBrokerConfig.setUpIdentityProvider());
+
+            // Configure browser flow with SAML IDP and OTP
+            configureBrowserFlowWithIdpAndOtp("browser-saml-idp-otp", samlBrokerConfig.getIDPAlias());
+
+            oauth.clientId("broker-app");
+            oauth.realm(bc.consumerRealmName());
+            oauth.openLoginForm();
+
+            // Since we configured IDP Redirector with defaultProvider, it will auto-redirect
+            // to the SAML provider without showing a button. Wait for provider login page.
+            waitForPage(driver, "sign in to", false);
+            assertTrue("Should be redirected to provider realm",
+                driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+            loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+            // OTP should appear
+            totpPage.assertCurrent();
+            String totpSecret = totpPage.getTotpSecret();
+            totpPage.configure(totp.generateTOTP(totpSecret));
+
+            waitAndNavigateToAccountPage();
+            assertLoggedInConsumerRealm();
+
+            // UI-level verification: ensure user has an active session
+            assertUserHasActiveSession(bc.getUserLogin());
+
+            // Verify SAML broker session notes
+            assertBrokerSessionNotes(bc.getUserLogin(), samlBrokerConfig.getIDPAlias());
+
+            // Note: SAML doesn't have access/ID tokens like OIDC, so we don't check for those
+        } finally {
+            updateExecutions(AbstractBrokerTest::setUpMissingUpdateProfileOnFirstLogin);
+            removeUserByUsername(consumerRealm, "consumer");
+        }
+    }
+
+    /**
+     * Multiple Authenticators after IDP
+     *
+     * Tests that multiple authenticators following the IDP redirector are
+     * all executed correctly in sequence.
+     */
+    @Test
+    public void testBrokerLoginWithMultipleFollowingAuthenticators() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // Configure flow: Cookie -> IDP -> OTP (both as REQUIRED in sequence)
+        configureBrowserFlowWithIdpAndMultipleAuthenticators("browser-idp-multi-auth", bc.getIDPAlias());
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // First authenticator: OTP configuration
+        totpPage.assertCurrent();
+        String totpSecret = totpPage.getTotpSecret();
+        totpPage.configure(totp.generateTOTP(totpSecret));
+
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify everything is set up correctly
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+    }
+
+
+    /**
+     * Broker Login with IDP+OTP in Subflow and Browser Forms Alternative
+     *
+     * Tests the flow structure requested:
+     * - Cookie (ALTERNATIVE)
+     * - SubFlow (ALTERNATIVE): IDP Redirector (REQUIRED) + OTP Form (REQUIRED)
+     * - Browser Forms (ALTERNATIVE): Username/Password form
+     *
+     * This ensures that:
+     * 1. Users can authenticate via IDP + OTP (both required in sequence)
+     * 2. OR users can authenticate via username/password
+     * 3. Tokens are properly stored when going through IDP path
+     */
+    @Test
+    public void testBrokerLoginWithIdpOtpSubflowAndBrowserForms() {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // Configure the flow with IDP+OTP subflow and browser forms
+        configureBrowserFlowWithIdpOtpSubflowAndForms("browser-idp-otp-subflow", bc.getIDPAlias());
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        // User should be redirected to IDP automatically (because of defaultProvider config)
+        waitForPage(driver, "sign in to", false);
+        assertTrue("Should be redirected to provider realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+        // Login at provider
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // After broker login, OTP configuration page should appear (REQUIRED in subflow)
+        totpPage.assertCurrent();
+        String totpSecret = totpPage.getTotpSecret();
+        totpPage.configure(totp.generateTOTP(totpSecret));
+
+        // Should now be logged in
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify broker session notes and tokens
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+        assertAuthNotesCleanedUp(bc.getUserLogin());
+
+        // Logout and test second login with existing federated identity
+        AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), bc.getUserLogin());
+        AccountHelper.logout(adminClient.realm(bc.providerRealmName()), bc.getUserLogin());
+
+        setOtpTimeOffset(DEFAULT_INTERVAL_SECONDS, totp);
+
+        // Second login - should still go through OTP
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // OTP should be required again (REQUIRED in subflow)
+        loginTotpPage.assertCurrent();
+        loginTotpPage.login(totp.generateTOTP(totpSecret));
+
+        // Wait and navigate to account page
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+
+        // UI-level verification: ensure user has an active session
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Verify broker session notes and tokens
+        assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+        assertOidcTokensStored(bc.getUserLogin());
+    }
+
+    /**
+     * Combined Test: Browser Flow Continuation + Post-Broker-Login Flow
+     *
+     * Tests that after browser flow continuation completes, the post-broker-login
+     * flow is also executed. The sequence for the second login is:
+     * 1. IDP Redirector triggers broker authentication
+     * 2. OTP from browser flow continuation is required
+     * 3. Post-broker-login flow with OTP is required
+     *
+     * The first login sets up the user and configures OTP (without post-broker flow).
+     * The post-broker-login flow is then configured, and the second login verifies
+     * both OTP steps execute in order.
+     */
+    @Test
+    public void testBrokerLoginWithOtpContinuationAndPostBrokerLogin() throws Exception {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // Configure browser flow with IDP + OTP (flow continuation) - WITHOUT PBL first
+        configureBrowserFlowWithIdpAndOtp("browser-with-idp-otp-and-pbl", bc.getIDPAlias());
+
+        // === First login WITHOUT PBL: create user and configure OTP ===
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        assertTrue("Should be redirected to provider realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // OTP configuration from browser flow continuation
+        totpPage.assertCurrent();
+        String totpSecret = totpPage.getTotpSecret();
+        totpPage.configure(totp.generateTOTP(totpSecret));
+
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Logout
+        AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), bc.getUserLogin());
+        AccountHelper.logout(adminClient.realm(bc.providerRealmName()), bc.getUserLogin());
+
+        // NOW configure post-broker-login flow with OTP
+        testingClient.server(bc.consumerRealmName()).run(configurePostBrokerLoginWithOTP(bc.getIDPAlias()));
+
+        // Enable OTP code reuse: two OTP entries in the same session (browser flow + PBL)
+        // may generate the same code when within the same TOTP interval.
+        // Pattern from testReauthenticationBothBrokersWithOTPRequired in KcOidcPostBrokerLoginTest.
+        RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
+        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(consumerRealm)
+                .setOtpPolicyCodeReusable(true).update()) {
+
+            // === Second login WITH PBL: IDP → OTP (browser flow) → OTP (post-broker-login) ===
+            setOtpTimeOffset(DEFAULT_INTERVAL_SECONDS, totp);
+
+            oauth.clientId("broker-app");
+            oauth.realm(bc.consumerRealmName());
+            oauth.openLoginForm();
+
+            waitForPage(driver, "sign in to", false);
+            loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+            // OTP from browser flow continuation (user already has OTP)
+            loginTotpPage.assertCurrent();
+            loginTotpPage.login(totp.generateTOTP(totpSecret));
+
+            // OTP from post-broker-login flow (user already has OTP)
+            loginTotpPage.assertCurrent();
+            loginTotpPage.login(totp.generateTOTP(totpSecret));
+
+            // Should be logged in
+            waitAndNavigateToAccountPage();
+            assertLoggedInConsumerRealm();
+            assertUserHasActiveSession(bc.getUserLogin());
+            assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+            assertOidcTokensStored(bc.getUserLogin());
+        }
+    }
+
+    /**
+     * Combined Test: Browser Flow Continuation + Required Actions + Post-Broker-Login Flow
+     *
+     * Tests the PBL redirect from finishedRequiredActions() in AuthenticationManager.
+     * When an existing user logs in via browser flow continuation but has NOT yet
+     * configured OTP, the CONFIGURE_TOTP required action runs first. After it completes,
+     * finishedRequiredActions() detects BROKER_CONTINUATION_PBL_PENDING and redirects to PBL.
+     *
+     * The sequence is:
+     * 1. First login with IDP-only flow (creates user, no OTP)
+     * 2. Configure browser flow with IDP+OTP and PBL with OTP
+     * 3. Second login: IDP → OTP (SETUP_REQUIRED → CONFIGURE_TOTP) → PBL OTP
+     */
+    @Test
+    public void testBrokerLoginWithRequiredActionThenPostBrokerLogin() throws Exception {
+        updateExecutions(AbstractBrokerTest::disableUpdateProfileOnFirstLogin);
+
+        // === Step 1: First login with IDP-only flow to create user (no OTP) ===
+        configureBrowserFlowWithIdpOnly("browser-simple-for-pbl", bc.getIDPAlias());
+
+        oauth.clientId("broker-app");
+        oauth.realm(bc.consumerRealmName());
+        oauth.openLoginForm();
+
+        waitForPage(driver, "sign in to", false);
+        assertTrue("Should be redirected to provider realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.providerRealmName() + "/"));
+
+        loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+        // Should log in directly (no additional authenticators)
+        waitAndNavigateToAccountPage();
+        assertLoggedInConsumerRealm();
+        assertUserHasActiveSession(bc.getUserLogin());
+
+        // Logout
+        AccountHelper.logout(adminClient.realm(bc.consumerRealmName()), bc.getUserLogin());
+        AccountHelper.logout(adminClient.realm(bc.providerRealmName()), bc.getUserLogin());
+
+        // === Step 2: Configure IDP+OTP browser flow AND PBL with OTP ===
+        configureBrowserFlowWithIdpAndOtp("browser-idp-otp-reqaction-pbl", bc.getIDPAlias());
+        testingClient.server(bc.consumerRealmName()).run(configurePostBrokerLoginWithOTP(bc.getIDPAlias()));
+
+        // Enable OTP code reuse: CONFIGURE_TOTP and PBL OTP in the same session
+        // may generate the same code when within the same TOTP interval.
+        RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
+        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(consumerRealm)
+                .setOtpPolicyCodeReusable(true).update()) {
+
+            // === Step 3: Second login - user has NO OTP configured ===
+            // Flow: IDP → OTP (SETUP_REQUIRED → CONFIGURE_TOTP) → finishedRequiredActions() → PBL OTP
+            setOtpTimeOffset(DEFAULT_INTERVAL_SECONDS, totp);
+
+            oauth.clientId("broker-app");
+            oauth.realm(bc.consumerRealmName());
+            oauth.openLoginForm();
+
+            waitForPage(driver, "sign in to", false);
+            loginPage.login(bc.getUserLogin(), bc.getUserPassword());
+
+            // OTP configuration should appear (SETUP_REQUIRED → CONFIGURE_TOTP required action)
+            totpPage.assertCurrent();
+            String totpSecret = totpPage.getTotpSecret();
+            totpPage.configure(totp.generateTOTP(totpSecret));
+
+            // After configuring TOTP, PBL flow should run (through finishedRequiredActions() path)
+            loginTotpPage.assertCurrent();
+            loginTotpPage.login(totp.generateTOTP(totpSecret));
+
+            // Should be logged in
+            waitAndNavigateToAccountPage();
+            assertLoggedInConsumerRealm();
+            assertUserHasActiveSession(bc.getUserLogin());
+            assertBrokerSessionNotes(bc.getUserLogin(), bc.getIDPAlias());
+            assertOidcTokensStored(bc.getUserLogin());
+        }
+    }
+
+    /**
+     * Configures a browser flow with IDP Redirector and OTP authenticator in a subflow.
+     *
+     * Flow structure (CORRECT - avoids REQUIRED and ALTERNATIVE at same level):
+     * - Cookie (ALTERNATIVE)
+     * - Auth Subflow (ALTERNATIVE)
+     *   - IDP Redirector (REQUIRED) with default provider
+     *   - OTP Form (REQUIRED)
+     */
+    private void configureBrowserFlowWithIdpAndOtp(String flowAlias, String idpAlias) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            // Step 1: Create main flow with cookie and auth subflow
+            FlowUtil.inCurrentRealm(session)
+                .copyBrowserFlow(flowAlias)
+                .clear()
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "auth-cookie")
+                .addSubFlowExecution(
+                    "Auth Subflow",
+                    AuthenticationFlow.BASIC_FLOW,
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    subflow -> subflow
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "identity-provider-redirector")
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "auth-otp-form")
+                );
+
+            // Step 2: Configure the IDP Redirector with defaultProvider
+            Map<String, String> idpConfig = new HashMap<>();
+            idpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, idpAlias);
+
+            // Find the auth subflow
+            List<AuthenticationExecutionModel> executions = FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .getExecutions();
+
+            // Find the subflow execution
+            int subflowIndex = IntStream.range(0, executions.size())
+                .filter(i -> executions.get(i).isAuthenticatorFlow())
+                .findFirst()
+                .orElse(-1);
+
+            assertTrue("Auth Subflow not found", subflowIndex >= 0);
+
+            // Get the subflow ID
+            String subflowId = executions.get(subflowIndex).getFlowId();
+            AuthenticationFlowModel subflow = session.getContext().getRealm().getAuthenticationFlowById(subflowId);
+
+            // Find IDP Redirector in subflow
+            List<AuthenticationExecutionModel> subflowExecutions = session.getContext().getRealm()
+                .getAuthenticationExecutionsStream(subflowId)
+                .collect(java.util.stream.Collectors.toList());
+
+            int idpIndex = IntStream.range(0, subflowExecutions.size())
+                .filter(i -> "identity-provider-redirector".equals(subflowExecutions.get(i).getAuthenticator()))
+                .findFirst()
+                .orElse(-1);
+
+            assertTrue("IDP Redirector execution not found in subflow", idpIndex >= 0);
+
+            // Step 3: Set config on IDP Redirector
+            AuthenticationExecutionModel idpExecution = subflowExecutions.get(idpIndex);
+            AuthenticatorConfigModel authConfig = new AuthenticatorConfigModel();
+            authConfig.setId(UUID.randomUUID().toString());
+            authConfig.setAlias("idp-redirector-config-" + authConfig.getId().hashCode());
+            authConfig.setConfig(idpConfig);
+
+            session.getContext().getRealm().addAuthenticatorConfig(authConfig);
+            idpExecution.setAuthenticatorConfig(authConfig.getId());
+            session.getContext().getRealm().updateAuthenticatorExecution(idpExecution);
+
+            // Step 4: Define as browser flow
+            FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .defineAsBrowserFlow();
+        });
+    }
+
+    /**
+     * Configures a browser flow with only IDP Redirector (no additional authenticators).
+     *
+     * Flow structure:
+     * - Cookie (ALTERNATIVE)
+     * - IDP Redirector (ALTERNATIVE)
+     */
+    private void configureBrowserFlowWithIdpOnly(String flowAlias, String idpAlias) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            // Step 1: Copy the browser flow and add executions
+            FlowUtil.inCurrentRealm(session)
+                .copyBrowserFlow(flowAlias)
+                .clear()
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "auth-cookie")
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "identity-provider-redirector");
+
+            // Step 2: Configure the IDP Redirector with defaultProvider
+            Map<String, String> idpConfig = new HashMap<>();
+            idpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, idpAlias);
+
+            List<AuthenticationExecutionModel> executions = FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .getExecutions();
+
+            int index = IntStream.range(0, executions.size())
+                .filter(i -> "identity-provider-redirector".equals(executions.get(i).getAuthenticator()))
+                .findFirst()
+                .orElse(-1);
+
+            assertTrue("IDP Redirector execution not found", index >= 0);
+
+            // Step 3: Set config and define as browser flow in same session
+            FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .updateExecution(index, config -> {
+                    AuthenticatorConfigModel authConfig = new AuthenticatorConfigModel();
+                    authConfig.setId(UUID.randomUUID().toString());
+                    authConfig.setAlias("idp-redirector-config-" + authConfig.getId().hashCode());
+                    authConfig.setConfig(idpConfig);
+
+                    session.getContext().getRealm().addAuthenticatorConfig(authConfig);
+                    config.setAuthenticatorConfig(authConfig.getId());
+                })
+                .defineAsBrowserFlow();
+        });
+    }
+
+    /**
+     * Configures a browser flow with IDP inside a conditional subflow and OTP after.
+     *
+     * Flow structure:
+     * - Cookie (ALTERNATIVE)
+     * - Auth Subflow (ALTERNATIVE)
+     *   - Conditional IDP Subflow (CONDITIONAL)
+     *     - Conditional - User Configured (REQUIRED)
+     *     - IDP Redirector (ALTERNATIVE)
+     *   - OTP Form (REQUIRED)
+     */
+    private void configureBrowserFlowWithConditionalIdpAndOtp(String flowAlias, String idpAlias) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            // Step 1: Copy the browser flow and create structure
+            FlowUtil.inCurrentRealm(session)
+                .copyBrowserFlow(flowAlias)
+                .clear()
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "auth-cookie")
+                .addSubFlowExecution("Auth Subflow",
+                    AuthenticationFlow.BASIC_FLOW,
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    authSubflow -> authSubflow
+                        .addSubFlowExecution("Conditional IDP Subflow",
+                            "basic-flow",
+                            AuthenticationExecutionModel.Requirement.CONDITIONAL,
+                            subFlow -> subFlow
+                                .addAuthenticatorExecution(
+                                    AuthenticationExecutionModel.Requirement.REQUIRED,
+                                    ConditionalUserConfiguredAuthenticatorFactory.PROVIDER_ID)
+                                .addAuthenticatorExecution(
+                                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                                    "identity-provider-redirector")
+                        )
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "auth-otp-form")
+                );
+
+            // Step 2: Configure the IDP Redirector in the nested subflow with defaultProvider
+            Map<String, String> idpConfig = new HashMap<>();
+            idpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, idpAlias);
+
+            RealmModel realm = session.getContext().getRealm();
+
+            // Find the "Conditional IDP Subflow" (nested in "Auth Subflow")
+            AuthenticationFlowModel conditionalSubFlow = realm.getAuthenticationFlowsStream()
+                .filter(f -> f.getAlias().equals("Conditional IDP Subflow"))
+                .findFirst()
+                .orElse(null);
+
+            assertNotNull("Conditional IDP Subflow should exist", conditionalSubFlow);
+
+            // Find IDP Redirector in the conditional subflow
+            List<AuthenticationExecutionModel> conditionalSubFlowExecutions =
+                realm.getAuthenticationExecutionsStream(conditionalSubFlow.getId()).toList();
+
+            int index = IntStream.range(0, conditionalSubFlowExecutions.size())
+                .filter(i -> "identity-provider-redirector".equals(conditionalSubFlowExecutions.get(i).getAuthenticator()))
+                .findFirst()
+                .orElse(-1);
+
+            assertTrue("IDP Redirector execution not found in conditional subflow", index >= 0);
+
+            AuthenticationExecutionModel idpExecution = conditionalSubFlowExecutions.get(index);
+            AuthenticatorConfigModel authConfig = new AuthenticatorConfigModel();
+            authConfig.setId(UUID.randomUUID().toString());
+            authConfig.setAlias("idp-redirector-config-" + authConfig.getId().hashCode());
+            authConfig.setConfig(idpConfig);
+
+            realm.addAuthenticatorConfig(authConfig);
+            idpExecution.setAuthenticatorConfig(authConfig.getId());
+            realm.updateAuthenticatorExecution(idpExecution);
+
+            // Step 3: Define as browser flow in same session
+            FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .defineAsBrowserFlow();
+        });
+    }
+
+    /**
+     * Configures a browser flow with IDP followed by multiple authenticators.
+     *
+     * Flow structure:
+     * - Cookie (ALTERNATIVE)
+     * - IDP + OTP Subflow (ALTERNATIVE)
+     *   - IDP Redirector (REQUIRED)
+     *   - OTP Form (REQUIRED)
+     */
+    private void configureBrowserFlowWithIdpAndMultipleAuthenticators(String flowAlias, String idpAlias) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            // Step 1: Copy the browser flow and add executions
+            // Create a subflow with REQUIRED authenticators so they execute in sequence
+            FlowUtil.inCurrentRealm(session)
+                .copyBrowserFlow(flowAlias)
+                .clear()
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "auth-cookie")
+                .addSubFlowExecution("IDP + OTP Subflow",
+                    AuthenticationFlow.BASIC_FLOW,
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    subflow -> subflow
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "identity-provider-redirector")
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "auth-otp-form")
+                );
+
+            // Step 2: Configure the IDP Redirector with defaultProvider
+            Map<String, String> idpConfig = new HashMap<>();
+            idpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, idpAlias);
+
+            RealmModel realm = session.getContext().getRealm();
+
+            // Find the "IDP + OTP Subflow"
+            AuthenticationFlowModel subFlow = realm.getAuthenticationFlowsStream()
+                .filter(f -> f.getAlias().equals("IDP + OTP Subflow"))
+                .findFirst()
+                .orElse(null);
+
+            assertNotNull("IDP + OTP Subflow should exist", subFlow);
+
+            // Find IDP Redirector in the subflow
+            List<AuthenticationExecutionModel> subFlowExecutions =
+                realm.getAuthenticationExecutionsStream(subFlow.getId()).toList();
+
+            int index = IntStream.range(0, subFlowExecutions.size())
+                .filter(i -> "identity-provider-redirector".equals(subFlowExecutions.get(i).getAuthenticator()))
+                .findFirst()
+                .orElse(-1);
+
+            assertTrue("IDP Redirector execution not found in subflow", index >= 0);
+
+            AuthenticationExecutionModel idpExecution = subFlowExecutions.get(index);
+            AuthenticatorConfigModel authConfig = new AuthenticatorConfigModel();
+            authConfig.setId(UUID.randomUUID().toString());
+            authConfig.setAlias("idp-redirector-config-" + authConfig.getId().hashCode());
+            authConfig.setConfig(idpConfig);
+
+            realm.addAuthenticatorConfig(authConfig);
+            idpExecution.setAuthenticatorConfig(authConfig.getId());
+            realm.updateAuthenticatorExecution(idpExecution);
+
+            // Step 3: Define as browser flow
+            FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .defineAsBrowserFlow();
+        });
+    }
+
+    /**
+     * Configures a browser flow with IDP+OTP in a subflow and browser forms as alternative.
+     *
+     * Flow structure:
+     * - Cookie (ALTERNATIVE)
+     * - IDP + OTP Subflow (ALTERNATIVE)
+     *   - IDP Redirector (REQUIRED)
+     *   - OTP Form (REQUIRED)
+     * - Browser Forms (ALTERNATIVE) - Username/Password form
+     */
+    private void configureBrowserFlowWithIdpOtpSubflowAndForms(String flowAlias, String idpAlias) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            // Step 1: Copy the browser flow and create structure
+            FlowUtil.inCurrentRealm(session)
+                .copyBrowserFlow(flowAlias)
+                .clear()
+                // Cookie authentication
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "auth-cookie")
+                // Subflow with IDP + OTP (both REQUIRED inside)
+                .addSubFlowExecution("IDP + OTP SubFlow",
+                    AuthenticationFlow.BASIC_FLOW,
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    subFlow -> subFlow
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "identity-provider-redirector")
+                        .addAuthenticatorExecution(
+                            AuthenticationExecutionModel.Requirement.REQUIRED,
+                            "auth-otp-form")
+                )
+                // Browser forms (username/password)
+                .addAuthenticatorExecution(
+                    AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+                    "auth-username-password-form");
+
+            // Step 2: Configure the IDP Redirector in the subflow with defaultProvider
+            Map<String, String> idpConfig = new HashMap<>();
+            idpConfig.put(IdentityProviderAuthenticatorFactory.DEFAULT_PROVIDER, idpAlias);
+
+            RealmModel realm = session.getContext().getRealm();
+
+            // Find the subflow by alias
+            AuthenticationFlowModel subFlow = realm.getAuthenticationFlowsStream()
+                .filter(f -> "IDP + OTP SubFlow".equals(f.getAlias()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("IDP + OTP SubFlow not found"));
+
+            // Find the IDP Redirector execution inside the subflow
+            List<AuthenticationExecutionModel> subFlowExecutions = realm.getAuthenticationExecutionsStream(subFlow.getId())
+                .collect(Collectors.toList());
+
+            int idpIndex = IntStream.range(0, subFlowExecutions.size())
+                .filter(i -> "identity-provider-redirector".equals(subFlowExecutions.get(i).getAuthenticator()))
+                .findFirst()
+                .orElse(-1);
+
+            assertTrue("IDP Redirector execution not found in subflow", idpIndex >= 0);
+
+            AuthenticationExecutionModel idpExecution = subFlowExecutions.get(idpIndex);
+            AuthenticatorConfigModel authConfig = new AuthenticatorConfigModel();
+            authConfig.setId(UUID.randomUUID().toString());
+            authConfig.setAlias("idp-redirector-config-" + authConfig.getId().hashCode());
+            authConfig.setConfig(idpConfig);
+
+            realm.addAuthenticatorConfig(authConfig);
+            idpExecution.setAuthenticatorConfig(authConfig.getId());
+            realm.updateAuthenticatorExecution(idpExecution);
+
+            // Step 3: Define as browser flow in same session
+            FlowUtil.inCurrentRealm(session)
+                .selectFlow(flowAlias)
+                .defineAsBrowserFlow();
+        });
+    }
+
+    /**
+     * Waits for OAuth callback to complete and navigates to account page if needed.
+     * This is necessary because after OTP configuration in broker flow, the redirect
+     * doesn't always automatically go to the account page.
+     */
+    private void waitAndNavigateToAccountPage() {
+        log.debug("After authentication step, waiting for redirect. Current URL: " + driver.getCurrentUrl());
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            // ignore
+        }
+        log.debug("After wait, current URL: " + driver.getCurrentUrl());
+
+        // Check if we're already at the right place or need to navigate
+        if (!driver.getCurrentUrl().contains("/account")) {
+            log.debug("Not at account page, navigating explicitly");
+            driver.navigate().to(getConsumerRoot() + "/realms/" + bc.consumerRealmName() + "/account");
+        }
+    }
+
+    /**
+     * Verifies that the user is logged in to the consumer realm.
+     */
+    private void assertLoggedInConsumerRealm() {
+        assertTrue("Should be in consumer realm",
+            driver.getCurrentUrl().contains("/realms/" + bc.consumerRealmName() + "/"));
+    }
+
+    /**
+     * UI-level verification: Verifies that the user has an active session.
+     * This confirms that authentication was successful at the session level.
+     */
+    private void assertUserHasActiveSession(String username) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            UserModel user = session.users().getUserByUsername(realm, username);
+            assertNotNull("User should exist", user);
+
+            List<UserSessionModel> userSessions = session.sessions()
+                .getUserSessionsStream(realm, user)
+                .toList();
+            assertTrue("User should have at least one active session after successful login",
+                userSessions.size() > 0);
+        });
+    }
+
+    /**
+     * Verifies that broker session notes are correctly set in the user session.
+     */
+    private void assertBrokerSessionNotes(String username, String expectedIdpAlias) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            UserModel user = session.users().getUserByUsername(realm, username);
+            assertNotNull("User should exist", user);
+
+            List<UserSessionModel> userSessions = session.sessions()
+                .getUserSessionsStream(realm, user)
+                .toList();
+            assertTrue("User should have at least one session", userSessions.size() > 0);
+            UserSessionModel userSession = userSessions.get(0);
+
+            assertEquals("Identity provider should be set",
+                expectedIdpAlias,
+                userSession.getNote(Details.IDENTITY_PROVIDER));
+            assertNotNull("Identity provider username should be set",
+                userSession.getNote(Details.IDENTITY_PROVIDER_USERNAME));
+        });
+    }
+
+    /**
+     * Verifies that OIDC tokens are stored in the user session.
+     */
+    private void assertOidcTokensStored(String username) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            UserModel user = session.users().getUserByUsername(realm, username);
+            assertNotNull("User should exist", user);
+
+            List<UserSessionModel> userSessions = session.sessions()
+                .getUserSessionsStream(realm, user)
+                .toList();
+            assertTrue("User should have at least one session", userSessions.size() > 0);
+            UserSessionModel userSession = userSessions.get(0);
+
+            // Check that OIDC tokens are stored (from authenticationFinished())
+            String idToken = userSession.getNote(OIDCIdentityProvider.FEDERATED_ID_TOKEN);
+            assertNotNull("ID token should be stored", idToken);
+
+            // Access token is stored in FEDERATED_ACCESS_TOKEN
+            String accessToken = userSession.getNote(OIDCIdentityProvider.FEDERATED_ACCESS_TOKEN);
+            assertNotNull("Access token should be stored", accessToken);
+        });
+    }
+
+    /**
+     * Verifies that temporary auth notes used during flow continuation are cleaned up.
+     */
+    private void assertAuthNotesCleanedUp(String username) {
+        testingClient.server(bc.consumerRealmName()).run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+            UserModel user = session.users().getUserByUsername(realm, username);
+            assertNotNull("User should exist", user);
+
+            // Note: We cannot easily access AuthenticationSessionModel from here to verify
+            // that auth notes are cleaned up, as the session is already finished.
+            // The fact that login succeeds and tokens are stored correctly indicates
+            // that the flow completed successfully and cleanup happened.
+
+            // We can verify that the user session was created successfully
+            List<UserSessionModel> userSessions = session.sessions()
+                .getUserSessionsStream(realm, user)
+                .toList();
+            assertTrue("User session should exist", userSessions.size() > 0);
+        });
+    }
+
+    /**
+     * Creates a user in the specified realm for testing.
+     */
+    private void createUserInRealm(String realmName, String username, String password,
+                          String firstName, String lastName, String email) {
+        RealmResource realm = adminClient.realm(realmName);
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        user.setEmail(email);
+        user.setFirstName(firstName);
+        user.setLastName(lastName);
+        user.setEnabled(true);
+        user.setEmailVerified(true);
+
+        try (jakarta.ws.rs.core.Response response = realm.users().create(user)) {
+            String userId = org.keycloak.testsuite.admin.ApiUtil.getCreatedId(response);
+            org.keycloak.testsuite.admin.ApiUtil.resetUserPassword(
+                realm.users().get(userId), password, false);
+        }
+    }
+
+}


### PR DESCRIPTION
Enable additional authentication steps (e.g., OTP, conditional flows) to execute after Identity Provider (IDP) redirect in browser authentication flows. This allows complex multi-factor authentication scenarios where users authenticate via external IDP and then continue with additional local authenticators.

This change also makes it possible to add details to the login event, which was previously only possible via the post-login flow. 

Closes: #10250

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
