### PR TITLE
Mark built-in execute-actions required actions as one-time

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/requiredactions/DeleteCredentialAction.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/DeleteCredentialAction.java
@@ -63,6 +63,11 @@ public class DeleteCredentialAction implements RequiredActionProvider, RequiredA
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public void init(Config.Scope config) {
 
     }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/TermsAndConditions.java
@@ -45,6 +45,11 @@ public class TermsAndConditions implements RequiredActionProvider, RequiredActio
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public void init(Config.Scope config) {
 
     }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateEmail.java
@@ -124,6 +124,11 @@ public class UpdateEmail implements RequiredActionProvider, RequiredActionFactor
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public String getDisplayText() {
         return "Update Email";
     }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateProfile.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateProfile.java
@@ -57,6 +57,11 @@ public class UpdateProfile implements RequiredActionProvider, RequiredActionFact
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public void evaluateTriggers(RequiredActionContext context) {
     }
 

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateUserLocaleAction.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/UpdateUserLocaleAction.java
@@ -13,6 +13,11 @@ import org.keycloak.models.UserModel;
 public class UpdateUserLocaleAction implements RequiredActionProvider, RequiredActionFactory {
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public String getDisplayText() {
         return "Update User Locale";
     }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/VerifyEmail.java
@@ -85,6 +85,11 @@ public class VerifyEmail implements RequiredActionProvider, RequiredActionFactor
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public void requiredActionChallenge(RequiredActionContext context) {
         process(context, true);
     }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegisterFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegisterFactory.java
@@ -79,6 +79,11 @@ public class WebAuthnRegisterFactory implements RequiredActionFactory, Environme
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public boolean isSupported(Config.Scope config) {
         return Profile.isFeatureEnabled(Profile.Feature.WEB_AUTHN);
     }

--- a/services/src/main/java/org/keycloak/broker/provider/IdpLinkAction.java
+++ b/services/src/main/java/org/keycloak/broker/provider/IdpLinkAction.java
@@ -81,6 +81,11 @@ public class IdpLinkAction implements RequiredActionProvider, RequiredActionFact
     }
 
     @Override
+    public boolean isOneTimeAction() {
+        return true;
+    }
+
+    @Override
     public void init(Config.Scope config) {
 
     }

--- a/services/src/test/java/org/keycloak/authentication/requiredactions/RequiredActionOneTimeActionTest.java
+++ b/services/src/test/java/org/keycloak/authentication/requiredactions/RequiredActionOneTimeActionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.requiredactions;
+
+import java.util.List;
+
+import org.keycloak.authentication.RequiredActionFactory;
+import org.keycloak.broker.provider.IdpLinkAction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RequiredActionOneTimeActionTest {
+
+    @Test
+    public void testBuiltInRequiredActionsAreOneTime() {
+        List<RequiredActionFactory> requiredActions = List.of(
+                new DeleteAccount(),
+                new DeleteCredentialAction(),
+                new IdpLinkAction(),
+                new RecoveryAuthnCodesAction(),
+                new TermsAndConditions(),
+                new UpdateEmail(),
+                new UpdatePassword(),
+                new UpdateProfile(),
+                new UpdateTotp(),
+                new UpdateUserLocaleAction(),
+                new VerifyEmail(),
+                new VerifyUserProfile(),
+                new WebAuthnRegisterFactory(),
+                new WebAuthnPasswordlessRegisterFactory()
+        );
+
+        for (RequiredActionFactory requiredAction : requiredActions) {
+            Assert.assertTrue("Expected one-time action: " + requiredAction.getClass().getSimpleName(), requiredAction.isOneTimeAction());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #47078

Set `isOneTimeAction()` to `true` for built-in required action factories used by execute-actions links.

This ensures execute-actions tokens are invalidated after first use for these actions.

Adds regression coverage in `RequiredActionOneTimeActionTest`.