### PR TITLE
Assignment of realmRoles to user on creation REST service

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -170,6 +170,7 @@ public class UsersResource {
             UserResource.updateUserFromRep(profile, user, rep, session, false);
             RepresentationToModel.createFederatedIdentities(rep, session, realm, user);
             RepresentationToModel.createGroups(session, rep, realm, user);
+            RepresentationToModel.createRoleMappings(rep, user, realm);
 
             RepresentationToModel.createCredentials(rep, session, realm, user, true);
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), user.getId()).representation(rep).success();


### PR DESCRIPTION
Currently when calling the admin REST API to create a new user (`/admin/realms/{{realm}}/users` ) passing the `realmRoles` parameter, it is simply ignored, and the role mapping is not created. 

Relevant Issue: https://github.com/keycloak/keycloak/issues/46031

This is a solution for the problem, correctly making the role assignment.

This is my first contribution to the project, so if there is something I should do differently I'm open to feedback..