### PR TITLE
Adding getResourcesCommonUrl() to UrlBean

### DIFF
--- a/docs/guides/ui-customization/themes.adoc
+++ b/docs/guides/ui-customization/themes.adoc
@@ -131,7 +131,7 @@ Theme properties are set in the file `<THEME TYPE>/theme.properties` in the them
 * parent - Parent theme to extend
 * import - Import resources from another theme
 * abstract - Boolean that, when present and `true`, marks the theme is only used as base for other extensions and is not displayed to be selected in the admin console on the realm themes page. Examples of this are the `base` themes described on this guide.
-* common - Override the common resource path. The default value is `common/keycloak` when not specified. This value would be used as value of suffix of ${r"`${url.resourcesCommonPath}`"}, which is used typically in freemarker templates (prefix of ${r"`${url.resoucesCommonPath}`"} value is theme root uri).
+* common - Override the common resource path. The default value is `common/keycloak` when not specified. This value would be used as value of suffix of ${r"`${url.resourcesCommonPath}`"} and ${r"`${url.resourcesCommonUrl}`"}, which are used typically in freemarker templates. ${r"`${url.resourcesCommonPath}`"} returns only the path, while ${r"`${url.resourcesCommonUrl}`"} returns the full URL including scheme and host, which is required for email templates.
 * styles - Space-separated list of styles to include
 * locales - Comma-separated list of supported locales
 * contentHashPattern - Regex pattern of a file path in the theme where files have a content hash as part of their file name.
@@ -285,6 +285,15 @@ To use directly in HTML templates add the following to a custom HTML template:
 ----
 <img src="${r"${url.resourcesUrl}"}/img/image.jpg" alt="My image description">
 ----
+
+To reference images from common theme resources in email templates, use `url.resourcesCommonUrl` which provides the full URL (including scheme and host) required by email clients:
+
+[source,html]
+----
+<img src="${r"${url.resourcesCommonUrl}"}/img/logo.png" alt="My logo">
+----
+
+NOTE: Email clients require absolute URLs for images since they cannot resolve relative paths. Use `url.resourcesCommonUrl` or `url.resourcesUrl` instead of their `Path` counterparts (`url.resourcesCommonPath`, `url.resourcesPath`) in email templates.
 
 [[custom-identity-providers-icons]]
 === Adding custom Identity Providers icons

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/UrlBean.java
@@ -123,6 +123,14 @@ public class UrlBean {
 
     public String getResourcesCommonPath() {
         URI uri = getThemeRootUri();
+        return uri.getPath() + "/" + getCommonPath();
+    }
+
+    public String getResourcesCommonUrl() {
+        return getThemeRootUri().toString() + "/" + getCommonPath();
+    }
+
+    private String getCommonPath() {
         String commonPath = "";
         try {
             commonPath = theme.getProperties().getProperty("common");
@@ -132,7 +140,7 @@ public class UrlBean {
         if (commonPath == null || commonPath.isEmpty()) {
             commonPath = "common/keycloak";
         }
-        return uri.getPath() + "/" + commonPath;
+        return commonPath;
     }
 
     private URI getThemeRootUri() {

--- a/tests/base/src/test/java/org/keycloak/tests/forms/UrlBeanTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/forms/UrlBeanTest.java
@@ -1,0 +1,64 @@
+package org.keycloak.tests.forms;
+
+import java.net.URI;
+
+import org.keycloak.forms.login.freemarker.model.UrlBean;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.Urls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.annotations.TestOnServer;
+import org.keycloak.theme.Theme;
+
+import org.junit.jupiter.api.Assertions;
+
+@KeycloakIntegrationTest
+public class UrlBeanTest {
+
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @TestOnServer
+    public void resourcesCommonUrlReturnsFullUrl(KeycloakSession session) throws Exception {
+        RealmModel realm = session.realms().getRealmByName("default");
+        Theme theme = session.theme().getTheme(Theme.Type.EMAIL);
+        URI baseUri = session.getContext().getUri().getBaseUri();
+
+        UrlBean urlBean = new UrlBean(realm, theme, baseUri, null);
+        String themeRoot = Urls.themeRoot(baseUri).toString();
+
+        Assertions.assertEquals(themeRoot + "/common/keycloak", urlBean.getResourcesCommonUrl());
+        Assertions.assertTrue(urlBean.getResourcesCommonUrl().startsWith("http"),
+                "resourcesCommonUrl must be an absolute URL");
+    }
+
+    @TestOnServer
+    public void resourcesCommonPathReturnsPathOnly(KeycloakSession session) throws Exception {
+        RealmModel realm = session.realms().getRealmByName("default");
+        Theme theme = session.theme().getTheme(Theme.Type.EMAIL);
+        URI baseUri = session.getContext().getUri().getBaseUri();
+
+        UrlBean urlBean = new UrlBean(realm, theme, baseUri, null);
+        String themeRoot = Urls.themeRoot(baseUri).getPath();
+
+        Assertions.assertEquals(themeRoot + "/common/keycloak", urlBean.getResourcesCommonPath());
+        Assertions.assertTrue(urlBean.getResourcesCommonPath().startsWith("/"),
+                "resourcesCommonPath must not contain scheme");
+    }
+
+    @TestOnServer
+    public void resourcesCommonUrlAndPathShareSameSuffix(KeycloakSession session) throws Exception {
+        RealmModel realm = session.realms().getRealmByName("default");
+        Theme theme = session.theme().getTheme(Theme.Type.EMAIL);
+        URI baseUri = session.getContext().getUri().getBaseUri();
+
+        UrlBean urlBean = new UrlBean(realm, theme, baseUri, null);
+
+        String url = urlBean.getResourcesCommonUrl();
+        String path = urlBean.getResourcesCommonPath();
+        Assertions.assertTrue(url.endsWith("/common/keycloak") && path.endsWith("/common/keycloak"),
+                "URL and Path should end with the same common suffix");
+    }
+}


### PR DESCRIPTION
Picking up from #33366 which was closed due to inactivity.

I ran into the fact that `resourcesCommonPath` doesn't really work in email templates - email clients need the full URL with scheme and host, not just a path. There was already `getResourcesUrl()` for theme-specific resources but nothing equivalent for common resources.

So I added `getResourcesCommonUrl()` to mirror the existing URL/Path pattern. I also pulled the common-path lookup into a small private helper (`getCommonPath()`) since the same logic was going to end up in two places otherwise.

For the docs I added a quick example showing `url.resourcesCommonUrl` in an email template and a note about why you need the `Url` variant instead of `Path` for emails. Also caught a typo in the existing text (`resoucesCommonPath` -> `resourcesCommonPath`) while I was in there.

Tests cover the new method, the existing path method, custom `common` property and that both variants share the same suffix.

Closes #33198

**AI disclosure:** Used GitHub Copilot to help me explore the codebase and review my changes. The implementation and approach are my own.