### PR TITLE
Fix OIDC IdP prompt dropdown to persist protocol values

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/ExtendedOAuth2Settings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/ExtendedOAuth2Settings.tsx
@@ -22,11 +22,11 @@ export const ExtendedOAuth2Settings = () => {
           name="config.prompt"
           label={t("prompt")}
           options={[
-            { key: t("prompts.unspecified"), value: "" },
-            { key: t("prompts.none"), value: "none" },
-            { key: t("prompts.consent"), value: "consent" },
-            { key: t("prompts.login"), value: "login" },
-            { key: t("prompts.select_account"), value: "select_account" },
+            { key: "", value: t("prompts.unspecified") },
+            { key: "none", value: t("prompts.none") },
+            { key: "consent", value: t("prompts.consent") },
+            { key: "login", value: t("prompts.login") },
+            { key: "select_account", value: t("prompts.select_account") },
           ]}
           controller={{ defaultValue: "" }}
         />


### PR DESCRIPTION
Fixes #46193

The OAuth2 IdP prompt dropdown in admin-ui was wiring SelectControl options with label/value reversed. This change stores OIDC-compliant prompt values (for example select_account) while keeping localized labels only for display.