### PR TITLE
Add createdAfter/createdBefore filter to GET /admin/realms/{realm}/users

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -274,6 +274,40 @@ public interface UsersResource {
                   @QueryParam("enabled") Boolean enabled,
                   @QueryParam("q") String searchQuery);
 
+    /**
+     * Search for users based on the given filters, including creation timestamp filters.
+     *
+     * @param username a value contained in username
+     * @param firstName a value contained in first name
+     * @param lastName a value contained in last name
+     * @param email a value contained in email
+     * @param emailVerified whether the email has been verified
+     * @param idpAlias the alias of the Identity Provider
+     * @param idpUserId the userId at the Identity Provider
+     * @param firstResult the position of the first result to retrieve
+     * @param maxResults the maximum number of results to retrieve
+     * @param enabled only return enabled or disabled users
+     * @param briefRepresentation Only return basic information
+     * @param createdAfter only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
+     * @param createdBefore only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
+     * @return a list of {@link UserRepresentation}
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> search(@QueryParam("username") String username,
+                                    @QueryParam("firstName") String firstName,
+                                    @QueryParam("lastName") String lastName,
+                                    @QueryParam("email") String email,
+                                    @QueryParam("emailVerified") Boolean emailVerified,
+                                    @QueryParam("idpAlias") String idpAlias,
+                                    @QueryParam("idpUserId") String idpUserId,
+                                    @QueryParam("first") Integer firstResult,
+                                    @QueryParam("max") Integer maxResults,
+                                    @QueryParam("enabled") Boolean enabled,
+                                    @QueryParam("briefRepresentation") Boolean briefRepresentation,
+                                    @QueryParam("createdAfter") String createdAfter,
+                                    @QueryParam("createdBefore") String createdBefore);
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> list(@QueryParam("first") Integer firstResult,
@@ -432,6 +466,42 @@ public interface UsersResource {
                   @QueryParam("idpUserId") String idpUserId,
                   @QueryParam("exact") Boolean exact,
                   @QueryParam("q") String searchQuery);
+
+    /**
+     * Returns the number of users that can be viewed and match the given filters,
+     * including creation timestamp filters.
+     *
+     * @param search        arbitrary search string for all the fields below
+     * @param last          last name field of a user
+     * @param first         first name field of a user
+     * @param email         email field of a user
+     * @param emailVerified emailVerified field of a user
+     * @param username      username field of a user
+     * @param enabled       Boolean representing if user is enabled or not
+     * @param idpAlias      The alias of an Identity Provider linked to the user
+     * @param idpUserId     The userId at an Identity Provider linked to the user
+     * @param exact         Boolean which defines whether the params must match exactly
+     * @param searchQuery   A query to search for custom attributes
+     * @param createdAfter  only count users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
+     * @param createdBefore only count users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
+     * @return number of users matching the given filters
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("search") String search,
+                  @QueryParam("lastName") String last,
+                  @QueryParam("firstName") String first,
+                  @QueryParam("email") String email,
+                  @QueryParam("emailVerified") Boolean emailVerified,
+                  @QueryParam("username") String username,
+                  @QueryParam("enabled") Boolean enabled,
+                  @QueryParam("idpAlias") String idpAlias,
+                  @QueryParam("idpUserId") String idpUserId,
+                  @QueryParam("exact") Boolean exact,
+                  @QueryParam("q") String searchQuery,
+                  @QueryParam("createdAfter") String createdAfter,
+                  @QueryParam("createdBefore") String createdBefore);
 
     /**
      * Returns the number of users with the given status for emailVerified.

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -1072,6 +1072,12 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
                     }
                     break;
                 }
+                case UserModel.CREATED_AFTER:
+                    predicates.add(builder.greaterThanOrEqualTo(root.get("createdTimestamp"), Long.parseLong(value)));
+                    break;
+                case UserModel.CREATED_BEFORE:
+                    predicates.add(builder.lessThanOrEqualTo(root.get("createdTimestamp"), Long.parseLong(value)));
+                    break;
                 default:
                     // All unknown attributes will be assumed as custom attributes
                     Join<UserEntity, UserAttributeEntity> attributesJoin = root.join("attributes", JoinType.LEFT);

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.6.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.6.0.xml
@@ -120,4 +120,16 @@
         </addColumn>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.6.0-43829-user-created-timestamp-index">
+        <preConditions onSqlOutput="TEST" onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="USER_ENTITY" indexName="IDX_USER_CREATED_TIMESTAMP" />
+            </not>
+        </preConditions>
+        <createIndex tableName="USER_ENTITY" indexName="IDX_USER_CREATED_TIMESTAMP">
+            <column name="REALM_ID" type="VARCHAR(255)" />
+            <column name="CREATED_TIMESTAMP" type="BIGINT" />
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/server-spi/src/main/java/org/keycloak/models/UserModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserModel.java
@@ -47,6 +47,8 @@ public interface UserModel extends RoleMapperModel, Model {
     String GROUPS = "keycloak.session.realm.users.query.groups";
     String SEARCH = "keycloak.session.realm.users.query.search";
     String EXACT = "keycloak.session.realm.users.query.exact";
+    String CREATED_AFTER = "keycloak.session.realm.users.query.created_after";
+    String CREATED_BEFORE = "keycloak.session.realm.users.query.created_before";
     String DISABLED_REASON = "disabledReason";
     //attribute name used to mark a temporary admin user/service account as temporary
     String IS_TEMP_ADMIN_ATTR_NAME = "is_temporary_admin";

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryMethodsProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryMethodsProvider.java
@@ -94,6 +94,8 @@ public interface UserQueryMethodsProvider {
      *     from idp with the given alias configured (case sensitive string)</li>
      *     <li>{@link UserModel#IDP_USER_ID} - search for users with federated identity with
      *     the given userId (case sensitive string)</li>
+     *     <li>{@link UserModel#CREATED_AFTER} - search only for users created after (inclusive) the given timestamp (epoch milliseconds)</li>
+     *     <li>{@link UserModel#CREATED_BEFORE} - search only for users created before (inclusive) the given timestamp (epoch milliseconds)</li>
      * </ul>
      * <p>
      * Any other parameters will be treated as custom user attributes.
@@ -126,6 +128,8 @@ public interface UserQueryMethodsProvider {
      *     from idp with the given alias configured (case sensitive string)</li>
      *     <li>{@link UserModel#IDP_USER_ID} - search for users with federated identity with
      *     the given userId (case sensitive string)</li>
+     *     <li>{@link UserModel#CREATED_AFTER} - search only for users created after (inclusive) the given timestamp (epoch milliseconds)</li>
+     *     <li>{@link UserModel#CREATED_BEFORE} - search only for users created before (inclusive) the given timestamp (epoch milliseconds)</li>
      * </ul>
      * <p>
      * Any other parameters will be treated as custom user attributes.

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
@@ -67,6 +68,7 @@ import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.UserPermissionEvaluator;
+import org.keycloak.services.util.DateUtil;
 import org.keycloak.userprofile.UserProfile;
 import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.userprofile.UserProfileProvider;
@@ -287,7 +289,9 @@ public class UsersResource {
             @Parameter(description = "Boolean representing if user is enabled or not") @QueryParam("enabled") Boolean enabled,
             @Parameter(description = "Boolean which defines whether brief representations are returned (default: false)") @QueryParam("briefRepresentation") Boolean briefRepresentation,
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
-            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery) {
+            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
+            @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
 
         userPermissionEvaluator.requireQuery();
@@ -316,12 +320,14 @@ public class UsersResource {
                 if (emailVerified != null) {
                     attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
                 }
+                addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
 
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
                         maxResults, false);
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
-                || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()) {
+                || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
+                || createdAfter != null || createdBefore != null) {
                     Map<String, String> attributes = new HashMap<>();
                     if (last != null) {
                         attributes.put(UserModel.LAST_NAME, last);
@@ -350,6 +356,7 @@ public class UsersResource {
                     if (exact != null) {
                         attributes.put(UserModel.EXACT, exact.toString());
                     }
+                    addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
 
                     attributes.putAll(searchAttributes);
 
@@ -417,7 +424,9 @@ public class UsersResource {
             @Parameter(description = "The userId at an Identity Provider linked to the user") @QueryParam("idpUserId") String idpUserId,
             @Parameter(description = "Boolean representing if user is enabled or not") @QueryParam("enabled") Boolean enabled,
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
-            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery) {
+            @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
+            @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
         userPermissionEvaluator.requireQuery();
 
@@ -439,6 +448,7 @@ public class UsersResource {
             if (emailVerified != null) {
                 parameters.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
             }
+            addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             // search /users equivalent to this doesn't include service-accounts so counting shouldn't as well
             parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
             if (userPermissionEvaluator.canView()) {
@@ -451,7 +461,8 @@ public class UsersResource {
                 }
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
-                || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()) {
+                || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
+                || createdAfter != null || createdBefore != null) {
             Map<String, String> parameters = new HashMap<>();
             if (last != null) {
                 parameters.put(UserModel.LAST_NAME, last);
@@ -480,6 +491,7 @@ public class UsersResource {
             if (exact != null) {
                 parameters.put(UserModel.EXACT, exact.toString());
             }
+            addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             parameters.putAll(searchAttributes);
             // search /users equivalent to this does include service-accounts so we should be explicit
             parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "true");
@@ -517,6 +529,23 @@ public class UsersResource {
     @Path("profile")
     public UserProfileResource userProfile() {
         return new UserProfileResource(session, auth, adminEvent);
+    }
+
+    private static void addCreatedTimestampConditions(Map<String, String> attributes, String createdAfter, String createdBefore) {
+        if (createdAfter != null) {
+            try {
+                attributes.put(UserModel.CREATED_AFTER, String.valueOf(DateUtil.toStartOfDay(createdAfter)));
+            } catch (Throwable t) {
+                throw new BadRequestException("Invalid value for 'createdAfter', expected format is yyyy-MM-dd or an Epoch timestamp");
+            }
+        }
+        if (createdBefore != null) {
+            try {
+                attributes.put(UserModel.CREATED_BEFORE, String.valueOf(DateUtil.toEndOfDay(createdBefore)));
+            } catch (Throwable t) {
+                throw new BadRequestException("Invalid value for 'createdBefore', expected format is yyyy-MM-dd or an Epoch timestamp");
+            }
+        }
     }
 
     private Stream<UserRepresentation> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -1,5 +1,7 @@
 package org.keycloak.tests.admin.user;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -864,6 +866,149 @@ public class UserSearchTest extends AbstractUserTest {
         assertEquals(countWithIdpUserId.intValue(), usersWithIdpUserId.size(), "Count and search should return same number with idpUserId parameter");
         
         managedRealm.admin().clients().get(clientId).remove();
+    }
+
+    @Test
+    public void searchByCreatedAfter() {
+        long beforeCreation = System.currentTimeMillis();
+        createUser("timestampuser1", "timestampuser1@localhost");
+        createUser("timestampuser2", "timestampuser2@localhost");
+
+        // All users created at or after beforeCreation should be returned
+        List<UserRepresentation> users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                String.valueOf(beforeCreation), null);
+        List<String> usernames = users.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        assertTrue(usernames.contains("timestampuser1"), "Should contain timestampuser1");
+        assertTrue(usernames.contains("timestampuser2"), "Should contain timestampuser2");
+
+        // Using a future timestamp should return no users
+        long futureTimestamp = System.currentTimeMillis() + 100_000;
+        users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                String.valueOf(futureTimestamp), null);
+        assertTrue(users.isEmpty(), "No users should be created after a future timestamp");
+    }
+
+    @Test
+    public void searchByCreatedBefore() {
+        createUser("beforeuser1", "beforeuser1@localhost");
+        long afterCreation = System.currentTimeMillis();
+
+        // All users created at or before afterCreation should include beforeuser1
+        List<UserRepresentation> users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                null, String.valueOf(afterCreation));
+        List<String> usernames = users.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        assertTrue(usernames.contains("beforeuser1"), "Should contain beforeuser1");
+
+        // Using a very old timestamp should return no users
+        List<UserRepresentation> noUsers = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                null, "1");
+        assertTrue(noUsers.isEmpty(), "No users should be created before epoch 1ms");
+    }
+
+    @Test
+    public void searchByCreatedBeforeAndAfter() {
+        long beforeFirst = System.currentTimeMillis();
+        createUser("rangeuser1", "rangeuser1@localhost");
+        long afterFirst = System.currentTimeMillis();
+
+        // Range query: both inclusive bounds
+        List<UserRepresentation> users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                String.valueOf(beforeFirst), String.valueOf(afterFirst));
+        List<String> usernames = users.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        assertTrue(usernames.contains("rangeuser1"), "Should contain rangeuser1 in range");
+
+        // Empty range: after > before should return no users
+        users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                String.valueOf(afterFirst + 100_000), String.valueOf(beforeFirst));
+        assertTrue(users.isEmpty(), "Inverted range should return no users");
+    }
+
+    @Test
+    public void searchByCreatedTimestampWithIsoDate() {
+        createUser("isodateuser1", "isodateuser1@localhost");
+
+        // Today's date in ISO-8601 format should include the user we just created
+        String today = LocalDate.now(ZoneOffset.UTC).toString();
+        List<UserRepresentation> users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                today, today);
+        List<String> usernames = users.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        assertTrue(usernames.contains("isodateuser1"), "Should contain user created today using ISO date filter");
+
+        // Yesterday should work as createdBefore (end-of-day) — but user was created today, so createdAfter=tomorrow should exclude
+        String tomorrow = LocalDate.now(ZoneOffset.UTC).plusDays(1).toString();
+        users = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, null, null,
+                tomorrow, null);
+        usernames = users.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        Assertions.assertFalse(usernames.contains("isodateuser1"), "Should not contain user when createdAfter is tomorrow");
+    }
+
+    @Test
+    public void countByCreatedTimestamp() {
+        long beforeCreation = System.currentTimeMillis();
+        createUser("countuser1", "countuser1@localhost");
+        createUser("countuser2", "countuser2@localhost");
+        long afterCreation = System.currentTimeMillis();
+
+        Integer count = managedRealm.admin().users().count(
+                null, null, null, null, null, null, null, null, null, null, null,
+                String.valueOf(beforeCreation), String.valueOf(afterCreation));
+        assertEquals(2, count.intValue(), "Should count 2 users created in the time range");
+
+        // Future range should count 0
+        Integer zeroCount = managedRealm.admin().users().count(
+                null, null, null, null, null, null, null, null, null, null, null,
+                String.valueOf(afterCreation + 100_000), null);
+        assertEquals(0, zeroCount.intValue(), "Should count 0 users for future timestamp");
+
+        // Count using ISO date (today) should include the users
+        String today = LocalDate.now(ZoneOffset.UTC).toString();
+        Integer isoCount = managedRealm.admin().users().count(
+                null, null, null, null, null, null, null, null, null, null, null,
+                today, today);
+        assertTrue(isoCount >= 2, "Should count at least 2 users created today using ISO date");
+    }
+
+    @Test
+    public void searchByCreatedTimestampWithOtherFilters() {
+        long beforeCreation = System.currentTimeMillis();
+
+        UserRepresentation enabledUser = new UserRepresentation();
+        enabledUser.setUsername("tsenableduser");
+        enabledUser.setEmail("tsenableduser@localhost");
+        enabledUser.setEnabled(true);
+        createUser(enabledUser);
+
+        UserRepresentation disabledUser = new UserRepresentation();
+        disabledUser.setUsername("tsdisableduser");
+        disabledUser.setEmail("tsdisableduser@localhost");
+        disabledUser.setEnabled(false);
+        createUser(disabledUser);
+
+        long afterCreation = System.currentTimeMillis();
+
+        // Search with createdAfter + enabled=true
+        List<UserRepresentation> enabledUsers = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, true, null,
+                String.valueOf(beforeCreation), String.valueOf(afterCreation));
+        List<String> usernames = enabledUsers.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        assertTrue(usernames.contains("tsenableduser"), "Should contain enabled user");
+        Assertions.assertFalse(usernames.contains("tsdisableduser"), "Should not contain disabled user");
+
+        // Search with createdAfter + enabled=false
+        List<UserRepresentation> disabledUsers = managedRealm.admin().users().search(
+                null, null, null, null, null, null, null, 0, 100, false, null,
+                String.valueOf(beforeCreation), String.valueOf(afterCreation));
+        usernames = disabledUsers.stream().map(UserRepresentation::getUsername).collect(Collectors.toList());
+        assertTrue(usernames.contains("tsdisableduser"), "Should contain disabled user");
+        Assertions.assertFalse(usernames.contains("tsenableduser"), "Should not contain enabled user");
     }
 
     @Test


### PR DESCRIPTION
Add server-side filtering of users by creation timestamp on the admin REST API. This avoids the need to retrieve all users and filter client-side, which is inefficient for large realms.

Two optional query parameters are added to both the user list and count endpoints. They accept either ISO-8601 date strings (yyyy-MM-dd) or epoch milliseconds, consistent with the existing events API date filtering via DateUtil.

Closes #43829

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
