### PR TITLE
The drawer splitter in Organization Groups only extends as far as the…

### DIFF
--- a/js/apps/admin-ui/src/groups/GroupsSection.css
+++ b/js/apps/admin-ui/src/groups/GroupsSection.css
@@ -8,3 +8,10 @@
   font-size: var(--pf-v5-global--FontSize--md);
   margin-right: var(--pf-v5-global--spacer--sm);
 }
+
+.keycloak-admin--groups__section {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  height: 100vh;
+}

--- a/js/apps/admin-ui/src/groups/GroupsSection.tsx
+++ b/js/apps/admin-ui/src/groups/GroupsSection.tsx
@@ -137,7 +137,10 @@ export default function GroupsSection({ orgId }: { orgId?: string } = {}) {
           handleModalToggle={() => setRename(undefined)}
         />
       )}
-      <PageSection variant={PageSectionVariants.light} className="pf-v5-u-p-0">
+      <PageSection
+        variant={PageSectionVariants.light}
+        className="pf-v5-u-p-0 keycloak-admin--groups__section"
+      >
         <Drawer isInline isExpanded={open} key={key} position="left">
           <DrawerContent
             panelContent={


### PR DESCRIPTION
… content, not the full page height.

Closes #46774

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
