### PR TITLE
[Backport 26.5] Do not cache users when failing validations from their storage providers

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -67,6 +67,7 @@ import org.keycloak.models.cache.infinispan.events.UserUpdatedEvent;
 import org.keycloak.models.cache.infinispan.stream.InIdentityProviderPredicate;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
+import org.keycloak.models.utils.StorageUnavailableUserModelDelegate;
 import org.keycloak.storage.CacheableStorageProviderModel;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.OnCreateComponent;
@@ -403,6 +404,10 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
             UserStorageProviderModel model = new UserStorageProviderModel(component);
             if (!model.isEnabled()) {
                 return new ReadOnlyUserModelDelegate(delegate, false);
+            }
+
+            if (delegate instanceof StorageUnavailableUserModelDelegate) {
+                return delegate;
             }
 
             long lifespan = getLifespan(realm, delegate);

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -59,6 +59,7 @@ import org.keycloak.models.cache.OnUserCache;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.utils.ComponentUtil;
 import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
+import org.keycloak.models.utils.StorageUnavailableUserModelDelegate;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.storage.client.ClientStorageProvider;
 import org.keycloak.storage.datastore.DefaultDatastoreProvider;
@@ -168,7 +169,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
             return validated;
         } catch (Exception e) {
             logger.warnf(e, "User storage provider %s failed during federated user validation", model.getName());
-            return new ReadOnlyUserModelDelegate(user, false, ignore -> new ReadOnlyException("The user is read-only. The user storage provider '" + model.getName() + "' is currently unavailable. Check the server logs for more details."));
+            return new StorageUnavailableUserModelDelegate(user, ignore -> new ReadOnlyException("The user is read-only. The user storage provider '" + model.getName() + "' is currently unavailable. Check the server logs for more details."));
         }
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/StorageUnavailableUserModelDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/StorageUnavailableUserModelDelegate.java
@@ -1,0 +1,12 @@
+package org.keycloak.models.utils;
+
+import java.util.function.Function;
+
+import org.keycloak.models.UserModel;
+
+public class StorageUnavailableUserModelDelegate extends ReadOnlyUserModelDelegate {
+
+    public StorageUnavailableUserModelDelegate(UserModel delegate, Function<String, RuntimeException> exceptionCreator) {
+        super(delegate, false, exceptionCreator);
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProvider.java
@@ -57,11 +57,13 @@ public class FailableHardcodedStorageProvider implements UserStorageProvider, Us
     protected ComponentModel model;
     protected KeycloakSession session;
     protected boolean componentFail;
+    private boolean failOnValidation;
 
-    public FailableHardcodedStorageProvider(ComponentModel model, KeycloakSession session) {
+    public FailableHardcodedStorageProvider(ComponentModel model, KeycloakSession session, boolean failOnValidation) {
         this.model = model;
         this.session = session;
         componentFail = isInFailMode(model);
+        this.failOnValidation = failOnValidation;
     }
 
     public static boolean isInFailMode(ComponentModel model) {
@@ -169,6 +171,9 @@ public class FailableHardcodedStorageProvider implements UserStorageProvider, Us
     @Override
     public UserModel validate(RealmModel realm, UserModel user) {
         checkForceFail();
+        if (failOnValidation) {
+            throw new RuntimeException("Forcing validation failure");
+        }
         return new Delegate(user);
     }
 

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/FailableHardcodedStorageProviderFactory.java
@@ -36,10 +36,11 @@ import org.keycloak.storage.user.SynchronizationResult;
 public class FailableHardcodedStorageProviderFactory implements UserStorageProviderFactory<FailableHardcodedStorageProvider>, ImportSynchronization {
 
     public static final String PROVIDER_ID = "failable-hardcoded-storage";
+    private boolean failOnValidation;
 
     @Override
     public FailableHardcodedStorageProvider create(KeycloakSession session, ComponentModel model) {
-        return new FailableHardcodedStorageProvider(model, session);
+        return new FailableHardcodedStorageProvider(model, session, isFailOnValidation());
     }
 
     @Override
@@ -67,5 +68,13 @@ public class FailableHardcodedStorageProviderFactory implements UserStorageProvi
     public SynchronizationResult syncSince(Date lastSync, KeycloakSessionFactory sessionFactory, String realmId, UserStorageProviderModel model) {
         if (FailableHardcodedStorageProvider.isInFailMode(model)) FailableHardcodedStorageProvider.throwFailure();
         return SynchronizationResult.empty();
+    }
+
+    public void setFailOnValidation(boolean enabled) {
+        this.failOnValidation = enabled;
+    }
+
+    public boolean isFailOnValidation() {
+        return failOnValidation;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPAdminRestApiTest.java
@@ -59,6 +59,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -259,6 +260,8 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
         assertThat(user1.isEnabled(), is(false));
 
         UserResource userResource = testRealm().users().get(newUserId1);
+        user1 = userResource.toRepresentation();
+        assertFalse(user1.isEnabled());
 
         try {
             user1.setFirstName(user1.getFirstName() + " updated");
@@ -281,6 +284,15 @@ public class LDAPAdminRestApiTest extends AbstractLDAPTest {
         user1 = userResource.toRepresentation();
         assertTrue(user1.isEnabled());
         assertEquals("changed", user1.getLastName());
+
+        ldapProvider.getConfig().put(LDAPConstants.CONNECTION_URL, List.of("ldap://invalid"));
+        testRealm().components().component(ldapProvider.getId()).update(ldapProvider);
+        user1 = userResource.toRepresentation();
+        assertFalse(user1.isEnabled());
+        ldapProviderValid.getConfig().put(LDAPConstants.CONNECTION_URL, originalUrl);
+        testRealm().components().component(ldapProviderValid.getId()).update(ldapProviderValid);
+        user1 = userResource.toRepresentation();
+        assertTrue(user1.isEnabled());
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageFailureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/UserStorageFailureTest.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.testsuite.federation.storage;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,7 +38,9 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.RealmManager;
+import org.keycloak.storage.CacheableStorageProviderModel.CachePolicy;
 import org.keycloak.storage.UserStoragePrivateUtil;
 import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderModel;
@@ -59,6 +62,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static org.keycloak.storage.CacheableStorageProviderModel.CACHE_POLICY;
+import static org.keycloak.storage.CacheableStorageProviderModel.MAX_LIFESPAN;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -202,6 +212,19 @@ public class UserStorageFailureTest extends AbstractTestRealmKeycloakTest {
             memoryProvider.getConfig().putSingle("fail", Boolean.toString(toggle));
             realm.updateComponent(memoryProvider);
         });
+        getCleanup().addCleanup(() -> testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName(AuthRealm.TEST);
+            ComponentModel memoryProvider = realm.getComponent(failureProviderId);
+            memoryProvider.getConfig().remove("fail");
+            realm.updateComponent(memoryProvider);
+        }));
+    }
+
+    private void toggleForceFailOnValidation(final boolean toggle) {
+        testingClient.server().run(session -> {
+            FailableHardcodedStorageProviderFactory factory = (FailableHardcodedStorageProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(UserStorageProvider.class, FailableHardcodedStorageProviderFactory.PROVIDER_ID);
+            factory.setFailOnValidation(toggle);
+        });
     }
 
     protected void toggleProviderEnabled(final boolean toggle) {
@@ -295,10 +318,10 @@ public class UserStorageFailureTest extends AbstractTestRealmKeycloakTest {
             session.users().getUsersCount(realm);
 
             UserModel user = session.users().getUserByUsername(realm, FailableHardcodedStorageProvider.username);
-            Assert.assertFalse(user instanceof CachedUserModel);
+            assertFalse(user instanceof CachedUserModel);
             Assert.assertEquals(FailableHardcodedStorageProvider.username, user.getUsername());
             Assert.assertEquals(FailableHardcodedStorageProvider.email, user.getEmail());
-            Assert.assertFalse(user.isEnabled());
+            assertFalse(user.isEnabled());
             try {
                 user.setEmail("error@error.com");
                 Assert.fail();
@@ -312,7 +335,7 @@ public class UserStorageFailureTest extends AbstractTestRealmKeycloakTest {
             RealmModel realm = session.realms().getRealmByName(AuthRealm.TEST);
 
             UserModel user = session.users().getUserByUsername(realm, FailableHardcodedStorageProvider.username);
-            Assert.assertFalse(user instanceof CachedUserModel);
+            assertFalse(user instanceof CachedUserModel);
             Assert.assertEquals(FailableHardcodedStorageProvider.username, user.getUsername());
             Assert.assertEquals(FailableHardcodedStorageProvider.email, user.getEmail());
         });
@@ -322,7 +345,7 @@ public class UserStorageFailureTest extends AbstractTestRealmKeycloakTest {
             RealmModel realm = session.realms().getRealmByName(AuthRealm.TEST);
 
             UserModel user = session.users().getUserByUsername(realm, FailableHardcodedStorageProvider.username);
-            Assert.assertFalse(user instanceof CachedUserModel);
+            assertFalse(user instanceof CachedUserModel);
             Assert.assertEquals(FailableHardcodedStorageProvider.username, user.getUsername());
             Assert.assertEquals(FailableHardcodedStorageProvider.email, user.getEmail());
         });
@@ -343,5 +366,70 @@ public class UserStorageFailureTest extends AbstractTestRealmKeycloakTest {
         });
 
         events.clear();
+    }
+
+    @Test
+    public void testDisableUsersWhenFailing() {
+        enableCache();
+        events.clear();
+        toggleForceFailOnValidation(true);
+        UserRepresentation user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+        assertFalse(user.isEnabled());
+        toggleForceFailOnValidation(false);
+        user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+        assertTrue(user.isEnabled());
+        oauth.client("offline-client", "secret");
+        oauth.redirectUri(OAuthClient.AUTH_SERVER_ROOT + "/offline-client");
+        oauth.doLogin(FailableHardcodedStorageProvider.username, "password");
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
+        assertNotNull(tokenResponse.getIdToken());
+        toggleForceFailOnValidation(true);
+        user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+        // user still enabled because it was cached before and the cache is still valid based on the storage cache policy config
+        assertTrue(user.isEnabled());
+
+        try {
+            // force cache to expire
+            setTimeOffset(Math.toIntExact(Duration.ofMinutes(10).toSeconds()));
+            user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+            assertFalse(user.isEnabled());
+            toggleForceFailOnValidation(false);
+            user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+            assertTrue(user.isEnabled());
+
+            // force cache to expire again and make sure user is disabled
+            setTimeOffset(Math.toIntExact(Duration.ofMinutes(20).toSeconds()));
+            toggleForceFailOnValidation(true);
+            user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+            assertFalse(user.isEnabled());
+
+            // make sure that once provider is available again user is enabled
+            toggleForceFailOnValidation(false);
+            user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+            assertTrue(user.isEnabled());
+
+            // user should still be enabled even if provider is failing again because user is cached and cache is valid based on the storage cache policy config
+            toggleForceFailOnValidation(true);
+            user = testRealm().users().search(FailableHardcodedStorageProvider.username).get(0);
+            assertTrue(user.isEnabled());
+        } finally {
+            resetTimeOffset();
+            toggleForceFailOnValidation(false);
+        }
+    }
+
+    private void enableCache() {
+        ComponentRepresentation component = testRealm().components().query().stream()
+                .filter(c -> c.getProviderId().equals(FailableHardcodedStorageProviderFactory.PROVIDER_ID))
+                .findAny().orElse(null);
+        component.getConfig().putSingle(CACHE_POLICY, CachePolicy.MAX_LIFESPAN.name());
+        component.getConfig().putSingle(MAX_LIFESPAN, String.valueOf(Duration.ofMinutes(5).toMillis()));
+        testRealm().components().component(component.getId()).update(component);
+        getCleanup().addCleanup(() -> {
+            component.getConfig().remove(CACHE_POLICY);
+            component.getConfig().remove(MAX_LIFESPAN);
+            testRealm().components().component(component.getId()).update(component);
+        });
     }
 }


### PR DESCRIPTION
Closes #45889

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
