### PR TITLE
Fix token type hint injection vulnerability in TokenIntrospectionEndpoint

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -99,7 +99,9 @@ public class TokenIntrospectionEndpoint {
         TokenIntrospectionProvider provider = this.session.getProvider(TokenIntrospectionProvider.class, tokenTypeHint);
 
         if (provider == null) {
-            throw throwErrorResponseException(Errors.INVALID_REQUEST, "Unsupported token type [" + tokenTypeHint + "].", Status.BAD_REQUEST);
+            event.detail(Details.TOKEN_TYPE, tokenTypeHint);
+            event.error(Errors.INVALID_REQUEST);
+            throw throwErrorResponseException(Errors.INVALID_REQUEST, "Unsupported token type.", Status.BAD_REQUEST);
         }
 
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -27,6 +27,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSInput;
@@ -580,6 +581,22 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void testIntrospectionUnknownType() throws Exception {
+        events.clear();
+        String tokenResponse = introspectUnknownTokenType("confidential-cli", "secret1", "xxx");
+
+        OAuth2ErrorRepresentation errorRep = JsonSerialization.readValue(tokenResponse, OAuth2ErrorRepresentation.class);
+        assertEquals("Unsupported token type.", errorRep.getErrorDescription());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, errorRep.getError());
+        events.expect(EventType.INTROSPECT_TOKEN)
+                .client("confidential-cli")
+                .user((String) null)
+                .detail(Details.TOKEN_TYPE, "unknown")
+                .error(Errors.INVALID_REQUEST)
+                .assertEvent();
+    }
+
+    @Test
     public void testIntrospectRevokeRefreshToken() throws Exception {
         RealmRepresentation realm = adminClient.realm(oauth.getRealm()).toRepresentation();
         realm.setRevokeRefreshToken(true);
@@ -640,6 +657,29 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
             realm.setRevokeRefreshToken(false);
             realm.setRefreshTokenMaxReuse(0);
             adminClient.realm(oauth.getRealm()).update(realm);
+        }
+    }
+
+    private String introspectUnknownTokenType(String clientId, String clientSecret, String tokenToIntrospect) {
+        HttpPost post = new HttpPost(oauth.getEndpoints().getIntrospection());
+
+        String authorization = BasicAuthHelper.createHeader(clientId, clientSecret);
+        post.setHeader("Authorization", authorization);
+
+        List<NameValuePair> parameters = new LinkedList<>();
+
+        parameters.add(new BasicNameValuePair("token", tokenToIntrospect));
+        parameters.add(new BasicNameValuePair("token_type_hint", "unknown"));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        post.setEntity(formEntity);
+
+        try (CloseableHttpResponse response = HttpClientBuilder.create().build().execute(post)) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            response.getEntity().writeTo(out);
+            return new String(out.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to retrieve access token", e);
         }
     }
 


### PR DESCRIPTION
## Description

This PR addresses a security vulnerability in the `TokenIntrospectionEndpoint` where unsanitized user input from the `token_type_hint` parameter was being reflected directly into error responses.

### Changes Made

- Changed error message to static string to prevent reflection of user input
- Added `event.detail(Details.TOKEN_TYPE, tokenTypeHint)` for server-side auditing
- Added `event.error(Errors.INVALID_REQUEST)` before throwing exception
- Prevents potential log injection and issues in downstream systems

### Before
```json
{
  "error": "invalid_request",
  "error_description": "Unsupported token type [ATTACKER_INPUT]."
}
```


### After 
```json
{
  "error": "invalid_request",
  "error_description": "Unsupported token type."
}
```

The token_type_hint value is now properly logged in the server's audit logs via event.detail() for debugging purposes, without exposing it in the client-facing error response.

Security Impact
This fix prevents:

Log injection attacks through malicious token_type_hint values
Potential issues in downstream systems that render the error_description
Information leakage through error message reflection
Closes #46689

Signed-off-by: Shashank Goel goelshashank13@gmail.com