### PR TITLE
Add Account REST resource interfaces to JS admin client

### DIFF
--- a/js/libs/keycloak-admin-client/README.md
+++ b/js/libs/keycloak-admin-client/README.md
@@ -102,6 +102,25 @@ await kcAdminClient.auth(credentials);
 setInterval(() => kcAdminClient.auth(credentials), 58 * 1000); // 58 seconds
 ```
 
+You can also call the Account REST endpoints (for user-token based self-service flows):
+
+```js
+const userScopedClient = new KcAdminClient({
+  baseUrl: 'http://127.0.0.1:8080',
+  realmName: 'master',
+});
+
+userScopedClient.registerTokenProvider({
+  getAccessToken: async () => userAccessToken, // token of the current user
+});
+
+const account = await userScopedClient.account.getProfile();
+await userScopedClient.account.updateProfile({
+  ...account,
+  firstName: 'Updated',
+});
+```
+
 ## Building and running the tests
 
 To build the source do a build:
@@ -130,6 +149,31 @@ pnpm test
 ```
 
 ## Supported APIs
+
+### [Account REST](https://www.keycloak.org/docs-api/latest/rest-api/index.html#AccountRestService)
+
+Demo code: https://github.com/keycloak/keycloak/blob/main/js/libs/keycloak-admin-client/test/account.spec.ts
+
+- Get account profile (`GET /realms/{realm}/account`)
+- Update account profile (`POST /realms/{realm}/account`)
+- List sessions (`GET /realms/{realm}/account/sessions`)
+- List session devices (`GET /realms/{realm}/account/sessions/devices`)
+- Logout sessions (`DELETE /realms/{realm}/account/sessions`)
+- Logout a specific session (`DELETE /realms/{realm}/account/sessions/{id}`)
+- List credential types (`GET /realms/{realm}/account/credentials`)
+- Remove credential (`DELETE /realms/{realm}/account/credentials/{credentialId}`)
+- Set credential label (`PUT /realms/{realm}/account/credentials/{credentialId}/label`)
+- Get supported locales (`GET /realms/{realm}/account/supportedLocales`)
+- List organizations (`GET /realms/{realm}/account/organizations`)
+- List linked accounts (`GET /realms/{realm}/account/linked-accounts`)
+- Build linked account URI (`GET /realms/{realm}/account/linked-accounts/{providerAlias}`)
+- Remove linked account (`DELETE /realms/{realm}/account/linked-accounts/{providerAlias}`)
+- List groups (`GET /realms/{realm}/account/groups`)
+- List applications (`GET /realms/{realm}/account/applications`)
+- Get application consent (`GET /realms/{realm}/account/applications/{clientId}/consent`)
+- Grant application consent (`POST /realms/{realm}/account/applications/{clientId}/consent`)
+- Update application consent (`PUT /realms/{realm}/account/applications/{clientId}/consent`)
+- Revoke application consent (`DELETE /realms/{realm}/account/applications/{clientId}/consent`)
 
 ### [Realm admin](https://www.keycloak.org/docs-api/20.0.2/rest-api/index.html#_realms_admin_resource)
 

--- a/js/libs/keycloak-admin-client/src/client.ts
+++ b/js/libs/keycloak-admin-client/src/client.ts
@@ -1,4 +1,5 @@
 import type { RequestArgs } from "./resources/agent.js";
+import { Account } from "./resources/account.js";
 import { AttackDetection } from "./resources/attackDetection.js";
 import { AuthenticationManagement } from "./resources/authenticationManagement.js";
 import { Cache } from "./resources/cache.js";
@@ -44,6 +45,7 @@ const MIN_VALIDITY = 5; // in seconds
 
 export class KeycloakAdminClient {
   // Resources
+  public account: Account;
   public users: Users;
   public userStorageProvider: UserStorageProvider;
   public groups: Groups;
@@ -88,6 +90,7 @@ export class KeycloakAdminClient {
     this.#globalRequestArgOptions = connectionConfig?.requestArgOptions;
 
     // Initialize resources
+    this.account = new Account(this);
     this.users = new Users(this);
     this.userStorageProvider = new UserStorageProvider(this);
     this.groups = new Groups(this);

--- a/js/libs/keycloak-admin-client/src/defs/accountRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/accountRepresentation.ts
@@ -1,0 +1,106 @@
+import type CredentialRepresentation from "./credentialRepresentation.js";
+
+export interface AccountConsentScopeRepresentation {
+  id?: string;
+  name?: string;
+  displayText?: string;
+  /**
+   * @deprecated Use `displayText` instead.
+   */
+  displayTest?: string;
+}
+
+export interface AccountConsentRepresentation {
+  grantedScopes?: AccountConsentScopeRepresentation[];
+  createdDate?: number;
+  lastUpdatedDate?: number;
+}
+
+export interface AccountClientRepresentation {
+  clientId?: string;
+  clientName?: string;
+  description?: string;
+  userConsentRequired?: boolean;
+  inUse?: boolean;
+  offlineAccess?: boolean;
+  rootUrl?: string;
+  baseUrl?: string;
+  effectiveUrl?: string;
+  consent?: AccountConsentRepresentation;
+  logoUri?: string;
+  policyUri?: string;
+  tosUri?: string;
+}
+
+export interface AccountSessionRepresentation {
+  id?: string;
+  ipAddress?: string;
+  started?: number;
+  lastAccess?: number;
+  expires?: number;
+  clients?: AccountClientRepresentation[];
+  browser?: string;
+  current?: boolean;
+}
+
+export interface AccountDeviceRepresentation {
+  id?: string;
+  ipAddress?: string;
+  os?: string;
+  osVersion?: string;
+  browser?: string;
+  device?: string;
+  lastAccess?: number;
+  current?: boolean;
+  sessions?: AccountSessionRepresentation[];
+  mobile?: boolean;
+}
+
+export interface AccountLinkedAccountRepresentation {
+  connected?: boolean;
+  social?: boolean;
+  providerAlias?: string;
+  providerName?: string;
+  displayName?: string;
+  linkedUsername?: string;
+}
+
+export interface AccountLinkUriRepresentation {
+  accountLinkUri?: string;
+  nonce?: string;
+  hash?: string;
+}
+
+export interface AccountOrganizationRepresentation {
+  id?: string;
+  name?: string;
+  alias?: string;
+  enabled?: boolean;
+  description?: string;
+  domains?: string[];
+}
+
+export interface AccountLocalizedMessageRepresentation {
+  key?: string;
+  parameters?: string[];
+}
+
+export interface AccountCredentialMetadataRepresentation {
+  infoMessage?: AccountLocalizedMessageRepresentation;
+  infoProperties?: AccountLocalizedMessageRepresentation[];
+  warningMessageTitle?: AccountLocalizedMessageRepresentation;
+  warningMessageDescription?: AccountLocalizedMessageRepresentation;
+  credential?: CredentialRepresentation;
+}
+
+export interface AccountCredentialContainerRepresentation {
+  type?: string;
+  category?: string;
+  displayName?: string;
+  helptext?: string;
+  iconCssClass?: string;
+  createAction?: string;
+  updateAction?: string;
+  removeable?: boolean;
+  userCredentialMetadatas?: AccountCredentialMetadataRepresentation[];
+}

--- a/js/libs/keycloak-admin-client/src/index.ts
+++ b/js/libs/keycloak-admin-client/src/index.ts
@@ -10,6 +10,20 @@ export type { default as OrganizationInvitationRepresentation } from "./defs/org
 export { OrganizationInvitationStatus } from "./defs/organizationInvitationRepresentation.js";
 
 export { Groups } from "./resources/groups.js";
+export { Account } from "./resources/account.js";
+export type {
+  AccountClientRepresentation,
+  AccountConsentRepresentation,
+  AccountConsentScopeRepresentation,
+  AccountCredentialContainerRepresentation,
+  AccountCredentialMetadataRepresentation,
+  AccountDeviceRepresentation,
+  AccountLinkUriRepresentation,
+  AccountLinkedAccountRepresentation,
+  AccountLocalizedMessageRepresentation,
+  AccountOrganizationRepresentation,
+  AccountSessionRepresentation,
+} from "./defs/accountRepresentation.js";
 // V2 API types (Kiota-generated)
 export type {
   OIDCClientRepresentation,

--- a/js/libs/keycloak-admin-client/src/resources/account.ts
+++ b/js/libs/keycloak-admin-client/src/resources/account.ts
@@ -1,0 +1,190 @@
+import type {
+  AccountClientRepresentation,
+  AccountConsentRepresentation,
+  AccountCredentialContainerRepresentation,
+  AccountDeviceRepresentation,
+  AccountLinkedAccountRepresentation,
+  AccountLinkUriRepresentation,
+  AccountOrganizationRepresentation,
+  AccountSessionRepresentation,
+} from "../defs/accountRepresentation.js";
+import type GroupRepresentation from "../defs/groupRepresentation.js";
+import type UserRepresentation from "../defs/userRepresentation.js";
+import type KeycloakAdminClient from "../index.js";
+import Resource from "./resource.js";
+
+interface LinkedAccountQuery {
+  linked?: boolean;
+  search?: string;
+  first?: number;
+  max?: number;
+}
+
+export class Account extends Resource<{ realm?: string }> {
+  constructor(client: KeycloakAdminClient) {
+    super(client, {
+      path: "/realms/{realm}/account",
+      getUrlParams: () => ({
+        realm: client.realmName,
+      }),
+      getBaseUrl: () => client.baseUrl,
+    });
+  }
+
+  public getProfile = this.makeRequest<
+    { userProfileMetadata?: boolean },
+    UserRepresentation
+  >({
+    method: "GET",
+    path: "/",
+    queryParamKeys: ["userProfileMetadata"],
+  });
+
+  public updateProfile = this.makeRequest<UserRepresentation, void>({
+    method: "POST",
+    path: "/",
+  });
+
+  public listSessions = this.makeRequest<{}, AccountSessionRepresentation[]>({
+    method: "GET",
+    path: "/sessions",
+  });
+
+  public listSessionDevices = this.makeRequest<
+    {},
+    AccountDeviceRepresentation[]
+  >({
+    method: "GET",
+    path: "/sessions/devices",
+  });
+
+  public logoutSessions = this.makeRequest<{ current?: boolean }, void>({
+    method: "DELETE",
+    path: "/sessions",
+    queryParamKeys: ["current"],
+  });
+
+  public logoutSession = this.makeRequest<{ id: string }, void>({
+    method: "DELETE",
+    path: "/sessions/{id}",
+    urlParamKeys: ["id"],
+  });
+
+  public listCredentialTypes = this.makeRequest<
+    { type?: string; userCredentials?: boolean },
+    AccountCredentialContainerRepresentation[]
+  >({
+    method: "GET",
+    path: "/credentials",
+    queryParamKeys: ["type", "userCredentials"],
+    keyTransform: {
+      userCredentials: "user-credentials",
+    },
+  });
+
+  public removeCredential = this.makeRequest<{ credentialId: string }, void>({
+    method: "DELETE",
+    path: "/credentials/{credentialId}",
+    urlParamKeys: ["credentialId"],
+  });
+
+  public setCredentialLabel = this.makeUpdateRequest<
+    { credentialId: string },
+    string,
+    void
+  >({
+    method: "PUT",
+    path: "/credentials/{credentialId}/label",
+    urlParamKeys: ["credentialId"],
+  });
+
+  public supportedLocales = this.makeRequest<{}, string[]>({
+    method: "GET",
+    path: "/supportedLocales",
+  });
+
+  public listOrganizations = this.makeRequest<
+    {},
+    AccountOrganizationRepresentation[]
+  >({
+    method: "GET",
+    path: "/organizations/",
+  });
+
+  public listLinkedAccounts = this.makeRequest<
+    LinkedAccountQuery,
+    AccountLinkedAccountRepresentation[]
+  >({
+    method: "GET",
+    path: "/linked-accounts/",
+    queryParamKeys: ["linked", "search", "first", "max"],
+  });
+
+  public buildLinkedAccountUri = this.makeRequest<
+    { providerAlias: string; redirectUri: string },
+    AccountLinkUriRepresentation
+  >({
+    method: "GET",
+    path: "/linked-accounts/{providerAlias}",
+    urlParamKeys: ["providerAlias"],
+    queryParamKeys: ["redirectUri"],
+  });
+
+  public removeLinkedAccount = this.makeRequest<
+    { providerAlias: string },
+    void
+  >({
+    method: "DELETE",
+    path: "/linked-accounts/{providerAlias}",
+    urlParamKeys: ["providerAlias"],
+  });
+
+  public listGroups = this.makeRequest<{}, GroupRepresentation[]>({
+    method: "GET",
+    path: "/groups",
+  });
+
+  public listApplications = this.makeRequest<
+    { name?: string },
+    AccountClientRepresentation[]
+  >({
+    method: "GET",
+    path: "/applications",
+    queryParamKeys: ["name"],
+  });
+
+  public getConsent = this.makeRequest<
+    { clientId: string },
+    AccountConsentRepresentation
+  >({
+    method: "GET",
+    path: "/applications/{clientId}/consent",
+    urlParamKeys: ["clientId"],
+  });
+
+  public revokeConsent = this.makeRequest<{ clientId: string }, void>({
+    method: "DELETE",
+    path: "/applications/{clientId}/consent",
+    urlParamKeys: ["clientId"],
+  });
+
+  public grantConsent = this.makeUpdateRequest<
+    { clientId: string },
+    AccountConsentRepresentation,
+    AccountConsentRepresentation
+  >({
+    method: "POST",
+    path: "/applications/{clientId}/consent",
+    urlParamKeys: ["clientId"],
+  });
+
+  public updateConsent = this.makeUpdateRequest<
+    { clientId: string },
+    AccountConsentRepresentation,
+    AccountConsentRepresentation
+  >({
+    method: "PUT",
+    path: "/applications/{clientId}/consent",
+    urlParamKeys: ["clientId"],
+  });
+}

--- a/js/libs/keycloak-admin-client/test/account.spec.ts
+++ b/js/libs/keycloak-admin-client/test/account.spec.ts
@@ -1,0 +1,195 @@
+import { expect } from "chai";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import { KeycloakAdminClient } from "../src/client.js";
+
+const createToken = (payload: object = { exp: 9999999999 }) => {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "HS256", typ: "JWT" }),
+  ).toString("base64url");
+  const tokenPayload = Buffer.from(JSON.stringify(payload)).toString(
+    "base64url",
+  );
+  return `${header}.${tokenPayload}.signature`;
+};
+
+const readBody = async (request: IncomingMessage) =>
+  await new Promise<string>((resolve) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer | string) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    request.on("end", () => {
+      resolve(Buffer.concat(chunks).toString("utf8"));
+    });
+  });
+
+const startServer = async (
+  handler: (
+    request: IncomingMessage,
+    response: ServerResponse,
+  ) => Promise<void>,
+) => {
+  const server = createServer((request, response) => {
+    handler(request, response).catch((error: unknown) => {
+      response.writeHead(500, { "content-type": "text/plain" });
+      response.end(String(error));
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const { port } = server.address() as AddressInfo;
+  const close = async () =>
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+
+  return {
+    close,
+    server,
+    url: `http://127.0.0.1:${port}`,
+  };
+};
+
+const createAuthenticatedClient = (baseUrl: string) => {
+  const client = new KeycloakAdminClient({
+    baseUrl,
+  });
+  client.setAccessToken(createToken());
+  return client;
+};
+
+describe("Account resource", () => {
+  it("gets account profile with userProfileMetadata query", async () => {
+    const server = await startServer(async (request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      expect(request.method).to.equal("GET");
+      expect(url.pathname).to.match(/^\/realms\/master\/account\/?$/);
+      expect(url.searchParams.get("userProfileMetadata")).to.equal("true");
+      expect(request.headers.authorization).to.match(/^Bearer /);
+
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ username: "demo-user" }));
+    });
+
+    try {
+      const client = createAuthenticatedClient(server.url);
+      const profile = await client.account.getProfile({
+        userProfileMetadata: true,
+      });
+      expect(profile.username).to.equal("demo-user");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("updates account profile using POST /realms/{realm}/account", async () => {
+    const server = await startServer(async (request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      expect(request.method).to.equal("POST");
+      expect(url.pathname).to.match(/^\/realms\/master\/account\/?$/);
+      expect(request.headers.authorization).to.match(/^Bearer /);
+
+      const body = await readBody(request);
+      expect(JSON.parse(body)).to.deep.equal({
+        firstName: "John",
+        lastName: "Doe",
+      });
+
+      response.writeHead(204);
+      response.end();
+    });
+
+    try {
+      const client = createAuthenticatedClient(server.url);
+      await client.account.updateProfile({
+        firstName: "John",
+        lastName: "Doe",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("sets credential label using JSON string payload", async () => {
+    const server = await startServer(async (request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      expect(request.method).to.equal("PUT");
+      expect(url.pathname).to.equal(
+        "/realms/master/account/credentials/cred-1/label",
+      );
+      expect(request.headers.authorization).to.match(/^Bearer /);
+      expect(request.headers["content-type"]).to.include("application/json");
+
+      const body = await readBody(request);
+      expect(body).to.equal('"My label"');
+
+      response.writeHead(204);
+      response.end();
+    });
+
+    try {
+      const client = createAuthenticatedClient(server.url);
+      await client.account.setCredentialLabel(
+        { credentialId: "cred-1" },
+        "My label",
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("lists linked accounts with query params", async () => {
+    const server = await startServer(async (request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      expect(request.method).to.equal("GET");
+      expect(url.pathname).to.match(
+        /^\/realms\/master\/account\/linked-accounts\/?$/,
+      );
+      expect(url.searchParams.get("linked")).to.equal("true");
+      expect(url.searchParams.get("search")).to.equal("github");
+      expect(url.searchParams.get("first")).to.equal("1");
+      expect(url.searchParams.get("max")).to.equal("10");
+      expect(request.headers.authorization).to.match(/^Bearer /);
+
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify([
+          {
+            connected: true,
+            providerAlias: "github",
+          },
+        ]),
+      );
+    });
+
+    try {
+      const client = createAuthenticatedClient(server.url);
+      const linkedAccounts = await client.account.listLinkedAccounts({
+        linked: true,
+        search: "github",
+        first: 1,
+        max: 10,
+      });
+
+      expect(linkedAccounts).to.have.length(1);
+      expect(linkedAccounts[0].providerAlias).to.equal("github");
+      expect(linkedAccounts[0].connected).to.equal(true);
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a new account resource to the JS admin client (`client.account`) for Account REST endpoints
- add TypeScript interfaces for account representations (sessions/devices/consents/linked-accounts/credentials/organizations)
- wire account resource into the client and export account-related types from package entrypoint
- document account resource usage and supported account endpoints in README
- add `account.spec.ts` request-level regression tests for profile, profile update, credential label update, and linked-account list queries

## Verification
- pnpm exec eslint libs/keycloak-admin-client/src/resources/account.ts libs/keycloak-admin-client/src/defs/accountRepresentation.ts libs/keycloak-admin-client/src/client.ts libs/keycloak-admin-client/src/index.ts libs/keycloak-admin-client/test/account.spec.ts
- TS_NODE_PROJECT=tsconfig.test.json pnpm exec mocha "test/account.spec.ts" --timeout 10000
- pnpm --filter @keycloak/keycloak-admin-client build

Closes #16939
