### PR TITLE
Detect insecure context for HTTPS iframes embedded in HTTP pages

### DIFF
--- a/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
+++ b/services/src/main/java/org/keycloak/utils/SecureContextResolver.java
@@ -2,10 +2,14 @@ package org.keycloak.utils;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.function.Supplier;
 
+import jakarta.ws.rs.core.HttpHeaders;
+
 import org.keycloak.device.DeviceRepresentationProvider;
+import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.representations.account.DeviceRepresentation;
 
@@ -22,7 +26,8 @@ public class SecureContextResolver {
      * @return Whether the session can be considered potentially trustworthy by user-agents.
      */
     public static boolean isSecureContext(KeycloakSession session) {
-        URI uri = session.getContext().getUri().getRequestUri();
+        KeycloakContext context = session.getContext();
+        URI uri = context.getUri().getRequestUri();
 
         // Use a Supplier so the user-agent is evaluated lazily, avoiding unnecessary parsing in production deployments.
         Supplier<DeviceRepresentation> deviceRepresentationSupplier = () -> {
@@ -30,11 +35,29 @@ public class SecureContextResolver {
             return deviceRepresentationProvider.deviceRepresentation();
         };
 
-        return isSecureContext(uri, deviceRepresentationSupplier);
+        HttpHeaders headers = context.getRequestHeaders();
+        String referer = headers.getHeaderString("Referer");
+        String secFetchDest = headers.getHeaderString("Sec-Fetch-Dest");
+
+        return isSecureContext(uri, deviceRepresentationSupplier, referer, secFetchDest);
     }
 
     static boolean isSecureContext(URI uri, Supplier<DeviceRepresentation> deviceRepresentationSupplier) {
+        return isSecureContext(uri, deviceRepresentationSupplier, null, null);
+    }
+
+    static boolean isSecureContext(URI uri, Supplier<DeviceRepresentation> deviceRepresentationSupplier, String referer, String secFetchDest) {
         if (uri.getScheme().equals("https")) {
+            // Per the W3C Secure Contexts spec, a page is only contextually secure if all its
+            // ancestor contexts are also secure. An HTTPS iframe embedded in an HTTP parent page
+            // is therefore not a secure context. Detect this using browser-sent fetch metadata.
+            // See:
+            // - https://github.com/keycloak/keycloak/issues/37355
+            // - https://w3c.github.io/webappsec-secure-contexts/#is-settings-object-contextually-secure
+            // - https://w3c.github.io/webappsec-secure-contexts/#examples-framed
+            if ("iframe".equals(secFetchDest) && isInsecureReferer(referer)) {
+                return false;
+            }
             return true;
         }
 
@@ -91,6 +114,18 @@ public class SecureContextResolver {
         }
 
         return false;
+    }
+
+    private static boolean isInsecureReferer(String referer) {
+        if (referer == null) {
+            return false;
+        }
+
+        try {
+            return "http".equals(new URI(referer).getScheme());
+        } catch (URISyntaxException e) {
+            return false;
+        }
     }
 
 }

--- a/services/src/test/java/org/keycloak/utils/SecureContextResolverTest.java
+++ b/services/src/test/java/org/keycloak/utils/SecureContextResolverTest.java
@@ -94,6 +94,30 @@ public class SecureContextResolverTest {
         assertSecureContext("http://localhost", null, true);
     }
 
+    @Test
+    public void testHttpsIframeInInsecureParent() {
+        // HTTPS iframe embedded in an HTTP parent is not a secure context
+        assertSecureContext("https://keycloak.example.com/iframe", DEVICE_UNKOWN, "http://admin.internal:8080/admin", "iframe", false);
+
+        // HTTPS iframe embedded in an HTTPS parent remains secure
+        assertSecureContext("https://keycloak.example.com/iframe", DEVICE_UNKOWN, "https://admin.example.com/admin", "iframe", true);
+
+        // HTTPS top-level navigation from an HTTP page is still a secure context (not an iframe)
+        assertSecureContext("https://keycloak.example.com/admin", DEVICE_UNKOWN, "http://other.com", "document", true);
+
+        // HTTPS iframe without a Referer header remains secure (can't determine parent scheme)
+        assertSecureContext("https://keycloak.example.com/iframe", DEVICE_UNKOWN, null, "iframe", true);
+
+        // HTTPS request with HTTP Referer but no Sec-Fetch-Dest remains secure (can't confirm it's an iframe)
+        assertSecureContext("https://keycloak.example.com/admin", DEVICE_UNKOWN, "http://other.com", null, true);
+
+        // HTTP iframe in HTTP parent still follows existing logic (localhost is secure)
+        assertSecureContext("http://localhost/iframe", DEVICE_UNKOWN, "http://localhost/admin", "iframe", true);
+
+        // HTTP iframe in HTTP parent, non-local host is insecure
+        assertSecureContext("http://admin.internal:8080/iframe", DEVICE_UNKOWN, "http://admin.internal:8080/admin", "iframe", false);
+    }
+
     void assertSecureContext(String url, boolean expectedSecureContext) {
         assertSecureContext(url, DEVICE_UNKOWN, expectedSecureContext);
     }
@@ -103,6 +127,16 @@ public class SecureContextResolverTest {
 
         try {
             Assert.assertEquals(expectedSecureContext, SecureContextResolver.isSecureContext(new URI(url), deviceRepresentationSupplier));
+        } catch (URISyntaxException e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    void assertSecureContext(String url, DeviceRepresentation deviceRepresentation, String referer, String secFetchDest, boolean expectedSecureContext) {
+        Supplier<DeviceRepresentation> deviceRepresentationSupplier = () -> deviceRepresentation;
+
+        try {
+            Assert.assertEquals(expectedSecureContext, SecureContextResolver.isSecureContext(new URI(url), deviceRepresentationSupplier, referer, secFetchDest));
         } catch (URISyntaxException e) {
             Assert.fail(e.getMessage());
         }


### PR DESCRIPTION
`SecureContextResolver` now checks the [`Sec-Fetch-Dest`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Dest) and [`Referer`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referer) request headers. When a request is HTTPS but `Sec-Fetch-Dest` is `iframe` (meaning the request is intended for an iframe), and the `Referer` has an `http://` scheme (meaning the embedding page is served insecurely), the context is now correctly treated as an insecure context.

Closes #37355