### PR TITLE
Support raw Quarkus properties in operator additionalOptions

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -76,6 +76,7 @@ import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 import io.quarkus.logging.Log;
 
 import static org.keycloak.operator.Utils.addResources;
+import static io.smallrye.config.common.utils.StringUtil.replaceNonAlphanumericByUnderscores;
 import static org.keycloak.operator.controllers.KeycloakDistConfigurator.getKeycloakOptionEnvVarName;
 import static org.keycloak.operator.crds.v2alpha1.CRDUtils.LEGACY_MANAGEMENT_ENABLED;
 import static org.keycloak.operator.crds.v2alpha1.CRDUtils.isTlsConfigured;
@@ -559,7 +560,14 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
         // set env vars
         List<EnvVar> envVars = serverConfigsList.stream()
                 .flatMap(v -> {
-                    var envBuilder = new EnvVarBuilder().withName(getKeycloakOptionEnvVarName(v.getName()));
+                    // Quarkus properties (starting with "quarkus.") must be set as env vars
+                    // without the KC_ prefix, so that SmallRye Config can pick them up directly.
+                    boolean isQuarkusProperty = v.getName().startsWith("quarkus.");
+                    String envVarName = isQuarkusProperty
+                            ? replaceNonAlphanumericByUnderscores(v.getName()).toUpperCase()
+                            : getKeycloakOptionEnvVarName(v.getName());
+
+                    var envBuilder = new EnvVarBuilder().withName(envVarName);
                     var secret = v.getSecret();
                     if (secret != null) {
                         envBuilder.withValueFrom(
@@ -568,7 +576,9 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
                         envBuilder.withValue(v.getValue());
                     }
                     EnvVar mainVar = envBuilder.build();
-                    if (!defaultKeys.contains(v.getName())) {
+                    // Quarkus properties don't need KCKEY_ companions as they bypass
+                    // KcEnvConfigSource and are handled directly by SmallRye Config.
+                    if (!defaultKeys.contains(v.getName()) && !isQuarkusProperty) {
                         EnvVar keyVar = new EnvVarBuilder()
                                 .withName("KCKEY_" + mainVar.getName().substring(KeycloakDistConfigurator.KC_PREFIX.length()))
                                 .withValue(v.getName()).build();

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -618,6 +618,45 @@ public class PodTemplateTest {
     }
 
     @Test
+    public void testQuarkusPropertyInAdditionalOptions() {
+        // Arrange
+        PodTemplateSpec additionalPodTemplate = null;
+
+        var additionalOptions = List.of(
+                new ValueOrSecret("quarkus.log.console.json.additional-field.\"service.name\".value", "my-service"),
+                new ValueOrSecret("quarkus.log.console.json.additional-field.\"service.environment\".value", "production")
+        );
+
+        // Act
+        var podTemplate = getDeployment(additionalPodTemplate, null,
+                s -> s.addAllToAdditionalOptions(additionalOptions))
+                .getSpec().getTemplate();
+
+        // Assert - Quarkus properties should NOT have KC_ prefix and should NOT have KCKEY_ companions
+        var envVars = podTemplate.getSpec().getContainers().get(0).getEnv().stream()
+                .filter(e -> e.getValue() != null)
+                .collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+
+        // Env var names should follow SmallRye convention (no KC_ prefix)
+        assertThat(envVars).containsEntry(
+                "QUARKUS_LOG_CONSOLE_JSON_ADDITIONAL_FIELD__SERVICE_NAME__VALUE", "my-service");
+        assertThat(envVars).containsEntry(
+                "QUARKUS_LOG_CONSOLE_JSON_ADDITIONAL_FIELD__SERVICE_ENVIRONMENT__VALUE", "production");
+
+        // Should NOT have KC_ prefixed versions
+        assertThat(envVars).doesNotContainKey(
+                "KC_QUARKUS_LOG_CONSOLE_JSON_ADDITIONAL_FIELD__SERVICE_NAME__VALUE");
+        assertThat(envVars).doesNotContainKey(
+                "KC_QUARKUS_LOG_CONSOLE_JSON_ADDITIONAL_FIELD__SERVICE_ENVIRONMENT__VALUE");
+
+        // Should NOT have KCKEY_ companions
+        assertThat(envVars).doesNotContainKey(
+                "KCKEY_QUARKUS_LOG_CONSOLE_JSON_ADDITIONAL_FIELD__SERVICE_NAME__VALUE");
+        assertThat(envVars).doesNotContainKey(
+                "KCKEY_QUARKUS_LOG_CONSOLE_JSON_ADDITIONAL_FIELD__SERVICE_ENVIRONMENT__VALUE");
+    }
+
+    @Test
     public void testImageForceOptimized() {
         // Arrange
         PodTemplateSpec additionalPodTemplate = null;


### PR DESCRIPTION
Closes #47086

Signed-off-by: Daniele Mammarella <dmammare@redhat.com>

additionalOptions entries starting with "quarkus." are now set as environment variables without the KC_ prefix, so that SmallRye Config can resolve them directly. Previously, all additionalOptions were unconditionally prefixed with KC_, causing raw Quarkus properties (e.g. quarkus.log.console.json.additional-field."service.name".value) to be mapped to kc.quarkus.* which SmallRye Config does not recognize.

KCKEY_ companion variables are also skipped for Quarkus properties since they bypass KcEnvConfigSource entirely.