### PR TITLE
Fix update client policy name validation logic

### DIFF
--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
@@ -478,7 +478,9 @@ export default function NewClientPolicy() {
               rules={{
                 required: t("required"),
                 validate: (value) =>
-                  policies.some((policy) => policy.name === value)
+                  policies.some(
+                    (policy) => policyName !== value && policy.name === value,
+                  )
                     ? t("createClientProfileNameHelperText")
                     : true,
               }}


### PR DESCRIPTION
- [x] Update the name field form validation logic using the `policyName` value.
  - This update addresses a few of the "other observations" from this issue #45948.
- [ ] Save button is enabled even when no changes were made.
  - I've set this PR as a draft because the issue of the save button is enabled even when no changes were made from #46623 is still open however.
 
Closes #46623