### PR TITLE
docs: Remove mention of deprecated direct to server JS upload policy from documentation

### DIFF
--- a/docs/documentation/authorization_services/topics/policy-js-policy.adoc
+++ b/docs/documentation/authorization_services/topics/policy-js-policy.adoc
@@ -7,10 +7,11 @@ users are not able to edit the protected attributes and the corresponding attrib
 You can use this type of policy to define conditions for your permissions using JavaScript. It is one of the rule-based policy types
 supported by {project_name}, and provides flexibility to write any policy based on the <<_policy_evaluation_api, Evaluation API>>.
 
-To create a new JavaScript-based policy, select *JavaScript* in the item list in the upper right corner of the policy listing.
+To create a new JavaScript-based policy, first deploy your script as a JAR file as described below. Once deployed, your script will appear as a selectable option in the policy listing.
 
-NOTE: By default, JavaScript Policies can not be uploaded to the server. You should prefer deploying your JS Policies directly to
-the server as described in link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}].
+NOTE: JavaScript Policies cannot be uploaded directly through the Admin Console. Direct script upload was removed in version 18 of {project_name} due to potential security risks.
+You must deploy your JavaScript policies as a JAR file to the server as described in link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}]
+before they will appear as selectable options in the policy listing.
 
 == Creating a JS policy from a deployed JAR file
 

--- a/docs/documentation/release_notes/topics/7_0_1.adoc
+++ b/docs/documentation/release_notes/topics/7_0_1.adoc
@@ -3,5 +3,5 @@
 Until now, administrators were allowed to upload scripts to the server through the {project_name} Administration Console as well as
 through the RESTful Admin API.
 
-For now on, this capability is *disabled* by default and users should prefer to deploy scripts directly to the server. For more details,
+For now on, this capability is *disabled* and users should deploy scripts to the server as a JAR file. For more details,
 please take a look at link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}].

--- a/docs/documentation/upgrading/topics/changes/changes-19_0_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-19_0_2.adoc
@@ -18,7 +18,7 @@ WARNING: The backwards compatibility switch will be removed in some future versi
 Until now, administrators, which used SAML javascript protocol mapper on their SAML clients or client scopes, were allowed to upload scripts to the server through the {project_name} Administration Console as well as
 through the RESTful Admin API.
 
-For now on, this capability is *disabled* and users should deploy scripts directly to the server. This behaviour is aligned with other script based providers. For more details,
+For now on, this capability is *disabled* and users should deploy scripts to the server as a JAR file. For more details,
 please take a look at link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}].
 
 = UserInfo Endpoint Changes

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -446,7 +446,7 @@ Cross-Datacenter Replication changes::
 Until now, administrators were allowed to upload scripts to the server through the {project_name} Administration Console as well as
 through the RESTful Admin API.
 
-For now on, this capability is *disabled* by default and users should prefer to deploy scripts directly to the server. For more details,
+For now on, this capability is *disabled* and users should deploy scripts to the server as a JAR file. For more details,
 please take a look at link:{developerguide_jsproviders_link}[{developerguide_jsproviders_name}].
 
 ==== Client credentials in the JavaScript adapter


### PR DESCRIPTION
Fixes #27426