### PR TITLE
test(admin-client): re-enable profile and client-scope update tests

### DIFF
--- a/js/libs/keycloak-admin-client/test/clientScopes.spec.ts
+++ b/js/libs/keycloak-admin-client/test/clientScopes.spec.ts
@@ -138,11 +138,18 @@ describe("Client Scopes", () => {
     expect(scope).to.be.undefined;
   });
 
-  it.skip("update client scope", async () => {
+  it("update client scope", async () => {
     const { id, description: oldDescription } = currentClientScope;
     const description = "This scope is totally awesome.";
 
-    await kcAdminClient.clientScopes.update({ id: id! }, { description });
+    await kcAdminClient.clientScopes.update(
+      { id: id! },
+      {
+        name: currentClientScope.name,
+        protocol: currentClientScope.protocol,
+        description,
+      },
+    );
     const updatedScope = (await kcAdminClient.clientScopes.findOne({
       id: id!,
     }))!;

--- a/js/libs/keycloak-admin-client/test/users.spec.ts
+++ b/js/libs/keycloak-admin-client/test/users.spec.ts
@@ -94,14 +94,21 @@ describe("Users", () => {
     expect(numUsers).to.equal(1);
   });
 
-  it.skip("gets the profile", async () => {
+  it("gets the profile", async () => {
     const profile = await kcAdminClient.users.getProfile();
     expect(profile).to.be.ok;
   });
 
-  it.skip("updates the profile", async () => {
-    const profile = await kcAdminClient.users.updateProfile({});
-    expect(profile).to.be.ok;
+  it("updates the profile", async () => {
+    const currentProfile = await kcAdminClient.users.getProfile();
+    const updatedProfile = await kcAdminClient.users.updateProfile({
+      ...currentProfile,
+      unmanagedAttributePolicy: UnmanagedAttributePolicy.Enabled,
+    });
+    expect(updatedProfile).to.be.ok;
+    expect(updatedProfile.unmanagedAttributePolicy).to.eql(
+      UnmanagedAttributePolicy.Enabled,
+    );
   });
 
   it("find users by custom attributes", async () => {


### PR DESCRIPTION
## Summary
- re-enable `Users` profile tests (`gets the profile`, `updates the profile`)
- re-enable `Client Scopes` update test
- update test payloads to match current API expectations:
  - `users.updateProfile` now uses current profile payload instead of `{}`
  - `clientScopes.update` now sends `name` and `protocol` along with `description`

Part of #16956
