### PR TITLE
Removing userProfileMetaData from Representation

### DIFF
--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/BruteForceUsersResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/BruteForceUsersResource.java
@@ -177,9 +177,13 @@ public class BruteForceUsersResource {
         return userModels.map(user -> {
             UserProfile profile = provider.create(UserProfileContext.USER_API, user);
             UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
-            UserRepresentation userRep = briefRepresentationB ?
-                    ModelToRepresentation.toBriefRepresentation(user, rep, false) :
-                    ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
+            UserRepresentation userRep;
+            if (briefRepresentationB) {
+                userRep = ModelToRepresentation.toBriefRepresentation(user, rep, false);
+                userRep.setUserProfileMetadata(null);
+            } else {
+                userRep = ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
+            }
             userRep.setAccess(usersEvaluator.getAccessForListing(user));
             return userRep;
         }).map(this::getBruteForceStatus);


### PR DESCRIPTION
Closes #46296

This PR removes user profile metadata from the `UserRepresentation` within the Brute Force detection context to optimize performance.

# The Problem
The API response body was becoming excessively large when retrieving multiple users. Including the full user profile metadata for every entry in the list led to:
- High memory consumption on the server.
- Increased network latency due to payload size.
- Browser performance issues when the `UserDataTable` attempted to process the oversized JSON response.

# The Solution
I have updated the Brute Force user retrieval logic to exclude the metadata block. This significantly trims the response body size while still providing all the necessary fields required for the Brute Force management UI.

# Changes
- Stripped metadata from `UserRepresentation` in Brute Force endpoints.
- Verified that the `UserDataTable` still functions correctly with the leaner payload.

@pedroigor Can you review please?