### PR TITLE
Ability to retrieve subgroups count for organization groups

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationGroupResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationGroupResource.java
@@ -41,7 +41,7 @@ public interface OrganizationGroupResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    GroupRepresentation toRepresentation();
+    GroupRepresentation toRepresentation(@QueryParam("subGroupsCount") boolean subGroupsCount);
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationGroupsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationGroupsResource.java
@@ -44,10 +44,20 @@ public interface OrganizationGroupsResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<GroupRepresentation> getAll(
             @QueryParam("search") String search,
+            @QueryParam("q") String searchQuery,
             @QueryParam("exact") Boolean exact,
             @QueryParam("first") Integer first,
             @QueryParam("max") Integer max,
-            @QueryParam("briefRepresentation") boolean briefRepresentation
+            @QueryParam("briefRepresentation") boolean briefRepresentation,
+            @QueryParam("subGroupsCount") boolean subGroupsCount
+    );
+
+    @GET
+    @Path("group-by-path/{path: .*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    GroupRepresentation getGroupByPath(
+            @PathParam("path") String path,
+            @QueryParam("subGroupsCount") boolean subGroupsCount
     );
 
     @Path("{group-id}")

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupMovedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/GroupMovedEvent.java
@@ -54,7 +54,7 @@ public class GroupMovedEvent extends InvalidationEvent implements RealmCacheInva
     }
 
     public static GroupMovedEvent create(GroupModel group, GroupModel toParent, String realmId) {
-        return new GroupMovedEvent(group.getId(), group.getId(), toParent == null ? null : toParent.getId(), realmId);
+        return new GroupMovedEvent(group.getId(), toParent == null ? null : toParent.getId(), group.getParentId(), realmId);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
@@ -365,6 +365,11 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
     }
 
     @Override
+    public GroupModel getOrganizationGroup(OrganizationModel organization) {
+        return getDelegate().getOrganizationGroup(organization);
+    }
+
+    @Override
     public boolean addIdentityProvider(OrganizationModel organization, IdentityProviderModel identityProvider) {
         boolean added = getDelegate().addIdentityProvider(organization, identityProvider);
         if (added) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -183,7 +183,9 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
             predicates.add(builder.like(builder.lower(root.get("name")), search.toLowerCase(), '\\'));
         }
 
-        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.GROUPS, (PartialEvaluationStorageProvider) UserStoragePrivateUtil.userLocalStorage(session), realm, builder, queryBuilder, root));
+        if (Type.REALM.intValue() == group.getType()) {
+            predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.GROUPS, (PartialEvaluationStorageProvider) UserStoragePrivateUtil.userLocalStorage(session), realm, builder, queryBuilder, root));
+        }
 
         queryBuilder.where(predicates.toArray(new Predicate[0]));
         queryBuilder.orderBy(builder.asc(root.get("name")));
@@ -206,9 +208,12 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
         List<Predicate> predicates = new ArrayList<>();
 
         predicates.add(builder.equal(root.get("realm"), realm.getId()));
-        predicates.add(builder.equal(root.get("type"), Type.REALM.intValue()));
+        predicates.add(builder.equal(root.get("type"), group.getType()));
         predicates.add(builder.equal(root.get("parentId"), group.getId()));
-        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.GROUPS, (PartialEvaluationStorageProvider) UserStoragePrivateUtil.userLocalStorage(session), realm, builder, queryBuilder, root));
+
+        if (Type.REALM.intValue() == group.getType()) {
+            predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.GROUPS, (PartialEvaluationStorageProvider) UserStoragePrivateUtil.userLocalStorage(session), realm, builder, queryBuilder, root));
+        }
 
         queryBuilder.where(predicates.toArray(new Predicate[0]));
 

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -815,7 +815,8 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         return groupProvider.createGroup(getRealm(), null, Type.ORGANIZATION, orgId, null);
     }
 
-    private GroupModel getOrganizationGroup(OrganizationModel organization) {
+    @Override
+    public GroupModel getOrganizationGroup(OrganizationModel organization) {
         throwExceptionIfObjectIsNull(organization, "Organization");
         OrganizationEntity entity = getEntity(organization.getId());
         GroupModel group = getOrganizationGroup(entity);

--- a/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -316,6 +316,17 @@ public interface OrganizationProvider extends Provider {
     Stream<GroupModel> getOrganizationGroupsByMember(OrganizationModel organization, UserModel member, Integer first, Integer max);
 
     /**
+     * Returns the internal organization group for the given {@link OrganizationModel}.
+     * The internal group is a special group with the same name as the organization's ID,
+     * used as the root of the organization's group hierarchy.
+     *
+     * @param organization the organization
+     * @return the internal organization group
+     * @throws org.keycloak.models.ModelException if the organization or its internal group is not found
+     */
+    GroupModel getOrganizationGroup(OrganizationModel organization);
+
+    /**
      * Associate the given {@link IdentityProviderModel} with the given {@link OrganizationModel}.
      *
      * @param organization the organization

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
@@ -94,8 +94,10 @@ public class OrganizationGroupResource {
     @APIResponses(value = {
         @APIResponse(responseCode = "200", description = "OK")
     })
-    public GroupRepresentation getGroup() {
-        return ModelToRepresentation.toRepresentation(group, true);
+    public GroupRepresentation getGroup(@Parameter(description = "Whether to return the count of subgroups (default: false)") @QueryParam("subGroupsCount") @DefaultValue("false") boolean subGroupsCount) {
+        GroupRepresentation rep = ModelToRepresentation.toRepresentation(group, true);
+        if (subGroupsCount) rep.setSubGroupCount(group.getSubGroupsCount());
+        return rep;
     }
 
     @DELETE

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/exportimport/OrganizationExportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/exportimport/OrganizationExportTest.java
@@ -209,7 +209,7 @@ public class OrganizationExportTest extends AbstractOrganizationTest {
     }
 
     private void validateOrganizationGroups(OrganizationResource organization, Map<String, String> expectedGroupIds) {
-        List<GroupRepresentation> topLevelGroups = organization.groups().getAll(null, null, null, null, true);
+        List<GroupRepresentation> topLevelGroups = organization.groups().getAll(null, null, null, null, null, true, false);
         assertThat(topLevelGroups, hasSize(2));
 
         // Validate top-level group names

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/group/OrganizationGroupDeletionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/group/OrganizationGroupDeletionTest.java
@@ -77,7 +77,7 @@ public class OrganizationGroupDeletionTest extends AbstractOrganizationTest {
         }
 
         // Verify groups exist
-        List<GroupRepresentation> groups = orgResource.groups().getAll(null, null, null, null, true);
+        List<GroupRepresentation> groups = orgResource.groups().getAll(null, null, null, null, null, true, false);
         assertThat(groups, hasSize(2)); // Engineering, Sales (Backend is nested)
 
         // Delete organization
@@ -137,7 +137,7 @@ public class OrganizationGroupDeletionTest extends AbstractOrganizationTest {
         }
 
         // Verify unmanaged user still exists
-        UserRepresentation foundUser = testRealm().users().get(unmanagedMember.getId()).toRepresentation();
+        UserRepresentation foundUser = testRealm().users().get(unmanagedMember.getId()).toRepresentation(false);
         assertNotNull(foundUser);
         assertThat(foundUser.getEmail(), is("unmanaged@example.com"));
     }
@@ -175,7 +175,7 @@ public class OrganizationGroupDeletionTest extends AbstractOrganizationTest {
         }
 
         // Member should still exist (unmanaged)
-        UserRepresentation foundUser = testRealm().users().get(member.getId()).toRepresentation();
+        UserRepresentation foundUser = testRealm().users().get(member.getId()).toRepresentation(false);
         assertNotNull(foundUser);
 
         // Cannot verify groups are deleted via org API since org no longer exists
@@ -224,7 +224,7 @@ public class OrganizationGroupDeletionTest extends AbstractOrganizationTest {
 
         // Group should be deleted
         try {
-            orgResource.groups().group(groupId).toRepresentation();
+            orgResource.groups().group(groupId).toRepresentation(false);
             fail("Group should have been deleted");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString(Response.Status.NOT_FOUND.toString()));
@@ -256,7 +256,7 @@ public class OrganizationGroupDeletionTest extends AbstractOrganizationTest {
         orgResource.groups().group(backendId).delete();
 
         // Engineering should still exist
-        GroupRepresentation engineering = orgResource.groups().group(engineeringId).toRepresentation();
+        GroupRepresentation engineering = orgResource.groups().group(engineeringId).toRepresentation(false);
         assertNotNull(engineering);
         assertThat(engineering.getName(), is("Engineering"));
 
@@ -305,7 +305,7 @@ public class OrganizationGroupDeletionTest extends AbstractOrganizationTest {
         }
 
         // User should still exist
-        UserRepresentation user = testRealm().users().get(member.getId()).toRepresentation();
+        UserRepresentation user = testRealm().users().get(member.getId()).toRepresentation(false);
         assertNotNull(user);
 
         // User should no longer be in Org A

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/group/OrganizationGroupIsolationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/group/OrganizationGroupIsolationTest.java
@@ -104,18 +104,18 @@ public class OrganizationGroupIsolationTest extends AbstractOrganizationTest {
         }
 
         // Org A should only see its own groups
-        List<GroupRepresentation> orgAGroups = orgAResource.groups().getAll(null, null, 0, 10, true);
+        List<GroupRepresentation> orgAGroups = orgAResource.groups().getAll(null, null, null, 0, 10, true, false);
         assertThat(orgAGroups, hasSize(1));
         assertThat(orgAGroups.get(0).getName(), is("Engineering"));
 
         // Org B should only see its own groups
-        List<GroupRepresentation> orgBGroups = orgBResource.groups().getAll(null, null, 0, 10, true);
+        List<GroupRepresentation> orgBGroups = orgBResource.groups().getAll(null, null, null, 0, 10, true, false);
         assertThat(orgBGroups, hasSize(1));
         assertThat(orgBGroups.get(0).getName(), is("Sales"));
 
         // Org A cannot access Org B's group
         try {
-            orgAResource.groups().group(groupBId).toRepresentation();
+            orgAResource.groups().group(groupBId).toRepresentation(false);
             fail("Org A should not be able to access Org B's groups");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString(Status.BAD_REQUEST.toString()));
@@ -123,7 +123,7 @@ public class OrganizationGroupIsolationTest extends AbstractOrganizationTest {
 
         // Org B cannot access Org A's group
         try {
-            orgBResource.groups().group(groupAId).toRepresentation();
+            orgBResource.groups().group(groupAId).toRepresentation(false);
             fail("Org B should not be able to access Org A's groups");
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString(Status.BAD_REQUEST.toString()));
@@ -237,7 +237,7 @@ public class OrganizationGroupIsolationTest extends AbstractOrganizationTest {
         getCleanup().addCleanup(() -> testRealm().groups().group(realmGroupId).remove());
 
         // Both should exist and be different groups
-        GroupRepresentation orgGroup = orgResource.groups().group(orgGroupId).toRepresentation();
+        GroupRepresentation orgGroup = orgResource.groups().group(orgGroupId).toRepresentation(false);
         assertThat(orgGroup.getName(), is(groupName));
 
         GroupRepresentation realmGroup = testRealm().groups().group(realmGroupId).toRepresentation();
@@ -272,7 +272,7 @@ public class OrganizationGroupIsolationTest extends AbstractOrganizationTest {
         getCleanup().addCleanup(() -> testRealm().groups().group(realmGroupId).remove());
 
         // Search org groups for "Engineering"
-        List<GroupRepresentation> results = orgResource.groups().getAll("Engineering", null, null, null, true);
+        List<GroupRepresentation> results = orgResource.groups().getAll("Engineering", null, null, null, null, true, false);
 
         // Should only find org group, not realm group
         assertThat(results, hasSize(1));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/group/OrganizationGroupUserQueryTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/group/OrganizationGroupUserQueryTest.java
@@ -221,7 +221,7 @@ public class OrganizationGroupUserQueryTest extends AbstractOrganizationTest {
         OrganizationResource orgResource = testRealm().organizations().get(orgRep.getId());
 
         try {
-            orgResource.groups().group("non-existent-id").toRepresentation();
+            orgResource.groups().group("non-existent-id").toRepresentation(false);
         } catch (Exception e) {
             assertThat(e.getMessage(), containsString(Response.Status.NOT_FOUND.toString()));
         }


### PR DESCRIPTION
Closes #46445

By default subGroupsCount is not returned, it is needed to send a request with `subGroupsCount=true`
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
