### PR TITLE
Reduce database calls for evaluation of client roles

### DIFF
--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -80,6 +80,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/server-spi-private/src/test/java/org/keycloak/models/KeycloakModelUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/KeycloakModelUtilsTest.java
@@ -135,6 +135,11 @@ public class KeycloakModelUtilsTest {
                         .findFirst()
                         .orElse(null);
             }
+
+            @Override
+            public String getId() {
+                return "realm";
+            }
         };
 
         assertGetRoleFromString(realm, ".client.role", ".client|role");


### PR DESCRIPTION
Closes #43726

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

The previous algorithm made `n+1` database calls, where `n` is the number of dots in the client/role name. 
This PR changes to a flat 2 database calls. 