### PR TITLE
26.4 Backport: Use quay.io instead of DockerHub in testsuite createCurlContainer()

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/utils/K8sUtils.java
@@ -167,7 +167,7 @@ public final class K8sUtils {
     private static void createCurlContainer(PodBuilder builder) {
         builder.withNewSpec()
                 .addNewContainer()
-                .withImage("curlimages/curl:8.1.2")
+                .withImage("quay.io/curl/curl:8.1.2")
                 .withCommand("sh")
                 .withName("curl")
                 .withStdin()


### PR DESCRIPTION
Re: #47025