### PR TITLE
fix: refining how the junit Keycloak is launched

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -184,7 +184,7 @@ public class Picocli {
             // to reuse the previous result either means we need to duplicate the logic in the execute method
             // or refactor the above logic so that it happens in the command logic
             // We could also reduce the memory footprint of the ParseResult, but that looks a little hackish
-            int exitCode = cmd.execute(argArray);
+            int exitCode = execute(cmd, argArray);
 
             exit(exitCode);
         } catch (ParameterException parEx) {
@@ -192,6 +192,10 @@ public class Picocli {
         } catch (ProfileException | PropertyException proEx) {
             usageException(proEx.getMessage(), proEx.getCause());
         }
+    }
+
+    protected int execute(CommandLine cmd, String[] argArray) {
+        return cmd.execute(argArray);
     }
 
     public Optional<AbstractCommand> getParsedCommand() {

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/CLITestExtension.java
@@ -110,7 +110,9 @@ public class CLITestExtension extends QuarkusMainTestExtension {
                 result = dist.run(List.of(launch.value()));
             }
         } else {
-            Keycloak.initSys(launch == null ? new String[] {} : launch.value());
+            if (!Keycloak.initSys(launch == null ? new String[] {} : launch.value())) {
+                return;
+            }
             configureProfile(context);
             super.beforeEach(context);
         }

--- a/services/src/main/java/org/keycloak/timer/basic/BasicTimerProviderFactory.java
+++ b/services/src/main/java/org/keycloak/timer/basic/BasicTimerProviderFactory.java
@@ -49,7 +49,7 @@ public class BasicTimerProviderFactory implements TimerProviderFactory {
     @Override
     public void init(Config.Scope config) {
         transactionTimeout = config.getInt(TRANSACTION_TIMEOUT, 0);
-        timer = new Timer();
+        timer = new Timer(true);
     }
 
     @Override
@@ -59,8 +59,10 @@ public class BasicTimerProviderFactory implements TimerProviderFactory {
 
     @Override
     public void close() {
-        timer.cancel();
-        timer = null;
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
closes: #46160

Turns out the problem wasn't with asyncExit, it was more of an issue with initSys. To prevent it from causing the start to hang and / or produce duplicate results we need to only let it have an effect for auto build commands and require it to return the built exit code.

~~The change to the QuarkusKeycloakSessionFactory is to address that some failed launches, such as when the hostname provider fails validation, will leave provider factories as not being cleaned up - for example BasicTimerProviderFactory starts a non-daemon thread.~~

Limited the additional fix to just BasicTimerProviderFactory - the factory logic seems pretty fragile in terms of when close can be called - some expect postInit to have been called, while other it's just after init.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
