### PR TITLE
Fix NPE in AbstractClaimMapper when claim is null or empty

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
@@ -43,6 +43,9 @@ public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper
     public static final String CLAIM_VALUE = "claim.value";
 
     public static Object getClaimValue(JsonWebToken token, String claim) {
+        if (claim == null || claim.isEmpty()) {
+            return null;
+        }
 
         switch (claim) {
             case "sub":
@@ -74,6 +77,9 @@ public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper
     }
 
     public static Object getClaimValue(BrokeredIdentityContext context, String claim) {
+        if (claim == null || claim.isEmpty()) {
+            return null;
+        }
         {  // search access token
             JsonWebToken token = (JsonWebToken)context.getContextData().get(KeycloakOIDCIdentityProvider.VALIDATED_ACCESS_TOKEN);
             if (token != null) {

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/ClaimToRoleMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/ClaimToRoleMapper.java
@@ -50,6 +50,7 @@ public class ClaimToRoleMapper extends AbstractClaimToRoleMapper {
         property1.setLabel("Claim");
         property1.setHelpText("Name of claim to search for in token. You can reference nested claims using a '.', i.e. 'address.locality'. To use dot (.) literally, escape it with backslash (\\.)");
         property1.setType(ProviderConfigProperty.STRING_TYPE);
+        property1.setRequired(true);
         configProperties.add(property1);
         property1 = new ProviderConfigProperty();
         property1.setName(CLAIM_VALUE);

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/UserAttributeMapper.java
@@ -63,6 +63,7 @@ public class UserAttributeMapper extends AbstractClaimMapper {
         property1.setLabel("Claim");
         property1.setHelpText("Name of claim to search for in token. You can reference nested claims using a '.', i.e. 'address.locality'. To use dot (.) literally, escape it with backslash (\\.)");
         property1.setType(ProviderConfigProperty.STRING_TYPE);
+        property1.setRequired(true);
         configProperties.add(property1);
         property = new ProviderConfigProperty();
         property.setName(USER_ATTRIBUTE);

--- a/services/src/test/java/org/keycloak/test/broker/oidc/mappers/AbstractClaimMapperTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/oidc/mappers/AbstractClaimMapperTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.test.broker.oidc.mappers;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.keycloak.broker.oidc.mappers.AbstractClaimMapper;
+import org.keycloak.representations.JsonWebToken;
+
+/**
+ * Unit test for {@link AbstractClaimMapper}
+ *
+ * @author Nikita Nagar
+ */
+public class AbstractClaimMapperTest {
+
+    @Test
+    public void getClaimValue_nullClaim() {
+        JsonWebToken token = new JsonWebToken();
+        token.setSubject("test-subject");
+        Assert.assertNull(AbstractClaimMapper.getClaimValue(token, null));
+    }
+
+    @Test
+    public void getClaimValue_emptyClaim() {
+        JsonWebToken token = new JsonWebToken();
+        token.setSubject("test-subject");
+        Assert.assertNull(AbstractClaimMapper.getClaimValue(token, ""));
+    }
+
+    @Test
+    public void getClaimValue_validClaim() {
+        JsonWebToken token = new JsonWebToken();
+        token.setSubject("test-subject");
+        Assert.assertEquals("test-subject", AbstractClaimMapper.getClaimValue(token, "sub"));
+    }
+
+    @Test
+    public void getClaimValue_unknownClaim() {
+        JsonWebToken token = new JsonWebToken();
+        token.setSubject("test-subject");
+        Assert.assertNull(AbstractClaimMapper.getClaimValue(token, "unknown"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add null/empty checks in `AbstractClaimMapper.getClaimValue()` methods to prevent `NullPointerException` when an IdP mapper has a blank claim configured
- Mark the `claim` config property as required in `UserAttributeMapper` and `ClaimToRoleMapper` to prevent incomplete mapper configurations from being saved
- Add unit tests for null/empty claim handling in `AbstractClaimMapperTest`

## Motivation

Closes #46137 — When the IdP Mapper of type "Attribute Importer" has no claim configured, it causes `NullPointerException: Cannot invoke "String.hashCode()" because "<local2>" is null` at `AbstractClaimMapper.getClaimValue()`. The user gets "Unexpected error when authenticating with identity provider" with no clear indication of the root cause.

As suggested by @pedroigor:
> We need to enforce the `claim` field as required and add null checks to avoid unexpected errors when processing a mapper with an invalid configuration.

## Changes

| File | Change |
|------|--------|
| `AbstractClaimMapper.java` | Added null/empty guard in `getClaimValue(JsonWebToken, String)` and `getClaimValue(BrokeredIdentityContext, String)` |
| `UserAttributeMapper.java` | Set `claim` property as required (`setRequired(true)`) |
| `ClaimToRoleMapper.java` | Set `claim` property as required (`setRequired(true)`) |
| `AbstractClaimMapperTest.java` | New unit tests for null, empty, valid, and unknown claim handling |

## Test plan

- [x] `getClaimValue_nullClaim` — verifies null claim returns null (no NPE)
- [x] `getClaimValue_emptyClaim` — verifies empty claim returns null (no NPE)
- [x] `getClaimValue_validClaim` — verifies "sub" claim returns subject
- [x] `getClaimValue_unknownClaim` — verifies unknown claim returns null
- [x] All 394 existing services module tests pass (0 failures)

Signed-off-by: Nikita Nagar <permanayan84@gmail.com>