### PR TITLE
[OID4VCI] Generate pre-authorized codes using the JWT format

### DIFF
--- a/common/src/main/java/org/keycloak/common/VerificationException.java
+++ b/common/src/main/java/org/keycloak/common/VerificationException.java
@@ -22,11 +22,19 @@ package org.keycloak.common;
  * @version $Revision: 1 $
  */
 public class VerificationException extends Exception {
+
+    private String errorType;
+
     public VerificationException() {
     }
 
     public VerificationException(String message) {
         super(message);
+    }
+
+    public VerificationException(String message, String errorType) {
+        super(message);
+        this.errorType = errorType;
     }
 
     public VerificationException(String message, Throwable cause) {
@@ -35,5 +43,9 @@ public class VerificationException extends Exception {
 
     public VerificationException(Throwable cause) {
         super(cause);
+    }
+
+    public String getErrorType() {
+        return errorType;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -609,7 +609,7 @@ public class OID4VCIssuerEndpoint {
 
         // Remove the nonce entry atomically for replay protection
         // This prevents the same offer URL from being accessed multiple times
-        // while keeping pre-authorized code and credential identifier entries available
+        // while keeping offerId entries available
         Map<String, String> removed = session.singleUseObjects().remove(nonce);
         if (removed == null) {
             var errorMessage = "Credential offer not found or already consumed";

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferStorage.java
@@ -26,8 +26,6 @@ public interface CredentialOfferStorage extends Provider {
 
     CredentialOfferState getOfferStateByNonce(String nonce);
 
-    CredentialOfferState getOfferStateByPreAuthCode(String code);
-
     void removeOfferState(CredentialOfferState entry);
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.keycloak.common.Profile;
-import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.events.Errors;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -29,10 +28,12 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.CredentialOfferException;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.AuthorizationCodeGrant;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.IssuerState;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
 import org.keycloak.protocol.oid4vc.utils.CredentialScopeModelUtils;
 import org.keycloak.util.Strings;
@@ -106,7 +107,7 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
         });
 
         if (preAuthorized) {
-            String code = "urn:oid4vci:code:" + SecretGenerator.getInstance().randomString(64);
+            String code = createPreAuthorizedCode(offerState);
             credOffer.addGrant(new PreAuthorizedCodeGrant().setPreAuthorizedCode(code));
         } else {
             IssuerState issuerState = new IssuerState().setCredentialsOfferId(offerState.getCredentialsOfferId());
@@ -145,5 +146,21 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
         }
 
         return targetUserModel;
+    }
+
+    /**
+     * Creates a pre-authorized code associated with credential offer state.
+     */
+    private String createPreAuthorizedCode(CredentialOfferState offerState) {
+        PreAuthCodeHandler preAuthCodeHandler = session.getProvider(PreAuthCodeHandler.class);
+        if (preAuthCodeHandler == null) {
+            throw new IllegalStateException("No PreAuthCodeHandler provider available");
+        }
+
+        // A PreAuthCodeCtx prevents accidental leaking of sensitive information.
+        // For instance, transactions codes must never leak into the pre-auth code.
+        PreAuthCodeCtx ctx = new PreAuthCodeCtx(offerState);
+
+        return preAuthCodeHandler.createPreAuthCode(ctx);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferStorage.java
@@ -81,11 +81,6 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
 
         // Store with key=nonce
         session.singleUseObjects().put(entry.getNonce(), lifespanSeconds, Map.of(ENTRY_KEY, entryJson));
-
-        // Store with key=pre_auth_code
-        entry.getPreAuthorizedCode().ifPresent(preAuthCode ->
-            session.singleUseObjects().put(preAuthCode, lifespanSeconds, Map.of(ENTRY_KEY, entryJson))
-        );
     }
 
     @Override
@@ -105,18 +100,9 @@ class DefaultCredentialOfferStorage implements CredentialOfferStorage {
     }
 
     @Override
-    public CredentialOfferState getOfferStateByPreAuthCode(String preAuthCode) {
-        return Optional.ofNullable(session.singleUseObjects().get(preAuthCode))
-                .map(o -> o.get(ENTRY_KEY))
-                .map(o -> JsonSerialization.valueFromString(o, CredentialOfferState.class))
-                .orElse(null);
-    }
-
-    @Override
     public void removeOfferState(CredentialOfferState offerState) {
         SingleUseObjectProvider singleUseObjects = session.singleUseObjects();
         singleUseObjects.remove(offerState.getCredentialsOfferId());
         singleUseObjects.remove(offerState.getNonce());
-        offerState.getPreAuthorizedCode().ifPresent(singleUseObjects::remove);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
@@ -1,0 +1,259 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.crypto.SignatureVerifierContext;
+import org.keycloak.events.Errors;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSHeader;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.model.JwtPreAuthCode;
+import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
+import org.keycloak.protocol.oidc.OIDCWellKnownProviderFactory;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.utils.StringUtil;
+import org.keycloak.wellknown.WellKnownProvider;
+
+import org.jboss.logging.Logger;
+
+import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
+
+/**
+ * Implementation of {@link PreAuthCodeHandler} for JWT pre-authorized codes.
+ */
+public class JwtPreAuthCodeHandler implements PreAuthCodeHandler {
+
+    private static final Logger logger = Logger.getLogger(JwtPreAuthCodeHandler.class);
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+
+    public JwtPreAuthCodeHandler(KeycloakSession session) {
+        this.session = session;
+        this.realm = session.getContext().getRealm();
+    }
+
+    @Override
+    public String createPreAuthCode(PreAuthCodeCtx preAuthCodeCtx) {
+        // Clone and nullify exp claim to avoid duplication
+        PreAuthCodeCtx clonedCtx = preAuthCodeCtx.clone();
+        clonedCtx.setExpiresAt(null);
+
+        // Building
+        String salt = Base64Url.encode(SecretGenerator.getInstance().randomBytes());
+        JwtPreAuthCode jwtBody = (JwtPreAuthCode) new JwtPreAuthCode()
+                .salt(salt)
+                .context(clonedCtx)
+                .issuer(getCredentialIssuer())
+                .addAudience(getTokenEndpoint())
+                .issuedNow()
+                .exp(preAuthCodeCtx.getExpiresAt());
+
+        // Signing
+        SignatureSignerContext signer = getSignerContext(preAuthCodeCtx);
+        return new JWSBuilder()
+                .type(OAuth2Constants.JWT)
+                .jsonContent(jwtBody)
+                .sign(signer);
+    }
+
+    @Override
+    public PreAuthCodeCtx verifyPreAuthCode(String preAuthCode) throws VerificationException {
+        // Parse the JWT
+        JWSInput jwsInput;
+        try {
+            jwsInput = new JWSInput(preAuthCode);
+        } catch (JWSInputException e) {
+            throw new VerificationException("Failed to parse pre-auth code: Not JWT", e);
+        }
+
+        // Verify JWT (Signature + claim conformance)
+        TokenVerifier<JwtPreAuthCode> verifier = TokenVerifier.create(preAuthCode, JwtPreAuthCode.class);
+        verifier.verifierContext(getVerifierContext(jwsInput.getHeader()));
+        getPropertyVerifiers().forEach(verifier::withChecks);
+        verifier.verify();
+
+        // Parse payload as JwtPreAuthCode and extract PreAuthCodeCtx
+        try {
+            JwtPreAuthCode jwtBody = jwsInput.readJsonContent(JwtPreAuthCode.class);
+            PreAuthCodeCtx preAuthCodeCtx = jwtBody.getContext();
+            preAuthCodeCtx.setExpiresAt(jwtBody.getExp());
+            return preAuthCodeCtx;
+        } catch (JWSInputException e) {
+            throw new VerificationException("Failed to recover credential offer state", e);
+        }
+    }
+
+    private String getCredentialIssuer() {
+        return OID4VCIssuerWellKnownProvider.getIssuer(session.getContext());
+    }
+
+    private String getTokenEndpoint() {
+        WellKnownProvider oidcProvider = session.getProvider(
+                WellKnownProvider.class, OIDCWellKnownProviderFactory.PROVIDER_ID);
+        OIDCConfigurationRepresentation oidcConfig = (OIDCConfigurationRepresentation) oidcProvider.getConfig();
+        return oidcConfig.getTokenEndpoint();
+    }
+
+    /**
+     * Retrieves the preferred signing algorithms for JWT pre-auth codes,
+     * based on the configuration of credentials under consideration.
+     */
+    private List<String> getPreferredSigningAlgs(PreAuthCodeCtx preAuthCodeCtx) {
+        List<String> configIds = Optional.ofNullable(preAuthCodeCtx)
+                .map(PreAuthCodeCtx::getCredentialConfigurationIds)
+                .orElse(List.of());
+
+        Stream<CredentialScopeModel> credentialScopes = session.clientScopes()
+                .getClientScopesByProtocol(realm, OID4VC_PROTOCOL)
+                .map(CredentialScopeModel::new)
+                .filter(s -> configIds.contains(
+                        s.getCredentialConfigurationId()
+                ));
+
+        return credentialScopes.map(CredentialScopeModel::getSigningAlg)
+                .filter(StringUtil::isNotBlank)
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Retrieves a SignatureSignerContext for signing JWT pre-auth codes, based on the preferred
+     * signing algorithms derived from the pre-auth code context.
+     */
+    private SignatureSignerContext getSignerContext(PreAuthCodeCtx preAuthCodeCtx) {
+        List<String> preferredAlgs = getPreferredSigningAlgs(preAuthCodeCtx);
+        logger.debugf("Preferred signing algorithms for JWT pre-auth code: %s", preferredAlgs);
+        for (String alg : preferredAlgs) {
+            try {
+                return getSignerContext(alg);
+            } catch (RuntimeException ignored) {
+                logger.debugf("No active signing key/context found for algorithm %s, skipping", alg);
+            }
+        }
+
+        try {
+            // Default to Algorithm.ES256 if no preferred algorithm is found or signing key available.
+            // Under normal circumstances, an ES256 key should be generated on the fly.
+            logger.debugf("Falling back to default algorithm %s for signing JWT pre-auth codes", Algorithm.ES256);
+            return getSignerContext(Algorithm.ES256);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("No active signing key/context found for JWT pre-auth code signing", e);
+        }
+    }
+
+    /**
+     * Retrieves the SignatureSignerContext associated with the given algorithm.
+     */
+    private SignatureSignerContext getSignerContext(String alg) {
+        KeyWrapper signingKey = session.keys().getActiveKey(realm, KeyUse.SIG, alg);
+        if (signingKey == null) {
+            throw new IllegalArgumentException(String.format("No active signing key found for algorithm %s", alg));
+        }
+
+        SignatureProvider signatureProvider = session.getProvider(
+                SignatureProvider.class,
+                signingKey.getAlgorithm());
+
+        return signatureProvider.signer(signingKey);
+    }
+
+    /**
+     * Retrieves a SignatureVerifierContext for verifying JWT pre-auth codes,
+     * based on signing metadata in the JWS header and available keys.
+     */
+    private SignatureVerifierContext getVerifierContext(JWSHeader jwsHeader) throws VerificationException {
+        String kid = jwsHeader.getKeyId();
+        String alg = jwsHeader.getAlgorithm().toString();
+        KeyWrapper key = session.keys().getKey(realm, kid, KeyUse.SIG, alg);
+
+        if (key == null) {
+            throw new VerificationException(String.format(
+                    "No key found for verifying JWT pre-auth code with alg '%s' and kid '%s'",
+                    alg, kid));
+        }
+
+        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, key.getAlgorithm());
+        return signatureProvider.verifier(key);
+    }
+
+    /**
+     * Property verifiers.
+     */
+    private List<TokenVerifier.Predicate<JwtPreAuthCode>> getPropertyVerifiers() {
+        TokenVerifier.Predicate<JwtPreAuthCode> offerStateCheck = jwt -> {
+            if (jwt.getContext() == null) {
+                throw new VerificationException("Not a jwt pre-auth code: no pre-auth code context found");
+            }
+
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> issuerCheck = jwt -> {
+            String expectedIssuer = getCredentialIssuer();
+            if (!expectedIssuer.equals(jwt.getIssuer())) {
+                String message = String.format(
+                        "Unexpected issuer of jwt pre-auth code: %s (expected) != %s (actual)",
+                        expectedIssuer, jwt.getIssuer());
+                throw new VerificationException(message);
+            }
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> audienceCheck = jwt -> {
+            String expectedAudience = getTokenEndpoint();
+            List<String> actualAudiences = Optional.ofNullable(jwt.getAudience())
+                    .map(Arrays::asList)
+                    .orElse(List.of());
+
+            if (actualAudiences.isEmpty() || !actualAudiences.contains(expectedAudience)) {
+                String message = String.format(
+                        "Invalid audience of jwt pre-auth code: %s (expected) not in %s (actual)",
+                        expectedAudience, actualAudiences);
+                throw new VerificationException(message);
+            }
+
+            return true;
+        };
+
+        TokenVerifier.Predicate<JwtPreAuthCode> expirationCheck = jwt -> {
+            Long exp = jwt.getExp();
+            if (exp == null) {
+                throw new VerificationException("Jwt pre-auth code has no expiration time");
+            }
+
+            long now = Time.currentTime();
+            if (exp < now) {
+                String message = String.format("Jwt pre-auth code not valid: %s (exp) < %s (now)", exp, now);
+                throw new VerificationException(message, Errors.EXPIRED_CODE);
+            }
+
+            return true;
+        };
+
+        return List.of(offerStateCheck, issuerCheck, audienceCheck, expirationCheck);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandler.java
@@ -3,53 +3,29 @@ package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
-import org.keycloak.OAuth2Constants;
-import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
-import org.keycloak.crypto.Algorithm;
-import org.keycloak.crypto.KeyUse;
-import org.keycloak.crypto.KeyWrapper;
-import org.keycloak.crypto.SignatureProvider;
-import org.keycloak.crypto.SignatureSignerContext;
-import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.events.Errors;
-import org.keycloak.jose.jws.JWSBuilder;
-import org.keycloak.jose.jws.JWSHeader;
-import org.keycloak.jose.jws.JWSInput;
-import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.model.JwtPreAuthCode;
 import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
 import org.keycloak.protocol.oidc.OIDCWellKnownProviderFactory;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
-import org.keycloak.utils.StringUtil;
 import org.keycloak.wellknown.WellKnownProvider;
-
-import org.jboss.logging.Logger;
-
-import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
 
 /**
  * Implementation of {@link PreAuthCodeHandler} for JWT pre-authorized codes.
  */
 public class JwtPreAuthCodeHandler implements PreAuthCodeHandler {
 
-    private static final Logger logger = Logger.getLogger(JwtPreAuthCodeHandler.class);
-
     private final KeycloakSession session;
-    private final RealmModel realm;
 
     public JwtPreAuthCodeHandler(KeycloakSession session) {
         this.session = session;
-        this.realm = session.getContext().getRealm();
     }
 
     @Override
@@ -69,37 +45,64 @@ public class JwtPreAuthCodeHandler implements PreAuthCodeHandler {
                 .exp(preAuthCodeCtx.getExpiresAt());
 
         // Signing
-        SignatureSignerContext signer = getSignerContext(preAuthCodeCtx);
-        return new JWSBuilder()
-                .type(OAuth2Constants.JWT)
-                .jsonContent(jwtBody)
-                .sign(signer);
+        return session.tokens().encode(jwtBody);
     }
 
     @Override
     public PreAuthCodeCtx verifyPreAuthCode(String preAuthCode) throws VerificationException {
-        // Parse the JWT
-        JWSInput jwsInput;
-        try {
-            jwsInput = new JWSInput(preAuthCode);
-        } catch (JWSInputException e) {
-            throw new VerificationException("Failed to parse pre-auth code: Not JWT", e);
+        // Decode and verify the JWT pre-auth code, and recover jwt payload
+        JwtPreAuthCode jwtPayload = session.tokens().decode(preAuthCode, JwtPreAuthCode.class);
+        if (jwtPayload == null) {
+            throw new VerificationException("Pre-auth code decoding/verification failed");
         }
 
-        // Verify JWT (Signature + claim conformance)
-        TokenVerifier<JwtPreAuthCode> verifier = TokenVerifier.create(preAuthCode, JwtPreAuthCode.class);
-        verifier.verifierContext(getVerifierContext(jwsInput.getHeader()));
-        getPropertyVerifiers().forEach(verifier::withChecks);
-        verifier.verify();
+        // Perform routine verification on claims
+        verifyPreAuthCodeClaims(jwtPayload);
 
-        // Parse payload as JwtPreAuthCode and extract PreAuthCodeCtx
-        try {
-            JwtPreAuthCode jwtBody = jwsInput.readJsonContent(JwtPreAuthCode.class);
-            PreAuthCodeCtx preAuthCodeCtx = jwtBody.getContext();
-            preAuthCodeCtx.setExpiresAt(jwtBody.getExp());
-            return preAuthCodeCtx;
-        } catch (JWSInputException e) {
-            throw new VerificationException("Failed to recover credential offer state", e);
+        // Restore exp information to pre-auth code context
+        PreAuthCodeCtx preAuthCodeCtx = jwtPayload.getContext();
+        preAuthCodeCtx.setExpiresAt(jwtPayload.getExp());
+
+        return preAuthCodeCtx;
+    }
+
+    /**
+     * Performs routine verification of the claims in the JWT pre-auth code.
+     */
+    private void verifyPreAuthCodeClaims(JwtPreAuthCode jwtPayload) throws VerificationException {
+        if (jwtPayload.getContext() == null) {
+            throw new VerificationException("Not a jwt pre-auth code: no pre-auth code context found");
+        }
+
+        String expectedIssuer = getCredentialIssuer();
+        if (!expectedIssuer.equals(jwtPayload.getIssuer())) {
+            String message = String.format(
+                    "Unexpected issuer of jwt pre-auth code: %s (expected) != %s (actual)",
+                    expectedIssuer, jwtPayload.getIssuer());
+            throw new VerificationException(message);
+        }
+
+        String expectedAudience = getTokenEndpoint();
+        List<String> actualAudiences = Optional.ofNullable(jwtPayload.getAudience())
+                .map(Arrays::asList)
+                .orElse(List.of());
+
+        if (actualAudiences.isEmpty() || !actualAudiences.contains(expectedAudience)) {
+            String message = String.format(
+                    "Invalid audience of jwt pre-auth code: %s (expected) not in %s (actual)",
+                    expectedAudience, actualAudiences);
+            throw new VerificationException(message);
+        }
+
+        Long exp = jwtPayload.getExp();
+        if (exp == null) {
+            throw new VerificationException("Jwt pre-auth code has no expiration time");
+        }
+
+        long now = Time.currentTime();
+        if (exp < now) {
+            String message = String.format("Jwt pre-auth code not valid: %s (exp) < %s (now)", exp, now);
+            throw new VerificationException(message, Errors.EXPIRED_CODE);
         }
     }
 
@@ -112,145 +115,6 @@ public class JwtPreAuthCodeHandler implements PreAuthCodeHandler {
                 WellKnownProvider.class, OIDCWellKnownProviderFactory.PROVIDER_ID);
         OIDCConfigurationRepresentation oidcConfig = (OIDCConfigurationRepresentation) oidcProvider.getConfig();
         return oidcConfig.getTokenEndpoint();
-    }
-
-    /**
-     * Retrieves the preferred signing algorithms for JWT pre-auth codes,
-     * based on the configuration of credentials under consideration.
-     */
-    private List<String> getPreferredSigningAlgs(PreAuthCodeCtx preAuthCodeCtx) {
-        List<String> configIds = Optional.ofNullable(preAuthCodeCtx)
-                .map(PreAuthCodeCtx::getCredentialConfigurationIds)
-                .orElse(List.of());
-
-        Stream<CredentialScopeModel> credentialScopes = session.clientScopes()
-                .getClientScopesByProtocol(realm, OID4VC_PROTOCOL)
-                .map(CredentialScopeModel::new)
-                .filter(s -> configIds.contains(
-                        s.getCredentialConfigurationId()
-                ));
-
-        return credentialScopes.map(CredentialScopeModel::getSigningAlg)
-                .filter(StringUtil::isNotBlank)
-                .distinct()
-                .toList();
-    }
-
-    /**
-     * Retrieves a SignatureSignerContext for signing JWT pre-auth codes, based on the preferred
-     * signing algorithms derived from the pre-auth code context.
-     */
-    private SignatureSignerContext getSignerContext(PreAuthCodeCtx preAuthCodeCtx) {
-        List<String> preferredAlgs = getPreferredSigningAlgs(preAuthCodeCtx);
-        logger.debugf("Preferred signing algorithms for JWT pre-auth code: %s", preferredAlgs);
-        for (String alg : preferredAlgs) {
-            try {
-                return getSignerContext(alg);
-            } catch (RuntimeException ignored) {
-                logger.debugf("No active signing key/context found for algorithm %s, skipping", alg);
-            }
-        }
-
-        try {
-            // Default to Algorithm.ES256 if no preferred algorithm is found or signing key available.
-            // Under normal circumstances, an ES256 key should be generated on the fly.
-            logger.debugf("Falling back to default algorithm %s for signing JWT pre-auth codes", Algorithm.ES256);
-            return getSignerContext(Algorithm.ES256);
-        } catch (RuntimeException e) {
-            throw new IllegalStateException("No active signing key/context found for JWT pre-auth code signing", e);
-        }
-    }
-
-    /**
-     * Retrieves the SignatureSignerContext associated with the given algorithm.
-     */
-    private SignatureSignerContext getSignerContext(String alg) {
-        KeyWrapper signingKey = session.keys().getActiveKey(realm, KeyUse.SIG, alg);
-        if (signingKey == null) {
-            throw new IllegalArgumentException(String.format("No active signing key found for algorithm %s", alg));
-        }
-
-        SignatureProvider signatureProvider = session.getProvider(
-                SignatureProvider.class,
-                signingKey.getAlgorithm());
-
-        return signatureProvider.signer(signingKey);
-    }
-
-    /**
-     * Retrieves a SignatureVerifierContext for verifying JWT pre-auth codes,
-     * based on signing metadata in the JWS header and available keys.
-     */
-    private SignatureVerifierContext getVerifierContext(JWSHeader jwsHeader) throws VerificationException {
-        String kid = jwsHeader.getKeyId();
-        String alg = jwsHeader.getAlgorithm().toString();
-        KeyWrapper key = session.keys().getKey(realm, kid, KeyUse.SIG, alg);
-
-        if (key == null) {
-            throw new VerificationException(String.format(
-                    "No key found for verifying JWT pre-auth code with alg '%s' and kid '%s'",
-                    alg, kid));
-        }
-
-        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, key.getAlgorithm());
-        return signatureProvider.verifier(key);
-    }
-
-    /**
-     * Property verifiers.
-     */
-    private List<TokenVerifier.Predicate<JwtPreAuthCode>> getPropertyVerifiers() {
-        TokenVerifier.Predicate<JwtPreAuthCode> offerStateCheck = jwt -> {
-            if (jwt.getContext() == null) {
-                throw new VerificationException("Not a jwt pre-auth code: no pre-auth code context found");
-            }
-
-            return true;
-        };
-
-        TokenVerifier.Predicate<JwtPreAuthCode> issuerCheck = jwt -> {
-            String expectedIssuer = getCredentialIssuer();
-            if (!expectedIssuer.equals(jwt.getIssuer())) {
-                String message = String.format(
-                        "Unexpected issuer of jwt pre-auth code: %s (expected) != %s (actual)",
-                        expectedIssuer, jwt.getIssuer());
-                throw new VerificationException(message);
-            }
-            return true;
-        };
-
-        TokenVerifier.Predicate<JwtPreAuthCode> audienceCheck = jwt -> {
-            String expectedAudience = getTokenEndpoint();
-            List<String> actualAudiences = Optional.ofNullable(jwt.getAudience())
-                    .map(Arrays::asList)
-                    .orElse(List.of());
-
-            if (actualAudiences.isEmpty() || !actualAudiences.contains(expectedAudience)) {
-                String message = String.format(
-                        "Invalid audience of jwt pre-auth code: %s (expected) not in %s (actual)",
-                        expectedAudience, actualAudiences);
-                throw new VerificationException(message);
-            }
-
-            return true;
-        };
-
-        TokenVerifier.Predicate<JwtPreAuthCode> expirationCheck = jwt -> {
-            Long exp = jwt.getExp();
-            if (exp == null) {
-                throw new VerificationException("Jwt pre-auth code has no expiration time");
-            }
-
-            long now = Time.currentTime();
-            if (exp < now) {
-                String message = String.format("Jwt pre-auth code not valid: %s (exp) < %s (now)", exp, now);
-                throw new VerificationException(message, Errors.EXPIRED_CODE);
-            }
-
-            return true;
-        };
-
-        return List.of(offerStateCheck, issuerCheck, audienceCheck, expirationCheck);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/JwtPreAuthCodeHandlerFactory.java
@@ -1,0 +1,19 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.models.KeycloakSession;
+
+public class JwtPreAuthCodeHandlerFactory implements PreAuthCodeHandlerFactory {
+
+    public static final String PROVIDER_ID = "jwt-pre-auth-code-handler";
+
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public JwtPreAuthCodeHandler create(KeycloakSession session) {
+        return new JwtPreAuthCodeHandler(session);
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandler.java
@@ -1,0 +1,22 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
+import org.keycloak.provider.Provider;
+
+/**
+ * Handles the production and verification of pre-authorized codes.
+ */
+public interface PreAuthCodeHandler extends Provider {
+
+    /**
+     * Generates a pre-authorized code for a given context of non-sensitive fields.
+     * The implementation is responsible for embedding this context so it is recovered with verification.
+     */
+    String createPreAuthCode(PreAuthCodeCtx ctx);
+
+    /**
+     * Verifies the given pre-authorized code and returns its associated context if valid.
+     */
+    PreAuthCodeCtx verifyPreAuthCode(String preAuthCode) throws VerificationException;
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerFactory.java
@@ -1,0 +1,20 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderFactory;
+
+public interface PreAuthCodeHandlerFactory extends ProviderFactory<PreAuthCodeHandler> {
+
+    @Override
+    default void init(Config.Scope config) {
+    }
+
+    @Override
+    default void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    default void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerSpi.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/preauth/PreAuthCodeHandlerSpi.java
@@ -1,0 +1,33 @@
+package org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+/**
+ * SPI for handling the production and verification of pre-authorized codes.
+ */
+public class PreAuthCodeHandlerSpi implements Spi {
+
+    private static final String NAME = "preAuthCodeHandler";
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return PreAuthCodeHandler.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory<PreAuthCodeHandler>> getProviderFactoryClass() {
+        return PreAuthCodeHandlerFactory.class;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -49,8 +49,7 @@ import org.keycloak.protocol.oid4vc.model.JwtCNonce;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.saml.RandomSecret;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * @author Pascal Knüppel
@@ -63,7 +62,7 @@ public class JwtCNonceHandler implements CNonceHandler {
 
     public static final int NONCE_LENGTH_RANDOM_OFFSET = 15;
 
-    private static final Logger logger = LoggerFactory.getLogger(JwtCNonceHandler.class);
+    private static final Logger logger = Logger.getLogger(JwtCNonceHandler.class);
 
     private final KeycloakSession keycloakSession;
 
@@ -189,7 +188,7 @@ public class JwtCNonceHandler implements CNonceHandler {
         try {
             signingKey = keycloakSession.keys().getActiveKey(realm, KeyUse.SIG, Algorithm.ES256);
         } catch (RuntimeException ex) {
-            logger.debug("Failed to find active ES256 signing key for realm {}. Falling back to RSA...",
+            logger.debugf("Failed to find active ES256 signing key for realm %s. Falling back to RSA...",
                          realm.getName());
             logger.debug(ex.getMessage(), ex);
             // use RSA only as fallback since the preferred algorithm by OpenID4VC is elliptic curve

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCIssuedAtTimeClaimMapper.java
@@ -34,8 +34,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.provider.ProviderConfigProperty;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * Map issuance date to the credential, under the default claim name "iat"
@@ -62,7 +61,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
     public static final String VALUE_SOURCE = "valueSource";
 
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
-    private static final Logger log = LoggerFactory.getLogger(OID4VCIssuedAtTimeClaimMapper.class);
+    private static final Logger log = Logger.getLogger(OID4VCIssuedAtTimeClaimMapper.class);
 
     static {
         ProviderConfigProperty subjectPropertyNameConfig = new ProviderConfigProperty();
@@ -112,7 +111,7 @@ public class OID4VCIssuedAtTimeClaimMapper extends OID4VCMapper {
         List<String> attributePath = getMetadataAttributePath();
         String propertyName = attributePath.get(attributePath.size() - 1);
         if (propertyName == null) {
-            log.error("Invalid configuration: missing config-property '{}' for mapper '{}' of type '{}'. Mapper is ignored.",
+            log.errorf("Invalid configuration: missing config-property '%s' for mapper '%s' of type '%s'. Mapper is ignored.",
                       CLAIM_NAME,
                       mapperModel.getName(),
                       MAPPER_ID);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/DisplayObject.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/DisplayObject.java
@@ -30,8 +30,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.jboss.logging.Logger;
 
 /**
  * Represents a DisplayObject, as used in the OID4VCI Credentials Issuer Metadata
@@ -47,7 +46,7 @@ import org.slf4j.LoggerFactory;
 )
 public class DisplayObject {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DisplayObject.class);
+    private static final Logger LOGGER = Logger.getLogger(DisplayObject.class);
 
     @JsonIgnore
     private static final String NAME_KEY = "name";
@@ -97,7 +96,7 @@ public class DisplayObject {
             // lets say we have an invalid value we should not kill the whole execution if just the display value is
             // broken
             LOGGER.debug(e.getMessage(), e);
-            LOGGER.warn("Failed to parse display-metadata for credential '{}': {}", credentialScope.getName(), e.getMessage());
+            LOGGER.warnf("Failed to parse display-metadata for credential '%s': %s", credentialScope.getName(), e.getMessage());
             return null;
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/JwtPreAuthCode.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/JwtPreAuthCode.java
@@ -1,0 +1,38 @@
+package org.keycloak.protocol.oid4vc.model;
+
+import org.keycloak.representations.JsonWebToken;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Payloads for JWT pre-authorized codes for OpenID4VCI.
+ * They embed a partial, public view of the credential offer state.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class JwtPreAuthCode extends JsonWebToken {
+
+    @JsonProperty("context")
+    private PreAuthCodeCtx context;
+
+    @JsonProperty("salt")
+    private String salt;
+
+    public PreAuthCodeCtx getContext() {
+        return context;
+    }
+
+    public JwtPreAuthCode context(PreAuthCodeCtx context) {
+        this.context = context;
+        return this;
+    }
+
+    public String getSalt() {
+        return salt;
+    }
+
+    public JwtPreAuthCode salt(String salt) {
+        this.salt = salt;
+        return this;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/PreAuthCodeCtx.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/PreAuthCodeCtx.java
@@ -1,0 +1,138 @@
+package org.keycloak.protocol.oid4vc.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Non-sensitive fields a pre-authorized code representation may embed.
+ * <p></p>
+ * Mainly intended to be used as a partial, public view of {@link CredentialOfferState}.
+ */
+public class PreAuthCodeCtx implements Cloneable {
+
+    @JsonProperty("credentials_offer_id")
+    private String credentialsOfferId;
+
+    @JsonProperty("target_client_id")
+    private String targetClientId;
+
+    @JsonProperty("target_user_id")
+    private String targetUserId;
+
+    @JsonProperty("nonce")
+    private String nonce;
+
+    @JsonProperty("exp")
+    private Long expiresAt;
+
+    @JsonProperty("authorization_details")
+    private List<OID4VCAuthorizationDetail> authorizationDetails;
+
+    public PreAuthCodeCtx() {
+    }
+
+    /**
+     * This construction makes it explicit what data can be made public.
+     * For example, transactions codes must never leak into pre-auth codes.
+     */
+    public PreAuthCodeCtx(CredentialOfferState offerState) {
+        Objects.requireNonNull(offerState);
+
+        this.credentialsOfferId = offerState.getCredentialsOfferId();
+        this.targetClientId = offerState.getTargetClientId();
+        this.targetUserId = offerState.getTargetUserId();
+        this.nonce = offerState.getNonce();
+        this.expiresAt = offerState.getExpiresAt();
+
+        List<OID4VCAuthorizationDetail> details = offerState.getAuthorizationDetails();
+        this.authorizationDetails = details == null ? null : details.stream()
+                .map(OID4VCAuthorizationDetail::clone)
+                .peek(d -> d.setCredentialsOfferId(null))
+                .toList();
+    }
+
+    @JsonIgnore
+    public List<String> getCredentialConfigurationIds() {
+        if (authorizationDetails == null) {
+            return List.of();
+        }
+
+        return authorizationDetails.stream()
+                .map(OID4VCAuthorizationDetail::getCredentialConfigurationId)
+                .toList();
+    }
+
+    public String getCredentialsOfferId() {
+        return credentialsOfferId;
+    }
+
+    public void setCredentialsOfferId(String credentialsOfferId) {
+        this.credentialsOfferId = credentialsOfferId;
+    }
+
+    public List<OID4VCAuthorizationDetail> getAuthorizationDetails() {
+        return authorizationDetails;
+    }
+
+    public void setAuthorizationDetails(List<OID4VCAuthorizationDetail> authorizationDetails) {
+        this.authorizationDetails = authorizationDetails;
+    }
+
+    public String getTargetClientId() {
+        return targetClientId;
+    }
+
+    public void setTargetClientId(String targetClientId) {
+        this.targetClientId = targetClientId;
+    }
+
+    public String getTargetUserId() {
+        return targetUserId;
+    }
+
+    public void setTargetUserId(String targetUserId) {
+        this.targetUserId = targetUserId;
+    }
+
+    public String getNonce() {
+        return nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
+    public Long getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Long expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        PreAuthCodeCtx that = (PreAuthCodeCtx) o;
+        return Objects.equals(getCredentialsOfferId(), that.getCredentialsOfferId()) && Objects.equals(getCredentialConfigurationIds(), that.getCredentialConfigurationIds()) && Objects.equals(getAuthorizationDetails(), that.getAuthorizationDetails()) && Objects.equals(getTargetClientId(), that.getTargetClientId()) && Objects.equals(getTargetUserId(), that.getTargetUserId()) && Objects.equals(getNonce(), that.getNonce()) && Objects.equals(getExpiresAt(), that.getExpiresAt());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getCredentialsOfferId(), getCredentialConfigurationIds(), getAuthorizationDetails(), getTargetClientId(), getTargetUserId(), getNonce(), getExpiresAt());
+    }
+
+    @Override
+    public PreAuthCodeCtx clone() {
+        try {
+            return (PreAuthCodeCtx) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -17,29 +17,38 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
+import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakUriInfo;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
 import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
 import org.keycloak.protocol.oid4vc.utils.CredentialScopeModelUtils;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -91,8 +100,13 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                     errorMessage, Response.Status.BAD_REQUEST);
         }
 
+        // Verify the pre-auth code and recover the public context associated with it.
+        // The verification logic is delegated to the configured PreAuthCodeHandler provider.
+        PreAuthCodeCtx ctx = verifyPreAuthCode(preAuthCode);
+
+        // Recover matching credential offer state in storage
         var offerStorage = session.getProvider(CredentialOfferStorage.class);
-        var offerState = offerStorage.getOfferStateByPreAuthCode(preAuthCode);
+        var offerState = offerStorage.getOfferStateById(ctx.getCredentialsOfferId());
         if (offerState == null) {
             var errorMessage = "No credential offer state for pre-auth code: " + preAuthCode;
             event.detail(REASON, errorMessage).error(Errors.INVALID_CODE);
@@ -249,7 +263,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
     public boolean isTokenAllowed(KeycloakSession session, AccessToken token) {
         // Check if the request path ends with the credential endpoint path
         boolean isCredentialEndpoint = Optional.ofNullable(session.getContext().getUri())
-                .map(uri -> uri.getPath())
+                .map(KeycloakUriInfo::getPath)
                 .map(path -> path.endsWith("/" + OID4VCIssuerEndpoint.CREDENTIAL_PATH))
                 .orElse(false);
 
@@ -262,5 +276,53 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         String expectedAudience = OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(session.getContext());
         String[] audiences = token.getAudience();
         return audiences != null && audiences.length == 1 && expectedAudience.equals(audiences[0]);
+    }
+
+    /**
+     * Runs the pre-auth code verification logic using the configured PreAuthCodeHandler provider.
+     * A public, partial view of the CredentialOfferState is returned upon successful verification.
+     */
+    private PreAuthCodeCtx verifyPreAuthCode(String code) {
+        PreAuthCodeHandler preAuthCodeHandler = session.getProvider(PreAuthCodeHandler.class);
+        if (preAuthCodeHandler == null) {
+            throw new IllegalStateException("No PreAuthCodeHandler provider available");
+        }
+
+        PreAuthCodeCtx preAuthCodeCtx;
+        try {
+            preAuthCodeCtx = preAuthCodeHandler.verifyPreAuthCode(code);
+        } catch (VerificationException e) {
+            String errorType = Optional.ofNullable(e.getErrorType()).orElse(Errors.INVALID_CODE);
+            String errorMessage = String.format("Pre-authorized code failed handler verification (%s)", errorType);
+            LOGGER.error(errorMessage, e);
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors,
+                    errorType.equals(Errors.INVALID_CODE)
+                            ? OAuthErrorException.INVALID_REQUEST
+                            : OAuthErrorException.EXPIRED_TOKEN,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        // Pre-auth code is valid, but let's prevent replay attacks
+        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
+        String key = getPreAuthCodeSingleObjectKey(code);
+        if (singleUseStore.get(key) != null) {
+            String errorMessage = "Pre-authorized code has already been used";
+            event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        // Prevent code replay for the remaining validity period
+        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTime();
+        singleUseStore.put(key, expiresIn, Map.of());
+
+        return preAuthCodeCtx;
+    }
+
+    private static String getPreAuthCodeSingleObjectKey(String code) {
+        String hash = HashUtils.sha256UrlEncodedHash(code.trim(), StandardCharsets.UTF_8);
+        String fqcn = PreAuthorizedCodeGrantType.class.getName().toLowerCase();
+        return fqcn + "." + hash;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -20,7 +20,6 @@ package org.keycloak.protocol.oidc.grants;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import jakarta.ws.rs.core.Response;
@@ -303,19 +302,17 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                     errorMessage, Response.Status.BAD_REQUEST);
         }
 
-        // Pre-auth code is valid, but let's prevent replay attacks
+        // Pre-auth code is valid, but let's prevent replay attacks (for the remaining validity period)
         SingleUseObjectProvider singleUseStore = session.singleUseObjects();
         String key = getPreAuthCodeSingleObjectKey(code);
-        if (singleUseStore.get(key) != null) {
+        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTime();
+        boolean firstInsertion = singleUseStore.putIfAbsent(key, expiresIn);
+        if (!firstInsertion) {
             String errorMessage = "Pre-authorized code has already been used";
             event.detail(Details.REASON, errorMessage).error(Errors.INVALID_CODE);
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
                     errorMessage, Response.Status.BAD_REQUEST);
         }
-
-        // Prevent code replay for the remaining validity period
-        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTime();
-        singleUseStore.put(key, expiresIn, Map.of());
 
         return preAuthCodeCtx;
     }

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandlerFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandlerFactory
@@ -1,0 +1,1 @@
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandlerFactory

--- a/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/services/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -34,6 +34,7 @@ org.keycloak.theme.freemarker.FreeMarkerSPI
 org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBuilderSpi
 org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorageSpi
 org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferProviderSpi
+org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandlerSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.ProofValidatorSpi
 org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerSpi
 org.keycloak.protocol.oid4vc.issuance.keybinding.CNonceHandlerSpi

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -174,6 +174,12 @@ public abstract class OID4VCIssuerTestBase {
                 .orElse(null);
     }
 
+    protected UserRepresentation getExistingUser(String username) {
+        return testRealm.admin().users().search(username).stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No such user: " + username));
+    }
+
     protected KeyWrapper getRsaKey(KeyUse keyUse, String algorithm, String keyName) {
         try {
             KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
@@ -54,6 +54,14 @@ public class OID4VCTestContext {
         this.credConfigId = credentialScope.getCredentialConfigurationId();
     }
 
+    public String getHolder() {
+        return holder;
+    }
+
+    public CredentialScopeRepresentation getCredentialScope() {
+        return credentialScope;
+    }
+
     public List<String> getAuthorizedCredentialIdentifiers() {
         OID4VCAuthorizationDetail tokenAuthDetails = getOID4VCAuthorizationDetail();
         return Optional.ofNullable(tokenAuthDetails)

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -1,7 +1,6 @@
 package org.keycloak.tests.oid4vc.preauth;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
@@ -15,7 +14,6 @@ import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
-import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.JwtPreAuthCode;
 import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
@@ -66,8 +64,8 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
     public void shouldGenerateValidJwtPreAuthCodes() {
         // Request a pre-auth code. This will create an offer state in the server
         // and return a pre-auth code linked to that state.
-        String preAuthCode = createPreAuthOffer(null);
-        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+        String preAuthCode = createPreAuthOffer();
+        assertValidPreAuthCodeJwt(preAuthCode);
 
         // Verify pre-auth code and recover associated context
         PreAuthCodeCtx preAuthCodeCtx = runOnServer.fetch((session) -> {
@@ -86,12 +84,6 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
         AccessTokenResponse resp = wallet.preAuthAccessTokenRequest(testCtx, preAuthCode).send();
         assertEquals(HttpStatus.SC_OK, resp.getStatusCode());
         assertNotNull(resp.getAccessToken(), "Access token must not be null");
-    }
-
-    @Test
-    public void shouldGenerateValidJwtPreAuthCodes_SignedWithPreferredAlg() {
-        String preAuthCode = createPreAuthOffer(Algorithm.RS256);
-        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.RS256);
     }
 
     @Test
@@ -130,11 +122,23 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
     }
 
     @Test
+    public void mustRejectNonPreAuthCodeJwts_MalformedJwt() {
+        runOnServer.run((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+            VerificationException exception = assertThrows(VerificationException.class,
+                    () -> handler.verifyPreAuthCode("not-jwt-pre-auth-code"));
+
+            assertEquals("Pre-auth code decoding/verification failed",
+                    exception.getMessage());
+        });
+    }
+
+    @Test
     public void mustRejectExpiredPreAuthCodeJwts() {
         // Request a pre-auth code. This will create an offer state in the server
         // and return a pre-auth code linked to that state.
-        String preAuthCode = createPreAuthOffer(null);
-        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+        String preAuthCode = createPreAuthOffer();
+        assertValidPreAuthCodeJwt(preAuthCode);
 
         // Assert that an expired pre-auth code fails verification
         runOnServer.run((session) -> {
@@ -157,8 +161,8 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
     public void mustRejectReplayedPreAuthCodeJwts() {
         // Request a pre-auth code. This will create an offer state in the server
         // and return a pre-auth code linked to that state.
-        String preAuthCode = createPreAuthOffer(null);
-        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+        String preAuthCode = createPreAuthOffer();
+        assertValidPreAuthCodeJwt(preAuthCode);
 
         // First use: the pre-auth code can be exchanged for an access token
         AccessTokenResponse resp = wallet.preAuthAccessTokenRequest(testCtx, preAuthCode).send();
@@ -170,10 +174,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
         assertEquals("Pre-authorized code has already been used", replayResp.getErrorDescription());
     }
 
-    private String createPreAuthOffer(String signingAlg) {
-        // Configure signing algorithm in credential client scope
-        configureCredentialSigningAlgorithm(signingAlg);
-
+    private String createPreAuthOffer() {
         runOnServer.run(session -> {
             PreAuthCodeHandler handler = session.getProvider(PreAuthCodeHandler.class);
             assertInstanceOf(JwtPreAuthCodeHandler.class, handler,
@@ -188,15 +189,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
         }
     }
 
-    private void configureCredentialSigningAlgorithm(String alg) {
-        CredentialScopeRepresentation scope = testCtx.getCredentialScope();
-        scope.setSigningAlg(Objects.requireNonNullElse(alg, ""));
-
-        // Update the credential scope with the new signing algorithm configuration
-        testRealm.admin().clientScopes().get(scope.getId()).update(scope);
-    }
-
-    public static void assertValidPreAuthCodeJwt(String jwt, String expectedAlg) {
+    public static void assertValidPreAuthCodeJwt(String jwt) {
         JWSInput jws;
         JwtPreAuthCode payload;
 
@@ -207,7 +200,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
             throw new RuntimeException(e);
         }
 
-        assertEquals(expectedAlg, jws.getHeader().getAlgorithm().toString(),
+        assertEquals(Algorithm.HS512, jws.getHeader().getAlgorithm().toString(),
                 "Must use expected signing algorithm");
 
         assertNotNull(payload.getContext(), "Must embed an associated context");

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -1,0 +1,223 @@
+package org.keycloak.tests.oid4vc.preauth;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.ECDSASignatureSignerContext;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
+import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.JwtPreAuthCode;
+import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.tests.oid4vc.OID4VCBasicWallet;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.tests.oid4vc.OID4VCTestContext;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.DEFAULT_CODE_LIFESPAN_S;
+import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest(config = VCTestServerWithPreAuthCodeEnabled.class)
+public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
+
+    OID4VCBasicWallet wallet;
+    OID4VCTestContext testCtx;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @BeforeEach
+    void beforeEach() {
+        wallet = new OID4VCBasicWallet(keycloak, oauth);
+        testCtx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+    }
+
+    @AfterEach
+    void afterEach() {
+        wallet.logout();
+    }
+
+    @Test
+    public void shouldGenerateValidJwtPreAuthCodes() {
+        // Request a pre-auth code. This will create an offer state in the server
+        // and return a pre-auth code linked to that state.
+        String preAuthCode = createPreAuthOffer(null);
+        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+
+        // Verify pre-auth code and recover associated context
+        PreAuthCodeCtx preAuthCodeCtx = runOnServer.fetch((session) -> {
+            try {
+                JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+                return handler.verifyPreAuthCode(preAuthCode);
+            } catch (VerificationException e) {
+                throw new RuntimeException(e);
+            }
+        }, PreAuthCodeCtx.class);
+
+        // Validate the context embedded in the pre-auth code
+        assertPreAuthCodeCtx(preAuthCodeCtx);
+
+        // Ensure that the pre-auth code can be exchanged for an access token
+        AccessTokenResponse resp = wallet.preAuthAccessTokenRequest(testCtx, preAuthCode).send();
+        assertEquals(HttpStatus.SC_OK, resp.getStatusCode());
+        assertNotNull(resp.getAccessToken(), "Access token must not be null");
+    }
+
+    @Test
+    public void shouldGenerateValidJwtPreAuthCodes_SignedWithPreferredAlg() {
+        String preAuthCode = createPreAuthOffer(Algorithm.RS256);
+        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.RS256);
+    }
+
+    @Test
+    public void mustRejectNonPreAuthCodeJwts() {
+        // Get a valid but not pre-auth code JWT
+        String imposterPreAuthCode = runOnServer.fetch((session) -> {
+            // Build a random JWT
+            JsonWebToken jwt = new JsonWebToken()
+                    .issuer("issuer")
+                    .addAudience("audience")
+                    .issuedNow()
+                    .exp((long) (Time.currentTime() + 60));
+
+            // Sign to yield a valid JWT
+            RealmModel realm = session.getContext().getRealm();
+            KeyWrapper keyWrapper = session.keys().getActiveKey(realm, KeyUse.SIG, Algorithm.ES256);
+            ECDSASignatureSignerContext signer = new ECDSASignatureSignerContext(keyWrapper);
+            return new JWSBuilder().jsonContent(jwt).sign(signer);
+        }, String.class);
+
+        // Ensure that it fails handler verification
+        runOnServer.run((session) -> {
+            JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+            VerificationException exception = assertThrows(VerificationException.class,
+                    () -> handler.verifyPreAuthCode(imposterPreAuthCode));
+
+            assertEquals("Not a jwt pre-auth code: no pre-auth code context found",
+                    exception.getMessage());
+        });
+
+        // Ensure that it cannot be exchanged for an access token
+        AccessTokenResponse resp = wallet.preAuthAccessTokenRequest(testCtx, imposterPreAuthCode).send();
+        assertEquals(HttpStatus.SC_BAD_REQUEST, resp.getStatusCode());
+        assertEquals("Pre-authorized code failed handler verification (invalid_code)",
+                resp.getErrorDescription());
+    }
+
+    @Test
+    public void mustRejectExpiredPreAuthCodeJwts() {
+        // Request a pre-auth code. This will create an offer state in the server
+        // and return a pre-auth code linked to that state.
+        String preAuthCode = createPreAuthOffer(null);
+        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+
+        // Assert that an expired pre-auth code fails verification
+        runOnServer.run((session) -> {
+            try {
+                // Move time forward to ensure code is expired
+                Time.setOffset(2 * DEFAULT_CODE_LIFESPAN_S);
+
+                JwtPreAuthCodeHandler handler = new JwtPreAuthCodeHandler(session);
+                VerificationException exception = assertThrows(VerificationException.class,
+                        () -> handler.verifyPreAuthCode(preAuthCode));
+
+                assertTrue(exception.getMessage().startsWith("Jwt pre-auth code not valid:"));
+            } finally {
+                Time.setOffset(0);
+            }
+        });
+    }
+
+    @Test
+    public void mustRejectReplayedPreAuthCodeJwts() {
+        // Request a pre-auth code. This will create an offer state in the server
+        // and return a pre-auth code linked to that state.
+        String preAuthCode = createPreAuthOffer(null);
+        assertValidPreAuthCodeJwt(preAuthCode, Algorithm.ES256);
+
+        // First use: the pre-auth code can be exchanged for an access token
+        AccessTokenResponse resp = wallet.preAuthAccessTokenRequest(testCtx, preAuthCode).send();
+        assertEquals(HttpStatus.SC_OK, resp.getStatusCode());
+
+        // Second use: the same pre-auth code must be rejected as replayed
+        AccessTokenResponse replayResp = wallet.preAuthAccessTokenRequest(testCtx, preAuthCode).send();
+        assertEquals(HttpStatus.SC_BAD_REQUEST, replayResp.getStatusCode());
+        assertEquals("Pre-authorized code has already been used", replayResp.getErrorDescription());
+    }
+
+    private String createPreAuthOffer(String signingAlg) {
+        // Configure signing algorithm in credential client scope
+        configureCredentialSigningAlgorithm(signingAlg);
+
+        runOnServer.run(session -> {
+            PreAuthCodeHandler handler = session.getProvider(PreAuthCodeHandler.class);
+            assertInstanceOf(JwtPreAuthCodeHandler.class, handler,
+                    "This testsuite expects JwtPreAuthCodeHandler as PreAuthCodeHandler provider");
+        });
+
+        try {
+            CredentialsOffer offer = wallet.createPreAuthCredentialOffer(testCtx, testCtx.getHolder());
+            return offer.getPreAuthorizedCode();
+        } catch (Exception e) {
+            throw new AssertionError("Should not fail to create pre-auth code", e);
+        }
+    }
+
+    private void configureCredentialSigningAlgorithm(String alg) {
+        CredentialScopeRepresentation scope = testCtx.getCredentialScope();
+        scope.setSigningAlg(Objects.requireNonNullElse(alg, ""));
+
+        // Update the credential scope with the new signing algorithm configuration
+        testRealm.admin().clientScopes().get(scope.getId()).update(scope);
+    }
+
+    public static void assertValidPreAuthCodeJwt(String jwt, String expectedAlg) {
+        JWSInput jws;
+        JwtPreAuthCode payload;
+
+        try {
+            jws = new JWSInput(jwt);
+            payload = jws.readJsonContent(JwtPreAuthCode.class);
+        } catch (JWSInputException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertEquals(expectedAlg, jws.getHeader().getAlgorithm().toString(),
+                "Must use expected signing algorithm");
+
+        assertNotNull(payload.getContext(), "Must embed an associated context");
+        assertNotNull(payload.getSalt(), "Must be salted");
+    }
+
+    private void assertPreAuthCodeCtx(PreAuthCodeCtx preAuthCodeCtx) {
+        assertEquals(client.getClientId(), preAuthCodeCtx.getTargetClientId());
+        assertEquals(getExistingUser(testCtx.getHolder()).getId(), preAuthCodeCtx.getTargetUserId());
+        assertEquals(List.of(testCtx.getCredentialScope().getCredentialConfigurationId()),
+                preAuthCodeCtx.getCredentialConfigurationIds());
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/rest/TestingResourceProvider.java
@@ -55,6 +55,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.common.VerificationException;
 import org.keycloak.common.enums.HostnameVerificationPolicy;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
 import org.keycloak.common.util.HtmlUtils;
@@ -89,9 +90,11 @@ import org.keycloak.models.utils.ResetTimeOffsetEvent;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.JwtPreAuthCodeHandler;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
-import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
+import org.keycloak.protocol.oid4vc.model.PreAuthCodeCtx;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
 import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.provider.Provider;
@@ -1132,11 +1135,9 @@ public class TestingResourceProvider implements RealmResourceProvider {
 
         String credConfigId = "oid4vc_natural_person_sd";
 
-        String code = "urn:oid4vci:code:" + UUID.randomUUID();
         CredentialsOffer credOffer = new CredentialsOffer()
                 .setCredentialIssuer(OID4VCIssuerWellKnownProvider.getIssuer(session.getContext()))
-                .setCredentialConfigurationIds(List.of(credConfigId))
-                .addGrant(new PreAuthorizedCodeGrant().setPreAuthorizedCode(code));
+                .setCredentialConfigurationIds(List.of(credConfigId));
 
         String targetUserId = userSession.getUser().getId();
         CredentialOfferState offerState = new CredentialOfferState(credOffer, clientId, targetUserId, expireAt, credOfferId -> {
@@ -1150,15 +1151,20 @@ public class TestingResourceProvider implements RealmResourceProvider {
         var offerStorage = session.getProvider(CredentialOfferStorage.class);
         offerStorage.putOfferState( offerState);
 
-        return code;
+        PreAuthCodeCtx preAuthCodeCtx = new PreAuthCodeCtx(offerState);
+        return new JwtPreAuthCodeHandler(session).createPreAuthCode(preAuthCodeCtx);
     }
 
     @GET
     @Path("/tx-code")
     @NoCache
-    public String getTxCode(@QueryParam("pre-auth-code") final String preAuthCode) {
+    public String getTxCode(@QueryParam("pre-auth-code") final String preAuthCode) throws VerificationException {
+        var preAuthCodeHandler = session.getProvider(PreAuthCodeHandler.class);
+        PreAuthCodeCtx ctx = preAuthCodeHandler.verifyPreAuthCode(preAuthCode);
+
         var offerStorage = session.getProvider(CredentialOfferStorage.class);
-        var offerState = offerStorage.getOfferStateByPreAuthCode( preAuthCode);
+        var offerState = offerStorage.getOfferStateById(ctx.getCredentialsOfferId());
+
         return Optional.ofNullable(offerState).map(CredentialOfferState::getTxCode).orElse(null);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
@@ -62,7 +62,7 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testPreAuthorizedGrant() throws Exception {
         String userSessionId = getUserSession();
-        String preAuthorizedCode = getTestingClient().testing().getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
+        String preAuthorizedCode = getTestingClient().testing(TEST_REALM_NAME).getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() + 30);
         AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
 
         assertEquals("An access token should have successfully been returned.", HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
@@ -71,7 +71,7 @@ public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testPreAuthorizedGrantExpired() throws Exception {
         String userSessionId = getUserSession();
-        String preAuthorizedCode = getTestingClient().testing().getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() - 30);
+        String preAuthorizedCode = getTestingClient().testing(TEST_REALM_NAME).getPreAuthorizedCode(TEST_REALM_NAME, userSessionId, "test-app", Time.currentTime() - 30);
         AccessTokenResponse accessTokenResponse = postCode(preAuthorizedCode);
         assertEquals("An expired code should not get an access token.", HttpStatus.SC_BAD_REQUEST, accessTokenResponse.getStatusCode());
     }


### PR DESCRIPTION
Closes #45231

The implemented JWT format looks like this (updated with review comments):

```json
{
  "header" : {
    "alg" : "HS512",
    "typ" : "JWT",
    "kid" : "a109ad9d-0144-40c9-80e7-42dc7e55b2e6"
  },
  "payload" : {
    "exp" : 1774447450,
    "iat" : 1774447420,
    "iss" : "http://localhost:8080/realms/test",
    "aud" : "http://localhost:8080/realms/test/protocol/openid-connect/token",
    "context" : {
      "credentials_offer_id" : "jPYrg61ZmpG0Dwb7qSn3B5AmiyJuScjtflP001s-jZlacJxhnnx5p8zwAni4GJUQ-pWO_EhZZrzOx1cugo5zjw",
      "target_client_id" : "oid4vci-client",
      "target_user_id" : "0599083e-fb4b-4e9f-8e05-685adfab65a5",
      "nonce" : "OCYXrKWen1TFaCwXvx5RYYwWdEfGbYF1fqlsqnwoO3FCHG5SL-s2fbvTScNLwKtgKvVj8E2tSEUIXDo4Z3dXdQ",
      "authorization_details" : [ {
        "type" : "openid_credential",
        "credential_configuration_id" : "jwt-credential-config-id",
        "credential_identifiers" : [ "jwt-credential" ]
      } ]
    },
    "salt" : "fVLiYLHQ6ALVRF2V2KXyZ5AVh284h2k1TZMBO6k6fF0"
  },
  "signature" : "oLYISMsP4ZlwfDNl8joXQ58kZPVL8yECbAOa3AX_vPCjIpLD9XUKFvJgbUo34CG1h56YMFIOj9qN48_iZit-1A"
}
```