### PR TITLE
Fix NPE in updateFederatedIdentity after IDP deletion and re-creation

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -957,7 +957,9 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
 
     @Override
     public void preRemove(RealmModel realm, IdentityProviderModel provider) {
-        cache.addInvalidations(InIdentityProviderPredicate.create().provider(provider.getAlias()), invalidations);
+        // Invalidates all user-related cache entries for this realm, including federated identity
+        // lookups, and propagates the invalidation across the cluster.
+        addRealmInvalidation(realm.getId());
         getDelegate().preRemove(realm, provider);
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaIdentityProviderStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaIdentityProviderStorageProvider.java
@@ -173,6 +173,10 @@ public class JpaIdentityProviderStorageProvider implements IdentityProviderStora
             //call toModel(entity) now as after em.remove(entity) and the flush it might throw LazyInitializationException
             //when accessing the config of the entity (entity.getConfig()) withing the toModel(entity)
             IdentityProviderModel model = toModel(entity);
+            RealmModel realm = this.getRealm();
+
+            // Remove all federated identity links and invalidate user caches for this IDP.
+            session.users().preRemove(realm, model);
 
             em.remove(entity);
             // flush so that constraint violations are flagged and converted into model exception now rather than at the end of the tx.
@@ -181,7 +185,6 @@ public class JpaIdentityProviderStorageProvider implements IdentityProviderStora
             session.identityProviders().getMappersByAliasStream(alias).forEach(session.identityProviders()::removeMapper);
 
             // send identity provider removed event.
-            RealmModel realm = this.getRealm();
             session.getKeycloakSessionFactory().publish(new RealmModel.IdentityProviderRemovedEvent() {
 
                 @Override

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1142,6 +1142,16 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
     private void updateFederatedIdentity(BrokeredIdentityContext context, UserModel federatedUser) {
         FederatedIdentityModel federatedIdentityModel = this.session.users().getFederatedIdentity(this.realmModel, federatedUser, context.getIdpConfig().getAlias());
 
+        if (federatedIdentityModel == null) {
+            // No federated identity link found. Defensively re-add it so the session can continue.
+            // This can occur when a stale cache entry bypasses first-broker-login after IDP re-creation.
+            logger.debugf("Federated identity not found for user '%s' and provider '%s'. Re-adding link.",
+                    federatedUser.getUsername(), context.getIdpConfig().getAlias());
+            federatedIdentityModel = new FederatedIdentityModel(context.getIdpConfig().getAlias(),
+                    context.getId(), context.getUsername(), context.getToken());
+            this.session.users().addFederatedIdentity(this.realmModel, federatedUser, federatedIdentityModel);
+        }
+
         if (context.getIdpConfig().getSyncMode() == IdentityProviderSyncMode.FORCE) {
             setBasicUserAttributes(context, federatedUser);
 


### PR DESCRIPTION
## Summary

Fixes #47153

When an identity provider is deleted, `JpaIdentityProviderStorageProvider.remove()`
never called `session.users().preRemove()`. This left the `federated_identity`
database rows intact and the Infinispan user caches un-invalidated.

On a subsequent login after the IDP is re-created, `getUserByFederatedIdentity()`
returns the user from the stale `realmId.idp.alias.externalUserId` cache
(a `UserListQuery` entry), bypassing first-broker-login entirely.
`updateFederatedIdentity()` then calls `getFederatedIdentity()` which returns
null because the `userId.idplinks` cache was cleared by an earlier operation,
causing a `NullPointerException` when sync mode is `FORCE`.

The existing `InIdentityProviderPredicate` in `UserCacheSession.preRemove()`
only matches `CachedFederatedIdentityLinks` entries but silently skips
`UserListQuery` entries, which have an infinite TTL for non-federated users.

## Changes

- `JpaIdentityProviderStorageProvider.remove()`: call `session.users().preRemove()`
  before entity deletion to clean up DB rows and trigger cache invalidation
- `UserCacheSession.preRemove(RealmModel, IdentityProviderModel)`: replace
  `InIdentityProviderPredicate` with `addRealmInvalidation()` to cover all
  affected cache key types and propagate invalidation cluster-wide
- `IdentityBrokerService.updateFederatedIdentity()`: null guard as a safety
  net for any remaining stale-cache window

## Test plan

- [ ] Add IDP → user logs in → delete IDP → re-add IDP → user logs in again — no NPE
- [ ] Verify with both `FORCE` and `IMPORT` sync modes
- [ ] Verify cache invalidation propagates in a clustered deployment