### PR TITLE
Fix NPE on mixed-case email domain in Keycloak Organization

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
@@ -141,7 +141,7 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
             realmCache.getCache().addRevisioned(cached, realmCache.getStartupRevision());
         }
 
-        return cached.getOrgIds().stream().map(this::getById).findAny().orElse(null);
+        return cached.getOrgIds().stream().map(this::getById).filter(Objects::nonNull).findAny().orElse(null);
     }
 
     @Override
@@ -469,7 +469,10 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
     }
 
     private String cacheKeyByDomain(String domainName) {
-        return getRealm().getId() + ".org.domain.name." + domainName;
+        if (domainName == null) {
+            throw new IllegalArgumentException("domainName must not be null");
+        }
+        return getRealm().getId() + ".org.domain.name." + domainName.toLowerCase();
     }
 
     private String cacheKeyByMember(UserModel user) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/cache/OrganizationCacheTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/cache/OrganizationCacheTest.java
@@ -299,7 +299,7 @@ public class OrganizationCacheTest extends AbstractOrganizationTest {
             final String alias = "org-idp-" + i;
             idpRep.setAlias(alias);
             testRealm().identityProviders().create(idpRep).close();
-            getCleanup().addCleanup(testRealm().identityProviders().get("alias")::remove);
+            getCleanup().addCleanup(testRealm().identityProviders().get(alias)::remove);
         }
 
         String orgaId = testRealm().organizations().list(-1, -1).get(0).getId();
@@ -369,13 +369,14 @@ public class OrganizationCacheTest extends AbstractOrganizationTest {
     public void testCacheIDPForLogin() {
         // create 20 providers, and associate 10 of them with an organization.
         for (int i = 0; i < 20; i++) {
+            final String alias = "idp-alias-" + i;
             IdentityProviderRepresentation idpRep = new IdentityProviderRepresentation();
-            idpRep.setAlias("idp-alias-" + i);
+            idpRep.setAlias(alias);
             idpRep.setEnabled((i % 2) == 0); // half of the IDPs will be disabled and won't qualify for login.
             idpRep.setDisplayName("Broker " + i);
             idpRep.setProviderId("keycloak-oidc");
             testRealm().identityProviders().create(idpRep).close();
-            getCleanup().addCleanup(testRealm().identityProviders().get("alias")::remove);
+            getCleanup().addCleanup(testRealm().identityProviders().get(alias)::remove);
         }
 
         String orgaId = testRealm().organizations().list(-1, -1).get(0).getId();
@@ -527,6 +528,52 @@ public class OrganizationCacheTest extends AbstractOrganizationTest {
             assertNotNull(identityProviderListQuery);
             assertEquals(11, identityProviderListQuery.getIDPs(orgaId).size());
 
+        });
+    }
+
+    @Test
+    public void testGetByDomainCaseInsensitiveAndStaleCacheHandling() {
+        final String domainLower = "case.org";
+        final String domainMixed = "CaSe.Org";
+
+        // 1. Create org with lowercase domain
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.create(null, "case-org", "case-org");
+            org.setDomains(Set.of(new OrganizationDomainModel(domainLower)));
+        });
+
+        // 2. Look up by mixed-case domain (simulates login with user@CaSe.Org) to populate the cache
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.getByDomainName(domainMixed);
+            assertNotNull("Mixed-case domain lookup should find the organization", org);
+        });
+
+        // 3. Delete the org
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.getByDomainName(domainLower);
+            assertNotNull(org);
+            orgProvider.remove(org);
+        });
+
+        // 4. Recreate the org with the same domain
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.create(null, "case-org", "case-org");
+            org.setDomains(Set.of(new OrganizationDomainModel(domainLower)));
+        });
+
+        // 5. Look up by mixed-case again (simulates login with user@CaSe.Org after org recreation).
+        // Without the fix, the stale cache entry from step 2 (stored under the mixed-case key)
+        // was not invalidated in step 3 (invalidation only targets the lowercase key), so it
+        // still points to the old deleted org ID. getById returns null for that ID, and
+        // findAny() on a null element throws NPE.
+        getTestingClient().server(TEST_REALM_NAME).run((RunOnServer) session -> {
+            OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+            OrganizationModel org = orgProvider.getByDomainName(domainMixed);
+            assertNotNull("Mixed-case domain lookup should find the recreated organization", org);
         });
     }
 }


### PR DESCRIPTION
This PR addresses the authentication failure caused by case-sensitivity issues in the Organization Infinispan cache.

### Key Changes
- **Cache Key Normalization**: Updated `InfinispanOrganizationProvider` to always lowercase domain names when generating cache keys. This ensures cache entries are consistent with the JPA layer and are correctly invalidated during organization updates.
- **Defensive Null Handling**: Added a null check when resolving organizations from the cache. This prevents `NullPointerException` if a stale or corrupted cache entry points to a non-existent organization ID.
- **Integration Test**: Added a new test case `testStaleCacheEntryDoesNotThrowNPE` in `OrganizationCacheTest.java` that specifically validates the fix by simulating a stale cache scenario.

Closes #46969 