### PR TITLE
Use react-i18next i18n instance in Account Console Personal Info page

### DIFF
--- a/js/apps/account-ui/src/personal-info/PersonalInfo.tsx
+++ b/js/apps/account-ui/src/personal-info/PersonalInfo.tsx
@@ -31,12 +31,12 @@ import {
 } from "../api/representations";
 import { Page } from "../components/page/Page";
 import type { Environment } from "../environment";
-import { TFuncKey, i18n } from "../i18n";
+import { TFuncKey } from "../i18n";
 import { useAccountAlerts } from "../utils/useAccountAlerts";
 import { usePromise } from "../utils/usePromise";
 
 export const PersonalInfo = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const context = useEnvironment<Environment>();
   const [userProfileMetadata, setUserProfileMetadata] =
     useState<UserProfileMetadata>();


### PR DESCRIPTION
Use the i18next instance hooked into react-i18next instead of the instance created by the built-in app. This ensures an initialized instance is used by both built-in and extending apps.

Closes #45766
