### PR TITLE
Upgrade wildlfy and eap versions to 35 and 8.1 respectively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,19 +61,14 @@
         <dist.archive.file>${dist.archive.file.prefix}-${dist.archive.file.version}</dist.archive.file>
         <dist.archive.dir>${dist.archive.dir.prefix}-${dist.archive.dir.version}</dist.archive.dir>
 
-        <!-- core version for app-server-wildfly/eap tests, should match wildfly/eap server -->
-        <tests.wildfly.core.version>21.1.1.Final</tests.wildfly.core.version>
-
         <!-- Upstream WildFly Versions -->
-        <upstream.wildfly.version>29.0.0.Final</upstream.wildfly.version>
-        <upstream.wildfly.build-tools.version>1.2.13.Final</upstream.wildfly.build-tools.version>
-        <upstream.wildfly.core.version>21.1.0.Final</upstream.wildfly.core.version>
+        <upstream.wildfly.version>35.0.1.Final</upstream.wildfly.version>
+        <upstream.wildfly.core.version>27.0.1.Final</upstream.wildfly.core.version>
 
         <!-- Downstream Builds WildFly Versions Override -->
-        <eap8.version>8.0.0.GA-redhat-00007</eap8.version>  <!-- G:A = org.jboss.eap:jboss-eap-parent -->
+        <eap8.version>8.1.0.GA-redhat-00015</eap8.version>  <!-- G:A = org.jboss.eap:jboss-eap-parent -->
         <eap8.wildfly.version>${eap8.version}</eap8.wildfly.version>
-        <eap8.wildfly.core.version>21.1.0.Final</eap8.wildfly.core.version>
-        <eap8.wildfly.build-tools.version>1.2.13.Final</eap8.wildfly.build-tools.version>
+        <eap8.wildfly.core.version>27.1.0.Final-redhat-00010</eap8.wildfly.core.version>
 
         <wildfly.jakarta.adapters>true</wildfly.jakarta.adapters>
 
@@ -1478,11 +1473,6 @@
                     <version>${liquibase.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.wildfly.build</groupId>
-                    <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
-                    <version>${wildfly.build-tools.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>io.smallrye</groupId>
                     <artifactId>smallrye-open-api-maven-plugin</artifactId>
                     <version>${smallrye.openapi.generator.plugin.version}</version>
@@ -1627,13 +1617,12 @@
                 <ee.maven.groupId>org.jboss.eap</ee.maven.groupId>
                 <ee.maven.version>${eap8.version}</ee.maven.version>
                 <wildfly.version>${eap8.version}</wildfly.version>
-                <wildfly.build-tools.version>${eap8.wildfly.build-tools.version}</wildfly.build-tools.version>
                 <wildfly.core.version>${eap8.wildfly.core.version}</wildfly.core.version>
                 <!-- relative directory for galleon pack with layer spec files -->
                 <saml.adapter.galleon.pack.metadata.dir>non-metadata</saml.adapter.galleon.pack.metadata.dir>
                 <!-- WildFly Galleon Build related properties -->
-                <org.wildfly.galleon-plugins.version>6.4.2.Final</org.wildfly.galleon-plugins.version>
-                <org.jboss.galleon.version>5.1.0.Final</org.jboss.galleon.version>
+                <org.wildfly.galleon-plugins.version>7.3.1.Final</org.wildfly.galleon-plugins.version>
+                <org.jboss.galleon.version>6.0.4.Final</org.jboss.galleon.version>
                 <org.wildfly.maven.plugins.licenses-plugin.version>2.3.1.Final</org.wildfly.maven.plugins.licenses-plugin.version>
             </properties>
         </profile>
@@ -1648,13 +1637,12 @@
                 <ee.maven.groupId>org.wildfly</ee.maven.groupId>
                 <ee.maven.version>${upstream.wildfly.version}</ee.maven.version>
                 <wildfly.version>${upstream.wildfly.version}</wildfly.version>
-                <wildfly.build-tools.version>${upstream.wildfly.build-tools.version}</wildfly.build-tools.version>
                 <wildfly.core.version>${upstream.wildfly.core.version}</wildfly.core.version>
                 <!-- relative directory for galleon pack with layer spec files -->
                 <saml.adapter.galleon.pack.metadata.dir>metadata</saml.adapter.galleon.pack.metadata.dir>
                 <!-- WildFly Galleon Build related properties -->
-                <org.wildfly.galleon-plugins.version>6.5.2.Final</org.wildfly.galleon-plugins.version>
-                <org.jboss.galleon.version>5.2.2.Final</org.jboss.galleon.version>
+                <org.wildfly.galleon-plugins.version>7.3.1.Final</org.wildfly.galleon-plugins.version>
+                <org.jboss.galleon.version>6.0.4.Final</org.jboss.galleon.version>
                 <org.wildfly.maven.plugins.licenses-plugin.version>2.3.1.Final</org.wildfly.maven.plugins.licenses-plugin.version>
             </properties>
 

--- a/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/pom.xml
+++ b/testsuite/integration-arquillian/servers/app-server/jboss/wildfly/pom.xml
@@ -31,7 +31,7 @@
     <name>App Server - Wildfly</name>
     
     <properties>
-        <wildfly.server.version>29.0.1.Final</wildfly.server.version>
+        <wildfly.server.version>${wildfly.version}</wildfly.server.version>
         <app.server.jboss>wildfly</app.server.jboss>
         
         <app.server.jboss.groupId>org.wildfly</app.server.jboss.groupId>

--- a/testsuite/integration-arquillian/tests/base/pom.xml
+++ b/testsuite/integration-arquillian/tests/base/pom.xml
@@ -460,7 +460,7 @@
             <properties>
                 <app.server>wildfly</app.server> <!--in case the profile is called directly-->
                 <app.server.skip.unpack>false</app.server.skip.unpack>
-                <wildfly.core.version>${tests.wildfly.core.version}</wildfly.core.version>
+                <wildfly.core.version>${upstream.wildfly.core.version}</wildfly.core.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -473,14 +473,7 @@
                 <dependency>
                     <groupId>org.wildfly.core</groupId>
                     <artifactId>wildfly-cli</artifactId>
-                    <scope>test</scope>
                     <version>${wildfly.core.version}</version>
-                </dependency>
-                <!-- FIXME: Override in order to prevent NoClassDefFoundError: org/jboss/threads/AsyncFuture in ClientContainerController -->
-                <dependency>
-                    <groupId>org.jboss.threads</groupId>
-                    <artifactId>jboss-threads</artifactId>
-                    <version>2.4.0.Final</version>
                 </dependency>
             </dependencies>
             <build>
@@ -504,7 +497,7 @@
                 <app.server>eap8</app.server>
                 <app.server.skip.unpack>false</app.server.skip.unpack>
                 <app.server.artifactId>integration-arquillian-servers-app-server-jboss-galleon</app.server.artifactId>
-                <wildfly.core.version>${tests.wildfly.core.version}</wildfly.core.version>
+                <wildfly.core.version>${eap8.wildfly.core.version}</wildfly.core.version>
             </properties>
             <dependencies>
                 <dependency>
@@ -517,14 +510,7 @@
                 <dependency>
                     <groupId>org.wildfly.core</groupId>
                     <artifactId>wildfly-cli</artifactId>
-                    <scope>test</scope>
                     <version>${wildfly.core.version}</version>
-                </dependency>
-                <!-- FIXME: Override in order to prevent NoClassDefFoundError: org/jboss/threads/AsyncFuture in ClientContainerController -->
-                <dependency>
-                    <groupId>org.jboss.threads</groupId>
-                    <artifactId>jboss-threads</artifactId>
-                    <version>2.4.0.Final</version>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
Closes #45907

Draft to upgrade the wildfly/EAP version to the 35 and 8.1 respectively (EAP 8.1 seems to be based in widlfy 35). The update 12 for EAP 8.0 is the last one (see [this note](https://access.redhat.com/articles/6961381)), so I think using the new versions for 25.6 is OK. I have updated the galleon versions too to use the ones associated to the new versions. I tested and the testsuite works now for both and with java 25.

@pskopek Please take a look if you see this OK. Specially the upgrade of galleon versions. Thanks!
