### PR TITLE
Fix client policy conditions and profiles disappear after updating the policy name

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
@@ -197,9 +197,11 @@ export default function NewClientPolicy() {
     };
 
     try {
+      const updatedPolicies = getAllPolicies();
       await adminClient.clientPolicies.updatePolicy({
-        policies: getAllPolicies(),
+        policies: updatedPolicies,
       });
+      setAllPolicies(updatedPolicies);
       addAlert(
         policyName
           ? t("updateClientPolicySuccess")


### PR DESCRIPTION
The Client policies and conditions lists are populated by filtering the `allPolicies` state on the `policyName` which comes from the URL and is updated in the save method. When the name is changed `allPolicies` did not have the new state after changing the name.

- [x] The save method now updates the `allPolicies` state with the new state from the form.

Closes #46628 and #45948