### PR TITLE
fix: exposing more property names

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -160,10 +160,10 @@ public class DatabaseOptions {
         private static final Map<Option<?>, Consumer<OptionBuilder<?>>> DATASOURCES_OVERRIDES_OPTIONS = Map.of(
                 DatabaseOptions.DB, builder -> builder
                         .defaultValue(Optional.empty()) // no default value for DB kind for datasources
-                        .connectedOptions(
-                                getDatasourceOption(DatabaseOptions.DB_URL).orElseThrow(),
-                                TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE
-                        )
+                        .connectedOptions(TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE,
+                                getDatasourceOption(DB_POOL_MAX_SIZE).orElseThrow(),
+                                getDatasourceOption(DB_SQL_JPA_DEBUG).orElseThrow(),
+                                getDatasourceOption(DB_SQL_LOG_SLOW_QUERIES).orElseThrow())
         );
 
         private static final Map<String, Option<?>> cachedDatasourceOptions = new HashMap<>();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -276,7 +276,12 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                     customTransformer.accept(created);
                 }
 
-                datasourceMappers.add(created.build());
+                PropertyMapper<?> mapper = created.build();
+                if (mapper.getMapFrom() == null && mapper.getDefaultValue().isPresent() && !getDatasourceOption(DB)
+                        .orElseThrow().getConnectedOptions().contains(mapper.getOption().getKey())) {
+                    throw new AssertionError("Mapper should be connected to the primary to be discovered");
+                }
+                datasourceMappers.add(mapper);
             }
 
             datasourceMappers.addAll(mappers);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -694,7 +694,7 @@ public class PropertyMapper<T> {
         return !option.getConnectedOptions().isEmpty();
     }
 
-    String getMapFrom() {
+    public String getMapFrom() {
         return mapFrom;
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -195,8 +195,12 @@ public final class PropertyMappers {
         return MAPPERS.getWildcardMappers();
     }
 
-    public static WildcardPropertyMapper<?> getWildcardMappedFrom(Option<?> from) {
-        return MAPPERS.wildcardConfig.wildcardMapFrom.get(from.getKey());
+    public static List<WildcardPropertyMapper<?>> getWildcardsMappedFrom(Option<?> from) {
+        var result = MAPPERS.wildcardConfig.wildcardMapFrom.get(from.getKey());
+        if (result == null) {
+            return List.of();
+        }
+        return result;
     }
 
     public static boolean isSupported(PropertyMapper<?> mapper) {
@@ -372,11 +376,11 @@ public final class PropertyMappers {
      */
     private static class WildcardMappersConfig {
         private final Set<WildcardPropertyMapper<?>> wildcardMappers = new HashSet<>();
-        private final Map<String, WildcardPropertyMapper<?>> wildcardMapFrom = new HashMap<>();
+        private final MultivaluedHashMap<String, WildcardPropertyMapper<?>> wildcardMapFrom = new MultivaluedHashMap<>();
 
         public void addMapper(WildcardPropertyMapper<?> mapper) {
             if (mapper.getMapFrom() != null) {
-                wildcardMapFrom.put(mapper.getMapFrom(), mapper);
+                wildcardMapFrom.add(mapper.getMapFrom(), mapper);
             }
             wildcardMappers.add(mapper);
         }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -3,6 +3,7 @@ package org.keycloak.quarkus.runtime.configuration;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.keycloak.quarkus.runtime.Environment;
@@ -498,7 +499,12 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
                 "kc.db-kind-user-store",
                 "quarkus.datasource.\"user-store\".db-kind",
                 "quarkus.datasource.\"user-store\".jdbc.url",
-                "quarkus.datasource.\"user-store\".jdbc.transactions"
+                "quarkus.datasource.\"user-store\".jdbc.transactions",
+                "quarkus.datasource.\"user-store\".jdbc.max-size",
+                "quarkus.datasource.\"user-store\".jdbc.driver",
+                "quarkus.datasource.jdbc.min-size",
+                "quarkus.datasource.jdbc.driver",
+                "quarkus.datasource.jdbc.url"
         ));
 
         // verify the db-kind is there only once
@@ -507,11 +513,8 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
                 .count();
         assertThat(quarkusDbKindCount, is(1L));
 
-        assertThat(propertyNames, not(hasItems(
-                "kc.db-dialect-user-store",
-                "quarkus.datasource.\"user-store\".username",
-                "quarkus.datasource.\"user-store\".password",
-                "quarkus.datasource.\"user-store\".jdbc.driver"
-        )));
+        Stream.of("quarkus.datasource.\"user-store\".username"
+                , "quarkus.datasource.\"user-store\".password")
+                .forEach(n -> assertThat(propertyNames, not(hasItem(n))));
     }
 }


### PR DESCRIPTION
closes: #46569

These refinements seem to cover most situations, and generalizes advertising wildcards that can be mapped from other properties. What still doesn't work well:
- you can have something with a mapFrom that maps to a null value, but we'll still report it in the property names. Most of the time this is not a problem as you are allowed to do things like putting an empty property in a properties file "foo=".
- we need to explicitly "connect" wildcards with defaults to a primary property - that seems fine for db properties, but we may eventually want something more automatic.
- we're only looking at a single mapFrom level to see what other wildcards are in use.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
