### PR TITLE
Expand IDP display name message keys in the account console linked accounts page

### DIFF
--- a/js/apps/account-ui/src/account-security/AccountRow.tsx
+++ b/js/apps/account-ui/src/account-security/AccountRow.tsx
@@ -1,4 +1,8 @@
-import { IconMapper, useEnvironment } from "@keycloak/keycloak-ui-shared";
+import {
+  IconMapper,
+  label,
+  useEnvironment,
+} from "@keycloak/keycloak-ui-shared";
 import {
   Button,
   DataListAction,
@@ -63,7 +67,7 @@ export const AccountRow = ({
                 </SplitItem>
                 <SplitItem className="pf-v5-u-my-xs" isFilled>
                   <span id={`${account.providerAlias}-idp-name`}>
-                    {account.displayName}
+                    {label(t, account.displayName)}
                   </span>
                 </SplitItem>
               </Split>


### PR DESCRIPTION
Expand identity provider display names in the account console linked accounts page before rendering them. This allows names with message key syntax (e.g., ${idps.google.displayName}) to be unwrapped and rendered correctly based on the selected locale.

Closes #46512
