### PR TITLE
Check offline session too in the broker OIDC endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -385,6 +385,9 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
             }
             UserSessionModel userSession = session.sessions().getUserSession(realm, state);
             if (userSession == null) {
+                userSession = session.sessions().getOfflineUserSession(realm, state);
+            }
+            if (userSession == null) {
                 logger.error("no valid user session");
                 EventBuilder event = new EventBuilder(realm, session, clientConnection);
                 event.event(EventType.LOGOUT);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -308,15 +308,20 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
         return contextRoot + "/auth/realms/" + realmName + "/account";
     }
 
+    protected String getLoginUrl(String contextRoot, String realmName, String clientId) {
+        return getLoginUrl(contextRoot, realmName, clientId, "openid");
+    }
+
     /**
      * Get the login page for an existing client in provided realm
      *
      * @param contextRoot server base url without /auth
      * @param realmName Name of the realm
      * @param clientId ClientId of a client. Client has to exists in the realm.
+     * @param scope The scope parameter for the request
      * @return Login URL
      */
-    protected String getLoginUrl(String contextRoot, String realmName, String clientId) {
+    protected String getLoginUrl(String contextRoot, String realmName, String clientId, String scope) {
         List<ClientRepresentation> clients = adminClient.realm(realmName).clients().findByClientId(clientId);
 
         assertThat(clients, Matchers.is(Matchers.not(Matchers.empty())));
@@ -327,7 +332,7 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
         }
 
         return contextRoot + "/auth/realms/" + realmName + "/protocol/openid-connect/auth?client_id=" +
-                clientId + "&redirect_uri=" + redirectURI + "&response_type=code&scope=openid";
+                clientId + "&redirect_uri=" + redirectURI + "&response_type=code&scope=" + scope;
     }
 
     protected void logoutFromRealm(String contextRoot, String realm) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutFrontChannelTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutFrontChannelTest.java
@@ -9,6 +9,8 @@ import org.keycloak.representations.IDToken;
 import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -73,6 +75,42 @@ public class KcOidcBrokerLogoutFrontChannelTest extends AbstractKcOidcBrokerLogo
         oauth.redirectUri(getConsumerRoot() + "/auth/realms/" + REALM_PROV_NAME + "/account");
         loginPage.open(REALM_PROV_NAME);
 
+        waitForPage(driver, "sign in to provider", true);
+    }
+
+    @Test
+    public void logoutIdPWithOfflineSession() {
+        // login with offline_access in the application using IdP
+        driver.navigate().to(getLoginUrl(getConsumerRoot(), bc.consumerRealmName(), "broker-app", "openid offline_access"));
+        logInWithBroker(bc);
+        updateAccountInformation();
+
+        // Exchange code from "broker-app" client of "consumer" realm for the tokens
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse response = oauth.realm(bc.consumerRealmName())
+                .client("broker-app", "broker-app-secret")
+                .redirectUri(getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/app")
+                .doAccessTokenRequest(code);
+        assertEquals(200, response.getStatusCode());
+        MatcherAssert.assertThat(response.getScope(), Matchers.containsString("offline_access"));
+
+        String idTokenString = response.getIdToken();
+
+        executeLogoutFromRealm(
+                getConsumerRoot(),
+                bc.consumerRealmName(),
+                "something-else",
+                idTokenString,
+                null,
+                null
+        );
+        infoPage.assertCurrent();
+        assertEquals("You are logged out", infoPage.getInfo());
+
+        // user should be logged out successfully from the IDP
+        oauth.clientId(bc.getIDPClientIdInProviderRealm());
+        oauth.redirectUri(BrokerTestTools.getConsumerRoot() + "/auth/realms/" + REALM_CONS_NAME + "/broker/" + bc.getIDPAlias() + "/endpoint/*");
+        loginPage.open(REALM_PROV_NAME);
         waitForPage(driver, "sign in to provider", true);
     }
 }


### PR DESCRIPTION
Closes #46379

Commit https://github.com/keycloak/keycloak/commit/88069cd5fb2a30c8a388040b0aebef0b38641604 in issue https://github.com/keycloak/keycloak/issues/40398 added offline sessions in the logout. But the endpoint was not modified in the same way. This way the frontend logout failed because the session is not found when going back from the external IdP. Test added.