### PR TITLE
Added RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST - Fixes policy enforcement gap for direct access grant flows

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
@@ -70,6 +70,7 @@ public class ClientAccessTypeCondition extends AbstractClientPolicyConditionProv
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
         switch (context.getEvent()) {
             case AUTHORIZATION_REQUEST:
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
             case TOKEN_REQUEST:
             case TOKEN_RESPONSE:
             case SERVICE_ACCOUNT_TOKEN_REQUEST:

--- a/services/src/main/resources/keycloak-lax-client-policies.json
+++ b/services/src/main/resources/keycloak-lax-client-policies.json
@@ -1,0 +1,44 @@
+{
+    "policies": [
+        {
+           "name": "Openid-connect OAuth 2.1 confidential client",
+           "description": "Openid-connect confidential client policy to ensure OAuth 2.1 specification.",
+           "enabled": true,
+           "conditions": [
+               {
+                   "condition": "client-type",
+                   "configuration": {
+                       "protocol": "openid-connect"
+                   }
+               },
+               {
+                   "condition": "client-access-type",
+                   "configuration": {
+                       "type": [
+                           "confidential"
+                       ]
+                   }
+               }
+           ],
+           "profiles": [
+               "oauth-2-1-for-confidential-client"
+           ]
+       },
+       {
+           "name": "Saml secure client (signatures, post, https)",
+           "description": "Saml policy to ensure signatures, POST binding and https URLs.",
+           "enabled": true,
+           "conditions": [
+               {
+                   "condition": "client-type",
+                   "configuration": {
+                       "protocol": "saml"
+                   }
+               }
+           ],
+           "profiles": [
+               "saml-security-profile"
+           ]
+       }
+   ]
+}

--- a/services/src/main/resources/lax-security-profile.json
+++ b/services/src/main/resources/lax-security-profile.json
@@ -1,5 +1,5 @@
 {
   "name":"lax",
   "client-profiles":"keycloak-default-client-profiles",
-  "client-policies":null
+  "client-policies":"keycloak-lax-client-policies"
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
@@ -111,6 +111,7 @@ import static org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper.PAIRWIS
 import static org.keycloak.protocol.oidc.mappers.RoleNameMapper.NEW_ROLE_NAME;
 import static org.keycloak.protocol.oidc.mappers.RoleNameMapper.ROLE_CONFIG;
 import static org.keycloak.testsuite.AbstractAdminTest.loadJson;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createAnyClientConditionConfig;
 
 public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
     private static final Logger logger = Logger.getLogger(LightWeightAccessTokenTest.class);
@@ -937,7 +938,7 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Use Lightweight Access Token Policy", Boolean.TRUE)
                         .addCondition(AnyClientConditionFactory.PROVIDER_ID,
-                                ClientPoliciesUtil.createAnyClientConditionConfig())
+                                createAnyClientConditionConfig())
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
@@ -56,6 +56,7 @@ import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.executor.UseLightweightAccessTokenExecutorFactory;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -110,7 +111,6 @@ import static org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper.PAIRWIS
 import static org.keycloak.protocol.oidc.mappers.RoleNameMapper.NEW_ROLE_NAME;
 import static org.keycloak.protocol.oidc.mappers.RoleNameMapper.ROLE_CONFIG;
 import static org.keycloak.testsuite.AbstractAdminTest.loadJson;
-import static org.keycloak.testsuite.util.ClientPoliciesUtil.createAnyClientConditionConfig;
 
 public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
     private static final Logger logger = Logger.getLogger(LightWeightAccessTokenTest.class);
@@ -608,6 +608,43 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
         setScopeProtocolMapper("master", OIDCLoginProtocolFactory.BASIC_SCOPE, "sub", true, false, false);
     }
 
+    @Test
+    public void testPublicClientWithLightweightAccessTokenViaDirectGrant() throws Exception {
+        // Setup client policy with client-access-type=public + lightweight token executor
+        String json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Lightweight Token for Public Clients")
+                        .addExecutor(UseLightweightAccessTokenExecutorFactory.PROVIDER_ID, null)
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Public Client Policy", Boolean.TRUE)
+                        .addCondition(ClientAccessTypeConditionFactory.PROVIDER_ID,
+                                ClientPoliciesUtil.createClientAccessTypeConditionConfig(List.of(ClientAccessTypeConditionFactory.TYPE_PUBLIC)))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // Create public client with direct access grants
+        String publicClientId = generateSuffixedName("public-direct-grant-client");
+        createClientByAdmin(publicClientId, (ClientRepresentation clientRep) -> {
+            clientRep.setPublicClient(Boolean.TRUE);
+            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
+        });
+
+        // Perform direct access grant (POST with username/password)
+        oauth.client(publicClientId);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        // Verify lightweight token
+        AccessToken token = oauth.verifyToken(response.getAccessToken());
+        AccessTokenContext ctx = testingClient.testing(REALM_NAME).getTokenContext(token.getId());
+        Assert.assertEquals(AccessTokenContext.TokenType.LIGHTWEIGHT, ctx.getTokenType());
+        Assert.assertEquals(TEST_USER_PASSWORD, ctx.getGrantType());
+    }
+
     private void removeSession(final String sessionId) {
         testingClient.testing().removeExpired(REALM_NAME);
         try {
@@ -900,7 +937,7 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
         json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
                 (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Use Lightweight Access Token Policy", Boolean.TRUE)
                         .addCondition(AnyClientConditionFactory.PROVIDER_ID,
-                                createAnyClientConditionConfig())
+                                ClientPoliciesUtil.createAnyClientConditionConfig())
                         .addProfile(PROFILE_NAME)
                         .toRepresentation()
         ).toString();


### PR DESCRIPTION
Apply ClientAccessTypeCondition to password grant requests

Add RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST event handling to 
ClientAccessTypeCondition for consistent policy enforcement. 

Closes [#45740](https://github.com/keycloak/keycloak/issues/45740)