### PR TITLE
Fix admin event logging to use event realm and include auth realm

### DIFF
--- a/services/src/main/java/org/keycloak/events/log/JBossLoggingEventListenerProvider.java
+++ b/services/src/main/java/org/keycloak/events/log/JBossLoggingEventListenerProvider.java
@@ -147,19 +147,24 @@ public class JBossLoggingEventListenerProvider implements EventListenerProvider 
 
         if (logger.isEnabled(level)) {
             StringBuilder sb = new StringBuilder();
+            var authDetails = adminEvent.getAuthDetails();
 
             sb.append("operationType=");
             sanitize(sb, adminEvent.getOperationType().toString());
             sb.append(", realmId=");
-            sanitize(sb, adminEvent.getAuthDetails().getRealmId());
+            sanitize(sb, adminEvent.getRealmId());
             sb.append(", realmName=");
-            sanitize(sb, adminEvent.getAuthDetails().getRealmName());
+            sanitize(sb, adminEvent.getRealmName());
+            sb.append(", authRealmId=");
+            sanitize(sb, authDetails.getRealmId());
+            sb.append(", authRealmName=");
+            sanitize(sb, authDetails.getRealmName());
             sb.append(", clientId=");
-            sanitize(sb, adminEvent.getAuthDetails().getClientId());
+            sanitize(sb, authDetails.getClientId());
             sb.append(", userId=");
-            sanitize(sb, adminEvent.getAuthDetails().getUserId());
+            sanitize(sb, authDetails.getUserId());
             sb.append(", ipAddress=");
-            sanitize(sb, adminEvent.getAuthDetails().getIpAddress());
+            sanitize(sb, authDetails.getIpAddress());
             sb.append(", resourceType=");
             sanitize(sb, adminEvent.getResourceTypeAsString());
             sb.append(", resourcePath=");

--- a/services/src/test/java/org/keycloak/events/log/JBossLoggingEventListenerProviderTest.java
+++ b/services/src/test/java/org/keycloak/events/log/JBossLoggingEventListenerProviderTest.java
@@ -242,9 +242,11 @@ public class JBossLoggingEventListenerProviderTest {
         AdminEvent adminEvent = new AdminEvent();
         adminEvent.setId("id");
         adminEvent.setOperationType(OperationType.UPDATE);
+        adminEvent.setRealmId("event-realm-id");
+        adminEvent.setRealmName("event-realm-name");
         AuthDetails authDetails = new AuthDetails();
-        authDetails.setRealmId("realm-id");
-        authDetails.setRealmName("realm-name");
+        authDetails.setRealmId("auth-realm-id");
+        authDetails.setRealmName("auth-realm-name");
         authDetails.setClientId("client-id");
         authDetails.setUserId("user-id");
         authDetails.setIpAddress("localhost");
@@ -261,8 +263,10 @@ public class JBossLoggingEventListenerProviderTest {
 
     private static void assertAdminEvent(AdminEvent adminEvent, String message, String quote) {
         assertAdminEventKey(message, "operationType", adminEvent.getOperationType().name(), quote);
-        assertAdminEventKey(message, "realmId", adminEvent.getAuthDetails().getRealmId(), quote);
-        assertAdminEventKey(message, "realmName", adminEvent.getAuthDetails().getRealmName(), quote);
+        assertAdminEventKey(message, "realmId", adminEvent.getRealmId(), quote);
+        assertAdminEventKey(message, "realmName", adminEvent.getRealmName(), quote);
+        assertAdminEventKey(message, "authRealmId", adminEvent.getAuthDetails().getRealmId(), quote);
+        assertAdminEventKey(message, "authRealmName", adminEvent.getAuthDetails().getRealmName(), quote);
         assertAdminEventKey(message, "clientId", adminEvent.getAuthDetails().getClientId(), quote);
         assertAdminEventKey(message, "userId", adminEvent.getAuthDetails().getUserId(), quote);
         assertAdminEventKey(message, "ipAddress", adminEvent.getAuthDetails().getIpAddress(), quote);


### PR DESCRIPTION
## Summary
- log realmId/realmName from the admin event realm instead of auth details
- add authRealmId/authRealmName to keep authentication realm context in logs
- update admin event logging tests to cover distinct event/auth realms

## Testing
- ./mvnw -pl services -am -Dtest=JBossLoggingEventListenerProviderTest test -DskipTests=false

Closes #46080
