### PR TITLE
fix: correct Enter key selection in single-select typeahead

### DIFF
--- a/js/libs/ui-shared/src/controls/select-control/TypeaheadSelectControl.tsx
+++ b/js/libs/ui-shared/src/controls/select-control/TypeaheadSelectControl.tsx
@@ -117,11 +117,15 @@ export const TypeaheadSelectControl = <
 
         if (!isTypeaheadMulti) {
           setFilterValue(getValue(focusedItem));
+          field.onChange(
+            Array.isArray(field.value)
+              ? [key(focusedItem)]
+              : key(focusedItem),
+          );
         } else {
           setFilterValue("");
+          updateValue(key(focusedItem), field);
         }
-
-        updateValue(key(focusedItem), field);
 
         setOpen(false);
         setFocusedItemIndex(0);


### PR DESCRIPTION
When using keyboard Enter to select an option in a single-select typeahead (variant="typeahead"), the handler was calling updateValue() which is designed for multi-select. updateValue() uses [...field.value, option] to append to the existing value. When field.value is a string (e.g. a previously selected client UUID), the spread operator splits it character-by-character, causing getSingleValue() to return only the first character when evaluating permissions.

Fix: separate single-select and multi-select Enter key handling. For single-select, use the same replace logic as the onSelect mouse handler: Array.isArray(field.value) ? [key] : key. Multi-select (typeaheadMulti) continues to use updateValue() unchanged.

Fixes #42904

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
