### PR TITLE
fix: updating the fix for docker ulimits

### DIFF
--- a/docs/guides/server/containers.adoc
+++ b/docs/guides/server/containers.adoc
@@ -193,14 +193,7 @@ Opening up `https://localhost:9000/metrics` leads to a page containing operation
 === Known issues with Docker
 
 * If a `RUN dnf install` command seems to be taking an excessive amount of time, then likely your Docker systemd service has the file limit setting `LimitNOFILE` configured incorrectly.
-Either update the service configuration to use a better value, such as 1024000, or directly use `ulimit` in the RUN command:
-
-[source, dockerfile]
-----
-...
-RUN ulimit -n 1024000 && dnf install --installroot ...
-...
-----
+Either update the service configuration to use a better value, such as 1024000, or use `--ulimit` in the https://docs.docker.com/reference/cli/docker/buildx/build/#ulimit[docker build command], e.g. `--ulimit nofile=1024000`.
 
 * If you are including provider JARs and your container fails a `start --optimized` with a notification that a provider JAR has changed, this is due to Docker truncating
 or otherwise modifying file modification timestamps from what the `build` command recorded to what is seen at runtime.

--- a/operator/README.md
+++ b/operator/README.md
@@ -48,7 +48,7 @@ Vanilla minikube does not support Network Policies, and Cilium implements the CN
 Another CNI implementation may work too.
 
 ```bash
-minikube start --addons ingress --cni cilium
+minikube start --addons ingress --cni cilium --cpus=max
 ```
 
 Enable the Minikube Docker daemon:
@@ -113,7 +113,7 @@ minikube addons enable ingress
 To avoid skipping tests that are depending on custom Keycloak images, you need to build those first:
 
 ```bash
-./build-testing-docker-images.sh [SOURCE KEYCLOAK IMAGE TAG] [SOURCE KEYCLOAK IMAGE]
+./scripts/build-testing-docker-images.sh [SOURCE KEYCLOAK IMAGE TAG] [SOURCE KEYCLOAK IMAGE]
 ```
 
 And run the tests passing an extra Java property:

--- a/operator/scripts/olm-testing.sh
+++ b/operator/scripts/olm-testing.sh
@@ -17,7 +17,7 @@ VERSION="86400000.0.0"
 (
   cd $SCRIPT_DIR/../../quarkus/container
   
-  docker build --build-arg KEYCLOAK_DIST=$(ls keycloak-*.tar.gz) . -t "$REGISTRY/${UUID}keycloak:${VERSION}"
+  docker build --ulimit nofile=1024000 --build-arg KEYCLOAK_DIST=$(ls keycloak-*.tar.gz) . -t "$REGISTRY/${UUID}keycloak:${VERSION}"
   docker push "$REGISTRY/${UUID}keycloak:${VERSION}"
 )
 

--- a/operator/src/main/resources/application.properties
+++ b/operator/src/main/resources/application.properties
@@ -30,3 +30,5 @@ quarkus.operator-sdk.bundle.channels=fast
 
 quarkus.operator-sdk.namespaces=JOSDK_WATCH_CURRENT
 quarkus.operator-sdk.generate-with-watched-namespaces=JOSDK_WATCH_CURRENT
+
+quarkus.docker.additional-args=--ulimit,nofile=1024000


### PR DESCRIPTION
it will now be applied by default in the operator image building

To be considered as a replacement for https://github.com/keycloak/keycloak/pull/44233 since the updates directly in the Dockerfiles were getting messy.

closes: #44232

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
