### PR TITLE
Provide basic Client API v2 CLI client

### DIFF
--- a/integration/client-cli/admin-cli/pom.xml
+++ b/integration/client-cli/admin-cli/pom.xml
@@ -51,6 +51,23 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <!-- required during compilation by the exec-maven-plugin as we need the OpenAPI document stored in the resources -->
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-v2-rest</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-open-api-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -59,6 +76,27 @@
 
     <build>
         <plugins>
+            <!-- generates the default descriptor for CLI v2 for faster start-ups -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-v2-descriptor</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.keycloak.client.admin.cli.v2.KcAdmV2DescriptorBuilder</mainClass>
+                            <classpathScope>compile</classpathScope>
+                            <arguments>
+                                <argument>${project.build.outputDirectory}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/integration/client-cli/admin-cli/src/main/bin/kcadm.sh
+++ b/integration/client-cli/admin-cli/src/main/bin/kcadm.sh
@@ -28,4 +28,101 @@ if [ -z "$JAVA" ]; then
     fi
 fi
 
+# Shell completion script generation (no JVM needed)
+if [ "$1" = "--v2" ] && [ "$2" = "completion" ]; then
+    COMP_SHELL="${3:-$(basename "$SHELL")}"
+    case "$COMP_SHELL" in
+        bash)
+            cat << 'BASH_COMPLETION'
+__kcadm_v2_complete() {
+    local -r v2_flag="--v2"
+    local -r cur="${COMP_WORDS[COMP_CWORD]}"
+    local args=()
+    local saw_v2=false
+
+    for ((i=1; i < COMP_CWORD; i++)); do
+        case "${COMP_WORDS[$i]}" in
+            "$v2_flag") saw_v2=true ;;
+            *) args+=("${COMP_WORDS[$i]}") ;;
+        esac
+    done
+
+    if [[ "$saw_v2" != true ]]; then
+        [[ "$cur" == "$v2_flag" ]] && COMPREPLY=("$v2_flag")
+        return
+    fi
+
+    args+=("${cur}")
+
+    local IFS=$'\n'
+    local completions
+    completions=$(kcadm.sh "$v2_flag" __complete "${args[@]}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${completions}" -- "${cur}"))
+}
+
+complete -o default -F __kcadm_v2_complete kcadm.sh
+BASH_COMPLETION
+            ;;
+        zsh)
+            cat << 'ZSH_COMPLETION'
+#compdef kcadm.sh
+
+_kcadm_v2() {
+    local -a args
+    local saw_v2=false
+
+    for ((i=2; i < CURRENT; i++)); do
+        case "${words[$i]}" in
+            --v2) saw_v2=true ;;
+            *) args+=("${words[$i]}") ;;
+        esac
+    done
+
+    if [[ "$saw_v2" != true ]]; then
+        return
+    fi
+
+    args+=("${words[CURRENT]}")
+
+    local -a completions
+    completions=($(kcadm.sh --v2 __complete "${args[@]}" 2>/dev/null))
+    compadd -a completions
+}
+
+compdef _kcadm_v2 kcadm.sh
+ZSH_COMPLETION
+            ;;
+        fish)
+            cat << 'FISH_COMPLETION'
+function __kcadm_v2_needs_completion
+    set -l cmd (commandline -opc)
+    contains -- --v2 $cmd
+end
+
+function __kcadm_v2_completions
+    set -l tokens (commandline -opc)
+    set -l args
+    for i in (seq 2 (count $tokens))
+        switch $tokens[$i]
+            case --v2
+            case '*'
+                set -a args $tokens[$i]
+        end
+    end
+    set -l cur (commandline -ct)
+    set -a args $cur
+    kcadm.sh --v2 __complete $args 2>/dev/null
+end
+
+complete -c kcadm.sh -f -n __kcadm_v2_needs_completion -a '(__kcadm_v2_completions)'
+FISH_COMPLETION
+            ;;
+        *)
+            echo "Unsupported shell: $COMP_SHELL. Usage: kcadm.sh --v2 completion [bash|zsh|fish]" >&2
+            exit 1
+            ;;
+    esac
+    exit 0
+fi
+
 exec "$JAVA" $KC_OPTS -cp $DIRNAME/client/keycloak-admin-cli-${project.version}.jar --add-opens=java.base/java.security=ALL-UNNAMED -Dkc.lib.dir=$DIRNAME/client/lib org.keycloak.client.admin.cli.KcAdmMain "$@"

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/KcAdmMain.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/KcAdmMain.java
@@ -16,7 +16,13 @@
  */
 package org.keycloak.client.admin.cli;
 
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Set;
+
 import org.keycloak.client.admin.cli.commands.KcAdmCmd;
+import org.keycloak.client.admin.cli.v2.KcAdmV2Cmd;
+import org.keycloak.client.admin.cli.v2.KcAdmV2Completer;
 import org.keycloak.client.cli.common.CommandState;
 import org.keycloak.client.cli.common.Globals;
 import org.keycloak.client.cli.util.OsUtil;
@@ -51,8 +57,34 @@ public class KcAdmMain {
 
     };
 
-    public static void main(String [] args) {
-        Globals.main(args, new KcAdmCmd(), CMD, DEFAULT_CONFIG_FILE_STRING);
+    public static final String V2_FLAG = "--v2";
+
+    private static final String COMPLETE_FLAG = "__complete";
+
+    public static void main(String[] args) {
+        if (!containsArg(args, V2_FLAG)) {
+            Globals.main(args, new KcAdmCmd(), CMD, DEFAULT_CONFIG_FILE_STRING);
+            return;
+        }
+
+        String[] v2Args = stripArgs(args, V2_FLAG);
+
+        if (containsArg(v2Args, COMPLETE_FLAG)) {
+            KcAdmV2Completer.complete(stripArgs(v2Args, COMPLETE_FLAG),
+                    new PrintWriter(System.out, true));
+        } else {
+            Globals.main(v2Args, new KcAdmV2Cmd(), CMD, DEFAULT_CONFIG_FILE_STRING);
+        }
     }
 
+    private static boolean containsArg(String[] args, String arg) {
+        return Arrays.stream(args).anyMatch(arg::equalsIgnoreCase);
+    }
+
+    private static String[] stripArgs(String[] args, String... argsToStrip) {
+        Set<String> toStrip = Set.of(argsToStrip);
+        return Arrays.stream(args)
+                .filter(a -> !toStrip.contains(a.toLowerCase()))
+                .toArray(String[]::new);
+    }
 }

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/AbstractAuthOptionsCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/AbstractAuthOptionsCmd.java
@@ -16,34 +16,14 @@
  */
 package org.keycloak.client.admin.cli.commands;
 
-import org.keycloak.client.admin.cli.KcAdmMain;
-import org.keycloak.client.cli.common.BaseAuthOptionsCmd;
-import org.keycloak.client.cli.config.ConfigData;
-
 import picocli.CommandLine.Option;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
  */
-public abstract class AbstractAuthOptionsCmd extends BaseAuthOptionsCmd implements GlobalOptionsCmdHelper {
+public abstract class AbstractAuthOptionsCmd extends AbstractTargetAuthOptionsCmd {
 
     @Option(names = {"-a", "--admin-root"}, description = "URL of Admin REST endpoint root if not default - e.g. http://localhost:8080/admin")
     String adminRestRoot;
-
-    @Option(names = {"-r", "--target-realm"}, description = "Realm to target - when it's different than the realm we authenticate against")
-    String targetRealm;
-
-    @Option(names = "--token", description = "Token to use for invocations.  With this option set, every other authentication option is ignored")
-    public void setToken(String token) {
-        this.externalToken = token;
-    }
-
-    public AbstractAuthOptionsCmd() {
-        super(KcAdmMain.COMMAND_STATE);
-    }
-
-    protected String getTargetRealm(ConfigData config) {
-        return targetRealm != null ? targetRealm : config.getRealm();
-    }
 
 }

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/AbstractTargetAuthOptionsCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/commands/AbstractTargetAuthOptionsCmd.java
@@ -1,0 +1,29 @@
+package org.keycloak.client.admin.cli.commands;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.cli.common.BaseAuthOptionsCmd;
+import org.keycloak.client.cli.config.ConfigData;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Extends {@link BaseAuthOptionsCmd} with token authentication and target realm support.
+ */
+public abstract class AbstractTargetAuthOptionsCmd extends BaseAuthOptionsCmd implements GlobalOptionsCmdHelper {
+
+    @Option(names = {"-r", "--target-realm"}, description = "Realm to target - when it's different than the realm we authenticate against")
+    protected String targetRealm;
+
+    @Option(names = "--token", description = "Token to use for invocations.  With this option set, every other authentication option is ignored")
+    public void setToken(String token) {
+        this.externalToken = token;
+    }
+
+    public AbstractTargetAuthOptionsCmd() {
+        super(KcAdmMain.COMMAND_STATE);
+    }
+
+    protected String getTargetRealm(ConfigData config) {
+        return targetRealm != null ? targetRealm : config.getRealm();
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/CliJsonOutputHighlighter.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/CliJsonOutputHighlighter.java
@@ -1,0 +1,176 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.keycloak.client.cli.util.OutputUtil;
+
+public final class CliJsonOutputHighlighter {
+
+    public static final String ESC = "\033[";
+    public static final String RESET = ESC + "0m";
+    public static final String COLOR_KEY     = ESC + "36m"; // Standard Cyan
+    public static final String COLOR_STRING  = ESC + "32m"; // Standard Green
+    public static final String COLOR_NUMBER  = ESC + "35m"; // Standard Magenta
+    public static final String COLOR_BOOLEAN = ESC + "31m"; // Standard Red
+    public static final String COLOR_NULL    = ESC + "91m"; // Bright Red
+
+    private static final String[] OBJECT_COLORS = {
+            ESC + "1;37m",  // Level 1: Bold White
+            ESC + "37m",  // Level 2: Light Gray / Standard White
+            ESC + "94m",  // Level 3: Bright Blue
+            ESC + "96m",  // Level 4: Bright Cyan
+            ESC + "92m",  // Level 5: Bright Green
+            ESC + "95m"   // Level 6: Bright Magenta
+    };
+    private static final String[] ARRAY_COLORS = OBJECT_COLORS;
+    private static final int CONTEXT_OBJECT = 1;
+    private static final int CONTEXT_ARRAY = 2;
+    private static final char COLON = ':';
+    private static final char COMMA = ',';
+    private static final char DOUBLE_QUOTES = '"';
+    private static final int TRUE_LENGTH = "true".length();
+    private static final int FALSE_LENGTH = "false".length();
+    private static final int NULL_LENGTH = "null".length();
+
+    private CliJsonOutputHighlighter() {
+    }
+
+    public static String objectColorAtDepth(int depth) {
+        return OBJECT_COLORS[Math.floorMod(depth, getObjectDepthCycle())];
+    }
+
+    public static String arrayColorAtDepth(int depth) {
+        return ARRAY_COLORS[Math.floorMod(depth, getArrayDepthCycle())];
+    }
+
+    public static int getObjectDepthCycle() {
+        return OBJECT_COLORS.length;
+    }
+
+    public static int getArrayDepthCycle() {
+        return ARRAY_COLORS.length;
+    }
+
+    public static String highlight(String json) throws IOException {
+        final StringBuilder sb = new StringBuilder();
+        final Deque<Integer> contextStack = new ArrayDeque<>();
+        int objectDepth = -1;
+        int arrayDepth = -1;
+        int lastEnd = 0;
+
+        try (final var parser = OutputUtil.MAPPER.getFactory().createParser(json)) {
+            while (parser.nextToken() != null) {
+                final var token = parser.currentToken();
+                final int tokenStart = (int) parser.currentTokenLocation().getCharOffset();
+
+                if (tokenStart > lastEnd) {
+                    copyGapWithColoredSeparators(sb, json, lastEnd, tokenStart, contextStack, objectDepth, arrayDepth);
+                }
+
+                final String color;
+                final int tokenEnd;
+
+                switch (token) {
+                    case START_OBJECT -> {
+                        objectDepth++;
+                        contextStack.push(CONTEXT_OBJECT);
+                        color = objectColorAtDepth(objectDepth);
+                        tokenEnd = tokenStart + 1;
+                    }
+                    case END_OBJECT -> {
+                        color = objectColorAtDepth(objectDepth);
+                        objectDepth--;
+                        contextStack.pop();
+                        tokenEnd = tokenStart + 1;
+                    }
+                    case START_ARRAY -> {
+                        arrayDepth++;
+                        contextStack.push(CONTEXT_ARRAY);
+                        color = arrayColorAtDepth(arrayDepth);
+                        tokenEnd = tokenStart + 1;
+                    }
+                    case END_ARRAY -> {
+                        color = arrayColorAtDepth(arrayDepth);
+                        arrayDepth--;
+                        contextStack.pop();
+                        tokenEnd = tokenStart + 1;
+                    }
+                    case FIELD_NAME -> {
+                        color = COLOR_KEY;
+                        tokenEnd = findClosingQuote(json, tokenStart) + 1;
+                    }
+                    case VALUE_STRING -> {
+                        color = COLOR_STRING;
+                        tokenEnd = findClosingQuote(json, tokenStart) + 1;
+                    }
+                    case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> {
+                        color = COLOR_NUMBER;
+                        tokenEnd = tokenStart + parser.getText().length();
+                    }
+                    case VALUE_TRUE -> {
+                        color = COLOR_BOOLEAN;
+                        tokenEnd = tokenStart + TRUE_LENGTH;
+                    }
+                    case VALUE_FALSE -> {
+                        color = COLOR_BOOLEAN;
+                        tokenEnd = tokenStart + FALSE_LENGTH;
+                    }
+                    case VALUE_NULL -> {
+                        color = COLOR_NULL;
+                        tokenEnd = tokenStart + NULL_LENGTH;
+                    }
+                    default -> {
+                        color = null;
+                        tokenEnd = tokenStart;
+                    }
+                }
+
+                if (color != null) {
+                    sb.append(color);
+                    sb.append(json, tokenStart, tokenEnd);
+                    sb.append(RESET);
+                }
+
+                lastEnd = tokenEnd;
+            }
+        }
+
+        if (lastEnd < json.length()) {
+            copyGapWithColoredSeparators(sb, json, lastEnd, json.length(), contextStack, objectDepth, arrayDepth);
+        }
+
+        return sb.toString();
+    }
+
+    // Copies the gap between tokens (whitespace, separators) verbatim, except : and , which get colored
+    private static void copyGapWithColoredSeparators(StringBuilder sb, String json, int from, int to,
+                                                      Deque<Integer> contextStack, int objectDepth, int arrayDepth) {
+        for (int i = from; i < to; i++) {
+            char c = json.charAt(i);
+            if (c == COLON || c == COMMA) {
+                boolean inObject = Integer.valueOf(CONTEXT_OBJECT).equals(contextStack.peek());
+                String sepColor = inObject ? objectColorAtDepth(objectDepth) : arrayColorAtDepth(arrayDepth);
+                sb.append(sepColor).append(c).append(RESET);
+            } else {
+                sb.append(c);
+            }
+        }
+    }
+
+    private static int findClosingQuote(String json, int openQuotePos) {
+        int i = openQuotePos + 1;
+        while (i < json.length()) {
+            char c = json.charAt(i);
+            if (c == '\\') {
+                i += 2;
+            } else if (c == DOUBLE_QUOTES) {
+                return i;
+            } else {
+                i++;
+            }
+        }
+        return json.length() - 1;
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2Cmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2Cmd.java
@@ -1,0 +1,82 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+
+import org.keycloak.client.admin.cli.commands.ConfigCmd;
+import org.keycloak.client.cli.common.BaseGlobalOptionsCmd;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+import static org.keycloak.client.admin.cli.KcAdmMain.CMD;
+import static org.keycloak.client.admin.cli.KcAdmMain.V2_FLAG;
+import static org.keycloak.client.cli.util.OsUtil.PROMPT;
+
+@Command(name = "kcadm",
+        description = "%nCOMMAND [ARGUMENTS]"
+)
+public class KcAdmV2Cmd extends BaseGlobalOptionsCmd {
+
+    private static final String BUNDLED_DESCRIPTOR = "/kcadm-v2-commands.json";
+
+    @Spec
+    CommandSpec spec;
+
+    @Override
+    protected boolean nothingToDo() {
+        return true;
+    }
+
+    @Override
+    protected String help() {
+        return "";
+    }
+
+    @Override
+    protected void printHelpIfNeeded() {
+        PrintWriter out = new PrintWriter(System.out, true);
+        out.println("Keycloak Admin CLI v2 (experimental)");
+        out.println();
+        out.println("Use '" + CMD + " " + V2_FLAG + " config credentials' to start a session.");
+        out.println();
+        out.println("For example:");
+        out.println();
+        out.println("  " + PROMPT + " " + CMD + " " + V2_FLAG + " config credentials --server http://localhost:8080 --realm master --user admin");
+        out.println();
+        spec.commandLine().usage(out);
+        out.println();
+        out.println("Use '" + CMD + " " + V2_FLAG + " <command> --help' for more information about a command.");
+        out.println("Find more information at: https://www.keycloak.org/docs/latest");
+        System.exit(CommandLine.ExitCode.OK);
+    }
+
+    @Override
+    protected void configureCommandLine(CommandLine cli) {
+        cli.getCommandSpec().name(CMD + " " + V2_FLAG);
+        CommandLine configCmd = new CommandLine(new ConfigCmd());
+        configCmd.getCommandSpec().usageMessage().description("Configuration management");
+        cli.addSubcommand(configCmd);
+        KcAdmV2CommandDescriptor descriptor = loadDescriptor();
+        KcAdmV2CommandBuilder.addCommands(cli, descriptor);
+    }
+
+    private KcAdmV2CommandDescriptor loadDescriptor() {
+        // TODO: fetch and cache server-specific descriptor (follow-up PR)
+        return loadBundledDescriptor();
+    }
+
+    private KcAdmV2CommandDescriptor loadBundledDescriptor() {
+        try (InputStream is = getClass().getResourceAsStream(BUNDLED_DESCRIPTOR)) {
+            if (is == null) {
+                throw new RuntimeException("Bundled command descriptor not found: " + BUNDLED_DESCRIPTOR);
+            }
+            return KcAdmV2DescriptorBuilder.readDescriptor(is);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load command descriptor", e);
+        }
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandBuilder.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandBuilder.java
@@ -1,0 +1,184 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.util.List;
+
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.CommandDescriptor;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.OptionDescriptor;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.ResourceDescriptor;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.VariantDescriptor;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Model.ArgGroupSpec;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.Model.PositionalParamSpec;
+
+import static org.keycloak.client.admin.cli.KcAdmMain.CMD;
+import static org.keycloak.client.admin.cli.KcAdmMain.V2_FLAG;
+import static org.keycloak.common.util.ObjectUtil.capitalize;
+
+class KcAdmV2CommandBuilder {
+
+    private static final String OPT_HELP = "--help";
+    static final String OPT_FILE = "-f";
+    static final String OPT_COMPRESSED = "--compressed";
+
+
+    static void addCommands(CommandLine cli, KcAdmV2CommandDescriptor descriptor) {
+        for (ResourceDescriptor resource : descriptor.getResources()) {
+            GroupCommand groupCommand = new GroupCommand(resource.getName());
+            CommandSpec groupSpec = CommandSpec.wrapWithoutInspection(groupCommand);
+            groupSpec.name(resource.getName());
+            groupSpec.usageMessage().header(capitalize(resource.getName()) + " operations");
+            addHelpOption(groupSpec);
+
+            CommandLine groupCli = new CommandLine(groupSpec);
+            groupCommand.setSpec(groupSpec);
+
+            for (CommandDescriptor cmd : resource.getCommands()) {
+                groupCli.addSubcommand(cmd.getName(), buildSubcommand(cmd));
+            }
+
+            cli.addSubcommand(resource.getName(), groupCli);
+        }
+    }
+
+    private static CommandLine buildSubcommand(CommandDescriptor cmd) {
+        List<VariantDescriptor> variants = cmd.getVariants();
+        if (variants != null && !variants.isEmpty()) {
+            return buildVariantParentCommand(cmd);
+        }
+
+        return buildLeafCommand(cmd, cmd.getOptions(), null);
+    }
+
+    private static CommandLine buildVariantParentCommand(CommandDescriptor cmd) {
+        GroupCommand groupCommand = new GroupCommand(cmd.getName());
+        CommandSpec parentSpec = CommandSpec.wrapWithoutInspection(groupCommand);
+        parentSpec.name(cmd.getName());
+        parentSpec.usageMessage().description(cmd.getDescription());
+        addHelpOption(parentSpec);
+
+        CommandLine parentCli = new CommandLine(parentSpec);
+        groupCommand.setSpec(parentSpec);
+
+        for (VariantDescriptor variant : cmd.getVariants()) {
+            parentCli.addSubcommand(variant.getName(),
+                    buildLeafCommand(cmd, variant.getOptions(), variant));
+        }
+
+        return parentCli;
+    }
+
+    private static CommandLine buildLeafCommand(CommandDescriptor cmd,
+            List<OptionDescriptor> options, VariantDescriptor variant) {
+        KcAdmV2RequestExecutor executor = new KcAdmV2RequestExecutor(cmd, variant);
+        CommandSpec spec = CommandSpec.forAnnotatedObject(executor);
+        spec.name(variant != null ? variant.getName() : cmd.getName());
+        spec.usageMessage().description(cmd.getDescription());
+        spec.usageMessage().optionListHeading("%nConnection options:%n");
+
+        // Replace inherited --help with usageHelp=true so PicoCLI skips
+        // required parameter validation when --help is present
+        spec.remove(spec.findOption(OPT_HELP));
+        addHelpOption(spec);
+
+        if (cmd.isHasResponseBody()) {
+            addOutputGroup(spec);
+        }
+
+        if (cmd.isRequiresId()) {
+            spec.addPositional(PositionalParamSpec.builder()
+                    .index("0")
+                    .paramLabel("<id>")
+                    .description("Resource identifier")
+                    .required(true)
+                    .type(String.class)
+                    .build());
+        }
+
+        if (options != null && !options.isEmpty()) {
+            ArgGroupSpec.Builder fieldGroup = ArgGroupSpec.builder()
+                    .heading("%nOptions:%n")
+                    .exclusive(false)
+                    .validate(false)
+                    .order(1);
+
+            fieldGroup.addArg(OptionSpec.builder(OPT_FILE, "--file")
+                    .type(String.class)
+                    .paramLabel("<file>")
+                    .description("JSON file with request body (mutually exclusive with field options)")
+                    .build());
+
+            for (OptionDescriptor opt : options) {
+                fieldGroup.addArg(buildOption(opt));
+            }
+
+            spec.addArgGroup(fieldGroup.build());
+        }
+
+        return new CommandLine(spec);
+    }
+
+    private static OptionSpec buildOption(OptionDescriptor opt) {
+        String description = opt.getDescription() != null ? opt.getDescription() : "";
+        List<String> enumValues = opt.getEnumValues();
+        if (enumValues != null && !enumValues.isEmpty()) {
+            description += (description.isEmpty() ? "" : " ") + "Valid values: " + String.join(", ", enumValues);
+        }
+
+        OptionSpec.Builder builder = OptionSpec.builder("--" + opt.getName())
+                .type(opt.isArray() ? String[].class : String.class)
+                .paramLabel("<value>")
+                .description(description);
+
+        if (opt.isArray()) {
+            builder.splitRegex(",");
+        }
+
+        if (enumValues != null && !enumValues.isEmpty()) {
+            builder.completionCandidates(enumValues);
+        }
+
+        return builder.build();
+    }
+
+    private static void addOutputGroup(CommandSpec spec) {
+        spec.addArgGroup(ArgGroupSpec.builder()
+                .heading("%nOutput options:%n")
+                .exclusive(false)
+                .validate(false)
+                .order(10)
+                .addArg(OptionSpec.builder("-c", OPT_COMPRESSED)
+                        .type(boolean.class)
+                        .description("Don't pretty print the output")
+                        .build())
+                .build());
+    }
+
+    private static void addHelpOption(CommandSpec spec) {
+        spec.addOption(OptionSpec.builder("-h", OPT_HELP)
+                .usageHelp(true)
+                .hidden(true)
+                .build());
+    }
+
+    static class GroupCommand implements Runnable {
+        private final String name;
+        private CommandSpec spec;
+
+        GroupCommand(String name) {
+            this.name = name;
+        }
+
+        void setSpec(CommandSpec spec) {
+            this.spec = spec;
+        }
+
+        @Override
+        public void run() {
+            spec.commandLine().getErr().println(
+                    "Use '" + CMD + " " + V2_FLAG + " " + name + " --help' for available commands.");
+        }
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandDescriptor.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandDescriptor.java
@@ -1,0 +1,253 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.util.List;
+
+/**
+ * Compact descriptor for v2 CLI commands.
+ * Produced at build time from OpenAPI spec, cached per-server at runtime.
+ * Deserialized with Jackson — no SmallRye needed on the read path.
+ */
+public class KcAdmV2CommandDescriptor {
+
+    private String version;
+    private List<ResourceDescriptor> resources;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public List<ResourceDescriptor> getResources() {
+        return resources;
+    }
+
+    public void setResources(List<ResourceDescriptor> resources) {
+        this.resources = resources;
+    }
+
+    public static class ResourceDescriptor {
+        private String name;
+        private List<CommandDescriptor> commands;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public List<CommandDescriptor> getCommands() {
+            return commands;
+        }
+
+        public void setCommands(List<CommandDescriptor> commands) {
+            this.commands = commands;
+        }
+    }
+
+    public static class CommandDescriptor {
+        private String name;
+        private String resourceName;
+        private String httpMethod;
+        private String path;
+        private String description;
+        private boolean requiresId;
+        private boolean hasResponseBody = true;
+        private List<OptionDescriptor> options;
+        private List<VariantDescriptor> variants;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getResourceName() {
+            return resourceName;
+        }
+
+        public void setResourceName(String resourceName) {
+            this.resourceName = resourceName;
+        }
+
+        public String getHttpMethod() {
+            return httpMethod;
+        }
+
+        public void setHttpMethod(String httpMethod) {
+            this.httpMethod = httpMethod;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public boolean isRequiresId() {
+            return requiresId;
+        }
+
+        public void setRequiresId(boolean requiresId) {
+            this.requiresId = requiresId;
+        }
+
+        public boolean isHasResponseBody() {
+            return hasResponseBody;
+        }
+
+        public void setHasResponseBody(boolean hasResponseBody) {
+            this.hasResponseBody = hasResponseBody;
+        }
+
+        public List<OptionDescriptor> getOptions() {
+            return options;
+        }
+
+        public void setOptions(List<OptionDescriptor> options) {
+            this.options = options;
+        }
+
+        public List<VariantDescriptor> getVariants() {
+            return variants;
+        }
+
+        public void setVariants(List<VariantDescriptor> variants) {
+            this.variants = variants;
+        }
+    }
+
+    /**
+     * Represents a protocol-specific variant of a command (e.g., "oidc" vs "saml" for client create/patch).
+     * Derived from the OpenAPI schema discriminator — each variant becomes a CLI subcommand
+     * with its own set of options (base + protocol-specific fields merged).
+     */
+    public static class VariantDescriptor {
+        private String name;
+        private String discriminatorField;
+        private String discriminatorValue;
+        private List<OptionDescriptor> options;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDiscriminatorField() {
+            return discriminatorField;
+        }
+
+        public void setDiscriminatorField(String discriminatorField) {
+            this.discriminatorField = discriminatorField;
+        }
+
+        public String getDiscriminatorValue() {
+            return discriminatorValue;
+        }
+
+        public void setDiscriminatorValue(String discriminatorValue) {
+            this.discriminatorValue = discriminatorValue;
+        }
+
+        public List<OptionDescriptor> getOptions() {
+            return options;
+        }
+
+        public void setOptions(List<OptionDescriptor> options) {
+            this.options = options;
+        }
+    }
+
+    /**
+     * Maps an OpenAPI schema property to a CLI option.
+     * {@code fieldName} is the JSON property name (e.g., "clientId") used when building the request body,
+     * {@code name} is the kebab-case CLI flag (e.g., "client-id").
+     */
+    public static class OptionDescriptor {
+        public static final String TYPE_BOOLEAN = "boolean";
+        public static final String TYPE_STRING = "string";
+
+        private String name;
+        private String fieldName;
+        private String type;
+        private String description;
+        private boolean array;
+        private List<String> enumValues;
+        private String parentFieldName;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getFieldName() {
+            return fieldName;
+        }
+
+        public void setFieldName(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public boolean isArray() {
+            return array;
+        }
+
+        public void setArray(boolean array) {
+            this.array = array;
+        }
+
+        public List<String> getEnumValues() {
+            return enumValues;
+        }
+
+        public void setEnumValues(List<String> enumValues) {
+            this.enumValues = enumValues;
+        }
+
+        public String getParentFieldName() {
+            return parentFieldName;
+        }
+
+        public void setParentFieldName(String parentFieldName) {
+            this.parentFieldName = parentFieldName;
+        }
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2Completer.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2Completer.java
@@ -1,0 +1,74 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import picocli.AutoComplete;
+import picocli.CommandLine;
+
+/**
+ * Handles the {@code __complete} request for dynamic shell completion.
+ * Delegates to PicoCLI's {@link AutoComplete#complete} for candidate resolution.
+ */
+public class KcAdmV2Completer {
+
+    private static final String LONG_OPTION_PREFIX = "--";
+
+    public static void complete(String[] args, PrintWriter out) {
+        KcAdmV2Cmd rootCmd = new KcAdmV2Cmd();
+        CommandLine cli = new CommandLine(rootCmd);
+        rootCmd.configureCommandLine(cli);
+
+        String partial = args.length > 0 ? args[args.length - 1] : "";
+
+        if (LONG_OPTION_PREFIX.equals(partial)) {
+            completeLongOptions(cli, args, out);
+        } else {
+            completePicocli(cli, args, partial, out);
+        }
+
+        out.flush();
+    }
+
+    private static void completePicocli(CommandLine cli, String[] args, String partial, PrintWriter out) {
+        int cursor = 0;
+        for (String arg : args) {
+            cursor += arg.length() + 1;
+        }
+        if (cursor > 0) {
+            cursor--;
+        }
+
+        int argIndex = Math.max(0, args.length - 1);
+        int posInArg = partial.length();
+
+        List<CharSequence> candidates = new ArrayList<>();
+        AutoComplete.complete(cli.getCommandSpec(), args, argIndex, posInArg, cursor, candidates);
+
+        for (CharSequence candidate : candidates) {
+            out.println(partial + candidate);
+        }
+    }
+
+    // PicoCLI's AutoComplete.complete() treats "--" as ambiguous (end-of-options vs partial option),
+    // so we handle it ourselves by listing all long options for the resolved command.
+    private static void completeLongOptions(CommandLine cli, String[] args, PrintWriter out) {
+        CommandLine current = cli;
+        for (int i = 0; i < args.length - 1; i++) {
+            CommandLine sub = current.getSubcommands().get(args[i]);
+            if (sub == null) {
+                break;
+            }
+            current = sub;
+        }
+
+        for (var opt : current.getCommandSpec().options()) {
+            for (String name : opt.names()) {
+                if (name.startsWith(LONG_OPTION_PREFIX)) {
+                    out.println(name);
+                }
+            }
+        }
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2DescriptorBuilder.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2DescriptorBuilder.java
@@ -1,0 +1,414 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.OptionDescriptor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.smallrye.openapi.api.SmallRyeOpenAPI;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.openapi.models.Operation;
+import org.eclipse.microprofile.openapi.models.PathItem;
+import org.eclipse.microprofile.openapi.models.media.MediaType;
+import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.parameters.RequestBody;
+
+import static org.keycloak.client.cli.util.HttpUtil.APPLICATION_JSON;
+import static org.keycloak.common.util.ObjectUtil.capitalize;
+
+/**
+ * Converts an {@link OpenAPI} model into a {@link KcAdmV2CommandDescriptor}.
+ * Used at build time to produce the bundled default, and at runtime for server-fetch (future).
+ */
+public class KcAdmV2DescriptorBuilder {
+
+    static final String ID_PATH_PARAM = "{id}";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    private static final Map<PathItem.HttpMethod, String> HTTP_METHOD_TO_COMMAND = Map.of(
+            PathItem.HttpMethod.GET, "get",
+            PathItem.HttpMethod.POST, "create",
+            PathItem.HttpMethod.PATCH, "patch",
+            PathItem.HttpMethod.DELETE, "delete",
+            PathItem.HttpMethod.PUT, "update"
+    );
+
+    public static KcAdmV2CommandDescriptor convert(OpenAPI openApi) {
+        String version = openApi.getInfo() != null ? openApi.getInfo().getVersion() : "unknown";
+
+        // First pass: extract singular resource names from {id} paths (e.g., deleteClient -> "client")
+        // this way, we avoid dealing with plural, which can be tricky (getClients, getPolicies, ...)
+        Map<String, String> pathPrefixToResourceName = new LinkedHashMap<>();
+        for (var entry : openApi.getPaths().getPathItems().entrySet()) {
+            String path = entry.getKey();
+            if (path.contains(ID_PATH_PARAM)) {
+                String prefix = path.substring(0, path.lastIndexOf("/" + ID_PATH_PARAM));
+                pathPrefixToResourceName.put(prefix, extractResourceName(entry.getValue()));
+            }
+        }
+
+        Map<String, List<KcAdmV2CommandDescriptor.CommandDescriptor>> resourceCommands = new LinkedHashMap<>();
+
+        for (var entry : openApi.getPaths().getPathItems().entrySet()) {
+            String path = entry.getKey();
+            PathItem pathItem = entry.getValue();
+            boolean hasId = path.contains(ID_PATH_PARAM);
+            String pathPrefix = hasId ? path.substring(0, path.lastIndexOf("/" + ID_PATH_PARAM)) : path;
+            String resourceName = pathPrefixToResourceName.getOrDefault(pathPrefix,
+                    extractResourceName(pathItem));
+
+            for (var opEntry : pathItem.getOperations().entrySet()) {
+                PathItem.HttpMethod httpMethod = opEntry.getKey();
+                Operation operation = opEntry.getValue();
+
+                String cmdName = HTTP_METHOD_TO_COMMAND.get(httpMethod);
+                if (cmdName == null) {
+                    continue;
+                }
+
+                if (httpMethod == PathItem.HttpMethod.GET && !hasId) {
+                    cmdName = "list";
+                }
+
+                String description = operation.getSummary();
+                if (description == null || description.isBlank()) {
+                    description = capitalize(cmdName) + " " + resourceName;
+                }
+
+                KcAdmV2CommandDescriptor.CommandDescriptor cmd = new KcAdmV2CommandDescriptor.CommandDescriptor();
+                cmd.setName(cmdName);
+                cmd.setResourceName(resourceName);
+                cmd.setHttpMethod(httpMethod.name());
+                cmd.setPath(path);
+                cmd.setDescription(description);
+                cmd.setRequiresId(hasId);
+                cmd.setHasResponseBody(hasResponseBody(operation));
+                populateOptionsAndVariants(cmd, operation, openApi);
+
+                resourceCommands.computeIfAbsent(resourceName, k -> new ArrayList<>()).add(cmd);
+            }
+        }
+
+        List<KcAdmV2CommandDescriptor.ResourceDescriptor> resources = new ArrayList<>();
+        for (var resEntry : resourceCommands.entrySet()) {
+            KcAdmV2CommandDescriptor.ResourceDescriptor res = new KcAdmV2CommandDescriptor.ResourceDescriptor();
+            res.setName(resEntry.getKey());
+            res.setCommands(resEntry.getValue());
+            resources.add(res);
+        }
+
+        KcAdmV2CommandDescriptor descriptor = new KcAdmV2CommandDescriptor();
+        descriptor.setVersion(version);
+        descriptor.setResources(resources);
+        return descriptor;
+    }
+
+    public static void writeDescriptor(KcAdmV2CommandDescriptor descriptor, Path outputFile) throws IOException {
+        Files.createDirectories(outputFile.getParent());
+        MAPPER.writeValue(outputFile.toFile(), descriptor);
+    }
+
+    public static KcAdmV2CommandDescriptor readDescriptor(InputStream is) throws IOException {
+        return MAPPER.readValue(is, KcAdmV2CommandDescriptor.class);
+    }
+
+    private static String extractResourceName(PathItem pathItem) {
+        for (var cmdEntry : HTTP_METHOD_TO_COMMAND.entrySet()) {
+            PathItem.HttpMethod httpMethod = cmdEntry.getKey();
+            Operation op = pathItem.getOperations().get(httpMethod);
+            if (op != null && op.getOperationId() != null) {
+                String command = cmdEntry.getValue(); // what you see in autocomplete, like 'create', 'delete', 'get'
+                String name = stripVerbPrefix(op.getOperationId(), command);
+                if (name != null) {
+                    return name;
+                }
+            }
+        }
+        throw new IllegalStateException(
+                "Cannot extract resource name from operationId for path item with operations: "
+                        + pathItem.getOperations().keySet());
+    }
+
+    private static String stripVerbPrefix(String operationId, String verb) {
+        // operationId pattern: "deleteClient", "getClient", "patchClient"
+        // ignored patterns (that won't match in this method) are for example: getClients
+        // verb from HTTP_METHOD_TO_COMMAND: "delete", "get", "patch", "create"
+        if (!operationId.toLowerCase().startsWith(verb)) {
+            return null;
+        }
+        String suffix = operationId.substring(verb.length());
+        if (suffix.isEmpty()) {
+            return null;
+        }
+        return suffix.substring(0, 1).toLowerCase() + suffix.substring(1);
+    }
+
+    private static boolean hasResponseBody(Operation operation) {
+        if (operation.getResponses() == null) {
+            return true;
+        }
+        for (String statusCode : operation.getResponses().getAPIResponses().keySet()) {
+            if ("204".equals(statusCode)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void populateOptionsAndVariants(
+            KcAdmV2CommandDescriptor.CommandDescriptor cmd, Operation operation, OpenAPI openApi) {
+        Schema schema = extractRequestBodySchema(operation, openApi);
+
+        if (schema == null && operation.getRequestBody() != null) {
+            schema = extractResponseSchema(operation, openApi);
+        }
+
+        if (schema == null) {
+            cmd.setOptions(List.of());
+            return;
+        }
+
+        if (schema.getDiscriminator() != null && schema.getDiscriminator().getMapping() != null) {
+            cmd.setOptions(List.of());
+            cmd.setVariants(buildVariants(schema, openApi));
+        } else {
+            cmd.setOptions(toOptionDescriptors(collectProperties(schema, openApi), openApi));
+        }
+    }
+
+    private static List<KcAdmV2CommandDescriptor.VariantDescriptor> buildVariants(
+            Schema baseSchema, OpenAPI openApi) {
+        String discriminatorField = baseSchema.getDiscriminator().getPropertyName();
+        Map<String, Schema> baseProperties = collectProperties(baseSchema, openApi);
+
+        List<KcAdmV2CommandDescriptor.VariantDescriptor> variants = new ArrayList<>();
+        for (var mapping : baseSchema.getDiscriminator().getMapping().entrySet()) {
+            String discriminatorValue = mapping.getKey();
+            String ref = mapping.getValue();
+            Schema subtypeSchema = resolveSchema(ref, openApi);
+
+            Map<String, Schema> allProperties = new LinkedHashMap<>(baseProperties);
+            if (subtypeSchema != null) {
+                allProperties.putAll(collectProperties(subtypeSchema, openApi));
+            }
+            allProperties.remove(discriminatorField);
+
+            String variantName = toVariantName(discriminatorValue);
+
+            KcAdmV2CommandDescriptor.VariantDescriptor variant = new KcAdmV2CommandDescriptor.VariantDescriptor();
+            variant.setName(variantName);
+            variant.setDiscriminatorField(discriminatorField);
+            variant.setDiscriminatorValue(discriminatorValue);
+            variant.setOptions(toOptionDescriptors(allProperties, openApi));
+            variants.add(variant);
+        }
+        return variants;
+    }
+
+    private static List<KcAdmV2CommandDescriptor.OptionDescriptor> toOptionDescriptors(
+            Map<String, Schema> properties, OpenAPI openApi) {
+        List<KcAdmV2CommandDescriptor.OptionDescriptor> options = new ArrayList<>();
+        for (var propEntry : properties.entrySet()) {
+            String fieldName = propEntry.getKey();
+            Schema propSchema = propEntry.getValue();
+
+            Schema resolved = propSchema.getRef() != null ? resolveSchema(propSchema, openApi) : propSchema;
+
+            if (isObjectType(resolved)) {
+                flattenNestedObject(fieldName, resolved, openApi, options);
+            } else {
+                options.add(createOptionDescriptor(fieldName, null, propSchema, openApi));
+            }
+        }
+        return options;
+    }
+
+    private static void flattenNestedObject(String parentFieldName, Schema schema,
+            OpenAPI openApi, List<KcAdmV2CommandDescriptor.OptionDescriptor> options) {
+        Map<String, Schema> nestedProperties = collectProperties(schema, openApi);
+        for (var propEntry : nestedProperties.entrySet()) {
+            KcAdmV2CommandDescriptor.OptionDescriptor opt =
+                    createOptionDescriptor(propEntry.getKey(), parentFieldName, propEntry.getValue(), openApi);
+            opt.setName(camelToKebab(parentFieldName) + "-" + camelToKebab(propEntry.getKey()));
+            options.add(opt);
+        }
+    }
+
+    private static KcAdmV2CommandDescriptor.OptionDescriptor createOptionDescriptor(
+            String fieldName, String parentFieldName, Schema propSchema, OpenAPI openApi) {
+        KcAdmV2CommandDescriptor.OptionDescriptor opt = new KcAdmV2CommandDescriptor.OptionDescriptor();
+        opt.setFieldName(fieldName);
+        opt.setParentFieldName(parentFieldName);
+        opt.setName(camelToKebab(fieldName));
+        opt.setDescription(propSchema.getDescription());
+        opt.setArray(isArrayType(propSchema));
+        opt.setType(resolveType(propSchema));
+        opt.setEnumValues(extractEnumValues(propSchema, openApi));
+        return opt;
+    }
+
+    private static List<String> extractEnumValues(Schema schema, OpenAPI openApi) {
+        Schema target = schema;
+        if (isArrayType(schema) && schema.getItems() != null) {
+            target = schema.getItems();
+            if (target.getRef() != null) {
+                target = resolveSchema(target, openApi);
+            }
+        }
+        if (target != null && target.getEnumeration() != null && !target.getEnumeration().isEmpty()) {
+            return target.getEnumeration().stream().map(Object::toString).toList();
+        }
+        return null;
+    }
+
+    private static boolean isObjectType(Schema schema) {
+        return schema != null && schema.getProperties() != null && !schema.getProperties().isEmpty();
+    }
+
+    private static Schema extractRequestBodySchema(Operation operation, OpenAPI openApi) {
+        RequestBody requestBody = operation.getRequestBody();
+        if (requestBody == null || requestBody.getContent() == null) {
+            return null;
+        }
+        MediaType mediaType = requestBody.getContent().getMediaType(APPLICATION_JSON);
+        if (mediaType == null || mediaType.getSchema() == null) {
+            return null;
+        }
+        return resolveSchema(mediaType.getSchema(), openApi);
+    }
+
+    private static Schema extractResponseSchema(Operation operation, OpenAPI openApi) {
+        if (operation.getResponses() == null) {
+            return null;
+        }
+        for (var response : operation.getResponses().getAPIResponses().values()) {
+            if (response.getContent() == null) {
+                continue;
+            }
+            MediaType mediaType = response.getContent().getMediaType(APPLICATION_JSON);
+            if (mediaType != null && mediaType.getSchema() != null) {
+                return resolveSchema(mediaType.getSchema(), openApi);
+            }
+        }
+        return null;
+    }
+
+    private static Schema resolveSchema(Schema schema, OpenAPI openApi) {
+        if (schema.getRef() != null) {
+            return resolveSchema(schema.getRef(), openApi);
+        }
+        return schema;
+    }
+
+    private static Schema resolveSchema(String ref, OpenAPI openApi) {
+        String schemaName = ref.substring(ref.lastIndexOf('/') + 1);
+        return openApi.getComponents().getSchemas().get(schemaName);
+    }
+
+    private static Map<String, Schema> collectProperties(Schema schema, OpenAPI openApi) {
+        Map<String, Schema> result = new LinkedHashMap<>();
+        if (schema.getAllOf() != null) {
+            for (Schema part : schema.getAllOf()) {
+                Schema resolved = resolveSchema(part, openApi);
+                if (resolved != null) {
+                    result.putAll(collectProperties(resolved, openApi));
+                }
+            }
+        }
+
+        if (schema.getProperties() != null) {
+            result.putAll(schema.getProperties());
+        }
+
+        return result;
+    }
+
+    private static boolean isArrayType(Schema schema) {
+        return schema.getType() != null && schema.getType().contains(Schema.SchemaType.ARRAY);
+    }
+
+    private static String resolveType(Schema schema) {
+        if (isArrayType(schema)) {
+            if (schema.getItems() != null && schema.getItems().getType() != null
+                    && !schema.getItems().getType().isEmpty()) {
+                return schema.getItems().getType().get(0).name().toLowerCase();
+            }
+            return OptionDescriptor.TYPE_STRING;
+        }
+        if (schema.getType() != null && !schema.getType().isEmpty()) {
+            return schema.getType().get(0).name().toLowerCase();
+        }
+        if (schema.getRef() != null) {
+            return "object";
+        }
+        return "string";
+    }
+
+    private static final Map<String, String> VARIANT_NAME_MAP = Map.of(
+            "openid-connect", "oidc"
+    );
+
+    private static String toVariantName(String discriminatorValue) {
+        return VARIANT_NAME_MAP.getOrDefault(discriminatorValue, discriminatorValue);
+    }
+
+    private static String camelToKebab(String camelCase) {
+        return camelCase.replaceAll("([a-z])([A-Z])", "$1-$2").toLowerCase();
+    }
+
+    /**
+     * Parses an OpenAPI JSON spec using SmallRye. Used at build time and for future server-fetch.
+     */
+    public static OpenAPI parseOpenApi(java.util.function.Supplier<InputStream> specSupplier) {
+        return SmallRyeOpenAPI.builder()
+                .withCustomStaticFile(specSupplier)
+                .enableModelReader(false)
+                .enableAnnotationScan(false)
+                .enableStandardFilter(false)
+                .enableStandardStaticFiles(false)
+                .withConfig(EMPTY_CONFIG)
+                .build()
+                .model();
+    }
+
+    private static final Config EMPTY_CONFIG = new Config() {
+        @Override public <T> T getValue(String s, Class<T> c) { return null; }
+        @Override public ConfigValue getConfigValue(String s) { return null; }
+        @Override public <T> Optional<T> getOptionalValue(String s, Class<T> c) { return Optional.empty(); }
+        @Override public Iterable<String> getPropertyNames() { return List.of(); }
+        @Override public Iterable<ConfigSource> getConfigSources() { return List.of(); }
+        @Override public <T> Optional<Converter<T>> getConverter(Class<T> c) { return Optional.empty(); }
+        @Override public <T> T unwrap(Class<T> c) { return null; }
+    };
+
+    /**
+     * Build-time entry point: reads OpenAPI from classpath, writes descriptor to output directory.
+     */
+    public static void main(String[] args) throws IOException {
+        if (args.length != 1) {
+            System.err.println("Usage: KcAdmV2DescriptorBuilder <output-dir>");
+            System.exit(1);
+        }
+
+        OpenAPI openApi = parseOpenApi(
+                () -> KcAdmV2DescriptorBuilder.class.getResourceAsStream("/META-INF/openapi.json"));
+
+        KcAdmV2CommandDescriptor descriptor = convert(openApi);
+        writeDescriptor(descriptor, Path.of(args[0], "kcadm-v2-commands.json"));
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2RequestExecutor.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2RequestExecutor.java
@@ -1,0 +1,301 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.admin.cli.commands.AbstractTargetAuthOptionsCmd;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.CommandDescriptor;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.OptionDescriptor;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.VariantDescriptor;
+import org.keycloak.client.cli.common.Globals;
+import org.keycloak.client.cli.config.ConfigData;
+import org.keycloak.client.cli.config.FileConfigHandler;
+import org.keycloak.client.cli.config.InMemoryConfigHandler;
+import org.keycloak.client.cli.util.ConfigUtil;
+import org.keycloak.client.cli.util.Headers;
+import org.keycloak.client.cli.util.HeadersBody;
+import org.keycloak.client.cli.util.HeadersBodyStatus;
+import org.keycloak.client.cli.util.HttpUtil;
+import org.keycloak.client.cli.util.OutputUtil;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.HttpHeaders;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+import static org.keycloak.client.cli.util.ConfigUtil.credentialsAvailable;
+import static org.keycloak.client.cli.util.ConfigUtil.loadConfig;
+import static org.keycloak.client.cli.util.HttpUtil.APPLICATION_JSON;
+import static org.keycloak.client.cli.util.IoUtil.readFully;
+import static org.keycloak.common.util.ObjectUtil.capitalize;
+
+@Command
+class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
+
+    static final String MERGE_PATCH_JSON = "application/merge-patch+json";
+    static final String API_VERSION = "v2";
+    static final String DEFAULT_REALM = "master";
+
+    @Spec CommandSpec spec;
+    private final CommandDescriptor descriptor;
+    private final VariantDescriptor variant;
+
+    KcAdmV2RequestExecutor(CommandDescriptor descriptor, VariantDescriptor variant) {
+        super();
+        this.descriptor = descriptor;
+        this.variant = variant;
+    }
+
+    @Override
+    protected String help() {
+        return "";
+    }
+
+    @Override
+    protected void processOptions() {
+        if (config != null && noconfig) {
+            throw new IllegalArgumentException("Options --config and --no-config are mutually exclusive");
+        }
+
+        if (noconfig) {
+            InMemoryConfigHandler handler = new InMemoryConfigHandler();
+            handler.setConfigData(new ConfigData());
+            ConfigUtil.setHandler(handler);
+        } else {
+            FileConfigHandler.setConfigFile(config != null ? config : getDefaultConfigFilePath());
+            ConfigUtil.setHandler(new FileConfigHandler());
+        }
+    }
+
+    @Override
+    public void run() {
+        if (Globals.help) {
+            spec.commandLine().usage(spec.commandLine().getOut());
+            return;
+        }
+
+        PrintWriter out = spec.commandLine().getOut();
+
+        try {
+            processOptions();
+
+            ConfigData configData = loadConfig();
+
+            // Apply CLI overrides onto config
+            if (server != null) {
+                configData.setServerUrl(server);
+            }
+            if (realm != null) {
+                configData.setRealm(realm);
+            }
+            if (externalToken != null) {
+                configData.setExternalToken(externalToken);
+            }
+
+            // Default realm to master if not set anywhere
+            if (configData.getRealm() == null) {
+                configData.setRealm(DEFAULT_REALM);
+            }
+
+            String v2Cmd = KcAdmMain.CMD + " " + KcAdmMain.V2_FLAG;
+
+            if (configData.getServerUrl() == null) {
+                throw new RuntimeException(
+                        "No server URL configured. Use --server or '" + v2Cmd + " config credentials' first.");
+            }
+            if (!configData.getServerUrl().startsWith("http://") && !configData.getServerUrl().startsWith("https://")) {
+                throw new RuntimeException(
+                        "Invalid server URL: " + configData.getServerUrl() + ". URL must start with http:// or https://");
+            }
+
+            setupTruststore(configData);
+
+            // Set fields so ensureAuthInfo/BaseConfigCredentialsCmd can use them
+            if (server == null) {
+                server = configData.getServerUrl();
+            }
+            if (realm == null) {
+                realm = configData.getRealm();
+            }
+
+            configData = ensureAuthInfo(configData);
+            configData = copyWithServerInfo(configData);
+
+            String token = null;
+            if (credentialsAvailable(configData)) {
+                token = ensureToken(configData);
+            }
+
+            String requestRealm = getTargetRealm(configData);
+            if (requestRealm == null) {
+                requestRealm = DEFAULT_REALM;
+            }
+            configData.setRealm(requestRealm);
+
+            String url = buildUrl(configData);
+            String body = buildRequestBody();
+
+            Headers headers = new Headers();
+            if (token != null) {
+                headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+            }
+            headers.add(HttpHeaders.ACCEPT, APPLICATION_JSON);
+
+            InputStream bodyStream = null;
+            if (body != null) {
+                String contentType = "PATCH".equals(descriptor.getHttpMethod())
+                        ? MERGE_PATCH_JSON : APPLICATION_JSON;
+                headers.add(HttpHeaders.CONTENT_TYPE, contentType);
+                bodyStream = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            HeadersBodyStatus response = HttpUtil.doRequest(
+                    descriptor.getHttpMethod().toLowerCase(),
+                    url,
+                    new HeadersBody(headers, bodyStream));
+
+            response.checkSuccess();
+            String responseBody = response.getBody() != null ? readFully(response.getBody()) : "";
+
+            if (!responseBody.isBlank()) {
+                out.println(formatOutput(responseBody));
+            } else if ("delete".equals(descriptor.getName()) && !descriptor.isHasResponseBody()) {
+                out.println(capitalize(descriptor.getResourceName()) + " deleted");
+            }
+        } catch (CommandLine.ExecutionException e) {
+            throw e;
+        } catch (Exception e) {
+            String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            throw new CommandLine.ExecutionException(spec.commandLine(), message, e);
+        }
+    }
+
+    private String buildUrl(ConfigData configData) {
+        String path = descriptor.getPath()
+                .replace("{realmName}", HttpUtil.urlencode(configData.getRealm()))
+                .replace("{version}", API_VERSION);
+
+        if (descriptor.isRequiresId()) {
+            var positional = spec.commandLine().getParseResult().matchedPositional(0);
+            if (positional == null) {
+                throw new RuntimeException("Missing required ID argument");
+            }
+            path = path.replace(KcAdmV2DescriptorBuilder.ID_PATH_PARAM, HttpUtil.urlencode(positional.getValue()));
+        }
+
+        return configData.getServerUrl() + path;
+    }
+
+    private String buildRequestBody() throws IOException {
+        String file = spec.commandLine().getParseResult()
+                .matchedOptionValue(KcAdmV2CommandBuilder.OPT_FILE, null);
+
+        List<OptionDescriptor> options = variant != null
+                ? variant.getOptions() : descriptor.getOptions();
+
+        if (file != null) {
+            if (hasAnyFieldOptionSet(options)) {
+                throw new RuntimeException(
+                        "Options -f/--file and field options are mutually exclusive");
+            }
+            Path filePath = new File(file).toPath();
+            if (!Files.isRegularFile(filePath)) {
+                throw new RuntimeException("File not found: " + file);
+            }
+            return Files.readString(filePath);
+        }
+        if (options == null || options.isEmpty()) {
+            return null;
+        }
+
+        boolean anyFieldSet = false;
+        Map<String, Object> fields = new LinkedHashMap<>();
+
+        if (variant != null) {
+            fields.put(variant.getDiscriminatorField(), variant.getDiscriminatorValue());
+            anyFieldSet = true;
+        }
+
+        for (OptionDescriptor opt : options) {
+            Object value = spec.commandLine().getParseResult()
+                    .matchedOptionValue("--" + opt.getName(), null);
+            if (value != null) {
+                anyFieldSet = true;
+                Object converted;
+                if (opt.isArray() && value instanceof String[]) {
+                    converted = List.of((String[]) value);
+                } else if (OptionDescriptor.TYPE_BOOLEAN.equals(opt.getType())) {
+                    converted = Boolean.parseBoolean(value.toString());
+                } else {
+                    converted = value;
+                }
+
+                if (opt.getParentFieldName() != null) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> nested = (Map<String, Object>)
+                            fields.computeIfAbsent(opt.getParentFieldName(), k -> new LinkedHashMap<>());
+                    nested.put(opt.getFieldName(), converted);
+                } else {
+                    fields.put(opt.getFieldName(), converted);
+                }
+            }
+        }
+
+        if (!anyFieldSet) {
+            return null;
+        }
+
+        return JsonSerialization.writeValueAsString(fields);
+    }
+
+    private boolean hasAnyFieldOptionSet(List<OptionDescriptor> options) {
+        if (options == null) {
+            return false;
+        }
+        for (OptionDescriptor opt : options) {
+            if (spec.commandLine().getParseResult()
+                    .matchedOptionValue("--" + opt.getName(), null) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String formatOutput(String json) {
+        try {
+            var parseResult = spec.commandLine().getParseResult();
+            boolean compressed = parseResult.matchedOptionValue(KcAdmV2CommandBuilder.OPT_COMPRESSED, false);
+
+            JsonNode node = OutputUtil.MAPPER.readTree(json);
+
+            String jsonOutput = compressed ? node.toString() : OutputUtil.MAPPER.writeValueAsString(node);
+
+            if (CommandLine.Help.Ansi.AUTO.enabled()) {
+                try {
+                    return CliJsonOutputHighlighter.highlight(jsonOutput);
+                } catch (IOException e) {
+                    if (Globals.dumpTrace) {
+                        System.err.println("Syntax highlighting failed, falling back to plain output: " + e.getMessage());
+                    }
+                }
+            }
+
+            return jsonOutput;
+        } catch (Exception e) {
+            throw new RuntimeException("Error processing results: " + e.getMessage(), e);
+        }
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseAuthOptionsCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseAuthOptionsCmd.java
@@ -57,7 +57,7 @@ public abstract class BaseAuthOptionsCmd extends BaseGlobalOptionsCmd {
     @Option(names = "--realm", description = "Realm name to authenticate against")
     protected String realm;
 
-    @Option(names = "--client", description = "Realm name to authenticate against")
+    @Option(names = "--client", description = "Client ID (defaults to 'admin-cli')")
     protected String clientId;
 
     @Option(names = "--user", description = "Username to login with")

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseGlobalOptionsCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/BaseGlobalOptionsCmd.java
@@ -93,4 +93,7 @@ public abstract class BaseGlobalOptionsCmd implements Runnable {
         return value ? "true" : null;
     }
 
+    protected void configureCommandLine(CommandLine cli) {
+    }
+
 }

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/Globals.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/Globals.java
@@ -58,6 +58,7 @@ public class Globals {
         cmd.setExecutionExceptionHandler(new ExecutionExceptionHandler());
         cmd.setParameterExceptionHandler(new ShortErrorMessageHandler());
         cmd.setErr(errorWriter);
+        rootCommand.configureCommandLine(cmd);
 
         return cmd;
     }

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/ShortErrorMessageHandler.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/common/ShortErrorMessageHandler.java
@@ -35,7 +35,7 @@ public class ShortErrorMessageHandler implements IParameterExceptionHandler {
 
     static int shortErrorMessage(Exception ex, CommandLine cmd) {
         PrintWriter writer = cmd.getErr();
-        String errorMessage = ex.getMessage();
+        String errorMessage = ex.getMessage() != null ? ex.getMessage() : ex.getClass().getSimpleName();
 
         writer.println(cmd.getColorScheme().errorText(errorMessage));
         if (ex instanceof ParameterException) {

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/HttpUtil.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/HttpUtil.java
@@ -43,6 +43,7 @@ import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -134,6 +135,9 @@ public class HttpUtil {
                 break;
             case "delete":
                 req = new HttpDelete(url);
+                break;
+            case "patch":
+                req = new HttpPatch(url);
                 break;
             case "options":
                 req = new HttpOptions(url);
@@ -233,6 +237,11 @@ public class HttpUtil {
         if (authorization != null) {
             request.setHeader(HttpHeaders.AUTHORIZATION, authorization);
         }
+    }
+
+    public static void clearHttpClient() {
+        httpClient = null;
+        sslsf = null;
     }
 
     public static HttpClient getHttpClient() {

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/CliJsonOutputHighlighterTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/CliJsonOutputHighlighterTest.java
@@ -1,0 +1,260 @@
+package org.keycloak.client.admin.cli.commands.v2;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter;
+import org.keycloak.client.cli.util.OutputUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.COLOR_BOOLEAN;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.COLOR_KEY;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.COLOR_NULL;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.COLOR_NUMBER;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.COLOR_STRING;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.ESC;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.RESET;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.arrayColorAtDepth;
+import static org.keycloak.client.admin.cli.v2.CliJsonOutputHighlighter.objectColorAtDepth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CliJsonOutputHighlighterTest {
+
+    private static final String ANSI_CODE_PATTERN = Pattern.quote(ESC) + "[0-9;]*m";
+
+    @Test
+    public void testStringValues() throws IOException {
+        String json = "{\"a\":\"hello\",\"b\":\"world\"}";
+        String result = highlight(json, false);
+
+        assertHasColor(result, "\"hello\"", COLOR_STRING);
+        assertHasColor(result, "\"world\"", COLOR_STRING);
+    }
+
+    @Test
+    public void testNumberValues() throws IOException {
+        String json = "{\"x\":42,\"y\":3.14}";
+        String result = highlight(json, false);
+
+        assertHasColor(result, "42", COLOR_NUMBER);
+        assertHasColor(result, "3.14", COLOR_NUMBER);
+    }
+
+    @Test
+    public void testBooleanValues() throws IOException {
+        String json = "{\"a\":true,\"b\":false}";
+        String result = highlight(json, false);
+
+        assertHasColor(result, "true", COLOR_BOOLEAN);
+        assertHasColor(result, "false", COLOR_BOOLEAN);
+    }
+
+    @Test
+    public void testNullValues() throws IOException {
+        String json = "{\"a\":null,\"b\":null}";
+        String result = highlight(json, false);
+
+        assertHasColor(result, "null", COLOR_NULL);
+    }
+
+    @Test
+    public void testKeys() throws IOException {
+        String json = "{\"firstName\":\"Alice\",\"lastName\":\"Bob\"}";
+        String result = highlight(json, false);
+
+        assertHasColor(result, "\"firstName\"", COLOR_KEY);
+        assertHasColor(result, "\"lastName\"", COLOR_KEY);
+    }
+
+    @Test
+    public void testObjectPunctuation() throws IOException {
+        String json = "{\"a\":1,\"b\":2}";
+        String result = highlight(json, false);
+
+        String expected = objectColorAtDepth(0);
+        assertHasColor(result, "{", expected);
+        assertHasColor(result, "}", expected);
+        assertHasColor(result, ":", expected);
+        assertHasColor(result, ",", expected);
+    }
+
+    @Test
+    public void testArrayPunctuation() throws IOException {
+        String json = "[1,2,3]";
+        String result = highlight(json, false);
+
+        String expected = arrayColorAtDepth(0);
+        assertHasColor(result, "[", expected);
+        assertHasColor(result, "]", expected);
+        assertHasColor(result, ",", expected);
+    }
+
+    @Test
+    public void testNestedObjectsHaveDifferentColors() throws IOException {
+        int depth = CliJsonOutputHighlighter.getObjectDepthCycle() + 1;
+        String json = buildNestedObjectJson(depth);
+        String result = highlight(json, false);
+
+        for (int i = 0; i < depth; i++) {
+            assertNthTokenHasColor(result, "{", i + 1, objectColorAtDepth(i));
+            // each level has 2 colons: {"key":"val","nested":{...}}
+            assertNthTokenHasColor(result, ":", 2 * i + 1, objectColorAtDepth(i));
+            assertNthTokenHasColor(result, ":", 2 * i + 2, objectColorAtDepth(i));
+            assertNthTokenHasColor(result, ",", i + 1, objectColorAtDepth(i));
+        }
+    }
+
+    @Test
+    public void testNestedArraysHaveDifferentColors() throws IOException {
+        int depth = CliJsonOutputHighlighter.getArrayDepthCycle() + 1;
+        String json = buildNestedArrayJson(depth);
+        String result = highlight(json, false);
+
+        for (int i = 0; i < depth; i++) {
+            assertNthTokenHasColor(result, "[", i + 1, arrayColorAtDepth(i));
+            assertNthTokenHasColor(result, ",", i + 1, arrayColorAtDepth(i));
+        }
+    }
+
+    @Test
+    public void testPrettyPrintedOutput() throws IOException {
+        String result = highlight("{\"name\":\"Alice\",\"age\":30}", false);
+
+        assertTrue("Pretty output should contain newlines", result.contains(System.lineSeparator()));
+        assertTrue("Pretty output should contain indentation", result.contains("  "));
+    }
+
+    @Test
+    public void testCompressedOutput() throws IOException {
+        String result = highlight("{\"name\":\"Alice\",\"age\":30}", true);
+
+        assertFalse("Compressed output should not contain newlines", result.contains(System.lineSeparator()));
+        assertFalse("Compressed output should not contain indentation", result.contains("  "));
+    }
+
+    @Test
+    public void testCompressedPreservesJsonStructure() throws IOException {
+        String json = "{\"name\":\"Alice\",\"age\":30,\"active\":true}";
+        String result = highlight(json, true);
+
+        assertEquals("Stripped output should be valid compressed JSON", json, stripAnsiCodes(result));
+    }
+
+    @Test
+    public void testPrettyPrintPreservesJsonContent() throws IOException {
+        String json = "{\"name\":\"Alice\",\"age\":30}";
+        String result = highlight(json, false);
+
+        String stripped = stripAnsiCodes(result);
+        assertTrue("Should contain all keys and values",
+                stripped.contains("\"name\"") && stripped.contains("\"Alice\"") && stripped.contains("30"));
+    }
+
+    @Test
+    public void testStringWithEscapedQuotes() throws IOException {
+        String json = "{\"msg\":\"hello \\\"world\\\"\"}";
+        String result = highlight(json, false);
+
+        assertHasColor(result, "\"hello \\\"world\\\"\"", COLOR_STRING);
+    }
+
+    @Test
+    public void testStringWithJsonEscapeSequences() throws IOException {
+        String json = "{\"a\":\"line1\\nline2\",\"b\":\"col1\\tcol2\",\"c\":\"back\\\\slash\"}";
+        String result = highlight(json, true);
+
+        String stripped = stripAnsiCodes(result);
+        assertEquals("Escape sequences should be preserved in output", json, stripped);
+    }
+
+    @Test
+    public void testPrettyFormatMatchesJacksonForSimpleObject() throws IOException {
+        String json = "{\"name\":\"Alice\",\"age\":30}";
+        assertFormattingMatchesJackson(json);
+    }
+
+    @Test
+    public void testPrettyFormatMatchesJacksonForArrayOfObjects() throws IOException {
+        String json = "[{\"a\":1},{\"b\":2}]";
+        assertFormattingMatchesJackson(json);
+    }
+
+    @Test
+    public void testPrettyFormatMatchesJacksonForNestedObject() throws IOException {
+        String json = "{\"user\":{\"name\":\"Bob\",\"active\":true}}";
+        assertFormattingMatchesJackson(json);
+    }
+
+    @Test
+    public void testPrettyFormatMatchesJacksonForArrayOfPrimitives() throws IOException {
+        String json = "{\"items\":[1,2,3]}";
+        assertFormattingMatchesJackson(json);
+    }
+
+    @Test
+    public void testOutputEndsWithReset() throws IOException {
+        String result = highlight("{\"a\":1}", false);
+
+        assertTrue("Output should end with ANSI reset to avoid color bleeding",
+                result.stripTrailing().endsWith(RESET));
+    }
+
+    private String highlight(String json, boolean compressed) throws IOException {
+        JsonNode tree = OutputUtil.MAPPER.readTree(json);
+        String formatted = compressed ? tree.toString() : OutputUtil.MAPPER.writeValueAsString(tree);
+        return CliJsonOutputHighlighter.highlight(formatted);
+    }
+
+    private void assertHasColor(String text, String token, String expectedColor) {
+        assertNthTokenHasColor(text, token, 1, expectedColor);
+    }
+
+    private void assertNthTokenHasColor(String text, String token, int n, String expectedColor) {
+        String tokenWithReset = token + RESET;
+        int idx = -1;
+        for (int i = 0; i < n; i++) {
+            idx = text.indexOf(tokenWithReset, idx + 1);
+            assertTrue("Occurrence " + n + " of '" + token + "' not found in: " + text, idx >= 0);
+        }
+        assertTrue("Occurrence " + n + " of '" + token + "' should have color " + expectedColor + " in: " + text,
+                text.startsWith(expectedColor + token, idx - expectedColor.length()));
+    }
+
+    private void assertFormattingMatchesJackson(String json) throws IOException {
+        JsonNode tree = OutputUtil.MAPPER.readTree(json);
+        String jacksonOutput = OutputUtil.MAPPER.writeValueAsString(tree);
+        String highlightedOutput = stripAnsiCodes(CliJsonOutputHighlighter.highlight(jacksonOutput));
+        assertEquals("Highlighted formatting should match Jackson's DefaultPrettyPrinter:", jacksonOutput, highlightedOutput);
+    }
+
+    private String stripAnsiCodes(String text) {
+        return text.replaceAll(ANSI_CODE_PATTERN, "");
+    }
+
+    private String buildNestedObjectJson(int depth) {
+        StringBuilder open = new StringBuilder();
+        StringBuilder close = new StringBuilder();
+        for (int i = 0; i < depth - 1; i++) {
+            open.append("{\"k").append(i).append("\":\"v").append(i).append("\",\"d").append(i).append("\":");
+            close.insert(0, "}");
+        }
+        open.append("{\"a\":1,\"b\":2}");
+        return open + close.toString();
+    }
+
+    private String buildNestedArrayJson(int depth) {
+        StringBuilder open = new StringBuilder();
+        StringBuilder close = new StringBuilder();
+        for (int i = 0; i < depth - 1; i++) {
+            open.append("[0,");
+            close.insert(0, "]");
+        }
+        open.append("[1,2]");
+        return open + close.toString();
+    }
+}

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2CompleterTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2CompleterTest.java
@@ -1,0 +1,174 @@
+package org.keycloak.client.admin.cli.commands.v2;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import org.keycloak.client.admin.cli.v2.KcAdmV2Completer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KcAdmV2CompleterTest {
+
+    @Test
+    public void testEmptyInputShowsResourceGroups() {
+        List<String> candidates = complete("");
+        assertTrue("Should suggest 'client'", candidates.contains("client"));
+    }
+
+    @Test
+    public void testPartialResourceName() {
+        List<String> candidates = complete("cl");
+        assertTrue("Should match 'client'", candidates.contains("client"));
+    }
+
+    @Test
+    public void testNoMatch() {
+        List<String> candidates = complete("xyz");
+        assertNoSubcommands(candidates);
+    }
+
+    @Test
+    public void testResourceGroupShowsCommands() {
+        List<String> candidates = complete("client", "");
+        assertTrue("Should suggest 'list'", candidates.contains("list"));
+        assertTrue("Should suggest 'create'", candidates.contains("create"));
+        assertTrue("Should suggest 'get'", candidates.contains("get"));
+        assertTrue("Should suggest 'patch'", candidates.contains("patch"));
+        assertTrue("Should suggest 'update'", candidates.contains("update"));
+        assertTrue("Should suggest 'delete'", candidates.contains("delete"));
+    }
+
+    @Test
+    public void testPartialCommand() {
+        List<String> candidates = complete("client", "l");
+        assertTrue("Should match 'list'", candidates.contains("list"));
+        assertSubcommandsDoNotContain(candidates);
+    }
+
+    @Test
+    public void testDashSuggestsOptions() {
+        List<String> candidates = complete("client", "list", "--");
+        assertTrue("Should suggest '--config'", candidates.contains("--config"));
+        assertTrue("Should suggest '--compressed'", candidates.contains("--compressed"));
+        assertTrue("Should suggest '--truststore'", candidates.contains("--truststore"));
+        assertTrue("Should suggest '--trustpass'", candidates.contains("--trustpass"));
+        assertTrue("Should suggest '--insecure'", candidates.contains("--insecure"));
+        assertTrue("Should suggest '--password'", candidates.contains("--password"));
+        assertTrue("Should suggest '--secret'", candidates.contains("--secret"));
+        assertTrue("Should suggest '--no-config'", candidates.contains("--no-config"));
+        assertTrue("Should suggest '--keystore'", candidates.contains("--keystore"));
+        assertTrue("Should suggest '--storepass'", candidates.contains("--storepass"));
+        assertTrue("Should suggest '--keypass'", candidates.contains("--keypass"));
+        assertTrue("Should suggest '--alias'", candidates.contains("--alias"));
+    }
+
+    @Test
+    public void testDoubleDashSuggestsLongOptionsForVariant() {
+        List<String> candidates = complete("client", "create", "oidc", "--");
+        assertTrue("Should suggest '--client-id'", candidates.contains("--client-id"));
+        assertTrue("Should suggest '--login-flows'", candidates.contains("--login-flows"));
+        assertTrue("Should suggest '--help'", candidates.contains("--help"));
+        assertFalse("Should not suggest short options", candidates.contains("-f"));
+    }
+
+    @Test
+    public void testProtocolVariantsInAutocompleteForCreate() {
+        List<String> candidates = complete("client", "create", "");
+        assertTrue("Should suggest 'oidc'", candidates.contains("oidc"));
+        assertTrue("Should suggest 'saml'", candidates.contains("saml"));
+    }
+
+    @Test
+    public void testFileOptionInAutocompleteForCreateOidc() {
+        List<String> candidates = complete("client", "create", "oidc", "-");
+        assertTrue("Should suggest '-f'", candidates.contains("-f"));
+    }
+
+    @Test
+    public void testFlattenedAuthOptionsInAutocomplete() {
+        List<String> candidates = complete("client", "create", "oidc", "--auth");
+        assertTrue("Should suggest '--auth-method'", candidates.contains("--auth-method"));
+        assertTrue("Should suggest '--auth-secret'", candidates.contains("--auth-secret"));
+        assertTrue("Should suggest '--auth-certificate'", candidates.contains("--auth-certificate"));
+    }
+
+    @Test
+    public void testOidcOptionsInAutocompleteForCreateOidc() {
+        List<String> candidates = complete("client", "create", "oidc", "--");
+        assertTrue("Should suggest '--login-flows'", candidates.contains("--login-flows"));
+        assertTrue("Should suggest '--web-origins'", candidates.contains("--web-origins"));
+        assertTrue("Should suggest '--auth-method'", candidates.contains("--auth-method"));
+        assertFalse("Should not suggest '--sign-documents'", candidates.contains("--sign-documents"));
+    }
+
+    @Test
+    public void testSamlOptionsInAutocompleteForCreateSaml() {
+        List<String> candidates = complete("client", "create", "saml", "--");
+        assertTrue("Should suggest '--sign-documents'", candidates.contains("--sign-documents"));
+        assertFalse("Should not suggest '--login-flows'", candidates.contains("--login-flows"));
+    }
+
+    @Test
+    public void testFileOptionNotInAutocompleteForList() {
+        List<String> candidates = complete("client", "list", "-");
+        assertFalse("list should not suggest '-f'", candidates.contains("-f"));
+    }
+
+    @Test
+    public void testOutputOptionsNotInAutocompleteForDelete() {
+        List<String> candidates = complete("client", "delete", "--");
+        assertFalse("delete should not suggest '--compressed'", candidates.contains("--compressed"));
+    }
+
+    @Test
+    public void testUpdateVariantsInAutocomplete() {
+        List<String> candidates = complete("client", "update", "");
+        assertTrue("Should suggest 'oidc'", candidates.contains("oidc"));
+        assertTrue("Should suggest 'saml'", candidates.contains("saml"));
+    }
+
+    @Test
+    public void testUpdateOidcOptionsInAutocomplete() {
+        List<String> candidates = complete("client", "update", "oidc", "--");
+        assertTrue("Should suggest '--client-id'", candidates.contains("--client-id"));
+        assertTrue("Should suggest '--login-flows'", candidates.contains("--login-flows"));
+        assertTrue("Should suggest '--compressed'", candidates.contains("--compressed"));
+        assertFalse("Should not suggest '--sign-documents'", candidates.contains("--sign-documents"));
+    }
+
+    @Test
+    public void testUnknownSubcommandStaysAtCurrentLevel() {
+        List<String> candidates = complete("client", "nonexistent", "");
+        assertTrue("Should still suggest commands under 'client'", candidates.contains("list"));
+    }
+
+    private List<String> complete(String... args) {
+        StringWriter sw = new StringWriter();
+        KcAdmV2Completer.complete(args, new PrintWriter(sw));
+        String output = sw.toString().trim();
+        if (output.isEmpty()) {
+            return List.of();
+        }
+        return List.of(output.split(System.lineSeparator()));
+    }
+
+    private void assertNoSubcommands(List<String> candidates) {
+        for (String c : candidates) {
+            if (!c.startsWith("-")) {
+                throw new AssertionError("Expected no subcommand candidates but found: " + c);
+            }
+        }
+    }
+
+    private void assertSubcommandsDoNotContain(List<String> candidates) {
+        for (String name : new String[]{"create", "get", "patch", "update", "delete"}) {
+            if (candidates.contains(name)) {
+                throw new AssertionError("Should not contain '" + name + "' but did");
+            }
+        }
+    }
+}

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2DescriptorBuilderTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2DescriptorBuilderTest.java
@@ -1,0 +1,132 @@
+package org.keycloak.client.admin.cli.commands.v2;
+
+import java.io.ByteArrayInputStream;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor;
+import org.keycloak.client.admin.cli.v2.KcAdmV2DescriptorBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class KcAdmV2DescriptorBuilderTest {
+
+    private static final String TEST_OPENAPI = "/test-openapi.json";
+
+    @Test
+    public void testConvertProducesCorrectResourceName() {
+        KcAdmV2CommandDescriptor descriptor = buildDescriptor();
+
+        assertNotNull(descriptor.getResources());
+        assertEquals(1, descriptor.getResources().size());
+        assertEquals("thing", descriptor.getResources().get(0).getName());
+    }
+
+    @Test
+    public void testVersion() {
+        KcAdmV2CommandDescriptor descriptor = buildDescriptor();
+        assertEquals("1.0.0-test", descriptor.getVersion());
+    }
+
+    @Test
+    public void testConvertProducesAllCommands() {
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> byName = commandsByName();
+
+        assertEquals("Should have 5 commands", 5, byName.size());
+        assertTrue(byName.containsKey("list"));
+        assertTrue(byName.containsKey("create"));
+        assertTrue(byName.containsKey("get"));
+        assertTrue(byName.containsKey("patch"));
+        assertTrue(byName.containsKey("delete"));
+    }
+
+    @Test
+    public void testCollectionCommandsDoNotRequireId() {
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> byName = commandsByName();
+
+        assertFalse("list should not require id", byName.get("list").isRequiresId());
+        assertFalse("create should not require id", byName.get("create").isRequiresId());
+    }
+
+    @Test
+    public void testSingleResourceCommandsRequireId() {
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> byName = commandsByName();
+
+        assertTrue("get should require id", byName.get("get").isRequiresId());
+        assertTrue("patch should require id", byName.get("patch").isRequiresId());
+        assertTrue("delete should require id", byName.get("delete").isRequiresId());
+    }
+
+    @Test
+    public void testHttpMethodsAreCorrect() {
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> byName = commandsByName();
+
+        assertEquals("GET", byName.get("list").getHttpMethod());
+        assertEquals("POST", byName.get("create").getHttpMethod());
+        assertEquals("GET", byName.get("get").getHttpMethod());
+        assertEquals("PATCH", byName.get("patch").getHttpMethod());
+        assertEquals("DELETE", byName.get("delete").getHttpMethod());
+    }
+
+    @Test
+    public void testDescriptionsFromOpenApiSummary() {
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> byName = commandsByName();
+
+        assertEquals("List all things", byName.get("list").getDescription());
+        assertEquals("Create a thing", byName.get("create").getDescription());
+    }
+
+    @Test
+    public void testFallbackDescriptionWhenNoSummary() {
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> byName = commandsByName();
+
+        // getThing has no summary in test-openapi.json
+        assertEquals("Get thing", byName.get("get").getDescription());
+    }
+
+    @Test
+    public void testSerializeDeserializeRoundtrip() throws Exception {
+        KcAdmV2CommandDescriptor original = buildDescriptor();
+
+        byte[] json = new ObjectMapper().writeValueAsBytes(original);
+        KcAdmV2CommandDescriptor deserialized = KcAdmV2DescriptorBuilder.readDescriptor(
+                new ByteArrayInputStream(json));
+
+        assertEquals(original.getVersion(), deserialized.getVersion());
+        assertEquals(original.getResources().size(), deserialized.getResources().size());
+        assertEquals(
+                original.getResources().get(0).getCommands().size(),
+                deserialized.getResources().get(0).getCommands().size());
+
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> originalByName = commandsByName(original);
+        Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> deserializedByName = commandsByName(deserialized);
+        for (String name : originalByName.keySet()) {
+            assertEquals(originalByName.get(name).getHttpMethod(), deserializedByName.get(name).getHttpMethod());
+            assertEquals(originalByName.get(name).isRequiresId(), deserializedByName.get(name).isRequiresId());
+            assertEquals(originalByName.get(name).getDescription(), deserializedByName.get(name).getDescription());
+        }
+    }
+
+    private static KcAdmV2CommandDescriptor buildDescriptor() {
+        OpenAPI openApi = KcAdmV2DescriptorBuilder.parseOpenApi(
+                () -> KcAdmV2DescriptorBuilderTest.class.getResourceAsStream(TEST_OPENAPI));
+        return KcAdmV2DescriptorBuilder.convert(openApi);
+    }
+
+    private static Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> commandsByName() {
+        return commandsByName(buildDescriptor());
+    }
+
+    private static Map<String, KcAdmV2CommandDescriptor.CommandDescriptor> commandsByName(
+            KcAdmV2CommandDescriptor descriptor) {
+        return descriptor.getResources().get(0).getCommands().stream()
+                .collect(Collectors.toMap(KcAdmV2CommandDescriptor.CommandDescriptor::getName, c -> c));
+    }
+}

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2HelpTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2HelpTest.java
@@ -1,0 +1,402 @@
+package org.keycloak.client.admin.cli.commands.v2;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.admin.cli.v2.KcAdmV2Cmd;
+import org.keycloak.client.cli.common.Globals;
+
+import org.junit.Test;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KcAdmV2HelpTest {
+
+    @Test
+    public void testHelpShowsResourceGroup() {
+        String help = createCli().getUsageMessage();
+
+        assertTrue("Help should list 'client' resource group", help.contains("client"));
+        assertTrue("Help should list 'config' command", help.contains("config"));
+    }
+
+    @Test
+    public void testHelpShowsConsistentDescriptions() {
+        String help = createCli().getUsageMessage();
+
+        assertTrue("config should have a proper description",
+                help.contains("Configuration management"));
+        assertTrue("client should have a proper description",
+                help.contains("Client operations"));
+    }
+
+    @Test
+    public void testGroupCommandWithoutSubcommand() {
+        CommandLine cli = createCli();
+        StringWriter err = new StringWriter();
+        cli.setErr(new PrintWriter(err));
+        int exitCode = cli.execute("client");
+        assertEquals("should exit normally", 0, exitCode);
+        assertTrue("should suggest full command with --v2",
+                err.toString().contains(KcAdmMain.CMD + " --v2 client --help"));
+    }
+
+    @Test
+    public void testClientHelpShowsAllCommands() {
+        CommandLine cli = createCli();
+        CommandLine clientCli = cli.getSubcommands().get("client");
+
+        String help = clientCli.getUsageMessage();
+        for (String cmd : List.of("list", "create", "get", "patch", "update", "delete")) {
+            assertTrue("Client help should list '" + cmd + "'", help.contains(cmd));
+        }
+    }
+
+    @Test
+    public void testCreateHasProtocolVariants() {
+        CommandLine cli = createCli();
+        CommandLine createCli = cli.getSubcommands().get("client").getSubcommands().get("create");
+        assertTrue("create should have 'oidc' subcommand", createCli.getSubcommands().containsKey("oidc"));
+        assertTrue("create should have 'saml' subcommand", createCli.getSubcommands().containsKey("saml"));
+    }
+
+    @Test
+    public void testCreateOidcShowsOidcOptions() {
+        String help = getVariantHelp("create", "oidc");
+        assertTrue("should have --login-flows", help.contains("--login-flows"));
+        assertTrue("should have --web-origins", help.contains("--web-origins"));
+        assertTrue("should have --service-account-roles", help.contains("--service-account-roles"));
+        assertTrue("should have -f", help.contains("-f"));
+        assertFalse("should not have --sign-documents", help.contains("--sign-documents"));
+    }
+
+    @Test
+    public void testAuthFlattenedToSubOptions() {
+        String help = getVariantHelp("create", "oidc");
+        assertTrue("should have --auth-method", help.contains("--auth-method"));
+        assertTrue("should have --auth-secret", help.contains("--auth-secret"));
+        assertTrue("should have --auth-certificate", help.contains("--auth-certificate"));
+        assertFalse("should not have bare --auth ", help.contains("  --auth "));
+    }
+
+    @Test
+    public void testLoginFlowsShowsEnumValues() {
+        String help = getVariantHelp("create", "oidc");
+        assertTrue("should show STANDARD", help.contains("STANDARD"));
+        assertTrue("should show SERVICE_ACCOUNT", help.contains("SERVICE_ACCOUNT"));
+        assertTrue("should show DIRECT_GRANT", help.contains("DIRECT_GRANT"));
+    }
+
+    @Test
+    public void testCreateSamlShowsSamlOptions() {
+        String help = getVariantHelp("create", "saml");
+        assertTrue("should have --sign-documents", help.contains("--sign-documents"));
+        assertTrue("should have --sign-assertions", help.contains("--sign-assertions"));
+        assertTrue("should have --name-id-format", help.contains("--name-id-format"));
+        assertTrue("should have -f", help.contains("-f"));
+        assertFalse("should not have --login-flows", help.contains("--login-flows"));
+    }
+
+    @Test
+    public void testPatchOidcShowsOidcOptions() {
+        String help = getVariantHelp("patch", "oidc");
+        assertTrue("should have --login-flows", help.contains("--login-flows"));
+        assertTrue("should have -f", help.contains("-f"));
+        assertFalse("should not have --sign-documents", help.contains("--sign-documents"));
+    }
+
+    @Test
+    public void testPatchSamlShowsSamlOptions() {
+        String help = getVariantHelp("patch", "saml");
+        assertTrue("should have --sign-documents", help.contains("--sign-documents"));
+        assertFalse("should not have --login-flows", help.contains("--login-flows"));
+    }
+
+    @Test
+    public void testUpdateHasProtocolVariants() {
+        CommandLine cli = createCli();
+        CommandLine updateCli = cli.getSubcommands().get("client").getSubcommands().get("update");
+        assertTrue("update should have 'oidc' subcommand", updateCli.getSubcommands().containsKey("oidc"));
+        assertTrue("update should have 'saml' subcommand", updateCli.getSubcommands().containsKey("saml"));
+    }
+
+    @Test
+    public void testUpdateOidcShowsOidcOptions() {
+        String help = getVariantHelp("update", "oidc");
+        assertTrue("should have --login-flows", help.contains("--login-flows"));
+        assertTrue("should have -f", help.contains("-f"));
+        assertTrue("should have <id> positional", help.contains("<id>"));
+        assertFalse("should not have --sign-documents", help.contains("--sign-documents"));
+    }
+
+    @Test
+    public void testUpdateSamlShowsSamlOptions() {
+        String help = getVariantHelp("update", "saml");
+        assertTrue("should have --sign-documents", help.contains("--sign-documents"));
+        assertTrue("should have <id> positional", help.contains("<id>"));
+        assertFalse("should not have --login-flows", help.contains("--login-flows"));
+    }
+
+    @Test
+    public void testUpdateHasOutputOptions() {
+        String help = getVariantHelp("update", "oidc");
+        assertTrue("update (200 response) should have Output options", help.contains("Output options:"));
+        assertTrue("should have --compressed", help.contains("--compressed"));
+    }
+
+    @Test
+    public void testHelpOnUpdateVariantLeafWithRequiredId() {
+        CommandLine cli = createCli();
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        int exitCode = cli.execute("client", "update", "oidc", "--help");
+        assertEquals("--help on update variant should exit with 0, err: " + err, 0, exitCode);
+        assertTrue("should show help with --client-id option", out.toString().contains("--client-id"));
+    }
+
+    @Test
+    public void testFileOptionNotAvailableOnGet() {
+        String help = getSubcommandHelp("client", "get");
+        assertFalse("get should not have --file option", help.contains("--file"));
+    }
+
+    @Test
+    public void testFileOptionNotAvailableOnList() {
+        String help = getSubcommandHelp("client", "list");
+        assertFalse("list should not have --file option", help.contains("--file"));
+    }
+
+    @Test
+    public void testFileOptionNotAvailableOnDelete() {
+        String help = getSubcommandHelp("client", "delete");
+        assertFalse("delete should not have --file option", help.contains("--file"));
+    }
+
+    @Test
+    public void testOutputOptionsNotAvailableOnDelete() {
+        String help = getSubcommandHelp("client", "delete");
+        assertFalse("delete (204 No Content) should not have --compressed", help.contains("--compressed"));
+        assertFalse("delete (204 No Content) should not have 'Output options:'", help.contains("Output options:"));
+    }
+
+    @Test
+    public void testOutputOptionsGroupedOnSubcommand() {
+        String help = getSubcommandHelp("client", "list");
+        assertTrue("should have 'Output options:' heading", help.contains("Output options:"));
+        assertTrue("should have -c", help.contains("-c"));
+        assertTrue("should have --compressed", help.contains("--compressed"));
+    }
+
+    @Test
+    public void testOutputOptionsAvailableOnVariant() {
+        String help = getVariantHelp("create", "oidc");
+        assertTrue("should have -c", help.contains("-c"));
+    }
+
+    @Test
+    public void testConnectionOptionsOnSubcommand() {
+        String help = getSubcommandHelp("client", "list");
+        assertTrue("should have 'Connection options:' heading", help.contains("Connection options:"));
+        assertTrue("should have --config", help.contains("--config"));
+        assertTrue("should have -r", help.contains("-r"));
+        assertTrue("should have --target-realm", help.contains("--target-realm"));
+        assertTrue("should have --realm", help.contains("--realm"));
+        assertTrue("should have --token", help.contains("--token"));
+        assertTrue("should have --truststore", help.contains("--truststore"));
+        assertTrue("should have --trustpass", help.contains("--trustpass"));
+        assertTrue("should have --insecure", help.contains("--insecure"));
+    }
+
+    @Test
+    public void testKeystoreOptionsAvailable() {
+        String help = getSubcommandHelp("client", "list");
+        assertTrue("should have --keystore", help.contains("--keystore"));
+        assertTrue("should have --storepass", help.contains("--storepass"));
+        assertTrue("should have --keypass", help.contains("--keypass"));
+        assertTrue("should have --alias", help.contains("--alias"));
+        assertTrue("--storepass should mention KC_CLI_STORE_PASSWORD", help.contains("KC_CLI_STORE_PASSWORD"));
+    }
+
+    @Test
+    public void testNoConfigOptionAvailable() {
+        String help = getSubcommandHelp("client", "list");
+        assertTrue("should have --no-config", help.contains("--no-config"));
+        assertTrue("should describe no-config purpose", help.contains("Don't use config file"));
+    }
+
+    @Test
+    public void testPasswordDescriptionMentionsEnvVar() {
+        String help = getSubcommandHelp("client", "list");
+        assertTrue("--password should mention KC_CLI_PASSWORD", help.contains("KC_CLI_PASSWORD"));
+    }
+
+    @Test
+    public void testSecretDescriptionMentionsEnvVar() {
+        String help = getSubcommandHelp("client", "list");
+        assertTrue("--secret should mention KC_CLI_CLIENT_SECRET", help.contains("KC_CLI_CLIENT_SECRET"));
+    }
+
+    @Test
+    public void testGroupCommandShowsSubcommands() {
+        CommandLine cli = createCli();
+        String help = cli.getSubcommands().get("client").getUsageMessage();
+        assertTrue("should list subcommands like 'list'", help.contains("list"));
+        assertTrue("should list subcommands like 'create'", help.contains("create"));
+    }
+
+    @Test
+    public void testConnectionOptionsAvailableOnVariant() {
+        String help = getVariantHelp("create", "oidc");
+        assertTrue("should have --config", help.contains("--config"));
+        assertTrue("should have --realm", help.contains("--realm"));
+    }
+
+    @Test
+    public void testFileOptionRejectsNonExistentFile() {
+        CommandLine cli = createCli();
+        cli.setErr(new PrintWriter(new StringWriter()));
+        int exitCode = cli.execute("client", "create", "oidc", "-f", "/nonexistent/file.json");
+        assertNotEquals("Should fail for non-existent file", 0, exitCode);
+    }
+
+    @Test
+    public void testErrorMessageIncludesV2Flag() {
+        CommandLine cli = createCli();
+        StringWriter err = new StringWriter();
+        cli.setErr(new PrintWriter(err));
+        cli.execute("client", "patch", "unknown-variant");
+        assertTrue("error hint should include --v2",
+                err.toString().contains(KcAdmMain.CMD + " --v2 client patch --help"));
+    }
+
+
+    @Test
+    public void testHelpFlagOnLeafCommand() {
+        Globals.help = false;
+        try {
+            CommandLine cli = createCli();
+            StringWriter out = new StringWriter();
+            StringWriter err = new StringWriter();
+            cli.setOut(new PrintWriter(out));
+            cli.setErr(new PrintWriter(err));
+
+            int exitCode = cli.execute("client", "list", "--help");
+            assertEquals("--help should exit with 0", 0, exitCode);
+            assertTrue("--help should show connection options", out.toString().contains("--config"));
+            assertTrue("--help should show output options", out.toString().contains("--compressed"));
+        } finally {
+            Globals.help = false;
+        }
+    }
+
+    @Test
+    public void testHelpFlagOnGroupCommand() {
+        CommandLine cli = createCli();
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        int exitCode = cli.execute("client", "--help");
+        assertEquals("--help on group command should exit with 0", 0, exitCode);
+        assertTrue("should show subcommands", out.toString().contains("list"));
+    }
+
+    @Test
+    public void testHelpFlagOnVariantParent() {
+        CommandLine cli = createCli();
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        int exitCode = cli.execute("client", "create", "--help");
+        assertEquals("--help on variant parent should exit with 0", 0, exitCode);
+        String help = out.toString();
+        assertTrue("should show oidc variant", help.contains("oidc"));
+        assertTrue("should show saml variant", help.contains("saml"));
+    }
+
+    @Test
+    public void testHelpOnVariantLeafWithRequiredId() {
+        CommandLine cli = createCli();
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        int exitCode = cli.execute("client", "patch", "oidc", "--help");
+        assertEquals("--help on variant leaf with required ID should exit with 0, err: " + err, 0, exitCode);
+        assertTrue("should show help with --client-id option", out.toString().contains("--client-id"));
+    }
+
+    @Test
+    public void testAdminRootNotAvailableOnLeafCommand() {
+        String help = getSubcommandHelp("client", "list");
+        assertFalse("v2 should not have --admin-root", help.contains("--admin-root"));
+        assertFalse("v2 should not have -a option", help.contains("-a,"));
+    }
+
+    @Test
+    public void testGroupCommandHelpOmitsConnectionOptions() {
+        CommandLine cli = createCli();
+        String help = cli.getSubcommands().get("client").getUsageMessage();
+        assertFalse("group command should not show --config", help.contains("--config"));
+        assertFalse("group command should not show --server", help.contains("--server"));
+        assertFalse("group command should not show --password", help.contains("--password"));
+    }
+
+    @Test
+    public void testDumpTraceOptionAccepted() {
+        Globals.dumpTrace = false;
+        java.io.PrintStream originalErr = System.err;
+        try {
+            // limit noise
+            System.setErr(new PrintStream(OutputStream.nullOutputStream()));
+
+            CommandLine cli = createCli();
+            StringWriter err = new StringWriter();
+            StringWriter out = new StringWriter();
+            cli.setErr(new PrintWriter(err));
+            cli.setOut(new PrintWriter(out));
+
+            cli.execute("client", "list", "-x", "--no-config");
+            // Will fail (no server) but -x should be accepted, not rejected as unknown
+            assertFalse("-x should not be reported as unknown option",
+                    err.toString().contains("Unknown option"));
+            assertTrue("should fail with server error, not option error",
+                    err.toString().contains("No server URL configured"));
+        } finally {
+            System.setErr(originalErr);
+            Globals.dumpTrace = false;
+        }
+    }
+
+    private String getVariantHelp(String command, String variant) {
+        CommandLine cli = createCli();
+        return cli.getSubcommands().get("client").getSubcommands().get(command)
+                .getSubcommands().get(variant).getUsageMessage();
+    }
+
+    private String getSubcommandHelp(String group, String command) {
+        CommandLine cli = createCli();
+        return cli.getSubcommands().get(group)
+                .getSubcommands().get(command)
+                .getUsageMessage();
+    }
+
+    private CommandLine createCli() {
+        return Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+    }
+}

--- a/integration/client-cli/admin-cli/src/test/resources/test-openapi.json
+++ b/integration/client-cli/admin-cli/src/test/resources/test-openapi.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test API",
+    "version": "1.0.0-test"
+  },
+  "paths": {
+    "/admin/api/{realmName}/things/{version}": {
+      "get": {
+        "summary": "List all things",
+        "operationId": "getThings"
+      },
+      "post": {
+        "summary": "Create a thing",
+        "operationId": "createThing"
+      },
+      "parameters": [
+        { "name": "realmName", "in": "path" },
+        { "name": "version", "in": "path" }
+      ]
+    },
+    "/admin/api/{realmName}/things/{version}/{id}": {
+      "get": {
+        "operationId": "getThing"
+      },
+      "patch": {
+        "operationId": "patchThing"
+      },
+      "delete": {
+        "operationId": "deleteThing"
+      },
+      "parameters": [
+        { "name": "realmName", "in": "path" },
+        { "name": "version", "in": "path" },
+        { "name": "id", "in": "path" }
+      ]
+    }
+  }
+}

--- a/rest/admin-v2/rest/pom.xml
+++ b/rest/admin-v2/rest/pom.xml
@@ -83,7 +83,7 @@
                 <executions>
                     <execution>
                         <id>copy-openapi-to-jar</id>
-                        <phase>prepare-package</phase>
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>copy-resources</goal>
                         </goals>

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2ClientCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2ClientCLITest.java
@@ -1,0 +1,683 @@
+package org.keycloak.tests.admin.cli.v2;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.admin.cli.v2.KcAdmV2Cmd;
+import org.keycloak.client.cli.common.Globals;
+import org.keycloak.client.cli.config.FileConfigHandler;
+import org.keycloak.client.cli.util.HttpUtil;
+import org.keycloak.common.Profile;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.config.Config;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.keycloak.client.cli.config.FileConfigHandler.setConfigFile;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+@KeycloakIntegrationTest(config = KcAdmV2ClientCLITest.V2ApiServerConfig.class)
+public class KcAdmV2ClientCLITest {
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectRealm
+    ManagedRealm realm;
+
+    @TempDir
+    static File tempDir;
+
+    private static String configFilePath;
+
+    @TestSetup
+    public void login() {
+        configFilePath = new File(tempDir, "kcadm.config").getAbsolutePath();
+        HttpUtil.clearHttpClient();
+
+        CommandResult result = kcAdmV2Cmd(
+                "config", "credentials",
+                "--server", keycloakUrls.getBase(),
+                "--realm", "master",
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret());
+
+        assertThat("login should succeed: " + result.err(), result.exitCode(), is(0));
+    }
+
+    @Test
+    void testCreateClientValidationError() {
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc");
+
+        assertThat("create without clientId should fail", result.exitCode(), is(not(0)));
+        assertThat("error should clarify that provided data are invalid: " + result.err(),
+                result.err().toLowerCase(), containsString("invalid"));
+    }
+
+    @Test
+    void testCreateClientFileNotFound() {
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc", "-f", "/nonexistent/file.json");
+
+        assertThat("create with missing file should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("not found"));
+    }
+
+    @Test
+    void testCreateWithMalformedJsonFile() throws Exception {
+        Path jsonFile = new File(tempDir, "bad.json").toPath();
+        Files.writeString(jsonFile, "{ not valid json }");
+
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc", "-f", jsonFile.toString());
+
+        assertThat("malformed JSON should fail", result.exitCode(), is(not(0)));
+        assertThat("should not produce a stack trace",
+                result.err(), not(containsString("Exception")));
+        assertThat("should tell user about JSON parsing problem",
+                result.err(), containsString("Cannot parse the JSON"));
+    }
+
+    @Test
+    void testGetWithoutIdFails() {
+        CommandResult result = kcAdmV2Cmd("client", "get");
+
+        assertThat("get without ID should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Missing required parameter"));
+    }
+
+    @Test
+    void testGetNonExistentClient() {
+        CommandResult result = kcAdmV2Cmd("client", "get", "non-existent-id");
+
+        assertThat("get non-existent client should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Could not find client"));
+    }
+
+    @Test
+    void testFileAndFieldOptionsMutuallyExclusive() throws Exception {
+        Path jsonFile = new File(tempDir, "exclusive.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "test-exclusive", "protocol": "openid-connect"}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc",
+                "-f", jsonFile.toString(), "--client-id", "test-exclusive");
+
+        assertThat("should fail when both -f and field options used", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("mutually exclusive"));
+    }
+
+    @Test
+    void testAuthNestedObjectMerged() {
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc",
+                "--client-id", "test-auth-nested",
+                "--auth-method", "client_secret",
+                "--auth-secret", "my-secret-value");
+
+        assertThat("create should succeed: " + result.err(), result.exitCode(), is(0));
+
+        String id = extractId(result);
+        CommandResult getResult = kcAdmV2Cmd("client", "get", id);
+        assertThat("get should succeed", getResult.exitCode(), is(0));
+        assertThat(getResult.out(), containsString("client_secret"));
+        assertThat(getResult.out(), containsString("my-secret-value"));
+    }
+
+    @Test
+    void testListClients() {
+        kcAdmV2Cmd("client", "create", "oidc", "--client-id", "test-for-list-1");
+        kcAdmV2Cmd("client", "create", "oidc", "--client-id", "test-for-list-2");
+
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c");
+        assertThat("list should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("test-for-list-1"));
+        assertThat(result.out(), containsString("test-for-list-2"));
+        assertThat("compressed output should not be indented",
+                result.out(), not(containsString("  \"")));
+    }
+
+    @Test
+    void testGetClient() {
+        String id = createClientWithAllParams("test-for-get");
+
+        CommandResult result = kcAdmV2Cmd("client", "get", id);
+
+        assertThat("get should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("test-for-get"));
+        assertThat(result.out(), containsString("A test client with all params"));
+        assertThat(result.out(), containsString("https://example.com/callback"));
+        assertThat(result.out(), containsString("https://example.com/logout"));
+        assertThat(result.out(), containsString("role1"));
+        assertThat(result.out(), containsString("role2"));
+        assertThat(result.out(), containsString("STANDARD"));
+        assertThat(result.out(), containsString("SERVICE_ACCOUNT"));
+        assertThat(result.out(), containsString("client_secret"));
+    }
+
+    @Test
+    void testPatchClient() {
+        CommandResult createResult = kcAdmV2Cmd("client", "create", "oidc",
+                "--client-id", "test-for-patch", "--enabled", "true");
+        assertThat("setup: create should succeed", createResult.exitCode(), is(0));
+        assertThat(createResult.out(), containsString("\"enabled\" : true"));
+
+        String id = extractId(createResult);
+        CommandResult patchResult = kcAdmV2Cmd("client", "patch", "oidc", id, "--enabled", "false");
+        assertThat("patch should succeed: " + patchResult.err(), patchResult.exitCode(), is(0));
+        assertThat(patchResult.out(), containsString("\"enabled\" : false"));
+    }
+
+    @Test
+    void testRealmOverrideWithMasterConfig() {
+        // Config login is for master — targeting another realm should work (master can manage other realms)
+        assertThat("managed realm should not be master", realm.getName(), is(not("master")));
+
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc",
+                "-r", realm.getName(),
+                "--client-id", "test-in-other-realm");
+        assertThat("create in other realm should succeed: " + result.err(),
+                result.exitCode(), is(0));
+
+        CommandResult listResult = kcAdmV2Cmd("client", "list", "-r", realm.getName(), "-c");
+        assertThat("list should succeed", listResult.exitCode(), is(0));
+        assertThat(listResult.out(), containsString("test-in-other-realm"));
+
+        CommandResult masterList = kcAdmV2Cmd("client", "list", "-c");
+        assertThat(masterList.out(), not(containsString("test-in-other-realm")));
+    }
+
+    @Test
+    void testRealmOverrideWithInlineAuth() {
+        // Inline auth with --realm uses that realm for authentication.
+        // The admin client only exists in master, so authenticating against a non-master realm
+        // should fail — proving --realm is actually used for auth, not just the request URL.
+        assertThat("managed realm should not be master", realm.getName(), is(not("master")));
+
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret(),
+                "--realm", realm.getName());
+        assertThat("should fail because admin client doesn't exist in non-master realm",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("invalid_client"));
+    }
+
+    @Test
+    void testInlineAuthWithClientSecret() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret());
+
+        assertThat("inline auth with secret should succeed: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat(result.out(), containsString("clientId"));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+    }
+
+    @Test
+    void testInlineAuthWithWrongSecret() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--client", Config.getAdminClientId(),
+                "--secret", "wrong-secret");
+
+        assertThat("wrong secret should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("unauthorized_client"));
+    }
+
+    @Test
+    void testInlineAuthWithUserPassword() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--user", Config.getAdminUsername(),
+                "--password", Config.getAdminPassword());
+
+        assertThat("inline auth with user/password should succeed: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat(result.out(), containsString("clientId"));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+    }
+
+    @Test
+    void testInlineAuthWithWrongPassword() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--user", Config.getAdminUsername(),
+                "--password", "wrong-password");
+
+        assertThat("wrong password should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Invalid user credentials"));
+    }
+
+    @Test
+    void testInlineAuthWithToken() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--token", getTokenFromConfig());
+
+        assertThat("inline auth with token should succeed: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat(result.out(), containsString("clientId"));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+    }
+
+    @Test
+    void testInlineAuthWithWrongToken() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--token", "invalid-token-value");
+
+        assertThat("wrong token should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("401"));
+    }
+
+    @Test
+    void testInlineTokenWithoutServerFails() {
+        // No config, no --server — should fail because server URL is unknown
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--token", getTokenFromConfig());
+
+        assertThat("token without server should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("No server URL configured"));
+    }
+
+    @Test
+    void testInlineServerOverridesConfig() {
+        // Config has a valid server, but we override with a wrong one
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--server", "http://localhost:1/nonexistent",
+                "--token", getTokenFromConfig());
+
+        assertThat("overridden server should be used and fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Connection refused"));
+    }
+
+    @Test
+    void testInlineUserPasswordOverridesSavedToken() {
+        // Config has a valid saved token, but wrong inline credentials should cause failure,
+        // proving the inline auth path is taken instead of using the saved token
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--user", "nonexistent-user",
+                "--password", "wrong-password");
+
+        assertThat("inline credentials should override saved token", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Invalid user credentials"));
+    }
+
+    @Test
+    void testUserWithoutPasswordPromptsInNonInteractive() {
+        // In test environment System.console() is null, so prompting fails with a clear message
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--user", Config.getAdminUsername());
+
+        assertThat("should fail when password can't be prompted",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Console is not active"));
+    }
+
+    @Test
+    void testClientWithoutSecretFails() {
+        // --client without --secret or --user doesn't trigger inline auth — server rejects with 401
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--client", Config.getAdminClientId());
+
+        assertThat("should fail without credentials",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("HTTP 401 Unauthorized"));
+    }
+
+    @Test
+    void testNoConfigAndConfigMutuallyExclusive() {
+        CommandResult result = kcAdmV2CmdRaw("client", "list", "-c",
+                "--no-config", "--config", "/some/path");
+
+        assertThat("--no-config and --config should be mutually exclusive",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("mutually exclusive"));
+    }
+
+    @Test
+    void testKeystoreAndSecretMutuallyExclusive() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--keystore", "/some/keystore.jks",
+                "--secret", "some-secret");
+
+        assertThat("--keystore and --secret should be mutually exclusive",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Can't use both --keystore and --secret"));
+    }
+
+    @Test
+    void testKeystoreFileNotFound() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--keystore", "/nonexistent/keystore.jks",
+                "--storepass", "password");
+
+        assertThat("non-existent keystore should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("No such keystore file"));
+    }
+
+    @Test
+    void testTlsOptionsIgnoredForHttp() {
+        // TLS options should be silently ignored for non-HTTPS server URLs
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--truststore", "/nonexistent/truststore.jks");
+
+        assertThat("should succeed (truststore ignored for HTTP): " + result.err(),
+                result.exitCode(), is(0));
+        assertThat("should return client data", result.out(), containsString("clientId"));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+    }
+
+    @Test
+    void testInvalidServerUrl() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "create", "saml",
+                "--server", "blab", "--token", "sh");
+
+        assertThat("should fail gracefully", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Invalid server URL"));
+    }
+
+    @Test
+    void testNoConfigNoServerShowsV2Hint() {
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c");
+
+        assertThat("should fail without server", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("No server URL configured"));
+        assertThat("error hint should include --v2",
+                result.err(), containsString("kcadm.sh --v2 config credentials"));
+    }
+
+    @Test
+    void testServerAndRealmWithoutCredentialsFails() {
+        // --server and --realm provided but no credentials — server rejects with 401
+        CommandResult result = kcAdmV2CmdNoConfig("client", "create", "saml",
+                "--server", keycloakUrls.getBase(), "--realm", "master");
+
+        assertThat("should fail without credentials", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("HTTP 401 Unauthorized"));
+    }
+
+    @Test
+    void testInlineAuthWithTargetRealm() {
+        // Auth against master (default), target another realm with -r
+        assertThat("managed realm should not be master", realm.getName(), is(not("master")));
+
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret(),
+                "-r", realm.getName());
+
+        assertThat("should succeed targeting other realm with master auth: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+        assertThat("should list clients from target realm, not master",
+                result.out(), containsString("/realms/" + realm.getName() + "/"));
+    }
+
+    @Test
+    void testDefaultRealmIsMaster() {
+        // No --realm passed, no config realm — should default to master
+        CommandResult result = kcAdmV2CmdNoConfig("client", "list", "-c",
+                "--server", keycloakUrls.getBase(),
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret());
+
+        assertThat("should succeed with default master realm: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat("should list clients from master realm",
+                result.out(), containsString("/realms/master/"));
+    }
+
+    @Test
+    void testRealmOptionOverridesConfigAuthRealm() {
+        // Config is for master. --realm non-master with inline credentials
+        // should authenticate against the specified realm, not master.
+        // The admin client only exists in master, so this should fail.
+        assertThat("managed realm should not be master", realm.getName(), is(not("master")));
+
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--realm", realm.getName(),
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret());
+
+        assertThat("should fail because admin client doesn't exist in non-master realm",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("invalid_client"));
+    }
+
+    @Test
+    void testGetClientWithSpecialCharsInId() {
+        // ID with URL-special characters — without URL encoding, the request URL would be malformed
+        CommandResult result = kcAdmV2Cmd("client", "get", "id with spaces/and#hash");
+
+        assertThat("should fail for non-existent client", result.exitCode(), is(not(0)));
+        assertThat("URL-encoded ID should reach the server and get a proper 404, not a malformed URL error",
+                result.err(), containsString("Could not find client"));
+    }
+
+    @Test
+    void testUpdateCreatesNewClient() throws Exception {
+        Path jsonFile = new File(tempDir, "put-create.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "put-created", "protocol": "openid-connect", "enabled": true}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "update", "oidc", "put-created", "-f", jsonFile.toString());
+        assertThat("PUT create should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("\"clientId\" : \"put-created\""));
+        assertThat(result.out(), containsString("\"enabled\" : true"));
+    }
+
+    @Test
+    void testUpdateExistingClient() throws Exception {
+        CommandResult createResult = kcAdmV2Cmd("client", "create", "oidc",
+                "--client-id", "put-existing", "--enabled", "true", "--description", "original");
+        assertThat("setup: create should succeed", createResult.exitCode(), is(0));
+
+        Path jsonFile = new File(tempDir, "put-update.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "put-existing", "protocol": "openid-connect", "enabled": false, "description": "updated"}
+                """);
+
+        CommandResult updateResult = kcAdmV2Cmd("client", "update", "oidc", "put-existing", "-f", jsonFile.toString());
+        assertThat("PUT update should succeed: " + updateResult.err(), updateResult.exitCode(), is(0));
+        assertThat(updateResult.out(), containsString("\"enabled\" : false"));
+        assertThat(updateResult.out(), containsString("\"description\" : \"updated\""));
+        assertThat("PUT replaces the whole resource", updateResult.out(), containsString("\"clientId\" : \"put-existing\""));
+    }
+
+    @Test
+    void testUpdateWithFieldOptions() {
+        kcAdmV2Cmd("client", "create", "oidc", "--client-id", "put-with-options", "--enabled", "true");
+
+        CommandResult result = kcAdmV2Cmd("client", "update", "oidc", "put-with-options",
+                "--client-id", "put-with-options", "--enabled", "false");
+        assertThat("PUT with field options should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("\"enabled\" : false"));
+        assertThat(result.out(), containsString("\"clientId\" : \"put-with-options\""));
+    }
+
+    @Test
+    void testUpdateWithoutClientIdFails() throws Exception {
+        Path jsonFile = new File(tempDir, "put-no-clientid.json").toPath();
+        Files.writeString(jsonFile, """
+                {"protocol": "openid-connect", "enabled": true}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "update", "oidc", "some-id", "-f", jsonFile.toString());
+        assertThat("PUT without clientId should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("does not match"));
+    }
+
+    @Test
+    void testUpdateWithMismatchedClientIdFails() throws Exception {
+        Path jsonFile = new File(tempDir, "put-mismatch.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "wrong-id", "protocol": "openid-connect"}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "update", "oidc", "correct-id", "-f", jsonFile.toString());
+        assertThat("PUT with mismatched clientId should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("does not match"));
+    }
+
+    @Test
+    void testUpdateWithMalformedJsonFile() throws Exception {
+        Path jsonFile = new File(tempDir, "put-bad.json").toPath();
+        Files.writeString(jsonFile, "not json at all");
+
+        CommandResult result = kcAdmV2Cmd("client", "update", "oidc", "any-id", "-f", jsonFile.toString());
+        assertThat("PUT with malformed JSON should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Cannot parse the JSON"));
+    }
+
+    @Test
+    void testUpdateNonExistentFile() {
+        CommandResult result = kcAdmV2Cmd("client", "update", "oidc", "any-id", "-f", "/nonexistent/file.json");
+        assertThat("PUT with missing file should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("File not found"));
+    }
+
+    @Test
+    void testDeleteClient() throws Exception {
+        String id = createClientFromFile("test-for-delete");
+
+        CommandResult getResult = kcAdmV2Cmd("client", "get", id);
+        assertThat("get before delete should succeed", getResult.exitCode(), is(0));
+
+        CommandResult deleteResult = kcAdmV2Cmd("client", "delete", id);
+        assertThat("delete should succeed: " + deleteResult.err(), deleteResult.exitCode(), is(0));
+        assertThat("delete should print confirmation", deleteResult.out(), containsString("Client deleted"));
+
+        getResult = kcAdmV2Cmd("client", "get", id);
+        assertThat("get after delete should fail", getResult.exitCode(), is(not(0)));
+        assertThat(getResult.err(), containsString("Could not find client"));
+    }
+
+    private String createClientWithAllParams(String clientId) {
+        CommandResult result = kcAdmV2Cmd("client", "create", "oidc",
+                "--client-id", clientId,
+                "--display-name", "Test Full Client",
+                "--description", "A test client with all params",
+                "--enabled", "true",
+                "--app-url", "https://example.com",
+                "--redirect-uris", "https://example.com/callback,https://example.com/logout",
+                "--roles", "role1,role2",
+                "--login-flows", "STANDARD,SERVICE_ACCOUNT",
+                "--auth-method", "client_secret");
+        assertThat("create should succeed: " + result.err(), result.exitCode(), is(0));
+        return extractId(result);
+    }
+
+    private String createClientFromFile(String clientId) throws Exception {
+        Path jsonFile = new File(tempDir, clientId + ".json").toPath();
+        Files.writeString(jsonFile, """
+                {
+                    "clientId": "%s",
+                    "protocol": "saml",
+                    "enabled": true
+                }
+                """.formatted(clientId));
+        CommandResult result = kcAdmV2Cmd("client", "create", "saml", "-f", jsonFile.toString());
+        assertThat("create from file should succeed: " + result.err(), result.exitCode(), is(0));
+        return extractId(result);
+    }
+
+    private CommandResult kcAdmV2Cmd(String... args) {
+        CommandLine cli = Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        String[] fullArgs = new String[args.length + 2];
+        System.arraycopy(args, 0, fullArgs, 0, args.length);
+        fullArgs[args.length] = "--config";
+        fullArgs[args.length + 1] = configFilePath;
+
+        int exitCode = cli.execute(fullArgs);
+        return new CommandResult(exitCode, out.toString(), err.toString());
+    }
+
+    private CommandResult kcAdmV2CmdRaw(String... args) {
+        CommandLine cli = Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        int exitCode = cli.execute(args);
+        return new CommandResult(exitCode, out.toString(), err.toString());
+    }
+
+    private CommandResult kcAdmV2CmdNoConfig(String... args) {
+        CommandLine cli = Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        String[] fullArgs = new String[args.length + 1];
+        System.arraycopy(args, 0, fullArgs, 0, args.length);
+        fullArgs[args.length] = "--no-config";
+
+        int exitCode = cli.execute(fullArgs);
+        return new CommandResult(exitCode, out.toString(), err.toString());
+    }
+
+    private String getTokenFromConfig() {
+        try {
+            setConfigFile(configFilePath);
+            var handler = new FileConfigHandler();
+            var config = handler.loadConfig();
+            return config.sessionRealmConfigData().getToken();
+        } catch (Exception e) {
+            throw new AssertionError("Could not read token from config", e);
+        }
+    }
+
+    private String extractId(CommandResult result) {
+        try {
+            return new ObjectMapper().readTree(result.out()).get("clientId").asText();
+        } catch (Exception e) {
+            throw new AssertionError("Could not extract clientId from: " + result.out(), e);
+        }
+    }
+
+    record CommandResult(int exitCode, String out, String err) {
+    }
+
+    public static class V2ApiServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.CLIENT_ADMIN_API_V2);
+        }
+    }
+}

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2KeystoreCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2KeystoreCLITest.java
@@ -1,0 +1,239 @@
+package org.keycloak.tests.admin.cli.v2;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.admin.cli.v2.KcAdmV2Cmd;
+import org.keycloak.client.cli.common.Globals;
+import org.keycloak.client.cli.util.HttpUtil;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.config.Config;
+import org.keycloak.testframework.https.CertificatesConfig;
+import org.keycloak.testframework.https.CertificatesConfigBuilder;
+import org.keycloak.testframework.https.InjectCertificates;
+import org.keycloak.testframework.https.ManagedCertificates;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+@KeycloakIntegrationTest(config = KcAdmV2KeystoreCLITest.V2ApiTlsServerConfig.class)
+public class KcAdmV2KeystoreCLITest {
+
+    private static final String JWT_CLIENT_ID = "admin-cli-jwt-test";
+    private static final String KEY_ALIAS = "client-key";
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectCertificates(config = TlsEnabledConfig.class)
+    ManagedCertificates managedCertificates;
+
+    @TempDir
+    static File tempDir;
+
+    private static String configFilePath;
+
+    @TestSetup
+    public void login() {
+        configFilePath = new File(tempDir, "kcadm.config").getAbsolutePath();
+        HttpUtil.clearHttpClient();
+
+        CommandResult result = kcAdmV2Cmd("config", "credentials",
+                "--server", keycloakUrls.getBase(),
+                "--realm", "master",
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret(),
+                "--truststore", getClientTruststorePath(),
+                "--trustpass", getStorePassword());
+
+        assertThat("login should succeed: " + result.err(), result.exitCode(), is(0));
+
+        setupJwtClient();
+    }
+
+    @BeforeEach
+    void clearHttpClientBeforeEach() {
+        // we need to reset the HTTP client as we switch the keystore in test methods
+        HttpUtil.clearHttpClient();
+    }
+
+    @Test
+    void testKeystoreAuthWithServiceAccount() {
+        CommandResult result = kcAdmV2CmdRaw("client", "list", "-c",
+                "--no-config",
+                "--server", keycloakUrls.getBase(),
+                "--client", JWT_CLIENT_ID,
+                "--keystore", getClientKeystorePath(),
+                "--storepass", getStorePassword(),
+                "--alias", KEY_ALIAS,
+                "--truststore", getClientTruststorePath(),
+                "--trustpass", getStorePassword());
+
+        assertThat("keystore auth should succeed: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat(result.out(), containsString("clientId"));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+    }
+
+    @Test
+    void testWithoutKeystoreFails() {
+        // Same as testKeystoreAuthWithServiceAccount but without --keystore — proves keystore is required
+        CommandResult result = kcAdmV2CmdRaw("client", "list", "-c",
+                "--no-config",
+                "--server", keycloakUrls.getBase(),
+                "--client", JWT_CLIENT_ID,
+                "--truststore", getClientTruststorePath(),
+                "--trustpass", getStorePassword());
+
+        assertThat("should fail without keystore", result.exitCode(), is(not(0)));
+    }
+
+    @Test
+    void testKeystoreAuthWithWrongAlias() {
+        CommandResult result = kcAdmV2CmdRaw("client", "list", "-c",
+                "--no-config",
+                "--server", keycloakUrls.getBase(),
+                "--client", JWT_CLIENT_ID,
+                "--keystore", getClientKeystorePath(),
+                "--storepass", getStorePassword(),
+                "--alias", "wrong-alias",
+                "--truststore", getClientTruststorePath(),
+                "--trustpass", getStorePassword());
+
+        assertThat("wrong alias should fail", result.exitCode(), is(not(0)));
+    }
+
+    private void setupJwtClient() {
+        var existing = adminClient.realm("master").clients().findByClientId(JWT_CLIENT_ID);
+        if (!existing.isEmpty()) {
+            return;
+        }
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(JWT_CLIENT_ID);
+        client.setClientAuthenticatorType(JWTClientAuthenticator.PROVIDER_ID);
+        client.setServiceAccountsEnabled(true);
+        client.setDirectAccessGrantsEnabled(false);
+        client.setPublicClient(false);
+
+        var response = adminClient.realm("master").clients().create(client);
+        String clientUuid = response.getLocation().getPath()
+                .substring(response.getLocation().getPath().lastIndexOf('/') + 1);
+        response.close();
+
+        var serviceAccountUser = adminClient.realm("master").clients()
+                .get(clientUuid).getServiceAccountUser();
+        var adminRole = adminClient.realm("master").roles().get("admin").toRepresentation();
+        adminClient.realm("master").users().get(serviceAccountUser.getId())
+                .roles().realmLevel().add(java.util.List.of(adminRole));
+
+        try {
+            String keystorePath = getClientKeystorePath();
+            KeyStore ks = KeyStore.getInstance("JKS");
+            try (var fis = new FileInputStream(keystorePath)) {
+                ks.load(fis, getStorePassword().toCharArray());
+            }
+            X509Certificate cert = (X509Certificate) ks.getCertificate(KEY_ALIAS);
+
+            ClientRepresentation updatedClient = adminClient.realm("master").clients()
+                    .get(clientUuid).toRepresentation();
+            if (updatedClient.getAttributes() == null) {
+                updatedClient.setAttributes(new java.util.HashMap<>());
+            }
+            updatedClient.getAttributes().put("jwt.credential.certificate",
+                    PemUtils.encodeCertificate(cert));
+            adminClient.realm("master").clients().get(clientUuid).update(updatedClient);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set client certificate", e);
+        }
+    }
+
+    private String getClientKeystorePath() {
+        // TODO: we should skip to the test framework methods once they are introduced
+        String serverPath = managedCertificates.getServerKeyStorePath();
+        return serverPath.replace("server-keystore", "client-keystore");
+    }
+
+    private String getClientTruststorePath() {
+        // TODO: we should skip to the test framework methods once they are introduced
+        String serverPath = managedCertificates.getServerKeyStorePath();
+        return serverPath.replace("server-keystore", "client-truststore");
+    }
+
+    private String getStorePassword() {
+        return managedCertificates.getServerKeyStorePassword();
+    }
+
+    private CommandResult kcAdmV2CmdRaw(String... args) {
+        CommandLine cli = Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        int exitCode = cli.execute(args);
+        return new CommandResult(exitCode, out.toString(), err.toString());
+    }
+
+    private CommandResult kcAdmV2Cmd(String... args) {
+        CommandLine cli = Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        String[] fullArgs = new String[args.length + 2];
+        System.arraycopy(args, 0, fullArgs, 0, args.length);
+        fullArgs[args.length] = "--config";
+        fullArgs[args.length + 1] = configFilePath;
+
+        int exitCode = cli.execute(fullArgs);
+        return new CommandResult(exitCode, out.toString(), err.toString());
+    }
+
+    record CommandResult(int exitCode, String out, String err) {
+    }
+
+    private static class TlsEnabledConfig implements CertificatesConfig {
+        @Override
+        public CertificatesConfigBuilder configure(CertificatesConfigBuilder config) {
+            return config.tlsEnabled(true);
+        }
+    }
+
+    public static class V2ApiTlsServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.CLIENT_ADMIN_API_V2);
+        }
+    }
+}

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2TlsCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2TlsCLITest.java
@@ -1,0 +1,171 @@
+package org.keycloak.tests.admin.cli.v2;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.admin.cli.v2.KcAdmV2Cmd;
+import org.keycloak.client.cli.common.Globals;
+import org.keycloak.client.cli.util.HttpUtil;
+import org.keycloak.common.Profile;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.config.Config;
+import org.keycloak.testframework.https.CertificatesConfig;
+import org.keycloak.testframework.https.CertificatesConfigBuilder;
+import org.keycloak.testframework.https.InjectCertificates;
+import org.keycloak.testframework.https.ManagedCertificates;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+@KeycloakIntegrationTest(config = KcAdmV2TlsCLITest.V2ApiTlsServerConfig.class)
+public class KcAdmV2TlsCLITest {
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectCertificates(config = TlsEnabledConfig.class)
+    ManagedCertificates managedCertificates;
+
+    @TempDir
+    static File tempDir;
+
+    private static String configFilePath;
+
+    @TestSetup
+    public void login() {
+        configFilePath = new File(tempDir, "kcadm.config").getAbsolutePath();
+        HttpUtil.clearHttpClient();
+
+        String truststorePath = getClientTruststorePath();
+        Assertions.assertTrue(new File(truststorePath).isFile(),
+                "Client truststore should exist at: " + truststorePath);
+
+        CommandResult result = kcAdmV2Cmd("config", "credentials",
+                "--server", keycloakUrls.getBase(),
+                "--realm", "master",
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret(),
+                "--truststore", truststorePath,
+                "--trustpass", getStorePassword());
+
+        assertThat("login should succeed: " + result.err(), result.exitCode(), is(0));
+    }
+
+    @BeforeEach
+    void clearHttpClientBeforeEach() {
+        // we want a new client as we change a client truststore for each test
+        HttpUtil.clearHttpClient();
+    }
+
+    @Test
+    void testWithoutTruststoreFails() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c");
+
+        assertThat("should fail without truststore on HTTPS server",
+                result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("PKIX path building failed"));
+    }
+
+    @Test
+    void testTruststoreWithCorrectPassword() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--truststore", getClientTruststorePath(),
+                "--trustpass", getStorePassword());
+
+        assertThat("list with truststore should succeed: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat(result.out(), containsString("clientId"));
+        assertThat("should return a JSON array", result.out().trim(), startsWith("["));
+    }
+
+    @Test
+    void testTruststoreWithWrongPassword() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--truststore", getClientTruststorePath(),
+                "--trustpass", "wrong-password");
+
+        assertThat("wrong truststore password should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Failed to load truststore"));
+    }
+
+    @Test
+    void testTruststoreWithNonExistentFile() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c",
+                "--truststore", "/nonexistent/truststore.jks",
+                "--trustpass", "password");
+
+        assertThat("non-existent truststore should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("Failed to load truststore"));
+    }
+
+    @Test
+    void testInsecureSkipsTlsValidation() {
+        CommandResult result = kcAdmV2Cmd("client", "list", "-c", "--insecure");
+
+        assertThat("--insecure should allow connection without truststore: " + result.err(),
+                result.exitCode(), is(0));
+        assertThat(result.out(), containsString("clientId"));
+    }
+
+    private String getClientTruststorePath() {
+        // Derive client truststore path from the server keystore path which follows the same
+        // naming convention: both are in the same directory with predictable names
+        // TODO: the new test framework should expose the client truststore, once that is done, we need to switch to it
+        String serverPath = managedCertificates.getServerKeyStorePath();
+        return serverPath.replace("server-keystore", "client-truststore");
+    }
+
+    private String getStorePassword() {
+        return managedCertificates.getServerKeyStorePassword();
+    }
+
+    private CommandResult kcAdmV2Cmd(String... args) {
+        CommandLine cli = Globals.createCommandLine(new KcAdmV2Cmd(), KcAdmMain.CMD, new PrintWriter(System.err, true));
+
+        StringWriter out = new StringWriter();
+        StringWriter err = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(err));
+
+        String[] fullArgs = new String[args.length + 2];
+        System.arraycopy(args, 0, fullArgs, 0, args.length);
+        fullArgs[args.length] = "--config";
+        fullArgs[args.length + 1] = configFilePath;
+
+        int exitCode = cli.execute(fullArgs);
+        return new CommandResult(exitCode, out.toString(), err.toString());
+    }
+
+    record CommandResult(int exitCode, String out, String err) {
+    }
+
+    private static class TlsEnabledConfig implements CertificatesConfig {
+        @Override
+        public CertificatesConfigBuilder configure(CertificatesConfigBuilder config) {
+            return config.tlsEnabled(true);
+        }
+    }
+
+    public static class V2ApiTlsServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.CLIENT_ADMIN_API_V2);
+        }
+    }
+}


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/47166
* Closes: https://github.com/keycloak/keycloak/issues/47208
* Closes: https://github.com/keycloak/keycloak/issues/47311

Provides basic Client API v2 CLI client.

Intended usage: `source <(kcadm.sh --v2 completion)` and `kcadm.sh --v2` (that is: without `--v2`, you get the v1 CLI for now)

Supports:

- client operations: create, patch, list, delete, get, update
- authetication options matching those of v1 CLI
- autocomplete for commands, sub-commands and options (invoked by repeated TABs as usual)
- showing help or autocomplete based on the selected OpenAPI document, though for now, only the default bundled one is available (later we can fetch them for Keycloak servers https://github.com/keycloak/keycloak/issues/47171 )

Omitted changes:

- documentation, we do not advertise this new client and it is hidden behind `--v2` flag that is not mentioned anywhere in doc or help, hence invisible; until we implement remaining https://github.com/keycloak/keycloak/issues/45366 tasks
- "config" subcommand is shared between v1 and v2, hence its printed "help" follows the v1 style to keep status quo
- validation error output on CLI client side (v1 and v2 has different validation object structure and we need to adjust the client)
