### PR TITLE
Expose organization group membership for a member

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMemberResource.java
@@ -28,6 +28,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 
@@ -62,5 +63,22 @@ public interface OrganizationMemberResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     List<OrganizationRepresentation> getOrganizations(
+            @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
+
+    /**
+     * Returns the organization group memberships for this member
+     *
+     * @param firstResult the position of the first result to be processed (pagination offset)
+     * @param maxResults the maximum number of results to be returned
+     * @param briefRepresentation if false, return the full representation. Otherwise, only the basic fields are returned. It is true by default.
+     * @since Keycloak server 26
+     * @return the organization groups the member belongs to
+     */
+    @Path("groups")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<GroupRepresentation> groups(
+            @QueryParam("first") Integer firstResult,
+            @QueryParam("max") Integer maxResults,
             @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation);
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
@@ -18,6 +18,7 @@ package org.keycloak.models.cache.infinispan.organization;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -330,6 +331,13 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
     }
 
     @Override
+    public Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member, Integer first, Integer max) {
+        // Don't cache paginated queries - delegate directly to DB
+        // This follows the same pattern as searchGroupsByName to avoid caching partial results
+        return getDelegate().getOrganizationGroupsByMember(organization, member, first, max);
+    }
+
+    @Override
     public Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member) {
         if (userCache == null) {
             return getDelegate().getOrganizationGroupsByMember(organization, member);
@@ -353,7 +361,7 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
         RealmModel realm = getRealm();
         return cached.getGroupIds().stream()
                 .map(realm::getGroupById)
-                .filter(java.util.Objects::nonNull);
+                .filter(Objects::nonNull);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -696,6 +696,11 @@ public class JpaOrganizationProvider implements OrganizationProvider {
 
     @Override
     public Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member) {
+        return getOrganizationGroupsByMember(organization, member, null, null);
+    }
+
+    @Override
+    public Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member, Integer first, Integer max) {
         throwExceptionIfObjectIsNull(organization, "Organization");
         throwExceptionIfObjectIsNull(member, "Member");
 
@@ -716,7 +721,7 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         query.setParameter("orgId", organization.getId());
         query.setParameter("internalOrgGroupId", getOrganizationGroup(organization).getId());
 
-        return closing(query.getResultStream()
+        return closing(paginateQuery(query, first, max).getResultStream()
                 .map(realm::getGroupById)
                 .filter(Objects::nonNull));
     }

--- a/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -302,6 +302,20 @@ public interface OrganizationProvider extends Provider {
     Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member);
 
     /**
+     * Returns organization groups that the given {@code member} explicitly belongs to within the given {@code organization},
+     * with pagination support.
+     * Only returns groups of type {@link org.keycloak.models.GroupModel.Type#ORGANIZATION} that belong to the specified organization.
+     * Membership is explicit - being a member of a child group does not imply membership in parent groups.
+     *
+     * @param organization the organization whose groups to check
+     * @param member the user whose group memberships to retrieve
+     * @param first the position of the first result to be processed (pagination offset). Ignored if negative or {@code null}.
+     * @param max the maximum number of results to be returned. Ignored if negative or {@code null}.
+     * @return Stream of organization groups the member belongs to. Never returns {@code null}.
+     */
+    Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member, Integer first, Integer max);
+
+    /**
      * Associate the given {@link IdentityProviderModel} with the given {@link OrganizationModel}.
      *
      * @param organization the organization


### PR DESCRIPTION
Closes #46454

Org member's organization group membership is available using `GET /admin/realms/{realm}/organizations/{org-id}/members/{member-id}/groups`

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
