### PR TITLE
Add release note for Envoy client certificate lookup

### DIFF
--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -88,14 +88,9 @@ This behavior is enabled by default and can be controlled with the server option
 
 Most deployments do not require any action. If you relied on the Operator to manage these truststore entries previously, the server now performs the same function directly.
 
-== Traefik Client certificate lookup
+= Client certificate lookup providers for Traefik and Envoy
 
-You can now use a new client certificate lookup provider specifically for Traefik proxies.
-For details, navigate to link:{server_guide_base_link}/reverseproxy#_enabling_client_certificate_lookup[Enabling Client Certificate Lookup] section of the documentation.
-
-== Envoy Client certificate lookup
-
-You can now use a new client certificate lookup provider specifically for Envoy proxies.
+You can now use a new client certificate lookup providers for Traefik and Envoy proxies.
 For details, navigate to link:{server_guide_base_link}/reverseproxy#_enabling_client_certificate_lookup[Enabling Client Certificate Lookup] section of the documentation.
 
 = Java 25 support
@@ -136,4 +131,3 @@ The existing `manage-membership` scope keeps its current behavior for target gro
 = JWT Authorization Grant promoted to supported
 
 In this release, the JWT Authorization Grant (https://datatracker.ietf.org/doc/html/rfc7523[RFC 7523]) feature is promoted from preview to default. This grant allows to use an external signed JWT assertions to request OAuth 2.0 access tokens. See the link:{securing_apps_base_link}/jwt-authorization-grant[JWT Authorization Grant guide] for additional details.
-

--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -93,6 +93,11 @@ Most deployments do not require any action. If you relied on the Operator to man
 You can now use a new client certificate lookup provider specifically for Traefik proxies.
 For details, navigate to link:{server_guide_base_link}/reverseproxy#_enabling_client_certificate_lookup[Enabling Client Certificate Lookup] section of the documentation.
 
+== Envoy Client certificate lookup
+
+You can now use a new client certificate lookup provider specifically for Envoy proxies.
+For details, navigate to link:{server_guide_base_link}/reverseproxy#_enabling_client_certificate_lookup[Enabling Client Certificate Lookup] section of the documentation.
+
 = Java 25 support
 
 {project_name} now supports running with JRE 25.


### PR DESCRIPTION
This PR adds a release note for the client certificate lookup for Envoy proxy. While PR #33159 provided the implementation, the release note was missing during the merge.

Updates #33160