### PR TITLE
Warn on deprecated admin endpoints in JS admin client

### DIFF
--- a/js/libs/keycloak-admin-client/README.md
+++ b/js/libs/keycloak-admin-client/README.md
@@ -129,6 +129,11 @@ Then start the tests with:
 pnpm test
 ```
 
+## Deprecation warnings
+
+The client emits a `console.warn` message when Keycloak marks an admin endpoint as deprecated through standard HTTP headers (`Deprecation`, `Warning`, `Sunset`, and deprecation `Link` metadata).
+
+Warnings are logged once per endpoint path to avoid noisy output.
 ## Supported APIs
 
 ### [Realm admin](https://www.keycloak.org/docs-api/20.0.2/rest-api/index.html#_realms_admin_resource)

--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -1,4 +1,95 @@
 const ERROR_FIELDS = ["error", "errorMessage"];
+const WARNED_DEPRECATED_ENDPOINTS = new Set<string>();
+
+function isDeprecatedResponse(response: Response): boolean {
+  const deprecationHeader = response.headers.get("deprecation");
+  const warningHeader = response.headers.get("warning");
+
+  const hasDeprecationHeader =
+    typeof deprecationHeader === "string" &&
+    deprecationHeader.toLowerCase() !== "false";
+  const warningMentionsDeprecation =
+    typeof warningHeader === "string" &&
+    warningHeader.toLowerCase().includes("deprecat");
+
+  return hasDeprecationHeader || warningMentionsDeprecation;
+}
+
+function resolveRequestUrl(
+  input: Request | string | URL,
+  response: Response,
+): URL | undefined {
+  try {
+    if (response.url) {
+      return new URL(response.url);
+    }
+
+    if (typeof input === "string") {
+      return new URL(input);
+    }
+
+    if (input instanceof URL) {
+      return input;
+    }
+
+    return new URL(input.url);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractDeprecationLink(linkHeader: string | null): string | undefined {
+  if (!linkHeader) {
+    return undefined;
+  }
+
+  const match = /<([^>]+)>;\s*rel="?deprecation"?/i.exec(linkHeader);
+  return match?.[1];
+}
+
+function warnIfDeprecatedEndpoint(
+  input: Request | string | URL,
+  response: Response,
+) {
+  if (!isDeprecatedResponse(response)) {
+    return;
+  }
+
+  const url = resolveRequestUrl(input, response);
+  if (!url?.pathname.includes("/admin/")) {
+    return;
+  }
+
+  const endpointKey = `${url.origin}${url.pathname}`;
+  if (WARNED_DEPRECATED_ENDPOINTS.has(endpointKey)) {
+    return;
+  }
+  WARNED_DEPRECATED_ENDPOINTS.add(endpointKey);
+
+  const details: string[] = [];
+  const deprecationHeader = response.headers.get("deprecation");
+  const warningHeader = response.headers.get("warning");
+  const sunsetHeader = response.headers.get("sunset");
+  const deprecationLink = extractDeprecationLink(response.headers.get("link"));
+
+  if (deprecationHeader) {
+    details.push(`Deprecation: ${deprecationHeader}`);
+  }
+  if (warningHeader) {
+    details.push(`Warning: ${warningHeader}`);
+  }
+  if (sunsetHeader) {
+    details.push(`Sunset: ${sunsetHeader}`);
+  }
+  if (deprecationLink) {
+    details.push(`Deprecation-Info: ${deprecationLink}`);
+  }
+
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  console.warn(
+    `Using deprecated Keycloak Admin endpoint: ${url.pathname}${suffix}.`,
+  );
+}
 
 export type NetworkErrorOptions = { response: Response; responseData: unknown };
 
@@ -29,6 +120,7 @@ export async function fetchWithError(
     });
   }
 
+  warnIfDeprecatedEndpoint(input, response);
   return response;
 }
 

--- a/js/libs/keycloak-admin-client/test/fetchWithError.spec.ts
+++ b/js/libs/keycloak-admin-client/test/fetchWithError.spec.ts
@@ -1,0 +1,63 @@
+import * as chai from "chai";
+import { fetchWithError } from "../src/utils/fetchWithError.js";
+
+const expect = chai.expect;
+
+describe("fetchWithError", () => {
+  const originalFetch = globalThis.fetch;
+  const originalWarn = console.warn;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    console.warn = originalWarn;
+  });
+
+  it("warns once per deprecated admin endpoint", async () => {
+    const warnings: string[] = [];
+    console.warn = ((message: string) => {
+      warnings.push(message);
+    }) as typeof console.warn;
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          Deprecation: "true",
+          Sunset: "Wed, 11 Jan 2028 23:59:59 GMT",
+        },
+      });
+
+    await fetchWithError("http://127.0.0.1:8180/admin/realms/master");
+    await fetchWithError("http://127.0.0.1:8180/admin/realms/master");
+
+    expect(warnings).to.have.length(1);
+    expect(warnings[0]).to.contain(
+      "Using deprecated Keycloak Admin endpoint: /admin/realms/master",
+    );
+    expect(warnings[0]).to.contain("Deprecation: true");
+    expect(warnings[0]).to.contain("Sunset: Wed, 11 Jan 2028 23:59:59 GMT");
+  });
+
+  it("does not warn for non-admin endpoints", async () => {
+    const warnings: string[] = [];
+    console.warn = ((message: string) => {
+      warnings.push(message);
+    }) as typeof console.warn;
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          Deprecation: "true",
+        },
+      });
+
+    await fetchWithError(
+      "http://127.0.0.1:8180/realms/master/protocol/openid-connect/token",
+    );
+
+    expect(warnings).to.have.length(0);
+  });
+});


### PR DESCRIPTION
## Summary
- emit a warning when Keycloak marks an admin endpoint as deprecated via response headers
- include Deprecation, Warning, Sunset, and deprecation Link metadata in the warning message
- deduplicate warnings so each admin endpoint path is only warned once per process
- document the new behavior in the admin client README
- add a focused unit test for deprecated endpoint warnings in fetchWithError

## Verification
- pnpm exec eslint libs/keycloak-admin-client/src/utils/fetchWithError.ts libs/keycloak-admin-client/test/fetchWithError.spec.ts
- TS_NODE_PROJECT=tsconfig.test.json pnpm exec mocha "test/fetchWithError.spec.ts" --timeout 10000
- pnpm --filter @keycloak/keycloak-admin-client build

Closes #16940
