### PR TITLE
fix: provide a simple mechanism to get a full export in dev mode

### DIFF
--- a/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirExportProviderFactory.java
+++ b/model/storage-services/src/main/java/org/keycloak/exportimport/dir/DirExportProviderFactory.java
@@ -18,6 +18,8 @@
 package org.keycloak.exportimport.dir;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
 
 import org.keycloak.Config;
 import org.keycloak.exportimport.ExportImportConfig;
@@ -41,18 +43,21 @@ import static org.keycloak.exportimport.ExportImportConfig.DEFAULT_USERS_PER_FIL
 public class DirExportProviderFactory implements ExportProviderFactory {
 
     public static final String PROVIDER_ID = "dir";
-    public static final String DIR = "dir";
-    public static final String REALM_NAME = "realmName";
+    public static final String DIR = ExportImportConfig.DIR_OPTION;
+    public static final String REALM_NAME = ExportImportConfig.REALM_NAME_OPTION;
     public static final String USERS_EXPORT_STRATEGY = "usersExportStrategy";
     public static final String USERS_PER_FILE = "usersPerFile";
     private Config.Scope config;
 
     @Override
     public ExportProvider create(KeycloakSession session) {
-        String dir = System.getProperty(ExportImportConfig.DIR, config.get(DIR));
-        String realmName = System.getProperty(ExportImportConfig.REALM_NAME, config.get(REALM_NAME));
-        String usersExportStrategy = System.getProperty(ExportImportConfig.USERS_EXPORT_STRATEGY, config.get(USERS_EXPORT_STRATEGY, DEFAULT_USERS_EXPORT_STRATEGY.toString()));
-        String usersPerFile = System.getProperty(ExportImportConfig.USERS_PER_FILE, config.get(USERS_PER_FILE, String.valueOf(DEFAULT_USERS_PER_FILE)));
+        BiFunction<String, String, String> configFunct = Optional
+                .ofNullable((BiFunction<String, String, String>) session.getAttribute(ExportImportConfig.CONFIG_OVERRIDE_ATTRIBUTE, BiFunction.class))
+                .orElse(this.config::get);
+        String dir = System.getProperty(ExportImportConfig.DIR, configFunct.apply(DIR, null));
+        String realmName = System.getProperty(ExportImportConfig.REALM_NAME, configFunct.apply(REALM_NAME, null));
+        String usersExportStrategy = System.getProperty(ExportImportConfig.USERS_EXPORT_STRATEGY, configFunct.apply(USERS_EXPORT_STRATEGY, DEFAULT_USERS_EXPORT_STRATEGY.toString()));
+        String usersPerFile = System.getProperty(ExportImportConfig.USERS_PER_FILE, configFunct.apply(USERS_PER_FILE, String.valueOf(DEFAULT_USERS_PER_FILE)));
         return new DirExportProvider(session.getKeycloakSessionFactory())
                 .withDir(dir)
                 .withRealmName(realmName)

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ExportDistTest.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.it.cli.dist;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.keycloak.it.junit5.extension.CLIResult;
@@ -71,6 +73,22 @@ public class ExportDistTest {
         CLIResult cliResult = rawDist.run("export", "--realm=fgap", "--dir=" + importDir.toAbsolutePath(), "--features=admin-fine-grained-authz:v2");
         cliResult.assertMessage("Export of realm 'fgap' requested.");
         cliResult.assertMessage("Export finished successfully");
+    }
+
+    @Test
+    void testDevExport(KeycloakDistribution dist) throws IOException {
+        dist.setEnvVar("MY_SECRET", "admin123");
+        RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
+        CLIResult result = rawDist.run("bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET");
+        assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
+
+        dist.setManualStop(true);
+        dist.run("start-dev");
+
+        rawDist.kcadm("create", "realms/master/dev-export", "--server", "http://localhost:8080", "--realm", "master", "--client", "admin", "--secret", "admin123");
+
+        Path file = rawDist.getDistPath().resolve("data").resolve("tmp").resolve("master").resolve("master-realm.json");
+        assertTrue(Files.exists(file), "Export failed");
     }
 
     @Test

--- a/services/src/main/java/org/keycloak/exportimport/ExportImportConfig.java
+++ b/services/src/main/java/org/keycloak/exportimport/ExportImportConfig.java
@@ -36,11 +36,14 @@ public class ExportImportConfig {
     public static final String PROVIDER = PREFIX + "provider";
     public static final String PROVIDER_DEFAULT = "dir";
 
-    // Name of the realm to export. If null, then full export will be triggered
-    public static final String REALM_NAME = PREFIX + "realmName";
+    public static final String REALM_NAME_OPTION = "realmName";
 
+    // Name of the realm to export. If null, then full export will be triggered
+    public static final String REALM_NAME = PREFIX + REALM_NAME_OPTION;
+
+    public static final String DIR_OPTION = "dir";
     // used for "dir" provider
-    public static final String DIR = PREFIX + "dir";
+    public static final String DIR = PREFIX + DIR_OPTION;
 
     // used for "singleFile" provider
     public static final String FILE = PREFIX + "file";
@@ -59,6 +62,8 @@ public class ExportImportConfig {
     // Strategy used during import data
     public static final String STRATEGY = PREFIX + "strategy";
     public static final Strategy DEFAULT_STRATEGY = Strategy.OVERWRITE_EXISTING;
+
+    public static final String CONFIG_OVERRIDE_ATTRIBUTE = "importExportSessionOverride";
 
     public static String getAction() {
         return System.getProperty(ACTION);

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
@@ -54,6 +55,7 @@ import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.Environment;
 import org.keycloak.common.util.PemUtils;
 import org.keycloak.email.EmailAuthenticator;
 import org.keycloak.email.EmailException;
@@ -68,6 +70,7 @@ import org.keycloak.exportimport.ClientDescriptionConverter;
 import org.keycloak.exportimport.ClientDescriptionConverterFactory;
 import org.keycloak.exportimport.ExportAdapter;
 import org.keycloak.exportimport.ExportOptions;
+import org.keycloak.exportimport.util.ExportUtils;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
@@ -292,9 +295,9 @@ public class RealmAdminResource {
         if (clientScope == null) {
             throw new NotFoundException("Client scope not found");
         }
-        
+
         ClientResource.validateClientScopeAssignment(session, clientScope, defaultScope, realm);
-        
+
         realm.addDefaultClientScope(clientScope, defaultScope);
 
         adminEvent.operation(OperationType.CREATE).resource(ResourceType.CLIENT_SCOPE).resourcePath(session.getContext().getUri()).success();
@@ -1396,6 +1399,24 @@ public class RealmAdminResource {
             }
         });
         return response.build();
+    }
+
+    @GET
+    @Path("dev-export")
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Full export of existing realm into a JSON file. Only for dev mode.")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "OK"),
+            @APIResponse(responseCode = "403", description = "Forbidden")
+        })
+    public RealmRepresentation devExport() {
+        auth.requireRealmAdmin();
+        if (!Environment.DEV_PROFILE_VALUE.equals(Environment.getProfile())) {
+            throw new ForbiddenException("Full export only allowed in dev mode.");
+        }
+        return ExportUtils.exportRealm(session, realm, true, true);
     }
 
     @Path("keys")

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.services.resources.admin;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -34,6 +36,7 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.FormParam;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -48,6 +51,7 @@ import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.StreamingOutput;
 
 import org.keycloak.Config;
+import org.keycloak.Config.Scope;
 import org.keycloak.KeyPairVerifier;
 import org.keycloak.authentication.CredentialRegistrator;
 import org.keycloak.authentication.RequiredActionProvider;
@@ -55,8 +59,8 @@ import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Environment;
 import org.keycloak.common.util.PemUtils;
+import org.keycloak.config.database.Database;
 import org.keycloak.email.EmailAuthenticator;
 import org.keycloak.email.EmailException;
 import org.keycloak.email.EmailTemplateProvider;
@@ -69,8 +73,9 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.exportimport.ClientDescriptionConverter;
 import org.keycloak.exportimport.ClientDescriptionConverterFactory;
 import org.keycloak.exportimport.ExportAdapter;
+import org.keycloak.exportimport.ExportImportConfig;
 import org.keycloak.exportimport.ExportOptions;
-import org.keycloak.exportimport.util.ExportUtils;
+import org.keycloak.exportimport.ExportProvider;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
@@ -103,6 +108,7 @@ import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.RealmManager;
 import org.keycloak.services.managers.ResourceAdminManager;
+import org.keycloak.services.resources.KeycloakApplication;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.ext.AdminRealmResourceProvider;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
@@ -131,6 +137,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
 
+import static org.keycloak.exportimport.ExportImportConfig.PROVIDER_DEFAULT;
 import static org.keycloak.util.JsonSerialization.readValue;
 
 /**
@@ -1411,12 +1418,31 @@ public class RealmAdminResource {
             @APIResponse(responseCode = "200", description = "OK"),
             @APIResponse(responseCode = "403", description = "Forbidden")
         })
-    public RealmRepresentation devExport() {
+    public Response devExport() {
         auth.requireRealmAdmin();
-        if (!Environment.DEV_PROFILE_VALUE.equals(Environment.getProfile())) {
-            throw new ForbiddenException("Full export only allowed in dev mode.");
+        Scope exportScope = Config.scope("export");
+        String db = exportScope.root().get("kc.db");
+        if (Database.getVendor(db).filter(Database.Vendor.H2::equals).isEmpty()) {
+            throw new ForbiddenException("Export endpoint is only for H2");
         }
-        return ExportUtils.exportRealm(session, realm, true, true);
+        try (KeycloakSession override = session.getKeycloakSessionFactory().create()) {
+            Map<String, String> config = Map.of(ExportImportConfig.DIR_OPTION,
+                    KeycloakApplication.getTmpDirectory() + "/" + realm.getName(), ExportImportConfig.REALM_NAME_OPTION,
+                    realm.getName());
+            BiFunction<String, String, String> func = config::getOrDefault;
+            override.setAttribute(ExportImportConfig.CONFIG_OVERRIDE_ATTRIBUTE, func);
+            ExportProvider exportProvider = override.getKeycloakSessionFactory()
+                    .getProviderFactory(ExportProvider.class, exportScope.get("exporter", PROVIDER_DEFAULT))
+                    .create(override);
+            try {
+                exportProvider.exportModel();
+            } catch (IOException e) {
+                throw new InternalServerErrorException(e);
+            } finally {
+                exportProvider.close();
+            }
+        }
+        return Response.ok().build();
     }
 
     @Path("keys")

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -1408,22 +1408,20 @@ public class RealmAdminResource {
         return response.build();
     }
 
-    @GET
+    @POST
     @Path("dev-export")
-    @NoCache
     @Tag(name = KeycloakOpenAPI.Admin.Tags.REALMS_ADMIN)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Full export of existing realm into a JSON file. Only for dev mode.")
+    @Operation(summary = "Full export of existing realm into a JSON file. Only for dev (H2) databases.")
     @APIResponses(value = {
-            @APIResponse(responseCode = "200", description = "OK"),
+            @APIResponse(responseCode = "204", description = "Success"),
             @APIResponse(responseCode = "403", description = "Forbidden")
         })
     public Response devExport() {
         auth.requireRealmAdmin();
         Scope exportScope = Config.scope("export");
-        String db = exportScope.root().get("kc.db");
+        String db = exportScope.root().get("db");
         if (Database.getVendor(db).filter(Database.Vendor.H2::equals).isEmpty()) {
-            throw new ForbiddenException("Export endpoint is only for H2");
+            throw new ForbiddenException("Export endpoint is only for dev (H2) databases.");
         }
         try (KeycloakSession override = session.getKeycloakSessionFactory().create()) {
             Map<String, String> config = Map.of(ExportImportConfig.DIR_OPTION,
@@ -1442,7 +1440,7 @@ public class RealmAdminResource {
                 exportProvider.close();
             }
         }
-        return Response.ok().build();
+        return Response.noContent().build();
     }
 
     @Path("keys")


### PR DESCRIPTION
closes: #33800

Based upon the previous attempts to resolve this and the continued comments on the issue, I'd like to propose adding a special purpose endpoint for this. It's not ideal and not something that is applicable to production, but it has a minimal code footprint and will work without a lot of additional documentation. We can just show using kcadm.sh (via docker):

`kcadm.sh get dev-export -r name > name-realm.json`

Thoughts @keycloak/cloud-native ?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
