### PR TITLE
test(admin-client): re-enable whoami and fine-grained permission tests

### DIFF
--- a/js/libs/keycloak-admin-client/test/clients.spec.ts
+++ b/js/libs/keycloak-admin-client/test/clients.spec.ts
@@ -1317,17 +1317,19 @@ describe("Clients", () => {
       expect(result).to.be.ok;
     });
 
-    it.skip("Enable fine grained permissions", async () => {
-      const permission = await kcAdminClient.clients.updateFineGrainPermission(
+    it("Enable fine grained permissions", async () => {
+      await kcAdminClient.clients.updateFineGrainPermission(
         { id: currentClient.id! },
         { enabled: true },
       );
-      expect(permission).to.include({
-        enabled: true,
+
+      const permission = await kcAdminClient.clients.listFineGrainPermissions({
+        id: currentClient.id!,
       });
+      expect(permission.enabled).to.be.true;
     });
 
-    it.skip("List fine grained permissions for this client", async () => {
+    it("List fine grained permissions for this client", async () => {
       const permissions = (await kcAdminClient.clients.listFineGrainPermissions(
         { id: currentClient.id! },
       ))!;

--- a/js/libs/keycloak-admin-client/test/idp.spec.ts
+++ b/js/libs/keycloak-admin-client/test/idp.spec.ts
@@ -165,17 +165,19 @@ describe("Identity providers", () => {
     );
   });
 
-  it.skip("Enable fine grained permissions", async () => {
-    const permission = await kcAdminClient.identityProviders.updatePermission(
+  it("Enable fine grained permissions", async () => {
+    await kcAdminClient.identityProviders.updatePermission(
       { alias: currentIdpAlias },
       { enabled: true },
     );
-    expect(permission).to.include({
-      enabled: true,
+
+    const permission = await kcAdminClient.identityProviders.listPermissions({
+      alias: currentIdpAlias,
     });
+    expect(permission.enabled).to.be.true;
   });
 
-  it.skip("list permissions", async () => {
+  it("list permissions", async () => {
     const permissions = await kcAdminClient.identityProviders.listPermissions({
       alias: currentIdpAlias,
     });

--- a/js/libs/keycloak-admin-client/test/roles.spec.ts
+++ b/js/libs/keycloak-admin-client/test/roles.spec.ts
@@ -105,17 +105,19 @@ describe("Roles", () => {
     expect(users).to.be.an("array");
   });
 
-  it.skip("Enable fine grained permissions", async () => {
-    const permission = await client.roles.updatePermission(
+  it("Enable fine grained permissions", async () => {
+    await client.roles.updatePermission(
       { id: currentRole.id! },
       { enabled: true },
     );
-    expect(permission).to.include({
-      enabled: true,
+
+    const permission = await client.roles.listPermissions({
+      id: currentRole.id!,
     });
+    expect(permission.enabled).to.be.true;
   });
 
-  it.skip("List fine grained permissions for this role", async () => {
+  it("List fine grained permissions for this role", async () => {
     const permissions = (await client.roles.listPermissions({
       id: currentRole.id!,
     }))!;

--- a/js/libs/keycloak-admin-client/test/whoAmI.spec.ts
+++ b/js/libs/keycloak-admin-client/test/whoAmI.spec.ts
@@ -13,9 +13,10 @@ describe("Who am I", () => {
     await client.auth(credentials);
   });
 
-  it.skip("list who I am", async () => {
+  it("list who I am", async () => {
     const whoAmI = await client.whoAmI.find();
     expect(whoAmI).to.be.ok;
-    expect(whoAmI.displayName).to.be.equal("admin");
+    expect(whoAmI.userId).to.be.a("string").and.not.empty;
+    expect(whoAmI.realm).to.be.a("string").and.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- re-enable `whoAmI` test (`list who I am`) with assertions that validate stable response fields
- re-enable fine-grained permission tests for `clients`, `roles`, and `identityProviders`
- make permission-enable checks robust by verifying state via subsequent `list*Permissions` requests

Part of #16956
