### PR TITLE
Use AESGCM for ecrypting the restart cookie with kid

### DIFF
--- a/core/src/main/java/org/keycloak/util/TokenUtil.java
+++ b/core/src/main/java/org/keycloak/util/TokenUtil.java
@@ -203,19 +203,23 @@ public class TokenUtil {
     }
 
     public static String jweDirectEncode(Key aesKey, Key hmacKey, byte[] contentBytes) throws JWEException {
+        return jweDirectEncode(null, aesKey, hmacKey, contentBytes);
+    }
+
+    public static String jweDirectEncode(String kid, Key aesKey, Key hmacKey, byte[] contentBytes) throws JWEException {
         int keyLength = aesKey.getEncoded().length;
         String encAlgorithm;
         switch (keyLength) {
-            case 16: encAlgorithm = JWEConstants.A128CBC_HS256;
+            case 16: encAlgorithm = hmacKey != null ? JWEConstants.A128CBC_HS256 : JWEConstants.A128GCM;
                 break;
-            case 24: encAlgorithm = JWEConstants.A192CBC_HS384;
+            case 24: encAlgorithm = hmacKey != null ? JWEConstants.A192CBC_HS384 : JWEConstants.A192GCM;
                 break;
-            case 32: encAlgorithm = JWEConstants.A256CBC_HS512;
+            case 32: encAlgorithm = hmacKey != null ? JWEConstants.A256CBC_HS512 : JWEConstants.A256GCM;
                 break;
             default: throw new IllegalArgumentException("Bad size for Encryption key: " + aesKey + ". Valid sizes are 16, 24, 32.");
         }
 
-        JWEHeader jweHeader = new JWEHeader(JWEConstants.DIRECT, encAlgorithm, null);
+        JWEHeader jweHeader = new JWEHeader(JWEConstants.DIRECT, encAlgorithm, null, kid);
         JWE jwe = new JWE()
                 .header(jweHeader)
                 .content(contentBytes);

--- a/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
+++ b/services/src/main/java/org/keycloak/protocol/RestartLoginCookie.java
@@ -27,6 +27,8 @@ import org.keycloak.TokenCategory;
 import org.keycloak.cookie.CookieProvider;
 import org.keycloak.cookie.CookieType;
 import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwe.JWE;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -174,31 +176,43 @@ public class RestartLoginCookie implements Token {
         return authSession;
     }
 
-    private static RestartLoginCookie decryptAndDecode(KeycloakSession session, String encodedToken) {
+    public static RestartLoginCookie decryptAndDecode(KeycloakSession session, String encodedToken) {
         try {
-            String sigAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
-            String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
-            SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm).getSecretKey();
-            SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
-
-            byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(encKey, signKey, encodedToken);
-            String jwt = new String(contentBytes, StandardCharsets.UTF_8);
-            return session.tokens().decode(jwt, RestartLoginCookie.class);
+            String kid = new JWE(encodedToken).getHeader().getKeyId();
+            if (kid != null) {
+                // new way using kid
+                String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
+                RealmModel realm = session.getContext().getRealm();
+                KeyWrapper encKey = session.keys().getKey(realm, kid, KeyUse.ENC, algAlgorithm);
+                if (encKey == null) {
+                    return null;
+                }
+                byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(encKey.getSecretKey(), null, encodedToken);
+                String jwt = new String(contentBytes, StandardCharsets.UTF_8);
+                return session.tokens().decode(jwt, RestartLoginCookie.class);
+            } else {
+                // decoding as before
+                String sigAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
+                String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
+                SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm).getSecretKey();
+                SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
+                byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(encKey, signKey, encodedToken);
+                String jwt = new String(contentBytes, StandardCharsets.UTF_8);
+                return session.tokens().decode(jwt, RestartLoginCookie.class);
+            }
         } catch (Exception e) {
             // Might be the cookie from the older version
             return session.tokens().decode(encodedToken, RestartLoginCookie.class);
         }
     }
 
-    private static String encodeAndEncrypt(KeycloakSession session, RestartLoginCookie cookie) {
+    public static String encodeAndEncrypt(KeycloakSession session, RestartLoginCookie cookie) {
         try {
-            String sigAlgorithm = session.tokens().signatureAlgorithm(cookie.getCategory());
             String algAlgorithm = session.tokens().cekManagementAlgorithm(cookie.getCategory());
-            SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm).getSecretKey();
-            SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
+            KeyWrapper encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm);
 
             String encodedJwt = session.tokens().encode(cookie);
-            return TokenUtil.jweDirectEncode(encKey, signKey, encodedJwt.getBytes(StandardCharsets.UTF_8));
+            return TokenUtil.jweDirectEncode(encKey.getKid(), encKey.getSecretKey(), null, encodedJwt.getBytes(StandardCharsets.UTF_8));
         } catch (Exception e) {
             throw new RuntimeException("Error encoding cookie.", e);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RestartCookieTest.java
@@ -20,6 +20,8 @@ package org.keycloak.testsuite.forms;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.crypto.SecretKey;
 
@@ -27,6 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenCategory;
+import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.KeyUse;
@@ -134,6 +137,34 @@ public class RestartCookieTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void testRestartCookieRotateAes() {
+        loginPage.open();
+        String restartCookie = driver.manage().getCookieNamed(RestartLoginCookie.KC_RESTART).getValue();
+        rotateAesKeys();
+        assertRestartCookie(restartCookie);
+    }
+
+    @Test
+    public void testRestartCookieParsedOldA128CBCHS256() throws IOException {
+        loginPage.open();
+        String restartCookie = driver.manage().getCookieNamed(RestartLoginCookie.KC_RESTART).getValue();
+        getTestingClient().server(TEST_REALM_NAME).run(session -> {
+            try {
+                RestartLoginCookie restartLoginCookie = RestartLoginCookie.decryptAndDecode(session, restartCookie);
+                String sigAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
+                String algAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
+                SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, algAlgorithm).getSecretKey();
+                SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
+                String encodedJwt = session.tokens().encode(restartLoginCookie);
+                String oldRestartCookie = TokenUtil.jweDirectEncode(encKey, signKey, encodedJwt.getBytes(StandardCharsets.UTF_8));
+                Assert.assertNotNull(RestartLoginCookie.decryptAndDecode(session, oldRestartCookie));
+            } catch (Exception e) {
+                Assert.fail();
+            }
+        });
+    }
+
+    @Test
     public void testRestartCookieWithPar() {
         String clientId = "par-confidential-client";
         adminClient.realm("test").clients().create(ClientBuilder.create()
@@ -163,20 +194,42 @@ public class RestartCookieTest extends AbstractTestRealmKeycloakTest {
         assertRestartCookie(restartCookie);
     }
 
+    private void rotateAesKeys() {
+        RealmResource realm = adminClient.realm(TEST_REALM_NAME);
+        String activeKid = realm.keys().getKeyMetadata().getActive().get(Algorithm.AES);
+
+        // Rotate public keys on the parent broker
+        String realmId = realm.toRepresentation().getId();
+        ComponentRepresentation keys = createComponentRep(Algorithm.AES, "aes-generated", realmId,
+                new MultivaluedHashMap<>(Map.of("secretSize", List.of("16"))));
+        try (Response response = realm.components().add(keys)) {
+            assertEquals(201, response.getStatus());
+        }
+
+        String updatedActiveKid = realm.keys().getKeyMetadata().getActive().get(Algorithm.AES);
+        Assert.assertNotEquals(activeKid, updatedActiveKid);
+    }
+
+    private ComponentRepresentation createComponentRep(String algorithm, String providerId, String realmId, MultivaluedHashMap<String,String> extra) {
+        ComponentRepresentation keys = new ComponentRepresentation();
+        keys.setName("generated");
+        keys.setProviderType(KeyProvider.class.getName());
+        keys.setProviderId(providerId);
+        keys.setParentId(realmId);
+        MultivaluedHashMap<String, String> config = new MultivaluedHashMap<>(extra);
+        keys.setConfig(config);
+        config.putSingle("priority", Long.toString(System.currentTimeMillis()));
+        config.putSingle("algorithm", algorithm);
+        return keys;
+    }
+
     private void assertRestartCookie(String restartCookie) {
         getTestingClient()
                 .server(TEST_REALM_NAME)
                 .run(session ->
                 {
                     try {
-                        String sigAlgorithm = session.tokens().signatureAlgorithm(TokenCategory.INTERNAL);
-                        String encAlgorithm = session.tokens().cekManagementAlgorithm(TokenCategory.INTERNAL);
-                        SecretKey encKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.ENC, encAlgorithm).getSecretKey();
-                        SecretKey signKey = session.keys().getActiveKey(session.getContext().getRealm(), KeyUse.SIG, sigAlgorithm).getSecretKey();
-
-                        byte[] contentBytes = TokenUtil.jweDirectVerifyAndDecode(encKey, signKey, restartCookie);
-                        String jwt = new String(contentBytes, StandardCharsets.UTF_8);
-                        RestartLoginCookie restartLoginCookie = session.tokens().decode(jwt, RestartLoginCookie.class);
+                        RestartLoginCookie restartLoginCookie = RestartLoginCookie.decryptAndDecode(session, restartCookie);
                         Assert.assertFalse(restartLoginCookie.getNotes().keySet().stream().anyMatch(sensitiveNotes::contains));
                     } catch (Exception e) {
                         Assert.fail();


### PR DESCRIPTION
Closes #46350

PR that adds the `kid` to the encryption of the restart cookie. By default the A128CBCHS256 algorithm is used (which uses an Hmac and AES combination), so it uses two keys. I changed to only use AESGCM and use only one key. The other option is using the same algorithm but adding the two keys somehow in the kid (for example `kid-aes##kid-hmac`). But, as it is a bit strange, I preferred to change to plain AESGCM and just use the aes kid in the header. Let me know if you prefer something different. Tests added.
