### PR TITLE
test(admin-client): add preconfigured container test setup

### DIFF
--- a/js/libs/keycloak-admin-client/README.md
+++ b/js/libs/keycloak-admin-client/README.md
@@ -129,6 +129,25 @@ Then start the tests with:
 pnpm test
 ```
 
+### Run tests with a preconfigured container
+
+If you prefer not to manually start and configure Keycloak, you can use the bundled Docker Compose setup:
+
+```bash
+pnpm run test:container
+```
+
+This command starts a preconfigured Keycloak container, waits for readiness on `127.0.0.1:8180`, runs the admin-client test suite, and then tears the container down.
+It requires Docker with the Compose plugin (`docker compose`).
+
+You can also run the steps manually:
+
+```bash
+pnpm run test:container:up
+pnpm test
+pnpm run test:container:down
+```
+
 ## Supported APIs
 
 ### [Realm admin](https://www.keycloak.org/docs-api/20.0.2/rest-api/index.html#_realms_admin_resource)

--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -18,6 +18,9 @@
     "build": "wireit",
     "lint": "wireit",
     "test": "wireit",
+    "test:container:up": "bash test/start-test-keycloak.sh",
+    "test:container:down": "bash test/stop-test-keycloak.sh",
+    "test:container": "bash test/run-tests-with-container.sh",
     "generate:openapi": "wireit",
     "postinstall": "pnpm generate:openapi",
     "prepublishOnly": "pnpm build"

--- a/js/libs/keycloak-admin-client/test/docker-compose.yml
+++ b/js/libs/keycloak-admin-client/test/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  keycloak:
+    image: ${KEYCLOAK_TEST_IMAGE:-quay.io/keycloak/keycloak:latest}
+    command:
+      - start-dev
+      - --http-port=8180
+      - --features=transient-users,oid4vc-vci,declarative-ui,quick-theme,spiffe,kubernetes-service-accounts,workflows,client-auth-federated,jwt-authorization-grant,client-admin-api:v2
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+    ports:
+      - "8180:8180"

--- a/js/libs/keycloak-admin-client/test/run-tests-with-container.sh
+++ b/js/libs/keycloak-admin-client/test/run-tests-with-container.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+bash "${SCRIPT_DIR}/start-test-keycloak.sh"
+trap 'bash "${SCRIPT_DIR}/stop-test-keycloak.sh"' EXIT
+
+cd "${PROJECT_DIR}"
+pnpm test

--- a/js/libs/keycloak-admin-client/test/start-test-keycloak.sh
+++ b/js/libs/keycloak-admin-client/test/start-test-keycloak.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to run admin-client tests with a preconfigured container."
+  exit 1
+fi
+
+echo "Starting Keycloak test container..."
+docker compose -f "${COMPOSE_FILE}" up -d
+
+echo "Waiting for Keycloak to be ready on http://127.0.0.1:8180 ..."
+for _ in $(seq 1 60); do
+  if curl --silent --fail --output /dev/null "http://127.0.0.1:8180/realms/master/.well-known/openid-configuration"; then
+    echo "Keycloak is ready."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Keycloak did not become ready in time. Container logs:"
+docker compose -f "${COMPOSE_FILE}" logs keycloak || true
+exit 1

--- a/js/libs/keycloak-admin-client/test/stop-test-keycloak.sh
+++ b/js/libs/keycloak-admin-client/test/stop-test-keycloak.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+
+echo "Stopping Keycloak test container..."
+docker compose -f "${COMPOSE_FILE}" down -v --remove-orphans


### PR DESCRIPTION
## Summary
- add a bundled Docker Compose setup for admin-client tests (`test/docker-compose.yml`)
- add helper scripts to start/stop Keycloak and wait for readiness (`test/start-test-keycloak.sh`, `test/stop-test-keycloak.sh`)
- add a one-command test runner that uses the preconfigured container (`test/run-tests-with-container.sh`)
- expose convenience npm scripts:
  - `pnpm run test:container:up`
  - `pnpm run test:container`
  - `pnpm run test:container:down`
- document the preconfigured-container workflow in the admin-client README

Resolves #16936
