### PR TITLE
Do not use offline sessions in the logout endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -413,10 +413,6 @@ public class LogoutEndpoint {
                 userSession = session.sessions().getUserSession(realm, userSessionIdFromIdToken);
 
                 if (userSession == null) {
-                    userSession = session.sessions().getOfflineUserSession(realm, userSessionIdFromIdToken);
-                }
-
-                if (userSession == null) {
                     event.event(EventType.LOGOUT);
                     event.error(Errors.SESSION_EXPIRED);
                     KeycloakContext context = session.getContext();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -308,15 +308,20 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
         return contextRoot + "/auth/realms/" + realmName + "/account";
     }
 
+    protected String getLoginUrl(String contextRoot, String realmName, String clientId) {
+        return getLoginUrl(contextRoot, realmName, clientId, "openid");
+    }
+
     /**
      * Get the login page for an existing client in provided realm
      *
      * @param contextRoot server base url without /auth
      * @param realmName Name of the realm
      * @param clientId ClientId of a client. Client has to exists in the realm.
+     * @param scope The scope parameter for the request
      * @return Login URL
      */
-    protected String getLoginUrl(String contextRoot, String realmName, String clientId) {
+    protected String getLoginUrl(String contextRoot, String realmName, String clientId, String scope) {
         List<ClientRepresentation> clients = adminClient.realm(realmName).clients().findByClientId(clientId);
 
         assertThat(clients, Matchers.is(Matchers.not(Matchers.empty())));
@@ -327,7 +332,7 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
         }
 
         return contextRoot + "/auth/realms/" + realmName + "/protocol/openid-connect/auth?client_id=" +
-                clientId + "&redirect_uri=" + redirectURI + "&response_type=code&scope=openid";
+                clientId + "&redirect_uri=" + redirectURI + "&response_type=code&scope=" + scope;
     }
 
     protected void logoutFromRealm(String contextRoot, String realm) {


### PR DESCRIPTION
Closes #46379

Removing the lookup of the offline session in the logout endpoint. After the conversation in the issue, removing the lookup was decided. This is better aligned with the spec and it never worked completely OK. Test added to check that poffline sessions are not managed at all.
