### PR TITLE
Added delay to flaky test AttackDetectionResourceTest

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/AttackDetectionResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AttackDetectionResourceTest.java
@@ -18,8 +18,8 @@
 package org.keycloak.tests.admin;
 
 import java.util.Map;
-
 import java.util.concurrent.TimeUnit;
+
 import org.keycloak.admin.client.resource.AttackDetectionResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AttackDetectionResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AttackDetectionResourceTest.java
@@ -19,6 +19,7 @@ package org.keycloak.tests.admin;
 
 import java.util.Map;
 
+import java.util.concurrent.TimeUnit;
 import org.keycloak.admin.client.resource.AttackDetectionResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
@@ -38,6 +39,7 @@ import org.keycloak.tests.utils.admin.AdminEventPaths;
 
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,6 +79,15 @@ public class AttackDetectionResourceTest {
         oauthClient.doPasswordGrantRequest(testUser2.getUsername(), "invalid");
         oauthClient.doPasswordGrantRequest(testUser2.getUsername(), "invalid");
         oauthClient.doPasswordGrantRequest("nosuchuser", "invalid");
+
+        // Check testUser2 to ensure all failure processing is completed
+        await().atMost(5, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    Map<String, Object> status = detection.bruteForceUserStatus(testUser2.getId());
+                    assertEquals(2, status.get("numFailures"),
+                            "Waiting for testUser2 processing to complete");
+                });
 
         assertBruteForce(detection.bruteForceUserStatus(testUser.getId()), 2, 1, true, true);
         assertBruteForce(detection.bruteForceUserStatus(testUser2.getId()), 2, 1, true, true);


### PR DESCRIPTION

AttackDetectionResourceTest would fail occasionally when checking db for login info. 
Added wait/retry to slightly delay db lookup, to cater for db/network latency. 

Closes #45986