### PR TITLE
Fix resource selection display in scope-based permission creation

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/ResourcesPolicySelect.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/ResourcesPolicySelect.tsx
@@ -284,7 +284,7 @@ export const ResourcesPolicySelect = ({
             selections={
               variant === SelectVariant.typeaheadMulti
                 ? field.value
-                : items.find((i) => i.id === field.value?.[0])?.name
+                : selected.find((i) => i.id === field.value?.[0])?.name
             }
             onSelect={(selectedValue) => {
               const option = selectedValue.toString();
@@ -297,6 +297,10 @@ export const ResourcesPolicySelect = ({
                 field.onChange(changedValue);
               } else {
                 field.onChange([option]);
+                const selectedItem = items.find((i) => i.id === option);
+                if (selectedItem) {
+                  setSelected([selectedItem]);
+                }
               }
 
               setSearch("");


### PR DESCRIPTION
### Summary

- Fix single-select typeahead not displaying the selected resource name when the resource is outside the initial 10 results
- Resolve display from selected state (fetched by ID, always stable) instead of items (paginated search results that reset)
- Eagerly update selected on item pick so the name is available immediately without waiting for an async round-trip

Closes #46384