### PR TITLE
Map transaction timeout to database lock timeout

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -171,8 +171,8 @@ Two new CLI options are now available to control transaction timeout behavior:
 * `transaction-default-timeout`: Controls the transaction timeout for regular transactions.
 The default value is 5 minutes, which is the same value used by the current {project_name} version.
 
-* `transaction-migration-timeout`: Controls the timeout for transactions responsible for migrating the database schema to a new version.
-The default value is 30 minutes, as schema migrations may take a while to complete for large tables.
+* `transaction-setup-timeout`: Controls the timeout for transactions used by database schema migration, import, and export commands.
+The default value is 30 minutes, as these operations may take a while to complete for large datasets.
 
 === Database character encoding checks during startup
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -174,6 +174,8 @@ The default value is 5 minutes, which is the same value used by the current {pro
 * `transaction-setup-timeout`: Controls the timeout for transactions used by database schema migration, import, and export commands.
 The default value is 30 minutes, as these operations may take a while to complete for large datasets.
 
+The provider configuration `spi-dblock--jpa--lock-wait-timeout` option has been replaced with the CLI option `transaction-setup-timeout`.
+
 === Database character encoding checks during startup
 
 {project_name} will log a warning if the database is not configured to use UTF-8 encoding.

--- a/docs/documentation/upgrading/topics/migrate_db.adoc
+++ b/docs/documentation/upgrading/topics/migrate_db.adoc
@@ -20,11 +20,11 @@ Migration is not supported with the default H2 based `dev-file` database type.
 The migration time of the database schema and its contents can vary depending on hardware, release and the amount of data.
 By default {project_name} sets a migration timeout of 30 minutes.
 
-To change the migration timeout, use the option `transaction-migration-timeout` to configure a longer value if your environment requires this.
+To change the migration timeout, use the option `transaction-setup-timeout` to configure a longer value if your environment requires this.
 
 [source,bash]
 ----
-kc.[sh|bat] start --transaction-migration-timeout=60m
+kc.[sh|bat] start --transaction-setup-timeout=60m
 ----
 
 === Automatic relational database migration

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -573,7 +573,7 @@ quarkus.datasource.user-store.jdbc.transactions=xa
 WARNING: Use Quarkus properties **without quotation** for the datasource name, as properties with the quoted datasource name clash with the new datasource options mapping.
 Therefore, use `quarkus.datasource.user-store.db-kind=h2`, instead of `quarkus.datasource."user-store".db-kind=h2` to prevent any issues.
 
-<@opts.printRelevantOptions includedOptions="db db-* transaction-xa-enabled transaction-default-timeout transaction-migration-timeout" excludedOptions="db-*-<datasource>">
+<@opts.printRelevantOptions includedOptions="db db-* transaction-xa-enabled transaction-default-timeout transaction-setup-timeout" excludedOptions="db-*-<datasource>">
 
 === Additional datasources options
 <@opts.includeOptions includedOptions="*-<datasource>"/>

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -384,14 +384,6 @@ However, on MS SQL Server, the database isolation level needs to be modified by 
 ALTER DATABASE <your-database-name> SET READ_COMMITTED_SNAPSHOT ON;
 ----
 
-== Changing database locking timeout in a cluster configuration
-
-Because cluster nodes can boot concurrently, they take extra time for database actions. For example, a booting server instance may perform some database migration, importing, or first time initializations. A database lock prevents start actions from conflicting with each other when cluster nodes boot up concurrently.
-
-The maximum timeout for this lock is 900 seconds. If a node waits on this lock for more than the timeout, the boot fails. The need to change the default value is unlikely, but you can change it by entering this command:
-
-<@kc.start parameters="--spi-dblock--jpa--lock-wait-timeout 900"/>
-
 == Using Database Vendors with XA transaction support
 {project_name} uses non-XA transactions and the appropriate database drivers by default.
 
@@ -419,13 +411,13 @@ To configure a different timeout, for example 10 minutes:
 +
 <@kc.start parameters="--transaction-default-timeout=10m"/>
 
-`transaction-migration-timeout`::
-Controls the timeout for transactions responsible for migrating the database schema to a new version.
-The default value is 30 minutes, as schema migrations may take a while to complete for large tables.
+`transaction-setup-timeout`::
+Controls the timeout for transactions used by database schema migration, import, and export commands.
+The default value is 30 minutes, as these operations may take a while to complete for large datasets.
 +
 To configure a different timeout, for example 1 hour:
 +
-<@kc.start parameters="--transaction-migration-timeout=1h"/>
+<@kc.start parameters="--transaction-setup-timeout=1h"/>
 
 Both options accept values as an ISO 8601 duration, an integer number of seconds, or an integer followed by one of `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), or `d` (days).
 These options can be configured via CLI, environment variables, or the `conf/keycloak.conf` configuration file.

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProvider.java
@@ -98,7 +98,7 @@ public class LiquibaseDBLockProvider implements DBLockProvider {
                     logger.warnf("Locking namespace %s which was already locked in this provider", lock);
                     return;
                 } else {
-                    throw new RuntimeException(String.format("Trying to get a lock when one was already taken by the provider"));
+                    throw new RuntimeException("Trying to get a lock when one was already taken by the provider");
                 }
             }
 
@@ -165,9 +165,7 @@ public class LiquibaseDBLockProvider implements DBLockProvider {
 
     @Override
     public void close() {
-        KeycloakModelUtils.suspendJtaTransaction(session.getKeycloakSessionFactory(), () -> {
-            safeCloseConnection();
-        });
+        KeycloakModelUtils.suspendJtaTransaction(session.getKeycloakSessionFactory(), this::safeCloseConnection);
     }
 
     private void safeRollbackConnection() {

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/lock/LiquibaseDBLockProviderFactory.java
@@ -17,16 +17,13 @@
 
 package org.keycloak.connections.jpa.updater.liquibase.lock;
 
-import java.util.List;
-
 import org.keycloak.Config;
-import org.keycloak.common.util.Time;
+import org.keycloak.config.TransactionOptions;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.dblock.DBLockProviderFactory;
-import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.provider.ProviderConfigurationBuilder;
 
+import io.quarkus.runtime.configuration.DurationConverter;
 import org.jboss.logging.Logger;
 
 /**
@@ -39,14 +36,14 @@ public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory {
 
     private long lockWaitTimeoutMillis;
 
-    protected long getLockWaitTimeoutMillis() {
+    public long getLockWaitTimeoutMillis() {
         return lockWaitTimeoutMillis;
     }
 
     @Override
     public void init(Config.Scope config) {
-        int lockWaitTimeout = config.getInt("lockWaitTimeout", 900);
-        this.lockWaitTimeoutMillis = Time.toMillis(lockWaitTimeout);
+        var lockWaitTimeout = config.get("lockWaitTimeout", TransactionOptions.MIGRATION_TRANSACTION_TIMEOUT);
+        this.lockWaitTimeoutMillis = DurationConverter.parseDuration(lockWaitTimeout).toSeconds();
         logger.debugf("Liquibase lock provider configured with lockWaitTime: %d seconds", lockWaitTimeout);
     }
 
@@ -78,15 +75,5 @@ public class LiquibaseDBLockProviderFactory implements DBLockProviderFactory {
     @Override
     public int order() {
         return PROVIDER_PRIORITY;
-    }
-
-    @Override
-    public List<ProviderConfigProperty> getConfigMetadata() {
-        return ProviderConfigurationBuilder.create()
-                .property()
-                .name("lockWaitTimeout")
-                .type("int")
-                .helpText("The maximum time to wait when waiting to release a database lock.")
-                .add().build();
     }
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
@@ -28,16 +28,16 @@ public class TransactionOptions {
             .defaultValue("5m")
             .build();
 
-    public static final Option<String> TRANSACTION_MIGRATION_TIMEOUT = new OptionBuilder<>("transaction-migration-timeout", String.class)
+    public static final Option<String> TRANSACTION_SETUP_TIMEOUT = new OptionBuilder<>("transaction-setup-timeout", String.class)
             .category(OptionCategory.TRANSACTION)
-            .description("The transaction timeout for database migration transaction. " + OptionsUtil.DURATION_DESCRIPTION)
+            .description("The transaction timeout for database migration/import/export transactions. " + OptionsUtil.DURATION_DESCRIPTION)
             .buildTime(false)
             .defaultValue(MIGRATION_TRANSACTION_TIMEOUT)
             .build();
 
     public static final Option<String> DB_LOCK_TIMEOUT = new OptionBuilder<>("transaction-db-lock-timeout", String.class)
             .category(OptionCategory.TRANSACTION)
-            .description("Hidden option to map transaction-migration-timeout to db lock timeout.")
+            .description("Hidden option to map transaction-setup-timeout to db lock timeout.")
             .buildTime(false)
             .hidden()
             .build();

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
@@ -35,6 +35,13 @@ public class TransactionOptions {
             .defaultValue(MIGRATION_TRANSACTION_TIMEOUT)
             .build();
 
+    public static final Option<String> DB_LOCK_TIMEOUT = new OptionBuilder<>("transaction-db-lock-timeout", String.class)
+            .category(OptionCategory.TRANSACTION)
+            .description("Hidden option to map transaction-migration-timeout to db lock timeout.")
+            .buildTime(false)
+            .hidden()
+            .build();
+
     public static String getNamedTxXADatasource(String namedProperty) {
         if ("<default>".equals(namedProperty)) {
             return TRANSACTION_XA_ENABLED.getKey();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -35,6 +35,11 @@ public class TransactionPropertyMappers implements PropertyMapperGrouping {
                         .to("kc.spi-connections-jpa--quarkus--migration-transaction-timeout")
                         .validator(value -> validateDuration(TransactionOptions.TRANSACTION_MIGRATION_TIMEOUT, value))
                         .paramLabel("timeout")
+                        .build(),
+                fromOption(TransactionOptions.DB_LOCK_TIMEOUT)
+                        .mapFrom(TransactionOptions.TRANSACTION_MIGRATION_TIMEOUT)
+                        .to("kc.spi-dblock--jpa--lock-wait-timeout")
+                        .paramLabel("timeout")
                         .build()
         );
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -31,13 +31,13 @@ public class TransactionPropertyMappers implements PropertyMapperGrouping {
                         .validator(value -> validateDuration(TransactionOptions.TRANSACTION_DEFAULT_TIMEOUT, value))
                         .paramLabel("timeout")
                         .build(),
-                fromOption(TransactionOptions.TRANSACTION_MIGRATION_TIMEOUT)
+                fromOption(TransactionOptions.TRANSACTION_SETUP_TIMEOUT)
                         .to("kc.spi-connections-jpa--quarkus--migration-transaction-timeout")
-                        .validator(value -> validateDuration(TransactionOptions.TRANSACTION_MIGRATION_TIMEOUT, value))
+                        .validator(value -> validateDuration(TransactionOptions.TRANSACTION_SETUP_TIMEOUT, value))
                         .paramLabel("timeout")
                         .build(),
                 fromOption(TransactionOptions.DB_LOCK_TIMEOUT)
-                        .mapFrom(TransactionOptions.TRANSACTION_MIGRATION_TIMEOUT)
+                        .mapFrom(TransactionOptions.TRANSACTION_SETUP_TIMEOUT)
                         .to("kc.spi-dblock--jpa--lock-wait-timeout")
                         .paramLabel("timeout")
                         .build()

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -29,7 +29,6 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor;
 import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
-import org.keycloak.quarkus.runtime.integration.QuarkusPlatform;
 import org.keycloak.quarkus.runtime.storage.database.jpa.QuarkusJpaConnectionProviderFactory;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.ApplianceBootstrap;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -21,6 +21,7 @@ import jakarta.enterprise.event.Observes;
 import jakarta.ws.rs.ApplicationPath;
 
 import org.keycloak.config.BootstrapAdminOptions;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.Environment;
@@ -28,6 +29,8 @@ import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor;
 import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
+import org.keycloak.quarkus.runtime.integration.QuarkusPlatform;
+import org.keycloak.quarkus.runtime.storage.database.jpa.QuarkusJpaConnectionProviderFactory;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.ApplianceBootstrap;
 import org.keycloak.services.resources.KeycloakApplication;
@@ -100,6 +103,11 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         } catch (NumberFormatException e) {
             throw new RuntimeException("Invalid admin expiration value provided. An integer is expected.", e);
         }
+    }
+
+    @Override
+    protected int getTransactionTimeout(KeycloakSessionFactory sessionFactory) {
+        return ((QuarkusJpaConnectionProviderFactory) sessionFactory.getProviderFactory(JpaConnectionProvider.class)).getMigrationTransactionTimeout();
     }
 
     private String getOption(String option, String envVar) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -171,12 +171,6 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
                 .type("string")
                 .helpText("Path for where to write manual database initialization/migration file.")
                 .add()
-                .property()
-                .name(MIGRATION_TRANSACTION_TIMEOUT_KEY)
-                .type("string")
-                .helpText("The transaction timeout for database migration transaction")
-                .defaultValue(MIGRATION_TRANSACTION_TIMEOUT)
-                .add()
                 .build();
     }
 

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResource.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResource.java
@@ -28,7 +28,9 @@ import org.infinispan.configuration.parsing.ParserRegistry;
 import org.jboss.logging.Logger;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.connections.jpa.updater.liquibase.lock.LiquibaseDBLockProviderFactory;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.dblock.DBLockProvider;
 import org.keycloak.quarkus.runtime.storage.database.jpa.QuarkusJpaConnectionProviderFactory;
 import org.keycloak.services.resource.RealmResourceProvider;
 
@@ -106,10 +108,12 @@ public class TestRealmResource implements RealmResourceProvider {
     public Response transactionTimeouts() throws IOException {
         var jpaConnectionProvider = (QuarkusJpaConnectionProviderFactory) session.getKeycloakSessionFactory()
                 .getProviderFactory(JpaConnectionProvider.class);
+        var dbLockProvider = (LiquibaseDBLockProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(DBLockProvider.class);
         var rsp = JsonSerialization.writeValueAsString(
                 Map.of(
                         "default", TxControl.getDefaultTimeout(),
-                        "migration", jpaConnectionProvider.getMigrationTransactionTimeout()
+                        "migration", jpaConnectionProvider.getMigrationTransactionTimeout(),
+                        "db-lock", dbLockProvider.getLockWaitTimeoutMillis()
                 )
         );
         return Response.ok(rsp, MediaType.APPLICATION_JSON_TYPE).build();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TransactionDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TransactionDistTest.java
@@ -42,30 +42,30 @@ public class TransactionDistTest {
     void testZeroTransactionTimeout(KeycloakDistribution dist) {
         var result = dist.run("start-dev", "--transaction-default-timeout=0s");
         result.assertError("Invalid duration '0s' for option 'transaction-default-timeout. Duration must be positive.");
-        result = dist.run("start-dev", "--transaction-migration-timeout=0s");
-        result.assertError("Invalid duration '0s' for option 'transaction-migration-timeout. Duration must be positive.");
+        result = dist.run("start-dev", "--transaction-setup-timeout=0s");
+        result.assertError("Invalid duration '0s' for option 'transaction-setup-timeout. Duration must be positive.");
     }
 
     @Test
     void testNegativeTransactionTimeout(KeycloakDistribution dist) {
         var result = dist.run("start-dev", "--transaction-default-timeout=-1s");
         result.assertError("Invalid duration '-1s' for option 'transaction-default-timeout. Duration must be positive.");
-        result = dist.run("start-dev", "--transaction-migration-timeout=-2s");
-        result.assertError("Invalid duration '-2s' for option 'transaction-migration-timeout. Duration must be positive.");
+        result = dist.run("start-dev", "--transaction-setup-timeout=-2s");
+        result.assertError("Invalid duration '-2s' for option 'transaction-setup-timeout. Duration must be positive.");
     }
 
     @Test
     void testNonNumberTransactionTimeout(KeycloakDistribution dist) {
         var result = dist.run("start-dev", "--transaction-default-timeout=abc");
         result.assertError("Invalid duration format 'abc' for option 'transaction-default-timeout'. May be an ISO 8601 duration value, an integer number of seconds, or an integer followed by one of [ms, h, m, s, d].");
-        result = dist.run("start-dev", "--transaction-migration-timeout=def");
-        result.assertError("Invalid duration format 'def' for option 'transaction-migration-timeout'. May be an ISO 8601 duration value, an integer number of seconds, or an integer followed by one of [ms, h, m, s, d].");
+        result = dist.run("start-dev", "--transaction-setup-timeout=def");
+        result.assertError("Invalid duration format 'def' for option 'transaction-setup-timeout'. May be an ISO 8601 duration value, an integer number of seconds, or an integer followed by one of [ms, h, m, s, d].");
     }
 
     @Test
     @TestProvider(TestRealmResourceTestProvider.class)
     void testValidTransactionTimeout(KeycloakDistribution dist) throws IOException {
-        var result = dist.run("start-dev", "--transaction-default-timeout=123s", "--transaction-migration-timeout=456s");
+        var result = dist.run("start-dev", "--transaction-default-timeout=123s", "--transaction-setup-timeout=456s");
         result.assertStartedDevMode();
         assertTimeouts();
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TransactionDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/TransactionDistTest.java
@@ -79,9 +79,10 @@ public class TransactionDistTest {
                 .prettyPrint();
         var timeout = JsonSerialization.readValue(rsp, new TypeReference<Map<String, Integer>>() {
         });
-        assertThat(timeout.size(), Matchers.is(2));
+        assertThat(timeout.size(), Matchers.is(3));
         assertThat(timeout.get("default"), Matchers.is(123));
         assertThat(timeout.get("migration"), Matchers.is(456));
+        assertThat(timeout.get("db-lock"), Matchers.is(456));
     }
 
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -136,10 +136,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -138,10 +138,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -131,10 +131,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -131,10 +131,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -131,10 +131,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -131,10 +131,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -179,10 +179,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -249,10 +249,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -227,10 +227,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -250,10 +250,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -212,10 +212,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 
 Hostname v2:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -235,10 +235,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 
 Hostname v2:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -226,10 +226,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -249,10 +249,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -224,10 +224,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -247,10 +247,10 @@ Transaction:
                      The default transaction timeout. May be an ISO 8601 duration value, an integer
                        number of seconds, or an integer followed by one of [ms, h, m, s, d].
                        Default: 5m.
---transaction-migration-timeout <timeout>
-                     The transaction timeout for database migration transaction. May be an ISO 8601
-                       duration value, an integer number of seconds, or an integer followed by one
-                       of [ms, h, m, s, d]. Default: 30m.
+--transaction-setup-timeout <timeout>
+                     The transaction timeout for database migration/import/export transactions. May
+                       be an ISO 8601 duration value, an integer number of seconds, or an integer
+                       followed by one of [ms, h, m, s, d]. Default: 30m.
 --transaction-xa-enabled <true|false>
                      If set to true, XA datasources will be used. Default: false.
 --transaction-xa-enabled-<datasource> <true|false>

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -53,11 +53,7 @@ public class ApplianceBootstrap {
     }
 
     public boolean isNewInstall() {
-        if (session.realms().getRealmByName(Config.getAdminRealm()) != null) {
-            return false;
-        } else {
-            return true;
-        }
+        return session.realms().getRealmByName(Config.getAdminRealm()) == null;
     }
 
     public boolean isNoMasterUser() {
@@ -66,7 +62,7 @@ public class ApplianceBootstrap {
         return session.users().getUsersCount(realm, true) == 0;
     }
 
-    public boolean createMasterRealm() {
+    public void createMasterRealm() {
         if (!isNewInstall()) {
             throw new IllegalStateException("Can't create default realm as realms already exists");
         }
@@ -110,8 +106,6 @@ public class ApplianceBootstrap {
             }
         }
         UserProfileProvider.setConfiguration(upConfig);
-
-        return true;
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -17,9 +17,8 @@
 package org.keycloak.services.resources;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
-import jakarta.transaction.SystemException;
-import jakarta.transaction.Transaction;
 import jakarta.ws.rs.core.Application;
 
 import org.keycloak.common.Profile;
@@ -28,13 +27,11 @@ import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.ExportImportManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
-import org.keycloak.models.KeycloakSessionTask;
 import org.keycloak.models.dblock.DBLockManager;
 import org.keycloak.models.dblock.DBLockProvider;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.PostMigrationEvent;
 import org.keycloak.services.managers.ApplianceBootstrap;
-import org.keycloak.transaction.JtaTransactionManagerLookup;
 
 import org.jboss.logging.Logger;
 
@@ -86,28 +83,30 @@ public abstract class KeycloakApplication extends Application {
         CryptoIntegration.init(KeycloakApplication.class.getClassLoader());
         KeycloakApplication.sessionFactory = createSessionFactory();
 
-        ExportImportManager[] exportImportManager = new ExportImportManager[1];
-
-        KeycloakModelUtils.runJobInTransaction(sessionFactory, new KeycloakSessionTask() {
-            @Override
-            public void run(KeycloakSession session) {
-                DBLockManager dbLockManager = new DBLockManager(session);
-                dbLockManager.checkForcedUnlock();
-                DBLockProvider dbLock = dbLockManager.getDBLock();
-                dbLock.waitForLock(DBLockProvider.Namespace.KEYCLOAK_BOOT);
-                try {
-                    exportImportManager[0] = bootstrap();
-                } finally {
-                    dbLock.releaseLock();
-                }
+        setTransactionTimeout();
+        var exportImportManager = KeycloakModelUtils.runJobInTransactionWithResult(sessionFactory, session -> {
+            DBLockManager dbLockManager = new DBLockManager(session);
+            dbLockManager.checkForcedUnlock();
+            DBLockProvider dbLock = dbLockManager.getDBLock();
+            dbLock.waitForLock(DBLockProvider.Namespace.KEYCLOAK_BOOT);
+            try {
+                return bootstrap(session);
+            } finally {
+                dbLock.releaseLock();
             }
         });
 
-        if (exportImportManager[0].isRunExport()) {
-            exportImportManager[0].runExport();
+        if (exportImportManager.isRunExport()) {
+            // the transaction timeout is stored in a thread-local, when exports creates a new transaction, it should fetch it.
+            exportImportManager.runExport();
         }
 
+        resetTransactionTimeout();
         sessionFactory.publish(new PostMigrationEvent(sessionFactory));
+    }
+
+    protected int getTransactionTimeout(KeycloakSessionFactory sessionFactory) {
+        return Math.toIntExact(TimeUnit.MINUTES.toSeconds(5));
     }
 
     protected void shutdown() {
@@ -116,61 +115,29 @@ public abstract class KeycloakApplication extends Application {
         }
     }
 
-    private static class BootstrapState {
-        ExportImportManager exportImportManager;
-        boolean newInstall;
-    }
-
     // Bootstrap master realm, import realms and create admin user.
-    protected ExportImportManager bootstrap() {
-        BootstrapState bootstrapState = new BootstrapState();
-
+    protected ExportImportManager bootstrap(KeycloakSession session) {
         logger.debug("bootstrap");
-        KeycloakModelUtils.runJobInTransaction(sessionFactory, new KeycloakSessionTask() {
-            @Override
-            public void run(KeycloakSession session) {
-                // TODO what is the purpose of following piece of code? Leaving it as is for now.
-                JtaTransactionManagerLookup lookup = (JtaTransactionManagerLookup) sessionFactory.getProviderFactory(JtaTransactionManagerLookup.class);
-                if (lookup != null) {
-                    if (lookup.getTransactionManager() != null) {
-                        try {
-                            Transaction transaction = lookup.getTransactionManager().getTransaction();
-                            logger.debugv("bootstrap current transaction? {0}", transaction != null);
-                            if (transaction != null) {
-                                logger.debugv("bootstrap current transaction status? {0}", transaction.getStatus());
-                            }
-                        } catch (SystemException e) {
-                            throw new RuntimeException(e);
-                        }
-                    }
+        boolean existing = ExportImportConfig.isSingleTransaction();
+        ExportImportConfig.setSingleTransaction(true);
+        try {
+            ApplianceBootstrap applianceBootstrap = new ApplianceBootstrap(session);
+            var exportImportManager = new ExportImportManager(session);
+            var newInstall = applianceBootstrap.isNewInstall();
+            if (newInstall) {
+                if (!exportImportManager.isImportMasterIncluded()) {
+                    applianceBootstrap.createMasterRealm();
                 }
-                // TODO up here ^^
-
-                ApplianceBootstrap applianceBootstrap = new ApplianceBootstrap(session);
-                var exportImportManager = bootstrapState.exportImportManager = new ExportImportManager(session);
-                bootstrapState.newInstall = applianceBootstrap.isNewInstall();
-                if (bootstrapState.newInstall) {
-                    boolean existing = ExportImportConfig.isSingleTransaction();
-                    ExportImportConfig.setSingleTransaction(true);
-                    try {
-                        if (!exportImportManager.isImportMasterIncluded()) {
-                            applianceBootstrap.createMasterRealm();
-                        }
-                        // these are also running in the initial bootstrap transaction - if there is a problem, the server won't be initialized at all
-                        exportImportManager.runImport();
-                        createTemporaryAdmin(session);
-                    } finally {
-                        ExportImportConfig.setSingleTransaction(existing);
-                    }
-                }
+                // these are also running in the initial bootstrap transaction - if there is a problem, the server won't be initialized at all
+                exportImportManager.runImport();
+                createTemporaryAdmin(session);
+            } else {
+                exportImportManager.runImport();
             }
-        });
-
-        if (!bootstrapState.newInstall) {
-            bootstrapState.exportImportManager.runImport();
+            return exportImportManager;
+        } finally {
+            ExportImportConfig.setSingleTransaction(existing);
         }
-
-        return bootstrapState.exportImportManager;
     }
 
     protected abstract void createTemporaryAdmin(KeycloakSession session);
@@ -181,6 +148,23 @@ public abstract class KeycloakApplication extends Application {
 
     public static KeycloakSessionFactory getSessionFactory() {
         return sessionFactory;
+    }
+
+    private void setTransactionTimeout() {
+        try {
+            var transactionTimeoutSeconds = getTransactionTimeout(sessionFactory);
+            KeycloakModelUtils.setTransactionLimit(sessionFactory, transactionTimeoutSeconds);
+        } catch (Exception e) {
+            logger.debug("Failed to set the transaction timeout, using the default value");
+        }
+    }
+
+    private void resetTransactionTimeout() {
+        try {
+            KeycloakModelUtils.setTransactionLimit(sessionFactory, 0);
+        } catch (Exception e) {
+            logger.debug("Failed to reset the transaction timeout");
+        }
     }
 
 }


### PR DESCRIPTION
Closes #46671

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Pending Tasks

- [x] Rename `transaction-migration-timeout` in code and docs.
- [x] Remove database lock timeout from `db.adoc`
- [x] Manually check import/export has the correct timeout