### PR TITLE
Save Remember Me authNote when an organization scope is set

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -199,7 +199,12 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         if (!enabledUser(context, user)) {
             return false;
         }
-        AuthenticatorUtils.processRememberMe(context, inputData);
+        // When the user was already set by a preceding authenticator (e.g. OrganizationAuthenticator),
+        // the username is hidden and the rememberMe checkbox is not rendered, so we must preserve
+        // any remember-me note set by the preceding authenticator.
+        if (!isUserAlreadySetBeforeUsernamePasswordAuth(context)) {
+            AuthenticatorUtils.processRememberMe(context, inputData);
+        }
         context.setUser(user);
         return true;
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/AbstractUsernameFormAuthenticator.java
@@ -199,9 +199,8 @@ public abstract class AbstractUsernameFormAuthenticator extends AbstractFormAuth
         if (!enabledUser(context, user)) {
             return false;
         }
-        // When the user was already set by a preceding authenticator (e.g. OrganizationAuthenticator),
-        // the username is hidden and the rememberMe checkbox is not rendered, so we must preserve
-        // any remember-me note set by the preceding authenticator.
+        // When the user is already set, the password form has no rememberMe checkbox,
+        // so the form data must not overwrite the authNote saved by the preceding authenticator.
         if (!isUserAlreadySetBeforeUsernamePasswordAuth(context)) {
             AuthenticatorUtils.processRememberMe(context, inputData);
         }

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -57,11 +57,13 @@ import org.keycloak.organization.forms.login.freemarker.model.OrganizationAwareR
 import org.keycloak.organization.protocol.mappers.oidc.OrganizationScope;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.Booleans;
 
 import static org.keycloak.authentication.AuthenticatorUtil.isSSOAuthentication;
+import static org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator.USER_SET_BEFORE_USERNAME_PASSWORD_AUTH;
 import static org.keycloak.models.OrganizationDomainModel.ANY_DOMAIN;
 import static org.keycloak.models.utils.KeycloakModelUtils.findUserByNameOrEmail;
 import static org.keycloak.organization.utils.Organizations.getEmailDomain;
@@ -441,6 +443,17 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
 
         if (loginHint != null) {
             form.setFormData(new MultivaluedHashMap<>(Map.of(UserModel.USERNAME, loginHint)));
+        } else {
+            context.getAuthenticationSession().removeAuthNote(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH);
+            String rememberMeUsername = AuthenticationManager.getRememberMeUsername(context.getSession());
+            MultivaluedHashMap<String, String> formData = new MultivaluedHashMap<>();
+
+            if (rememberMeUsername != null) {
+                formData.add(AuthenticationManager.FORM_USERNAME, rememberMeUsername);
+                formData.add("rememberMe", "on");
+                context.form().setFormData(formData);
+            }
+
         }
 
         return formCreator == null ? form.createLoginUsername() : formCreator.apply(form);

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -34,6 +34,7 @@ import org.keycloak.authentication.FlowStatus;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.authentication.authenticators.browser.IdentityProviderAuthenticator;
 import org.keycloak.authentication.authenticators.browser.WebAuthnConditionalUIAuthenticator;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.email.freemarker.beans.ProfileBean;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.forms.login.freemarker.model.AuthenticationContextBean;
@@ -110,6 +111,10 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         HttpRequest request = context.getHttpRequest();
         MultivaluedMap<String, String> parameters = request.getDecodedFormParameters();
         String username = parameters.getFirst(UserModel.USERNAME);
+
+        // preserve the rememberMe selection from the identity-first login form
+        // so it is not lost when the flow continues to the password authenticator
+        AuthenticatorUtils.processRememberMe(context, parameters);
 
         // check if it's a webauthn submission and perform the webauth login
         if (webauthnAuth.isPasskeysEnabled() && (parameters.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA)

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -114,9 +114,11 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         MultivaluedMap<String, String> parameters = request.getDecodedFormParameters();
         String username = parameters.getFirst(UserModel.USERNAME);
 
-        // preserve the rememberMe selection from the identity-first login form
-        // so it is not lost when the flow continues to the password authenticator
-        AuthenticatorUtils.processRememberMe(context, parameters);
+        // Skip when re-entered from a form without the rememberMe field (e.g. select-organization.ftl):
+        // an unconditional call would clear the authNote saved on the first action() call.
+        if (parameters.containsKey("rememberMe")) {
+            AuthenticatorUtils.processRememberMe(context, parameters);
+        }
 
         // check if it's a webauthn submission and perform the webauth login
         if (webauthnAuth.isPasskeysEnabled() && (parameters.containsKey(WebAuthnConstants.AUTHENTICATOR_DATA)
@@ -446,14 +448,12 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         } else {
             context.getAuthenticationSession().removeAuthNote(USER_SET_BEFORE_USERNAME_PASSWORD_AUTH);
             String rememberMeUsername = AuthenticationManager.getRememberMeUsername(context.getSession());
-            MultivaluedHashMap<String, String> formData = new MultivaluedHashMap<>();
-
             if (rememberMeUsername != null) {
+                MultivaluedHashMap<String, String> formData = new MultivaluedHashMap<>();
                 formData.add(AuthenticationManager.FORM_USERNAME, rememberMeUsername);
                 formData.add("rememberMe", "on");
-                context.form().setFormData(formData);
+                form.setFormData(formData);
             }
-
         }
 
         return formCreator == null ? form.createLoginUsername() : formCreator.apply(form);

--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/SelectOrganizationPage.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/SelectOrganizationPage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testframework.ui.page;
+
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class SelectOrganizationPage extends AbstractLoginPage {
+
+    public SelectOrganizationPage(ManagedWebDriver driver) {
+        super(driver);
+    }
+
+    public void selectOrganization(String alias) {
+        WebElement button = driver.findElement(By.id("organization-" + alias));
+        button.click();
+    }
+
+    public boolean isOrganizationButtonPresent(String alias) {
+        return !driver.driver().findElements(By.id("organization-" + alias)).isEmpty();
+    }
+
+    @Override
+    public String getExpectedPageId() {
+        return "login-select-organization";
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/organization/authentication/OrganizationRememberMeAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/authentication/OrganizationRememberMeAuthenticationTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.organization.authentication;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.page.LoginUsernamePage;
+import org.keycloak.testframework.ui.page.SelectOrganizationPage;
+import org.keycloak.tests.organization.admin.AbstractOrganizationTest;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the Remember Me note is preserved through the identity-first
+ * login flow rendered by the {@code OrganizationAuthenticator}, both for the
+ * initial login and when reopening the form after the user session is destroyed.
+ */
+@KeycloakIntegrationTest
+public class OrganizationRememberMeAuthenticationTest extends AbstractOrganizationTest {
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectPage
+    LoginUsernamePage usernamePage;
+
+    @InjectPage
+    LoginPage loginPage;
+
+    @InjectPage
+    SelectOrganizationPage selectOrganizationPage;
+
+    @InjectEvents
+    Events events;
+
+    @Test
+    public void testRememberMeWithOrganizationScope() {
+        realm.updateWithCleanup(r -> r.setRememberMe(true));
+
+        OrganizationResource organization = realm.admin().organizations().get(createOrganization().getId());
+        UserRepresentation member = addMember(organization, "contractor@contractor.org", "Contractor", "User");
+        String email = member.getEmail();
+
+        oauth.scope("organization").openLoginForm();
+        usernamePage.assertCurrent();
+        usernamePage.rememberMe(true);
+        assertTrue(usernamePage.isRememberMe());
+        usernamePage.fillLoginWithUsernameOnly(email);
+        usernamePage.submit();
+
+        loginPage.assertCurrent();
+        loginPage.fillPassword(memberPassword);
+        loginPage.submit();
+        oauth.parseLoginResponse();
+
+        List<UserSessionRepresentation> sessions = realm.admin().users().get(member.getId()).getUserSessions();
+        assertEquals(1, sessions.size());
+        assertTrue(sessions.get(0).isRememberMe(),
+                "User session should have rememberMe enabled");
+
+        EventRepresentation login1 = awaitNextEvent();
+        EventAssertion.assertSuccess(login1)
+                .type(EventType.LOGIN)
+                .clientId("test-app")
+                .userId(member.getId())
+                .details(Details.USERNAME, email)
+                .details(Details.REMEMBER_ME, "true");
+
+        realm.admin().deleteSession(login1.getSessionId(), false);
+
+        oauth.scope("organization").openLoginForm();
+        usernamePage.assertCurrent();
+        assertTrue(usernamePage.isRememberMe(),
+                "rememberMe should be pre-checked after session expiry");
+        assertEquals(email, usernamePage.getUsername());
+
+        usernamePage.rememberMe(false);
+        usernamePage.submit();
+
+        loginPage.assertCurrent();
+        loginPage.fillPassword(memberPassword);
+        loginPage.submit();
+        oauth.parseLoginResponse();
+
+        EventRepresentation login2 = awaitNextEvent();
+        EventAssertion.assertSuccess(login2)
+                .type(EventType.LOGIN)
+                .clientId("test-app")
+                .userId(member.getId())
+                .details(Details.USERNAME, email)
+                .withoutDetails(Details.REMEMBER_ME);
+
+        realm.admin().deleteSession(login2.getSessionId(), false);
+
+        oauth.scope("organization").openLoginForm();
+        usernamePage.assertCurrent();
+        assertFalse(usernamePage.isRememberMe(),
+                "rememberMe should not be pre-checked after disabling it");
+        assertEquals("", usernamePage.getUsername(),
+                "username field should be empty after session expiry without rememberMe");
+    }
+
+    @Test
+    public void testRememberMeNotCheckedWithOrganizationScope() {
+        realm.updateWithCleanup(r -> r.setRememberMe(true));
+
+        OrganizationResource organization = realm.admin().organizations().get(createOrganization().getId());
+        UserRepresentation member = addMember(organization, "contractor@contractor.org", "Contractor", "User");
+        String email = member.getEmail();
+
+        oauth.scope("organization").openLoginForm();
+        usernamePage.assertCurrent();
+        assertFalse(usernamePage.isRememberMe());
+        usernamePage.fillLoginWithUsernameOnly(email);
+        usernamePage.submit();
+
+        loginPage.assertCurrent();
+        loginPage.fillPassword(memberPassword);
+        loginPage.submit();
+        oauth.parseLoginResponse();
+
+        List<UserSessionRepresentation> sessions = realm.admin().users().get(member.getId()).getUserSessions();
+        assertEquals(1, sessions.size());
+        assertFalse(sessions.get(0).isRememberMe(),
+                "User session should not have rememberMe enabled");
+
+        EventRepresentation login = awaitNextEvent();
+        EventAssertion.assertSuccess(login)
+                .type(EventType.LOGIN)
+                .clientId("test-app")
+                .userId(member.getId())
+                .details(Details.USERNAME, email)
+                .withoutDetails(Details.REMEMBER_ME);
+    }
+
+    @Test
+    public void testRememberMePreservedThroughSelectOrganization() {
+        realm.updateWithCleanup(r -> r.setRememberMe(true));
+
+        OrganizationRepresentation orgA = createOrganization("orga");
+        OrganizationRepresentation orgB = createOrganization("orgb");
+        OrganizationResource orgAResource = realm.admin().organizations().get(orgA.getId());
+        OrganizationResource orgBResource = realm.admin().organizations().get(orgB.getId());
+
+        UserRepresentation member = addMember(orgAResource, "member@orga.org", "Member", "User");
+        orgBResource.members().addMember(member.getId()).close();
+        String email = member.getEmail();
+
+        oauth.scope("organization").openLoginForm();
+        usernamePage.assertCurrent();
+        usernamePage.rememberMe(true);
+        usernamePage.fillLoginWithUsernameOnly(email);
+        usernamePage.submit();
+
+        selectOrganizationPage.assertCurrent();
+        assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgA.getAlias()));
+        assertTrue(selectOrganizationPage.isOrganizationButtonPresent(orgB.getAlias()));
+        selectOrganizationPage.selectOrganization(orgA.getAlias());
+
+        loginPage.assertCurrent();
+        loginPage.fillPassword(memberPassword);
+        loginPage.submit();
+        oauth.parseLoginResponse();
+
+        // Regression check: the select-organization round-trip must not wipe the rememberMe authNote.
+        List<UserSessionRepresentation> sessions = realm.admin().users().get(member.getId()).getUserSessions();
+        assertEquals(1, sessions.size());
+        assertTrue(sessions.get(0).isRememberMe(),
+                "rememberMe should survive the select-organization round-trip");
+
+        EventRepresentation login = awaitNextEvent();
+        EventAssertion.assertSuccess(login)
+                .type(EventType.LOGIN)
+                .clientId("test-app")
+                .userId(member.getId())
+                .details(Details.USERNAME, email)
+                .details(Details.REMEMBER_ME, "true");
+    }
+
+    // The login event is published asynchronously after the OAuth callback completes,
+    // so a single events.poll() may return null between callback receipt and event-store persistence.
+    private EventRepresentation awaitNextEvent() {
+        return Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(50))
+                .until(events::poll, Objects::nonNull);
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
@@ -615,13 +615,42 @@ public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
             Assertions.assertTrue(sessions.get(0).isRememberMe(), "User session should have rememberMe enabled");
 
             // Also verify the login event records remember_me
-            events.expectLogin()
+            EventRepresentation loginEvent = events.expectLogin()
                     .client("broker-app")
                     .user(member.getId())
                     .detail(Details.USERNAME, email)
                     .detail(Details.REMEMBER_ME, "true")
                     .removeDetail(Details.REDIRECT_URI)
                     .assertEvent();
+            String sessionId = loginEvent.getSessionId();
+            // Expire the user session
+            testingClient.testing(bc.consumerRealmName()).removeUserSession(bc.consumerRealmName(), sessionId);
+            // After session expiry, opening login should show rememberMe pre-checked and email prefilled
+            loginPage.open(bc.consumerRealmName());
+            Assertions.assertTrue(loginPage.isRememberMeChecked(), "rememberMe should be pre-checked after session expiry");
+            assertEquals(member.getEmail(), loginPage.getUsername());
+
+            // disable rememberMe
+            loginPage.setRememberMe(false);
+            Assertions.assertFalse(loginPage.isRememberMeChecked());
+            loginPage.loginUsername(email);
+            waitForPage(driver, "sign in to", true);
+            Assertions.assertTrue(loginPage.isPasswordInputPresent());
+            Assertions.assertFalse(loginPage.isRememberMeCheckboxPresent());
+            loginPage.login(memberPassword);
+            appPage.assertCurrent();
+            loginEvent = events.expectLogin()
+                    .client("broker-app")
+                    .user(member.getId())
+                    .detail(Details.USERNAME, email)
+                    .removeDetail(Details.REDIRECT_URI)
+                    .assertEvent();
+            sessionId = loginEvent.getSessionId();
+            // Expire the user session
+            testingClient.testing(bc.consumerRealmName()).removeUserSession(bc.consumerRealmName(), sessionId);
+            loginPage.open(bc.consumerRealmName());
+            Assertions.assertFalse(loginPage.isRememberMeChecked(), "rememberMe should not be pre-checked as it was disabled");
+            assertEquals("", loginPage.getUsername());
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
@@ -27,16 +27,20 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.events.Details;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.organization.authentication.authenticators.browser.OrganizationAuthenticatorFactory;
 import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.remote.providers.runonserver.RunOnServer;
+import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AdminApiUtil;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.broker.KcOidcBrokerConfiguration;
@@ -47,6 +51,7 @@ import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
@@ -59,6 +64,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
 
     @Test
     public void testAuthenticateUnmanagedMember() {
@@ -562,6 +570,103 @@ public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
         // username should still be preserved after switching
         loginPage.assertAttemptedUsernameAvailability(true);
         assertThat(loginPage.getAttemptedUsername(), is(member.getEmail()));
+    }
+
+    @Test
+    public void testRememberMeWithOrganizationScope() throws IOException {
+        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(managedRealm.admin())
+                .setRememberMe(Boolean.TRUE)
+                .update()) {
+
+            OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+            UserRepresentation member = addMember(organization, "contractor@contractor.org");
+            String email = member.getEmail();
+
+            // Open the identity-first login page manually so we can interact with Remember Me before submitting
+            oauth.client("broker-app");
+            loginPage.open(bc.consumerRealmName());
+
+            // Identity-first page: username present, no password, Remember Me checkbox present and unchecked
+            Assertions.assertTrue(loginPage.isUsernameInputPresent());
+            Assertions.assertFalse(loginPage.isPasswordInputPresent());
+            Assertions.assertTrue(loginPage.isRememberMeCheckboxPresent());
+            Assertions.assertFalse(loginPage.isRememberMeChecked());
+
+            // Check Remember Me, then submit username
+            loginPage.setRememberMe(true);
+            Assertions.assertTrue(loginPage.isRememberMeChecked());
+            loginPage.loginUsername(email);
+
+            // Wait for password page
+            waitForPage(driver, "sign in to", true);
+
+            // Password page: password present, Remember Me checkbox NOT present (hidden in org flow)
+            Assertions.assertTrue(loginPage.isPasswordInputPresent());
+            Assertions.assertFalse(loginPage.isRememberMeCheckboxPresent());
+
+            // Submit password
+            loginPage.login(memberPassword);
+            appPage.assertCurrent();
+
+            // Verify the user session was created with rememberMe=true,
+            // proving the auth note survived the two-step org flow
+            List<UserSessionRepresentation> sessions = managedRealm.admin().users().get(member.getId()).getUserSessions();
+            assertEquals(1, sessions.size());
+            Assertions.assertTrue(sessions.get(0).isRememberMe(), "User session should have rememberMe enabled");
+
+            // Also verify the login event records remember_me
+            events.expectLogin()
+                    .client("broker-app")
+                    .user(member.getId())
+                    .detail(Details.USERNAME, email)
+                    .detail(Details.REMEMBER_ME, "true")
+                    .removeDetail(Details.REDIRECT_URI)
+                    .assertEvent();
+        }
+    }
+
+    @Test
+    public void testRememberMeNotCheckedWithOrganizationScope() throws IOException {
+        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(managedRealm.admin())
+                .setRememberMe(Boolean.TRUE)
+                .update()) {
+
+            OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+            UserRepresentation member = addMember(organization, "contractor@contractor.org");
+            String email = member.getEmail();
+
+            // Open the identity-first login page manually
+            oauth.client("broker-app");
+            loginPage.open(bc.consumerRealmName());
+
+            // Verify Remember Me checkbox is present but NOT checked; do not check it
+            Assertions.assertTrue(loginPage.isRememberMeCheckboxPresent());
+            Assertions.assertFalse(loginPage.isRememberMeChecked());
+
+            // Submit username
+            loginPage.loginUsername(email);
+
+            // Wait for password page
+            waitForPage(driver, "sign in to", true);
+
+            // Submit password
+            loginPage.login(memberPassword);
+            appPage.assertCurrent();
+
+            // Verify the user session was created WITHOUT rememberMe
+            List<UserSessionRepresentation> sessions = managedRealm.admin().users().get(member.getId()).getUserSessions();
+            assertEquals(1, sessions.size());
+            Assertions.assertFalse(sessions.get(0).isRememberMe(), "User session should NOT have rememberMe enabled");
+
+            // Also verify the login event does NOT have remember_me detail
+            EventRepresentation loginEvent = events.expectLogin()
+                    .client("broker-app")
+                    .user(member.getId())
+                    .detail(Details.USERNAME, email)
+                    .removeDetail(Details.REDIRECT_URI)
+                    .assertEvent();
+            assertThat(loginEvent.getDetails().get(Details.REMEMBER_ME), Matchers.nullValue());
+        }
     }
 
     private void runOnServer(RunOnServer function) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/authentication/OrganizationAuthenticationTest.java
@@ -27,20 +27,16 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.resource.OrganizationResource;
-import org.keycloak.events.Details;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel.RequiredAction;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.organization.authentication.authenticators.browser.OrganizationAuthenticatorFactory;
 import org.keycloak.representations.AccessToken;
-import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.remote.providers.runonserver.RunOnServer;
-import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AdminApiUtil;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.broker.KcOidcBrokerConfiguration;
@@ -51,7 +47,6 @@ import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
@@ -64,9 +59,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
-
-    @Rule
-    public AssertEvents events = new AssertEvents(this);
 
     @Test
     public void testAuthenticateUnmanagedMember() {
@@ -570,132 +562,6 @@ public class OrganizationAuthenticationTest extends AbstractOrganizationTest {
         // username should still be preserved after switching
         loginPage.assertAttemptedUsernameAvailability(true);
         assertThat(loginPage.getAttemptedUsername(), is(member.getEmail()));
-    }
-
-    @Test
-    public void testRememberMeWithOrganizationScope() throws IOException {
-        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(managedRealm.admin())
-                .setRememberMe(Boolean.TRUE)
-                .update()) {
-
-            OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
-            UserRepresentation member = addMember(organization, "contractor@contractor.org");
-            String email = member.getEmail();
-
-            // Open the identity-first login page manually so we can interact with Remember Me before submitting
-            oauth.client("broker-app");
-            loginPage.open(bc.consumerRealmName());
-
-            // Identity-first page: username present, no password, Remember Me checkbox present and unchecked
-            Assertions.assertTrue(loginPage.isUsernameInputPresent());
-            Assertions.assertFalse(loginPage.isPasswordInputPresent());
-            Assertions.assertTrue(loginPage.isRememberMeCheckboxPresent());
-            Assertions.assertFalse(loginPage.isRememberMeChecked());
-
-            // Check Remember Me, then submit username
-            loginPage.setRememberMe(true);
-            Assertions.assertTrue(loginPage.isRememberMeChecked());
-            loginPage.loginUsername(email);
-
-            // Wait for password page
-            waitForPage(driver, "sign in to", true);
-
-            // Password page: password present, Remember Me checkbox NOT present (hidden in org flow)
-            Assertions.assertTrue(loginPage.isPasswordInputPresent());
-            Assertions.assertFalse(loginPage.isRememberMeCheckboxPresent());
-
-            // Submit password
-            loginPage.login(memberPassword);
-            appPage.assertCurrent();
-
-            // Verify the user session was created with rememberMe=true,
-            // proving the auth note survived the two-step org flow
-            List<UserSessionRepresentation> sessions = managedRealm.admin().users().get(member.getId()).getUserSessions();
-            assertEquals(1, sessions.size());
-            Assertions.assertTrue(sessions.get(0).isRememberMe(), "User session should have rememberMe enabled");
-
-            // Also verify the login event records remember_me
-            EventRepresentation loginEvent = events.expectLogin()
-                    .client("broker-app")
-                    .user(member.getId())
-                    .detail(Details.USERNAME, email)
-                    .detail(Details.REMEMBER_ME, "true")
-                    .removeDetail(Details.REDIRECT_URI)
-                    .assertEvent();
-            String sessionId = loginEvent.getSessionId();
-            // Expire the user session
-            testingClient.testing(bc.consumerRealmName()).removeUserSession(bc.consumerRealmName(), sessionId);
-            // After session expiry, opening login should show rememberMe pre-checked and email prefilled
-            loginPage.open(bc.consumerRealmName());
-            Assertions.assertTrue(loginPage.isRememberMeChecked(), "rememberMe should be pre-checked after session expiry");
-            assertEquals(member.getEmail(), loginPage.getUsername());
-
-            // disable rememberMe
-            loginPage.setRememberMe(false);
-            Assertions.assertFalse(loginPage.isRememberMeChecked());
-            loginPage.loginUsername(email);
-            waitForPage(driver, "sign in to", true);
-            Assertions.assertTrue(loginPage.isPasswordInputPresent());
-            Assertions.assertFalse(loginPage.isRememberMeCheckboxPresent());
-            loginPage.login(memberPassword);
-            appPage.assertCurrent();
-            loginEvent = events.expectLogin()
-                    .client("broker-app")
-                    .user(member.getId())
-                    .detail(Details.USERNAME, email)
-                    .removeDetail(Details.REDIRECT_URI)
-                    .assertEvent();
-            sessionId = loginEvent.getSessionId();
-            // Expire the user session
-            testingClient.testing(bc.consumerRealmName()).removeUserSession(bc.consumerRealmName(), sessionId);
-            loginPage.open(bc.consumerRealmName());
-            Assertions.assertFalse(loginPage.isRememberMeChecked(), "rememberMe should not be pre-checked as it was disabled");
-            assertEquals("", loginPage.getUsername());
-        }
-    }
-
-    @Test
-    public void testRememberMeNotCheckedWithOrganizationScope() throws IOException {
-        try (RealmAttributeUpdater rau = new RealmAttributeUpdater(managedRealm.admin())
-                .setRememberMe(Boolean.TRUE)
-                .update()) {
-
-            OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
-            UserRepresentation member = addMember(organization, "contractor@contractor.org");
-            String email = member.getEmail();
-
-            // Open the identity-first login page manually
-            oauth.client("broker-app");
-            loginPage.open(bc.consumerRealmName());
-
-            // Verify Remember Me checkbox is present but NOT checked; do not check it
-            Assertions.assertTrue(loginPage.isRememberMeCheckboxPresent());
-            Assertions.assertFalse(loginPage.isRememberMeChecked());
-
-            // Submit username
-            loginPage.loginUsername(email);
-
-            // Wait for password page
-            waitForPage(driver, "sign in to", true);
-
-            // Submit password
-            loginPage.login(memberPassword);
-            appPage.assertCurrent();
-
-            // Verify the user session was created WITHOUT rememberMe
-            List<UserSessionRepresentation> sessions = managedRealm.admin().users().get(member.getId()).getUserSessions();
-            assertEquals(1, sessions.size());
-            Assertions.assertFalse(sessions.get(0).isRememberMe(), "User session should NOT have rememberMe enabled");
-
-            // Also verify the login event does NOT have remember_me detail
-            EventRepresentation loginEvent = events.expectLogin()
-                    .client("broker-app")
-                    .user(member.getId())
-                    .detail(Details.USERNAME, email)
-                    .removeDetail(Details.REDIRECT_URI)
-                    .assertEvent();
-            assertThat(loginEvent.getDetails().get(Details.REMEMBER_ME), Matchers.nullValue());
-        }
     }
 
     private void runOnServer(RunOnServer function) {


### PR DESCRIPTION
Prevent cleanup of Remember Me by AbstractUsernameFormAuthenticator if the checkbox is absent from the page (which is the case when using organization flow).

This PR make the assumption that OrganizationAuthenticator will execute before AbstractUserNameFormAuthenticator when the organization scope is specified. 

Generative AI was used during the writing of this pull request for the code. Originally it was just to figure out where the issue lied but since the fix it proposed (which I tested locally) worked. I figured I would make a pull request about it.
I made some adjustment to mimic the "remove auth note when rememberMe is absent". Otherwise it looked like the note would never get cleaned up from a session.

Closes #47017