### PR TITLE
[OID4VCI] Make sure persistent userSession not needed in preAuthorized code gra…

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
@@ -1,0 +1,54 @@
+package org.keycloak.protocol.oid4vc.utils;
+
+import java.util.List;
+
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.utils.StringUtil;
+
+import org.jboss.logging.Logger;
+
+import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
+
+public class OID4VCUtil {
+
+    private static final Logger logger = Logger.getLogger(OID4VCUtil.class);
+
+    private OID4VCUtil() {
+    }
+
+    /**
+     * Find OID4VCI client scope by credential config ID
+     *
+     * @param session Keycloak session
+     * @param realmModel realm
+     * @param credentialConfigId credential configuration ID
+     * @return Found OID4VCI client scope
+     */
+    public static ClientScopeModel getClientScopeByCredentialConfigId(KeycloakSession session, RealmModel realmModel, String credentialConfigId) {
+        if (StringUtil.isBlank(credentialConfigId)) {
+            return null;
+        }
+
+        List<ClientScopeModel> clientScopes = session.clientScopes()
+                .getClientScopesByProtocol(realmModel, OID4VC_PROTOCOL)
+                .filter(it -> credentialConfigId.equals(it.getAttribute(CredentialScopeModel.CONFIGURATION_ID)))
+                .toList();
+        if (clientScopes.size() > 1) {
+            List<String> clientScopeNames = clientScopes.stream()
+                    .map(ClientScopeModel::getName)
+                    .toList();
+            logger.warnf("Multiple client scopes find with credential config ID '%s' in the realm '%s'. Please make sure that credential-config-id is unique across client scopes. Found client scopes: %s",
+                    credentialConfigId, realmModel.getName(), clientScopeNames);
+            return null;
+        } else if (clientScopes.isEmpty()) {
+            logger.warnf("No client scopes find with credential config ID '%s' in the realm '%s'",
+                    credentialConfigId, realmModel.getName());
+            return null;
+        } else {
+            return clientScopes.get(0);
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCAuthorizationCodeFlowTestBase.java
@@ -178,9 +178,9 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerEn
         String error = credentialResponse.getError();
         String errorDescription = credentialResponse.getErrorDescription();
 
-        assertEquals("Credential request should fail with unknown credential configuration when OID4VCI scope is missing",
+        assertEquals("Credential request should fail with unknown credential configuration when OID4VCI scope is missing or authorization_details missing from the token",
             "UNKNOWN_CREDENTIAL_CONFIGURATION", error);
-        assertEquals("Scope check failure", errorDescription);
+        assertEquals("No authorization_details found in token", errorDescription);
     }
 
     // Test for the whole authorization_code flow with the credentialRequest using credential_configuration_id


### PR DESCRIPTION
…nt type

closes #44534

- Make sure there is no userSession created in pre-authorized code flow. This grant doesn't need to refresh token and hence does not need to save persistent session. There is only "transient" (request-scoped) session like in other similar grants (EG. OAuth2 client credentials grant)

- Make sure that credential-endpoint is called only with proper access-token, which was returned from pre-authorized grant OR from authorization-code grant, which requested the credential issuance. Before this PR, it was still possible to call the credential-endpoint with incorrect access token (corresponding test `OID4VCAuthorizationDetailsFlowTestBase.testCompleteFlowWithClaimsValidation()` updated to reflect that)
