### PR TITLE
Fix single-file export including non-imported LDAP users 

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -62,6 +62,7 @@ import org.keycloak.representations.idm.RolesRepresentation;
 import org.keycloak.representations.idm.ScopeMappingRepresentation;
 import org.keycloak.representations.idm.UserConsentRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.federated.UserFederatedStorageProvider;
 
 import com.fasterxml.jackson.core.JsonEncoding;
@@ -213,7 +214,7 @@ public class ExportUtils {
 
         // Finally users if needed
         if (options.isUsersIncluded()) {
-            List<UserRepresentation> users = session.users().searchForUserStream(realm, Collections.emptyMap())
+            List<UserRepresentation> users = UserStoragePrivateUtil.userLocalStorage(session).searchForUserStream(realm, Collections.emptyMap())
                     .map(user -> exportUser(session, realm, user, options, internal))
                     .collect(Collectors.toList());
 


### PR DESCRIPTION
- Single file export queried all providers including LDAP, exporting non-imported users with IDs longer than 36 characters. 
- Use local storage only, matching the existing directory export behavior.

Closes [#46537](https://github.com/keycloak/keycloak/issues/46537)