### PR TITLE
[26.4] Mask certain HTTP headers in the HTTP access log

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_4_10.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_4_10.adoc
@@ -27,3 +27,7 @@ bin/kc.[sh|bat] --spi-login-protocol--saml--max-inflating-size=524288
 ----
 
 The same restriction is applied for the link:{saml_galleon_layers_link}[{project_name} SAML Galleon feature pack]. Although, in this case, you need to add a system property to the Wildfly/EAP server to change the default maximum size: `-Dorg.keycloak.adapters.saml.maxInflatingSize=524288`.
+
+=== HTTP Access log does not contain specific sensitive information
+
+Specific sensitive information is omitted from the HTTP Access log, such as the value of the `Authorization` HTTP header. Moreover, values of specific sensitive {project_name} cookies, such as `KEYCLOAK_SESSION`, `KEYCLOAK_IDENTITY`, or `AUTH_SESSION_ID`, are also omitted.

--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -284,11 +284,29 @@ You can even specify your own pattern with your required data to be logged, such
 <@kc.start parameters="--http-access-log-pattern='%A %{METHOD} %{REQUEST_URL} %{i,User-Agent}'"/>
 
 WARNING: HTTP Access logs may contain sensitive HTTP headers like `Authorization`, `Cookie`, or external API keys references.
-Be careful with using the `long` pattern or printing the headers by the custom format - you should use it only for development purposes.
+The `Authorization` header and selected sensitive cookies are automatically masked in the HTTP Access log. However, the list of masked items might not be complete. Be careful with using the `long` pattern or printing the headers by the custom format - you should use it only for development purposes.
 
 Consult the https://quarkus.io/guides/http-reference#configuring-http-access-logs[Quarkus documentation] for the full list of variables that can be used.
 
-==== Exclude specific URL paths
+=== Masked specific HTTP headers and cookies
+
+Selected sensitive HTTP headers and cookies are automatically masked in the HTTP Access log.
+
+Masked sensitive HTTP headers:
+
+* `Authorization`
+
+Masked sensitive {project_name} cookies:
+
+* `AUTH_SESSION_ID`
+* `KC_AUTH_SESSION_HASH`
+* `KEYCLOAK_IDENTITY`
+* `KEYCLOAK_SESSION`
+* `AUTH_SESSION_ID_LEGACY`
+* `KEYCLOAK_IDENTITY_LEGACY`
+* `KEYCLOAK_SESSION_LEGACY`
+
+=== Exclude specific URL paths
 
 It is possible to exclude specific URL paths from the HTTP access logging, so they will not be recorded.
 

--- a/quarkus/runtime/src/main/resources/application.properties
+++ b/quarkus/runtime/src/main/resources/application.properties
@@ -33,6 +33,9 @@ quarkus.log.category."io.quarkus.arc.processor.IndexClassLookupUtils".level=off
 quarkus.log.category."io.quarkus.hibernate.orm.deployment.HibernateOrmProcessor".level=warn
 quarkus.log.category."io.quarkus.deployment.steps.ReflectiveHierarchyStep".level=error
 
+# Hide/mask sensitive Keycloak cookies from the HTTP Access log - see https://github.com/keycloak/keycloak/issues/43811
+quarkus.http.access-log.masked-cookies=AUTH_SESSION_ID,KC_AUTH_SESSION_HASH,KEYCLOAK_IDENTITY,KEYCLOAK_SESSION,AUTH_SESSION_ID_LEGACY,KEYCLOAK_IDENTITY_LEGACY,KEYCLOAK_SESSION_LEGACY
+
 # SqlExceptionHelper will log-and-throw error messages.
 # As those messages might later be caught and handled, this is an antipattern so we prevent logging them
 # https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/Feature.20Request.3A.20Disable.20logging.20of.20SqlExceptionHelper.20for

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -935,6 +935,12 @@ public class PicocliTest extends AbstractConfigurationTest {
 
         nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true", "--http-access-log-exclude='/realms/my-realm/.*");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        onAfter();
+
+        // masked headers and cookies - default
+        nonRunningPicocli = pseudoLaunch("start-dev", "--http-access-log-enabled=true");
+        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
+        assertExternalConfig("quarkus.http.access-log.masked-cookies", "AUTH_SESSION_ID,KC_AUTH_SESSION_HASH,KEYCLOAK_IDENTITY,KEYCLOAK_SESSION,AUTH_SESSION_ID_LEGACY,KEYCLOAK_IDENTITY_LEGACY,KEYCLOAK_SESSION_LEGACY");
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -31,10 +31,15 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.keycloak.config.LoggingOptions;
+import org.keycloak.connections.httpclient.HttpClientBuilder;
+import org.keycloak.cookie.CookieType;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.DryRun;
@@ -46,6 +51,13 @@ import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
 import io.quarkus.deployment.util.FileUtil;
 import io.quarkus.test.junit.main.Launch;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
+import org.hamcrest.Matchers;
+
+import static org.keycloak.OAuth2Constants.DPOP_HTTP_HEADER;
 
 @DistributionTest(keepAlive = true)
 @RawDistOnly(reason = "Too verbose for docker and enough to check raw dist")
@@ -301,5 +313,68 @@ public class LoggingDistTest {
         when().get("http://127.0.0.1:8080/realms/master/clients/account/redirect").then()
                 .statusCode(200);
         cliResult.assertNoMessage("http://127.0.0.1:8080/realms/master/clients/account/redirect");
+    }
+
+    @Test
+    @Launch({"start-dev", "--http-access-log-enabled=true", "--http-access-log-pattern=long"})
+    void httpAccessLogMaskedCookies(CLIResult cliResult) {
+        assertHttpAccessLogMaskedCookies(cliResult);
+    }
+
+    @Test
+    @Launch({"start-dev", "--http-access-log-enabled=true", "--http-access-log-pattern='%{ALL_REQUEST_HEADERS}'"})
+    void httpAccessLogMaskedCookiesDiffFormat(CLIResult cliResult) {
+        assertHttpAccessLogMaskedCookies(cliResult);
+    }
+
+    private void assertHttpAccessLogMaskedCookies(CLIResult cliResult) {
+        var defaultMaskedCookies = new ArrayList<>(List.of(CookieType.OLD_UNUSED_COOKIES));
+        defaultMaskedCookies.add(CookieType.AUTH_SESSION_ID);
+        defaultMaskedCookies.add(CookieType.AUTH_SESSION_ID_HASH);
+        defaultMaskedCookies.add(CookieType.IDENTITY);
+        defaultMaskedCookies.add(CookieType.SESSION);
+
+        var hiddenCookiesFromApplicationProps = Arrays.stream("AUTH_SESSION_ID,KC_AUTH_SESSION_HASH,KEYCLOAK_IDENTITY,KEYCLOAK_SESSION,AUTH_SESSION_ID_LEGACY,KEYCLOAK_IDENTITY_LEGACY,KEYCLOAK_SESSION_LEGACY".split(",")).toList();
+
+        assertThat(hiddenCookiesFromApplicationProps, Matchers.containsInAnyOrder(
+                defaultMaskedCookies.stream()
+                        .map(CookieType::getName)
+                        .toArray(String[]::new))
+        );
+
+        cliResult.assertStartedDevMode();
+
+        try (var httpClient = new HttpClientBuilder().build()) {
+            var baseRequest = RequestBuilder.post().setUri("http://localhost:8080/realms/master");
+
+            var sensitiveCookiesRequest = baseRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer something-that-should-be-hidden");
+            hiddenCookiesFromApplicationProps.forEach(cookie -> sensitiveCookiesRequest.addHeader("Cookie", cookie + "=something-that-should-be-hidden"));
+
+            try (CloseableHttpResponse response = httpClient.execute(sensitiveCookiesRequest.build())) {
+                assertThat(response, notNullValue());
+                EntityUtils.consumeQuietly(response.getEntity());
+            }
+
+            var differentAuthorizationHeader = baseRequest
+                    .addHeader(HttpHeaders.AUTHORIZATION, DPOP_HTTP_HEADER + " something-that-should-be-hidden")
+                    .addHeader(HttpHeaders.CONTENT_LANGUAGE, "cs")
+                    .addHeader("Cookie", "SOMETHING=something-not-sensitive")
+                    .build();
+
+            try (CloseableHttpResponse response = httpClient.execute(differentAuthorizationHeader)) {
+                assertThat(response, notNullValue());
+                EntityUtils.consumeQuietly(response.getEntity());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Verify that sensitive cookie values are masked in the access log
+        cliResult.assertMessage("[org.keycloak.http.access-log]");
+        cliResult.assertMessage("Authorization: Bearer ...");
+        cliResult.assertMessage("Authorization: DPoP ...");
+        cliResult.assertMessage("Cookie: SOMETHING=something-not-sensitive");
+        cliResult.assertMessage("Content-Language: cs");
+        hiddenCookiesFromApplicationProps.forEach(cookie -> cliResult.assertMessage("Cookie: %s=...".formatted(cookie)));
     }
 }


### PR DESCRIPTION
- Closes #43811

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
