### PR TITLE
Fix @TestSetup method ordering with inheritance

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/ReflectionUtils.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/ReflectionUtils.java
@@ -26,26 +26,21 @@ public class ReflectionUtils {
         List<Method> methods = new LinkedList<>();
         List<Class<?>> hierarchy = new LinkedList<>();
 
-        // Build class hierarchy bottom-up, inserting at head so superclass comes first
         Class<?> current = clazz;
         while (current != null && !current.equals(Object.class)) {
-            hierarchy.add(0, current);
+            hierarchy.add(current);
             current = current.getSuperclass();
         }
 
-        // Collect methods top-down (superclass first), skipping overridden methods
         for (Class<?> c : hierarchy) {
             for (Method m : c.getDeclaredMethods()) {
                 if (m.getAnnotation(annotationClass) == null) {
                     continue;
                 }
 
-                // Remove any superclass method that this method overrides
-                methods.removeIf(existing ->
-                        existing.getName().equals(m.getName())
-                                && Arrays.equals(existing.getParameterTypes(), m.getParameterTypes()));
-
-                methods.add(m);
+                if (methods.stream().noneMatch(e -> e.getName().equals(m.getName()) && Arrays.equals(e.getParameterTypes(), m.getParameterTypes()))) {
+                    methods.add(0, m);
+                }
             }
         }
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/injection/ReflectionUtils.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/injection/ReflectionUtils.java
@@ -24,13 +24,29 @@ public class ReflectionUtils {
 
     public static List<Method> listMethods(Class<?> clazz, Class<? extends Annotation> annotationClass) {
         List<Method> methods = new LinkedList<>();
+        List<Class<?>> hierarchy = new LinkedList<>();
 
-        Arrays.stream(clazz.getDeclaredMethods()).filter(m -> m.getAnnotation(annotationClass) != null).forEach(methods::add);
+        // Build class hierarchy bottom-up, inserting at head so superclass comes first
+        Class<?> current = clazz;
+        while (current != null && !current.equals(Object.class)) {
+            hierarchy.add(0, current);
+            current = current.getSuperclass();
+        }
 
-        Class<?> superclass = clazz.getSuperclass();
-        while (superclass != null && !superclass.equals(Object.class)) {
-            Arrays.stream(superclass.getDeclaredMethods()).filter(m -> m.getAnnotation(annotationClass) != null).forEach(methods::add);
-            superclass = superclass.getSuperclass();
+        // Collect methods top-down (superclass first), skipping overridden methods
+        for (Class<?> c : hierarchy) {
+            for (Method m : c.getDeclaredMethods()) {
+                if (m.getAnnotation(annotationClass) == null) {
+                    continue;
+                }
+
+                // Remove any superclass method that this method overrides
+                methods.removeIf(existing ->
+                        existing.getName().equals(m.getName())
+                                && Arrays.equals(existing.getParameterTypes(), m.getParameterTypes()));
+
+                methods.add(m);
+            }
         }
 
         return methods;

--- a/test-framework/core/src/test/java/org/keycloak/testframework/injection/ReflectionUtilsTest.java
+++ b/test-framework/core/src/test/java/org/keycloak/testframework/injection/ReflectionUtilsTest.java
@@ -1,0 +1,126 @@
+package org.keycloak.testframework.injection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ReflectionUtilsTest {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface MockSetup {
+    }
+
+    static class SuperClass {
+        @MockSetup
+        void superSetup() {
+        }
+    }
+
+    static class SubClass extends SuperClass {
+        @MockSetup
+        void subSetup() {
+        }
+    }
+
+    static class BaseWithSetup {
+        @MockSetup
+        void setup() {
+        }
+    }
+
+    static class OverridingChild extends BaseWithSetup {
+        @MockSetup
+        @Override
+        void setup() {
+        }
+    }
+
+    static class GrandParent {
+        @MockSetup
+        void grandParentSetup() {
+        }
+    }
+
+    static class Parent extends GrandParent {
+        @MockSetup
+        void parentSetup() {
+        }
+    }
+
+    static class Child extends Parent {
+        @MockSetup
+        void childSetup() {
+        }
+    }
+
+    static class NoAnnotatedMethods {
+        void notAnnotated() {
+        }
+    }
+
+    static class PlainBase {
+    }
+
+    static class AnnotatedChild extends PlainBase {
+        @MockSetup
+        void childOnly() {
+        }
+    }
+
+    @Test
+    public void superclassMethodRunsBeforeSubclass() {
+        List<Method> methods = ReflectionUtils.listMethods(SubClass.class, MockSetup.class);
+        List<String> names = methods.stream().map(Method::getName).collect(Collectors.toList());
+
+        Assertions.assertEquals(List.of("superSetup", "subSetup"), names);
+    }
+
+    @Test
+    public void overriddenMethodOnlyRunsOnce() {
+        List<Method> methods = ReflectionUtils.listMethods(OverridingChild.class, MockSetup.class);
+        List<String> names = methods.stream().map(Method::getName).collect(Collectors.toList());
+
+        Assertions.assertEquals(1, methods.size());
+        Assertions.assertEquals("setup", names.get(0));
+        Assertions.assertEquals(OverridingChild.class, methods.get(0).getDeclaringClass());
+    }
+
+    @Test
+    public void multiLevelInheritanceOrdering() {
+        List<Method> methods = ReflectionUtils.listMethods(Child.class, MockSetup.class);
+        List<String> names = methods.stream().map(Method::getName).collect(Collectors.toList());
+
+        Assertions.assertEquals(List.of("grandParentSetup", "parentSetup", "childSetup"), names);
+    }
+
+    @Test
+    public void noAnnotatedMethodsReturnsEmpty() {
+        List<Method> methods = ReflectionUtils.listMethods(NoAnnotatedMethods.class, MockSetup.class);
+
+        Assertions.assertTrue(methods.isEmpty());
+    }
+
+    @Test
+    public void singleClassWithNoInheritance() {
+        List<Method> methods = ReflectionUtils.listMethods(SuperClass.class, MockSetup.class);
+
+        Assertions.assertEquals(1, methods.size());
+        Assertions.assertEquals("superSetup", methods.get(0).getName());
+    }
+
+    @Test
+    public void childWithPlainBaseClass() {
+        List<Method> methods = ReflectionUtils.listMethods(AnnotatedChild.class, MockSetup.class);
+
+        Assertions.assertEquals(1, methods.size());
+        Assertions.assertEquals("childOnly", methods.get(0).getName());
+    }
+}


### PR DESCRIPTION
## Summary

`ReflectionUtils.listMethods()` had two bugs when class inheritance was involved:

1. **Wrong execution order**: Subclass `@TestSetup` methods were added before superclass methods. Expected behavior is superclass first, matching standard Java inheritance semantics (like constructors and JUnit lifecycle callbacks).

2. **Method overriding not respected**: When a subclass overrides a superclass method annotated with `@TestSetup`, both methods were collected — causing the subclass method to execute twice instead of only the override running once.

### Fix

The fix modifies `listMethods()` to:
- Build the class hierarchy top-down (superclass first) so superclass methods are ordered before subclass methods
- When a subclass declares a method with the same name and parameter types as a superclass method, remove the superclass version so only the override executes

### Test plan

- [x] Unit tests added for `ReflectionUtils.listMethods()` covering:
  - Superclass `@TestSetup` runs before subclass (different method names)
  - Overridden method only runs once (same name), with correct declaring class
  - Multi-level inheritance ordering (grandparent → parent → child)
  - Edge cases: no annotated methods, single class, child with plain base
- [ ] Existing test-framework tests pass: `mvn test -pl test-framework/core`

Closes #46667