### PR TITLE
docs(admin-client): document registerTokenProvider usage

### DIFF
--- a/js/libs/keycloak-admin-client/README.md
+++ b/js/libs/keycloak-admin-client/README.md
@@ -102,6 +102,16 @@ await kcAdminClient.auth(credentials);
 setInterval(() => kcAdminClient.auth(credentials), 58 * 1000); // 58 seconds
 ```
 
+If you manage access tokens outside of this client, you can register a custom token provider:
+
+```js
+kcAdminClient.registerTokenProvider({
+  getAccessToken: () => Promise.resolve('some access token'),
+});
+```
+
+`registerTokenProvider` can only be called once per `KcAdminClient` instance.
+
 ## Building and running the tests
 
 To build the source do a build:


### PR DESCRIPTION
## Summary
- add README usage docs for `registerTokenProvider` in the JS admin client
- include a minimal code example showing a custom token provider
- document that the token provider can only be registered once per client instance

Fixes #20044
