### PR TITLE
feat: delete LDAP group when group is deleted in Keycloak

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/membership/group/GroupLDAPStorageMapper.java
@@ -622,6 +622,27 @@ public class GroupLDAPStorageMapper extends AbstractLDAPStorageMapper implements
         LDAPUtils.addMember(ldapProvider, config.getMembershipTypeLdapAttribute(), config.getMembershipLdapAttribute(), membershipUserLdapAttrName, ldapGroup, ldapUser);
     }
 
+    public void deleteGroupFromLDAP(RealmModel realm, GroupModel group) {
+        if (config.getMode() != LDAPGroupMapperMode.LDAP_ONLY) {
+            return;
+        }
+
+        if (!isGroupInGroupPath(realm, group)) {
+            return;
+        }
+
+        String groupName = group.getName();
+        LDAPObject ldapGroup = loadLDAPGroupByName(groupName);
+
+        if (ldapGroup == null) {
+            logger.debugf("Group '%s' not found in LDAP. Skipping LDAP deletion.", groupName);
+            return;
+        }
+
+        logger.debugf("Deleting group '%s' from LDAP (DN: %s)", groupName, ldapGroup.getDn());
+        ldapProvider.getLdapIdentityStore().remove(ldapGroup);
+    }
+
     public void deleteGroupMappingInLDAP(LDAPObject ldapUser, LDAPObject ldapGroup) {
         String membershipUserLdapAttrName = getMembershipUserLdapAttribute();
         LDAPUtils.deleteMember(ldapProvider, config.getMembershipTypeLdapAttribute(), config.getMembershipLdapAttribute(), membershipUserLdapAttrName, ldapGroup, ldapUser);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncTest.java
@@ -88,17 +88,6 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
 
             // Add group mapper
             LDAPTestUtils.addOrUpdateGroupMapper(appRealm, ctx.getLdapModel(), LDAPGroupMapperMode.LDAP_ONLY, descriptionAttrName);
-
-            // Remove all LDAP groups
-            LDAPTestUtils.removeAllLDAPGroups(session, appRealm, ctx.getLdapModel(), "groupsMapper");
-
-            // Add some groups for testing
-            LDAPObject group1 = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "group1", descriptionAttrName, "group1 - description");
-            LDAPObject group11 = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "group11");
-            LDAPObject group12 = LDAPTestUtils.createLDAPGroup(session, appRealm, ctx.getLdapModel(), "group12", descriptionAttrName, "group12 - description");
-
-            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11);
-            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12);
         });
     }
 
@@ -110,7 +99,20 @@ public class LDAPGroupMapperSyncTest extends AbstractLDAPTest {
             LDAPTestContext ctx = LDAPTestContext.init(session);
             RealmModel realm = ctx.getRealm();
 
+            // Remove all LDAP groups first so preRemove finds nothing in LDAP
+            LDAPTestUtils.removeAllLDAPGroups(session, realm, ctx.getLdapModel(), "groupsMapper");
+
             realm.getTopLevelGroupsStream().forEach(realm::removeGroup);
+
+            // Recreate LDAP groups for testing
+            String descriptionAttrName = LDAPTestUtils.getGroupDescriptionLDAPAttrName(ctx.getLdapProvider());
+
+            LDAPObject group1 = LDAPTestUtils.createLDAPGroup(session, realm, ctx.getLdapModel(), "group1", descriptionAttrName, "group1 - description");
+            LDAPObject group11 = LDAPTestUtils.createLDAPGroup(session, realm, ctx.getLdapModel(), "group11");
+            LDAPObject group12 = LDAPTestUtils.createLDAPGroup(session, realm, ctx.getLdapModel(), "group12", descriptionAttrName, "group12 - description");
+
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11);
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12);
         });
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncWithGroupsPathTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPGroupMapperSyncWithGroupsPathTest.java
@@ -94,12 +94,25 @@ public class LDAPGroupMapperSyncWithGroupsPathTest extends AbstractLDAPTest {
             LDAPTestContext ctx = LDAPTestContext.init(session);
             RealmModel realm = ctx.getRealm();
 
+            // Remove all LDAP groups first so preRemove finds nothing in LDAP
+            LDAPTestUtils.removeAllLDAPGroups(session, realm, ctx.getLdapModel(), "groupsMapper");
+
             GroupModel groupsPathGroup = KeycloakModelUtils.findGroupByPath(session, realm, LDAP_GROUPS_PATH);
-            
+
             // Subgroup stream needs to be collected, because otherwise we can end up with finding group with id that is
             // already removed
             groupsPathGroup.getSubGroupsStream().collect(Collectors.toSet())
                     .forEach(realm::removeGroup);
+
+            // Recreate LDAP groups for testing
+            String descriptionAttrName = LDAPTestUtils.getGroupDescriptionLDAPAttrName(ctx.getLdapProvider());
+
+            LDAPObject group1 = LDAPTestUtils.createLDAPGroup(session, realm, ctx.getLdapModel(), "group1", descriptionAttrName, "group1 - description");
+            LDAPObject group11 = LDAPTestUtils.createLDAPGroup(session, realm, ctx.getLdapModel(), "group11");
+            LDAPObject group12 = LDAPTestUtils.createLDAPGroup(session, realm, ctx.getLdapModel(), "group12", descriptionAttrName, "group12 - description");
+
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group11);
+            LDAPUtils.addMember(ctx.getLdapProvider(), MembershipType.DN, LDAPConstants.MEMBER, "not-used", group1, group12);
         });
     }
 


### PR DESCRIPTION
When a group mapper is configured with LDAP_ONLY mode and the provider edit mode is WRITABLE, deleting a group in Keycloak now propagates the deletion to LDAP via the existing preRemove callback.

Closes #29099

Notes:
- in LDAP_ONLY mode, deleting a KC group now deletes it from LDAP too. 
- Only applies when editMode=WRITABLE (provider level) AND mode=LDAP_ONLY (mapper level).
- If LDAP is unreachable during deletion, the KC group deletion will also fail (transaction rollback). This is consistent with user deletion behavior.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
