### PR TITLE
Add length check in byteArrayToResolverProviderId to prevent out of b…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/saml/util/ArtifactBindingUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/saml/util/ArtifactBindingUtils.java
@@ -11,6 +11,9 @@ public class ArtifactBindingUtils {
     }
     
     public static String byteArrayToResolverProviderId(byte[] ar) {
+        if (ar.length < 4) {
+            throw new IllegalArgumentException("SAML artifact must be at least 4 bytes (TypeCode + EndpointIndex)");
+        }
         return String.format("%02X%02X", ar[0], ar[1]);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/SamlService.java
@@ -387,7 +387,7 @@ public class SamlService extends AuthorizationEndpointBase {
                     return;
                 }
 
-            } catch (ArtifactResolverProcessingException e) {
+            } catch (ArtifactResolverProcessingException | IllegalArgumentException e) {
                 event.event(EventType.LOGIN);
                 event.detail(Details.REASON, e.getMessage());
                 event.error(Errors.INVALID_SAML_ARTIFACT);
@@ -1218,7 +1218,13 @@ public class SamlService extends AuthorizationEndpointBase {
             return emptyArtifactResponseMessage(artifactResolveMessage, null, JBossSAMLURIConstants.STATUS_REQUEST_DENIED.getUri());
         }
 
-        ArtifactResolver artifactResolver = getArtifactResolver(artifact);
+        ArtifactResolver artifactResolver;
+        try {
+            artifactResolver = getArtifactResolver(artifact);
+        } catch (IllegalArgumentException e) {
+            logger.errorf("Invalid artifact format: %s", artifact);
+            return emptyArtifactResponseMessage(artifactResolveMessage, null, JBossSAMLURIConstants.STATUS_REQUEST_DENIED.getUri());
+        }
 
         if (artifactResolver == null) {
             logger.errorf("Cannot find ArtifactResolver for artifact %s", artifact);

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/CustomTestingSamlArtifactResolver.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/CustomTestingSamlArtifactResolver.java
@@ -12,7 +12,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.saml.ArtifactResolver;
 
-import static org.keycloak.testsuite.authentication.CustomTestingSamlArtifactResolverFactory.TYPE_CODE;
+import static org.keycloak.testsuite.authentication.CustomTestingSamlArtifactResolverFactory.TYPE_CODE_AND_INDEX;
 
 
 /**
@@ -34,7 +34,7 @@ public class CustomTestingSamlArtifactResolver implements ArtifactResolver {
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try {
-            bos.write(TYPE_CODE);
+            bos.write(TYPE_CODE_AND_INDEX);
             bos.write(artifactIndex);
         } catch (IOException e) {
             e.printStackTrace();
@@ -48,7 +48,7 @@ public class CustomTestingSamlArtifactResolver implements ArtifactResolver {
     public String resolveArtifact(AuthenticatedClientSessionModel clientSessionModel, String artifact) {
         byte[] byteArray = Base64.getDecoder().decode(artifact);
         ByteArrayInputStream bis = new ByteArrayInputStream(byteArray);
-        bis.skip(2);
+        bis.skip(TYPE_CODE_AND_INDEX.length);
         int index = bis.read();
 
         return list.get(index);

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/CustomTestingSamlArtifactResolverFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/authentication/CustomTestingSamlArtifactResolverFactory.java
@@ -12,7 +12,7 @@ import org.keycloak.protocol.saml.util.ArtifactBindingUtils;
  */
 public class CustomTestingSamlArtifactResolverFactory implements ArtifactResolverFactory {
 
-    public  static final byte[] TYPE_CODE = {0, 5};
+    public  static final byte[] TYPE_CODE_AND_INDEX = {0, 5, 0, 0}; // type code and endpoint index must be present, 2 bytes each
     public static final CustomTestingSamlArtifactResolver resolver = new CustomTestingSamlArtifactResolver();
     
     @Override
@@ -37,6 +37,6 @@ public class CustomTestingSamlArtifactResolverFactory implements ArtifactResolve
 
     @Override
     public String getId() {
-        return ArtifactBindingUtils.byteArrayToResolverProviderId(TYPE_CODE);
+        return ArtifactBindingUtils.byteArrayToResolverProviderId(TYPE_CODE_AND_INDEX);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingCustomResolverTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingCustomResolverTest.java
@@ -1,6 +1,5 @@
 package org.keycloak.testsuite.saml;
 
-import java.io.ByteArrayInputStream;
 import java.util.Base64;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -51,12 +50,13 @@ public class ArtifactBindingCustomResolverTest extends ArtifactBindingTest {
 
         String artifact = artifactReference.get();
         byte[] byteArray = Base64.getDecoder().decode(artifact);
-        ByteArrayInputStream bis = new ByteArrayInputStream(byteArray);
-        bis.skip(2);
-        int index = bis.read();
-        
+
         assertThat(byteArray[0], is((byte)0));
         assertThat(byteArray[1], is((byte)5));
+        assertThat(byteArray[2], is((byte)0));
+        assertThat(byteArray[3], is((byte)0));
+
+        int index = byteArray[4];
 
         if (!suiteContext.getAuthServerInfo().isUndertow()) return;
 
@@ -86,12 +86,13 @@ public class ArtifactBindingCustomResolverTest extends ArtifactBindingTest {
 
         String artifact = artifactReference.get();
         byte[] byteArray = Base64.getDecoder().decode(artifact);
-        ByteArrayInputStream bis = new ByteArrayInputStream(byteArray);
-        bis.skip(2);
-        int index = bis.read();
 
         assertThat(byteArray[0], is((byte)0));
         assertThat(byteArray[1], is((byte)5));
+        assertThat(byteArray[2], is((byte)0));
+        assertThat(byteArray[3], is((byte)0));
+
+        int index = byteArray[4];
 
         String storedResponse = CustomTestingSamlArtifactResolver.list.get(index);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/ArtifactBindingWithResolutionServiceTest.java
@@ -1,5 +1,8 @@
 package org.keycloak.testsuite.saml;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
 import org.keycloak.dom.saml.v2.SAML2Object;
 import org.keycloak.dom.saml.v2.assertion.NameIDType;
 import org.keycloak.dom.saml.v2.protocol.AuthnRequestType;
@@ -7,6 +10,7 @@ import org.keycloak.dom.saml.v2.protocol.ResponseType;
 import org.keycloak.dom.saml.v2.protocol.StatusResponseType;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.saml.SAML2LogoutRequestBuilder;
+import org.keycloak.saml.common.constants.GeneralConstants;
 import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
 import org.keycloak.saml.common.exceptions.ConfigurationException;
 import org.keycloak.saml.common.exceptions.ParsingException;
@@ -19,6 +23,9 @@ import org.keycloak.testsuite.util.SamlClient;
 import org.keycloak.testsuite.util.SamlClientBuilder;
 import org.keycloak.testsuite.util.saml.CreateArtifactMessageStepBuilder;
 
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -106,6 +113,24 @@ public class ArtifactBindingWithResolutionServiceTest extends AbstractSamlTest {
             ars.stop();
             arsThread.join();
         }
+    }
+
+    @Test
+    public void testResponseWithMalformedArtifact() {
+        new SamlClientBuilder()
+                .addStep((client, currentURI, currentResponse, context) -> {
+                    HttpPost post = new HttpPost(getAuthServerSamlEndpoint(REALM_NAME));
+                    post.setEntity(new UrlEncodedFormEntity(
+                            // submitting SAMLart=YQ== (valid Base64 decoding to a single byte)
+                            Collections.singletonList(new BasicNameValuePair(GeneralConstants.SAML_ARTIFACT_KEY, "YQ==")),
+                            StandardCharsets.UTF_8));
+                    return post;
+                })
+                .execute(r -> {
+                    // we should get a bad request back
+                    assertThat(r, statusCodeIsHC(400));
+                    assertThat(r, bodyHC(containsString("Invalid Request")));
+                });
     }
 
     @Test


### PR DESCRIPTION
…ounds exception

- enforces minimum size of 4 bytes for the mandatory type code and endpoint index

Closes #46819

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
