### PR TITLE
fix: correcting when the profile is initialized

### DIFF
--- a/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
@@ -46,10 +46,6 @@ public class ResteasyKeycloakApplication extends KeycloakApplication {
     protected Set<Class<?>> classes = new HashSet<>();
 
     public ResteasyKeycloakApplication() {
-        Profile.configure(
-                new PropertiesProfileConfigResolver(System.getProperties()),
-                new PropertiesFileProfileConfigResolver()
-        );
         classes.add(RealmsResource.class);
         if (Profile.isFeatureEnabled(Profile.Feature.ADMIN_API)) {
             classes.add(AdminRoot.class);
@@ -108,6 +104,10 @@ public class ResteasyKeycloakApplication extends KeycloakApplication {
     protected void initAndStart() {
         Config.init(new JsonConfigProviderFactory().create()
                 .orElseThrow(() -> new RuntimeException("Failed to load Keycloak configuration")));
+        Profile.configure(
+                new PropertiesProfileConfigResolver(System.getProperties()),
+                new PropertiesFileProfileConfigResolver()
+        );
         startup();
     }
 

--- a/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
@@ -24,8 +24,10 @@ import org.keycloak.Config;
 import org.keycloak.common.Profile;
 import org.keycloak.common.profile.PropertiesProfileConfigResolver;
 import org.keycloak.common.util.MultiSiteUtils;
+import org.keycloak.exportimport.ExportImportManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.error.KcUnrecognizedPropertyExceptionHandler;
 import org.keycloak.services.error.KeycloakErrorHandler;
 import org.keycloak.services.error.KeycloakMismatchedInputExceptionHandler;
@@ -109,6 +111,12 @@ public class ResteasyKeycloakApplication extends KeycloakApplication {
                 new PropertiesFileProfileConfigResolver()
         );
         startup();
+    }
+
+    @Override
+    protected ExportImportManager bootstrap(KeycloakSession session) {
+        // created a nested transaction as this triggers DefaultJpaConnectionProviderFactory.lazyInit
+        return KeycloakModelUtils.runJobInTransactionWithResult(getSessionFactory(), super::bootstrap);
     }
 
 }


### PR DESCRIPTION
closes: #46860

This is a regression from #46378 - the profile initialization needs to be in initAndStart, not the constructor.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
