### PR TITLE
Fix admin-client auth when client_credentials has no refresh token

### DIFF
--- a/js/libs/keycloak-admin-client/src/client.ts
+++ b/js/libs/keycloak-admin-client/src/client.ts
@@ -142,9 +142,9 @@ export class KeycloakAdminClient {
     this.#accessTokenDecoded = decodeToken(token);
   }
 
-  public setRefreshToken(token: string) {
+  public setRefreshToken(token?: string) {
     this.refreshToken = token;
-    this.#refreshTokenDecoded = decodeToken(token);
+    this.#refreshTokenDecoded = token ? decodeToken(token) : undefined;
   }
 
   public async getAccessToken() {
@@ -170,6 +170,7 @@ export class KeycloakAdminClient {
       throw new Error("Cannot refresh token: refresh token has expired");
     }
 
+    const previousRefreshToken = this.refreshToken;
     const { accessToken, refreshToken } = await getToken(
       this.#getTokenSettings({
         grantType: "refresh_token",
@@ -180,7 +181,7 @@ export class KeycloakAdminClient {
     );
 
     this.setAccessToken(accessToken);
-    this.setRefreshToken(refreshToken);
+    this.setRefreshToken(refreshToken ?? previousRefreshToken);
   }
 
   public isTokenExpired(): boolean {

--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -31,7 +31,7 @@ export interface TokenResponseRaw {
   access_token: string;
   expires_in: string;
   refresh_expires_in: number;
-  refresh_token: string;
+  refresh_token?: string;
   token_type: string;
   not_before_policy: number;
   session_state: string;
@@ -43,7 +43,7 @@ export interface TokenResponse {
   accessToken: string;
   expiresIn: string;
   refreshExpiresIn: number;
-  refreshToken: string;
+  refreshToken?: string;
   tokenType: string;
   notBeforePolicy: number;
   sessionState: string;

--- a/js/libs/keycloak-admin-client/test/client.spec.ts
+++ b/js/libs/keycloak-admin-client/test/client.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { KeycloakAdminClient } from "../src/client.js";
+
+const createToken = (payload: object = { exp: 9999999999 }) => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const tokenPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  return `${header}.${tokenPayload}.signature`;
+};
+
+describe("KeycloakAdminClient", () => {
+  it("does not throw when refresh token is undefined", () => {
+    const client = new KeycloakAdminClient();
+
+    expect(() => client.setRefreshToken(undefined)).to.not.throw();
+    expect(client.refreshToken).to.be.undefined;
+    expect(client.isRefreshTokenExpired()).to.be.false;
+  });
+
+  it("can clear a previously set refresh token", () => {
+    const client = new KeycloakAdminClient();
+    client.setRefreshToken(createToken());
+
+    expect(client.refreshToken).to.be.a("string");
+
+    client.setRefreshToken(undefined);
+
+    expect(client.refreshToken).to.be.undefined;
+    expect(client.isRefreshTokenExpired()).to.be.false;
+  });
+
+  it("auth succeeds for client_credentials responses without refresh_token", async () => {
+    let server: Server | undefined;
+    try {
+      server = createServer((req, res) => {
+        if (req.method !== "POST") {
+          res.writeHead(405).end();
+          return;
+        }
+
+        if (
+          req.url !== "/realms/master/protocol/openid-connect/token" &&
+          req.url !== "/realms/master/protocol/openid-connect/token/"
+        ) {
+          res.writeHead(404).end();
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            access_token: createToken(),
+            expires_in: "300",
+            refresh_expires_in: 0,
+            token_type: "Bearer",
+            not_before_policy: 0,
+            session_state: "state",
+            scope: "profile email",
+          }),
+        );
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+
+      const { port } = server.address() as AddressInfo;
+      const client = new KeycloakAdminClient({
+        baseUrl: `http://127.0.0.1:${port}`,
+      });
+
+      await client.auth({
+        grantType: "client_credentials",
+        clientId: "admin-cli",
+        clientSecret: "secret",
+      });
+
+      expect(client.accessToken).to.be.a("string");
+      expect(client.refreshToken).to.be.undefined;
+    } finally {
+      if (server) {
+        await server[Symbol.asyncDispose]();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow token responses without `refresh_token` in admin-client auth types
- make `setRefreshToken` resilient to missing token values (skip decoding when undefined)
- preserve existing refresh token during refresh flow if response does not include a new one
- add regression tests including a local token endpoint response for `client_credentials` without `refresh_token`

## Testing
- cd js/libs/keycloak-admin-client && pnpm build
- cd js/libs/keycloak-admin-client && TS_NODE_PROJECT=tsconfig.test.json pnpm exec mocha --recursive "test/client.spec.ts" --timeout 15000

Closes #46433
