### PR TITLE
[quarkus-next] Fix inconsistent Prometheus tag keys in user event met…

### DIFF
--- a/docs/guides/observability/metrics-for-troubleshooting-keycloak.adoc
+++ b/docs/guides/observability/metrics-for-troubleshooting-keycloak.adoc
@@ -41,10 +41,10 @@ The snippet below is an example of a response provided by the metric endpoint:
 ----
 # HELP keycloak_user_events_total Keycloak user events
 # TYPE keycloak_user_events_total counter
-keycloak_user_events_total{client_id="security-admin-console",event="code_to_token",realm="master"} 1.0
-keycloak_user_events_total{client_id="security-admin-console",event="login",realm="master"} 1.0
-keycloak_user_events_total{client_id="security-admin-console",event="logout",realm="master"} 1.0
-keycloak_user_events_total{client_id="security-admin-console",error="invalid_user_credentials",event="login",realm="master"} 1.0
+keycloak_user_events_total{client_id="security-admin-console",error="",event="code_to_token",idp="",realm="master",} 1.0
+keycloak_user_events_total{client_id="security-admin-console",error="",event="login",idp="",realm="master",} 1.0
+keycloak_user_events_total{client_id="security-admin-console",error="",event="logout",idp="",realm="master",} 1.0
+keycloak_user_events_total{client_id="security-admin-console",error="invalid_user_credentials",event="login",idp="",realm="master",} 1.0
 ----
 
 === Password hashing
@@ -82,7 +82,7 @@ The snippet below is an example of a response provided by the metric endpoint:
 ----
 # HELP keycloak_credentials_password_hashing_validations_total Password validations
 # TYPE keycloak_credentials_password_hashing_validations_total counter
-keycloak_credentials_password_hashing_validations_total{algorithm="argon2",hashing_strength="Argon2id-1.3[m=7168,t=5,p=1]",outcome="valid",realm="realm-0"} 39949.0
+keycloak_credentials_password_hashing_validations_total{algorithm="argon2",hashing_strength="Argon2id-1.3[m=7168,t=5,p=1]",outcome="valid",realm="realm-0",} 39949.0
 ----
 
 == Next steps

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/metrics/events/MicrometerUserEventMetricsEventListenerProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/metrics/events/MicrometerUserEventMetricsEventListenerProvider.java
@@ -126,9 +126,7 @@ public class MicrometerUserEventMetricsEventListenerProvider implements EventLis
     }
 
     private void addTag(List<Tag> tags, String tagName, String value) {
-        if (value != null && !value.isEmpty()) {
-            tags.add(Tag.of(tagName, value));
-        }
+        tags.add(Tag.of(tagName, value != null ? value : ""));
     }
 
     public static String format(EventType type) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventMetricsProviderTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/events/EventMetricsProviderTest.java
@@ -111,7 +111,7 @@ public class EventMetricsProviderTest extends AbstractKeycloakTest {
 
         testingClient.server().run(session -> {
             MatcherAssert.assertThat("Searching for metrics match in " + Metrics.globalRegistry.find("keycloak.user").meters(),
-                    Metrics.globalRegistry.counter("keycloak.user", "event", "login", "realm", TEST).count() == 1);
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "", "realm", TEST).count() == 1);
         });
 
         // Show all labels, but filter out events like logout@
@@ -149,7 +149,7 @@ public class EventMetricsProviderTest extends AbstractKeycloakTest {
             MatcherAssert.assertThat("Searching for login error metric",
                     Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "ERROR", "realm", TEST, "client.id", CLIENT_ID, "idp", "IDENTITY_PROVIDER").count() == 1);
             MatcherAssert.assertThat("Searching for refresh with unknown client",
-                    Metrics.globalRegistry.counter("keycloak.user", "event", "refresh_token", "error", "client_not_found", "realm", TEST, "client.id", "unknown").count() == 1);
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "refresh_token", "error", "client_not_found", "realm", TEST, "client.id", "unknown", "idp", "").count() == 1);
         });
 
     }


### PR DESCRIPTION
…rics

Closes: #47002

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Prometheus requires all meters with the same name to have identical tag key sets, so we now always include configured tag keys (using an empty string as the default value when the actual value is absent).