### PR TITLE
Add native KC options for JSON log service.name and service.environment fields

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -74,7 +74,8 @@ public class LoggingOptions {
 
     public static final Option<String> LOG_SERVICE_NAME = new OptionBuilder<>("log-service-name", String.class)
             .category(OptionCategory.LOGGING)
-            .description("Set the 'service.name' field in JSON log entries for all log handlers. In ECS format, defaults to 'Keycloak' if not set.")
+            .description("Set the 'service.name' field in JSON log entries for all log handlers.")
+            .defaultValue("keycloak")
             .build();
 
     public static final Option<String> LOG_SERVICE_ENVIRONMENT = new OptionBuilder<>("log-service-environment", String.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -120,6 +120,16 @@ public class LoggingOptions {
             .description("Set the format of the produced JSON.")
             .build();
 
+    public static final Option<String> LOG_CONSOLE_JSON_SERVICE_NAME = new OptionBuilder<>("log-console-json-service-name", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the 'service.name' field in the console JSON log entries. In ECS format, defaults to 'Keycloak' if not set.")
+            .build();
+
+    public static final Option<String> LOG_CONSOLE_JSON_SERVICE_ENVIRONMENT = new OptionBuilder<>("log-console-json-service-environment", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the 'service.environment' field in the console JSON log entries. In ECS format, defaults to the Quarkus profile if not set.")
+            .build();
+
     public static final Option<Boolean> LOG_CONSOLE_INCLUDE_TRACE = new OptionBuilder<>("log-console-include-trace", Boolean.class)
             .category(OptionCategory.LOGGING)
             .description(format("Include tracing information in the console log. If the '%s' option is specified, this option has no effect.", LOG_CONSOLE_FORMAT.getKey()))
@@ -187,6 +197,16 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .defaultValue(JsonFormat.DEFAULT)
             .description("Set the format of the produced JSON.")
+            .build();
+
+    public static final Option<String> LOG_FILE_JSON_SERVICE_NAME = new OptionBuilder<>("log-file-json-service-name", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the 'service.name' field in the file JSON log entries. In ECS format, defaults to 'Keycloak' if not set.")
+            .build();
+
+    public static final Option<String> LOG_FILE_JSON_SERVICE_ENVIRONMENT = new OptionBuilder<>("log-file-json-service-environment", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the 'service.environment' field in the file JSON log entries. In ECS format, defaults to the Quarkus profile if not set.")
             .build();
 
     public static final Option<Boolean> LOG_FILE_INCLUDE_TRACE = new OptionBuilder<>("log-file-include-trace", Boolean.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -72,6 +72,16 @@ public class LoggingOptions {
             .description("Indicates whether to log asynchronously to all handlers.")
             .build();
 
+    public static final Option<String> LOG_SERVICE_NAME = new OptionBuilder<>("log-service-name", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the 'service.name' field in JSON log entries for all log handlers. In ECS format, defaults to 'Keycloak' if not set.")
+            .build();
+
+    public static final Option<String> LOG_SERVICE_ENVIRONMENT = new OptionBuilder<>("log-service-environment", String.class)
+            .category(OptionCategory.LOGGING)
+            .description("Set the 'service.environment' field in JSON log entries for all log handlers. In ECS format, defaults to the Quarkus profile if not set.")
+            .build();
+
     public enum Output {
         DEFAULT,
         JSON;
@@ -118,16 +128,6 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .defaultValue(JsonFormat.DEFAULT)
             .description("Set the format of the produced JSON.")
-            .build();
-
-    public static final Option<String> LOG_CONSOLE_JSON_SERVICE_NAME = new OptionBuilder<>("log-console-json-service-name", String.class)
-            .category(OptionCategory.LOGGING)
-            .description("Set the 'service.name' field in the console JSON log entries. In ECS format, defaults to 'Keycloak' if not set.")
-            .build();
-
-    public static final Option<String> LOG_CONSOLE_JSON_SERVICE_ENVIRONMENT = new OptionBuilder<>("log-console-json-service-environment", String.class)
-            .category(OptionCategory.LOGGING)
-            .description("Set the 'service.environment' field in the console JSON log entries. In ECS format, defaults to the Quarkus profile if not set.")
             .build();
 
     public static final Option<Boolean> LOG_CONSOLE_INCLUDE_TRACE = new OptionBuilder<>("log-console-include-trace", Boolean.class)
@@ -197,16 +197,6 @@ public class LoggingOptions {
             .category(OptionCategory.LOGGING)
             .defaultValue(JsonFormat.DEFAULT)
             .description("Set the format of the produced JSON.")
-            .build();
-
-    public static final Option<String> LOG_FILE_JSON_SERVICE_NAME = new OptionBuilder<>("log-file-json-service-name", String.class)
-            .category(OptionCategory.LOGGING)
-            .description("Set the 'service.name' field in the file JSON log entries. In ECS format, defaults to 'Keycloak' if not set.")
-            .build();
-
-    public static final Option<String> LOG_FILE_JSON_SERVICE_ENVIRONMENT = new OptionBuilder<>("log-file-json-service-environment", String.class)
-            .category(OptionCategory.LOGGING)
-            .description("Set the 'service.environment' field in the file JSON log entries. In ECS format, defaults to the Quarkus profile if not set.")
             .build();
 
     public static final Option<Boolean> LOG_FILE_INCLUDE_TRACE = new OptionBuilder<>("log-file-include-trace", Boolean.class)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -78,12 +78,12 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.log.console.json.log-format")
                         .paramLabel("format")
                         .build(),
-                fromOption(LoggingOptions.LOG_CONSOLE_JSON_SERVICE_NAME)
+                fromOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
                         .to("quarkus.log.console.json.additional-field.\"service.name\".value")
                         .paramLabel("name")
                         .build(),
-                fromOption(LoggingOptions.LOG_CONSOLE_JSON_SERVICE_ENVIRONMENT)
+                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
                         .to("quarkus.log.console.json.additional-field.\"service.environment\".value")
                         .paramLabel("environment")
@@ -144,12 +144,12 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.log.file.json.log-format")
                         .paramLabel("format")
                         .build(),
-                fromOption(LoggingOptions.LOG_FILE_JSON_SERVICE_NAME)
+                fromOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.additional-field.\"service.name\".value")
                         .paramLabel("name")
                         .build(),
-                fromOption(LoggingOptions.LOG_FILE_JSON_SERVICE_ENVIRONMENT)
+                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.additional-field.\"service.environment\".value")
                         .paramLabel("environment")
@@ -265,6 +265,16 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.syslog.json.log-format")
                         .paramLabel("format")
+                        .build(),
+                fromOption(LoggingOptions.LOG_SERVICE_NAME)
+                        .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.syslog.json.additional-field.\"service.name\".value")
+                        .paramLabel("name")
+                        .build(),
+                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
+                        .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.syslog.json.additional-field.\"service.environment\".value")
+                        .paramLabel("environment")
                         .build(),
                 fromOption(LoggingOptions.LOG_SYSLOG_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isSyslogEnabled() && TracingPropertyMappers.isTracingEnabled(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -56,8 +56,10 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                 fromOption(LoggingOptions.LOG_ASYNC)
                         .build(),
                 fromOption(LoggingOptions.LOG_SERVICE_NAME)
+                        .paramLabel("name")
                         .build(),
                 fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
+                        .paramLabel("environment")
                         .build(),
                 // Console
                 fromOption(LoggingOptions.LOG_CONSOLE_OUTPUT)
@@ -86,12 +88,10 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                 fromParentOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
                         .to("quarkus.log.console.json.additional-field.\"service.name\".value")
-                        .paramLabel("name")
                         .build(),
                 fromParentOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
                         .to("quarkus.log.console.json.additional-field.\"service.environment\".value")
-                        .paramLabel("environment")
                         .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isConsoleEnabled() && TracingPropertyMappers.isTracingEnabled(),
@@ -152,12 +152,10 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                 fromParentOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.additional-field.\"service.name\".value")
-                        .paramLabel("name")
                         .build(),
                 fromParentOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.additional-field.\"service.environment\".value")
-                        .paramLabel("environment")
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isFileEnabled() && TracingPropertyMappers.isTracingEnabled(),
@@ -274,12 +272,10 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                 fromParentOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.syslog.json.additional-field.\"service.name\".value")
-                        .paramLabel("name")
                         .build(),
                 fromParentOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.syslog.json.additional-field.\"service.environment\".value")
-                        .paramLabel("environment")
                         .build(),
                 fromOption(LoggingOptions.LOG_SYSLOG_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isSyslogEnabled() && TracingPropertyMappers.isTracingEnabled(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -55,6 +55,10 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .build(),
                 fromOption(LoggingOptions.LOG_ASYNC)
                         .build(),
+                fromOption(LoggingOptions.LOG_SERVICE_NAME)
+                        .build(),
+                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
+                        .build(),
                 // Console
                 fromOption(LoggingOptions.LOG_CONSOLE_OUTPUT)
                         .isEnabled(LoggingPropertyMappers::isConsoleEnabled, CONSOLE_ENABLED_MSG)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -34,6 +34,7 @@ import static org.keycloak.config.LoggingOptions.LOG_SYSLOG_ENABLED;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isSet;
 import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
+import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromParentOption;
 
 public final class LoggingPropertyMappers implements PropertyMapperGrouping {
 
@@ -78,12 +79,12 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.log.console.json.log-format")
                         .paramLabel("format")
                         .build(),
-                fromOption(LoggingOptions.LOG_SERVICE_NAME)
+                fromParentOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
                         .to("quarkus.log.console.json.additional-field.\"service.name\".value")
                         .paramLabel("name")
                         .build(),
-                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
+                fromParentOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
                         .to("quarkus.log.console.json.additional-field.\"service.environment\".value")
                         .paramLabel("environment")
@@ -144,12 +145,12 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.log.file.json.log-format")
                         .paramLabel("format")
                         .build(),
-                fromOption(LoggingOptions.LOG_SERVICE_NAME)
+                fromParentOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.additional-field.\"service.name\".value")
                         .paramLabel("name")
                         .build(),
-                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
+                fromParentOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.additional-field.\"service.environment\".value")
                         .paramLabel("environment")
@@ -266,12 +267,12 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.log.syslog.json.log-format")
                         .paramLabel("format")
                         .build(),
-                fromOption(LoggingOptions.LOG_SERVICE_NAME)
+                fromParentOption(LoggingOptions.LOG_SERVICE_NAME)
                         .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.syslog.json.additional-field.\"service.name\".value")
                         .paramLabel("name")
                         .build(),
-                fromOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
+                fromParentOption(LoggingOptions.LOG_SERVICE_ENVIRONMENT)
                         .isEnabled(LoggingPropertyMappers::isSyslogJsonEnabled, SYSLOG_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.syslog.json.additional-field.\"service.environment\".value")
                         .paramLabel("environment")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/LoggingPropertyMappers.java
@@ -78,6 +78,16 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .to("quarkus.log.console.json.log-format")
                         .paramLabel("format")
                         .build(),
+                fromOption(LoggingOptions.LOG_CONSOLE_JSON_SERVICE_NAME)
+                        .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
+                        .to("quarkus.log.console.json.additional-field.\"service.name\".value")
+                        .paramLabel("name")
+                        .build(),
+                fromOption(LoggingOptions.LOG_CONSOLE_JSON_SERVICE_ENVIRONMENT)
+                        .isEnabled(LoggingPropertyMappers::isConsoleJsonEnabled, "%s and output is set to 'json'".formatted(CONSOLE_ENABLED_MSG))
+                        .to("quarkus.log.console.json.additional-field.\"service.environment\".value")
+                        .paramLabel("environment")
+                        .build(),
                 fromOption(LoggingOptions.LOG_CONSOLE_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isConsoleEnabled() && TracingPropertyMappers.isTracingEnabled(),
                                 "Console log handler and Tracing is activated")
@@ -133,6 +143,16 @@ public final class LoggingPropertyMappers implements PropertyMapperGrouping {
                         .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
                         .to("quarkus.log.file.json.log-format")
                         .paramLabel("format")
+                        .build(),
+                fromOption(LoggingOptions.LOG_FILE_JSON_SERVICE_NAME)
+                        .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.file.json.additional-field.\"service.name\".value")
+                        .paramLabel("name")
+                        .build(),
+                fromOption(LoggingOptions.LOG_FILE_JSON_SERVICE_ENVIRONMENT)
+                        .isEnabled(LoggingPropertyMappers::isFileJsonEnabled, FILE_ENABLED_MSG + " and output is set to 'json'")
+                        .to("quarkus.log.file.json.additional-field.\"service.environment\".value")
+                        .paramLabel("environment")
                         .build(),
                 fromOption(LoggingOptions.LOG_FILE_INCLUDE_TRACE)
                         .isEnabled(() -> LoggingPropertyMappers.isFileEnabled() && TracingPropertyMappers.isTracingEnabled(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -36,6 +36,7 @@ import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
 import org.keycloak.config.OptionCategory;
 import org.keycloak.config.WildcardOptionsUtil;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.cli.ShortErrorMessageHandler;
 import org.keycloak.quarkus.runtime.cli.command.AbstractCommand;
@@ -571,6 +572,18 @@ public class PropertyMapper<T> {
 
     public static <T> PropertyMapper.Builder<T> fromOption(Option<T> opt) {
         return new PropertyMapper.Builder<>(opt);
+    }
+
+    /**
+     * Create a property mapper that get value from the parent option
+     */
+    public static <T> PropertyMapper.Builder<T> fromParentOption(Option<T> parentOption) {
+        final var option = new OptionBuilder<>(parentOption.getKey() + KeycloakModelUtils.generateShortId(), parentOption.getType())
+                .buildTime(parentOption.isBuildTime())
+                .hidden()
+                .build();
+        return new Builder<>(option)
+                .mapFrom(parentOption);
     }
 
     /**

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -578,7 +578,7 @@ public class PropertyMapper<T> {
      * Create a property mapper that get value from the parent option
      */
     public static <T> PropertyMapper.Builder<T> fromParentOption(Option<T> parentOption) {
-        final var option = new OptionBuilder<>(parentOption.getKey() + KeycloakModelUtils.generateShortId(), parentOption.getType())
+        final var option = new OptionBuilder<>(parentOption.getKey() + KeycloakModelUtils.generateId(), parentOption.getType())
                 .buildTime(parentOption.isBuildTime())
                 .hidden()
                 .build();

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
@@ -308,29 +308,28 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void jsonServiceFields() {
         putEnvVars(Map.of(
+                "KC_LOG", "console,file,syslog",
                 "KC_LOG_CONSOLE_OUTPUT", "json",
-                "KC_LOG_CONSOLE_JSON_SERVICE_NAME", "my-service",
-                "KC_LOG_CONSOLE_JSON_SERVICE_ENVIRONMENT", "production",
-                "KC_LOG", "console,file",
                 "KC_LOG_FILE_OUTPUT", "json",
-                "KC_LOG_FILE_JSON_SERVICE_NAME", "my-service",
-                "KC_LOG_FILE_JSON_SERVICE_ENVIRONMENT", "production"
+                "KC_LOG_SYSLOG_OUTPUT", "json",
+                "KC_LOG_SERVICE_NAME", "my-service",
+                "KC_LOG_SERVICE_ENVIRONMENT", "production"
         ));
 
         initConfig();
 
         assertConfig(Map.of(
-                "log-console-json-service-name", "my-service",
-                "log-console-json-service-environment", "production",
-                "log-file-json-service-name", "my-service",
-                "log-file-json-service-environment", "production"
+                "log-service-name", "my-service",
+                "log-service-environment", "production"
         ));
 
         assertExternalConfig(Map.of(
                 "quarkus.log.console.json.additional-field.\"service.name\".value", "my-service",
                 "quarkus.log.console.json.additional-field.\"service.environment\".value", "production",
                 "quarkus.log.file.json.additional-field.\"service.name\".value", "my-service",
-                "quarkus.log.file.json.additional-field.\"service.environment\".value", "production"
+                "quarkus.log.file.json.additional-field.\"service.environment\".value", "production",
+                "quarkus.log.syslog.json.additional-field.\"service.name\".value", "my-service",
+                "quarkus.log.syslog.json.additional-field.\"service.environment\".value", "production"
         ));
     }
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
@@ -306,6 +306,35 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
     }
 
     @Test
+    public void jsonServiceFields() {
+        putEnvVars(Map.of(
+                "KC_LOG_CONSOLE_OUTPUT", "json",
+                "KC_LOG_CONSOLE_JSON_SERVICE_NAME", "my-service",
+                "KC_LOG_CONSOLE_JSON_SERVICE_ENVIRONMENT", "production",
+                "KC_LOG", "console,file",
+                "KC_LOG_FILE_OUTPUT", "json",
+                "KC_LOG_FILE_JSON_SERVICE_NAME", "my-service",
+                "KC_LOG_FILE_JSON_SERVICE_ENVIRONMENT", "production"
+        ));
+
+        initConfig();
+
+        assertConfig(Map.of(
+                "log-console-json-service-name", "my-service",
+                "log-console-json-service-environment", "production",
+                "log-file-json-service-name", "my-service",
+                "log-file-json-service-environment", "production"
+        ));
+
+        assertExternalConfig(Map.of(
+                "quarkus.log.console.json.additional-field.\"service.name\".value", "my-service",
+                "quarkus.log.console.json.additional-field.\"service.environment\".value", "production",
+                "quarkus.log.file.json.additional-field.\"service.name\".value", "my-service",
+                "quarkus.log.file.json.additional-field.\"service.environment\".value", "production"
+        ));
+    }
+
+    @Test
     public void testWildcardCliOptionCanBeMappedToQuarkusOption() {
         ConfigArgsConfigSource.setCliArgs("--log-level-org.keycloak=trace");
         SmallRyeConfig config = createConfig();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -275,6 +275,19 @@ public class LoggingDistTest {
     }
 
     @Test
+    @Launch({"start-dev", "--log=console,file", "--log-console-output=json", "--log-console-json-format=ecs", "--log-file-output=json", "--log-file-json-format=ecs", "--log-service-name=my-custom-service", "--log-service-environment=my-custom-env"})
+    void ecsFormatServiceFields(CLIResult cliResult, RawDistRootPath path) {
+        var output = cliResult.getOutput();
+
+        assertThat(output, containsString("\"service.name\":\"my-custom-service\""));
+        assertThat(output, containsString("\"service.environment\":\"my-custom-env\""));
+
+        String data = readDefaultFileLog(path);
+        assertThat(data, containsString("\"service.name\":\"my-custom-service\""));
+        assertThat(data, containsString("\"service.environment\":\"my-custom-env\""));
+    }
+
+    @Test
     @Launch({"start-dev", "--log-async=true"})
     void asyncLogging(CLIResult cliResult) {
         cliResult.assertStartedDevMode();

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OptionsDistTest.java
@@ -60,7 +60,7 @@ public class OptionsDistTest {
     @Launch({"start", "--db=dev-file", "--log=console", "--log-file-output=json", "--http-enabled=true", "--hostname-strict=false"})
     public void testServerDoesNotStartIfDisabledFileLogOption(CLIResult result) {
         result.assertError("Disabled option: '--log-file-output'. Available only when File log handler is activated");
-        result.assertError("--log, --log-async, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-console-async, --log-level, --log-level-<category>");
+        result.assertError("--log, --log-async, --log-service-name, --log-service-environment, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-console-async, --log-level, --log-level-<category>");
     }
 
     @DryRun
@@ -114,7 +114,7 @@ public class OptionsDistTest {
     @Launch({"start-dev", "--log=console", "--log-file-output=json"})
     public void testServerDoesNotStartDevIfDisabledFileLogOption(CLIResult result) {
         result.assertError("Disabled option: '--log-file-output'. Available only when File log handler is activated");
-        result.assertError("Possible solutions: --log, --log-async, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-console-async, --log-level, --log-level-<category>");
+        result.assertError("Possible solutions: --log, --log-async, --log-service-name, --log-service-environment, --log-console-output, --log-console-level, --log-console-format, --log-console-color, --log-console-async, --log-level, --log-level-<category>");
     }
 
     @DryRun
@@ -124,7 +124,7 @@ public class OptionsDistTest {
     public void testServerStartDevIfEnabledFileLogOption(CLIResult result) {
         result.assertNoError("Disabled option: '--log-file-output'. Available only when File log handler is activated");
         result.assertError("Disabled option: '--log-console-color'. Available only when Console log handler is activated");
-        result.assertError("Possible solutions: --log, --log-async, --log-file, --log-file-level, --log-file-format, --log-file-json-format, --log-file-output, --log-file-async, --log-file-rotation-enabled, --log-file-rotation-max-file-size, --log-file-rotation-max-backup-index, --log-file-rotation-file-suffix, --log-file-rotation-rotate-on-boot, --log-level, --log-level-<category>, --log-mdc-enabled");
+        result.assertError("Possible solutions: --log, --log-async, --log-service-name, --log-service-environment, --log-file, --log-file-level, --log-file-format, --log-file-json-format, --log-file-output, --log-file-async, --log-file-rotation-enabled, --log-file-rotation-max-file-size, --log-file-rotation-max-backup-index, --log-file-rotation-file-suffix, --log-file-rotation-rotate-on-boot, --log-level, --log-level-<category>, --log-mdc-enabled");
     }
 
     @DryRun

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -238,6 +238,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -240,6 +240,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -233,6 +233,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -312,6 +312,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -233,6 +233,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -312,6 +312,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -478,6 +478,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -677,6 +677,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -526,6 +526,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -678,6 +678,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -459,6 +459,12 @@ Logging:
                      The log level of a category. Takes precedence over the 'log-level' option.
                        Possible values are (case insensitive): off, fatal, error, warn, info,
                        debug, trace, all.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Truststore:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -607,6 +607,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -525,6 +525,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -677,6 +677,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -523,6 +523,12 @@ Logging:
                      Indicates whether to add information about the realm and other information to
                        the mapped diagnostic context. All elements will be prefixed with 'kc.'
                        Default: false. Available only when log-mdc preview feature is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 
 Tracing:
 

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -675,6 +675,12 @@ Logging:
                        ipAddress, org, sessionId, authenticationSessionId, authenticationTabId.
                        Default: realmName,clientId,org,sessionId,authenticationSessionId,
                        authenticationTabId. Available only when MDC logging is enabled.
+--log-service-environment <environment>
+                     Set the 'service.environment' field in JSON log entries for all log handlers.
+                       In ECS format, defaults to the Quarkus profile if not set.
+--log-service-name <name>
+                     Set the 'service.name' field in JSON log entries for all log handlers.
+                       Default: keycloak.
 --log-syslog-app-name <name>
                      Set the app name used when formatting the message in RFC5424 format. Default:
                        keycloak. Available only when Syslog is activated.


### PR DESCRIPTION
Add native KC options for JSON log service.name and service.environment fields

Closes: #47146

Signed-off-by: Daniele Mammarella <dmammare@redhat.com>

## Summary
- Add 4 new Keycloak options to customize the `service.name` and `service.environment` fields in JSON log entries (both console and file handlers)
- Each option maps to the corresponding Quarkus `additional-field` property via PropertyMapper, following the same pattern used by OpenTelemetry options (`telemetry-service-name` to `quarkus.otel.service.name`)

## New options
| Keycloak option | Maps to |
|---|---|
| `log-console-json-service-name` | `quarkus.log.console.json.additional-field."service.name".value` |
| `log-console-json-service-environment` | `quarkus.log.console.json.additional-field."service.environment".value` |
| `log-file-json-service-name` | `quarkus.log.file.json.additional-field."service.name".value` |
| `log-file-json-service-environment` | `quarkus.log.file.json.additional-field."service.environment".value` |

These options work through all standard configuration methods: `keycloak.conf`, CLI flags, environment variables (`KC_LOG_CONSOLE_JSON_SERVICE_NAME`), and operator `additionalOptions`.

## Example

```
# keycloak.conf
log-console-output=json
log-console-json-format=ecs
log-console-json-service-name=my-service
log-console-json-service-environment=production
```

Before (hardcoded defaults):
```json
"service.name": "Keycloak",
"service.environment": "prod"
```

After:
```json
"service.name": "my-service",
"service.environment": "production"
```