### PR TITLE
Update container images to use OpenJDK 25

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,6 +1,6 @@
 ## Building from source
 
-Ensure you have **JDK 17** or **JDK 21** and Git installed
+Ensure you have **JDK 17**, **JDK 21** or **JDK 25** and Git installed
 
     java -version
     git --version
@@ -9,7 +9,7 @@ Newer versions of the JDK are not supported. If you have multiple JDK versions
 installed, you can specify which one to use during the build by setting the `JAVA_HOME`
 environment variable (this should be the directory containing `/bin/` or `/jre/`).
 
-    JAVA_HOME=/path/to/jdk-21/ ./mvnw clean install
+    JAVA_HOME=/path/to/jdk-25/ ./mvnw clean install
 
 Instead of using a locally installed Maven, call the Maven wrapper script `mvnw` in the main folder of the project.
 This will use the Maven version which is supported by this project.

--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -57,4 +57,4 @@ For more details on the Operator configuration, see the https://www.keycloak.org
 
 = Java 25 support
 
-{project_name} now supports running with JRE 25.
+{project_name} now supports running with JRE 25. OpenJDK 25 is also now used in the official container images.

--- a/docs/documentation/server_admin/topics/user-federation/sssd.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/sssd.adoc
@@ -156,7 +156,7 @@ ipaapi:x:992:988:IPA Framework User:/:/sbin/nologin
 
 {project_name} uses https://github.com/hypfvieh/dbus-java[DBus-Java] project to communicate at a low level with D-Bus and https://github.com/java-native-access/jna[JNA] to authenticate via Operating System Pluggable Authentication Modules (PAM).
 
-Although now {project_name} contains all the needed libraries to run the `SSSD` provider, JDK version 21 is needed. Therefore the `SSSD` provider will only be displayed when the host configuration is correct and JDK 21 is used to run {project_name}.
+Although now {project_name} contains all the needed libraries to run the `SSSD` provider, JDK version 21 or later is needed. Therefore the `SSSD` provider will only be displayed when the host configuration is correct and JDK 21 or later is used to run {project_name}.
 
 ==== Configuring a federated SSSD store
 

--- a/docs/documentation/server_development/topics/preface.adoc
+++ b/docs/documentation/server_development/topics/preface.adoc
@@ -1,7 +1,14 @@
 == Preface
 
+=== Container Images
+
+The official {project_name} container image uses OpenJDK {jdk_version_recommended} as the Java runtime environment.
+Consider this when writing custom extensions.
+
+=== Example Listings
+
 In some of the example listings, what is meant to be displayed on one line does not fit inside the available page width. These lines have been broken up. A '\' at the end of a line means that a break has been introduced to fit in the page, with the following lines indented.
-So: 
+So:
 
 [source]
 ----
@@ -9,12 +16,12 @@ Let's pretend to have an extremely \
   long line that \
   does not fit
 This one is short
-----         
-Is really: 
+----
+Is really:
 
 [source]
 ----
 Let's pretend to have an extremely long line that does not fit
 This one is short
-----      
+----
 

--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -7,6 +7,8 @@
 :project_versionNpm: 999.0.0-SNAPSHOT
 :project_versionDoc: DEV
 
+:jdk_version_recommended: 25
+
 :archivebasename: keycloak
 :archivedownloadurl: https://github.com/keycloak/keycloak/releases/download/{project_version}/keycloak-{project_version}.zip
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -137,6 +137,10 @@ They should avoid keeping the returned items in memory by for example binding th
 
 A similar change was done for the `UserSessionPersisterProvider`.
 
+=== OpenJDK upgrade
+
+The official container images for server and the Operator now use OpenJDK 25 instead of previously used OpenJDK 21.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/docs/guides/attributes.adoc
+++ b/docs/guides/attributes.adoc
@@ -1,5 +1,8 @@
 :project_name: Keycloak
 :project_images: keycloak-images
+
+:jdk_version_recommended: 25
+
 :project_doc_base_url: https://www.keycloak.org/docs/latest
 :project_doc_base_url_latest: https://www.keycloak.org/docs/{version}
 :project_dirref: KEYCLOAK_HOME

--- a/docs/guides/getting-started/getting-started-zip.adoc
+++ b/docs/guides/getting-started/getting-started-zip.adoc
@@ -13,7 +13,7 @@ summary="Get started with {project_name} on a physical or virtual server.">
 
 include::templates/hw-requirements.adoc[]
 
-Make sure you have https://openjdk.java.net/[OpenJDK 25] installed.
+Make sure you have https://openjdk.java.net/[OpenJDK {jdk_version_recommended}] installed.
 
 == Download {project_name}
 

--- a/docs/guides/high-availability/single-cluster/concepts-threads.adoc
+++ b/docs/guides/high-availability/single-cluster/concepts-threads.adoc
@@ -19,9 +19,9 @@ For a configuration where this is applied, visit <@links.ha id="single-cluster-d
 // https://github.com/keycloak/keycloak/issues/31101
 
 JGroups communications, which is used in single-cluster setups for the communication between {project_name} nodes,
-benefits from the use of virtual threads which are available in OpenJDK 21 when at least four cores are available for {project_name}.
+benefits from the use of virtual threads which are available in OpenJDK 21 or later when at least four cores are available for {project_name}.
 This reduces the memory usage and removes the need to configure thread pool sizes.
-Therefore, the use of OpenJDK 21 is recommended.
+For best performance, use OpenJDK {jdk_version_recommended} or later.
 
 <#include "/high-availability/partials/concepts/threads.adoc" />
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 
 ADD target/ubi-null.sh /tmp/
-RUN bash /tmp/ubi-null.sh java-21-openjdk-headless glibc-langpack-en
+RUN bash /tmp/ubi-null.sh java-25-openjdk-headless glibc-langpack-en
 
 FROM registry.access.redhat.com/ubi9-micro
 ENV LANG=en_US.UTF-8

--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -17,7 +17,7 @@ RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 RUN chmod -R g+rwX /opt/keycloak
 
 ADD ubi-null.sh /tmp/
-RUN bash /tmp/ubi-null.sh java-21-openjdk-headless glibc-langpack-en findutils
+RUN bash /tmp/ubi-null.sh java-25-openjdk-headless glibc-langpack-en findutils
 
 FROM registry.access.redhat.com/ubi9-micro
 ENV LANG=en_US.UTF-8


### PR DESCRIPTION
This PR is mostly based on https://github.com/vmuzikar/keycloak/commit/303446b465f2896b269df42388a685ec69b22560. Additionally, I made few tweaks to documentation and introduce a doc variable for the recommended Java version so limit required changing when migrating the recommended JDK version. I didn't change `concepts-memory-and-cpu-sizing.adoc` references architecture of some past experiment, so when it says OpenJDK 21, I think it is still true.

* Closes: https://github.com/keycloak/keycloak/issues/45830
