### PR TITLE
Use cached realm attributes for PAR and CIBA config

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRealm.java
@@ -528,11 +528,11 @@ public class CachedRealm extends AbstractExtendableRevisioned {
     }
 
     public CibaConfig getCibaConfig(Supplier<RealmModel> modelSupplier) {
-        return new CibaConfig(modelSupplier.get());
+        return CibaConfig.fromCache(modelSupplier, Collections.unmodifiableMap(attributes));
     }
 
     public ParConfig getParConfig(Supplier<RealmModel> modelSupplier) {
-        return new ParConfig(modelSupplier.get());
+        return ParConfig.fromCache(modelSupplier, Collections.unmodifiableMap(attributes));
     }
 
     public int getActionTokenGeneratedByAdminLifespan() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -642,12 +642,12 @@ public class RealmAdapter implements StorageProviderRealmModel, JpaModel<RealmEn
 
     @Override
     public CibaConfig getCibaPolicy() {
-        return new CibaConfig(this);
+        return CibaConfig.fromModel(this);
     }
 
     @Override
     public ParConfig getParPolicy() {
-        return new ParConfig(this);
+        return ParConfig.fromModel(this);
     }
 
     @Override

--- a/server-spi/src/main/java/org/keycloak/models/AbstractConfig.java
+++ b/server-spi/src/main/java/org/keycloak/models/AbstractConfig.java
@@ -17,7 +17,10 @@
 package org.keycloak.models;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.function.Supplier;
+
+import org.keycloak.utils.StringUtil;
 
 public abstract class AbstractConfig implements Serializable {
 
@@ -38,6 +41,18 @@ public abstract class AbstractConfig implements Serializable {
         RealmModel realm = realmForWrite == null ? null : this.realmForWrite.get();
         if (realm != null) {
             realm.setAttribute(name, value);
+        }
+    }
+
+    protected static int getIntAttribute(Map<String, String> attributes, String name, int defaultValue) {
+        var value = attributes.get(name);
+        if (StringUtil.isBlank(value)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
         }
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/ParConfig.java
+++ b/server-spi/src/main/java/org/keycloak/models/ParConfig.java
@@ -16,6 +16,9 @@
  */
 package org.keycloak.models;
 
+import java.util.Map;
+import java.util.function.Supplier;
+
 public class ParConfig extends AbstractConfig {
 
     // realm attribute names
@@ -29,10 +32,29 @@ public class ParConfig extends AbstractConfig {
     // client attribute names
     public static final String REQUIRE_PUSHED_AUTHORIZATION_REQUESTS = "require.pushed.authorization.requests";
 
+    /**
+     * @deprecated use {@link #fromCache(Supplier, Map)} or {@link #fromModel(RealmModel)} factory methods
+     */
+    @Deprecated(since = "26.6", forRemoval = true)
     public ParConfig(RealmModel realm) {
         this.requestUriLifespan = realm.getAttribute(PAR_REQUEST_URI_LIFESPAN, DEFAULT_PAR_REQUEST_URI_LIFESPAN);
 
         this.realmForWrite = () -> realm;
+    }
+
+    private ParConfig(Supplier<RealmModel> realmForWrite, int requestUriLifespan) {
+        this.requestUriLifespan = requestUriLifespan;
+        this.realmForWrite = realmForWrite;
+    }
+
+    public static ParConfig fromModel(RealmModel realm) {
+        var requestUriLifespan = realm.getAttribute(PAR_REQUEST_URI_LIFESPAN, DEFAULT_PAR_REQUEST_URI_LIFESPAN);
+        return new ParConfig(() -> realm, requestUriLifespan);
+    }
+
+    public static ParConfig fromCache(Supplier<RealmModel> realmForWrite, Map<String, String> realmAttributes) {
+        var requestUriLifespan = getIntAttribute(realmAttributes, PAR_REQUEST_URI_LIFESPAN, DEFAULT_PAR_REQUEST_URI_LIFESPAN);
+        return new ParConfig(realmForWrite, requestUriLifespan);
     }
 
     public int getRequestUriLifespan() {


### PR DESCRIPTION
Closes #46100

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

### Benchmark

I've run a benchmark, doing 7000 logins
```
[benchamrk-run] ================================================================================
[benchamrk-run] 2026-02-09 14:05:35 GMT                                      80s elapsed
[benchamrk-run] ---- Requests ------------------------------------------------------------------
[benchamrk-run] > Global                                                   (OK=21000  KO=0     )
[benchamrk-run] > Browser to Log In Endpoint                               (OK=7000   KO=0     )
[benchamrk-run] > Browser posts correct credentials                        (OK=7000   KO=0     )
[benchamrk-run] > Exchange Code                                            (OK=7000   KO=0     )
```

And using `pg_stat_statements`, observed the following:
```
            calls   total_exec_time
Main:       7013	913.9978240000013
This PR:    13	    2.055732
```