### PR TITLE
Skip broken glibc-common requirement for patch release v10

### DIFF
--- a/quarkus/container/ubi-null.sh
+++ b/quarkus/container/ubi-null.sh
@@ -44,7 +44,7 @@ dnf install -y findutils diffutils
 # Install core packages to chroot
 rootfs="$(realpath rootfs)"
 mkdir -p "$rootfs"
-<keep xargs dnf install -y --installroot "$rootfs" --releasever 9 --setopt install_weak_deps=false --nodocs
+<keep xargs dnf install -y --installroot "$rootfs" --releasever 9 --setopt install_weak_deps=false --nodocs --skip-broken
 dnf --installroot "$rootfs" clean all
 rm -rf "$rootfs"/var/cache/* "$rootfs"/var/log/dnf* "$rootfs"/var/log/yum.*
 { set +x; } 2>/dev/null


### PR DESCRIPTION
**This unblocks our CI for now, but we'd need to find out why there's the requirement to have the v10 patch.**

Error:
```
#14 2.220 Error: 
#14 2.220  Problem: conflicting requests
#14 2.220   - nothing provides glibc-common = 2.34-231.el9_7.10 needed by glibc-langpack-en-2.34-231.el9_7.10.x86_64 from ubi-9-baseos-rpms
#14 2.221 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
#14 ERROR: process "/bin/sh -c bash /tmp/ubi-null.sh java-21-openjdk-headless glibc-langpack-en findutils" did not complete successfully: exit code: 123
```

The requirement is to use the `glibc-common = 2.34-231.el9_7.10`, but there's no patch release v10 for this. Only the v2 as the `glibc-common = 2.34-231.el9_7.2`.

After applying these changes, the installed package is `glibc-common = 2.34-231.el9_7.2`:
<img width="563" height="492" alt="Screenshot From 2026-02-17 13-56-23" src="https://github.com/user-attachments/assets/4c7c0393-d78d-4727-9f45-365d3dc8b94c" />
