### PR TITLE
Avoid NumberFormatException for invalid numeric OIDC attribute values

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -183,6 +183,9 @@ public class OIDCAttributeMapperHelper {
 
         String type = mappingModel.getConfig().get(JSON_TYPE);
         Object converted = convertToType(type, attributeValue);
+        if (converted == null && isNumericType(type) && attributeValue instanceof String) {
+            return null;
+        }
         return converted != null ? converted : attributeValue;
     }
 
@@ -212,6 +215,7 @@ public class OIDCAttributeMapperHelper {
             case "long":
                 Long longObject = getLong(attributeValue);
                 if (longObject != null) return longObject;
+                if (attributeValue instanceof String) return null;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getLong);
                 }
@@ -219,6 +223,7 @@ public class OIDCAttributeMapperHelper {
             case "int":
                 Integer intObject = getInteger(attributeValue);
                 if (intObject != null) return intObject;
+                if (attributeValue instanceof String) return null;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getInteger);
                 }
@@ -235,6 +240,10 @@ public class OIDCAttributeMapperHelper {
         }
     }
 
+    private static boolean isNumericType(String type) {
+        return "long".equals(type) || "int".equals(type);
+    }
+
     private static String getString(Object attributeValue) {
         return attributeValue.toString();
     }
@@ -242,13 +251,25 @@ public class OIDCAttributeMapperHelper {
 
     private static Long getLong(Object attributeValue) {
         if (attributeValue instanceof Long) return (Long) attributeValue;
-        if (attributeValue instanceof String) return Long.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            try {
+                return Long.valueOf((String) attributeValue);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
         return null;
     }
 
     private static Integer getInteger(Object attributeValue) {
         if (attributeValue instanceof Integer) return (Integer) attributeValue;
-        if (attributeValue instanceof String) return Integer.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            try {
+                return Integer.valueOf((String) attributeValue);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
         return null;
     }
 

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
@@ -16,12 +16,18 @@
  */
 package org.keycloak.protocol.oidc.mappers;
 
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.utils.JsonUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  *
@@ -43,5 +49,39 @@ public class OIDCAttributeMapperHelperTest {
         assertThat(JsonUtils.splitClaimPath("c.a\\\\\\.b"), Matchers.contains("c", "a\\.b"));
         assertThat(JsonUtils.splitClaimPath("c\\\\\\.b.a\\\\\\.b"), Matchers.contains("c\\.b", "a\\.b"));
         assertThat(JsonUtils.splitClaimPath("c\\h\\.b.a\\\\\\.b"), Matchers.contains("ch.b", "a\\.b"));
+    }
+
+    @Test
+    public void testMapAttributeValueLongEmptyStringCollectionReturnsNull() {
+        ProtocolMapperModel mappingModel = numericTypeMappingModel("long");
+
+        Object mapped = OIDCAttributeMapperHelper.mapAttributeValue(mappingModel, Collections.singletonList(""));
+
+        assertNull(mapped);
+    }
+
+    @Test
+    public void testMapAttributeValueLongInvalidStringReturnsNull() {
+        ProtocolMapperModel mappingModel = numericTypeMappingModel("long");
+
+        Object mapped = OIDCAttributeMapperHelper.mapAttributeValue(mappingModel, "invalid-number");
+
+        assertNull(mapped);
+    }
+
+    @Test
+    public void testMapAttributeValueLongValidStringReturnsLong() {
+        ProtocolMapperModel mappingModel = numericTypeMappingModel("long");
+
+        Object mapped = OIDCAttributeMapperHelper.mapAttributeValue(mappingModel, "123");
+
+        assertEquals(123L, mapped);
+    }
+
+    private static ProtocolMapperModel numericTypeMappingModel(String jsonType) {
+        ProtocolMapperModel model = new ProtocolMapperModel();
+        model.setConfig(new HashMap<>());
+        model.getConfig().put(OIDCAttributeMapperHelper.JSON_TYPE, jsonType);
+        return model;
     }
 }


### PR DESCRIPTION
## Summary
- guard numeric (`long`/`int`) OIDC attribute conversion against invalid string input
- return `null` for invalid numeric string claims instead of throwing from `Long.valueOf`/`Integer.valueOf`
- skip mapping invalid numeric string claims in `mapAttributeValue`
- add unit tests covering:
  - empty string from collection for `long`
  - invalid string for `long`
  - valid string conversion for `long`

## Why
`profile` scope can include `updated_at` (`long` claim type). In custom user-storage setups this attribute may resolve to an empty/invalid string, which currently bubbles up as `NumberFormatException` and breaks token issuance.

## Verification
- `./mvnw -pl services -am -Dtest=OIDCAttributeMapperHelperTest test -DskipTests=false`
- result: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0`

Fixes #46132

Supersedes #46764 (same functional patch with DCO signed commit history)
