### PR TITLE
feat(operator): Add `podLabels` support in `SchedulingSpec` for StatefulSet selector propagation

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/Utils.java
+++ b/operator/src/main/java/org/keycloak/operator/Utils.java
@@ -28,7 +28,12 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.keycloak.operator.crds.v2alpha1.deployment.Keycloak;
+import org.keycloak.operator.crds.v2alpha1.deployment.KeycloakSpec;
+import org.keycloak.operator.crds.v2alpha1.deployment.spec.SchedulingSpec;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
@@ -72,6 +77,12 @@ public final class Utils {
     public static Map<String, String> allInstanceLabels(HasMetadata primary) {
         var labels = new LinkedHashMap<>(Constants.DEFAULT_LABELS);
         labels.put(Constants.INSTANCE_LABEL, primary.getMetadata().getName());
+        if (primary instanceof Keycloak) {
+            Optional.ofNullable(((Keycloak) primary).getSpec())
+                    .map(KeycloakSpec::getSchedulingSpec)
+                    .map(SchedulingSpec::getPodLabels)
+                    .ifPresent(labels::putAll);
+        }
         return labels;
     }
 

--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakDeploymentDependentResource.java
@@ -299,7 +299,9 @@ public class KeycloakDeploymentDependentResource extends CRUDKubernetesDependent
 
     private StatefulSet createBaseDeployment(Keycloak keycloakCR, Context<Keycloak> context, Config operatorConfig) {
         Map<String, String> labels = Utils.allInstanceLabels(keycloakCR);
-        labels.put("app.kubernetes.io/component", "server");
+        if (!labels.containsKey("app.kubernetes.io/component")) {
+            labels.put("app.kubernetes.io/component", "server");
+        }
         Map<String, String> schedulingLabels = new LinkedHashMap<>(labels);
         if (operatorConfig.keycloak().podLabels() != null) {
             labels.putAll(operatorConfig.keycloak().podLabels());

--- a/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/SchedulingSpec.java
+++ b/operator/src/main/java/org/keycloak/operator/crds/v2alpha1/deployment/spec/SchedulingSpec.java
@@ -1,7 +1,9 @@
 package org.keycloak.operator.crds.v2alpha1.deployment.spec;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.fabric8.kubernetes.api.model.Affinity;
@@ -19,6 +21,8 @@ public class SchedulingSpec {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<TopologySpreadConstraint> topologySpreadConstraints = new ArrayList<TopologySpreadConstraint>();
     private String priorityClassName;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private Map<String, String> podLabels = Collections.emptyMap();
 
     public Affinity getAffinity() {
         return affinity;
@@ -50,6 +54,14 @@ public class SchedulingSpec {
 
     public void setPriorityClassName(String priorityClassName) {
         this.priorityClassName = priorityClassName;
+    }
+
+    public Map<String, String> getPodLabels() {
+        return podLabels;
+    }
+
+    public void setPodLabels(Map<String, String> podLabels) {
+        this.podLabels = podLabels;
     }
 
 }

--- a/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/unit/PodTemplateTest.java
@@ -657,6 +657,20 @@ public class PodTemplateTest {
 
 
     @Test
+    public void testPodLabels() {
+        var keycloak = createKeycloak(null, builder -> builder
+                .withNewSchedulingSpec()
+                .addToPodLabels("custom-label", "custom-value")
+                .endSchedulingSpec());
+
+        var deployment = getDeployment(keycloak.getSpec().getUnsupported() != null ? keycloak.getSpec().getUnsupported().getPodTemplate() : null, null,
+                builder -> builder.withSchedulingSpec(keycloak.getSpec().getSchedulingSpec()));
+
+        assertThat(deployment.getSpec().getSelector().getMatchLabels().get("custom-label")).isEqualTo("custom-value");
+        assertThat(deployment.getSpec().getTemplate().getMetadata().getLabels().get("custom-label")).isEqualTo("custom-value");
+    }
+
+    @Test
     public void testPriorityClass() {
         // Arrange
         PodTemplateSpec additionalPodTemplate = null;


### PR DESCRIPTION
### Description

This Pull Request introduces the ability to define custom labels for Keycloak Pods directly within the `SchedulingSpec` of the Keycloak Custom Resource (CR) as explained in [issue](https://github.com/keycloak/keycloak/issues/47159).

Previously, pod labels were mostly static or governed by the operator's default configuration. With this change, users can now specify additional labels that will be propagated to the Keycloak `StatefulSet`'s pod template metadata **and selector**.

---

### The Problem: Kyverno (and equivalent tools) break StatefulSet reconciliation

In Kubernetes clusters where a policy engine such as **Kyverno**, **OPA/Gatekeeper**, or any mutating admission webhook is configured to automatically inject labels onto Pod resources, a critical conflict arises with `StatefulSet`-managed workloads.

When the Keycloak operator creates a `StatefulSet`, Kubernetes records the `spec.selector.matchLabels` as **immutable for the lifetime of the resource**. If an admission controller subsequently injects additional labels into the pod template (`.spec.template.metadata.labels`) — for example to enforce organizational tagging policies, enable network policies, or feed observability pipelines — the resulting pod template labels no longer match the selector that was locked in at creation time.

This causes the operator's reconciliation loop to fail with errors of the form:

```
StatefulSet.apps is invalid:
  spec.selector: Invalid value: ... field is immutable
```

The operator then enters a permanent error state, unable to update or reconcile the `StatefulSet` without manual intervention (typically deleting and recreating the resource, which causes downtime).

**A concrete example:** a Kyverno `ClusterPolicy` of the following form:

```yaml
apiVersion: kyverno.io/v1
kind: ClusterPolicy
metadata:
  name: add-labels
spec:
  rules:
    - name: add-team-label
      match:
        resources:
          kinds: ["Pod"]
      mutate:
        patchStrategicMerge:
          metadata:
            labels:
              team: platform
```

...will silently inject `team: platform` on every pod at admission time. For `Deployment`-managed pods this is generally harmless, as the selector is flexible. For `StatefulSet`-managed pods — like those created by the Keycloak operator — the mismatch between the injected label and the original `matchLabels` causes irrecoverable reconciliation failures.

#### Why `unsupported` pod template is not a clean solution

The Keycloak operator does expose an `unsupported` pod template override mechanism, but using it solely to pre-declare externally-injected labels is fragile: it bypasses operator validation, is not semantically meaningful for this use case, and may conflict with future operator changes.

---

### Solution

By allowing users to declare the expected additional labels in `SchedulingSpec.podLabels`, the operator can include those labels **from the very first creation of the `StatefulSet`**, locking them into the selector alongside the standard instance labels. When the admission controller later injects the same labels, there is no divergence — the pod template and the selector remain consistent.

This transforms a reactive breakage into a proactive, declarative configuration:

```yaml
apiVersion: k8s.keycloak.org/v2alpha1
kind: Keycloak
metadata:
  name: keycloak
spec:
  scheduling:
    podLabels:
      team: platform
```

---

### Changes

- **`SchedulingSpec.java`**: Added a `podLabels` field (`Map<String, String>`) to allow users to define custom labels in the CRD.
- **`Utils.java`**: Updated `allInstanceLabels` to include labels from `SchedulingSpec` when present in the Keycloak CR.
- **`KeycloakDeploymentDependentResource.java`**: Adjusted the base deployment logic to ensure custom labels are correctly merged into both the pod template metadata and the `StatefulSet` selector, without overwriting the mandatory `app.kubernetes.io/component` label unless explicitly set by the user.
- **`PodTemplateTest.java`**: Added unit test `testPodLabels` to verify that custom labels defined in `SchedulingSpec` are correctly applied to both the `StatefulSet` selector and the pod template metadata.

---

### Motivation

This feature is useful for users who need to integrate Keycloak with external tools that rely on specific Pod labels for monitoring, logging, network policies, or any admission-based label injection — without having to resort to the `unsupported` pod template override.

---

### Verification

- [x] Unit tests passed.
- [x] New test case `testPodLabels` confirms labels are correctly applied to both the `StatefulSet` selector and template metadata.

---

PS: I used AI assistance to help generate the solution/tests for this PR.