### PR TITLE
Validate and document minimum  max pool size for JDBC PING cache stack

### DIFF
--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -37,7 +37,7 @@ spec:
     schema: schema
     poolInitialSize: 1
     poolMinSize: 2
-    poolMaxSize: 3
+    poolMaxSize: 30
   http:
     httpEnabled: true
     httpPort: 8180
@@ -59,7 +59,9 @@ spec:
     xaEnabled: false
 ----
 
-For a list of options, see the Keycloak CRD. For details on configuring options, see <@links.server id="all-config"/>.
+WARNING: These values are illustrative; choose values appropriate for your environment and workload.
+
+For a list of options, see the Keycloak CRD, and for guidance on each option and its acceptable values, see <@links.server id="all-config"/>.
 
 ==== Additional options
 

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -116,6 +116,22 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
                 .untilAsserted(() -> assertThat(k8sclient.apps().statefulSets().inNamespace(namespace).withName(deploymentName).get()).isNull());
     }
 
+    /**
+     * Currently, when using the JDBC_PING cache stack, we need at least 4 DB connecdtions to avoid dead lock.
+     * This value is documented as the minimal acceptable value.
+     *
+     * @see <a href="https://github.com/keycloak/keycloak/issues/46673">Issue #46673</a>
+     */
+    @Test
+    public void testDocumentedMinimalPoolMaxSizeWorks() {
+        var kc = getTestKeycloakDeployment(false);
+        kc.getSpec().getDatabaseSpec().setPoolMaxSize(4);
+        deployKeycloak(k8sclient, kc, true);
+
+        assertThat(k8sclient.apps().statefulSets().inNamespace(namespace)
+                .withName(kc.getMetadata().getName()).get().getStatus().getReadyReplicas()).isEqualTo(1);
+    }
+
     @Test
     public void testKeycloakDeploymentBeforeSecret() {
         // CR

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -8,11 +8,15 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.keycloak.config.CachingOptions;
+import org.keycloak.config.CachingOptions.Stack;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.TransactionOptions;
 import org.keycloak.config.database.Database;
+import org.keycloak.quarkus.runtime.cli.Picocli;
+import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.utils.StringUtil;
 
@@ -22,9 +26,11 @@ import io.smallrye.config.ConfigValue;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.config.DatabaseOptions.DB;
+import static org.keycloak.config.DatabaseOptions.DB_POOL_MAX_SIZE;
 import static org.keycloak.config.DatabaseOptions.Datasources.OPTIONS_DATASOURCES;
 import static org.keycloak.config.DatabaseOptions.Datasources.getDatasourceOption;
 import static org.keycloak.config.DatabaseOptions.Datasources.getKeyForDatasource;
+import static org.keycloak.quarkus.runtime.configuration.Configuration.getOptionalKcValue;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
 import static org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers.Datasources.appendDatasourceMappers;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
@@ -32,6 +38,13 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.
 public final class DatabasePropertyMappers implements PropertyMapperGrouping {
     public static final String PG_TARGET_SERVER_TYPE = "quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType";
     private static final Logger log = Logger.getLogger(DatabasePropertyMappers.class);
+
+    /**
+     * Minimum {@code db-pool-max-size} required for {@link Stack#jdbc_ping} and {@link Stack#jdbc_ping_udp}.
+     * Determined experimentally — lower values cause startup failures due to connection pool exhaustion.
+     * Verified by {@code KeycloakDeploymentTest#testDocumentedMinimalPoolMaxSizeWorks}.
+     */
+    private static final int JDBC_PING_MIN_POOL_MAX_SIZE = 4;
 
     @Override
     public List<PropertyMapper<?>> getPropertyMappers() {
@@ -118,6 +131,25 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 DatabaseOptions.DB_POOL_INITIAL_SIZE, mapper -> mapper.mapFrom(DatabaseOptions.DB_POOL_INITIAL_SIZE),
                 DatabaseOptions.DB_POOL_MAX_SIZE, mapper -> mapper.mapFrom(DatabaseOptions.DB_POOL_MAX_SIZE)
         ));
+    }
+
+    @Override
+    public void validateConfig(Picocli picocli) {
+        Configuration.getOptionalIntegerValue(DatabaseOptions.DB_POOL_MAX_SIZE).ifPresent(poolMaxSize -> {
+            if (poolMaxSize < JDBC_PING_MIN_POOL_MAX_SIZE && isJdbcPingStack()) {
+                throw new PropertyException(
+                        "The JDBC_PING cache stack requires '%s' to be at least %d (current: %d). A higher value is recommended."
+                                .formatted(DB_POOL_MAX_SIZE.getKey(), JDBC_PING_MIN_POOL_MAX_SIZE, poolMaxSize));
+            }
+        });
+    }
+
+    private static boolean isJdbcPingStack() {
+        if (!CachingPropertyMappers.cacheSetToInfinispan()) {
+            return false;
+        }
+        String stack = getOptionalKcValue(CachingOptions.CACHE_STACK).orElse(Stack.jdbc_ping.toString());
+        return Stack.jdbc_ping.toString().equals(stack) || Stack.jdbc_ping_udp.toString().equals(stack);
     }
 
     private static final Option<String> DB_URL_PATH = new OptionBuilder<>("db-url-path", String.class)

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -1958,4 +1958,28 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertTrue(nonRunningPicocli.getErrString().contains("Unknown option"));
     }
 
+    @Test
+    public void failPoolMaxSizeTooLowForJdbcPing() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--db=postgres", "--db-pool-max-size=3", "--cache=ispn");
+        assertError(nonRunningPicocli, "db-pool-max-size");
+    }
+
+    @Test
+    public void failPoolMaxSizeTooLowForExplicitJdbcPingStack() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start", "--db=postgres", "--db-pool-max-size=3", "--cache=ispn", "--cache-stack=jdbc-ping");
+        assertError(nonRunningPicocli, "db-pool-max-size");
+    }
+
+    @Test
+    public void poolMaxSizeLowAllowedWithoutJdbcPing() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--db-pool-max-size=3", "--cache=local");
+        assertNoError(nonRunningPicocli);
+    }
+
+    @Test
+    public void poolMaxSizeLowAllowedWithKubernetesStack() {
+        NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--db-pool-max-size=3", "--cache=ispn", "--cache-stack=kubernetes");
+        assertNoError(nonRunningPicocli);
+    }
+
 }


### PR DESCRIPTION
Currently when migration tasks are run, we see that the app startup fails with DB pool size 3 or less for JDBC_PING. Hence, we started to validate that the minimal max pool size is 4 for JDBC PING.

* Closes: https://github.com/keycloak/keycloak/issues/46673