### PR TITLE
Add KCRAW_ prefix for environment variables to preserve literal values

### DIFF
--- a/docs/documentation/release_notes/topics/26_6_0.adoc
+++ b/docs/documentation/release_notes/topics/26_6_0.adoc
@@ -139,6 +139,17 @@ This is a common setup for example in Kubernetes environments.
 Users should adjust those values depending on their proxy setup.
 See the section https://www.keycloak.org/server/reverseproxy#graceful-http-shutdown[Graceful HTTP shutdown] in the reverse proxy guide for more information.
 
+== New `KCRAW_` prefix for environment variables to preserve literal values
+
+{project_name} now supports a `KCRAW_` prefix for environment variables to preserve values containing `$` characters exactly as written, without expression evaluation.
+
+When using the standard `KC_` prefix, {project_name} (via SmallRye Config) evaluates expressions in values (for example, `${some_key}` is resolved and `$$` is collapsed to `$`).
+This can silently modify passwords or secrets injected by a secrets manager or orchestration tool where manual escaping is not feasible.
+
+Setting `KCRAW_<KEY>` instead of `KC_<KEY>` preserves the value exactly as provided.
+
+See the link:{server_guide_base_link}/configuration#kcraw-prefix[Preserving literal values with the KCRAW_ prefix] section in the Server Configuration guide for details.
+
 == Automatic reload of lists with disallowed passwords
 
 When a list of disallowed passwords (also known as blacklist) changes, it is automatically reloaded. This avoids the need a server restart when the list changes.

--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -46,3 +46,4 @@ https://www.keycloak.org/securing-apps/dpop
 https://www.keycloak.org/server/reverseproxy#graceful-http-shutdown
 https://www.keycloak.org/server/db#_secure_the_database_connection
 https://www.keycloak.org/server/logging#customize-service-fields
+https://www.keycloak.org/server/configuration#kcraw-prefix

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -287,6 +287,13 @@ See the https://www.keycloak.org/server/db#_secure_the_database_connection[Secur
 A new CLI option `--db-connect-timeout` sets the JDBC driver connection timeout and login timeout.
 It defaults to `10s` to improve failover behavior and startup resilience during network issues.
 
+=== New `KCRAW_` prefix for environment variables to preserve literal values
+
+{project_name} now supports a `KCRAW_` prefix for environment variables as an alternative to the standard `KC_` prefix.
+If you are already using the KCRAW_ prefix for another purpose, please migrate to a new key prefix.
+
+See the link:{server_guide_base_link}/configuration#kcraw-prefix[Preserving literal values with the KCRAW_ prefix] section in the Server Configuration guide for details.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/docs/guides/server/configuration.adoc
+++ b/docs/guides/server/configuration.adoc
@@ -51,7 +51,7 @@ The configuration uses a _unified-per-source_ format, which simplifies translati
 
 Command-line parameter format:: Values for the command-line use the `--_<key-with-dashes>_=_<value>_` format. For some values, an `-_<abbreviation>_=_<value>_` shorthand also exists.
 
-Environment variable format:: Values for environment variables use the uppercased `KC++_++__<key_with_underscores>__=_<value>_` format.
+Environment variable format:: Values for environment variables use the uppercased `KC++_++__<key_with_underscores>__=_<value>_` format. Alternatively, the `KCRAW++_++` prefix can be used instead of `KC++_++` to preserve values containing `$` characters — see <<Preserving literal values with the KCRAW_ prefix>>.
 
 Configuration file format:: Values that go into the configuration file use the `_<key-with-dashes>_=_<value>_` format.
 
@@ -165,6 +165,35 @@ When using PowerShell and your values contain special characters like commas, us
 ----
 
 PowerShell handles quotes differently. It interprets the quoted string before passing it to the `kc.bat` script, removing the outer quote characters. Therefore, an extra layer of quotes is needed to preserve the value structure. Otherwise, the comma would be interpreted as a delimiter. In Windows CMD, you can use double quotes directly.
+
+When manual escaping is not feasible (like when a password is injected by a secrets manager and you cannot control the value), use the `KCRAW_` prefix described in the next section.
+
+[[kcraw-prefix]]
+=== Preserving literal values with the KCRAW_ prefix
+
+When setting configuration values, {project_name} (via SmallRye Config) evaluates expressions such as `$\{some_key}` and collapses `$$` to `$`. This means passwords or secrets containing `$` characters may be silently modified. While the `\` escaping described above works for values you control directly, it is not always practical - for example, when a secrets manager or orchestration tool injects the value and you cannot add escape characters.
+
+In these cases, use the `KCRAW_` prefix instead of `KC_` for any environment variable whose value must be preserved exactly as written. {project_name} automatically escapes `$` characters in `KCRAW_` values so that expression evaluation preserves the original value.
+
+.Example: Setting a database password containing special characters
+[source, bash]
+----
+# Standard prefix — the value will be modified by expression evaluation:
+export KC_DB_PASSWORD='my$$pa$\{vault}word'
+# Result: "$$" is collapsed to "$" and "$\{vault}" is evaluated as an
+# expression, producing "my$paword" or an error
+
+# Raw prefix — the value is preserved exactly as written:
+export KCRAW_DB_PASSWORD='my$$pa$\{vault}word'
+# Result: the password is used as-is: my$$pa$\{vault}word
+----
+
+[NOTE]
+====
+* The `KCRAW_` prefix applies only to environment variables, where shell quoting rules make escaping of `$` unreliable. Other configuration sources are subject to their own format escaping mechanisms and their values are still treated as expressions.
+* You cannot set both `KC_<KEY>` and `KCRAW_<KEY>` for the same configuration key. If both are present, {project_name} will fail to start and report a configuration error.
+* Apart from escaping `$` characters, `KCRAW_` variables behave identically to their `KC_` counterparts: the same key mapping and priority rules apply.
+====
 
 === Formats for environment variable keys with special characters
 

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -156,6 +156,11 @@ bin/kc.[sh|bat] start --optimized
 
 WARNING: The examples above include the minimum settings needed to connect to the database but it exposes the database password and is not recommended. Use the `conf/keycloak.conf` as shown above, environment variables, or keystore for at least the password.
 
+[NOTE]
+====
+If your database password contains `$` or `$\{...}` characters, use the `KCRAW_DB_PASSWORD` environment variable instead of `KC_DB_PASSWORD`. The `KCRAW_` prefix ensures `$` characters are preserved as-is. See the _Preserving literal values with the KCRAW_ prefix_ section in <@links.server id="configuration"/> for details.
+====
+
 By default, no schema is explicitly set and {project_name} uses the default schema of the chosen database.
 You can override this by using the `db-schema` configuration option.
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
@@ -41,6 +41,7 @@ public class KcEnvConfigSource extends PropertiesConfigSource {
 
     public static final String NAME = "KcEnvVarConfigSource";
     public static final String KCKEY_PREFIX = "KCKEY_";
+    public static final String KCRAW_PREFIX = "KCRAW_";
 
     static final Map<String, String> ENV_OVERRIDE = new HashMap<String, String>();
 
@@ -55,13 +56,29 @@ public class KcEnvConfigSource extends PropertiesConfigSource {
         for (Map.Entry<String, String> entry : env.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            String transformedKey = null;
 
-            if (!key.startsWith(kcPrefix)) {
+            if (!(key.startsWith(kcPrefix) || key.startsWith(KCRAW_PREFIX))) {
                 continue;
             }
-            String baseKey = key.substring(kcPrefix.length());
 
+            boolean isRaw = key.startsWith(KCRAW_PREFIX);
+            String baseKey;
+
+            if (isRaw) {
+                baseKey = key.substring(KCRAW_PREFIX.length());
+
+                // Fail fast if both KC_ and KCRAW_ are set for the same base key
+                if (env.containsKey(kcPrefix + baseKey)) {
+                    throw new IllegalArgumentException(
+                            "Both " + kcPrefix + baseKey + " and " + KCRAW_PREFIX + baseKey
+                                    + " are set. Use only one.");
+                }
+            } else {
+                baseKey = key.substring(kcPrefix.length());
+            }
+
+            // Resolve the transformed key
+            String transformedKey;
             String actualKey = env.get(KCKEY_PREFIX + baseKey);
             if (actualKey != null) {
                 // use the explicit mapping
@@ -80,7 +97,10 @@ public class KcEnvConfigSource extends PropertiesConfigSource {
                             .orElseThrow();
                 }
             }
-            properties.put(transformedKey, value);
+
+            // KCRAW_ values escape $ as $$ to prevent SmallRye Config variable interpolation
+            // Then replace \$ with \\ to prevent SmallRye's escapeDollarIfExists from consuming backslashes before dollars
+            properties.put(transformedKey, isRaw ? value.replace("$", "$$").replace("\\$", "\\\\") : value);
         }
 
         return properties;

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -22,6 +22,7 @@ import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1005,5 +1006,78 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
         assertEquals("PT1M", config.getConfigValue(DatabasePropertyMappers.JDBC_ACQUISITION_TIMEOUT).getValue());
+    }
+
+    @Test
+    public void testRawEnvVarPreservesDoubleDollar() {
+        putEnvVar("KCRAW_DB_PASSWORD", "my$$password");
+        SmallRyeConfig config = createConfig();
+        assertEquals("my$$password", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawEnvVarPreservesExpression() {
+        putEnvVar("KCRAW_DB_PASSWORD", "${vault.secret}");
+        SmallRyeConfig config = createConfig();
+        assertEquals("${vault.secret}", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawEnvVarStandalone() {
+        // Only KCRAW_ set, no KC_ counterpart — should still register the property
+        putEnvVar("KCRAW_DB_PASSWORD", "standalone-value");
+        SmallRyeConfig config = createConfig();
+        assertEquals("standalone-value", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawAndKcConflictThrowsError() {
+        putEnvVar("KC_DB_PASSWORD", "from-kc");
+        putEnvVar("KCRAW_DB_PASSWORD", "from-kcraw");
+        try {
+            createConfig();
+            Assert.fail("Expected error for conflicting KC_ and KCRAW_ env vars");
+        } catch (ServiceConfigurationError e) {
+            assertNotNull(e.getCause());
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
+            assertTrue(e.getCause().getMessage().contains("KC_DB_PASSWORD"));
+            assertTrue(e.getCause().getMessage().contains("KCRAW_DB_PASSWORD"));
+        }
+    }
+
+    @Test
+    public void testNonRawPropertiesUnaffected() {
+        // Standard KC_ env var with $$ should still be subject to expression evaluation (collapsing $$ to $)
+        putEnvVar("KC_DB_PASSWORD", "has$$dollar");
+        SmallRyeConfig config = createConfig();
+        assertEquals("has$dollar", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawEnvVarPreservesBackslashDollar() {
+        putEnvVar("KCRAW_DB_PASSWORD", "has\\$dollar");
+        SmallRyeConfig config = createConfig();
+        assertEquals("has\\$dollar", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawEnvVarPreservesStandaloneBackslash() {
+        putEnvVar("KCRAW_DB_PASSWORD", "pass\\word");
+        SmallRyeConfig config = createConfig();
+        assertEquals("pass\\word", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawEnvVarPreservesMultipleBackslashDollar() {
+        putEnvVar("KCRAW_DB_PASSWORD", "test\\$\\$password");
+        SmallRyeConfig config = createConfig();
+        assertEquals("test\\$\\$password", config.getConfigValue("kc.db-password").getValue());
+    }
+
+    @Test
+    public void testRawEnvVarPreservesTrailingBackslash() {
+        putEnvVar("KCRAW_DB_PASSWORD", "trail\\");
+        SmallRyeConfig config = createConfig();
+        assertEquals("trail\\", config.getConfigValue("kc.db-password").getValue());
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/DatasourcesConfigurationTest.java
@@ -664,4 +664,14 @@ public class DatasourcesConfigurationTest extends AbstractConfigurationTest {
         assertAdditionalJdbcProperty(config, "users", trustStorePasswordProperty, "no-secret");
         assertAdditionalJdbcProperty(config, "users", trustStoreTypeProperty, "pem");
     }
+
+    @Test
+    public void testRawDatabasePassword() {
+        putEnvVar("KCRAW_DB_PASSWORD", "p@ss$$w0rd${special}");
+        ConfigArgsConfigSource.setCliArgs("--db=postgres");
+        SmallRyeConfig config = createConfig();
+        // The raw password should be preserved exactly as-is, with no expression evaluation
+        assertEquals("p@ss$$w0rd${special}", config.getConfigValue("kc.db-password").getValue());
+        assertEquals("p@ss$$w0rd${special}", config.getConfigValue("quarkus.datasource.password").getValue());
+    }
 }


### PR DESCRIPTION
Closes #46657

This adds the `KRAW` option we talked about in the above ticket to allow passwords with `$$` and `${...}` to work
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
