### PR TITLE
Allow scheduled sync to run on its configured time

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageSyncTask.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageSyncTask.java
@@ -9,6 +9,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ModelIllegalStateException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.UserStorageProviderModel.SyncMode;
 import org.keycloak.storage.user.ImportSynchronization;
 import org.keycloak.storage.user.SynchronizationResult;
@@ -162,7 +163,11 @@ final class UserStorageSyncTask implements ScheduledTask {
             SynchronizationResult result = syncFunction.apply(sessionFactory, factory, provider);
 
             if (!result.isIgnored()) {
-                updateLastSyncInterval(session);
+                KeycloakModelUtils.runJobInTransaction(sessionFactory, s -> {
+                    RealmModel realm = s.realms().getRealm(realmId);
+                    s.getContext().setRealm(realm);
+                    updateLastSyncInterval(s);
+                });
             }
 
             return result;
@@ -212,7 +217,7 @@ final class UserStorageSyncTask implements ScheduledTask {
         int currentTime = Time.currentTime();
         int timeSinceLastSync = currentTime - lastSyncTime;
 
-        return timeSinceLastSync > period;
+        return timeSinceLastSync >= (period - 1);
     }
 
     private boolean isSchedulable(UserStorageProviderModel provider) {


### PR DESCRIPTION
- schedule takes `lastSync` into consideration, so restarting nodes or new nodes joining cluster have about the same sync period

- logic that prevents duplicate syncs updated to prevent small clock skew differences from re-running a sync that just finished

Closes #46588

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
