### PR TITLE
Promote JWT Authorization Grant feature to supported

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -80,7 +80,7 @@ public class Profile {
         TOKEN_EXCHANGE_STANDARD_V2("Standard Token Exchange version 2", Type.DEFAULT, 2),
         TOKEN_EXCHANGE_EXTERNAL_INTERNAL_V2("External to Internal Token Exchange version 2", Type.EXPERIMENTAL, 2),
 
-        JWT_AUTHORIZATION_GRANT("JWT Profile for Oauth 2.0 Authorization Grant", Type.PREVIEW),
+        JWT_AUTHORIZATION_GRANT("JWT Profile for Oauth 2.0 Authorization Grant", Type.DEFAULT),
 
         WEB_AUTHN("W3C Web Authentication (WebAuthn)", Type.DEFAULT),
 

--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -121,3 +121,8 @@ Fine-Grained Admin Permissions (FGAP) now includes a new `Groups` scope: `manage
 
 This scope is now used as the group-side bridge for evaluating user-side `manage-group-membership` permissions based on a user's current group memberships.
 The existing `manage-membership` scope keeps its current behavior for target group membership management operations.
+
+= JWT Authorization Grant promoted to supported
+
+In this release, the JWT Authorization Grant (https://datatracker.ietf.org/doc/html/rfc7523[RFC 7523]) feature is promoted from preview to default. This grant allows to use an external signed JWT assertions to request OAuth 2.0 access tokens. See the link:{securing_apps_base_link}/jwt-authorization-grant[JWT Authorization Grant guide] for additional details.
+

--- a/docs/guides/securing-apps/jwt-authorization-grant.adoc
+++ b/docs/guides/securing-apps/jwt-authorization-grant.adoc
@@ -7,8 +7,6 @@ title="JWT Authorization Grant"
 priority=130
 summary="Guide for the JWT Authorization Grant specification RFC 7521 / 7523.">
 
-<@features.techpreview feature="jwt-authorization-grant"/>
-
 This guide defines how a JWT Bearer Token can be used in {project_name} as an authorization grant. This feature allows clients to send a JWT assertion to request an access token when the client wants to use an existing trust relationship without a direct user-approval step at the authorization server. The assertion is validated solely through the semantics of the JWT (its claims and signature). The trust relationship usually refers to another Identity Provider server (another OIDC server), and allows to obtain a cross-domain or cross-realm access token. In this sense, it is similar to the external to internal request in token exchange V1 (see <@links.securingapps id="token-exchange" anchor="_external-token-to-internal-token-exchange" /> for more information).
 
 The JWT Authorization grant is specified by two different RFCs.

--- a/docs/guides/securing-apps/oauth-identity-authorization-chaining-across-domains.adoc
+++ b/docs/guides/securing-apps/oauth-identity-authorization-chaining-across-domains.adoc
@@ -21,7 +21,7 @@ image::identity-authorization-chaining.dio.svg[Identity and Authorization Chaini
 . Authorization server of trust domain B validates the JWT authorization grant and returns an access token.
 . The client in trust domain A uses the access token received from the authorization server in trust domain B to access the protected resource in trust domain B.
 
-{project_name} currently provides standard Token Exchange (see <@links.securingapps id="token-exchange" anchor="_standard-token-exchange" />) as a supported feature and JWT Authorization Grant (see <@links.securingapps id="jwt-authorization-grant" />) as technology preview. This way, {project_name} can implement OAuth Identity and Authorization Chaining Across Domains between two different realms or servers. For domain A, domain B is an audience that can be restricted via token exchange. For domain B, domain A is an Identity Provider that is used to validate the assertion.
+{project_name} currently provides standard Token Exchange (see <@links.securingapps id="token-exchange" anchor="_standard-token-exchange" />) and JWT Authorization Grant (see <@links.securingapps id="jwt-authorization-grant" />) as supported features. This way, {project_name} can implement OAuth Identity and Authorization Chaining Across Domains between two different realms or servers. For domain A, domain B is an audience that can be restricted via token exchange. For domain B, domain A is an Identity Provider that is used to validate the assertion.
 
 WARNING: OAuth Identity and Authorization Chaining Across Domains is still in draft, it is not yet a definitive standard.
 

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -676,7 +676,7 @@ These types of changes required a configured identity provider in the Admin Cons
 
 NOTE:  SAML identity providers are not supported at this time.  Twitter tokens cannot be exchanged either.
 
-WARNING: External to internal Token Exchange will be replaced by <<_standard-token-exchange,Standard Token Exchange V2>> and <@links.securingapps id="jwt-authorization-grant" />. See <@links.securingapps id="oauth-identity-authorization-chaining-across-domains" /> for more information.
+NOTE: A combination of <<_standard-token-exchange,Standard Token Exchange V2>> and <@links.securingapps id="jwt-authorization-grant" /> is recommended instead of the legacy external to internal Token Exchange. See <@links.securingapps id="oauth-identity-authorization-chaining-across-domains" /> for more information about how those two supported features can be used to substitute the legacy Token Exchange.
 
 ==== Granting permission for the exchange
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderIssuerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderIssuerTest.java
@@ -220,7 +220,7 @@ public class IdentityProviderIssuerTest extends AbstractIdentityProviderTest {
     public static class TestServerConfig implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.KUBERNETES_SERVICE_ACCOUNTS, Profile.Feature.JWT_AUTHORIZATION_GRANT);
+            return config.features(Profile.Feature.KUBERNETES_SERVICE_ACCOUNTS);
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/AuthChainingAcrossDomainsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/AuthChainingAcrossDomainsTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.TestMethodOrder;
  *
  * @author rmartinc
  */
-@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class AuthChainingAcrossDomainsTest {
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/BaseAbstractJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/BaseAbstractJWTAuthorizationGrantTest.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
-import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
@@ -49,8 +48,6 @@ import org.keycloak.testframework.realm.UserConfig;
 import org.keycloak.testframework.realm.UserConfigBuilder;
 import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
 import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
-import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
-import org.keycloak.tests.client.authentication.external.ClientAuthIdpServerConfig;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.hamcrest.MatcherAssert;
@@ -131,14 +128,6 @@ public class BaseAbstractJWTAuthorizationGrantTest {
         @Override
         public OAuthIdentityProviderConfigBuilder configure(OAuthIdentityProviderConfigBuilder config) {
             return config;
-        }
-    }
-
-    public static class JWTAuthorizationGrantServerConfig extends ClientAuthIdpServerConfig {
-
-        @Override
-        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return super.configure(config).features(Profile.Feature.JWT_AUTHORIZATION_GRANT);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantDownscopeClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantDownscopeClientPoliciesTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author rmartinc
  */
-@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 public class JWTAuthorizationGrantDownscopeClientPoliciesTest extends BaseAbstractJWTAuthorizationGrantTest {
 
     @InjectRealm(config = JWTAuthorizationGranthRealmConfig.class)

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantJWTClaimsClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantJWTClaimsClientPoliciesTest.java
@@ -17,7 +17,7 @@ import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.junit.jupiter.api.Test;
 
-@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 public class JWTAuthorizationGrantJWTClaimsClientPoliciesTest extends BaseAbstractJWTAuthorizationGrantTest {
 
     @InjectRealm(config = JWTAuthorizationGrantRealmConfig.class)

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTAuthorizationGrantTest.java
@@ -12,7 +12,7 @@ import org.keycloak.testsuite.util.IdentityProviderBuilder;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class JWTAuthorizationGrantTest extends AbstractJWTAuthorizationGrantTest {
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTIdentityProviderConditionDownscopeClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTIdentityProviderConditionDownscopeClientPoliciesTest.java
@@ -30,7 +30,7 @@ import org.keycloak.testframework.realm.RealmConfigBuilder;
  *
  * @author rmartinc
  */
-@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 public class JWTIdentityProviderConditionDownscopeClientPoliciesTest extends JWTAuthorizationGrantDownscopeClientPoliciesTest {
 
     @InjectRealm(config = JWTAuthorizationGranthRealmConfig.class)

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/JWTNegativeIdentityProviderConditionDownscopeClientPoliciesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/JWTNegativeIdentityProviderConditionDownscopeClientPoliciesTest.java
@@ -30,7 +30,7 @@ import org.keycloak.testframework.realm.RealmConfigBuilder;
  *
  * @author rmartinc
  */
-@KeycloakIntegrationTest(config = JWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 public class JWTNegativeIdentityProviderConditionDownscopeClientPoliciesTest extends JWTAuthorizationGrantDownscopeClientPoliciesTest {
 
     @InjectRealm(config = JWTAuthorizationGranthRealmConfig.class)

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/OIDCIdentityProviderJWTAuthorizationGrantTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@KeycloakIntegrationTest(config = OIDCIdentityProviderJWTAuthorizationGrantTest.JWTAuthorizationGrantServerConfig.class)
+@KeycloakIntegrationTest
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class OIDCIdentityProviderJWTAuthorizationGrantTest extends AbstractJWTAuthorizationGrantTest {
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/AbstractWellKnownProviderTest.java
@@ -147,9 +147,10 @@ public abstract class AbstractWellKnownProviderTest extends AbstractKeycloakTest
 
             // Support standard + implicit + hybrid flow
             assertContains(oidcConfig.getResponseTypesSupported(), OAuth2Constants.CODE, OIDCResponseType.ID_TOKEN, "id_token token", "code id_token", "code token", "code id_token token");
-            assertEquals(9, oidcConfig.getGrantTypesSupported().size());
-            assertContains(oidcConfig.getGrantTypesSupported(), OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.IMPLICIT,
-                    OAuth2Constants.DEVICE_CODE_GRANT_TYPE, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
+            assertEquals(10, oidcConfig.getGrantTypesSupported().size());
+            assertContains(oidcConfig.getGrantTypesSupported(), OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.CLIENT_CREDENTIALS, OAuth2Constants.IMPLICIT,
+                    OAuth2Constants.PASSWORD, OAuth2Constants.REFRESH_TOKEN, OAuth2Constants.DEVICE_CODE_GRANT_TYPE,
+                    OAuth2Constants.JWT_AUTHORIZATION_GRANT, OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE, OAuth2Constants.UMA_GRANT_TYPE, OAuth2Constants.CIBA_GRANT_TYPE);
             assertContains(oidcConfig.getResponseModesSupported(), "query", "fragment", "form_post", "jwt", "query.jwt", "fragment.jwt", "form_post.jwt");
 
             Assert.assertNames(oidcConfig.getSubjectTypesSupported(), "pairwise", "public");


### PR DESCRIPTION
Closes #45463

Just promoting the jwt authorization grant to supported. Once https://github.com/keycloak/keycloak/pull/46662 is closed, I think we are OK to promote the feature.
