### PR TITLE
feat(admin-client): add role policy endpoint accessors

### DIFF
--- a/js/libs/keycloak-admin-client/README.md
+++ b/js/libs/keycloak-admin-client/README.md
@@ -279,6 +279,23 @@ Demo code: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-admin
 - Get available client-level roles that can be mapped to the user (`GET /{realm}/users/{id}/role-mappings/clients/{client}/available`)
 - Get effective client-level role mappings This will recurse all composite roles to get the result. (`GET /{realm}/users/{id}/role-mappings/clients/{client}/composite`)
 
+### Client authorization services
+
+Demo code: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-admin-client/test/clients.spec.ts
+
+- Get role policy by ID (`GET /{realm}/clients/{id}/authz/resource-server/policy/role/{policyId}`)
+  via `clients.findRolePolicy(...)`
+- Get policy by type and ID (`GET /{realm}/clients/{id}/authz/resource-server/policy/{type}/{policyId}`)
+  via `clients.findOnePolicyWithType(...)`
+- List authorization scopes (`GET /{realm}/clients/{id}/authz/resource-server/scope`)
+  via `clients.listAllScopes(...)`
+- Create authorization scope (`POST /{realm}/clients/{id}/authz/resource-server/scope`)
+  via `clients.createAuthorizationScope(...)`
+- Update authorization scope (`PUT /{realm}/clients/{id}/authz/resource-server/scope/{scopeId}`)
+  via `clients.updateAuthorizationScope(...)`
+- Delete authorization scope (`DELETE /{realm}/clients/{id}/authz/resource-server/scope/{scopeId}`)
+  via `clients.delAuthorizationScope(...)`
+
 ### [Client Attribute Certificate](https://www.keycloak.org/docs-api/20.0.2/rest-api/index.html#_client_attribute_certificate_resource)
 
 - Get key info (`GET /{realm}/clients/{id}/certificates/{attr}`)

--- a/js/libs/keycloak-admin-client/src/resources/clients.ts
+++ b/js/libs/keycloak-admin-client/src/resources/clients.ts
@@ -671,7 +671,7 @@ export class Clients extends Resource<{ realm?: string }> {
 
   public findOnePolicyWithType = this.makeRequest<
     { id: string; type: string; policyId: string },
-    void
+    PolicyRepresentation
   >({
     method: "GET",
     path: "/{id}/authz/resource-server/policy/{type}/{policyId}",
@@ -679,9 +679,19 @@ export class Clients extends Resource<{ realm?: string }> {
     catchNotFound: true,
   });
 
+  public findRolePolicy = this.makeRequest<
+    { id: string; policyId: string },
+    PolicyRepresentation
+  >({
+    method: "GET",
+    path: "/{id}/authz/resource-server/policy/role/{policyId}",
+    urlParamKeys: ["id", "policyId"],
+    catchNotFound: true,
+  });
+
   public findOnePolicy = this.makeRequest<
     { id: string; policyId: string },
-    void
+    PolicyRepresentation
   >({
     method: "GET",
     path: "/{id}/authz/resource-server/policy/{policyId}",

--- a/js/libs/keycloak-admin-client/test/clientAuthorizationPolicyEndpoints.spec.ts
+++ b/js/libs/keycloak-admin-client/test/clientAuthorizationPolicyEndpoints.spec.ts
@@ -1,0 +1,89 @@
+import { expect } from "chai";
+import { Server, createServer } from "node:http";
+import { KeycloakAdminClient } from "../src/client.js";
+
+describe("Client authorization policy endpoints", () => {
+  let server: Server;
+  const requestUrls: string[] = [];
+
+  before(async () => {
+    server = createServer((req, res) => {
+      requestUrls.push(req.url ?? "");
+      const payload = {
+        id: "policy-id",
+        name: "policy-name",
+      };
+
+      if (req.url?.includes("/policy/role/")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ...payload, type: "role" }));
+        return;
+      }
+
+      if (req.url?.includes("/policy/user/")) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ...payload, type: "user" }));
+        return;
+      }
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ...payload, type: "generic" }));
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(8889, "127.0.0.1", resolve),
+    );
+  });
+
+  after(async () => {
+    await server[Symbol.asyncDispose]();
+  });
+
+  it("gets role policy by id", async () => {
+    const client = new KeycloakAdminClient({
+      baseUrl: "http://localhost:8889",
+    });
+
+    const policy = await client.clients.findRolePolicy({
+      id: "client-id",
+      policyId: "policy-id",
+    });
+
+    expect(policy).to.include({ id: "policy-id", type: "role" });
+    expect(requestUrls[requestUrls.length - 1]).to.equal(
+      "/admin/realms/master/clients/client-id/authz/resource-server/policy/role/policy-id",
+    );
+  });
+
+  it("gets policy by type and id", async () => {
+    const client = new KeycloakAdminClient({
+      baseUrl: "http://localhost:8889",
+    });
+
+    const policy = await client.clients.findOnePolicyWithType({
+      id: "client-id",
+      type: "user",
+      policyId: "policy-id",
+    });
+
+    expect(policy).to.include({ id: "policy-id", type: "user" });
+    expect(requestUrls[requestUrls.length - 1]).to.equal(
+      "/admin/realms/master/clients/client-id/authz/resource-server/policy/user/policy-id",
+    );
+  });
+
+  it("gets policy by id", async () => {
+    const client = new KeycloakAdminClient({
+      baseUrl: "http://localhost:8889",
+    });
+
+    const policy = await client.clients.findOnePolicy({
+      id: "client-id",
+      policyId: "policy-id",
+    });
+
+    expect(policy).to.include({ id: "policy-id", type: "generic" });
+    expect(requestUrls[requestUrls.length - 1]).to.equal(
+      "/admin/realms/master/clients/client-id/authz/resource-server/policy/policy-id",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `clients.findRolePolicy(...)` for `GET /authz/resource-server/policy/role/{policyId}`
- correct return types of `findOnePolicyWithType` and `findOnePolicy` to `PolicyRepresentation` (with `catchNotFound` support)
- add a focused local HTTP regression test for these policy endpoints
- document client authorization policy/scope endpoint mappings in the admin-client README

Resolves #16957
