### PR TITLE
Iterate realm deletion in realm.spec.ts

### DIFF
--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -36,11 +36,14 @@ test.describe.serial("Realm tests", () => {
   });
 
   test.afterAll(async () => {
-    await Promise.all(
-      [testRealmName, newRealmName, editedRealmName, specialCharsName].map(
-        (realm) => adminClient.deleteRealm(realm),
-      ),
-    );
+    for (const realm of [
+      testRealmName,
+      newRealmName,
+      editedRealmName,
+      specialCharsName,
+    ]) {
+      await adminClient.deleteRealm(realm);
+    }
   });
 
   test("should fail creating duplicated or empty name realm", async ({


### PR DESCRIPTION
Closes #46081

The deletion is done just one by one instead of calling the four simultaneously. This fixes the issue for me in my laptop. I created https://github.com/keycloak/keycloak/issues/46172 for the root cause, although I think that this is something weird in hibernate (I don't see this error in other branches for example).
