### PR TITLE
Expose required clientId/protocol in admin-v2 schema and TS generation

### DIFF
--- a/js/libs/keycloak-admin-client/generate.ts
+++ b/js/libs/keycloak-admin-client/generate.ts
@@ -110,6 +110,7 @@ async function main() {
  */
 function postProcessGeneratedCode() {
   const adminClientPath = resolve(OUTPUT_PATH, "adminClient.ts");
+  const modelsPath = resolve(OUTPUT_PATH, "models/index.ts");
 
   if (!existsSync(adminClientPath)) {
     console.log("⚠️ adminClient.ts not found, skipping post-processing");
@@ -171,6 +172,40 @@ import { TextParseNodeFactory, TextSerializationWriterFactory } from "@microsoft
     writeFileSync(adminClientPath, content);
   } else {
     console.log("   ℹ️ No fixes needed");
+  }
+
+  // Work around Kiota optionality for discriminator-based models.
+  // We currently need clientId and protocol as required fields in TS.
+  if (existsSync(modelsPath)) {
+    let modelsContent = readFileSync(modelsPath, "utf-8");
+    let modelsModified = false;
+
+    const requiredFieldsByInterface: Record<string, string[]> = {
+      BaseClientRepresentation: ["clientId", "protocol"],
+    };
+
+    for (const [interfaceName, requiredFields] of Object.entries(
+      requiredFieldsByInterface,
+    )) {
+      for (const fieldName of requiredFields) {
+        const requiredFieldRegex = new RegExp(
+          `(export interface ${interfaceName}[^\\{]*\\{[\\s\\S]*?\\n\\s*${fieldName})\\?:`,
+        );
+        if (requiredFieldRegex.test(modelsContent)) {
+          modelsContent = modelsContent.replace(requiredFieldRegex, "$1:");
+          modelsModified = true;
+        }
+      }
+    }
+
+    if (modelsModified) {
+      writeFileSync(modelsPath, modelsContent);
+      console.log("   ✅ Enforced required fields in generated models");
+    } else {
+      console.log("   ℹ️ No model required-field fixes needed");
+    }
+  } else {
+    console.log("   ⚠️ models/index.ts not found, skipping required-field fix");
   }
 }
 

--- a/js/libs/keycloak-admin-client/openapi.yaml
+++ b/js/libs/keycloak-admin-client/openapi.yaml
@@ -12,9 +12,14 @@ components:
         certificate:
           type: string
     BaseClientRepresentation:
+      type: object
       description: Base client representation with common properties for all client
         types
-      type: object
+      discriminator:
+        propertyName: protocol
+        mapping:
+          openid-connect: "#/components/schemas/OIDCClientRepresentation"
+          saml: "#/components/schemas/SAMLClientRepresentation"
       properties:
         clientId:
           type: string
@@ -38,11 +43,9 @@ components:
             type: string
         protocol:
           type: string
-      discriminator:
-        propertyName: protocol
-        mapping:
-          openid-connect: "#/components/schemas/OIDCClientRepresentation"
-          saml: "#/components/schemas/SAMLClientRepresentation"
+      required:
+      - clientId
+      - protocol
     Flow:
       type: string
       enum:
@@ -55,6 +58,8 @@ components:
       - CIBA
     OIDCClientRepresentation:
       type: object
+      allOf:
+      - $ref: "#/components/schemas/BaseClientRepresentation"
       properties:
         loginFlows:
           type: array
@@ -75,11 +80,11 @@ components:
             type: string
         protocol:
           type: string
+    SAMLClientRepresentation:
+      type: object
+      description: SAML Client configuration
       allOf:
       - $ref: "#/components/schemas/BaseClientRepresentation"
-    SAMLClientRepresentation:
-      description: SAML Client configuration
-      type: object
       properties:
         nameIdFormat:
           type: string
@@ -107,8 +112,6 @@ components:
           type: boolean
         protocol:
           type: string
-      allOf:
-      - $ref: "#/components/schemas/BaseClientRepresentation"
 tags:
 - name: Clients (v2)
   x-smallrye-profile-admin: ""

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/BaseClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/BaseClientRepresentation.java
@@ -28,6 +28,7 @@ import org.hibernate.validator.constraints.URL;
 public abstract class BaseClientRepresentation extends BaseRepresentation {
     public static final String DISCRIMINATOR_FIELD = "protocol";
 
+    @Schema(required = true)
     @NotBlank(groups = CreateClient.class)
     @JsonPropertyDescription("ID uniquely identifying this client")
     protected String clientId;
@@ -109,6 +110,7 @@ public abstract class BaseClientRepresentation extends BaseRepresentation {
         this.roles = roles;
     }
 
+    @Schema(required = true)
     public abstract String getProtocol();
 
     void setProtocol(String protocol) {


### PR DESCRIPTION
## Summary
- mark `clientId` and `protocol` as required in `BaseClientRepresentation` OpenAPI metadata
- regenerate admin-v2 `openapi.yaml` so `BaseClientRepresentation.required` includes `clientId` and `protocol`
- extend `js/libs/keycloak-admin-client/generate.ts` post-processing to enforce these fields as required in Kiota-generated TS models (workaround for Kiota still emitting optional fields for this discriminator-based model)

## Why
`#16944` tracks stricter TypeScript generation. Even with OpenAPI `required`, Kiota currently still emits optional fields for `BaseClientRepresentation`, so strict TS users do not get compile-time guarantees. This patch makes requiredness effective for the generated admin-v2 model types today.

## Verification
- `./mvnw -pl :keycloak-admin-v2-rest -am process-classes -DskipTests`
- `OPENAPI_FILE=openapi.yaml pnpm --dir js/libs/keycloak-admin-client exec tsx generate.ts`
- `pnpm --dir js/libs/keycloak-admin-client run build`
- `pnpm --dir /root/github/keycloak/js exec eslint libs/keycloak-admin-client/generate.ts`

Related #16944
