### PR TITLE
fix: allowing targetServerType to always be used

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -117,6 +117,7 @@ public class DatabaseOptions {
 
     public static final Option<String> DB_POSTGRESQL_TARGET_SERVER_TYPE = new OptionBuilder<>("db-postgres-target-server-type", String.class)
             .category(OptionCategory.DATABASE)
+            .defaultValue("primary") // cause the propertymapping logic to always advertise this property
             .hidden()
             .build();
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -30,6 +30,7 @@ import java.util.stream.StreamSupport;
 import org.keycloak.Config;
 import org.keycloak.config.CachingOptions;
 import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
 import org.keycloak.quarkus.runtime.vault.FilesKeystoreVaultProviderFactory;
 import org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory;
@@ -390,21 +391,21 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
         ConfigArgsConfigSource.setCliArgs("--db=postgres");
         config = createConfig();
-        assertEquals("primary", config.getConfigValue("quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType").getValue());
-
+        assertTrue(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
+        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).anyMatch(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE::equals));
+        assertEquals("primary", config.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url-properties=?targetServerType=any");
         config = createConfig();
-        assertNull(config.getConfigValue("quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType").getValue());
-        assertEquals("jdbc:postgresql://localhost:5432/keycloak?targetServerType=any", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
+        assertFalse(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
 
         ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-driver=software.amazon.jdbc.Driver");
         config = createConfig();
-        assertNull(config.getConfigValue("quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType").getValue());
+        assertFalse(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
 
         ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url=jdbc:postgresql://localhost:5432/keycloak?targetServerType=any");
         config = createConfig();
-        assertNull(config.getConfigValue("quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType").getValue());
+        assertFalse(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
     }
 
     // KEYCLOAK-15632


### PR DESCRIPTION
closes: #46459

We're getting bitten again by quarkus needing a property advertised. 

We may want to eventually consider more systematic approaches to things like this:
- should there be an option / property mapper flag to indicate it should always be advertised?
- alternatively should we just go ahead and advertise all quarkus to keys even if there might not be a value? - trying this out did break an existing test, not sure if this would be a good idea for backport.
- and do we even need dummy/hidden keycloak options for something like this.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
