### PR TITLE
Change links from issues.redhat.com to redhat.atlassian.net

### DIFF
--- a/docs/documentation/release_notes/topics/4_3_0_final.adoc
+++ b/docs/documentation/release_notes/topics/4_3_0_final.adoc
@@ -19,7 +19,7 @@ changes we did were related with trying to optimize the policy evaluation path b
 as soon as they happen. We also introduced a policy decision cache on a per-request basis, avoiding redundant decisions from policies
 previously evaluated.
 
-We are also working on other layers of cache which should give a much better experience. See https://issues.redhat.com/browse/KEYCLOAK-7952[KEYCLOAK-7952].
+We are also working on other layers of cache which should give a much better experience. See https://redhat.atlassian.net/browse/KEYCLOAK-7952[KEYCLOAK-7952].
 
 = Choosing the response mode when obtaining permissions from the server
 

--- a/docs/documentation/upgrading/topics/changes/changes-20_0_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-20_0_0.adoc
@@ -118,7 +118,7 @@ Stream<GroupModel> getGroupsStream(RealmModel realm);
 ----
 +
 More details on streamification work can be found in
-https://issues.redhat.com/browse/KEYCLOAK-14011[KEYCLOAK-14011].
+https://redhat.atlassian.net/browse/KEYCLOAK-14011[KEYCLOAK-14011].
 
 * Consistent parameter ordering - methods now have strict parameter
 ordering where `RealmModel` is always the first parameter.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -676,7 +676,7 @@ Cross-Datacenter Replication changes::
   * You don't need to configure security anymore in the {jdgserver_name} server configuration file.
 ifeval::[{project_community}==true]
   * The `transaction` element needs to be removed from the configuration of replicated caches in the {jdgserver_name} server
-  configuration file. This is needed because of the infinispan bug https://issues.redhat.com/browse/ISPN-9323.
+  configuration file. This is needed because of the infinispan bug https://redhat.atlassian.net/browse/ISPN-9323.
 endif::[]
 
 === Migration to 4.3.0


### PR DESCRIPTION
Closes #47179

Just changing the links for issues after the migration to atlassian.
