### PR TITLE
Remove Tracing workaround in Infinispan/JGroups classes

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/infinispan/module/factory/OpenTelemetrySpan.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/module/factory/OpenTelemetrySpan.java
@@ -14,10 +14,6 @@ public class OpenTelemetrySpan<T> implements InfinispanSpan<T> {
 
     public OpenTelemetrySpan(Span span) {
         this.span = Objects.requireNonNull(span);
-        // TODO: This is actually wrong if you are doing asynchronous calls, but it allows the JGroups calls to be nested
-        // This should be fixed in ISPN 16+ so that it is no longer needed
-        // https://github.com/infinispan/infinispan/issues/15287
-        //this.scope = span.makeCurrent();
     }
 
     @Override


### PR DESCRIPTION
Closes #41629

This can safely be removed, as the code has already been uncommented for the 26.5 release, even before we upgraded to ISPN 16.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
