### PR TITLE
Invalidate auth session when password changes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -231,4 +231,7 @@ public final class Constants {
     // This attribute can be used in a realm import definition to signal that default client scopes should be created in addition to the client scopes defined by the realm import definition.
     // When this attribute is omitted or set to false, the default client scopes are not created if at least one other client scope is defined by the realm import definition.
     public static final String CREATE_DEFAULT_CLIENT_SCOPES = "CreateDefaultClientScopes";
+
+    //note to store create/update time of a password in the current auth session
+    public static final String PASSWORD_UPDATED = "password-updated";
 }

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationPassword.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationPassword.java
@@ -27,10 +27,12 @@ import org.keycloak.authentication.FormAction;
 import org.keycloak.authentication.FormActionFactory;
 import org.keycloak.authentication.FormContext;
 import org.keycloak.authentication.ValidationContext;
+import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
@@ -94,6 +96,7 @@ public class RegistrationPassword implements FormAction, FormActionFactory {
         String password = formData.getFirst(RegistrationPage.FIELD_PASSWORD);
         UserModel user = context.getUser();
         try {
+            context.getAuthenticationSession().setAuthNote(Constants.PASSWORD_UPDATED, String.valueOf(Time.currentTimeMillis()));
             user.credentialManager().updateCredential(UserCredentialModel.password(formData.getFirst("password"), false));
         } catch (Exception me) {
             user.addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
@@ -146,6 +146,7 @@ public class UpdatePassword implements RequiredActionProvider, RequiredActionFac
 
         try {
             user.credentialManager().updateCredential(UserCredentialModel.password(passwordNew, false));
+            authSession.setAuthNote(Constants.PASSWORD_UPDATED, String.valueOf(Time.currentTimeMillis()));
             context.success();
             deprecatedEvent.success();
         } catch (ModelException me) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/AbstractUserTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/AbstractUserTest.java
@@ -126,10 +126,14 @@ public class AbstractUserTest {
     }
 
     protected String createUser(String username, String email) {
+        return createUser(username, email, Collections.emptyList());
+    }
+
+    protected String createUser(String username, String email, List<String> requiredActions) {
         UserRepresentation user = new UserRepresentation();
         user.setUsername(username);
         user.setEmail(email);
-        user.setRequiredActions(Collections.emptyList());
+        user.setRequiredActions(requiredActions);
         user.setEnabled(true);
 
         return createUser(user);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
@@ -33,6 +33,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
@@ -191,6 +192,8 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
 
     @Test
     public void resetPasswordRequiresReAuth() {
+        resetUserPassword("test-user@localhost", "password");
+
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
 
@@ -379,6 +382,13 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
 
     @Test
     public void resetPasswordUserHasUpdatePasswordRequiredAction() {
+        //set password with correct creation time
+        CredentialRepresentation credPerm = new CredentialRepresentation();
+        credPerm.setType(CredentialRepresentation.PASSWORD);
+        credPerm.setValue("password");
+        credPerm.setTemporary(null);
+        realmsResouce().realm(TEST_REALM_NAME).users().get(findUser("test-user@localhost").getId()).resetPassword(credPerm);
+
         loginPage.open();
         loginPage.login("test-user@localhost", "password");
 
@@ -408,6 +418,8 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
 
     @Test
     public void checkLogoutSessions() {
+        resetUserPassword("test-user@localhost", "password");
+
         OAuthClient oauth2 = oauth.newConfig().driver(driver2);
 
         loginPage.open();
@@ -462,6 +474,16 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
         assertKcActionStatus(SUCCESS);
 
         assertEquals(2, testUser.getUserSessions().size());
+    }
+
+    private void resetUserPassword(String username, String password) {
+        setTimeOffset(0);
+        CredentialRepresentation credPerm = new CredentialRepresentation();
+        credPerm.setType(CredentialRepresentation.PASSWORD);
+        credPerm.setValue(password);
+        credPerm.setTemporary(null);
+        realmsResouce().realm(TEST_REALM_NAME).users().get(findUser(username).getId()).resetPassword(credPerm);
+
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -48,6 +48,7 @@ import org.keycloak.models.utils.SessionTimeoutHelper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -852,6 +853,13 @@ public class LoginTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Test
     public void loginAfterExpiredTimeout() throws Exception {
+        //set password with correct creation time
+        CredentialRepresentation credPerm = new CredentialRepresentation();
+        credPerm.setType(CredentialRepresentation.PASSWORD);
+        credPerm.setValue(generatePassword("login-test"));
+        credPerm.setTemporary(null);
+        realmsResouce().realm(TEST_REALM_NAME).users().get(userId).resetPassword(credPerm);
+
         try (AutoCloseable c = new RealmAttributeUpdater(adminClient.realm("test"))
                 .updateWith(r -> {
                     r.setSsoSessionMaxLifespan(5);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -203,6 +203,8 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         oauth.logoutForm().idTokenHint(idTokenHint).open();
         events.clear();
 
+        setTimeOffset(60);
+
         try (RealmAttributeUpdater rau = configureRealmRegistrationEmailAsUsername(true).update()) {
             loginPage.open();
             loginPage.assertCurrent();
@@ -218,6 +220,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         } finally {
             assertThat(userId, notNullValue());
             testRealm().users().get(userId).remove();
+            setTimeOffset(0);
         }
     }
 
@@ -458,6 +461,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         String email = username + "@email.com";
         registerPage.register("firstName", "lastName", email, username, generatePassword());
 
+      //  setTimeOffset(5);
         appPage.assertCurrent();
         assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
 


### PR DESCRIPTION
Closes #45568

Removing a user's auth sessions when the user changes their password is probably the best solution, but it is not possible to do so without iterating over the authentication sessions or introducing a new method to the auth session model. 

This PR proposes an alternative solution:

If there is a password with a creation date > auth session creation date (and the password was not updated within the same auth session), the auth session is terminated after the required actions.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
