### PR TITLE
Do not select disabled IdPs in the DefaultAlternativeLookupProvider

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -35,6 +35,11 @@ If you are using this Quarkus property, the new `transaction-default-timeout` CL
 
 To maintain your desired transaction timeout configuration, migrate to using the `transaction-default-timeout` CLI option and remove the `quarkus.transaction-manager.default-transaction-timeout` property from your configuration.
 
+=== The Identity Provider issuer should be unique for the JWT authorization grant and client assertions
+
+The JWT authorization grant and the client assertion authentication use the `issuer` claim passed in the assertion to locate the Identity Provider defined in {project_name}, and that provider validates the claims and signature in the assertion. Since this version, the `issuer` configuration option should be unique to only identify one provider. The grant operation or the assertion client authentication fail if more providers are returned for a single issuer. In the same way, the Identity Providers, when configured to allow the JWT authorization grant or client assertions, are validated to have a unique issuer defined in its configuration. Any update or add operation will fail if the issuer collides with another provider.
+
+If you have identity providers defined with the same issuer and tested the JWT authorization grants or client assertions features, please update the providers accordingly before the upgrade. You can update the issuer or disable the provider to avoid the duplicates.
 
 // ------------------------ Notable changes ------------------------ //
 == Notable changes

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/IdentityProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/IdentityProvider.java
@@ -22,7 +22,10 @@ import java.util.List;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.keycloak.broker.provider.util.IdentityProviderTypeUtil;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.Provider;
 
@@ -58,5 +61,17 @@ public interface IdentityProvider<C extends IdentityProviderModel> extends Provi
      */
     default boolean reloadKeys() {
         return false;
+    }
+
+    /**
+     * Returns if this Identity Provider is of the passed type. By default it just returns
+     * true when it implements the correct interface. Sub-classes like the OIDC
+     * provider can check specific configuration options.
+     * @param session The helper session
+     * @param type The type to check
+     * @return true if the provider is of the passed type, false otherwise
+     */
+    default boolean isType(KeycloakSession session, IdentityProviderType type) {
+        return IdentityProviderTypeUtil.listTypesFromProvider(session, this).contains(type);
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityProviderTypeUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/broker/provider/util/IdentityProviderTypeUtil.java
@@ -24,16 +24,18 @@ public class IdentityProviderTypeUtil {
     private IdentityProviderTypeUtil() {
     }
 
+    public static List<IdentityProviderType> listTypesFromProvider(KeycloakSession session, IdentityProvider provider) {
+        return listTypesFromClass(provider.getClass());
+    }
+
     public static List<IdentityProviderType> listTypesFromFactory(KeycloakSession session, String factoryId) {
         KeycloakSessionFactory sf = session.getKeycloakSessionFactory();
         ProviderFactory<?> factory = sf.getProviderFactory(IdentityProvider.class, factoryId);
         if (factory == null) {
             return List.of();
         }
-        Class<?> providerType = getType(factory);
-        return Arrays.stream(IdentityProviderType.values())
-                .filter(t -> !t.equals(IdentityProviderType.ANY) && toTypeClass(t).isAssignableFrom(providerType))
-                .collect(Collectors.toList());
+        Class<? extends IdentityProvider> providerType = getType(factory);
+        return listTypesFromClass(providerType);
     }
 
     public static List<String> listFactoriesByCapability(KeycloakSession session, IdentityProviderCapability capability) {
@@ -43,6 +45,12 @@ public class IdentityProviderTypeUtil {
 
     public static List<String> listFactoriesByType(KeycloakSession session, IdentityProviderType type) {
         return listFactoriesByTypes(session, Set.of(type));
+    }
+
+    private static List<IdentityProviderType> listTypesFromClass(Class<? extends IdentityProvider> providerType) {
+        return Arrays.stream(IdentityProviderType.values())
+                .filter(t -> !t.equals(IdentityProviderType.ANY) && toTypeClass(t).isAssignableFrom(providerType))
+                .collect(Collectors.toList());
     }
 
     private static List<String> listFactoriesByTypes(KeycloakSession session, Set<IdentityProviderType> types) {
@@ -60,9 +68,9 @@ public class IdentityProviderTypeUtil {
                 .toList();
     }
 
-    private static Class<?> getType(ProviderFactory<?> f) {
+    private static Class<? extends IdentityProvider> getType(ProviderFactory<?> f) {
         try {
-            return f.getClass().getMethod("create", KeycloakSession.class, IdentityProviderModel.class).getReturnType();
+            return (Class<? extends IdentityProvider>) f.getClass().getMethod("create", KeycloakSession.class, IdentityProviderModel.class).getReturnType();
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }

--- a/server-spi-private/src/main/java/org/keycloak/cache/AlternativeLookupProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/cache/AlternativeLookupProvider.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
@@ -11,7 +12,7 @@ import org.keycloak.provider.Provider;
 
 public interface AlternativeLookupProvider extends Provider {
 
-    IdentityProviderModel lookupIdentityProviderFromIssuer(KeycloakSession session, String issuerUrl);
+    IdentityProviderModel lookupIdentityProviderFromIssuer(KeycloakSession session, IdentityProviderType type, String issuerUrl);
 
     ClientModel lookupClientFromClientAttributes(KeycloakSession session, Map<String, String> attributes);
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/DefaultClientAssertionStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/DefaultClientAssertionStrategy.java
@@ -8,6 +8,7 @@ import org.keycloak.broker.provider.ClientAssertionIdentityProviderFactory;
 import org.keycloak.cache.AlternativeLookupProvider;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 
 public class DefaultClientAssertionStrategy implements ClientAssertionIdentityProviderFactory.ClientAssertionStrategy {
 
@@ -24,7 +25,7 @@ public class DefaultClientAssertionStrategy implements ClientAssertionIdentityPr
         String issuer = clientAssertionState.getToken().getIssuer();
         String federatedClientId =  clientAssertionState.getToken().getSubject();
 
-        IdentityProviderModel identityProvider = lookupProvider.lookupIdentityProviderFromIssuer(context.getSession(), issuer);
+        IdentityProviderModel identityProvider = lookupProvider.lookupIdentityProviderFromIssuer(context.getSession(), IdentityProviderType.CLIENT_ASSERTION, issuer);
         if (identityProvider == null) {
             return null;
         }

--- a/services/src/main/java/org/keycloak/broker/jwtauthorizationgrant/JWTAuthorizationGrantIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/jwtauthorizationgrant/JWTAuthorizationGrantIdentityProviderConfig.java
@@ -2,6 +2,7 @@ package org.keycloak.broker.jwtauthorizationgrant;
 
 import org.keycloak.broker.oidc.IssuerValidation;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.RealmModel;
 
 import static org.keycloak.broker.oidc.OIDCIdentityProviderConfig.JWKS_URL;
@@ -19,6 +20,6 @@ public class JWTAuthorizationGrantIdentityProviderConfig extends IdentityProvide
     @Override
     public void validate(RealmModel realm) {
         checkUrl(realm.getSslRequired(), getJwksUrl(), JWKS_URL);
-        validateIssuer(realm);
+        validateIssuer(realm, IdentityProviderType.JWT_AUTHORIZATION_GRANT);
     }
 }

--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java
@@ -3,6 +3,7 @@ package org.keycloak.broker.kubernetes;
 
 import org.keycloak.broker.oidc.IssuerValidation;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.RealmModel;
 
 
@@ -40,6 +41,6 @@ public class KubernetesIdentityProviderConfig extends IdentityProviderModel impl
     @Override
     public void validate(RealmModel realm) {
         super.validate(realm);
-        validateIssuer(realm);
+        validateIssuer(realm, IdentityProviderType.CLIENT_ASSERTION);
     }
 }

--- a/services/src/main/java/org/keycloak/broker/oidc/IssuerValidation.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/IssuerValidation.java
@@ -19,6 +19,8 @@ public interface IssuerValidation {
 
     String getInternalId();
 
+    boolean isEnabled();
+
     default void validateIssuer(RealmModel realm) {
 
         String issuer = getConfig().get(ISSUER);
@@ -28,13 +30,15 @@ public interface IssuerValidation {
 
         checkUrl(realm.getSslRequired(), issuer, "Issuer");
 
-        KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
-        AlternativeLookupProvider lookupProvider = session.getProvider(AlternativeLookupProvider.class);
+        if (isEnabled()) {
+            KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
+            AlternativeLookupProvider lookupProvider = session.getProvider(AlternativeLookupProvider.class);
 
-        if (lookupProvider != null) {
-            IdentityProviderModel existingIdp = lookupProvider.lookupIdentityProviderFromIssuer(session, getConfig().get(ISSUER));
-            if (existingIdp != null && (getInternalId() == null || !Objects.equals(existingIdp.getInternalId(), getInternalId()))) {
-                throw new IllegalArgumentException("Issuer URL already used for IDP '" + existingIdp.getAlias() + "', Issuer must be unique if the idp supports JWT Authorization Grant or Federated Client Authentication");
+            if (lookupProvider != null) {
+                IdentityProviderModel existingIdp = lookupProvider.lookupIdentityProviderFromIssuer(session, getConfig().get(ISSUER));
+                if (existingIdp != null && (getInternalId() == null || !Objects.equals(existingIdp.getInternalId(), getInternalId()))) {
+                    throw new IllegalArgumentException("Issuer URL already used for IDP '" + existingIdp.getAlias() + "', Issuer must be unique if the idp supports JWT Authorization Grant or Federated Client Authentication");
+                }
             }
         }
     }

--- a/services/src/main/java/org/keycloak/broker/oidc/IssuerValidation.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/IssuerValidation.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import org.keycloak.cache.AlternativeLookupProvider;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.util.Strings;
@@ -21,7 +22,7 @@ public interface IssuerValidation {
 
     boolean isEnabled();
 
-    default void validateIssuer(RealmModel realm) {
+    default void validateIssuer(RealmModel realm, IdentityProviderType type) {
 
         String issuer = getConfig().get(ISSUER);
         if (Strings.isEmpty(issuer)) {
@@ -35,7 +36,7 @@ public interface IssuerValidation {
             AlternativeLookupProvider lookupProvider = session.getProvider(AlternativeLookupProvider.class);
 
             if (lookupProvider != null) {
-                IdentityProviderModel existingIdp = lookupProvider.lookupIdentityProviderFromIssuer(session, getConfig().get(ISSUER));
+                IdentityProviderModel existingIdp = lookupProvider.lookupIdentityProviderFromIssuer(session, type, getConfig().get(ISSUER));
                 if (existingIdp != null && (getInternalId() == null || !Objects.equals(existingIdp.getInternalId(), getInternalId()))) {
                     throw new IllegalArgumentException("Issuer URL already used for IDP '" + existingIdp.getAlias() + "', Issuer must be unique if the idp supports JWT Authorization Grant or Federated Client Authentication");
                 }

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -72,6 +72,7 @@ import org.keycloak.keys.loader.OIDCIdentityProviderPublicKeyLoader;
 import org.keycloak.keys.loader.PublicKeyStorageManager;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.FederatedIdentityModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -126,6 +127,15 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
     @Override
     public Object callback(RealmModel realm, AuthenticationCallback callback, EventBuilder event) {
         return new OIDCEndpoint(callback, realm, event, this);
+    }
+
+    @Override
+    public boolean isType(KeycloakSession session, IdentityProviderType type) {
+        return switch(type) {
+            case JWT_AUTHORIZATION_GRANT -> getConfig().isJWTAuthorizationGrantEnabled();
+            case CLIENT_ASSERTION -> getConfig().isSupportsClientAssertions();
+            default -> super.isType(session, type);
+        };
     }
 
     /**

--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProviderConfig.java
@@ -19,6 +19,7 @@ package org.keycloak.broker.oidc;
 import org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantConfig;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.RealmModel;
 
 import static org.keycloak.common.util.UriUtils.checkUrl;
@@ -181,8 +182,11 @@ public class OIDCIdentityProviderConfig extends OAuth2IdentityProviderConfig imp
                 throw new IllegalArgumentException(String.format("The 'Validating public key' is required when '%s' enabled and 'Use JWKS URL' disabled", optionText));
             }
         }
-        if (isJWTAuthorizationGrantEnabled() || isSupportsClientAssertions()) {
-            validateIssuer(realm);
+        if (isJWTAuthorizationGrantEnabled()) {
+            validateIssuer(realm, IdentityProviderType.JWT_AUTHORIZATION_GRANT);
+        }
+        if (isSupportsClientAssertions()) {
+            validateIssuer(realm, IdentityProviderType.CLIENT_ASSERTION);
         }
     }
 }

--- a/services/src/main/java/org/keycloak/cache/DefaultAlternativeLookupProvider.java
+++ b/services/src/main/java/org/keycloak/cache/DefaultAlternativeLookupProvider.java
@@ -3,12 +3,15 @@ package org.keycloak.cache;
 import java.util.List;
 import java.util.Map;
 
+import org.keycloak.broker.provider.IdentityProvider;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderQuery;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
+import org.keycloak.services.resources.IdentityBrokerService;
 
 import org.jboss.logging.Logger;
 
@@ -25,13 +28,13 @@ public class DefaultAlternativeLookupProvider implements AlternativeLookupProvid
     }
 
     @Override
-    public IdentityProviderModel lookupIdentityProviderFromIssuer(KeycloakSession session, String issuerUrl) {
-        String alternativeKey = ComputedKey.computeKey(session.getContext().getRealm().getId(), "idp", issuerUrl);
+    public IdentityProviderModel lookupIdentityProviderFromIssuer(KeycloakSession session, IdentityProviderType type, String issuerUrl) {
+        String alternativeKey = ComputedKey.computeKey(session.getContext().getRealm().getId(), type.toString(), issuerUrl);
 
         CachedValue cachedIdpAlias = lookupCache.get(alternativeKey);
         if (cachedIdpAlias instanceof CachedValue.CachedString cachedString) {
             IdentityProviderModel idp = session.identityProviders().getByAlias(cachedString.value());
-            if (idp != null && issuerUrl.equals(idp.getConfig().get(IdentityProviderModel.ISSUER)) && idp.isEnabled()) {
+            if (idp != null && issuerUrl.equals(idp.getConfig().get(IdentityProviderModel.ISSUER)) && idp.isEnabled() && isType(session, idp, type)) {
                 return idp;
             } else {
                 lookupCache.invalidate(alternativeKey);
@@ -39,7 +42,7 @@ public class DefaultAlternativeLookupProvider implements AlternativeLookupProvid
         }
 
         List<IdentityProviderModel> idps = session.identityProviders().getAllStream(IdentityProviderQuery.any())
-                .filter(i -> issuerUrl.equals(i.getConfig().get(IdentityProviderModel.ISSUER)) && i.isEnabled())
+                .filter(i -> issuerUrl.equals(i.getConfig().get(IdentityProviderModel.ISSUER)) && i.isEnabled() && isType(session, i, type))
                 .limit(2)
                 .toList();
         IdentityProviderModel idp = null;
@@ -179,5 +182,10 @@ public class DefaultAlternativeLookupProvider implements AlternativeLookupProvid
 
     private static String cachedRoleKey(RealmModel realm, String roleName) {
         return realm.getId() + roleName;
+    }
+
+    private static boolean isType(KeycloakSession session, IdentityProviderModel idp, IdentityProviderType type) {
+        IdentityProvider provider = IdentityBrokerService.getIdentityProvider(session, idp, IdentityProvider.class);
+        return provider != null ? provider.isType(session, type) : false;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
@@ -31,6 +31,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
@@ -71,7 +72,7 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
             //select the idp using the issuer claim
             String jwtIssuer = authorizationGrantContext.getIssuer();
             AlternativeLookupProvider lookupProvider = context.getSession().getProvider(AlternativeLookupProvider.class);
-            IdentityProviderModel identityProviderModel = lookupProvider.lookupIdentityProviderFromIssuer(session, jwtIssuer);
+            IdentityProviderModel identityProviderModel = lookupProvider.lookupIdentityProviderFromIssuer(session, IdentityProviderType.JWT_AUTHORIZATION_GRANT, jwtIssuer);
             if (identityProviderModel == null) {
                 throw new RuntimeException("No Identity Provider for provided issuer");
             }

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1368,8 +1368,10 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
     public static <T extends IdentityProvider<?>> T getIdentityProvider(KeycloakSession session, IdentityProviderModel identityProviderModel, Class<T> type) {
         if (identityProviderModel != null) {
             IdentityProviderFactory<?> providerFactory = getIdentityProviderFactory(session, identityProviderModel);
-            IdentityProvider<?> idp = providerFactory.create(session, identityProviderModel);
-            return type.isInstance(idp) ? type.cast(idp) : null;
+            if (providerFactory != null) {
+                IdentityProvider<?> idp = providerFactory.create(session, identityProviderModel);
+                return type.isInstance(idp) ? type.cast(idp) : null;
+            }
         }
         return null;
     }

--- a/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/social/google/GoogleIdentityProviderConfig.java
@@ -20,6 +20,7 @@ import org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantConfig;
 import org.keycloak.broker.oidc.IssuerValidation;
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.RealmModel;
 
 /**
@@ -74,7 +75,7 @@ public class GoogleIdentityProviderConfig extends OIDCIdentityProviderConfig imp
            throw new IllegalArgumentException("The issuer url [" + getConfig().get(ISSUER) + "] is invalid");
         }
         if (isJWTAuthorizationGrantEnabled()) {
-            validateIssuer(realm);
+            validateIssuer(realm, IdentityProviderType.JWT_AUTHORIZATION_GRANT);
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderIssuerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderIssuerTest.java
@@ -51,8 +51,8 @@ public class IdentityProviderIssuerTest extends AbstractIdentityProviderTest {
         // Kubernetes idp - Kubernetes idp: not allowed
         testCreateIdentityProviderDuplicateNotAllowed(KubernetesIdentityProviderFactory.PROVIDER_ID, KubernetesIdentityProviderFactory.PROVIDER_ID, issuer);
 
-        // JWTAuthorizationGrant idp - Kubernetes idp: not allowed
-        testCreateIdentityProviderDuplicateNotAllowed(JWTAuthorizationGrantIdentityProviderFactory.PROVIDER_ID, KubernetesIdentityProviderFactory.PROVIDER_ID, issuer);
+        // JWTAuthorizationGrant idp - Kubernetes idp: allowed as they are different type (jwt vs client assertion)
+        testCreateIdentityProviderDuplicateAllowed(JWTAuthorizationGrantIdentityProviderFactory.PROVIDER_ID, KubernetesIdentityProviderFactory.PROVIDER_ID, issuer);
 
         // JWTAuthorizationGrant idp - OIDC idp: allowed
         testCreateIdentityProviderDuplicateAllowed(JWTAuthorizationGrantIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID, issuer, false, false);
@@ -60,7 +60,7 @@ public class IdentityProviderIssuerTest extends AbstractIdentityProviderTest {
         // JWTAuthorizationGrant idp - OIDC idp: not allowed
         testCreateIdentityProviderDuplicateNotAllowed(JWTAuthorizationGrantIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID, issuer, true, false);
 
-        // Kubernetes idp - OIDC idp: not allowed
+        // Kubernetes idp - OIDC idp client assertions: not allowed
         testCreateIdentityProviderDuplicateNotAllowed(KubernetesIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID, issuer, false, true);
 
         // OIDC idp - OIDC idp: allowed
@@ -84,7 +84,7 @@ public class IdentityProviderIssuerTest extends AbstractIdentityProviderTest {
     public void testCreateUpdateDuplicateIdentityProviderDisabled() {
         String issuer = "http://localhost:8080";
 
-        // test two OIDC adapters not allowed
+        // test two OIDC adapters not allowed, both with jwt and no assertions
         testCreateIdentityProviderDuplicateAllowedNoCleanUp(OIDCIdentityProviderFactory.PROVIDER_ID, OIDCIdentityProviderFactory.PROVIDER_ID,
                 issuer, true, false, false);
 
@@ -116,10 +116,26 @@ public class IdentityProviderIssuerTest extends AbstractIdentityProviderTest {
         idp1Rep = idp1.toRepresentation();
         idp1Rep.setEnabled(true);
         idp1.update(idp1Rep);
+
+        // make both enabled one with jwt and the other with client assertions
+        idp1Rep = idp1.toRepresentation();
+        idp1Rep.setEnabled(true);
+        idp1Rep.getConfig().put("jwtAuthorizationGrantEnabled", Boolean.FALSE.toString());
+        idp1Rep.getConfig().put("supportsClientAssertions", Boolean.TRUE.toString());
+        idp1.update(idp1Rep);
+        idp2Rep = idp2.toRepresentation();
+        idp2Rep.setEnabled(true);
+        idp1Rep.getConfig().put("jwtAuthorizationGrantEnabled", Boolean.TRUE.toString());
+        idp1Rep.getConfig().put("supportsClientAssertions", Boolean.FALSE.toString());
+        idp2.update(idp2Rep);
     }
 
     public void testCreateIdentityProviderDuplicateNotAllowed(String providerId1, String providerId2, String issuer) {
         testCreateIdentityProviderDuplicateAllowed(providerId1, providerId2, issuer, false, false, false);
+    }
+
+    public void testCreateIdentityProviderDuplicateAllowed(String providerId1, String providerId2, String issuer) {
+        testCreateIdentityProviderDuplicateAllowed(providerId1, providerId2, issuer, false, false, true);
     }
 
     public void testCreateIdentityProviderDuplicateNotAllowed(String providerId1, String providerId2, String issuer, boolean JWTAuthorizationGrantEnabled, boolean federatedAuthenticationEnabled) {

--- a/tests/base/src/test/java/org/keycloak/tests/model/AlternativeLookupProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/AlternativeLookupProviderTest.java
@@ -19,9 +19,13 @@ package org.keycloak.tests.model;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantConfig;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
 import org.keycloak.cache.AlternativeLookupProvider;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -42,22 +46,47 @@ public class AlternativeLookupProviderTest {
     @TestOnServer
     public void testDuplicateIssuerFoundInDatabase(KeycloakSession session) {
         try {
-            IdentityProviderModel idp = createModel("kubernetes1", "kubernetes");
+            IdentityProviderModel idp = createModel("oidc1", OIDCIdentityProviderFactory.PROVIDER_ID);
             idp.getConfig().put("issuer", "https://localhost");
+            idp.getConfig().put(JWTAuthorizationGrantConfig.JWT_AUTHORIZATION_GRANT_ENABLED, Boolean.TRUE.toString());
             session.identityProviders().create(idp);
 
-            idp = createModel("kubernetes2", "kubernetes");
+            idp = createModel("oidc2", OIDCIdentityProviderFactory.PROVIDER_ID);
             idp.getConfig().put("issuer", "https://localhost");
+            idp.getConfig().put(JWTAuthorizationGrantConfig.JWT_AUTHORIZATION_GRANT_ENABLED, Boolean.TRUE.toString());
             session.identityProviders().create(idp);
 
             RuntimeException ex = Assertions.assertThrows(RuntimeException.class, () ->
-                    session.getProvider(AlternativeLookupProvider.class).lookupIdentityProviderFromIssuer(session, "https://localhost")
+                    session.getProvider(AlternativeLookupProvider.class).lookupIdentityProviderFromIssuer(session, IdentityProviderType.JWT_AUTHORIZATION_GRANT, "https://localhost")
             );
-            Assertions.assertEquals("Multiple IDPs match the same issuer: [kubernetes1, kubernetes2]", ex.getMessage());
+            Assertions.assertEquals("Multiple IDPs match the same issuer: [oidc1, oidc2]", ex.getMessage());
 
         } finally {
-            session.identityProviders().remove("kubernetes1");
-            session.identityProviders().remove("kubernetes2");
+            session.identityProviders().remove("oidc1");
+            session.identityProviders().remove("oidc2");
+        }
+    }
+
+    @TestOnServer
+    public void testDuplicateIssuerCanExistsForDifferentType(KeycloakSession session) {
+        try {
+            IdentityProviderModel idp = createModel("oidc1", OIDCIdentityProviderFactory.PROVIDER_ID);
+            idp.getConfig().put("issuer", "https://localhost");
+            idp.getConfig().put(JWTAuthorizationGrantConfig.JWT_AUTHORIZATION_GRANT_ENABLED, Boolean.TRUE.toString());
+            session.identityProviders().create(idp);
+
+            idp = createModel("oidc2", OIDCIdentityProviderFactory.PROVIDER_ID);
+            idp.getConfig().put("issuer", "https://localhost");
+            idp.getConfig().put(OIDCIdentityProviderConfig.SUPPORTS_CLIENT_ASSERTIONS, Boolean.TRUE.toString());
+            session.identityProviders().create(idp);
+
+            idp = session.getProvider(AlternativeLookupProvider.class).lookupIdentityProviderFromIssuer(session, IdentityProviderType.JWT_AUTHORIZATION_GRANT, "https://localhost");
+            Assertions.assertEquals("oidc1", idp.getAlias());
+            idp = session.getProvider(AlternativeLookupProvider.class).lookupIdentityProviderFromIssuer(session, IdentityProviderType.CLIENT_ASSERTION, "https://localhost");
+            Assertions.assertEquals("oidc2", idp.getAlias());
+        } finally {
+            session.identityProviders().remove("oidc1");
+            session.identityProviders().remove("oidc2");
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/AbstractJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/AbstractJWTAuthorizationGrantTest.java
@@ -309,7 +309,7 @@ public abstract class AbstractJWTAuthorizationGrantTest extends BaseAbstractJWTA
 
         String jwt = getIdentityProvider().encodeToken(createDefaultAuthorizationGrantToken());
         AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        assertFailure("Identity Provider is not enabled", response, events.poll());
+        assertFailure("No Identity Provider for provided issuer", response, events.poll());
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
@@ -31,8 +31,7 @@ public class OIDCIdentityProviderJWTAuthorizationGrantTest extends AbstractJWTAu
 
         String jwt = getIdentityProvider().encodeToken(createAuthorizationGrantToken("basic-user-id", oAuthClient.getEndpoints().getIssuer(), IDP_ISSUER));
         AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
-        EventAssertion event = assertFailure("JWT Authorization Granted is not enabled for the identity provider", response, events.poll());
-        event.details(Details.IDENTITY_PROVIDER, IDP_ALIAS);
+        EventAssertion event = assertFailure("No Identity Provider for provided issuer", response, events.poll());
         event.details(Details.IDENTITY_PROVIDER_ISSUER, IDP_ISSUER);
         event.details(Details.IDENTITY_PROVIDER_USER_ID, "basic-user-id");
     }


### PR DESCRIPTION
Closes #46309

I'm creating a draft because don't know what we are going to finally decide. This PR just changes the default lookup provider to not take into account the disabled clients or identity providers. Test added for the IdP check.

If we want a real check in the DB, we need much more. We need to update the database to add the issuer as a new column in the IdP table, and create a constraint in it. We would need to smartly update the IdPs adding that column only when the issuer should be checked as unique (the IdP is of correct type, enabled, with jwt grant or spiffe enabled and so on and so forth). When the issuer is not needed, the column should be set to a unique different value (a generated ID or similar). The upgrade needs to check everything to be OK in the end.

What do you want to do? I think that this one is needed for sure. If we decide that the DB constraint is needed, we can also manage that as a follow-up.
