### PR TITLE
fix: reducing the cost of clear admin composite role cache

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheManager.java
@@ -43,6 +43,7 @@ public class RealmCacheManager extends CacheManager {
     private static final Logger logger = Logger.getLogger(RealmCacheManager.class);
 
     private final ConcurrentHashMap<String, ReentrantLock> cacheInteractions = new ConcurrentHashMap<>();
+    private volatile String adminRoleId;
 
     @Override
     protected Logger getLogger() {
@@ -153,4 +154,13 @@ public class RealmCacheManager extends CacheManager {
             cacheInteractions.remove(id, lock);
         }
     }
+
+    public String getAdminRoleId() {
+        return adminRoleId;
+    }
+
+    public void setAdminRoleId(String adminRoleId) {
+        this.adminRoleId = adminRoleId;
+    }
+
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheManager.java
@@ -43,7 +43,6 @@ public class RealmCacheManager extends CacheManager {
     private static final Logger logger = Logger.getLogger(RealmCacheManager.class);
 
     private final ConcurrentHashMap<String, ReentrantLock> cacheInteractions = new ConcurrentHashMap<>();
-    private volatile String adminRoleId;
 
     @Override
     protected Logger getLogger() {
@@ -154,13 +153,4 @@ public class RealmCacheManager extends CacheManager {
             cacheInteractions.remove(id, lock);
         }
     }
-
-    public String getAdminRoleId() {
-        return adminRoleId;
-    }
-
-    public void setAdminRoleId(String adminRoleId) {
-        this.adminRoleId = adminRoleId;
-    }
-
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -483,11 +483,8 @@ public class RealmCacheSession implements CacheRealmProvider {
         return adapter;
     }
 
-    /**
-     * Cache that we've triggered an admin role invalidation in this session already.
-     * This avoids loading the admin role again from the database
-     */
-    private boolean adminRoleInvalidated;
+    private RealmModel adminRealm;
+    private RoleModel adminRole;
 
     private RealmAdapter prepareCachedRealm(String id, KeycloakSession session) {
         CachedRealm cached = cache.get(id, CachedRealm.class);
@@ -499,15 +496,22 @@ public class RealmCacheSession implements CacheRealmProvider {
                 return null;
             }
 
-            // To accommodate imports of new realms in a separate process, always evict the admin role.
-            // As an alternative, one could iterate through all composite roles of the Admin role, but that would
-            // load about 20 roles per realm to the cache which is also inefficient.
-            if (!adminRoleInvalidated && !model.getName().equals(Config.getAdminRealm())) {
-                RealmModel adminRealm = session.realms().getRealmByName(Config.getAdminRealm());
+            // to accommodate imports of new realms, check to see if the master admin role is up-to-date
+            if (!model.getName().equals(Config.getAdminRealm()) && (adminRole == null || !invalidations.contains(adminRole.getId()))) {
+                if (adminRealm == null) {
+                    adminRealm = getRealmByName(Config.getAdminRealm());
+                }
                 if (adminRealm != null) {
-                    RoleModel adminRole = adminRealm.getRole(AdminRoles.ADMIN);
-                    invalidateRole(adminRole.getId());
-                    adminRoleInvalidated = true;
+                    if (adminRole == null) {
+                        adminRole = adminRealm.getRole(AdminRoles.ADMIN);
+                    }
+                    if (adminRole instanceof RoleAdapter ra && !ra.cached.getCachedComposites().isEmpty()) {
+                        ClientModel clientModel = session.clients().getClientByClientId(adminRealm, model.getName() + "-realm");
+                        if (clientModel != null && adminRole.getCompositesStream()
+                                .noneMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())))) {
+                            registerRoleInvalidation(adminRole.getId(), adminRole.getName(), adminRole.getContainerId());
+                        }
+                    }
                 }
             }
 
@@ -877,7 +881,8 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             logger.tracev("adding realm role cache miss: client {0} key {1}", realm.getName(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            return model;
+            addCachedRole(realm, loaded, model);
+            return getRoleById(realm, model.getId());
         }
         String roleId = query.getRole();
         if (roleId == null) {
@@ -915,7 +920,8 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             logger.tracev("adding client role cache miss: client {0} key {1}", client.getClientId(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            return model;
+            addCachedRole(client.getRealm(), loaded, model);
+            return getRoleById(client.getRealm(), model.getId());
         }
         String roleId = query.getRole();
         if (roleId == null) {
@@ -952,6 +958,12 @@ public class RealmCacheSession implements CacheRealmProvider {
 
     @Override
     public RoleModel getRoleById(RealmModel realm, String id) {
+        if (invalidations.contains(id)) {
+            return getRoleDelegate().getRoleById(realm, id);
+        } else if (managedRoles.containsKey(id)) {
+            return managedRoles.get(id);
+        }
+
         CachedRole cached = cache.get(id, CachedRole.class);
         if (cached != null && !cached.getRealm().equals(realm.getId())) {
             cached = null;
@@ -961,22 +973,22 @@ public class RealmCacheSession implements CacheRealmProvider {
             long loaded = cache.getCurrentRevision(id);
             RoleModel model = getRoleDelegate().getRoleById(realm, id);
             if (model == null) return null;
-            if (invalidations.contains(id)) return model;
-            if (model.isClientRole()) {
-                cached = new CachedClientRole(loaded, model.getContainerId(), model, realm);
-            } else {
-                cached = new CachedRealmRole(loaded, model, realm);
-            }
-            cache.addRevisioned(cached, startupRevision);
-
-        } else if (invalidations.contains(id)) {
-            return getRoleDelegate().getRoleById(realm, id);
-        } else if (managedRoles.containsKey(id)) {
-            return managedRoles.get(id);
+            cached = addCachedRole(realm, loaded, model);
         }
         RoleAdapter adapter = new RoleAdapter(cached,this, realm);
         managedRoles.put(id, adapter);
         return adapter;
+    }
+
+    private CachedRole addCachedRole(RealmModel realm, long loaded, RoleModel model) {
+        CachedRole cached;
+        if (model.isClientRole()) {
+            cached = new CachedClientRole(loaded, model.getContainerId(), model, realm);
+        } else {
+            cached = new CachedRealmRole(loaded, model, realm);
+        }
+        cache.addRevisioned(cached, startupRevision);
+        return cached;
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -23,6 +23,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -350,9 +352,6 @@ public class RealmCacheSession implements CacheRealmProvider {
     }
 
     protected void runInvalidations() {
-        if (invalidateAdminRole) {
-            registerRoleInvalidation(adminRole.getId(), adminRole.getName(), adminRole.getContainerId());
-        }
         for (String id : invalidations) {
             cache.invalidateObject(id);
         }
@@ -486,10 +485,6 @@ public class RealmCacheSession implements CacheRealmProvider {
         return adapter;
     }
 
-    private boolean invalidateAdminRole;
-    private RealmModel adminRealm;
-    private RoleModel adminRole;
-
     private RealmAdapter prepareCachedRealm(String id, KeycloakSession session) {
         CachedRealm cached = cache.get(id, CachedRealm.class);
         RealmAdapter adapter;
@@ -500,28 +495,14 @@ public class RealmCacheSession implements CacheRealmProvider {
                 return null;
             }
 
-            // to accommodate imports of new realms, check to see if the master admin role is up-to-date
-            if (!invalidateAdminRole && !model.getName().equals(Config.getAdminRealm())
-                    && (adminRole == null || !invalidations.contains(adminRole.getId()))) {
-                if (adminRealm == null) {
-                    adminRealm = getRealmByName(Config.getAdminRealm());
-                }
-                if (adminRealm != null) {
-                    if (adminRole == null) {
-                        adminRole = adminRealm.getRole(AdminRoles.ADMIN);
-                    }
-                    if (adminRole instanceof RoleAdapter ra && !ra.cached.getCachedComposites().isEmpty()) {
-                        ClientModel clientModel = session.clients().getClientByClientId(adminRealm, model.getName() + "-realm");
-                        if (clientModel != null && adminRole.getCompositesStream()
-                                .noneMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())))) {
-                            ra.clearCompositeCache();
-                            invalidateAdminRole = true;
-                        }
-                    }
-                }
+            cached = new CachedRealm(loaded, model);
+
+            String clientModelId = cached.getMasterAdminClient();
+
+            if (!model.getName().equals(Config.getAdminRealm()) && clientModelId != null) {
+                checkForNewAdminRoleComposites(id, clientModelId, model);
             }
 
-            cached = new CachedRealm(loaded, model);
             cache.addRevisioned(cached, startupRevision);
             adapter = new RealmAdapter(session, cached, this);
             CachedRealmModel.RealmCachedEvent event = new CachedRealmModel.RealmCachedEvent() {
@@ -541,6 +522,46 @@ public class RealmCacheSession implements CacheRealmProvider {
             logger.tracev("by id cache hit after locking: {0}", cached.getName());
         }
         return adapter;
+    }
+
+    /**
+     * The logic here is designed to avoid  additional database lookups and creation of new cache entries
+     */
+    private void checkForNewAdminRoleComposites(String id, String clientModelId, RealmModel model) {
+        String adminRoleId = cache.getAdminRoleId();
+        if (adminRoleId == null) {
+            RealmModel adminRealm = getRealmByName(Config.getAdminRealm());
+            if (adminRealm == null) {
+                return;
+            }
+            RoleModel adminRole = getRealmRole(adminRealm, AdminRoles.ADMIN);
+            if (adminRole == null) {
+                return;
+            }
+            cache.setAdminRoleId(adminRole.getId());
+            adminRoleId = adminRole.getId();
+        }
+        Predicate<CachedRole> predicate = role -> !role.getCachedComposites().isEmpty() && role.getCachedComposites().stream()
+                .noneMatch(r -> (r.clientRole() && r.containerId().equals(clientModelId)));
+
+        BiConsumer<CachedRole, Runnable> testAndClear = (role, clear) -> {
+            if (predicate.test(role)) {
+                synchronized (role) {
+                    if (predicate.test(role)) {
+                        clear.run();
+                    }
+                }
+            }
+        };
+
+        RoleAdapter managedRole = this.invalidations.contains(adminRoleId) ? null : this.managedRoles.get(adminRoleId);
+        if (managedRole != null) {
+            testAndClear.accept(managedRole.cached, managedRole::clearCompositeCache);
+        }
+        CachedRole cachedRole = cache.get(adminRoleId, CachedRole.class);
+        if (cachedRole != null && (managedRole == null || managedRole.cached != cachedRole)) {
+            testAndClear.accept(cachedRole, cachedRole::clearCompositeCache);
+        }
     }
 
     @Override
@@ -569,11 +590,9 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             query = new RealmListQuery(loaded, cacheKey, model.getId());
             cache.addRevisioned(query, startupRevision);
-            return model;
-        } else {
-            String realmId = query.getRealms().iterator().next();
-            return getRealm(realmId);
         }
+        String realmId = query.getRealms().iterator().next();
+        return getRealm(realmId);
     }
 
     static String getRealmByNameCacheKey(String name) {
@@ -767,7 +786,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             query = new RoleListQuery(loaded, cacheKey, realm, ids);
             logger.tracev("adding realm roles cache miss: realm {0} key {1}", realm.getName(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            return model.stream();
         }
         Set<RoleModel> list = new HashSet<>();
         for (String id : query.getRoles()) {
@@ -802,7 +820,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             query = new RoleListQuery(loaded, cacheKey, client.getRealm(), ids, client.getClientId());
             logger.tracev("adding client roles cache miss: client {0} key {1}", client.getClientId(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            return model.stream();
         }
         Set<RoleModel> list = new HashSet<>();
         for (String id : query.getRoles()) {
@@ -887,11 +904,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             logger.tracev("adding realm role cache miss: client {0} key {1}", realm.getName(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            if (model != null) {
-                addCachedRole(realm, loaded, model);
-                return getRoleById(realm, model.getId());
-            }
-            return null;
         }
         String roleId = query.getRole();
         if (roleId == null) {
@@ -929,11 +941,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             logger.tracev("adding client role cache miss: client {0} key {1}", client.getClientId(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            if (model != null) {
-                addCachedRole(client.getRealm(), loaded, model);
-                return getRoleById(client.getRealm(), model.getId());
-            }
-            return null;
         }
         String roleId = query.getRole();
         if (roleId == null) {
@@ -985,22 +992,16 @@ public class RealmCacheSession implements CacheRealmProvider {
             long loaded = cache.getCurrentRevision(id);
             RoleModel model = getRoleDelegate().getRoleById(realm, id);
             if (model == null) return null;
-            cached = addCachedRole(realm, loaded, model);
+            if (model.isClientRole()) {
+                cached = new CachedClientRole(loaded, model.getContainerId(), model, realm);
+            } else {
+                cached = new CachedRealmRole(loaded, model, realm);
+            }
+            cache.addRevisioned(cached, startupRevision);
         }
         RoleAdapter adapter = new RoleAdapter(cached,this, realm);
         managedRoles.put(id, adapter);
         return adapter;
-    }
-
-    private CachedRole addCachedRole(RealmModel realm, long loaded, RoleModel model) {
-        CachedRole cached;
-        if (model.isClientRole()) {
-            cached = new CachedClientRole(loaded, model.getContainerId(), model, realm);
-        } else {
-            cached = new CachedRealmRole(loaded, model, realm);
-        }
-        cache.addRevisioned(cached, startupRevision);
-        return cached;
     }
 
     @Override
@@ -1367,9 +1368,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             query = new ClientListQuery(loaded, cacheKey, realm, id);
             logger.tracev("adding client by name cache miss: {0}", clientId);
             cache.addRevisioned(query, startupRevision);
-            if (invalidations.contains(model.getId())) {
-                return model;
-            }
         } else {
             id = query.getClients().iterator().next();
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -23,17 +23,13 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.keycloak.Config;
 import org.keycloak.client.clienttype.ClientTypeManager;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.Profile;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientInitialAccessModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientProvider;
@@ -496,13 +492,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
 
             cached = new CachedRealm(loaded, model);
-
-            String clientModelId = cached.getMasterAdminClient();
-
-            if (!model.getName().equals(Config.getAdminRealm()) && clientModelId != null) {
-                checkForNewAdminRoleComposites(clientModelId);
-            }
-
             cache.addRevisioned(cached, startupRevision);
             adapter = new RealmAdapter(session, cached, this);
             CachedRealmModel.RealmCachedEvent event = new CachedRealmModel.RealmCachedEvent() {
@@ -522,47 +511,6 @@ public class RealmCacheSession implements CacheRealmProvider {
             logger.tracev("by id cache hit after locking: {0}", cached.getName());
         }
         return adapter;
-    }
-
-    /**
-     * The logic here is designed to avoid  additional database lookups and creation of new cache entries
-     */
-    private void checkForNewAdminRoleComposites(String clientModelId) {
-        String adminRoleId = cache.getAdminRoleId();
-        if (adminRoleId == null) {
-            RealmModel adminRealm = getRealmByName(Config.getAdminRealm());
-            if (adminRealm == null) {
-                return;
-            }
-            RoleModel adminRole = getRealmRole(adminRealm, AdminRoles.ADMIN);
-            if (adminRole == null) {
-                return;
-            }
-            cache.setAdminRoleId(adminRole.getId());
-            adminRoleId = adminRole.getId();
-        }
-        Predicate<CachedRole> predicate = role -> !role.getCachedComposites().isEmpty() && role.getCachedComposites().stream()
-                .noneMatch(r -> (r.clientRole() && r.containerId().equals(clientModelId)));
-
-        BiConsumer<CachedRole, Runnable> testAndClear = (role, clear) -> {
-            if (predicate.test(role)) {
-                synchronized (role) {
-                    if (predicate.test(role)) {
-                        clear.run();
-                    }
-                }
-            }
-        };
-
-        RoleAdapter managedRole = this.invalidations.contains(adminRoleId) ? null : this.managedRoles.get(adminRoleId);
-        if (managedRole != null) {
-            testAndClear.accept(managedRole.cached, managedRole::clearCompositeCache);
-        }
-        // Double-check that the current entry in the cache is not different from the one that we're using
-        CachedRole cachedRole = cache.get(adminRoleId, CachedRole.class);
-        if (cachedRole != null && (managedRole == null || managedRole.cached != cachedRole)) {
-            testAndClear.accept(cachedRole, cachedRole::clearCompositeCache);
-        }
     }
 
     @Override
@@ -984,6 +932,16 @@ public class RealmCacheSession implements CacheRealmProvider {
             return managedRoles.get(id);
         }
 
+        CachedRole cached = getCachedRole(realm, id);
+        if (cached == null) {
+            return null;
+        }
+        RoleAdapter adapter = new RoleAdapter(cached,this, realm);
+        managedRoles.put(id, adapter);
+        return adapter;
+    }
+
+    protected CachedRole getCachedRole(RealmModel realm, String id) {
         CachedRole cached = cache.get(id, CachedRole.class);
         if (cached != null && !cached.getRealm().equals(realm.getId())) {
             cached = null;
@@ -1000,9 +958,7 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             cache.addRevisioned(cached, startupRevision);
         }
-        RoleAdapter adapter = new RoleAdapter(cached,this, realm);
-        managedRoles.put(id, adapter);
-        return adapter;
+        return cached;
     }
 
     @Override
@@ -1629,5 +1585,39 @@ public class RealmCacheSession implements CacheRealmProvider {
     public void preRemove(RealmModel realm) {
         listInvalidations.add(realm.getId());
         getGroupDelegate().preRemove(realm);
+    }
+
+    @Override
+    public boolean refreshMasterAdminRole(RoleModel masterAdminRole, String clientId) {
+        if (!(masterAdminRole instanceof RoleAdapter)) {
+            return false;
+        }
+        RoleAdapter role = (RoleAdapter)masterAdminRole;
+        if (role.isUpdated() || role.cached.getCachedComposites().clientContainerIds().contains(clientId)) {
+            return false;
+        }
+        CachedRole inCache = getCachedRole(role.realm, role.getId());
+        if (inCache == null) {
+            return false;
+        }
+        if (!inCache.getComposites(session, role::getRoleModel).clientContainerIds().contains(clientId)) {
+            // we suspect that the cache entry is out-of-date, lock to prevent multiple invalidations
+            synchronized (inCache) {
+                inCache = getCachedRole(role.realm, role.getId());
+                if (inCache == null) {
+                    return false;
+                }
+                if (!inCache.getComposites(session, role::getRoleModel).clientContainerIds().contains(clientId)) {
+                    cache.invalidateObject(role.getId());
+                    inCache = getCachedRole(role.realm, role.getId());
+                }
+            }
+        }
+        if (inCache != null) {
+            role.composites = null;
+            role.cached = inCache;
+            return true;
+        }
+        return false;
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -350,6 +350,9 @@ public class RealmCacheSession implements CacheRealmProvider {
     }
 
     protected void runInvalidations() {
+        if (invalidateAdminRole) {
+            registerRoleInvalidation(adminRole.getId(), adminRole.getName(), adminRole.getContainerId());
+        }
         for (String id : invalidations) {
             cache.invalidateObject(id);
         }
@@ -483,6 +486,7 @@ public class RealmCacheSession implements CacheRealmProvider {
         return adapter;
     }
 
+    private boolean invalidateAdminRole;
     private RealmModel adminRealm;
     private RoleModel adminRole;
 
@@ -497,7 +501,8 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
 
             // to accommodate imports of new realms, check to see if the master admin role is up-to-date
-            if (!model.getName().equals(Config.getAdminRealm()) && (adminRole == null || !invalidations.contains(adminRole.getId()))) {
+            if (!invalidateAdminRole && !model.getName().equals(Config.getAdminRealm())
+                    && (adminRole == null || !invalidations.contains(adminRole.getId()))) {
                 if (adminRealm == null) {
                     adminRealm = getRealmByName(Config.getAdminRealm());
                 }
@@ -509,7 +514,8 @@ public class RealmCacheSession implements CacheRealmProvider {
                         ClientModel clientModel = session.clients().getClientByClientId(adminRealm, model.getName() + "-realm");
                         if (clientModel != null && adminRole.getCompositesStream()
                                 .noneMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())))) {
-                            registerRoleInvalidation(adminRole.getId(), adminRole.getName(), adminRole.getContainerId());
+                            ra.clearCompositeCache();
+                            invalidateAdminRole = true;
                         }
                     }
                 }
@@ -881,8 +887,11 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             logger.tracev("adding realm role cache miss: client {0} key {1}", realm.getName(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            addCachedRole(realm, loaded, model);
-            return getRoleById(realm, model.getId());
+            if (model != null) {
+                addCachedRole(realm, loaded, model);
+                return getRoleById(realm, model.getId());
+            }
+            return null;
         }
         String roleId = query.getRole();
         if (roleId == null) {
@@ -920,8 +929,11 @@ public class RealmCacheSession implements CacheRealmProvider {
             }
             logger.tracev("adding client role cache miss: client {0} key {1}", client.getClientId(), cacheKey);
             cache.addRevisioned(query, startupRevision);
-            addCachedRole(client.getRealm(), loaded, model);
-            return getRoleById(client.getRealm(), model.getId());
+            if (model != null) {
+                addCachedRole(client.getRealm(), loaded, model);
+                return getRoleById(client.getRealm(), model.getId());
+            }
+            return null;
         }
         String roleId = query.getRole();
         if (roleId == null) {

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -500,7 +500,7 @@ public class RealmCacheSession implements CacheRealmProvider {
             String clientModelId = cached.getMasterAdminClient();
 
             if (!model.getName().equals(Config.getAdminRealm()) && clientModelId != null) {
-                checkForNewAdminRoleComposites(id, clientModelId, model);
+                checkForNewAdminRoleComposites(clientModelId);
             }
 
             cache.addRevisioned(cached, startupRevision);
@@ -527,7 +527,7 @@ public class RealmCacheSession implements CacheRealmProvider {
     /**
      * The logic here is designed to avoid  additional database lookups and creation of new cache entries
      */
-    private void checkForNewAdminRoleComposites(String id, String clientModelId, RealmModel model) {
+    private void checkForNewAdminRoleComposites(String clientModelId) {
         String adminRoleId = cache.getAdminRoleId();
         if (adminRoleId == null) {
             RealmModel adminRealm = getRealmByName(Config.getAdminRealm());
@@ -558,6 +558,7 @@ public class RealmCacheSession implements CacheRealmProvider {
         if (managedRole != null) {
             testAndClear.accept(managedRole.cached, managedRole::clearCompositeCache);
         }
+        // Double-check that the current entry in the cache is not different from the one that we're using
         CachedRole cachedRole = cache.get(adminRoleId, CachedRole.class);
         if (cachedRole != null && (managedRole == null || managedRole.cached != cachedRole)) {
             testAndClear.accept(cachedRole, cachedRole::clearCompositeCache);

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
@@ -261,4 +261,9 @@ public class RoleAdapter implements RoleModel {
         return getId().hashCode();
     }
 
+    protected void clearCompositeCache() {
+        this.composites = null;
+        this.cached.clearCompositeCache();
+    }
+
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
@@ -32,7 +32,6 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.cache.infinispan.entities.CachedClientRole;
 import org.keycloak.models.cache.infinispan.entities.CachedRealmRole;
 import org.keycloak.models.cache.infinispan.entities.CachedRole;
-import org.keycloak.models.cache.infinispan.entities.CachedRole.RoleRecord;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
 /**
@@ -143,8 +142,8 @@ public class RoleAdapter implements RoleModel {
 
         if (composites == null) {
             composites = new HashSet<>();
-            for (RoleRecord rec : cached.getComposites(session, modelSupplier)) {
-                RoleModel role = realm.getRoleById(rec.id());
+            for (String id : cached.getComposites(session, modelSupplier).ids()) {
+                RoleModel role = realm.getRoleById(id);
                 if (role == null) {
                     // chance that composite role was removed, so invalidate this entry and fallback to delegate
                     getDelegateForUpdate();
@@ -161,7 +160,7 @@ public class RoleAdapter implements RoleModel {
     public Stream<RoleModel> getCompositesStream(String search, Integer first, Integer max) {
         if (isUpdated()) return updated.getCompositesStream(search, first, max);
 
-        return cacheSession.getRoleDelegate().getRolesStream(realm, cached.getComposites(session, modelSupplier).stream().map(RoleRecord::id), search, first, max);
+        return cacheSession.getRoleDelegate().getRolesStream(realm, cached.getComposites(session, modelSupplier).ids().stream(), search, first, max);
     }
 
     @Override
@@ -244,7 +243,7 @@ public class RoleAdapter implements RoleModel {
         return cached.getAttributes(session, modelSupplier);
     }
 
-    private RoleModel getRoleModel() {
+    protected RoleModel getRoleModel() {
         return cacheSession.getRoleDelegate().getRoleById(realm, cached.getId());
     }
 
@@ -260,11 +259,6 @@ public class RoleAdapter implements RoleModel {
     @Override
     public int hashCode() {
         return getId().hashCode();
-    }
-
-    protected void clearCompositeCache() {
-        this.composites = null;
-        this.cached.clearCompositeCache();
     }
 
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RoleAdapter.java
@@ -32,6 +32,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.cache.infinispan.entities.CachedClientRole;
 import org.keycloak.models.cache.infinispan.entities.CachedRealmRole;
 import org.keycloak.models.cache.infinispan.entities.CachedRole;
+import org.keycloak.models.cache.infinispan.entities.CachedRole.RoleRecord;
 import org.keycloak.models.utils.KeycloakModelUtils;
 
 /**
@@ -142,8 +143,8 @@ public class RoleAdapter implements RoleModel {
 
         if (composites == null) {
             composites = new HashSet<>();
-            for (String id : cached.getComposites(session, modelSupplier)) {
-                RoleModel role = realm.getRoleById(id);
+            for (RoleRecord rec : cached.getComposites(session, modelSupplier)) {
+                RoleModel role = realm.getRoleById(rec.id());
                 if (role == null) {
                     // chance that composite role was removed, so invalidate this entry and fallback to delegate
                     getDelegateForUpdate();
@@ -160,7 +161,7 @@ public class RoleAdapter implements RoleModel {
     public Stream<RoleModel> getCompositesStream(String search, Integer first, Integer max) {
         if (isUpdated()) return updated.getCompositesStream(search, first, max);
 
-        return cacheSession.getRoleDelegate().getRolesStream(realm, cached.getComposites(session, modelSupplier).stream(), search, first, max);
+        return cacheSession.getRoleDelegate().getRolesStream(realm, cached.getComposites(session, modelSupplier).stream().map(RoleRecord::id), search, first, max);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
@@ -17,10 +17,10 @@
 
 package org.keycloak.models.cache.infinispan.entities;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.models.KeycloakSession;
@@ -35,17 +35,17 @@ import org.keycloak.models.cache.infinispan.LazyLoader;
  */
 public class CachedRole extends AbstractRevisioned implements InRealm {
 
-    public record RoleRecord (String id, boolean clientRole, String containerId) {}
+    public record CompositeRolesRecord (Set<String> clientContainerIds, Set<String> ids) {}
 
     final protected String name;
     final protected String realm;
     final protected String description;
-    protected volatile LazyLoader<RoleModel, Set<RoleRecord>> composites;
+    final protected LazyLoader<RoleModel, CompositeRolesRecord> composites;
     /**
      * Use this so the cache invalidation can retrieve any previously cached role mappings to determine if this
      * items should be evicted.
      */
-    private volatile Set<RoleRecord> cachedComposites = new HashSet<>();
+    private volatile CompositeRolesRecord cachedComposites = new CompositeRolesRecord(Set.of(), Set.of());
     private final LazyLoader<RoleModel, MultivaluedHashMap<String, String>> attributes;
 
     public CachedRole(long revision, RoleModel model, RealmModel realm) {
@@ -53,14 +53,18 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
         description = model.getDescription();
         name = model.getName();
         this.realm = realm.getId();
-        initComposites();
+        composites = new DefaultLazyLoader<>(roleModel -> {
+            Set<String> ids = new HashSet<>();
+            Set<String> clientContainerIds = new HashSet<>();
+            roleModel.getCompositesStream().forEach(r -> {
+                ids.add(r.getId());
+                if (r.isClientRole()) {
+                    clientContainerIds.add(r.getContainerId());
+                }
+            });
+            return new CompositeRolesRecord(Collections.unmodifiableSet(clientContainerIds), Collections.unmodifiableSet(ids));
+        }, null);
         attributes = new DefaultLazyLoader<>(roleModel -> new MultivaluedHashMap<>(roleModel.getAttributes()), MultivaluedHashMap::new);
-    }
-
-    private void initComposites() {
-        composites = new DefaultLazyLoader<>(roleModel -> roleModel.getCompositesStream()
-                .map(r -> new RoleRecord(r.getId(), r.isClientRole(), r.getContainerId())).collect(Collectors.toSet()),
-                HashSet::new);
     }
 
     public String getName() {
@@ -77,10 +81,10 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
     }
 
     public boolean isComposite(KeycloakSession session, Supplier<RoleModel> roleModel) {
-        return !getComposites(session, roleModel).isEmpty();
+        return !getComposites(session, roleModel).ids().isEmpty();
     }
 
-    public Set<RoleRecord> getComposites(KeycloakSession session, Supplier<RoleModel> roleModel) {
+    public CompositeRolesRecord getComposites(KeycloakSession session, Supplier<RoleModel> roleModel) {
         cachedComposites = composites.get(session, roleModel);
         return cachedComposites;
     }
@@ -89,16 +93,11 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
      * Use this so the cache invalidation can retrieve any previously cached role mappings to determine if this
      * items should be evicted. Will return an empty list if it hasn't been cached yet (and then no invalidation is necessary)
      */
-    public Set<RoleRecord> getCachedComposites() {
+    public CompositeRolesRecord getCachedComposites() {
         return cachedComposites;
     }
 
     public MultivaluedHashMap<String, String> getAttributes(KeycloakSession session, Supplier<RoleModel> roleModel) {
         return attributes.get(session, roleModel);
-    }
-
-    public void clearCompositeCache() {
-        this.cachedComposites = new HashSet<RoleRecord>();
-        this.initComposites();
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
@@ -35,15 +35,17 @@ import org.keycloak.models.cache.infinispan.LazyLoader;
  */
 public class CachedRole extends AbstractRevisioned implements InRealm {
 
+    public record RoleRecord (String id, boolean clientRole, String containerId) {}
+
     final protected String name;
     final protected String realm;
     final protected String description;
-    protected volatile LazyLoader<RoleModel, Set<String>> composites;
+    protected volatile LazyLoader<RoleModel, Set<RoleRecord>> composites;
     /**
      * Use this so the cache invalidation can retrieve any previously cached role mappings to determine if this
      * items should be evicted.
      */
-    private volatile Set<String> cachedComposites = new HashSet<>();
+    private volatile Set<RoleRecord> cachedComposites = new HashSet<>();
     private final LazyLoader<RoleModel, MultivaluedHashMap<String, String>> attributes;
 
     public CachedRole(long revision, RoleModel model, RealmModel realm) {
@@ -56,7 +58,9 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
     }
 
     private void initComposites() {
-        composites = new DefaultLazyLoader<>(roleModel -> roleModel.getCompositesStream().map(RoleModel::getId).collect(Collectors.toSet()), HashSet::new);
+        composites = new DefaultLazyLoader<>(roleModel -> roleModel.getCompositesStream()
+                .map(r -> new RoleRecord(r.getId(), r.isClientRole(), r.getContainerId())).collect(Collectors.toSet()),
+                HashSet::new);
     }
 
     public String getName() {
@@ -76,7 +80,7 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
         return !getComposites(session, roleModel).isEmpty();
     }
 
-    public Set<String> getComposites(KeycloakSession session, Supplier<RoleModel> roleModel) {
+    public Set<RoleRecord> getComposites(KeycloakSession session, Supplier<RoleModel> roleModel) {
         cachedComposites = composites.get(session, roleModel);
         return cachedComposites;
     }
@@ -85,7 +89,7 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
      * Use this so the cache invalidation can retrieve any previously cached role mappings to determine if this
      * items should be evicted. Will return an empty list if it hasn't been cached yet (and then no invalidation is necessary)
      */
-    public Set<String> getCachedComposites() {
+    public Set<RoleRecord> getCachedComposites() {
         return cachedComposites;
     }
 
@@ -94,7 +98,7 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
     }
 
     public void clearCompositeCache() {
-        this.cachedComposites = new HashSet<String>();
+        this.cachedComposites = new HashSet<RoleRecord>();
         this.initComposites();
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedRole.java
@@ -38,12 +38,12 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
     final protected String name;
     final protected String realm;
     final protected String description;
-    final protected LazyLoader<RoleModel, Set<String>> composites;
+    protected volatile LazyLoader<RoleModel, Set<String>> composites;
     /**
      * Use this so the cache invalidation can retrieve any previously cached role mappings to determine if this
      * items should be evicted.
      */
-    private Set<String> cachedComposites = new HashSet<>();
+    private volatile Set<String> cachedComposites = new HashSet<>();
     private final LazyLoader<RoleModel, MultivaluedHashMap<String, String>> attributes;
 
     public CachedRole(long revision, RoleModel model, RealmModel realm) {
@@ -51,14 +51,19 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
         description = model.getDescription();
         name = model.getName();
         this.realm = realm.getId();
-        composites = new DefaultLazyLoader<>(roleModel -> roleModel.getCompositesStream().map(RoleModel::getId).collect(Collectors.toSet()), HashSet::new);
+        initComposites();
         attributes = new DefaultLazyLoader<>(roleModel -> new MultivaluedHashMap<>(roleModel.getAttributes()), MultivaluedHashMap::new);
+    }
+
+    private void initComposites() {
+        composites = new DefaultLazyLoader<>(roleModel -> roleModel.getCompositesStream().map(RoleModel::getId).collect(Collectors.toSet()), HashSet::new);
     }
 
     public String getName() {
         return name;
     }
 
+    @Override
     public String getRealm() {
         return realm;
     }
@@ -86,5 +91,10 @@ public class CachedRole extends AbstractRevisioned implements InRealm {
 
     public MultivaluedHashMap<String, String> getAttributes(KeycloakSession session, Supplier<RoleModel> roleModel) {
         return attributes.get(session, roleModel);
+    }
+
+    public void clearCompositeCache() {
+        this.cachedComposites = new HashSet<String>();
+        this.initComposites();
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/stream/HasRolePredicate.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/stream/HasRolePredicate.java
@@ -43,7 +43,7 @@ public class HasRolePredicate implements Predicate<Map.Entry<String, Revisioned>
     @Override
     public boolean test(Map.Entry<String, Revisioned> entry) {
         Object value = entry.getValue();
-        return (value instanceof CachedRole cachedRole && cachedRole.getCachedComposites().contains(role)) ||
+        return (value instanceof CachedRole cachedRole && cachedRole.getCachedComposites().ids().contains(role)) ||
                 (value instanceof CachedGroup cachedGroup && cachedGroup.getCachedRoleMappings().contains(role)) ||
                 (value instanceof RoleQuery roleQuery && roleQuery.getRoles().contains(role)) ||
                 (value instanceof CachedClient cachedClient && cachedClient.getScope().contains(role)) ||

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RoleAdapter.java
@@ -116,7 +116,8 @@ public class RoleAdapter implements RoleModel, JpaModel<RoleEntity> {
 
     @Override
     public Stream<RoleModel> getCompositesStream() {
-        Stream<RoleModel> composites = getChildRoles().map(c -> new RoleAdapter(session, realm, em, c));
+        // look up the roles via the session to allow returning cached entries
+        Stream<RoleModel> composites = getChildRoles().map(c -> session.roles().getRoleById(realm, c.getId()));
         return composites.filter(Objects::nonNull);
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/models/cache/CacheRealmProvider.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/cache/CacheRealmProvider.java
@@ -21,6 +21,7 @@ import org.keycloak.models.ClientProvider;
 import org.keycloak.models.ClientScopeProvider;
 import org.keycloak.models.GroupProvider;
 import org.keycloak.models.RealmProvider;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
 
 /**
@@ -40,4 +41,7 @@ public interface CacheRealmProvider extends RealmProvider, ClientProvider, Clien
 
     void registerGroupInvalidation(String id);
     void registerInvalidation(String id);
+    default boolean refreshMasterAdminRole(RoleModel masterAdminRole, String clientId) {
+        return false;
+    }
 }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ImportDistTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -78,6 +79,16 @@ public class ImportDistTest {
 
     @Test
     void testImportNewRealm(KeycloakDistribution dist) throws IOException {
+        dist.setEnvVar("MY_SECRET", "admin123");
+
+        RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
+        CLIResult result = rawDist.run("bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET");
+
+        assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
+
+        rawDist.setManualStop(true);
+        result = rawDist.run("start-dev", "--db-url-properties=;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=TRUE");
+
         File file = new File("target/realm.json");
 
         RealmRepresentation newRealm=new RealmRepresentation();
@@ -90,20 +101,14 @@ public class ImportDistTest {
             mapper.writeValue(fos, newRealm);
         }
 
-        var cliResult = dist.run("import", "--file=" + file.getAbsolutePath());
+        CLIResult adminResult = rawDist.kcadm("get", "realms", "--server", "http://localhost:8080", "--realm", "master", "--client", "admin", "--secret", "admin123");
+        assertEquals(0, adminResult.exitCode());
+        assertFalse(adminResult.getOutput().contains("anotherRealm"));
+
+        var cliResult = rawDist.kc("import", "--db-url-properties=;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=TRUE", "--file=" + file.getAbsolutePath());
         cliResult.assertMessage("Realm 'anotherRealm' imported");
 
-        dist.setEnvVar("MY_SECRET", "admin123");
-
-        RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
-        CLIResult result = rawDist.run("bootstrap-admin", "service", "--db=dev-file", "--client-id=admin", "--client-secret:env=MY_SECRET");
-
-        assertTrue(result.getErrorOutput().isEmpty(), result.getErrorOutput());
-
-        rawDist.setManualStop(true);
-        rawDist.run("start-dev");
-
-        CLIResult adminResult = rawDist.kcadm("get", "realms", "--server", "http://localhost:8080", "--realm", "master", "--client", "admin", "--secret", "admin123");
+        adminResult = rawDist.kcadm("get", "realms", "--server", "http://localhost:8080", "--realm", "master", "--client", "admin", "--secret", "admin123");
 
         assertEquals(0, adminResult.exitCode());
         assertTrue(adminResult.getOutput().contains("anotherRealm"));

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -134,14 +134,26 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         return this;
     }
 
+    public CLIResult kc(String... arguments) throws IOException {
+        return kc(Arrays.asList(arguments));
+    }
+
+    public CLIResult kc(List<String> arguments) throws IOException {
+        return invoke(SCRIPT_CMD, arguments);
+    }
+
     public CLIResult kcadm(String... arguments) throws IOException {
     	return kcadm(Arrays.asList(arguments));
     }
 
     public CLIResult kcadm(List<String> arguments) throws IOException {
+        return invoke(SCRIPT_KCADM_CMD, arguments);
+    }
+
+    private CLIResult invoke(String script, List<String> arguments) throws IOException {
         List<String> allArgs = new ArrayList<>();
 
-        invoke(allArgs, SCRIPT_KCADM_CMD);
+        invoke(allArgs, script);
 
         if (this.isDebug()) {
             allArgs.add("-x");
@@ -159,12 +171,12 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
 
         builder.environment().putAll(envVars);
 
-        Process kcadm = builder.start();
+        Process proc = builder.start();
 
         DefaultOutputConsumer outputConsumer = new DefaultOutputConsumer();
-        readOutput(kcadm, outputConsumer);
+        readOutput(proc, outputConsumer);
 
-        int exitValue = kcadm.exitValue();
+        int exitValue = proc.exitValue();
 
         return CLIResult.create(outputConsumer.getStdOut(), outputConsumer.getErrOut(), exitValue);
     }
@@ -257,7 +269,7 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         if (descendants.isEmpty()) {
             return;
         }
-        
+
         LOG.debugf("Found %d descendant processes to terminate", descendants.size());
         CompletableFuture<?> allProcesses = CompletableFuture.completedFuture(null);
 
@@ -498,7 +510,7 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
     }
 
     private Path inDistZipDirectory(File distFile) throws Exception{
-      
+
         try (ZipFile zipFile = new ZipFile(distFile)) {
             Optional<? extends ZipEntry> e = zipFile.stream().filter(ZipEntry::isDirectory).findFirst();
             if (e.isPresent()) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/MgmtPermissions.java
@@ -45,6 +45,7 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.cache.CacheRealmProvider;
 import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.Permission;
@@ -192,11 +193,13 @@ class MgmtPermissions implements AdminPermissionEvaluator, AdminPermissionManage
         if (!admin.hasRole(masterAdminRole)) {
             return false;
         }
+        CacheRealmProvider cache = session.getProvider(CacheRealmProvider.class);
+        if (cache == null || !cache.refreshMasterAdminRole(masterAdminRole, clientId)) {
+            return false;
+        }
         Set<String> roleNames = Set.of(adminRoles);
-        ClientModel clientModel = masterRealm.getClientByClientId(clientId);
-        return clientModel != null && masterAdminRole.getCompositesStream()
-                .anyMatch(r -> (r.isClientRole() && r.getContainerId().equals(clientModel.getId())
-                        && roleNames.contains(r.getName())));
+        return masterAdminRole.getCompositesStream().anyMatch(r -> (r.isClientRole()
+                && r.getContainerId().equals(clientId) && roleNames.contains(r.getName())));
     }
 
     public boolean isAdminSameRealm() {


### PR DESCRIPTION
closes: #47139

The code complexity is unfortunately greatly increasing. 

The original fix, and the subsequent change each have issues that this is trying to address:

- For roles the initial lookup by name returned the underlying, not cached, value - which means that the composite cache is not used. This change reorders the get role by name logic to return the cached value.

- invalidating makes operations against the invalidated role in that session quite expensive as everything reverts to direct db operations. ~~This change defers the invalidation until invalidations are being run, and instead just clears invalid caches on the session / local values. Ideally we should invalidate as soon as possible though.~~

- the repeated use of get by name calls can still lead to additional db queries if the cached query result gets evicted. This change caches the admin realm and role directly. An alternative would be to cache the admin role id and admin realm id on the RealmCacheManager - under the assumption that renaming either is not possible.

Another thought is that the test we're performing against the adminRole.getCompositesStream() will cause all of those RoleModel entries to be loaded into cache, which is not desirable for non-admin workloads. We could consider instead having the CachedRole composites hold a tuple of values, instead of just the id string, so the test can be performed directly without loading the RoleModel.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
