### PR TITLE
Fix broken refreshtoken destructure in JS client

### DIFF
--- a/js/libs/keycloak-admin-client/src/client.ts
+++ b/js/libs/keycloak-admin-client/src/client.ts
@@ -135,7 +135,10 @@ export class KeycloakAdminClient {
 
   public setRefreshToken(token: string) {
     this.refreshToken = token;
-    this.#refreshTokenDecoded = decodeToken(token);
+
+    if (token) {
+      this.#refreshTokenDecoded = decodeToken(token);
+    }
   }
 
   public async getAccessToken() {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Solves issue: https://github.com/keycloak/keycloak/issues/46418

## Changes

- Wraps refresh token decoding in a check for the refresh token in the first place

## Tests

- Manual test since there are no unit tests for this, works fine