### PR TITLE
Do not forward prompt=create to external identity providers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -528,7 +528,12 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             prompt = authenticationSession.getClientNote(OAuth2Constants.PROMPT);
         }
         if (prompt != null) {
-            uriBuilder.queryParam(OAuth2Constants.PROMPT, prompt);
+            // "create" is a Keycloak-internal prompt value used to initiate registration
+            // and should not be forwarded to external identity providers.
+            prompt = prompt.replace(OIDCLoginProtocol.PROMPT_VALUE_CREATE, "").trim();
+            if (!prompt.isEmpty()) {
+                uriBuilder.queryParam(OAuth2Constants.PROMPT, prompt);
+            }
         }
 
         if (getConfig().isPkceEnabled()) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptParameterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerPromptParameterTest.java
@@ -9,6 +9,8 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.Assert;
 
+import org.junit.Test;
+
 import static org.keycloak.testsuite.broker.BrokerTestTools.waitForPage;
 
 public class KcOidcBrokerPromptParameterTest extends AbstractBrokerTest {
@@ -73,6 +75,31 @@ public class KcOidcBrokerPromptParameterTest extends AbstractBrokerTest {
 
         Assert.assertTrue("There must be user " + bc.getUserLogin() + " in realm " + bc.consumerRealmName(),
                 isUserFound);
+    }
+
+    @Test
+    public void testPromptCreateNotForwardedToIdP() {
+        oauth.clientId("broker-app");
+        loginPage.open(bc.consumerRealmName());
+
+        // Use "create login" so the auth endpoint stores both values in the session
+        // but does not redirect to the registration page (which has no social buttons).
+        driver.navigate().to(driver.getCurrentUrl() + "&" + OIDCLoginProtocol.PROMPT_PARAM + "="
+                + OIDCLoginProtocol.PROMPT_VALUE_CREATE + " " + PROMPT_LOGIN);
+
+        log.debug("Clicking social " + bc.getIDPAlias());
+        loginPage.clickSocial(bc.getIDPAlias());
+
+        waitForPage(driver, "sign in to", true);
+
+        Assert.assertTrue("Driver should be on the provider realm page right now",
+                driver.getCurrentUrl().contains("/auth/realms/" + bc.providerRealmName() + "/"));
+
+        Assert.assertFalse(OIDCLoginProtocol.PROMPT_PARAM + "=" + OIDCLoginProtocol.PROMPT_VALUE_CREATE + " should NOT be part of the url",
+                driver.getCurrentUrl().contains(OIDCLoginProtocol.PROMPT_PARAM + "=" + OIDCLoginProtocol.PROMPT_VALUE_CREATE));
+
+        Assert.assertTrue(OIDCLoginProtocol.PROMPT_PARAM + "=" + PROMPT_LOGIN + " should be part of the url",
+                driver.getCurrentUrl().contains(OIDCLoginProtocol.PROMPT_PARAM + "=" + PROMPT_LOGIN));
     }
 
     private class KcOidcBrokerConfiguration2 extends KcOidcBrokerConfiguration {


### PR DESCRIPTION
## Summary

Since `prompt=create` is a Keycloak-internal parameter (per [OpenID Connect Prompt Create 1.0](https://openid.net/specs/openid-connect-prompt-create-1_0.html)) used to initiate registration and is not a valid value for most external IdPs (e.g., Google returns 400 Bad Request), add a way to filter out the `prompt=create` value before forwarding the prompt parameter to external identity providers in the broker authorization URL

Closes #45959