### PR TITLE
feat: added whitelist emails for password expiration policy

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2794,6 +2794,7 @@ jsonEditor=JSON editor
 mappingCreatedError=Could not create mapping\: '{{error}}'
 deleteClientPolicyProfileConfirmTitle=Delete profile?
 passwordPoliciesHelp.forceExpiredPasswordChange=The number of days the password is valid before a new password is required.
+passwordPoliciesHelp.forceExpiredPasswordChangeWhitelist=Comma/space/newline separated list of email addresses and/or domains to exclude from password expiration. Use full emails (user@example.com) or a domain match (@example.com).
 envelopeFromHelp=An email address used for bounces (optional).
 allowutf8Help=Enable to allow UTF-8 characters in the local part of the email address. This should only be enabled if the mail server supports UTF-8 via the SMTPUTF8 extension. If disabled, domain names containing UTF-8 characters will be encoded using punycode, and addresses containing UTF-8 characters in the local part of the address will return an error.
 passwordPoliciesHelp.upperCase=The number of uppercase letters required in the password string.

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.cluster.ClusterProvider;
+import org.keycloak.common.Profile;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.support.EntityManagers;
@@ -67,6 +68,7 @@ import org.keycloak.models.cache.infinispan.events.UserUpdatedEvent;
 import org.keycloak.models.cache.infinispan.stream.InIdentityProviderPredicate;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.storage.CacheableStorageProviderModel;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.OnCreateComponent;
@@ -83,8 +85,6 @@ import org.keycloak.userprofile.UserProfileMetadata;
 import org.jboss.logging.Logger;
 
 import static java.util.Optional.ofNullable;
-
-import static org.keycloak.organization.utils.Organizations.isReadOnlyOrganizationMember;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -112,6 +112,27 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
         this.startupRevision = cache.getCurrentCounter();
         this.datastoreProvider = (StoreManagers) session.getProvider(DatastoreProvider.class);
         session.getTransactionManager().enlistAfterCompletion(getTransaction());
+    }
+
+    private static boolean isReadOnlyOrganizationMember(KeycloakSession session, UserModel delegate) {
+        if (delegate == null) {
+            return false;
+        }
+
+        if (!Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION)) {
+            return false;
+        }
+
+        OrganizationProvider organizationProvider = session.getProvider(OrganizationProvider.class);
+
+        if (organizationProvider == null || organizationProvider.count() == 0) {
+            return false;
+        }
+
+        // check if provider is enabled and user is managed member of a disabled organization OR provider is disabled and user is managed member
+        return organizationProvider.getByMember(delegate)
+                .anyMatch((org) -> (organizationProvider.isEnabled() && org.isManaged(delegate) && !org.isEnabled()) ||
+                        (!organizationProvider.isEnabled() && org.isManaged(delegate)));
     }
 
     @Override

--- a/server-spi-private/src/main/java/org/keycloak/policy/ForceExpiredPasswordChangeWhitelistPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/ForceExpiredPasswordChangeWhitelistPolicyProviderFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.policy;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * Whitelist (by email/domain) for {@code forceExpiredPasswordChange} required action.
+ *
+ * Config format: comma/whitespace/newline separated items. Supported:
+ * - Full email, e.g. {@code user@example.com}
+ * - Domain match, e.g. {@code @example.com} or {@code *@example.com}
+ */
+public class ForceExpiredPasswordChangeWhitelistPolicyProviderFactory implements PasswordPolicyProviderFactory, PasswordPolicyProvider {
+
+    public static final String ID = "forceExpiredPasswordChangeWhitelist";
+
+    @Override
+    public PasswordPolicyProvider create(KeycloakSession session) {
+        return this;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public PolicyError validate(RealmModel realm, UserModel user, String password) {
+        return null;
+    }
+
+    @Override
+    public PolicyError validate(String user, String password) {
+        return null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Expire Password - Whitelist";
+    }
+
+    @Override
+    public String getConfigType() {
+        return PasswordPolicyProvider.STRING_CONFIG_TYPE;
+    }
+
+    @Override
+    public String getDefaultConfigValue() {
+        return "";
+    }
+
+    @Override
+    public boolean isMultiplSupported() {
+        return false;
+    }
+
+    @Override
+    public Object parseConfig(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return Collections.<String>emptySet();
+        }
+
+        // Split by comma/semicolon and all whitespace.
+        String[] tokens = value.split("[,;\\s]+");
+        Set<String> out = new LinkedHashSet<>();
+        for (String token : tokens) {
+            if (token == null) {
+                continue;
+            }
+
+            String normalized = token.trim().toLowerCase(Locale.ROOT);
+            if (normalized.isEmpty()) {
+                continue;
+            }
+
+            // Support "*@example.com" as synonym for "@example.com"
+            if (normalized.startsWith("*@")) {
+                normalized = normalized.substring(1);
+            }
+
+            out.add(normalized);
+        }
+
+        return Collections.unmodifiableSet(out);
+    }
+}
+

--- a/server-spi-private/src/main/resources/META-INF/services/org.keycloak.policy.PasswordPolicyProviderFactory
+++ b/server-spi-private/src/main/resources/META-INF/services/org.keycloak.policy.PasswordPolicyProviderFactory
@@ -17,6 +17,7 @@
 
 org.keycloak.policy.DigitsPasswordPolicyProviderFactory
 org.keycloak.policy.ForceExpiredPasswordPolicyProviderFactory
+org.keycloak.policy.ForceExpiredPasswordChangeWhitelistPolicyProviderFactory
 org.keycloak.policy.HashAlgorithmPasswordPolicyProviderFactory
 org.keycloak.policy.HashIterationsPasswordPolicyProviderFactory
 org.keycloak.policy.HistoryPasswordPolicyProviderFactory

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdatePassword.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.authentication.requiredactions;
 
+import java.util.Locale;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -60,6 +62,7 @@ import org.jboss.logging.Logger;
 public class UpdatePassword implements RequiredActionProvider, RequiredActionFactory {
 
     private static final Logger logger = Logger.getLogger(UpdatePassword.class);
+    private static final String FORCE_EXPIRED_PASSWORD_CHANGE_WHITELIST_ID = "forceExpiredPasswordChangeWhitelist";
 
     @Override
     public InitiatedActionSupport initiatedActionSupport() {
@@ -74,6 +77,9 @@ public class UpdatePassword implements RequiredActionProvider, RequiredActionFac
         }
         int daysToExpirePassword = context.getRealm().getPasswordPolicy().getDaysToExpirePassword();
         if (daysToExpirePassword != -1) {
+            if (isUserWhitelistedFromPasswordExpiry(context)) {
+                return;
+            }
             PasswordCredentialProvider passwordProvider = (PasswordCredentialProvider) context.getSession().getProvider(CredentialProvider.class, PasswordCredentialProviderFactory.PROVIDER_ID);
             CredentialModel password = passwordProvider.getPassword(context.getRealm(), context.getUser());
             if (password != null) {
@@ -91,6 +97,32 @@ public class UpdatePassword implements RequiredActionProvider, RequiredActionFac
                 }
             }
         }
+    }
+
+    private static boolean isUserWhitelistedFromPasswordExpiry(RequiredActionContext context) {
+        Set<String> whitelist = context.getRealm().getPasswordPolicy().getPolicyConfig(FORCE_EXPIRED_PASSWORD_CHANGE_WHITELIST_ID);
+        if (whitelist == null || whitelist.isEmpty()) {
+            return false;
+        }
+
+        String email = context.getUser().getEmail();
+        if (email == null || email.trim().isEmpty()) {
+            return false;
+        }
+
+        String normalizedEmail = email.trim().toLowerCase(Locale.ROOT);
+
+        if (whitelist.contains(normalizedEmail)) {
+            return true;
+        }
+
+        int atIdx = normalizedEmail.lastIndexOf('@');
+        if (atIdx <= 0 || atIdx == normalizedEmail.length() - 1) {
+            return false;
+        }
+
+        String domain = normalizedEmail.substring(atIdx); // includes '@'
+        return whitelist.contains(domain);
     }
 
     @Override

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LoginTest.java
@@ -563,6 +563,27 @@ public class LoginTest extends AbstractChangeImportedUserPasswordsTest {
     }
 
     @Test
+    public void loginWithForcePasswordChangePolicyWhitelist() {
+        setPasswordPolicy("forceExpiredPasswordChange(1) and forceExpiredPasswordChangeWhitelist(login@test.com)");
+        try {
+            // Setting offset to more than one day would normally force password update,
+            // but the user is whitelisted by email.
+            setTimeOffset(86405);
+
+            loginPage.open();
+            loginPage.login("login-test", getPassword("login-test"));
+
+            Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+            Assert.assertNotNull(oauth.parseLoginResponse().getCode());
+
+            setTimeOffset(0);
+            events.expectLogin().user(userId).detail(Details.USERNAME, "login-test").assertEvent();
+        } finally {
+            setPasswordPolicy(null);
+        }
+    }
+
+    @Test
     public void loginWithoutForcePasswordChangePolicy() {
         setPasswordPolicy("forceExpiredPasswordChange(1)");
 


### PR DESCRIPTION
add a whitelist section for a list of emails that we will enter in the keycloak admin console, so only these emails won't get password expiration policy?

Closes https://github.com/keycloak/keycloak/issues/46727