### PR TITLE
Fix catchNotFound typings for admin-client findOne methods

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/resource.ts
+++ b/js/libs/keycloak-admin-client/src/resources/resource.ts
@@ -1,6 +1,34 @@
 import type { KeycloakAdminClient } from "../client.js";
 import { Agent, RequestArgs } from "./agent.js";
 
+type RequestFunction<
+  PayloadType,
+  ParamType,
+  ResponseType,
+> = {
+  (
+    payload?: PayloadType & ParamType,
+    options?: { catchNotFound?: false },
+  ): Promise<ResponseType>;
+  (
+    payload?: PayloadType & ParamType,
+    options?: { catchNotFound: true },
+  ): Promise<ResponseType | null>;
+  (
+    payload?: PayloadType & ParamType,
+    options?: Pick<RequestArgs, "catchNotFound">,
+  ): Promise<ResponseType | null>;
+};
+
+type RequestFunctionWithDefaultCatchNotFound<
+  PayloadType,
+  ParamType,
+  ResponseType,
+> = (
+  payload?: PayloadType & ParamType,
+  options?: Pick<RequestArgs, "catchNotFound">,
+) => Promise<ResponseType | null>;
+
 export default class Resource<ParamType = {}> {
   #agent: Agent;
   constructor(
@@ -17,14 +45,21 @@ export default class Resource<ParamType = {}> {
     });
   }
 
-  public makeRequest = <PayloadType = any, ResponseType = any>(
+  public makeRequest<PayloadType = any, ResponseType = any>(
+    args: RequestArgs & { catchNotFound: true },
+  ): RequestFunctionWithDefaultCatchNotFound<
+    PayloadType,
+    ParamType,
+    ResponseType
+  >;
+  public makeRequest<PayloadType = any, ResponseType = any>(
     args: RequestArgs,
-  ): ((
-    payload?: PayloadType & ParamType,
-    options?: Pick<RequestArgs, "catchNotFound">,
-  ) => Promise<ResponseType>) => {
+  ): RequestFunction<PayloadType, ParamType, ResponseType>;
+  public makeRequest<PayloadType = any, ResponseType = any>(
+    args: RequestArgs,
+  ) {
     return this.#agent.request(args);
-  };
+  }
 
   // update request will take three types: query, payload and response
   public makeUpdateRequest = <

--- a/js/libs/keycloak-admin-client/test/catchNotFound.types.ts
+++ b/js/libs/keycloak-admin-client/test/catchNotFound.types.ts
@@ -1,0 +1,23 @@
+import type { KeycloakAdminClient } from "../src/client.js";
+import type OrganizationRepresentation from "../src/defs/organizationRepresentation.js";
+
+declare const organizations: KeycloakAdminClient["organizations"];
+
+const nullableResult = organizations.findOne(
+  { id: "organization-id" },
+  { catchNotFound: true },
+);
+const acceptsNullable: Promise<OrganizationRepresentation | null> =
+  nullableResult;
+
+const strictResult = organizations.findOne({ id: "organization-id" });
+const acceptsStrict: Promise<OrganizationRepresentation> = strictResult;
+
+type FindOneReturnType = Awaited<
+  ReturnType<KeycloakAdminClient["organizations"]["findOne"]>
+>;
+const acceptsNullFromReturnType: FindOneReturnType = null;
+
+void acceptsNullable;
+void acceptsStrict;
+void acceptsNullFromReturnType;


### PR DESCRIPTION
## Summary
- add typed overloads to `Resource.makeRequest` so `catchNotFound` is reflected as `... | null`
- keep non-`catchNotFound` calls strongly typed as non-null response
- add a dedicated type regression file to ensure `findOne(..., { catchNotFound: true })` and `ReturnType<findOne>` accept `null`

## Testing
- cd js/libs/keycloak-admin-client && pnpm build
- cd js/libs/keycloak-admin-client && pnpm exec tsc -p tsconfig.catchNotFound.json --noEmit

Closes #46280
