### PR TITLE
Show button in tokens tab when openId4vci is not enabled

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -55,6 +55,8 @@ export const RealmSettingsTokensTab = ({
   const serverInfo = useServerInfo();
   const isFeatureEnabled = useIsFeatureEnabled();
   const { whoAmI } = useWhoAmI();
+  const openId4vciEnabled =
+    isFeatureEnabled(Feature.OpenId4VCI) && realm.verifiableCredentialsEnabled;
 
   const [defaultSigAlgDrpdwnIsOpen, setDefaultSigAlgDrpdwnOpen] =
     useState(false);
@@ -654,7 +656,7 @@ export const RealmSettingsTokensTab = ({
               )}
             />
           </FormGroup>
-          {!isFeatureEnabled(Feature.OpenId4VCI) && (
+          {!openId4vciEnabled && (
             <FixedButtonsGroup
               name="tokens-tab"
               isSubmit
@@ -667,9 +669,7 @@ export const RealmSettingsTokensTab = ({
     },
     {
       title: t("oid4vciAttributes"),
-      isHidden:
-        !isFeatureEnabled(Feature.OpenId4VCI) ||
-        !realm.verifiableCredentialsEnabled,
+      isHidden: !openId4vciEnabled,
       panel: (
         <FormAccess
           isHorizontal


### PR DESCRIPTION
Closes #45818

Just changing the condition to always check that the feature and the realm are enabled for openid4vci. There is a test already, but it loads the realm with verify credentials enabled (and the problem was it was disabled).
