### PR TITLE
Added the shutdown delay and shutdown timeout for the testcases to default options 

### DIFF
--- a/operator/src/test/resources/correct-podtemplate-keycloak.yml
+++ b/operator/src/test/resources/correct-podtemplate-keycloak.yml
@@ -13,6 +13,8 @@ spec:
       value: postgres
     - name: db-password
       value: testpassword
+    - name: shutdown-delay
+      value: "0s"
   hostname:
     hostname: example.com
   unsupported:

--- a/operator/src/test/resources/empty-podtemplate-keycloak.yml
+++ b/operator/src/test/resources/empty-podtemplate-keycloak.yml
@@ -13,6 +13,8 @@ spec:
       value: postgres
     - name: db-password
       value: testpassword
+    - name: shutdown-delay
+      value: "0s"
   hostname:
     hostname: example.com
   unsupported:

--- a/operator/src/test/resources/example-keycloak.yaml
+++ b/operator/src/test/resources/example-keycloak.yaml
@@ -22,3 +22,5 @@ spec:
   additionalOptions:
     - name: metrics-enabled
       value: "true"
+    - name: shutdown-delay
+      value: "0s"

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/BuildCommandDistTest.java
@@ -66,7 +66,12 @@ class BuildCommandDistTest {
     @Test
     @Launch({ "build", "--db=postgres", "--db-username=myuser", "--db-password=mypassword", "--http-enabled=true" })
     void testIgnoreRuntimeOptions(CLIResult cliResult) {
-        cliResult.assertMessage("The following run time options were found, but will be ignored during build time: kc.db-username, kc.http-enabled, kc.db-password");
+        String output = cliResult.getOutput();
+        assertTrue(output.contains("The following run time options were found, but will be ignored during build time:"));
+        assertTrue(output.contains("kc.db-username"));
+        assertTrue(output.contains("kc.http-enabled"));
+        assertTrue(output.contains("kc.db-password"));
+        assertTrue(output.contains("kc.shutdown-delay"));
         cliResult.assertBuild();
     }
 

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakDistributionDecorator.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/junit5/extension/KeycloakDistributionDecorator.java
@@ -41,9 +41,8 @@ public class KeycloakDistributionDecorator implements KeycloakDistribution {
     @Override
     public CLIResult run(List<String> rawArgs) {
         List<String> args = new ArrayList<>(rawArgs);
-
         args.addAll(List.of(config.defaultOptions()));
-
+        setEnvVar("KC_SHUTDOWN_DELAY", "0s");
         return delegate.run(new ServerOptions(storageConfig, databaseConfig, args));
     }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
@@ -27,6 +27,8 @@ public class KeycloakServerConfigBuilder {
     private final Set<KeycloakDependency> dependencies = new HashSet<>();
     private CacheType cacheType = CacheType.LOCAL;
     private boolean externalInfinispan = false;
+    private String shutdownDelay = "0s";
+    private String shutdownTimeout = "1s";
 
     private KeycloakServerConfigBuilder(String command) {
         this.command = command;
@@ -91,6 +93,16 @@ public class KeycloakServerConfigBuilder {
 
     public boolean isExternalInfinispanEnabled() {
         return this.externalInfinispan;
+    }
+
+    public KeycloakServerConfigBuilder shutdownDelay(String shutdownDelay) {
+        this.shutdownDelay = shutdownDelay;
+        return this;
+    }
+
+    public KeycloakServerConfigBuilder shutdownTimeout(String shutdownTimeout) {
+        this.shutdownTimeout = shutdownTimeout;
+        return this;
     }
 
     /**
@@ -287,6 +299,10 @@ public class KeycloakServerConfigBuilder {
     List<String> toArgs() {
         // Cache setup -> supported values: local or ispn
         option("cache", cacheType.name().toLowerCase());
+
+        // Shutdown options - defaults optimised for test speed
+        option("shutdown-delay", shutdownDelay);
+        option("shutdown-timeout", shutdownTimeout);
 
         log.build();
 

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/arquillian/containers/AbstractQuarkusDeployableContainer.java
@@ -172,10 +172,12 @@ public abstract class AbstractQuarkusDeployableContainer implements DeployableCo
         commands.add("--http-relative-path=/auth");
         commands.add("--health-enabled=true"); // expose something to management interface to turn it on
 
+
         if (suiteContext.get().isAuthServerMigrationEnabled()) {
             commands.add("--hostname-strict=false");
         } else { // Do not set management port for older versions of Keycloak for migration tests - available since Keycloak 25
             commands.add("--http-management-port=" + configuration.getManagementPort());
+            commands.add("--shutdown-delay=0");
         }
 
         if (suiteContext.get().getMigrationContext().isRunningMigrationTest()) {


### PR DESCRIPTION
Closes #46337

Approach 1: 
Added --shutdown-delay=0s", "--shutdown-timeout=1s"

Tested eg: $ time mvn clean test -Dtest=UpdateCommandDistTest

Before changes output:
real    1m57.160s
user    12m21.342s
sys     0m34.469s

After changes output:
real    0m43.130s
user    3m2.158s
sys     0m5.901s

Approach 2: 

Added the Added --shutdown-delay=0s", "--shutdown-timeout=1s" implicitly instead of the default options.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
