### PR TITLE
Added `parentId` to `GroupRepresentation`

### DIFF
--- a/js/libs/keycloak-admin-client/src/defs/groupRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/groupRepresentation.ts
@@ -7,6 +7,7 @@ export default interface GroupRepresentation {
   name?: string;
   description?: string;
   path?: string;
+  parentId?: string;
   subGroupCount?: number;
   subGroups?: GroupRepresentation[];
 


### PR DESCRIPTION
Fixing the definition of `GroupRepresentation` in the nodejs package [@keycloak/keycloak-admin-client](https://www.npmjs.com/package/@keycloak/keycloak-admin-client) by adding `parentId`, as it exists in the latest [Keycloak Admin API documentation](https://www.keycloak.org/docs-api/latest/rest-api/index.html#GroupRepresentation).

Closes #46366