### PR TITLE
Fix #46132: Handle empty/invalid strings in numeric OIDC attribute conversion

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -202,7 +202,8 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getBoolean);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                // Return null for unconvertible values instead of throwing exception
+                return null;
             case "String":
                 if (attributeValue instanceof String) return attributeValue;
                 if (attributeValue instanceof List) {
@@ -215,21 +216,24 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getLong);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                // Return null for unconvertible values instead of throwing exception
+                return null;
             case "int":
                 Integer intObject = getInteger(attributeValue);
                 if (intObject != null) return intObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getInteger);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                // Return null for unconvertible values instead of throwing exception
+                return null;
             case "JSON":
                 JsonNode jsonNodeObject = getJsonNode(attributeValue);
                 if (jsonNodeObject != null) return jsonNodeObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getJsonNode);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                // Return null for unconvertible values instead of throwing exception
+                return null;
             default:
                 return null;
         }
@@ -242,19 +246,49 @@ public class OIDCAttributeMapperHelper {
 
     private static Long getLong(Object attributeValue) {
         if (attributeValue instanceof Long) return (Long) attributeValue;
-        if (attributeValue instanceof String) return Long.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            String strValue = (String) attributeValue;
+            if (strValue == null || strValue.trim().isEmpty()) {
+                return null;
+            }
+            try {
+                return Long.valueOf(strValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 
     private static Integer getInteger(Object attributeValue) {
         if (attributeValue instanceof Integer) return (Integer) attributeValue;
-        if (attributeValue instanceof String) return Integer.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            String strValue = (String) attributeValue;
+            if (strValue == null || strValue.trim().isEmpty()) {
+                return null;
+            }
+            try {
+                return Integer.valueOf(strValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 
     private static Boolean getBoolean(Object attributeValue) {
         if (attributeValue instanceof Boolean) return (Boolean) attributeValue;
-        if (attributeValue instanceof String) return Boolean.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            String strValue = (String) attributeValue;
+            if (strValue == null || strValue.trim().isEmpty()) {
+                return null;
+            }
+            try {
+                return Boolean.valueOf(strValue);
+            } catch (Exception e) {
+                return null;
+            }
+        }
         return null;
     }
 

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +16,19 @@
  */
 package org.keycloak.protocol.oidc.mappers;
 
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
 import org.keycloak.utils.JsonUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  *
@@ -43,5 +50,82 @@ public class OIDCAttributeMapperHelperTest {
         assertThat(JsonUtils.splitClaimPath("c.a\\\\\\.b"), Matchers.contains("c", "a\\.b"));
         assertThat(JsonUtils.splitClaimPath("c\\\\\\.b.a\\\\\\.b"), Matchers.contains("c\\.b", "a\\.b"));
         assertThat(JsonUtils.splitClaimPath("c\\h\\.b.a\\\\\\.b"), Matchers.contains("ch.b", "a\\.b"));
+    }
+
+    @Test
+    public void testMapAttributeValueWithEmptyStringReturnsOriginalValueForLong() {
+        ProtocolMapperModel model = createMapperModel("long");
+        // When conversion fails, returns the original value instead of null
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, ""), is(""));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "   "), is("   "));
+    }
+
+    @Test
+    public void testMapAttributeValueWithEmptyStringReturnsOriginalValueForInteger() {
+        ProtocolMapperModel model = createMapperModel("int");
+        // When conversion fails, returns the original value instead of null
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, ""), is(""));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "   "), is("   "));
+    }
+
+    @Test
+    public void testMapAttributeValueWithEmptyStringReturnsOriginalValueForBoolean() {
+        ProtocolMapperModel model = createMapperModel("boolean");
+        // When conversion fails, returns the original value instead of null
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, ""), is(""));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "   "), is("   "));
+    }
+
+    @Test
+    public void testMapAttributeValueWithInvalidStringReturnsOriginalValueForLong() {
+        ProtocolMapperModel model = createMapperModel("long");
+        // When conversion fails, returns the original value instead of null
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "abc"), is("abc"));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "12.34"), is("12.34"));
+    }
+
+    @Test
+    public void testMapAttributeValueWithInvalidStringReturnsOriginalValueForInteger() {
+        ProtocolMapperModel model = createMapperModel("int");
+        // When conversion fails, returns the original value instead of null
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "abc"), is("abc"));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "12.34"), is("12.34"));
+    }
+
+    @Test
+    public void testMapAttributeValueWithValidStringReturnsCorrectValueForLong() {
+        ProtocolMapperModel model = createMapperModel("long");
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "123"), is(123L));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "-456"), is(-456L));
+    }
+
+    @Test
+    public void testMapAttributeValueWithValidStringReturnsCorrectValueForInteger() {
+        ProtocolMapperModel model = createMapperModel("int");
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "123"), is(123));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "-456"), is(-456));
+    }
+
+    @Test
+    public void testMapAttributeValueWithValidStringReturnsCorrectValueForBoolean() {
+        ProtocolMapperModel model = createMapperModel("boolean");
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "true"), is(true));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "false"), is(false));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "TRUE"), is(true));
+        assertThat(OIDCAttributeMapperHelper.mapAttributeValue(model, "FALSE"), is(false));
+    }
+
+    private ProtocolMapperModel createMapperModel(String jsonType) {
+        return OIDCAttributeMapperHelper.createClaimMapper(
+            "testMapper",
+            "userAttr",
+            "testClaim",
+            jsonType,
+            true,
+            true,
+            true,
+            false,
+            null
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixed NumberFormatException when converting empty or invalid strings to numeric types (long, int) in OIDC attribute mappers.

## Problem

When the `profile` scope is enabled and a custom federation provider does not set the `updatedAt` attribute, the OIDC attribute mapper tries to convert an empty string to a Long, causing a NumberFormatException:

```
java.lang.NumberFormatException: For input string: ""
    at java.base/java.lang.Long.parseLong(Long.java:719)
    at java.base/java.lang.Long.valueOf(Long.java:1157)
    at org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.getLong(OIDCAttributeMapperHelper.java:242)
```

## Solution

1. Modified `getLong()`, `getInteger()`, and `getBoolean()` methods to:
   - Check for null or empty/blank strings before parsing
   - Return null instead of throwing NumberFormatException

2. Modified `convertToType()` to:
   - Return null instead of throwing RuntimeException for unconvertible values
   - This allows the caller to handle the failure gracefully

3. Added comprehensive unit tests covering:
   - Empty string handling
   - Blank string handling
   - Invalid string handling
   - Valid value conversion

## Changes

**Modified:**
- `services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java`
- `services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java`

## Test Plan

- [x] All existing tests pass
- [x] New tests added for empty/invalid string handling
- [x] Local testing with custom federation provider

Fixes #46132