### PR TITLE
fix: refinement to advertising property names

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -166,10 +166,7 @@ public class DatabaseOptions {
         private static final Map<Option<?>, Consumer<OptionBuilder<?>>> DATASOURCES_OVERRIDES_OPTIONS = Map.of(
                 DatabaseOptions.DB, builder -> builder
                         .defaultValue(Optional.empty()) // no default value for DB kind for datasources
-                        .connectedOptions(TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE,
-                                getDatasourceOption(DB_POOL_MAX_SIZE).orElseThrow(),
-                                getDatasourceOption(DB_SQL_JPA_DEBUG).orElseThrow(),
-                                getDatasourceOption(DB_SQL_LOG_SLOW_QUERIES).orElseThrow())
+                        .connectedOptions(TransactionOptions.TRANSACTION_XA_ENABLED_DATASOURCE)
         );
 
         private static final Map<String, Option<?>> cachedDatasourceOptions = new HashMap<>();

--- a/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/Option.java
@@ -99,9 +99,11 @@ public class Option<T> {
     /**
      * Get connected options that have a certain relationship with the current option.
      * Usually when the current option is set, the connected options should be set as well.
+     * <br>
+     * Not currently meaningful for non-wildcard options
      */
     public Set<String> getConnectedOptions() {
-        return connectedOptions;
+        return connectedOptions; // return the set directly for ease of mutability
     }
 
     /**

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/PropertyMappingInterceptor.java
@@ -126,25 +126,26 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
 
                 var wildcardValue = wildcardMapper.extractWildcardValue(name).orElseThrow();
 
-                // non-wildcard connected options should be already advertised by the logic in iterateNames()
                 if (mapper.hasConnectedOptions()) {
                     var connectedTo = wildcardMapper.getConnectedOptions(wildcardValue).stream()
                             .map(option -> Optional.ofNullable(PropertyMappers.getMapper(NS_KEYCLOAK_PREFIX + option)).orElseThrow(() -> new IllegalArgumentException("Cannot find connected options")))
-                            .map(m -> m.hasWildcard() ? ((WildcardPropertyMapper<?>) m).getTo(wildcardValue) : m.getTo());
-
-                    return Stream.concat(toDistinctStream(name, wildcardMapper.getTo(wildcardValue)), Stream.concat(connectedTo, wildcardsMappedFrom.stream()));
+                            .map(m -> m.hasWildcard() ? ((WildcardPropertyMapper<?>) m).getTo(wildcardValue) : m.getTo())
+                            .filter(key -> hasValue(key, context));
+                    String to = wildcardMapper.getTo(wildcardValue);
+                    return Stream.concat(toDistinctStream(name, !Configuration.isInitialized() || hasValue(to, context) ? to : null), Stream.concat(connectedTo, wildcardsMappedFrom.stream()));
                 }
             }
 
-            // there are corner cases here: -1 for the reload period has no 'to' value.
-            // if that becomes an issue we could use more metadata or perform a full mapping
-            return Stream.concat(toDistinctStream(name, mappedMapper.getTo()), wildcardsMappedFrom.stream());
+            return Stream.concat(toDistinctStream(name,
+                    !Configuration.isInitialized() || hasValue(mappedMapper.getTo(), context) ? mappedMapper.getTo() : null),
+                    wildcardsMappedFrom.stream());
         });
 
-        // include anything remaining that has a value
+        // include anything remaining that has a value - we only care about the to (typically quarkus) values
         var inferredValueStream = allMappers.stream()
                 .filter(m -> m.getCategory() != OptionCategory.CONFIG // advertising the keystore type causes the keystore to be used early
-                        && hasValue(m, allMappers))
+                        && !m.hasWildcard()
+                        && hasValue(m.getTo(), context))
                 .map(m -> m.getTo());
 
         return IteratorUtils.chainedIterator(baseStream.iterator(), inferredValueStream.iterator());
@@ -175,17 +176,13 @@ public class PropertyMappingInterceptor implements ConfigSourceInterceptor {
         return mappedFromWildCardKeys;
     }
 
-    private boolean hasValue(PropertyMapper<?> m, Set<PropertyMapper<?>> mappersWithNoValue) {
-        if (m.hasWildcard()) {
-            return false;
+    private boolean hasValue(String key, ConfigSourceInterceptorContext context) {
+        try {
+            return Configuration.isInitialized()
+                    && Optional.ofNullable(context.restart(key)).map(ConfigValue::getValue).isPresent();
+        } catch (Exception e) {
+            return false; // corner case - validation or other failure, we won't report it as having a value
         }
-
-        if (m.getDefaultValue().isPresent() || !mappersWithNoValue.contains(m)) {
-            return true;
-        }
-
-        return Optional.ofNullable(m.getMapFrom()).map(from -> PropertyMappers.getMapper(NS_KEYCLOAK_PREFIX + from))
-                .filter(fm -> hasValue(fm, mappersWithNoValue)).isPresent();
     }
 
     private static Stream<String> toDistinctStream(String... values) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -180,7 +180,7 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
         // targetServerType already set to same or different value in db-url, ignore
         return dbUrl == null || !dbUrl.contains("targetServerType");
     }
-    
+
     public static boolean isMssqlSendStringParametersAsUnicode() {
         String db = Configuration.getConfigValue(DB).getValue();
         Database.Vendor vendor = Database.getVendor(db).orElse(null);
@@ -337,10 +337,7 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 }
 
                 PropertyMapper<?> mapper = created.build();
-                if (mapper.getMapFrom() == null && mapper.getDefaultValue().isPresent() && !getDatasourceOption(DB)
-                        .orElseThrow().getConnectedOptions().contains(mapper.getOption().getKey())) {
-                    throw new AssertionError("Mapper should be connected to the primary to be discovered");
-                }
+                getDatasourceOption(DB).orElseThrow().getConnectedOptions().add(mapper.getOption().getKey());
                 datasourceMappers.add(mapper);
             }
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -149,8 +149,16 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     public void testProfiledPropertyExposure() {
         ConfigArgsConfigSource.setCliArgs("");
         SmallRyeConfig config = createConfig();
-        // the "nope" profile is not active, the property should not be advertised
-        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).noneMatch("quarkus.http.proxy.proxy-address-forwarding"::equals));
+        // profiled values are not support in keycloak.conf
+        assertNull(config.getConfigValue("key").getValue());
+    }
+
+    @Test
+    public void testProfiledPropertyExposure2() {
+        ConfigArgsConfigSource.setCliArgs("");
+        SmallRyeConfig config = createConfig();
+        // profiled values are not support in keycloak.conf
+        assertNull(config.getConfigValue("key").getValue());
     }
 
     @Test
@@ -598,14 +606,17 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void testReloadPeriod() {
         ConfigArgsConfigSource.setCliArgs("");
-        initConfig();
+        var config = createConfig();
         assertExternalConfig(Map.of(
                 "quarkus.http.ssl.certificate.reload-period", "1h",
                 "quarkus.management.ssl.certificate.reload-period", "1h"
         ));
+        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).anyMatch("quarkus.http.ssl.certificate.reload-period"::equals));
 
         ConfigArgsConfigSource.setCliArgs("--https-certificates-reload-period=-1");
-        initConfig();
+        config = createConfig();
+
+        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).noneMatch("quarkus.http.ssl.certificate.reload-period"::equals));
         assertExternalConfigNull("quarkus.http.ssl.certificate.reload-period");
         assertExternalConfigNull("quarkus.management.ssl.certificate.reload-period");
 

--- a/quarkus/runtime/src/test/resources/conf/keycloak.conf
+++ b/quarkus/runtime/src/test/resources/conf/keycloak.conf
@@ -9,4 +9,4 @@ config-keystore-password=secret
 #quarkus option should not be used
 quarkus.management.ssl.cipher-suites=foo
 
-%nope.proxy-headers=forwarded
+%nope.key=value


### PR DESCRIPTION
new database related options need to null themselves in the tranformer and not be seen by quarkus

closes: #46569

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
