### PR TITLE
[26.5] JGroups bind port configuration ignored when --cache-embedded-network-bind-port set

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
@@ -460,8 +460,10 @@ public final class JGroupsConfigurator {
                 return;
             }
             checkPropertyAlreadySet(userConfig, property);
-            if (altProperty != null)
+            if (altProperty != null) {
                 checkPropertyAlreadySet(userConfig, altProperty);
+                System.setProperty(altProperty, userConfig);
+            }
             System.setProperty(property, userConfig);
         }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigDistTest.java
@@ -50,6 +50,14 @@ public class ClusterConfigDistTest {
     }
 
     @Test
+    @Launch({ "start-dev", "--cache=ispn", "--cache-embedded-network-bind-address=127.0.0.2","--cache-embedded-network-bind-port=7802"})
+    void changeBindAddressAndPort(CLIResult result) {
+        result.assertClusteredCache();
+        result.assertMessage("physical addresses are `[127.0.0.2:7802]`");
+        result.assertMessage("ISPN000078: Starting JGroups channel `ISPN` with stack `jdbc-ping`");
+    }
+
+    @Test
     @Launch({ "start-dev", "--cache=ispn", "--cache-embedded-network-bind-address=127.0.0.1","--cache-embedded-network-bind-port=7801", "--cache-embedded-network-external-address=127.0.0.2", "--cache-embedded-network-external-port=7802"})
     void changeBindAndExternalAddress(CLIResult result) {
         result.assertClusteredCache();


### PR DESCRIPTION
Closes #46663 