### PR TITLE
Update name field validation logic in `NewClientPolicy` component

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
@@ -478,7 +478,9 @@ export default function NewClientPolicy() {
               rules={{
                 required: t("required"),
                 validate: (value) =>
-                  policies.some((policy) => policy.name === value)
+                  policies.some(
+                    (policy) => policyName !== value && policy.name === value,
+                  )
                     ? t("createClientProfileNameHelperText")
                     : true,
               }}


### PR DESCRIPTION
The `NewClientPolicy` component is reused for creating a client policy and editing an existing client policy. If the form is not valid the save button is disabled. This PR updates the name field form validation. Given the `policyName` constant is only defined when editing an existing client policy, short-circuit the validation logic to only verify the new policy name has not been taken if `policyName` does not match the new name.

With this form validation logic, the expected behavior of the form is enabled:
### Fixes:
- [x] The Save-button does not become active when I add a client profile
- [x] The Save-button does not become inactive when I save the client profile
- [x] When I change the name, and then change the name back to the original name, I get the error message "The name must be unique within the realm"
- [x] ~~When I save a client policy, the conditions and client profiles should be visible~~
  - this may have been fixed somewhere else, I was not able to reproduce invisible conditions or policies after rebase on main

Closes #45948
