### PR TITLE
add managed identity for all db except azure sql and sql managed instance and oracle

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/IdentityOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/IdentityOptions.java
@@ -1,0 +1,30 @@
+package org.keycloak.config;
+
+public class IdentityOptions {
+  public static final Option<Boolean> USE_IDENTITY = new OptionBuilder<>("use-identity", Boolean.class)
+    .category(OptionCategory.DATABASE_IDENTITY)
+    .defaultValue(false)
+    .description("boolean value to define is managed identity is used.")
+    .build();
+  public static final Option<String> CLOUD_PROVIDER = new OptionBuilder<>("cloud-provider", String.class)
+    .category(OptionCategory.DATABASE_IDENTITY)
+    .defaultValue("")
+    .description("boolean value to define is managed identity is used.")
+    .build();
+
+  public static final Option<String> AWS_REGION = new OptionBuilder<>("aws-region", String.class)
+    .category(OptionCategory.DATABASE_IDENTITY)
+    .defaultValue("")
+    .description("boolean value to define is managed identity is used.")
+    .build();
+  public static final Option<String> AWS_PORT = new OptionBuilder<>("aws-port", String.class)
+    .category(OptionCategory.DATABASE_IDENTITY)
+    .defaultValue("0")
+    .description("boolean value to define is managed identity is used.")
+    .build();
+  public static final Option<String> AWS_HOSTNAME = new OptionBuilder<>("aws-hostname", String.class)
+    .category(OptionCategory.DATABASE_IDENTITY)
+    .defaultValue("")
+    .description("boolean value to define is managed identity is used.")
+    .build();
+}

--- a/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/OptionCategory.java
@@ -3,6 +3,7 @@ package org.keycloak.config;
 public enum OptionCategory {
     CACHE("Cache", 10, ConfigSupportLevel.SUPPORTED),
     CONFIG("Config", 15, ConfigSupportLevel.SUPPORTED),
+    DATABASE_IDENTITY("Identity", 17, ConfigSupportLevel.SUPPORTED),
     DATABASE("Database", 20, ConfigSupportLevel.SUPPORTED),
     DATABASE_DATASOURCES("Database - additional datasources", 21, ConfigSupportLevel.SUPPORTED),
     TRANSACTION("Transaction",30, ConfigSupportLevel.SUPPORTED),
@@ -27,6 +28,7 @@ public enum OptionCategory {
     OPENAPI("OpenAPI configuration", 150, ConfigSupportLevel.SUPPORTED),
     BOOTSTRAP_ADMIN("Bootstrap Admin", 998, ConfigSupportLevel.SUPPORTED),
     GENERAL("General", 999, ConfigSupportLevel.SUPPORTED);
+
 
     private final String heading;
     //Categories with a lower number are shown before groups with a higher number

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -163,7 +163,33 @@
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
         </dependency>
-
+        <!-- azure dependency to be shipped with app inside quarkus app-->
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+            <version>1.52.0</version>
+        </dependency>
+        <!-- aws dependency to be shipped with app inside quarkus app -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+            <version>2.40.17</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>rds</artifactId>
+            <version>2.40.17</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>2.40.17</version>
+        </dependency>
         <!-- Keycloak -->
         <dependency>
             <groupId>org.keycloak</groupId>
@@ -707,6 +733,11 @@
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
         </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 
     <build>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/AwsDatabaseTokenProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/AwsDatabaseTokenProvider.java
@@ -1,0 +1,63 @@
+package org.keycloak.quarkus.runtime.configuration.ManagedIdentity;
+
+import java.time.Instant;
+
+import org.keycloak.config.DatabaseOptions;
+import org.keycloak.config.IdentityOptions;
+import org.keycloak.config.Option;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.rds.RdsUtilities;
+
+public class AwsDatabaseTokenProvider implements DatabaseTokenProvider {
+
+  @Override
+  public TokenResponse getToken(String vendor) {
+
+    String region = requireConfig(IdentityOptions.AWS_REGION);
+
+    String hostName = requireConfig(IdentityOptions.AWS_HOSTNAME);
+    String portStr = requireConfig(IdentityOptions.AWS_PORT);
+    String username = requireConfig(DatabaseOptions.DB_USERNAME);
+
+    Region awsRegion = Region.of(region);
+
+    int port;
+    try {
+      port = Integer.parseInt(portStr);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException("Invalid AWS port: " + portStr, e);
+    }
+
+    RdsUtilities utilities = RdsUtilities.builder()
+      .region(awsRegion)
+      .credentialsProvider(DefaultCredentialsProvider.builder().build())
+      .build();
+
+    String token= utilities.generateAuthenticationToken(builder -> builder
+      .hostname(hostName)
+      .port(port)
+      .username(username));
+    if (token == null) {
+      throw new IllegalStateException("Failed to acquire Aws token");
+    }
+    //max time for aws token are 15 min
+    // 900 sec -300 (found in token manager) is the time the token will refresh
+    Instant expires = Instant.now().plusSeconds(900);
+    return new TokenResponse(token, expires);
+  }
+
+  private String requireConfig( Option<String> key) {
+    String value = Configuration.getConfigValue(key).getValue();
+
+    if (value == null || value.isBlank()) {
+      throw new IllegalStateException(
+        "Required configuration property is missing or empty: " + key
+      );
+    }
+
+    return value.trim();
+  }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/AzureDatabaseTokenProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/AzureDatabaseTokenProvider.java
@@ -1,0 +1,39 @@
+package org.keycloak.quarkus.runtime.configuration.ManagedIdentity;
+
+import java.time.Instant;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+
+public class AzureDatabaseTokenProvider implements DatabaseTokenProvider {
+  private final DefaultAzureCredential credential;
+  public AzureDatabaseTokenProvider() {
+    this.credential = new DefaultAzureCredentialBuilder().build();
+  }
+  @Override
+  public TokenResponse getToken(String vendor) {
+
+    TokenRequestContext context = switch (vendor) {
+      case "mssql" -> new TokenRequestContext()
+        .addScopes("https://database.windows.net/.default");
+
+      case "postgresql", "postgres", "mariadb", "mysql" -> new TokenRequestContext()
+        .addScopes("https://ossrdbms-aad.database.windows.net/.default");
+
+      default -> throw new IllegalArgumentException("Unsupported vendor type");
+    };
+
+    AccessToken accesstoken = credential.getToken(context).block();
+    if (accesstoken == null) {
+      throw new IllegalStateException("Failed to acquire Azure token");
+    }
+    String token = accesstoken.getToken();
+    //max time for aws token are 60 min
+    // 3600 sec -300 (found in token manager) is the time the token will refresh
+    Instant expires = Instant.now().plusSeconds(3600);
+
+    return new TokenResponse(token, expires);
+  }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/DatabaseTokenManager.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/DatabaseTokenManager.java
@@ -1,0 +1,41 @@
+package org.keycloak.quarkus.runtime.configuration.ManagedIdentity;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class DatabaseTokenManager {
+  private final DatabaseTokenProvider provider;
+  private final AtomicReference<CachedToken> cache = new AtomicReference<>();
+
+  public DatabaseTokenManager(DatabaseTokenProvider provider) {
+    this.provider = provider;
+  }
+
+  public synchronized String getToken(String vendor) {
+
+    CachedToken current = cache.get();
+
+    if (current != null && !current.isExpiringSoon()) {
+      return current.token();
+    }
+
+    DatabaseTokenProvider.TokenResponse response =
+      provider.getToken(vendor);
+
+    CachedToken updated = new CachedToken(
+      response.token(),
+      response.expiresAt()
+    );
+
+    cache.set(updated);
+
+    return updated.token();
+  }
+
+  private record CachedToken(String token, Instant expiresAt) {
+    //moment to refresh existing password sent to quarkus
+    boolean isExpiringSoon() {
+      return Instant.now().isAfter(expiresAt.minusSeconds(300));
+    }
+  }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/DatabaseTokenProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ManagedIdentity/DatabaseTokenProvider.java
@@ -1,0 +1,8 @@
+package org.keycloak.quarkus.runtime.configuration.ManagedIdentity;
+
+import java.time.Instant;
+
+public interface DatabaseTokenProvider  {
+   TokenResponse  getToken(String vendor);
+   record TokenResponse (String token, Instant expiresAt) {}
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -9,11 +9,16 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.keycloak.config.DatabaseOptions;
+import org.keycloak.config.IdentityOptions;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.TransactionOptions;
 import org.keycloak.config.database.Database;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.AwsDatabaseTokenProvider;
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.AzureDatabaseTokenProvider;
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.DatabaseTokenManager;
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.DatabaseTokenProvider;
 import org.keycloak.utils.StringUtil;
 
 import io.quarkus.datasource.common.runtime.DatabaseKind;
@@ -75,6 +80,7 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
                         .paramLabel("username")
                         .build(),
                 fromOption(DatabaseOptions.DB_PASSWORD)
+                        .mapFrom(DatabaseOptions.DB, DatabasePropertyMappers::getPassword)
                         .to("quarkus.datasource.password")
                         .paramLabel("password")
                         .isMasked(true)
@@ -236,6 +242,47 @@ final class DatabasePropertyMappers implements PropertyMapperGrouping {
             case MYSQL, MARIADB -> "PT7H50M";
             default -> "";
         };
+    }
+    private static volatile  DatabaseTokenManager TOKEN_MANAGER ;
+
+    private static String getPassword(String name, String value, ConfigSourceInterceptorContext context) {
+      String IdentityEnabled = Configuration.getConfigValue(IdentityOptions.USE_IDENTITY).getValue();
+      Supplier<String> configuredPassword  = () -> Optional.ofNullable(context.proceed(NS_KEYCLOAK_PREFIX + DatabaseOptions.DB_PASSWORD.getKey()))
+        .map(ConfigValue::getValue)
+        .orElse(null);
+      String db = Configuration.getConfigValue(DatabaseOptions.DB).getValue();
+      Database.Vendor vendorEnum = Database.getVendor(db).orElseThrow();
+      String vendor = vendorEnum.name().toLowerCase(); //postgres
+      if ("true".equalsIgnoreCase(IdentityEnabled)) {
+        log.debug("token is:"+ configuredPassword);
+        return getTokenManager().getToken(vendor);
+      }
+      return configuredPassword.get();
+    }
+
+  private static DatabaseTokenManager getTokenManager() {
+
+    if (TOKEN_MANAGER == null) {
+      synchronized (DatabasePropertyMappers.class) {
+        if (TOKEN_MANAGER == null) {
+          TOKEN_MANAGER = new DatabaseTokenManager(resolveProvider());
+        }
+      }
+    }
+    return TOKEN_MANAGER;
+  }
+
+    private static DatabaseTokenProvider resolveProvider() {
+
+      String cloud = Configuration.getConfigValue(IdentityOptions.CLOUD_PROVIDER).getValue();
+
+      if ("azure".equalsIgnoreCase(cloud)) {
+        return new AzureDatabaseTokenProvider();
+      }
+      if ("aws".equalsIgnoreCase(cloud)) {
+        return new AwsDatabaseTokenProvider();
+      }
+      throw new IllegalStateException("Unsupported cloud provider: " + cloud);
     }
 
     public static final class Datasources {

--- a/quarkus/runtime/src/test/java/org/keycloak/config/DatabaseTokenManagerTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/config/DatabaseTokenManagerTest.java
@@ -1,0 +1,71 @@
+package org.keycloak.config;
+
+import java.time.Instant;
+
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.DatabaseTokenManager;
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.DatabaseTokenProvider;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DatabaseTokenManagerTest {
+  @Test
+  public void should_return_TokenResponse() {
+    DatabaseTokenProvider mockProvider = mock(DatabaseTokenProvider.class);
+    DatabaseTokenManager manager = new DatabaseTokenManager(mockProvider);
+    Instant future = Instant.now().plusSeconds(3600);
+
+    when(mockProvider.getToken("postgres"))
+      .thenReturn(new DatabaseTokenProvider.TokenResponse(
+        "fake-token",
+        future
+      ));
+    String token = manager.getToken("postgres");
+
+    assertEquals("fake-token", token);
+  }
+
+  @Test
+  public void should_cache_tokens() {
+    DatabaseTokenProvider mockProvider = mock(DatabaseTokenProvider.class);
+    DatabaseTokenManager manager = new DatabaseTokenManager(mockProvider);
+    Instant future = Instant.now().plusSeconds(3600);
+
+    when(mockProvider.getToken("postgres"))
+      .thenReturn(new DatabaseTokenProvider.TokenResponse(
+        "fake-token",
+        future
+      ));
+    manager.getToken("postgres");
+    manager.getToken("postgres");
+    verify(mockProvider, times(1)).getToken("postgres");
+  }
+
+  @Test
+  public void should_refresh_token_that_will_Expire() {
+    DatabaseTokenProvider mockProvider = mock(DatabaseTokenProvider.class);
+    DatabaseTokenManager manager = new DatabaseTokenManager(mockProvider);
+
+    when(mockProvider.getToken("postgres"))
+      .thenReturn(new DatabaseTokenProvider.TokenResponse(
+        "token1",
+        Instant.now().plusSeconds(100)  // < 300 seconds
+      ))
+      .thenReturn(new DatabaseTokenProvider.TokenResponse(
+        "token2",
+        Instant.now().plusSeconds(3600)
+      ));
+
+    String first = manager.getToken("postgres");
+    // manager should return the second token obtained from the provider the second time is called since first token will expire in 100 sec
+    String second = manager.getToken("postgres");
+
+    assertEquals("token1", first);
+    assertEquals("token2", second);
+  }
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/config/DatabaseTokenProviderTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/config/DatabaseTokenProviderTest.java
@@ -1,0 +1,34 @@
+package org.keycloak.config;
+
+import java.time.Instant;
+
+import org.keycloak.quarkus.runtime.configuration.ManagedIdentity.DatabaseTokenProvider;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DatabaseTokenProviderTest {
+
+  @Test
+  public void should_return_token() {
+    DatabaseTokenProvider mockProvider = mock(DatabaseTokenProvider.class);
+
+    DatabaseTokenProvider.TokenResponse fakeResponse =
+      new DatabaseTokenProvider.TokenResponse(
+        "fake-token",
+        Instant.now().plusSeconds(3600)
+      );
+
+    when(mockProvider.getToken("postgres"))
+      .thenReturn(fakeResponse);
+
+    DatabaseTokenProvider.TokenResponse result =
+      mockProvider.getToken("postgres");
+
+    assertEquals("fake-token", result.token());
+  }
+
+}


### PR DESCRIPTION
adding managed identity support for 

- azure flexible server postgresql (tested on 17.7, 16.11)
- azure mysql flexible server 8.0 8.4 (in both can connect but liquibase fails becuase some tables have multiple primary keys or somethign along those lines)
- azure mariadb flexible server ( havent tested yet  ,probably also work but need to check tomorrow)
- azure sql and sql managed instance is skipped since the way access token is used is different
- aws rds posgresql 17.6 (proably can work on other version but havent tested, will try tomorrow with 1 more)
- aws rds aurora postgresql 17.4 (probably can work on other versino but havent tested, will try tomorrow with 1 more)
- pending to test on aws rds mariadb and aws rds mysl 
- oracle db is not included since work different 


added step on here 
https://github.com/gabo89/keycloak-validation-yaml

reason of pull request
- avoid the use of credential on the application itself to connect to database
