### PR TITLE
Invalid links in logging guides

### DIFF
--- a/docs/guides/server/logging.adoc
+++ b/docs/guides/server/logging.adoc
@@ -108,6 +108,7 @@ When using other config sources, the category name must be specified "as is", fo
 
 <@kc.start parameters="--log-level=\"INFO,org.hibernate:debug\" --log-level-org.keycloak=trace"/>
 
+[[specify-log-level-each-handler]]
 === Specify log level for each handler
 
 The `log-level` property specifies the global root log level and levels for selected categories.

--- a/docs/guides/server/logging/console.adoc
+++ b/docs/guides/server/logging/console.adoc
@@ -13,6 +13,7 @@ levelOffset=2 >
 The console log handler is enabled by default, providing unstructured log messages for the console.
 As shown in the following section, the more specific console handler configuration takes effect only when the console logging is enabled. Console logging is enabled by default.
 
+[[console-log-format]]
 == Configuring the console log format
 {project_name} uses a pattern-based logging formatter that generates human-readable text logs by default.
 
@@ -93,8 +94,7 @@ Log level for console log handler can be specified by `--log-console-level` prop
 
 <@kc.start parameters="--log-console-level=warn"/>
 
-For more information, see <<Specify log level for each handler>>.
-
+For more information, see <@links.server id="logging" anchor="specify-log-level-each-handler"/>.
 
 <@opts.printRelevantOptions includedOptions="log-console-*" excludedOptions="log-console-async*">
 

--- a/docs/guides/server/logging/file.adoc
+++ b/docs/guides/server/logging/file.adoc
@@ -37,14 +37,14 @@ To configure a different logging format for the file log handler, enter the foll
 
 <@kc.start parameters="--log-file-format=\"<pattern>\""/>
 
-See <<Configuring the console log format>> for more information and a table of the available pattern configuration.
+See <@links.server id="logging-console" anchor="console-log-format"/> for more information and a table of the available pattern configuration.
 
 == Configuring the file log level
 Log level for file log handler can be specified by `--log-file-level` property as follows:
 
 <@kc.start parameters="--log-file-level=warn"/>
 
-For more information, see <<Specify log level for each handler>>.
+For more information, see <@links.server id="logging" anchor="specify-log-level-each-handler"/>.
 
 <@opts.printRelevantOptions includedOptions="log-file-*" excludedOptions="log-file-async*">
 

--- a/docs/guides/server/logging/syslog.adoc
+++ b/docs/guides/server/logging/syslog.adoc
@@ -40,7 +40,7 @@ Log level for Syslog log handler can be specified by `--log-syslog-level` proper
 
 <@kc.start parameters="--log-syslog-level=warn"/>
 
-For more information, see <<Specify log level for each handler>>.
+For more information, see <@links.server id="logging" anchor="specify-log-level-each-handler"/>.
 
 == Configuring the protocol
 Syslog uses TCP as the default protocol for communication.


### PR DESCRIPTION
- Closes #46892

Works now:

https://github.com/user-attachments/assets/046e6e0a-a234-401b-998d-356df709d384

