### PR TITLE
fix: Prevent querying all clients for dynamic scope update

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -277,7 +277,9 @@ public class ClientScopeResource {
         validateClientScopeName(rep.getName());
 
         // Only check this if the representation has been sent to make it dynamic
-        if (rep.getAttributes() != null && rep.getAttributes().getOrDefault(ClientScopeModel.IS_DYNAMIC_SCOPE, "false").equalsIgnoreCase("true")) {
+        if (rep.getAttributes() != null
+                && rep.getAttributes().getOrDefault(ClientScopeModel.IS_DYNAMIC_SCOPE, "false").equalsIgnoreCase("true")
+                && !clientScope.isDynamicScope()) {
             Optional<String> scopeModelOpt = realm.getClientsStream()
                     .flatMap(clientModel -> clientModel.getClientScopes(true).values().stream())
                     .map(ClientScopeModel::getId)


### PR DESCRIPTION
Check existing scope dynamic property to prevent long-running validation if dynamic scope property is unchanged

closes #46542

Result after running updateDynamicScopeDemo.js script (attached in issue): 0.012s to update client scope
