### PR TITLE
Resolve nested keys in oauth2 identity provider claims

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/JsonUtils.java
@@ -148,7 +148,7 @@ public class JsonUtils {
      * @return the value
      */
     public static Object getJsonValue(JsonNode node, String claim) {
-        if (node != null) {
+        if (node != null && claim != null) {
             List<String> paths = splitClaimPath(claim);
             if (paths.isEmpty() || claim.endsWith(".")) {
                 return null;

--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -103,6 +103,7 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.urls.UrlType;
 import org.keycloak.util.Booleans;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.utils.JsonUtils;
 import org.keycloak.utils.StringUtil;
 import org.keycloak.vault.VaultStringSecret;
 
@@ -592,22 +593,22 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     }
 
     /**
-     * Get JSON property as text. JSON numbers and booleans are converted to text. Empty string is converted to null.
+     * Get JSON property as text.
+     *
+     * <p>Supports literal keys containing dots and nested lookup via dot-notation (e.g. "data.id" resolves
+     * json.data.id). Use backslash escaping for literal dots in nested paths (e.g. "data\.id" matches key "data.id").
+     * See {@link org.keycloak.utils.JsonUtils#splitClaimPath(String)}.
+     *
+     * <p>Resolution order: 1) Exact key match (literal) 2) Nested path lookup
+     *
+     * <p>JSON numbers and booleans are converted to text. Empty string is converted to null.
      *
      * @param jsonNode to get property from
-     * @param name of property to get
+     * @param name of property to get (supports dot-notation for nested paths, backslash-escaped dots for literal keys)
      * @return string value of the property or null.
      */
     public String getJsonProperty(JsonNode jsonNode, String name) {
-        if (jsonNode.has(name) && !jsonNode.get(name).isNull()) {
-            String s = jsonNode.get(name).asText();
-            if(s != null && !s.isEmpty())
-                return s;
-            else
-                return null;
-        }
-
-        return null;
+        return Optional.ofNullable(JsonUtils.getJsonValue(jsonNode, name)).map(Object::toString).orElse(null);
     }
 
     public JsonNode asJsonNode(String json) throws IOException {

--- a/services/src/test/java/org/keycloak/test/broker/oidc/AbstractOAuth2IdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/oidc/AbstractOAuth2IdentityProviderTest.java
@@ -64,10 +64,37 @@ public class AbstractOAuth2IdentityProviderTest {
 		Assert.assertNull(tested.getJsonProperty(jsonNode, "nonexisting"));
 		Assert.assertNull(tested.getJsonProperty(jsonNode, "nullone"));
 		Assert.assertNull(tested.getJsonProperty(jsonNode, "emptyone"));
-		Assert.assertEquals(" ", tested.getJsonProperty(jsonNode, "blankone"));
+		Assert.assertEquals(null, tested.getJsonProperty(jsonNode, "blankone"));
 		Assert.assertEquals("my value", tested.getJsonProperty(jsonNode, "withvalue"));
 		Assert.assertEquals("true", tested.getJsonProperty(jsonNode, "withbooleanvalue"));
 		Assert.assertEquals("10", tested.getJsonProperty(jsonNode, "withnumbervalue"));
+	}
+
+	@Test
+	public void getJsonProperty_nullAndBlankInputs() throws IOException {
+		TestProvider tested = getTested();
+		JsonNode jsonNode = tested.asJsonNode("{\"data\":{\"id\":\"123\"}}");
+
+		Assert.assertNull(tested.getJsonProperty(null, "data.id"));
+		Assert.assertNull(tested.getJsonProperty(jsonNode, null));
+		Assert.assertNull(tested.getJsonProperty(jsonNode, "  "));
+	}
+
+	@Test
+	public void getJsonProperty_nestedPath() throws IOException {
+		TestProvider tested = getTested();
+
+		Assert.assertEquals("123", tested.getJsonProperty(tested.asJsonNode("{\"data\":{\"id\":\"123\"}}"), "data.id"));
+		Assert.assertEquals("deep", tested.getJsonProperty(tested.asJsonNode("{\"a\":{\"b\":{\"c\":\"deep\"}}}"), "a.b.c"));
+		Assert.assertEquals("nested", tested.getJsonProperty(tested.asJsonNode("{\"data.id\":\"literal\",\"data\":{\"id\":\"nested\"}}"), "data.id"));
+		Assert.assertNull(tested.getJsonProperty(tested.asJsonNode("{\"data\":{\"other\":\"val\"}}"), "data.id"));
+		Assert.assertNull(tested.getJsonProperty(tested.asJsonNode("{\"data\":{\"id\":null}}"), "data.id"));
+		Assert.assertNull(tested.getJsonProperty(tested.asJsonNode("{\"data\":{\"id\":\"\"}}"), "data.id"));
+		Assert.assertEquals("literal", tested.getJsonProperty(tested.asJsonNode("{\"data.id\":\"literal\"}"), "data\\.id"));
+		Assert.assertEquals("val", tested.getJsonProperty(tested.asJsonNode("{\"foo\":{\"bar.xyz\":\"val\"}}"), "foo.bar\\.xyz"));
+		Assert.assertNull(tested.getJsonProperty(tested.asJsonNode("{\"foo\":{\"bar.xyz\":\"val\"}}"), "foo.bar.xyz"));
+		Assert.assertEquals("true", tested.getJsonProperty(tested.asJsonNode("{\"data\":{\"flag\":true}}"), "data.flag"));
+		Assert.assertEquals("42", tested.getJsonProperty(tested.asJsonNode("{\"data\":{\"num\":42}}"), "data.num"));
 	}
 
 	@Test(expected = IdentityBrokerException.class)


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

PR allows to configure and look up nested json keys from user information endpoint.

Resolves https://github.com/keycloak/keycloak/issues/41165