### PR TITLE
Document process/system CPU metrics in JVM observability guide

### DIFF
--- a/docs/guides/observability/metrics-for-troubleshooting-jvm.adoc
+++ b/docs/guides/observability/metrics-for-troubleshooting-jvm.adoc
@@ -54,7 +54,7 @@ m| jvm_gc_overhead
 
 |===
 
-=== CPU Usage in Kubernetes
+=== CPU usage
 
 |===
 |Metric |Description
@@ -62,6 +62,13 @@ m| jvm_gc_overhead
 m| container_cpu_usage_seconds_total
 
 | Cumulative CPU time consumed by the container in core-seconds.
+
+m| process_cpu_usage
+| The recent CPU usage of the {project_name} JVM process as a ratio between `0` and `1`.
+`1` means the process is fully using one CPU core.
+
+m| system_cpu_usage
+| The recent CPU usage of the whole system as a ratio between `0` and `1`.
 
 |===
 


### PR DESCRIPTION
## Summary
- add missing CPU metrics used by Keycloak Grafana dashboards to the JVM metrics guide
- document `process_cpu_usage` and `system_cpu_usage` with value semantics
- generalize section title from Kubernetes-only wording to `CPU usage`

## Testing
- ./mvnw -pl misc/theme-verifier,docs/maven-plugin -am -DskipTests install
- ./mvnw -f docs/guides/pom.xml -DskipTests validate

Closes #46546
