### PR TITLE
fix(admin-client): re-enable realm localization tests

### DIFF
--- a/js/libs/keycloak-admin-client/src/resources/realms.ts
+++ b/js/libs/keycloak-admin-client/src/resources/realms.ts
@@ -395,14 +395,42 @@ export class Realms extends Resource {
     headers: { "content-type": "text/plain" },
   });
 
-  public deleteRealmLocalizationTexts = this.makeRequest<
-    { realm: string; selectedLocale: string; key?: string },
+  private deleteRealmLocalizationTextByKey = this.makeRequest<
+    { realm: string; selectedLocale: string; key: string },
     void
   >({
     method: "DELETE",
     path: "/{realm}/localization/{selectedLocale}/{key}",
     urlParamKeys: ["realm", "selectedLocale", "key"],
   });
+
+  private deleteRealmLocalizationByLocale = this.makeRequest<
+    { realm: string; selectedLocale: string },
+    void
+  >({
+    method: "DELETE",
+    path: "/{realm}/localization/{selectedLocale}",
+    urlParamKeys: ["realm", "selectedLocale"],
+  });
+
+  public deleteRealmLocalizationTexts = (payload: {
+    realm: string;
+    selectedLocale: string;
+    key?: string;
+  }) => {
+    if (typeof payload.key === "string" && payload.key.length > 0) {
+      return this.deleteRealmLocalizationTextByKey({
+        realm: payload.realm,
+        selectedLocale: payload.selectedLocale,
+        key: payload.key,
+      });
+    }
+
+    return this.deleteRealmLocalizationByLocale({
+      realm: payload.realm,
+      selectedLocale: payload.selectedLocale,
+    });
+  };
 
   constructor(client: KeycloakAdminClient) {
     super(client, {

--- a/js/libs/keycloak-admin-client/test/realms.spec.ts
+++ b/js/libs/keycloak-admin-client/test/realms.spec.ts
@@ -466,23 +466,42 @@ describe("Realms", () => {
   });
 
   describe("Realm localization", () => {
-    currentRealmName = "master";
+    before(async () => {
+      kcAdminClient = new KeycloakAdminClient();
+      await kcAdminClient.auth(credentials);
 
-    it.skip("enable localization", async () => {
-      await kcAdminClient.realms.getRealmLocalizationTexts({
+      const created = await createRealm(kcAdminClient);
+      currentRealmId = created.realmId;
+      currentRealmName = created.realmName;
+
+      await kcAdminClient.realms.update(
+        { realm: currentRealmName },
+        {
+          internationalizationEnabled: true,
+          supportedLocales: ["en", "nl"],
+          defaultLocale: "en",
+        },
+      );
+    });
+
+    it("enable localization", async () => {
+      const texts = await kcAdminClient.realms.getRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: "nl",
       });
+
+      expect(texts).to.be.ok;
+      expect(texts).to.be.deep.eq({});
     });
 
-    it.skip("should add localization", async () => {
+    it("should add localization", async () => {
       await kcAdminClient.realms.addLocalization(
         { realm: currentRealmName, selectedLocale: "nl", key: "theKey" },
         "value",
       );
     });
 
-    it.skip("should get realm specific locales", async () => {
+    it("should get realm specific locales", async () => {
       const locales = await kcAdminClient.realms.getRealmSpecificLocales({
         realm: currentRealmName,
       });
@@ -491,7 +510,7 @@ describe("Realms", () => {
       expect(locales).to.be.deep.eq(["nl"]);
     });
 
-    it.skip("should get localization for specified locale", async () => {
+    it("should get localization for specified locale", async () => {
       const texts = await kcAdminClient.realms.getRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: "nl",
@@ -501,7 +520,7 @@ describe("Realms", () => {
       expect(texts.theKey).to.be.eq("value");
     });
 
-    it.skip("should delete localization for specified locale key", async () => {
+    it("should delete localization for specified locale key", async () => {
       await kcAdminClient.realms.deleteRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: "nl",
@@ -516,7 +535,7 @@ describe("Realms", () => {
       expect(texts).to.be.deep.eq({});
     });
 
-    it.skip("should delete localization for specified locale", async () => {
+    it("should delete localization for specified locale", async () => {
       await kcAdminClient.realms.deleteRealmLocalizationTexts({
         realm: currentRealmName,
         selectedLocale: "nl",
@@ -527,6 +546,10 @@ describe("Realms", () => {
       });
       expect(locales).to.be.ok;
       expect(locales).to.be.deep.eq([]);
+    });
+
+    after(async () => {
+      await deleteRealm(kcAdminClient, currentRealmName);
     });
   });
 });


### PR DESCRIPTION
## Summary
- re-enable the skipped realm localization tests in `realms.spec.ts`
- make localization tests isolated by creating a dedicated realm in setup/teardown (instead of relying on `master`)
- enable internationalization in test setup before asserting localization APIs
- fix `deleteRealmLocalizationTexts` to support deleting by locale without a key (`DELETE /{realm}/localization/{selectedLocale}`)

Fixes #16945
