### PR TITLE
Upgrade docker-maven-plugin to last version (26.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <central.publishing.plugin.version>0.7.0</central.publishing.plugin.version>
         <nexus3.staging.plugin.version>1.0.7</nexus3.staging.plugin.version>
         <frontend.plugin.version>1.15.0</frontend.plugin.version>
-        <docker.maven.plugin.version>0.40.3</docker.maven.plugin.version>
+        <docker.maven.plugin.version>0.48.1</docker.maven.plugin.version>
         <verifier.plugin.version>1.1</verifier.plugin.version>
         <shade.plugin.version>3.4.1</shade.plugin.version>
         <smallrye.openapi.generator.plugin.version>3.6.2</smallrye.openapi.generator.plugin.version>


### PR DESCRIPTION
Closes #46312

PR:             https://github.com/keycloak/keycloak/pull/46313
Commit:         https://github.com/keycloak/keycloak/commit/1f49f67991b5f8f52ab8c77c586c8eb3be545b6b
PR branch:      backport-46313-26.4
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.4

