### PR TITLE
Allow to expose WellKnown provider via ServerMetadataResource (#46292)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oauth2/OAuth2WellKnownProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oauth2/OAuth2WellKnownProviderFactory.java
@@ -30,4 +30,9 @@ public class OAuth2WellKnownProviderFactory extends OIDCWellKnownProviderFactory
     public String getId() {
         return PROVIDER_ID;
     }
+
+    @Override
+    public boolean isAvailableViaServerMetadata() {
+        return true;
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/JWTVCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/JWTVCIssuerWellKnownProvider.java
@@ -91,7 +91,7 @@ public class JWTVCIssuerWellKnownProvider implements WellKnownProvider {
         }
 
         var base = session.getContext().getUri().getBaseUriBuilder();
-        var successor = ServerMetadataResource.wellKnownOAuthProviderUrl(base)
+        var successor = ServerMetadataResource.wellKnownProviderUrl(base)
                 .build(JWTVCIssuerWellKnownProviderFactory.PROVIDER_ID, realm.getName());
 
         HttpResponse httpResponse = session.getContext().getHttpResponse();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/JWTVCIssuerWellKnownProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/JWTVCIssuerWellKnownProviderFactory.java
@@ -58,4 +58,9 @@ public class JWTVCIssuerWellKnownProviderFactory implements WellKnownProviderFac
     public String getId() {
         return PROVIDER_ID;
     }
+
+    @Override
+    public boolean isAvailableViaServerMetadata() {
+        return true;
+    }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProvider.java
@@ -571,7 +571,7 @@ public class OID4VCIssuerWellKnownProvider implements WellKnownProvider {
 
         UriBuilder base = session.getContext().getUri().getBaseUriBuilder();
         String logKey = session.getContext().getRealm().getName();
-        URI successor = ServerMetadataResource.wellKnownOAuthProviderUrl(base)
+        URI successor = ServerMetadataResource.wellKnownProviderUrl(base)
                 .build(WELL_KNOWN_OPENID_CREDENTIAL_ISSUER, logKey);
 
         HttpResponse httpResponse = session.getContext().getHttpResponse();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProviderFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerWellKnownProviderFactory.java
@@ -60,4 +60,9 @@ public class OID4VCIssuerWellKnownProviderFactory implements WellKnownProviderFa
     public String getId() {
         return PROVIDER_ID;
     }
+
+    @Override
+    public boolean isAvailableViaServerMetadata() {
+        return true;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/resources/RealmsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/RealmsResource.java
@@ -17,7 +17,6 @@
 package org.keycloak.services.resources;
 
 import java.net.URI;
-import java.util.Comparator;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
@@ -53,6 +52,7 @@ import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.services.resources.account.AccountLoader;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.services.util.ResolveRelative;
+import org.keycloak.services.util.WellKnownProviderUtil;
 import org.keycloak.utils.ProfileHelper;
 import org.keycloak.wellknown.WellKnownProvider;
 import org.keycloak.wellknown.WellKnownProviderFactory;
@@ -230,20 +230,17 @@ public class RealmsResource {
     @GET
     @Path("{realm}/.well-known/{alias}")
     @Produces({MediaType.APPLICATION_JSON, APPLICATION_JWT})
-    public Response getWellKnown(final @PathParam("realm") String name,
+    public Response getWellKnown(final @PathParam("realm") String realm,
                                  final @PathParam("alias") String alias) {
-        return getWellKnownResponse(session, name, alias, logger);
+        return getWellKnownResponse(session, realm, alias, logger);
     }
 
-    public static Response getWellKnownResponse(KeycloakSession session, String name, String alias, Logger logger) throws NotFoundException {
-        resolveRealmAndUpdateSession(session, name);
+    public static Response getWellKnownResponse(KeycloakSession session, String realm, String alias, Logger logger) throws NotFoundException {
+        resolveRealmAndUpdateSession(session, realm);
         checkSsl(session, session.getContext().getRealm());
 
-        WellKnownProviderFactory wellKnownProviderFactoryFound = session.getKeycloakSessionFactory().getProviderFactoriesStream(WellKnownProvider.class)
-                .map(providerFactory -> (WellKnownProviderFactory) providerFactory)
-                .filter(wellKnownProviderFactory -> alias.equals(wellKnownProviderFactory.getAlias()))
-                .sorted(Comparator.comparingInt(WellKnownProviderFactory::getPriority))
-                .findFirst().orElseThrow(NotFoundException::new);
+        WellKnownProviderFactory wellKnownProviderFactoryFound = WellKnownProviderUtil.resolveFromAlias(session.getKeycloakSessionFactory(), alias)
+                .orElseThrow(NotFoundException::new);
 
         logger.tracef("Use provider with ID '%s' for well-known alias '%s'", wellKnownProviderFactoryFound.getId(), alias);
 

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -67,10 +67,8 @@ public class ServerMetadataResource {
     }
 
     private boolean isValidProvider(String alias) {
-
-        WellKnownProviderFactory factory = WellKnownProviderUtil.resolveFromAlias(session.getKeycloakSessionFactory(), alias)
-                .orElse(null);
-        if (factory == null) return false;
-        return factory.isAvailableViaServerMetadata();
+        return WellKnownProviderUtil.resolveFromAlias(session.getKeycloakSessionFactory(), alias)
+                .map(WellKnownProviderFactory::isAvailableViaServerMetadata)
+                .orElse(false);
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -48,8 +48,8 @@ public class ServerMetadataResource {
     @OPTIONS
     @Path("{provider}/realms/{realm}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getOAuth2AuthorizationServerWellKnownVersionPreflight(final @PathParam("provider") String alias,
-                                                                          final @PathParam("realm") String realm) {
+    public Response getWellKnownPreflight(final @PathParam("provider") String alias,
+                                          final @PathParam("realm") String realm) {
         if (!isValidProvider(alias)) throw new NotFoundException();
         return Cors.builder().allowedMethods("GET").preflight().auth().add(Response.ok());
     }
@@ -57,8 +57,8 @@ public class ServerMetadataResource {
     @GET
     @Path("{provider}/realms/{realm}")
     @Produces({MediaType.APPLICATION_JSON, org.keycloak.utils.MediaType.APPLICATION_JWT})
-    public Response getOAuth2AuthorizationServerWellKnown(final @PathParam("provider") String alias,
-                                                          final @PathParam("realm") String realm) {
+    public Response getWellKnown(final @PathParam("provider") String alias,
+                                 final @PathParam("realm") String realm) {
         if (!isValidProvider(alias)) throw new NotFoundException();
         return RealmsResource.getWellKnownResponse(session, realm, alias, logger);
     }

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -66,7 +66,23 @@ public class ServerMetadataResource {
         return RealmsResource.getWellKnownResponse(session, realm, alias, logger);
     }
 
+    /**
+     * @Deprecated use {@link #wellKnownProviderUrl(UriBuilder)} instead.
+     * @return the updated UriBuilder instance.
+     */
+    @Deprecated
     public static UriBuilder wellKnownOAuthProviderUrl(UriBuilder builder) {
+        return wellKnownProviderUrl(builder);
+    }
+
+    /**
+     * Constructs the URI path for the well-known provider URL based on the provided UriBuilder.
+     *
+     * @param builder the base UriBuilder instance to which the well-known provider path will be appended.
+     *                It must not be null.
+     * @return the updated UriBuilder instance with the well-known provider path appended.
+     */
+    public static UriBuilder wellKnownProviderUrl(UriBuilder builder) {
         return builder.path(ServerMetadataResource.class).path("{provider}/realms/{realm}");
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -35,7 +35,6 @@ import org.keycloak.wellknown.WellKnownProviderFactory;
 
 import org.jboss.logging.Logger;
 
-
 @Provider
 @Path("/.well-known")
 public class ServerMetadataResource {

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -49,7 +49,9 @@ public class ServerMetadataResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getWellKnownPreflight(final @PathParam("provider") String alias,
                                           final @PathParam("realm") String realm) {
-        if (!isValidProvider(alias)) throw new NotFoundException();
+        if (!isValidProvider(alias)) {
+            throw new NotFoundException();
+        }
         return Cors.builder().allowedMethods("GET").preflight().auth().add(Response.ok());
     }
 
@@ -58,7 +60,9 @@ public class ServerMetadataResource {
     @Produces({MediaType.APPLICATION_JSON, org.keycloak.utils.MediaType.APPLICATION_JWT})
     public Response getWellKnown(final @PathParam("provider") String alias,
                                  final @PathParam("realm") String realm) {
-        if (!isValidProvider(alias)) throw new NotFoundException();
+        if (!isValidProvider(alias)) {
+            throw new NotFoundException();
+        }
         return RealmsResource.getWellKnownResponse(session, realm, alias, logger);
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -30,7 +30,7 @@ import jakarta.ws.rs.ext.Provider;
 
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.cors.Cors;
-import org.keycloak.wellknown.WellKnownProvider;
+import org.keycloak.services.util.WellKnownProviderUtil;
 import org.keycloak.wellknown.WellKnownProviderFactory;
 
 import org.jboss.logging.Logger;
@@ -48,28 +48,30 @@ public class ServerMetadataResource {
     @OPTIONS
     @Path("{provider}/realms/{realm}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getOAuth2AuthorizationServerWellKnownVersionPreflight(final @PathParam("provider") String providerName,
-                                                                          final @PathParam("realm") String name) {
-        if (!isValidProvider(providerName)) throw new NotFoundException();
+    public Response getOAuth2AuthorizationServerWellKnownVersionPreflight(final @PathParam("provider") String alias,
+                                                                          final @PathParam("realm") String realm) {
+        if (!isValidProvider(alias)) throw new NotFoundException();
         return Cors.builder().allowedMethods("GET").preflight().auth().add(Response.ok());
     }
 
     @GET
     @Path("{provider}/realms/{realm}")
     @Produces({MediaType.APPLICATION_JSON, org.keycloak.utils.MediaType.APPLICATION_JWT})
-    public Response getOAuth2AuthorizationServerWellKnown(final @PathParam("provider") String providerName,
-                                                          final @PathParam("realm") String name) {
-        if (!isValidProvider(providerName)) throw new NotFoundException();
-        return RealmsResource.getWellKnownResponse(session, name, providerName, logger);
+    public Response getOAuth2AuthorizationServerWellKnown(final @PathParam("provider") String alias,
+                                                          final @PathParam("realm") String realm) {
+        if (!isValidProvider(alias)) throw new NotFoundException();
+        return RealmsResource.getWellKnownResponse(session, realm, alias, logger);
     }
 
     public static UriBuilder wellKnownOAuthProviderUrl(UriBuilder builder) {
         return builder.path(ServerMetadataResource.class).path("{provider}/realms/{realm}");
     }
 
-    private boolean isValidProvider(String providerName) {
-        WellKnownProviderFactory providerFactory = (WellKnownProviderFactory)session.getKeycloakSessionFactory().getProviderFactory(WellKnownProvider.class, providerName);
-        if (providerFactory == null) return false;
-        return providerFactory.isAvailableViaServerMetadata();
+    private boolean isValidProvider(String alias) {
+
+        WellKnownProviderFactory factory = WellKnownProviderUtil.resolveFromAlias(session.getKeycloakSessionFactory(), alias)
+                .orElse(null);
+        if (factory == null) return false;
+        return factory.isAvailableViaServerMetadata();
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ServerMetadataResource.java
@@ -29,14 +29,11 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.ext.Provider;
 
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.protocol.oauth2.OAuth2WellKnownProviderFactory;
-import org.keycloak.protocol.oid4vc.issuance.JWTVCIssuerWellKnownProviderFactory;
-import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProviderFactory;
 import org.keycloak.services.cors.Cors;
+import org.keycloak.wellknown.WellKnownProvider;
+import org.keycloak.wellknown.WellKnownProviderFactory;
 
 import org.jboss.logging.Logger;
-
-import static org.keycloak.utils.MediaType.APPLICATION_JWT;
 
 
 @Provider
@@ -59,7 +56,7 @@ public class ServerMetadataResource {
 
     @GET
     @Path("{provider}/realms/{realm}")
-    @Produces({MediaType.APPLICATION_JSON, APPLICATION_JWT})
+    @Produces({MediaType.APPLICATION_JSON, org.keycloak.utils.MediaType.APPLICATION_JWT})
     public Response getOAuth2AuthorizationServerWellKnown(final @PathParam("provider") String providerName,
                                                           final @PathParam("realm") String name) {
         if (!isValidProvider(providerName)) throw new NotFoundException();
@@ -71,10 +68,8 @@ public class ServerMetadataResource {
     }
 
     private boolean isValidProvider(String providerName) {
-        // you can add codes here considering the current status of the implementation (preview, experimental).
-        if (OAuth2WellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
-        if (OID4VCIssuerWellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
-        if (JWTVCIssuerWellKnownProviderFactory.PROVIDER_ID.equals(providerName)) return true;
-        return false;
+        WellKnownProviderFactory providerFactory = (WellKnownProviderFactory)session.getKeycloakSessionFactory().getProviderFactory(WellKnownProvider.class, providerName);
+        if (providerFactory == null) return false;
+        return providerFactory.isAvailableViaServerMetadata();
     }
 }

--- a/services/src/main/java/org/keycloak/services/util/WellKnownProviderUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/WellKnownProviderUtil.java
@@ -37,7 +37,6 @@ public class WellKnownProviderUtil {
         return sessionFactory.getProviderFactoriesStream(WellKnownProvider.class)
                 .map(providerFactory -> (WellKnownProviderFactory) providerFactory)
                 .filter(wellKnownProviderFactory -> alias.equals(wellKnownProviderFactory.getAlias()))
-                .sorted(Comparator.comparingInt(WellKnownProviderFactory::getPriority))
-                .findFirst();
+                .min(Comparator.comparingInt(WellKnownProviderFactory::getPriority));
     }
 }

--- a/services/src/main/java/org/keycloak/services/util/WellKnownProviderUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/WellKnownProviderUtil.java
@@ -1,0 +1,43 @@
+package org.keycloak.services.util;
+
+import java.util.Comparator;
+import java.util.Optional;
+
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.wellknown.WellKnownProvider;
+import org.keycloak.wellknown.WellKnownProviderFactory;
+
+/**
+ * Utility class for resolving {@link WellKnownProviderFactory} instances based on their alias.
+ * This class provides methods to interact with the available provider factories within the context
+ * of a {@link KeycloakSessionFactory}.
+ *
+ * This is a utility class and is not intended to be instantiated.
+ */
+public class WellKnownProviderUtil {
+
+    private WellKnownProviderUtil() {
+        // Utility class
+    }
+
+    /**
+     * Resolves a {@link WellKnownProviderFactory} from the specified alias.
+     * If multiple factories share the same alias, the one with the lowest priority is selected.
+     *
+     * @param sessionFactory the {@link KeycloakSessionFactory} to retrieve provider factories from
+     * @param alias the alias of the desired {@link WellKnownProviderFactory}; if null, an empty {@link Optional} is returned
+     * @return an {@link Optional} containing the resolved {@link WellKnownProviderFactory}, or empty if no matching factory is found
+     */
+    public static Optional<WellKnownProviderFactory> resolveFromAlias(KeycloakSessionFactory sessionFactory, String alias) {
+
+        if (alias == null) {
+            return Optional.empty();
+        }
+
+        return sessionFactory.getProviderFactoriesStream(WellKnownProvider.class)
+                .map(providerFactory -> (WellKnownProviderFactory) providerFactory)
+                .filter(wellKnownProviderFactory -> alias.equals(wellKnownProviderFactory.getAlias()))
+                .sorted(Comparator.comparingInt(WellKnownProviderFactory::getPriority))
+                .findFirst();
+    }
+}

--- a/services/src/main/java/org/keycloak/wellknown/WellKnownProviderFactory.java
+++ b/services/src/main/java/org/keycloak/wellknown/WellKnownProviderFactory.java
@@ -19,6 +19,7 @@ package org.keycloak.wellknown;
 
 import org.keycloak.provider.ProviderFactory;
 
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
@@ -47,11 +48,12 @@ public interface WellKnownProviderFactory extends ProviderFactory<WellKnownProvi
 
     /**
      * Controls if the {@link WellKnownProvider} is available via server metadata endpoint.
-     * If this method returns true, then the provider will be available under {@code /.well-known/<alias>}.
+     * If this method returns true, then the provider will be available under {@code /.well-known/{alias}/realms/{realm}},
+     * where {@code {alias}} is the well-known alias returned by {@link #getAlias()}.
      *
      * Default implementation returns false.
      *
-     * @return
+     * @return true if this provider may be exposed via ServerMetadataResource
      */
     default boolean isAvailableViaServerMetadata() {
         return false;

--- a/services/src/main/java/org/keycloak/wellknown/WellKnownProviderFactory.java
+++ b/services/src/main/java/org/keycloak/wellknown/WellKnownProviderFactory.java
@@ -44,4 +44,16 @@ public interface WellKnownProviderFactory extends ProviderFactory<WellKnownProvi
     default int getPriority() {
         return 1;
     }
+
+    /**
+     * Controls if the {@link WellKnownProvider} is available via server metadata endpoint.
+     * If this method returns true, then the provider will be available under {@code /.well-known/<alias>}.
+     *
+     * Default implementation returns false.
+     *
+     * @return
+     */
+    default boolean isAvailableViaServerMetadata() {
+        return false;
+    }
 }

--- a/services/src/main/java/org/keycloak/wellknown/WellKnownProviderFactory.java
+++ b/services/src/main/java/org/keycloak/wellknown/WellKnownProviderFactory.java
@@ -19,7 +19,6 @@ package org.keycloak.wellknown;
 
 import org.keycloak.provider.ProviderFactory;
 
-
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RFC8414CompliantOAuth2WellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/RFC8414CompliantOAuth2WellKnownProviderTest.java
@@ -32,7 +32,7 @@ public class RFC8414CompliantOAuth2WellKnownProviderTest extends AbstractWellKno
     }
 
     protected URI getOIDCDiscoveryUri(UriBuilder builder) {
-        return ServerMetadataResource.wellKnownOAuthProviderUrl(builder).build(this.getWellKnownProviderId(), "test");
+        return ServerMetadataResource.wellKnownProviderUrl(builder).build(this.getWellKnownProviderId(), "test");
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -17,7 +17,20 @@
 
 package org.keycloak.testsuite.oidc;
 
+import java.net.URI;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
 import org.keycloak.protocol.oidc.OIDCWellKnownProviderFactory;
+import org.keycloak.services.resources.ServerMetadataResource;
+import org.keycloak.testsuite.util.AdminClientUtil;
+import org.keycloak.testsuite.util.oauth.OAuthClient;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
@@ -28,4 +41,21 @@ public class OIDCWellKnownProviderTest extends AbstractWellKnownProviderTest {
         return OIDCWellKnownProviderFactory.PROVIDER_ID;
     }
 
+    /**
+     * Ensures that the OpenID Connect configuration is not exposed by default via the server metadata
+     * root endpoint. This test verifies that accessing the `.well-known/openid-configuration`
+     * endpoint results in an HTTP 404 response, indicating the resource is not available.
+     */
+    @Test
+    public void openIdConfigurationShouldNotBeExposedViaServerMetadataRoot() {
+
+        UriBuilder builder = UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT);
+        URI serverMetadataWellKnownUri = ServerMetadataResource.wellKnownOAuthProviderUrl(builder).build(getWellKnownProviderId(), "test");
+
+        try (Client client = AdminClientUtil.createResteasyClient()) {
+            try (Response response = client.target(serverMetadataWellKnownUri).request().get()) {
+                assertEquals(404, response.getStatus());
+            }
+        }
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/OIDCWellKnownProviderTest.java
@@ -50,7 +50,7 @@ public class OIDCWellKnownProviderTest extends AbstractWellKnownProviderTest {
     public void openIdConfigurationShouldNotBeExposedViaServerMetadataRoot() {
 
         UriBuilder builder = UriBuilder.fromUri(OAuthClient.AUTH_SERVER_ROOT);
-        URI serverMetadataWellKnownUri = ServerMetadataResource.wellKnownOAuthProviderUrl(builder).build(getWellKnownProviderId(), "test");
+        URI serverMetadataWellKnownUri = ServerMetadataResource.wellKnownProviderUrl(builder).build(getWellKnownProviderId(), "test");
 
         try (Client client = AdminClientUtil.createResteasyClient()) {
             try (Response response = client.target(serverMetadataWellKnownUri).request().get()) {


### PR DESCRIPTION
- Introduce isAvailableViaServerMetadata() on WellKnownProviderFactory to let each provider control whether it is exposed via the root /.well-known/{alias}/realms/{realm} endpoint, defaulting to false to preserve existing behavior
- Extract shared alias-resolution logic into a new WellKnownProviderUtil.resolveFromAlias() utility, replacing duplicated lookup code in both RealmsResource and ServerMetadataResource
- Opt in OAuth2WellKnownProviderFactory, OID4VCIssuerWellKnownProviderFactory, and JWTVCIssuerWellKnownProviderFactory by overriding isAvailableViaServerMetadata() to return true
- Align ServerMetadataResource method names by replacing getOAuth2AuthorizationServerWellKnownVersionPreflight with getWellKnownPreflight and getOAuth2AuthorizationServerWellKnown with getWellKnown.
- Add test to verify .well-known/openid-configuration is not exposed via server metadata root by default.
- Added wellKnownProviderUrl(..) method to ServerMetadataResource, se we could also have non-oauth well-known providers.
- Marked the old ServerMetadataResource.wellKnownOAuthProviderUrl(..) as deprecated. Changed current call-sites to use wellKnownProviderUrl.

Previously, ServerMetadataResource.isValidProvider() used a hardcoded allowlist of provider IDs to decide which well-known endpoints were exposed at the server root. This meant every new provider required a code change in ServerMetadataResource. With this change, each WellKnownProviderFactory can declare its own eligibility, making the mechanism extensible for custom and future providers without modifying the resource class.

Fixes https://github.com/keycloak/keycloak/issues/46292

Followup PR to #46294 with all changes requested in code review.