### PR TITLE
Implement expired password change for LDAP federated user

### DIFF
--- a/docs/documentation/server_admin/topics/user-federation/ldap.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/ldap.adoc
@@ -189,6 +189,13 @@ When enabling this feature, make sure your LDAP server is configured to not forc
 second time after the user changes their password. Not doing so might cause a password change loop where the user is
 forced to change their password every time they log in.
 
+==== Enabling password expiration
+
+You can force users to change their password when it reaches its maximum age as defined by the LDAP password policy.
+
+To do this, enable the `Enable LDAP password policy` setting so that a `UPDATE_PASSWORD` required action will be added to
+the user whenever the LDAP server indicates that the user's password has expired.
+
 [NOTE]
 ====
 This capability is based on https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy-11[Password Policy for LDAP Directories (IETF draft-behera-ldap-password-policy)].

--- a/docs/documentation/server_admin/topics/user-federation/ldap.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/ldap.adoc
@@ -172,12 +172,19 @@ WARNING: Always verify that user passwords are properly hashed and not stored as
 directory entry using `ldapsearch` and base64 decode the `userPassword` attribute value.
 
 [[_ldap_password_policy]]
-==== Enabling password change after reset
+==== Enabling LDAP password policy enforcement
 
-You can force users to change their password after an administrator resets their password. This feature is useful for
-security reasons because it prevents users from using the temporary password set by the administrator for a long time.
+The following features are currently supported:
 
-For that, enable the `Enable LDAP password policy` setting so that a `UPDATE_PASSWORD` required action will be added to
+Password change after reset::
+When an administrator resets a user's password, the LDAP server can signal that the user must change their password on next login.
+Enforcing this change prevents users from using a temporary password set by the administrator for an extended period.
+
+Password expiration:
+When a user's password reaches its maximum age as defined by the LDAP password policy, the LDAP server signals that the
+password has expired and the user must choose a new one before continuing.
+
+For these, enable the `Enable LDAP password policy` setting so that a `UPDATE_PASSWORD` required action will be added to
 the user whenever the LDAP server indicates that the user must update their password.
 
 {project_name} is usually configured to connect to the LDAP server using an administrator account even when users are
@@ -188,13 +195,6 @@ account and not by the user itself.
 When enabling this feature, make sure your LDAP server is configured to not force users to change their password a
 second time after the user changes their password. Not doing so might cause a password change loop where the user is
 forced to change their password every time they log in.
-
-==== Enabling password expiration
-
-You can force users to change their password when it reaches its maximum age as defined by the LDAP password policy.
-
-To do this, enable the `Enable LDAP password policy` setting so that a `UPDATE_PASSWORD` required action will be added to
-the user whenever the LDAP server indicates that the user's password has expired.
 
 [NOTE]
 ====

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 import javax.naming.AuthenticationException;
 import javax.naming.Binding;
 import javax.naming.Context;
@@ -534,17 +535,7 @@ public class LDAPOperationManager {
 
             // Check for password policy response control in the response.
             // If present and forced password change is required, throw an exception.
-            Control[] responseControls = authCtx.getResponseControls();
-            if (responseControls != null) {
-                for (Control control : responseControls) {
-                    if (control instanceof PasswordPolicyControl) {
-                        PasswordPolicyControl response = (PasswordPolicyControl) control;
-                        if (response.changeAfterReset()) {
-                            throw new PasswordPolicyPasswordChangeException();
-                        }
-                    }
-                }
-            }
+            checkPasswordPolicy(authCtx, PasswordPolicyControl::changeAfterReset);
 
         } catch (AuthenticationException ae) {
             if (logger.isDebugEnabled()) {
@@ -552,19 +543,14 @@ public class LDAPOperationManager {
             }
 
             try {
-                Control[] responseControls = authCtx.getResponseControls();
-                if (responseControls != null) {
-                    for (Control control : responseControls) {
-                        if (control instanceof PasswordPolicyControl) {
-                            PasswordPolicyControl response = (PasswordPolicyControl) control;
-                            if (response.passwordExpired()) {
-                                throw new PasswordPolicyPasswordChangeException();
-                            }
-                        }
-                    }
-                }
-
+                // Check for password policy response control in the response.
+                // If present and indicate an expired password, throw an exception.
+                checkPasswordPolicy(authCtx, PasswordPolicyControl::passwordExpired);
             } catch (PasswordPolicyPasswordChangeException ppe) {
+                // PasswordPolicyPasswordChangeException must be caught before NamingException
+                // because it extends NamingException. If not explicitly handled first, it would
+                // be swallowed by the broader catch block below, and the caller would never
+                // receive the intended password‑policy specific error.
                 tracing.error(ppe);
                 throw ppe;
             } catch (NamingException ne) {
@@ -826,5 +812,40 @@ public class LDAPOperationManager {
         result.add(LDAPConstants.OBJECT_CLASS);
 
         return result;
+    }
+
+
+    /**
+     * Reads the LDAP response controls after a bind operation and evaluates the
+     * password policy using a supplied rule.
+     * 
+     * If the rule evaluates to true for any PasswordPolicyControl, a
+     * PasswordPolicyPasswordChangeException is thrown.
+     * 
+     * @param authCtx The LDAP context to read response controls from
+     * @param rule  A predicate representing the password policy condition to test
+     * @throws NamingException If reading the LDAP response controls fails
+     * @throws PasswordPolicyPasswordChangeException If the policy condition is true
+     */
+    private void checkPasswordPolicy(LdapContext authCtx, Predicate<PasswordPolicyControl> rule)
+            throws NamingException, PasswordPolicyPasswordChangeException {
+
+        if (authCtx == null) {
+            return;
+        }
+
+        Control[] responseControls = authCtx.getResponseControls();
+        if (responseControls == null) {
+            return;
+        }
+
+        for (Control control : responseControls) {
+            if (control instanceof PasswordPolicyControl) {
+                PasswordPolicyControl response = (PasswordPolicyControl) control;
+                if (rule.test(response)) {
+                    throw new PasswordPolicyPasswordChangeException();
+                }
+            }
+        }
     }
 }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -542,11 +542,12 @@ public class LDAPOperationManager {
                 logger.debugf(ae, "Authentication failed for DN [%s]", dn);
             }
 
+            tracing.error(ae);
+
             // Check for password policy response control in failed bind response.
             // If present and indicate an expired password, throw an exception.
             checkPasswordPolicy(authCtx, PasswordPolicyControl::passwordExpired);
 
-            tracing.error(ae);
             throw ae;
         } catch(RuntimeException re){
             if (logger.isDebugEnabled()) {

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -533,7 +533,7 @@ public class LDAPOperationManager {
             // Send bind request. Throws AuthenticationException when authentication fails.
             authCtx.reconnect(getControls());
 
-            // Check for password policy response control in the response.
+            // Check for password policy response control in successful bind response.
             // If present and forced password change is required, throw an exception.
             checkPasswordPolicy(authCtx, PasswordPolicyControl::changeAfterReset);
 
@@ -542,20 +542,9 @@ public class LDAPOperationManager {
                 logger.debugf(ae, "Authentication failed for DN [%s]", dn);
             }
 
-            try {
-                // Check for password policy response control in the response.
-                // If present and indicate an expired password, throw an exception.
-                checkPasswordPolicy(authCtx, PasswordPolicyControl::passwordExpired);
-            } catch (PasswordPolicyPasswordChangeException ppe) {
-                // PasswordPolicyPasswordChangeException must be caught before NamingException
-                // because it extends NamingException. If not explicitly handled first, it would
-                // be swallowed by the broader catch block below, and the caller would never
-                // receive the intended password‑policy specific error.
-                tracing.error(ppe);
-                throw ppe;
-            } catch (NamingException ne) {
-                logger.debugf(ne, "Could not read response controls after failed bind");
-            }
+            // Check for password policy response control in failed bind response.
+            // If present and indicate an expired password, throw an exception.
+            checkPasswordPolicy(authCtx, PasswordPolicyControl::passwordExpired);
 
             tracing.error(ae);
             throw ae;
@@ -818,23 +807,28 @@ public class LDAPOperationManager {
     /**
      * Reads the LDAP response controls after a bind operation and evaluates the
      * password policy using a supplied rule.
-     * 
+     *
      * If the rule evaluates to true for any PasswordPolicyControl, a
      * PasswordPolicyPasswordChangeException is thrown.
-     * 
+     *
      * @param authCtx The LDAP context to read response controls from
      * @param rule  A predicate representing the password policy condition to test
-     * @throws NamingException If reading the LDAP response controls fails
+     * @throws AuthenticationException If reading the LDAP response controls fails
      * @throws PasswordPolicyPasswordChangeException If the policy condition is true
      */
     private void checkPasswordPolicy(LdapContext authCtx, Predicate<PasswordPolicyControl> rule)
-            throws NamingException, PasswordPolicyPasswordChangeException {
+            throws AuthenticationException, PasswordPolicyPasswordChangeException {
 
         if (authCtx == null) {
             return;
         }
 
-        Control[] responseControls = authCtx.getResponseControls();
+        Control[] responseControls;
+        try {
+            responseControls = authCtx.getResponseControls();
+        } catch (NamingException e) {
+            throw new AuthenticationException("Could not get LDAP response controls");
+        }
         if (responseControls == null) {
             return;
         }

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/LDAPOperationManager.java
@@ -550,6 +550,27 @@ public class LDAPOperationManager {
             if (logger.isDebugEnabled()) {
                 logger.debugf(ae, "Authentication failed for DN [%s]", dn);
             }
+
+            try {
+                Control[] responseControls = authCtx.getResponseControls();
+                if (responseControls != null) {
+                    for (Control control : responseControls) {
+                        if (control instanceof PasswordPolicyControl) {
+                            PasswordPolicyControl response = (PasswordPolicyControl) control;
+                            if (response.passwordExpired()) {
+                                throw new PasswordPolicyPasswordChangeException();
+                            }
+                        }
+                    }
+                }
+
+            } catch (PasswordPolicyPasswordChangeException ppe) {
+                tracing.error(ppe);
+                throw ppe;
+            } catch (NamingException ne) {
+                logger.debugf(ne, "Could not read response controls after failed bind");
+            }
+
             tracing.error(ae);
             throw ae;
         } catch(RuntimeException re){

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyControl.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyControl.java
@@ -37,7 +37,11 @@ public class PasswordPolicyControl implements Control {
 
     private static final int ERROR_CHANGE_AFTER_RESET = 2;
 
+    private static final int ERROR_PASSWORD_EXPIRED = 0;
+
     private boolean changeAfterReset;
+
+    private boolean passwordExpired;
 
     /*
      * https://datatracker.ietf.org/doc/html/draft-behera-ldap-password-policy-11#section-6.2
@@ -74,6 +78,7 @@ public class PasswordPolicyControl implements Control {
             if (ber.isNextTag(BERDecoder.TAG_CLASS_CONTEXT_SPECIFIC, BERDecoder.TAG_FORM_PRIMITIVE, 1)) { // error   [1] ENUMERATED
                 int error = new BigInteger(ber.drainElementValue()).intValue();
                 this.changeAfterReset = error == ERROR_CHANGE_AFTER_RESET;
+                this.passwordExpired = error == ERROR_PASSWORD_EXPIRED;
             }
 
         } catch (BERDecoder.DecodeException ignored) {
@@ -83,6 +88,10 @@ public class PasswordPolicyControl implements Control {
 
     public boolean changeAfterReset() {
         return changeAfterReset;
+    }
+
+    public boolean passwordExpired() {
+        return passwordExpired;
     }
 
     @Override

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyPasswordChangeException.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyPasswordChangeException.java
@@ -20,7 +20,7 @@ package org.keycloak.storage.ldap.idm.store.ldap.control;
 import javax.naming.AuthenticationException;
 
 /**
- * PasswordPolicyPasswordChangeException is thrown when LDAP password policy response control indicates error "changeAfterReset".
+ * PasswordPolicyPasswordChangeException is thrown when LDAP password policy response control indicates that a password change is required.
  */
 public class PasswordPolicyPasswordChangeException extends AuthenticationException {
 

--- a/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyControlTest.java
+++ b/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyControlTest.java
@@ -25,8 +25,13 @@ public class PasswordPolicyControlTest {
     @Test
     public void testDecodeResponseValue() {
         // SEQUENCE { error changeAfterReset(2) }
-        PasswordPolicyControl control = new PasswordPolicyControl(new byte[] { 0x30, 0x03, (byte) 0x81, 0x01, 0x02 });
-        Assert.assertTrue(control.changeAfterReset());
+        PasswordPolicyControl changeAfterResetControl = new PasswordPolicyControl(new byte[] { 0x30, 0x03, (byte) 0x81, 0x01, 0x02 });
+        Assert.assertTrue(changeAfterResetControl.changeAfterReset());
+        Assert.assertFalse(changeAfterResetControl.passwordExpired());
+
+        PasswordPolicyControl passwordExpiredControl = new PasswordPolicyControl(new byte[] { 0x30, 0x03, (byte) 0x81, 0x01, 0x00 });
+        Assert.assertFalse(passwordExpiredControl.changeAfterReset());
+        Assert.assertTrue(passwordExpiredControl.passwordExpired());
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/util/LDAPRule.java
@@ -166,10 +166,11 @@ public class LDAPRule extends ExternalResource {
         if (passwordPolicyAnnotations != null) {
             LDAPPasswordPolicy passwordPolicy = (LDAPPasswordPolicy) passwordPolicyAnnotations;
 
-            log.debugf("Enabling LDAP password policy: mustChange=%s.", passwordPolicy.mustChange());
+            log.debugf("Enabling LDAP password policy: mustChange=%s, maxAge=%d.", passwordPolicy.mustChange(), passwordPolicy.maxAge());
 
             defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_PPOLICY_ENABLED, "true");
             defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_PPOLICY_MUST_CHANGE, String.valueOf(passwordPolicy.mustChange()));
+            defaultProperties.setProperty(LDAPEmbeddedServer.PROPERTY_PPOLICY_MAX_AGE, String.valueOf(passwordPolicy.maxAge()));
 
             if (passwordPolicy.mustChange()) {
                 // Workaround for password policy behavior:
@@ -355,5 +356,6 @@ public class LDAPRule extends ExternalResource {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface LDAPPasswordPolicy {
         public boolean mustChange() default false;
+        public int maxAge() default 0;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordPolicyTest.java
@@ -102,14 +102,14 @@ public class LDAPPasswordPolicyTest extends AbstractLDAPTest {
     @LDAPPasswordPolicy(mustChange=true, maxAge=31536000)
     public void testExpiredPassword() throws Exception {
         // Login with user that has an expired password.
-        loginPage.open();
+        oauth.loginForm().open();
         loginPage.login("expired", "Password1");
 
         // Forced password change sends user to update password page.
         passwordUpdatePage.assertCurrent();
 
         // Repeated login without changing password should still send user to update password page.
-        loginPage.open();
+        oauth.loginForm().open();
         loginPage.login("expired", "Password1");
         passwordUpdatePage.assertCurrent();
 
@@ -119,7 +119,7 @@ public class LDAPPasswordPolicyTest extends AbstractLDAPTest {
 
         UserRepresentation user = testRealm().users().search("expired").get(0);
         testRealm().users().get(user.getId()).logout();
-        loginPage.open();
+        oauth.loginForm().open();
         loginPage.login("expired", "changedpassword");
         appPage.assertCurrent();
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordPolicyTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPPasswordPolicyTest.java
@@ -26,6 +26,7 @@ import org.keycloak.testsuite.util.LDAPRule.LDAPPasswordPolicy;
 import org.keycloak.testsuite.util.LDAPTestConfiguration;
 import org.keycloak.testsuite.util.LDAPTestUtils;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -45,16 +46,30 @@ public class LDAPPasswordPolicyTest extends AbstractLDAPTest {
 
     @Override
     protected void afterImportTestRealm() {
+    }
+
+    @Before
+    public void setupLdapUsers() {
         testingClient.server().run(session -> {
             LDAPTestContext ctx = LDAPTestContext.init(session);
             RealmModel appRealm = ctx.getRealm();
 
-            LDAPObject user = LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "mustchange", "John", "Doe",
-                    "john_old@email.org", null, "1234");
-            LDAPTestUtils.updateLDAPPassword(ctx.getLdapProvider(), user, "Password1");
+            // Purge
+            LDAPTestUtils.removeAllLDAPUsers(ctx.getLdapProvider(), appRealm);
+
+            // Recreate
+            LDAPObject userPwdReset = LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "mustchange", "John", "Doe", "john_old@email.org", null, "1234");
+            LDAPTestUtils.updateLDAPPassword(ctx.getLdapProvider(), userPwdReset, "Password1");
+
+            LDAPObject userPwdExpired = LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "expired", "John", "Dodo", "john_dodo@email.org", null, "1234");
+            LDAPTestUtils.updateLDAPPassword(ctx.getLdapProvider(), userPwdExpired, "Password1");
+
+            // Reapply flags
+            ctx.getLdapProvider().getLdapIdentityStore().getConfig(); // ensure loaded
         });
 
         ldapRule.getLdapEmbeddedServer().setPwdReset("uid=mustchange,ou=People,dc=keycloak,dc=org", true);
+        ldapRule.getLdapEmbeddedServer().setPwdChangedTime("uid=expired,ou=People,dc=keycloak,dc=org", "19790101000000Z");
     }
 
     @Test
@@ -83,4 +98,29 @@ public class LDAPPasswordPolicyTest extends AbstractLDAPTest {
         appPage.assertCurrent();
     }
 
+    @Test
+    @LDAPPasswordPolicy(mustChange=true, maxAge=31536000)
+    public void testExpiredPassword() throws Exception {
+        // Login with user that has an expired password.
+        loginPage.open();
+        loginPage.login("expired", "Password1");
+
+        // Forced password change sends user to update password page.
+        passwordUpdatePage.assertCurrent();
+
+        // Repeated login without changing password should still send user to update password page.
+        loginPage.open();
+        loginPage.login("expired", "Password1");
+        passwordUpdatePage.assertCurrent();
+
+        // Change password and verify that user can login with new password.
+        passwordUpdatePage.changePassword("changedpassword", "changedpassword");
+        appPage.assertCurrent();
+
+        UserRepresentation user = testRealm().users().search("expired").get(0);
+        testRealm().users().get(user.getId()).logout();
+        loginPage.open();
+        loginPage.login("expired", "changedpassword");
+        appPage.assertCurrent();
+    }
 }

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
@@ -86,6 +86,7 @@ public class LDAPEmbeddedServer {
     public static final String PROPERTY_SET_CONFIDENTIALITY_REQUIRED = "setConfidentialityRequired";
     public static final String PROPERTY_PPOLICY_ENABLED = "ppolicy.enabled";
     public static final String PROPERTY_PPOLICY_MUST_CHANGE = "ppolicy.mustChange";
+    public static final String PROPERTY_PPOLICY_MAX_AGE = "ppolicy.maxAge";
 
     private static final String DEFAULT_BASE_DN = "dc=keycloak,dc=org";
     private static final String DEFAULT_BIND_HOST = "localhost";
@@ -117,6 +118,7 @@ public class LDAPEmbeddedServer {
     protected String certPassword;
     protected boolean ppolicyEnabled = false;
     protected boolean ppolicyMustChange = false;
+    protected int ppolicyMaxAge = 0;
 
     protected DirectoryService directoryService;
     protected LdapServer ldapServer;
@@ -176,6 +178,8 @@ public class LDAPEmbeddedServer {
         this.certPassword = readProperty(PROPERTY_CERTIFICATE_PASSWORD, null);
         this.ppolicyEnabled = Boolean.valueOf(readProperty(PROPERTY_PPOLICY_ENABLED, "false"));
         this.ppolicyMustChange = Boolean.valueOf(readProperty(PROPERTY_PPOLICY_MUST_CHANGE, "false"));
+        String ppolicyMaxAge = readProperty(PROPERTY_PPOLICY_MAX_AGE, "0");
+        this.ppolicyMaxAge = Integer.parseInt(ppolicyMaxAge);
     }
 
     protected String readProperty(String propertyName, String defaultValue) {
@@ -443,6 +447,7 @@ public class LDAPEmbeddedServer {
                 .getInterceptor(InterceptorEnum.AUTHENTICATION_INTERCEPTOR.getName());
         PasswordPolicyConfiguration policyConfig = new PasswordPolicyConfiguration();
         policyConfig.setPwdMustChange(ppolicyMustChange);
+        policyConfig.setPwdMaxAge(ppolicyMaxAge);
 
         PpolicyConfigContainer policyContainer = new PpolicyConfigContainer();
         Dn defaultPolicyDn = new Dn( ldapServer.getDirectoryService().getSchemaManager(), "cn=defaultPasswordPolicy" );
@@ -466,4 +471,16 @@ public class LDAPEmbeddedServer {
         }
     }
 
+    public void setPwdChangedTime(String userDn, String value) {
+        // pwdChangedTime is a ppolicy operational attribute that can only be modified via the
+        // embedded server's internal admin session, not through the LDAP protocol.
+        try {
+            Dn dn = new Dn(directoryService.getSchemaManager(), userDn);
+            directoryService.getAdminSession().modify(dn,
+                    new DefaultModification(ModificationOperation.REPLACE_ATTRIBUTE,
+                            "pwdChangedTime", value));
+        } catch (LdapException e) {
+            throw new RuntimeException("Failed to set pwdChangedTime for " + userDn, e);
+        }
+    }
 }


### PR DESCRIPTION
Hello,

The goal of this Pull Request is to enhance the excellent work done by @tsaarni on the LDAP password policy support in keycloak.

The main idea is to allow a user to change his password when he authenticate but his password has expired, which is when his password's age exceeds the maxAge parameter defined in the password policy.

As this is my first contribution to Keycloak, any feedback or suggestions for improvement are more than welcome.
I remain available for any questions or additional information.

Fixes #47170 
