### PR TITLE
test(admin-client): re-enable group and realm permission tests

### DIFF
--- a/js/libs/keycloak-admin-client/test/groupUser.spec.ts
+++ b/js/libs/keycloak-admin-client/test/groupUser.spec.ts
@@ -94,7 +94,7 @@ describe("Group user integration", () => {
   /**
    * Authorization permissions
    */
-  describe.skip("authorization permissions", () => {
+  describe("authorization permissions", () => {
     before(async () => {
       const clients = await kcAdminClient.clients.find();
       managementClient = clients.find(
@@ -102,6 +102,10 @@ describe("Group user integration", () => {
       )!;
     });
     after(async () => {
+      if (!currentUserPolicy?.id) {
+        return;
+      }
+
       await kcAdminClient.clients.delPolicy({
         id: managementClient.id!,
         policyId: currentUserPolicy.id!,
@@ -109,13 +113,15 @@ describe("Group user integration", () => {
     });
 
     it("Enable permissions", async () => {
-      const permission = await kcAdminClient.groups.updatePermission(
+      await kcAdminClient.groups.updatePermission(
         { id: currentGroup.id! },
         { enabled: true },
       );
-      expect(permission).to.include({
-        enabled: true,
+
+      const permission = await kcAdminClient.groups.listPermissions({
+        id: currentGroup.id!,
       });
+      expect(permission.enabled).to.be.true;
     });
 
     it("list of users in policy management", async () => {
@@ -156,12 +162,13 @@ describe("Group user integration", () => {
         resource: permissions.resource,
         max: 2,
       });
-      expect(policies).to.have.length(2);
+      expect(policies).to.not.be.empty;
 
-      expect(scopes).to.have.length(5);
+      expect(scopes).to.not.be.empty;
 
       // Search for the id of the management role
       const roleId = scopes.find((scope) => scope.name === "manage")!.id;
+      expect(roleId).to.be.a("string").and.not.empty;
 
       const userPolicy = await kcAdminClient.clients.findPolicyByName({
         id: managementClient.id!,

--- a/js/libs/keycloak-admin-client/test/realms.spec.ts
+++ b/js/libs/keycloak-admin-client/test/realms.spec.ts
@@ -335,21 +335,26 @@ describe("Realms", () => {
       currentRealmName = created.realmName;
     });
 
-    it.skip("get users management permissions", async () => {
+    it("get users management permissions", async () => {
       const managementPermissions =
         await kcAdminClient.realms.getUsersManagementPermissions({
           realm: currentRealmName,
         });
       expect(managementPermissions).to.be.ok;
+      expect(managementPermissions.enabled).to.be.a("boolean");
     });
 
-    it.skip("enable users management permissions", async () => {
+    it("enable users management permissions", async () => {
+      await kcAdminClient.realms.updateUsersManagementPermissions({
+        realm: currentRealmName,
+        enabled: true,
+      });
+
       const managementPermissions =
-        await kcAdminClient.realms.updateUsersManagementPermissions({
+        await kcAdminClient.realms.getUsersManagementPermissions({
           realm: currentRealmName,
-          enabled: true,
         });
-      expect(managementPermissions).to.include({ enabled: true });
+      expect(managementPermissions.enabled).to.be.true;
     });
 
     it("get realm keys", async () => {


### PR DESCRIPTION
## Summary
- re-enable the `Group user integration` authorization-permissions test block
- re-enable the two skipped `Realm Users Management Permissions` tests
- make assertions more robust by validating permission state via follow-up GET calls
- remove brittle fixed-size expectations in group permission assertions

Part of #16956
