### PR TITLE
Correct client sessions pagination in admin UI

### DIFF
--- a/js/apps/admin-ui/src/clients/ClientSessions.tsx
+++ b/js/apps/admin-ui/src/clients/ClientSessions.tsx
@@ -34,6 +34,7 @@ export const ClientSessions = ({ client }: ClientSessionsProps) => {
         loader={loader}
         hiddenColumns={["clients"]}
         emptyInstructions={t("noSessionsForClient")}
+        isPaginated
       />
     </PageSection>
   );


### PR DESCRIPTION
Fixes #46009

`ClientSessions` uses a server-paginated loader, but `SessionsTable` was not marked as paginated.

This caused client-side slicing of the first response and incorrect data on next pages.

This change sets `isPaginated` on `ClientSessions` so page transitions use backend pagination consistently.
