### PR TITLE
fix: avoid enforcing request_uri for PAR requests

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/ParEndpointRequestParserProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/ParEndpointRequestParserProcessor.java
@@ -16,14 +16,10 @@
  */
 package org.keycloak.protocol.oidc.par.endpoints.request;
 
-import java.util.HashSet;
-import java.util.List;
-
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.Profile;
-import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
@@ -34,7 +30,6 @@ import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointQueryStringParser;
-import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.messages.Messages;
@@ -60,36 +55,19 @@ public class ParEndpointRequestParserProcessor {
             }
 
             String requestParam = requestParams.getFirst(OIDCLoginProtocol.REQUEST_PARAM);
-            String requestUriParam = requestParams.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
-
-            if (requestParam != null && requestUriParam != null) {
-                throw new RuntimeException("Illegal to use both 'request' and 'request_uri' parameters together");
-            }
 
             String requestObjectRequired = OIDCAdvancedConfigWrapper.fromClientModel(client).getRequestObjectRequired();
 
             if (OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_OR_REQUEST_URI.equals(requestObjectRequired)
-                    && requestParam == null && requestUriParam == null) {
-                throw new RuntimeException("Client is required to use 'request' or 'request_uri' parameter.");
+                    && requestParam == null) {
+                throw new RuntimeException("Client is required to use 'request' parameter.");
             } else if (OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST.equals(requestObjectRequired)
                     && requestParam == null) {
                 throw new RuntimeException("Client is required to use 'request' parameter.");
-            } else if (OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI.equals(requestObjectRequired)
-                    && requestUriParam == null) {
-                throw new RuntimeException("Client is required to use 'request_uri' parameter.");
             }
 
             if (requestParam != null) {
                 new ParEndpointRequestObjectParser(session, requestParam, client).parseRequest(request);
-            } else if (requestUriParam != null) {
-                // Validate "requestUriParam" with allowed requestUris
-                List<String> requestUris = OIDCAdvancedConfigWrapper.fromClientModel(client).getRequestUris();
-                String requestUri = RedirectUtils.verifyRedirectUri(session, client.getRootUrl(), requestUriParam, new HashSet<>(requestUris), false);
-                if (requestUri == null) {
-                    throw new RuntimeException("Specified 'request_uri' not allowed for this client.");
-                }
-                String retrievedRequest = session.getProvider(HttpClientProvider.class).getString(requestUri);
-                new ParEndpointRequestObjectParser(session, retrievedRequest, client).parseRequest(request);
             }
 
             if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
@@ -1075,6 +1075,32 @@ public class ParTest extends AbstractClientPoliciesTest {
         assertEquals(OAuthErrorException.INVALID_REQUEST, pResp.getError());
     }
 
+    // valid PAR when Request Object Required is set to request_uri
+    @Test
+    public void testSuccessfulParWithRequiredRequestUri() throws Exception {
+        // create client dynamically
+        String clientId = createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+            clientRep.setRedirectUris(new ArrayList<>(List.of(CLIENT_REDIRECT_URI)));
+        });
+        OIDCClientRepresentation oidcCRep = getClientDynamically(clientId);
+        String clientSecret = oidcCRep.getClientSecret();
+        assertEquals(Boolean.FALSE, oidcCRep.getRequirePushedAuthorizationRequests());
+        assertTrue(oidcCRep.getRedirectUris().contains(CLIENT_REDIRECT_URI));
+        updateClientByAdmin(clientId, (ClientRepresentation cRep)->
+                OIDCAdvancedConfigWrapper.fromClientRepresentation(cRep)
+                        .setRequestObjectRequired(OIDCConfigAttributes.REQUEST_OBJECT_REQUIRED_REQUEST_URI));
+
+        // Pushed Authorization Request
+        oauth.client(clientId, clientSecret);
+        oauth.redirectUri(CLIENT_REDIRECT_URI);
+        ParResponse pResp = oauth.doPushedAuthorizationRequest();
+        assertEquals(201, pResp.getStatusCode());
+        String requestUri = pResp.getRequestUri();
+        assertTrue(requestUri.startsWith("urn:ietf:params:oauth:request_uri:"));
+
+        doNormalAuthzProcess(requestUri, CLIENT_REDIRECT_URI, clientId, clientSecret);
+    }
+
     // PAR including invalid redirect_uri
     @Test
     public void testFailureParIncludesInvalidRedirectUri() throws Exception {


### PR DESCRIPTION
 This PR fixes PAR request parsing so `request_uri` is not enforced for PAR requests when the client has `requestObjectRequired = request_uri`.

  In PAR, the client sends parameters to the PAR endpoint and receives a generated `request_uri` in response, so requiring an incoming `request_uri` at PAR time is incorrect.

  ## Changes

  - Updated `ParEndpointRequestParserProcessor` to stop enforcing `request_uri` in PAR request input validation.
  - Removed `request_uri`-specific parsing/fetching logic from PAR request processing.
  - Added integration test coverage in `ParTest`:
    - `testSuccessfulParWithRequiredRequestUri`

Closes #46926
