### PR TITLE
Batch Event deletes to only 500 at a time to prevent db locks

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
@@ -36,11 +36,13 @@ import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.AuthDetails;
 import org.keycloak.events.admin.OperationType;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.jpa.entities.RealmAttributeEntity;
 import org.keycloak.models.jpa.entities.RealmAttributes;
 import org.keycloak.models.jpa.entities.RealmEntity;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
@@ -51,6 +53,7 @@ import org.jboss.logging.Logger;
 public class JpaEventStoreProvider implements EventStoreProvider {
 
     private static final Logger logger = Logger.getLogger(JpaEventStoreProvider.class);
+    private static final int EXPIRED_DELETE_MAX_RESULTS = 500;
 
     private final KeycloakSession session;
     private final EntityManager em;
@@ -67,17 +70,24 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
     @Override
     public void clear() {
-        em.createQuery("delete from EventEntity").executeUpdate();
+        deleteByIdBatches("select event.id from EventEntity event", query -> {
+        }, "delete from EventEntity event where event.id in :eventIds");
     }
 
     @Override
     public void clear(RealmModel realm) {
-        em.createQuery("delete from EventEntity where realmId = :realmId").setParameter("realmId", realm.getId()).executeUpdate();
+        deleteByIdBatches(
+                "select event.id from EventEntity event where event.realmId = :realmId",
+                query -> query.setParameter("realmId", realm.getId()),
+                "delete from EventEntity event where event.id in :eventIds");
     }
 
     @Override
     public void clear(RealmModel realm, long olderThan) {
-        em.createQuery("delete from EventEntity where realmId = :realmId and time < :time").setParameter("realmId", realm.getId()).setParameter("time", olderThan).executeUpdate();
+        deleteByIdBatches(
+                "select event.id from EventEntity event where event.realmId = :realmId and event.time < :time",
+                query -> query.setParameter("realmId", realm.getId()).setParameter("time", olderThan),
+                "delete from EventEntity event where event.id in :eventIds");
     }
 
     @Override
@@ -86,15 +96,16 @@ public class JpaEventStoreProvider implements EventStoreProvider {
         long currentTimeMillis = Time.currentTimeMillis();
 
         // Group realms by expiration times. This will be effective if different realms have same/similar event expiration times, which will probably be the case in most environments
-        List<Long> eventExpirations = em.createQuery("select distinct realm.eventsExpiration from RealmEntity realm where realm.eventsExpiration > 0").getResultList();
+        List<Long> eventExpirations = em.createQuery("select distinct realm.eventsExpiration from RealmEntity realm where realm.eventsExpiration > 0", Long.class).getResultList();
         for (Long expiration : eventExpirations) {
-            List<String> realmIds = em.createQuery("select realm.id from RealmEntity realm where realm.eventsExpiration = :expiration")
+            List<String> realmIds = em.createQuery("select realm.id from RealmEntity realm where realm.eventsExpiration = :expiration", String.class)
                     .setParameter("expiration", expiration)
                     .getResultList();
-            int currentNumDeleted = em.createQuery("delete from EventEntity where realmId in :realmIds and time < :eventTime")
-                    .setParameter("realmIds", realmIds)
-                    .setParameter("eventTime", currentTimeMillis - (expiration * 1000))
-                    .executeUpdate();
+            long eventTime = currentTimeMillis - (expiration * 1000);
+            int currentNumDeleted = deleteByIdBatches(
+                    "select event.id from EventEntity event where event.realmId in :realmIds and event.time < :eventTime",
+                    query -> query.setParameter("realmIds", realmIds).setParameter("eventTime", eventTime),
+                    "delete from EventEntity event where event.id in :eventIds");
             logger.tracef("Deleted %d events for the expiration %d", currentNumDeleted, expiration);
             numDeleted += currentNumDeleted;
         }
@@ -113,17 +124,24 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
     @Override
     public void clearAdmin() {
-        em.createQuery("delete from AdminEventEntity").executeUpdate();
+        deleteByIdBatches("select event.id from AdminEventEntity event", query -> {
+        }, "delete from AdminEventEntity event where event.id in :eventIds");
     }
 
     @Override
     public void clearAdmin(RealmModel realm) {
-        em.createQuery("delete from AdminEventEntity where realmId = :realmId").setParameter("realmId", realm.getId()).executeUpdate();
+        deleteByIdBatches(
+                "select event.id from AdminEventEntity event where event.realmId = :realmId",
+                query -> query.setParameter("realmId", realm.getId()),
+                "delete from AdminEventEntity event where event.id in :eventIds");
     }
 
     @Override
     public void clearAdmin(RealmModel realm, long olderThan) {
-        em.createQuery("delete from AdminEventEntity where realmId = :realmId and time < :time").setParameter("realmId", realm.getId()).setParameter("time", olderThan).executeUpdate();
+        deleteByIdBatches(
+                "select event.id from AdminEventEntity event where event.realmId = :realmId and event.time < :time",
+                query -> query.setParameter("realmId", realm.getId()).setParameter("time", olderThan),
+                "delete from AdminEventEntity event where event.id in :eventIds");
     }
 
     @Override
@@ -251,12 +269,44 @@ public class JpaEventStoreProvider implements EventStoreProvider {
         long current = Time.currentTimeMillis();
         realms.forEach((key, value) -> {
             List<String> realmIds = value.stream().map(RealmAttributeEntity::getRealm).map(RealmEntity::getId).collect(Collectors.toList());
-            int currentNumDeleted = em.createQuery("delete from AdminEventEntity where realmId in :realmIds and time < :eventTime")
-                    .setParameter("realmIds", realmIds)
-                    .setParameter("eventTime", current - (key * 1000))
-                    .executeUpdate();
+            long eventTime = current - (key * 1000);
+            int currentNumDeleted = deleteByIdBatches(
+                    "select event.id from AdminEventEntity event where event.realmId in :realmIds and event.time < :eventTime",
+                    queryBuilder -> queryBuilder.setParameter("realmIds", realmIds).setParameter("eventTime", eventTime),
+                    "delete from AdminEventEntity event where event.id in :eventIds");
             logger.tracef("Deleted %d admin events for the expiration %d", currentNumDeleted, key);
         });
+    }
+
+    private int deleteByIdBatches(String selectIdsQuery, Consumer<TypedQuery<String>> queryConfigurator, String deleteByIdsQuery) {
+        int deleted = 0;
+        while (true) {
+            int currentBatchDeleted = KeycloakModelUtils.runJobInTransactionWithResult(
+                    session.getKeycloakSessionFactory(),
+                    session.getContext(),
+                    innerSession -> {
+                        EntityManager innerEm = innerSession.getProvider(JpaConnectionProvider.class).getEntityManager();
+                        TypedQuery<String> selectQuery = innerEm.createQuery(selectIdsQuery, String.class);
+                        queryConfigurator.accept(selectQuery);
+                        List<String> eventIds = selectQuery
+                                .setMaxResults(EXPIRED_DELETE_MAX_RESULTS)
+                                .getResultList();
+                        if (eventIds.isEmpty()) {
+                            return 0;
+                        }
+
+                        return innerEm.createQuery(deleteByIdsQuery)
+                                .setParameter("eventIds", eventIds)
+                                .executeUpdate();
+                    },
+                    "event-store-delete-batch");
+
+            if (currentBatchDeleted == 0) {
+                // No IDs left in this scope. Return how many rows were deleted across previous batches.
+                return deleted;
+            }
+            deleted += currentBatchDeleted;
+        }
     }
 
     private static void setDetails(Consumer<String> setter, Map<String, String> details) {

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
@@ -28,6 +28,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
 import org.keycloak.common.util.Time;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.events.Event;
 import org.keycloak.events.EventQuery;
 import org.keycloak.events.EventStoreProvider;
@@ -36,7 +37,6 @@ import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.AdminEventQuery;
 import org.keycloak.events.admin.AuthDetails;
 import org.keycloak.events.admin.OperationType;
-import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.jpa.entities.RealmAttributeEntity;
@@ -70,24 +70,17 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
     @Override
     public void clear() {
-        deleteByIdBatches("select event.id from EventEntity event", query -> {
-        }, "delete from EventEntity event where event.id in :eventIds");
+        em.createQuery("delete from EventEntity").executeUpdate();
     }
 
     @Override
     public void clear(RealmModel realm) {
-        deleteByIdBatches(
-                "select event.id from EventEntity event where event.realmId = :realmId",
-                query -> query.setParameter("realmId", realm.getId()),
-                "delete from EventEntity event where event.id in :eventIds");
+        em.createQuery("delete from EventEntity where realmId = :realmId").setParameter("realmId", realm.getId()).executeUpdate();
     }
 
     @Override
     public void clear(RealmModel realm, long olderThan) {
-        deleteByIdBatches(
-                "select event.id from EventEntity event where event.realmId = :realmId and event.time < :time",
-                query -> query.setParameter("realmId", realm.getId()).setParameter("time", olderThan),
-                "delete from EventEntity event where event.id in :eventIds");
+        em.createQuery("delete from EventEntity where realmId = :realmId and time < :time").setParameter("realmId", realm.getId()).setParameter("time", olderThan).executeUpdate();
     }
 
     @Override
@@ -124,24 +117,17 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
     @Override
     public void clearAdmin() {
-        deleteByIdBatches("select event.id from AdminEventEntity event", query -> {
-        }, "delete from AdminEventEntity event where event.id in :eventIds");
+        em.createQuery("delete from AdminEventEntity").executeUpdate();
     }
 
     @Override
     public void clearAdmin(RealmModel realm) {
-        deleteByIdBatches(
-                "select event.id from AdminEventEntity event where event.realmId = :realmId",
-                query -> query.setParameter("realmId", realm.getId()),
-                "delete from AdminEventEntity event where event.id in :eventIds");
+        em.createQuery("delete from AdminEventEntity where realmId = :realmId").setParameter("realmId", realm.getId()).executeUpdate();
     }
 
     @Override
     public void clearAdmin(RealmModel realm, long olderThan) {
-        deleteByIdBatches(
-                "select event.id from AdminEventEntity event where event.realmId = :realmId and event.time < :time",
-                query -> query.setParameter("realmId", realm.getId()).setParameter("time", olderThan),
-                "delete from AdminEventEntity event where event.id in :eventIds");
+        em.createQuery("delete from AdminEventEntity where realmId = :realmId and time < :time").setParameter("realmId", realm.getId()).setParameter("time", olderThan).executeUpdate();
     }
 
     @Override
@@ -271,7 +257,7 @@ public class JpaEventStoreProvider implements EventStoreProvider {
             List<String> realmIds = value.stream().map(RealmAttributeEntity::getRealm).map(RealmEntity::getId).collect(Collectors.toList());
             long eventTime = current - (key * 1000);
             int currentNumDeleted = deleteByIdBatches(
-                    "select event.id from AdminEventEntity event where event.realmId in :realmIds and event.time < :eventTime",
+                    "select event.id from AdminEventEntity event where event.realmId in :realmIds and event.time < :eventTime order by event.time",
                     queryBuilder -> queryBuilder.setParameter("realmIds", realmIds).setParameter("eventTime", eventTime),
                     "delete from AdminEventEntity event where event.id in :eventIds");
             logger.tracef("Deleted %d admin events for the expiration %d", currentNumDeleted, key);

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
@@ -22,9 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
 
 import org.keycloak.common.util.Time;
@@ -41,11 +41,12 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.jpa.entities.RealmAttributeEntity;
 import org.keycloak.models.jpa.entities.RealmAttributes;
-import org.keycloak.models.jpa.entities.RealmEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
+
+import static jakarta.persistence.PersistenceConfiguration.LOCK_TIMEOUT;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -54,6 +55,7 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
     private static final Logger logger = Logger.getLogger(JpaEventStoreProvider.class);
     private static final int EXPIRED_DELETE_MAX_RESULTS = 500;
+    private static final long EXPIRED_DELETE_TIME_LIMIT_MS = 5 * 60 * 1000L;
 
     private final KeycloakSession session;
     private final EntityManager em;
@@ -88,18 +90,19 @@ public class JpaEventStoreProvider implements EventStoreProvider {
         int numDeleted = 0;
         long currentTimeMillis = Time.currentTimeMillis();
 
-        // Group realms by expiration times. This will be effective if different realms have same/similar event expiration times, which will probably be the case in most environments
-        List<Long> eventExpirations = em.createQuery("select distinct realm.eventsExpiration from RealmEntity realm where realm.eventsExpiration > 0", Long.class).getResultList();
-        for (Long expiration : eventExpirations) {
-            List<String> realmIds = em.createQuery("select realm.id from RealmEntity realm where realm.eventsExpiration = :expiration", String.class)
-                    .setParameter("expiration", expiration)
-                    .getResultList();
+        List<Object[]> realmExpirations = em.createQuery(
+                "select r.id, r.eventsExpiration from RealmEntity r where r.eventsExpiration > 0", Object[].class)
+                .getResultList();
+
+        for (Object[] row : realmExpirations) {
+            String realmId = (String) row[0];
+            long expiration = (Long) row[1];
             long eventTime = currentTimeMillis - (expiration * 1000);
             int currentNumDeleted = deleteByIdBatches(
-                    "select event.id from EventEntity event where event.realmId in :realmIds and event.time < :eventTime",
-                    query -> query.setParameter("realmIds", realmIds).setParameter("eventTime", eventTime),
+                    "select event.id from EventEntity event where event.realmId = :realmId and event.time < :eventTime order by event.time",
+                    query -> query.setParameter("realmId", realmId).setParameter("eventTime", eventTime),
                     "delete from EventEntity event where event.id in :eventIds");
-            logger.tracef("Deleted %d events for the expiration %d", currentNumDeleted, expiration);
+            logger.tracef("Deleted %d events for realm %s with expiration %d", (Object) currentNumDeleted, realmId, expiration);
             numDeleted += currentNumDeleted;
         }
         logger.debugf("Cleared %d expired events in all realms", numDeleted);
@@ -236,37 +239,46 @@ public class JpaEventStoreProvider implements EventStoreProvider {
     protected void clearExpiredAdminEvents() {
         TypedQuery<RealmAttributeEntity> query = em.createNamedQuery("selectRealmAttributesNotEmptyByName", RealmAttributeEntity.class)
                 .setParameter("name", RealmAttributes.ADMIN_EVENTS_EXPIRATION);
-        Map<Long, List<RealmAttributeEntity>> realms = query.getResultStream()
-                // filtering again on the attribute as parsing the CLOB to BIGINT didn't work in H2 2.x, and it also different on OracleDB
+        // filtering on the attribute in Java as parsing the CLOB to BIGINT didn't work in H2 2.x, and it is also different on OracleDB
+        List<Object[]> realmExpirations = query.getResultStream()
                 .filter(attribute -> {
                     try {
                         return Long.parseLong(attribute.getValue()) > 0;
                     } catch (NumberFormatException ex) {
-                        logger.warnf("Unable to parse value '%s' for attribute '%s' in realm '%s' (expecting it to be decimal numeric)",
+                        logger.warnf(ex, "Unable to parse value '%s' for attribute '%s' in realm '%s' (expecting it to be decimal numeric)",
                                 attribute.getValue(),
                                 RealmAttributes.ADMIN_EVENTS_EXPIRATION,
-                                attribute.getRealm().getId(),
-                                ex);
+                                attribute.getRealm().getId());
                         return false;
                     }
                 })
-                .collect(Collectors.groupingBy(attribute -> Long.valueOf(attribute.getValue())));
+                .map(attribute -> new Object[]{attribute.getRealm().getId(), Long.parseLong(attribute.getValue())})
+                .toList();
 
+        int numDeleted = 0;
         long current = Time.currentTimeMillis();
-        realms.forEach((key, value) -> {
-            List<String> realmIds = value.stream().map(RealmAttributeEntity::getRealm).map(RealmEntity::getId).collect(Collectors.toList());
-            long eventTime = current - (key * 1000);
+        for (Object[] row : realmExpirations) {
+            String realmId = (String) row[0];
+            long expiration = (Long) row[1];
+            long eventTime = current - (expiration * 1000);
             int currentNumDeleted = deleteByIdBatches(
-                    "select event.id from AdminEventEntity event where event.realmId in :realmIds and event.time < :eventTime order by event.time",
-                    queryBuilder -> queryBuilder.setParameter("realmIds", realmIds).setParameter("eventTime", eventTime),
+                    "select event.id from AdminEventEntity event where event.realmId = :realmId and event.time < :eventTime order by event.time",
+                    queryBuilder -> queryBuilder.setParameter("realmId", realmId).setParameter("eventTime", eventTime),
                     "delete from AdminEventEntity event where event.id in :eventIds");
-            logger.tracef("Deleted %d admin events for the expiration %d", currentNumDeleted, key);
-        });
+            logger.tracef("Deleted %d admin events for realm %s with expiration %d", (Object) currentNumDeleted, realmId, expiration);
+            numDeleted += currentNumDeleted;
+        }
+        logger.debugf("Cleared %d expired admin events in all realms", numDeleted);
     }
 
     private int deleteByIdBatches(String selectIdsQuery, Consumer<TypedQuery<String>> queryConfigurator, String deleteByIdsQuery) {
         int deleted = 0;
+        long startTime = Time.currentTimeMillis();
         while (true) {
+            if (Time.currentTimeMillis() - startTime > EXPIRED_DELETE_TIME_LIMIT_MS) {
+                logger.debugf("Batch delete reached time limit after deleting %d rows", deleted);
+                return deleted;
+            }
             int currentBatchDeleted = KeycloakModelUtils.runJobInTransactionWithResult(
                     session.getKeycloakSessionFactory(),
                     session.getContext(),
@@ -276,6 +288,8 @@ public class JpaEventStoreProvider implements EventStoreProvider {
                         queryConfigurator.accept(selectQuery);
                         List<String> eventIds = selectQuery
                                 .setMaxResults(EXPIRED_DELETE_MAX_RESULTS)
+                                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                                .setHint(LOCK_TIMEOUT, -2) // skip locked
                                 .getResultList();
                         if (eventIds.isEmpty()) {
                             return 0;

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/JpaEventStoreProvider.java
@@ -55,7 +55,8 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
     private static final Logger logger = Logger.getLogger(JpaEventStoreProvider.class);
     private static final int EXPIRED_DELETE_MAX_RESULTS = 500;
-    private static final long EXPIRED_DELETE_TIME_LIMIT_MS = 5 * 60 * 1000L;
+    // maximum 4 minutes duration in case there is a big backlog of old events to be deleted
+    private static final long EXPIRED_DELETE_TIME_LIMIT_MS = 4 * 60 * 1000L;
 
     private final KeycloakSession session;
     private final EntityManager em;
@@ -89,6 +90,7 @@ public class JpaEventStoreProvider implements EventStoreProvider {
     public void clearExpiredEvents() {
         int numDeleted = 0;
         long currentTimeMillis = Time.currentTimeMillis();
+        long deadline = currentTimeMillis + EXPIRED_DELETE_TIME_LIMIT_MS;
 
         List<Object[]> realmExpirations = em.createQuery(
                 "select r.id, r.eventsExpiration from RealmEntity r where r.eventsExpiration > 0", Object[].class)
@@ -101,7 +103,8 @@ public class JpaEventStoreProvider implements EventStoreProvider {
             int currentNumDeleted = deleteByIdBatches(
                     "select event.id from EventEntity event where event.realmId = :realmId and event.time < :eventTime order by event.time",
                     query -> query.setParameter("realmId", realmId).setParameter("eventTime", eventTime),
-                    "delete from EventEntity event where event.id in :eventIds");
+                    "delete from EventEntity event where event.id in :eventIds",
+                    deadline);
             logger.tracef("Deleted %d events for realm %s with expiration %d", (Object) currentNumDeleted, realmId, expiration);
             numDeleted += currentNumDeleted;
         }
@@ -257,6 +260,7 @@ public class JpaEventStoreProvider implements EventStoreProvider {
 
         int numDeleted = 0;
         long current = Time.currentTimeMillis();
+        long deadline = current + EXPIRED_DELETE_TIME_LIMIT_MS;
         for (Object[] row : realmExpirations) {
             String realmId = (String) row[0];
             long expiration = (Long) row[1];
@@ -264,18 +268,18 @@ public class JpaEventStoreProvider implements EventStoreProvider {
             int currentNumDeleted = deleteByIdBatches(
                     "select event.id from AdminEventEntity event where event.realmId = :realmId and event.time < :eventTime order by event.time",
                     queryBuilder -> queryBuilder.setParameter("realmId", realmId).setParameter("eventTime", eventTime),
-                    "delete from AdminEventEntity event where event.id in :eventIds");
+                    "delete from AdminEventEntity event where event.id in :eventIds",
+                    deadline);
             logger.tracef("Deleted %d admin events for realm %s with expiration %d", (Object) currentNumDeleted, realmId, expiration);
             numDeleted += currentNumDeleted;
         }
         logger.debugf("Cleared %d expired admin events in all realms", numDeleted);
     }
 
-    private int deleteByIdBatches(String selectIdsQuery, Consumer<TypedQuery<String>> queryConfigurator, String deleteByIdsQuery) {
+    private int deleteByIdBatches(String selectIdsQuery, Consumer<TypedQuery<String>> queryConfigurator, String deleteByIdsQuery, long deadline) {
         int deleted = 0;
-        long startTime = Time.currentTimeMillis();
         while (true) {
-            if (Time.currentTimeMillis() - startTime > EXPIRED_DELETE_TIME_LIMIT_MS) {
+            if (Time.currentTimeMillis() > deadline) {
                 logger.debugf("Batch delete reached time limit after deleting %d rows", deleted);
                 return deleted;
             }

--- a/server-spi-private/src/main/java/org/keycloak/events/EventStoreProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventStoreProvider.java
@@ -52,6 +52,7 @@ public interface EventStoreProvider extends EventListenerProvider {
      *
      * @deprecated Unused method. Currently, used only in the testsuite
      */
+    @Deprecated(forRemoval = true, since = "26.6")
     void clear();
 
     /**
@@ -84,6 +85,7 @@ public interface EventStoreProvider extends EventListenerProvider {
      *
      * @deprecated Unused method. Currently, used only in the testsuite
      */
+    @Deprecated(forRemoval = true, since = "26.6")
     void clearAdmin();
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/events/EventStoreProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/EventStoreProvider.java
@@ -52,7 +52,7 @@ public interface EventStoreProvider extends EventListenerProvider {
      *
      * @deprecated Unused method. Currently, used only in the testsuite
      */
-    @Deprecated(forRemoval = true, since = "26.6")
+    @Deprecated(forRemoval = true, since = "26.7")
     void clear();
 
     /**
@@ -85,7 +85,7 @@ public interface EventStoreProvider extends EventListenerProvider {
      *
      * @deprecated Unused method. Currently, used only in the testsuite
      */
-    @Deprecated(forRemoval = true, since = "26.6")
+    @Deprecated(forRemoval = true, since = "26.7")
     void clearAdmin();
 
     /**

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/RealmBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/RealmBuilder.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.keycloak.models.jpa.entities.RealmAttributes;
 import org.keycloak.representations.idm.ClientPoliciesRepresentation;
 import org.keycloak.representations.idm.ClientPolicyRepresentation;
 import org.keycloak.representations.idm.ClientProfileRepresentation;
@@ -242,6 +243,10 @@ public class RealmBuilder extends Builder<RealmRepresentation> {
     public RealmBuilder eventsExpiration(long eventsExpiration) {
         rep.setEventsExpiration(eventsExpiration);
         return this;
+    }
+
+    public RealmBuilder adminEventsExpiration(long adminEventsExpiration) {
+        return attribute(RealmAttributes.ADMIN_EVENTS_EXPIRATION, String.valueOf(adminEventsExpiration));
     }
 
     public RealmBuilder internationalizationEnabled(boolean enabled) {

--- a/test-framework/tests/src/test/java/org/keycloak/testframework/tests/AdminEventsTest.java
+++ b/test-framework/tests/src/test/java/org/keycloak/testframework/tests/AdminEventsTest.java
@@ -143,6 +143,9 @@ public class AdminEventsTest {
                 .adminEventsEnabled(true)
                 .adminEventsExpiration(1));
 
+        // create at least one event
+        realm.addUser(UserBuilder.create("expire_admin_event"));
+
         List<AdminEventRepresentation> storedAdminEvents = realm.admin().getAdminEvents();
         Assertions.assertFalse(storedAdminEvents.isEmpty(), "Expected at least one admin event in the store");
 

--- a/test-framework/tests/src/test/java/org/keycloak/testframework/tests/AdminEventsTest.java
+++ b/test-framework/tests/src/test/java/org/keycloak/testframework/tests/AdminEventsTest.java
@@ -6,8 +6,10 @@ import java.util.List;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.AdminEventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.scheduled.ClearExpiredAdminEvents;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectAdminEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -16,6 +18,10 @@ import org.keycloak.testframework.events.AdminEventAssertion;
 import org.keycloak.testframework.events.AdminEvents;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
+import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
 import org.keycloak.testframework.util.ApiUtil;
 
 import org.junit.jupiter.api.Assertions;
@@ -38,6 +44,12 @@ public class AdminEventsTest {
 
     @InjectAdminClient
     private Keycloak adminClient;
+
+    @InjectTimeOffSet
+    TimeOffSet timeOffSet;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
 
     @Test
     public void testAdminEventOnUserCreateAndDelete() {
@@ -123,6 +135,23 @@ public class AdminEventsTest {
             userIds.add(userId);
         }
         return userIds;
+    }
+
+    @Test
+    public void testExpireAdminEvents() {
+        this.realm.updateWithCleanup(r -> r
+                .adminEventsEnabled(true)
+                .adminEventsExpiration(1));
+
+        List<AdminEventRepresentation> storedAdminEvents = realm.admin().getAdminEvents();
+        Assertions.assertFalse(storedAdminEvents.isEmpty(), "Expected at least one admin event in the store");
+
+        timeOffSet.set(10);
+
+        runOnServer.run(session -> new ClearExpiredAdminEvents().run(session));
+
+        List<AdminEventRepresentation> remainingAdminEvents = realm.admin().getAdminEvents();
+        Assertions.assertTrue(remainingAdminEvents.isEmpty(), "Expected all admin events to be expired and removed");
     }
 
 }

--- a/test-framework/tests/src/test/java/org/keycloak/testframework/tests/EventsTest.java
+++ b/test-framework/tests/src/test/java/org/keycloak/testframework/tests/EventsTest.java
@@ -2,6 +2,8 @@ package org.keycloak.testframework.tests;
 
 import org.keycloak.events.EventType;
 import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.services.scheduled.ClearExpiredAdminEvents;
+import org.keycloak.services.scheduled.ClearExpiredEvents;
 import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -10,10 +12,14 @@ import org.keycloak.testframework.events.Events;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
 import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
 
 import org.junit.jupiter.api.Test;
+
+import static org.keycloak.models.jpa.entities.RealmAttributes.ADMIN_EVENTS_EXPIRATION;
 
 @KeycloakIntegrationTest
 public class EventsTest {
@@ -29,6 +35,9 @@ public class EventsTest {
 
     @InjectTimeOffSet
     TimeOffSet timeOffSet;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
 
     @Test
     public void testFailedLogin() {
@@ -57,6 +66,23 @@ public class EventsTest {
         oAuthClient.doClientCredentialsGrantAccessTokenRequest();
 
         EventAssertion.assertSuccess(events.poll()).type(EventType.CLIENT_LOGIN);
+    }
+
+    @Test
+    public void testExpireEvents() {
+        this.realm.updateWithCleanup(r -> r
+                .eventsEnabled(true)
+                .adminEventsEnabled(true)
+                .eventsExpiration(1)
+                // TODO: Create a new method in the builder
+                .update(r1 -> r1.getAttributes().put(ADMIN_EVENTS_EXPIRATION, "1")));
+        // TODO create a user and an admin event. Ensure that they are in the store
+        timeOffSet.set(10);
+        runOnServer.run(session -> {
+            new ClearExpiredAdminEvents().run(session);
+            new ClearExpiredEvents().run(session);
+        });
+        // TODO: Verify that those events have been removed from the database
     }
 
 }

--- a/test-framework/tests/src/test/java/org/keycloak/testframework/tests/EventsTest.java
+++ b/test-framework/tests/src/test/java/org/keycloak/testframework/tests/EventsTest.java
@@ -1,8 +1,9 @@
 package org.keycloak.testframework.tests;
 
+import java.util.List;
+
 import org.keycloak.events.EventType;
 import org.keycloak.representations.idm.EventRepresentation;
-import org.keycloak.services.scheduled.ClearExpiredAdminEvents;
 import org.keycloak.services.scheduled.ClearExpiredEvents;
 import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -17,9 +18,8 @@ import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
 import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import static org.keycloak.models.jpa.entities.RealmAttributes.ADMIN_EVENTS_EXPIRATION;
 
 @KeycloakIntegrationTest
 public class EventsTest {
@@ -69,20 +69,23 @@ public class EventsTest {
     }
 
     @Test
-    public void testExpireEvents() {
+    public void testExpireLoginEvents() {
         this.realm.updateWithCleanup(r -> r
                 .eventsEnabled(true)
-                .adminEventsEnabled(true)
-                .eventsExpiration(1)
-                // TODO: Create a new method in the builder
-                .update(r1 -> r1.getAttributes().put(ADMIN_EVENTS_EXPIRATION, "1")));
-        // TODO create a user and an admin event. Ensure that they are in the store
+                .eventsExpiration(1));
+
+        oAuthClient.doPasswordGrantRequest("invalid", "invalid");
+        events.poll();
+
+        List<EventRepresentation> storedEvents = realm.admin().getEvents();
+        Assertions.assertFalse(storedEvents.isEmpty(), "Expected at least one login event in the store");
+
         timeOffSet.set(10);
-        runOnServer.run(session -> {
-            new ClearExpiredAdminEvents().run(session);
-            new ClearExpiredEvents().run(session);
-        });
-        // TODO: Verify that those events have been removed from the database
+
+        runOnServer.run(session -> new ClearExpiredEvents().run(session));
+
+        List<EventRepresentation> remainingEvents = realm.admin().getEvents();
+        Assertions.assertTrue(remainingEvents.isEmpty(), "Expected all login events to be expired and removed");
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/event/LoginEventsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/event/LoginEventsTest.java
@@ -242,21 +242,6 @@ public class LoginEventsTest {
         Assertions.assertEquals(0, events().size());
     }
 
-
-    /*
-    Removed this test because it takes too long.  The default interval for
-    event cleanup is 15 minutes (900 seconds).  I don't have time to figure out
-    a way to set the cleanup thread to a lower interval for testing.
-    @Test
-    public void eventExpirationTest() {
-        configRep.setEventsExpiration(1L); //  second
-        saveConfig();
-        badLogin();
-        assertEquals(1, events().size());
-        pause(900); // pause 900 seconds
-        assertEquals(0, events().size());
-    }**/
-
     private static class LoginEventsRealmConfig implements RealmConfig {
 
         @Override


### PR DESCRIPTION
Closes: #46954 

ClearExpiredEvents job crashes app and locks DB when EVENT_ENTITY Table has large amount of records .

Batch deletes to 500 at a time to prevent database locks due to large table records.