### PR TITLE
Reload password blacklist file on change without restart

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/password-policies.adoc
+++ b/docs/documentation/server_admin/topics/authentication/password-policies.adoc
@@ -142,6 +142,8 @@ Password must not be in a blacklist file.
 * Blacklist files resolve against `+${kc.home.dir}/data/password-blacklists/+` by default. Customize this path using:
 ** The `keycloak.password.blacklists.path` system property.
 ** The `blacklistsPath` property of the `passwordBlacklist` policy SPI configuration. To configure the blacklist folder using the CLI, use `+--spi-password-policy--password-blacklist--blacklists-path=/path/to/blacklistsFolder+`.
+* Blacklist files are reloaded automatically when modified. The file is checked for updates during password policy validation but at most once every 60 seconds.
+** The blacklist file must be updated atomically (write to a temp file, then rename) to avoid reading a partially written file.
 
 .A note about False Positives
 

--- a/docs/documentation/server_admin/topics/authentication/password-policies.adoc
+++ b/docs/documentation/server_admin/topics/authentication/password-policies.adoc
@@ -142,7 +142,8 @@ Password must not be in a blacklist file.
 * Blacklist files resolve against `+${kc.home.dir}/data/password-blacklists/+` by default. Customize this path using:
 ** The `keycloak.password.blacklists.path` system property.
 ** The `blacklistsPath` property of the `passwordBlacklist` policy SPI configuration. To configure the blacklist folder using the CLI, use `+--spi-password-policy--password-blacklist--blacklists-path=/path/to/blacklistsFolder+`.
-* Blacklist files are reloaded automatically when modified. The file is checked for updates during password policy validation but at most once every 60 seconds.
+* Blacklist files are reloaded automatically when modified.
+** The file is checked for updates during password policy validation but at most once every 60 seconds. Use `+--spi-password-policy--password-blacklist--check-interval-seconds=<seconds>+` to change the default (0 to disable).
 ** The blacklist file must be updated atomically (write to a temp file, then rename) to avoid reading a partially written file.
 
 .A note about False Positives

--- a/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
@@ -299,10 +299,10 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
                 return;
             }
             synchronized (this) {
+                now = System.currentTimeMillis();
                 if (now - lastCheckedMillis < checkIntervalMillis) {
                     return;
                 }
-                lastCheckedMillis = now;
                 try {
                     long currentModified = Files.getLastModifiedTime(path).toMillis();
                     long currentSize = Files.size(path);
@@ -314,6 +314,7 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
                 } catch (Exception e) {
                     LOG.warnf("Failed to reload blacklist %s, continuing with cached version: %s", name, e.getMessage());
                 }
+                lastCheckedMillis = now;
             }
         }
 

--- a/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
@@ -82,9 +82,11 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
 
     public static final String BLACKLISTS_FALSE_POSITIVE_PROBABILITY_PROPERTY = "falsePositiveProbability";
 
+    public static final String CHECK_INTERVAL_SECONDS_PROPERTY = "checkIntervalSeconds";
+
     public static final double DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.0001;
 
-    public static final int CHECK_INTERVAL_SECONDS = 60;
+    public static final int DEFAULT_CHECK_INTERVAL_SECONDS = 60;
 
     public static final String JBOSS_SERVER_DATA_DIR = "jboss.server.data.dir";
 
@@ -175,7 +177,7 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
 
         return blacklistRegistry.computeIfAbsent(listName, (name) -> {
             double fpp = getFalsePositiveProbability();
-            return new FileBasedPasswordBlacklist(this.blacklistsBasePath, name, fpp, CHECK_INTERVAL_SECONDS * 1000L);
+            return new FileBasedPasswordBlacklist(this.blacklistsBasePath, name, fpp, getCheckIntervalSeconds() * 1000L);
         });
     }
 
@@ -197,6 +199,26 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
             return DEFAULT_FALSE_POSITIVE_PROBABILITY;
         }
     }
+
+    protected int getCheckIntervalSeconds() {
+
+        if (config == null) {
+            return DEFAULT_CHECK_INTERVAL_SECONDS;
+        }
+
+        String checkIntervalString = config.get(CHECK_INTERVAL_SECONDS_PROPERTY);
+        if (checkIntervalString == null) {
+            return DEFAULT_CHECK_INTERVAL_SECONDS;
+        }
+
+        try {
+            return Integer.parseInt(checkIntervalString);
+        } catch (NumberFormatException nfe) {
+            LOG.warnf("Could not parse check interval seconds from string %s", checkIntervalString);
+            return DEFAULT_CHECK_INTERVAL_SECONDS;
+        }
+    }
+
 
     /**
      * A {@link PasswordBlacklist} describes a list of too easy to guess
@@ -294,6 +316,9 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
          * Uses double-checked locking to avoid redundant reloads by concurrent threads.
          */
         private void reloadIfNeeded() {
+            if (checkIntervalMillis == 0) {
+                return;
+            }
             long now = System.currentTimeMillis();
             if (now - lastCheckedMillis < checkIntervalMillis) {
                 return;

--- a/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
@@ -352,6 +352,7 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
 
             try {
                 LOG.infof("Loading blacklist start: name=%s path=%s", name, path);
+                long loadStartMillis = System.currentTimeMillis();
 
                 long passwordCount = countPasswordsInBlacklistFile();
                 double fpp = getFalsePositiveProbability();
@@ -364,8 +365,9 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
                 insertPasswordsInto(filter);
 
                 double expectedFfp = filter.expectedFpp();
-                LOG.infof("Loading blacklist finished: name=%s passwords=%s path=%s falsePositiveProbability=%s expectedFalsePositiveProbability=%s",
-                        name, passwordCount, path, fpp, expectedFfp);
+                long loadTimeMillis = System.currentTimeMillis() - loadStartMillis;
+                LOG.infof("Loading blacklist finished: name=%s passwords=%s path=%s falsePositiveProbability=%s expectedFalsePositiveProbability=%s loadTime=%dms",
+                        name, passwordCount, path, fpp, expectedFfp, loadTimeMillis);
 
                 return filter;
             } catch (IOException e) {

--- a/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
@@ -24,6 +24,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.DecimalFormat;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -32,6 +34,8 @@ import java.util.function.Supplier;
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import com.google.common.hash.BloomFilter;
 import com.google.common.hash.Funnels;
@@ -219,6 +223,29 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
         }
     }
 
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        ProviderConfigurationBuilder builder = ProviderConfigurationBuilder.create();
+
+        DecimalFormat df = new DecimalFormat();
+        df.setMaximumFractionDigits(Integer.MAX_VALUE);
+
+        builder.property()
+                .name(BLACKLISTS_FALSE_POSITIVE_PROBABILITY_PROPERTY)
+                .type("string")
+                .helpText("False positive probability of the bloom filter to reject a valid password.")
+                .defaultValue(df.format(DEFAULT_FALSE_POSITIVE_PROBABILITY))
+                .add();
+
+        builder.property()
+                .name(CHECK_INTERVAL_SECONDS_PROPERTY)
+                .type("string")
+                .helpText("Interval in number of seconds when the server should check the password file for changes and reload it. Set to 0 to disable reloading.")
+                .defaultValue(DEFAULT_CHECK_INTERVAL_SECONDS)
+                .add();
+
+        return builder.build();
+    }
 
     /**
      * A {@link PasswordBlacklist} describes a list of too easy to guess

--- a/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/BlacklistPasswordPolicyProviderFactory.java
@@ -84,6 +84,8 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
 
     public static final double DEFAULT_FALSE_POSITIVE_PROBABILITY = 0.0001;
 
+    public static final int CHECK_INTERVAL_SECONDS = 60;
+
     public static final String JBOSS_SERVER_DATA_DIR = "jboss.server.data.dir";
 
     public static final String PASSWORD_BLACKLISTS_FOLDER = "password-blacklists" + File.separator;
@@ -173,9 +175,7 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
 
         return blacklistRegistry.computeIfAbsent(listName, (name) -> {
             double fpp = getFalsePositiveProbability();
-            FileBasedPasswordBlacklist pbl = new FileBasedPasswordBlacklist(this.blacklistsBasePath, name, fpp);
-            pbl.lazyInit();
-            return pbl;
+            return new FileBasedPasswordBlacklist(this.blacklistsBasePath, name, fpp, CHECK_INTERVAL_SECONDS * 1000L);
         });
     }
 
@@ -244,22 +244,17 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
 
         private final double falsePositiveProbability;
 
-        /**
-         * Initialized lazily via {@link #lazyInit()}
-         */
-        private BloomFilter<String> blacklist;
+        private volatile BloomFilter<String> blacklist;
 
-        /**
-         * Creates a new {@link FileBasedPasswordBlacklist} with {@link #DEFAULT_FALSE_POSITIVE_PROBABILITY}.
-         *
-         * @param blacklistBasePath folder containing the blacklists
-         * @param name name of blacklist file
-         */
-        public FileBasedPasswordBlacklist(Path blacklistBasePath, String name) {
-            this(blacklistBasePath, name, DEFAULT_FALSE_POSITIVE_PROBABILITY);
-        }
+        private final long checkIntervalMillis;
 
-        public FileBasedPasswordBlacklist(Path blacklistBasePath, String name, double falsePositiveProbability) {
+        private volatile long lastCheckedMillis;
+
+        private long lastModifiedMillis;
+
+        private long lastSizeBytes;
+
+        public FileBasedPasswordBlacklist(Path blacklistBasePath, String name, double falsePositiveProbability, long checkIntervalMillis) {
 
             if (name.contains("/")) {
                 // disallow '/' to avoid accidental filesystem traversal
@@ -269,10 +264,16 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
             this.name = name;
             this.path = blacklistBasePath.resolve(name);
             this.falsePositiveProbability = falsePositiveProbability;
+            this.checkIntervalMillis = checkIntervalMillis;
 
             if (!Files.exists(this.path)) {
                 throw new IllegalArgumentException("Password blacklist " + name + " not found!");
             }
+
+            this.lastModifiedMillis = path.toFile().lastModified();
+            this.lastSizeBytes = path.toFile().length();
+            this.blacklist = load();
+            this.lastCheckedMillis = System.currentTimeMillis();
         }
 
         public String getName() {
@@ -284,16 +285,36 @@ public class BlacklistPasswordPolicyProviderFactory implements PasswordPolicyPro
         }
 
         public boolean contains(String password) {
-            return blacklist != null && blacklist.mightContain(password);
+            reloadIfNeeded();
+            return blacklist.mightContain(password);
         }
 
-        void lazyInit() {
-
-            if (blacklist != null) {
+        /**
+         * Check the modification time and file size and reload if it has changed since the last load.
+         * Uses double-checked locking to avoid redundant reloads by concurrent threads.
+         */
+        private void reloadIfNeeded() {
+            long now = System.currentTimeMillis();
+            if (now - lastCheckedMillis < checkIntervalMillis) {
                 return;
             }
-
-            this.blacklist = load();
+            synchronized (this) {
+                if (now - lastCheckedMillis < checkIntervalMillis) {
+                    return;
+                }
+                lastCheckedMillis = now;
+                try {
+                    long currentModified = Files.getLastModifiedTime(path).toMillis();
+                    long currentSize = Files.size(path);
+                    if (currentModified != lastModifiedMillis || currentSize != lastSizeBytes) {
+                        blacklist = load();
+                        lastModifiedMillis = currentModified;
+                        lastSizeBytes = currentSize;
+                    }
+                } catch (Exception e) {
+                    LOG.warnf("Failed to reload blacklist %s, continuing with cached version: %s", name, e.getMessage());
+                }
+            }
         }
 
         /**

--- a/server-spi-private/src/test/java/org/keycloak/policy/BlacklistPasswordPolicyProviderTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/policy/BlacklistPasswordPolicyProviderTest.java
@@ -1,19 +1,30 @@
 package org.keycloak.policy;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+
+import org.keycloak.policy.BlacklistPasswordPolicyProviderFactory.FileBasedPasswordBlacklist;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.keycloak.policy.BlacklistPasswordPolicyProviderFactory.FileBasedPasswordBlacklist;
 
 public class BlacklistPasswordPolicyProviderTest {
 
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
     @Test
     public void testUpperCaseInFile() {
         FileBasedPasswordBlacklist blacklist =
-                new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt");
-        blacklist.lazyInit();
+                new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt",
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY,
+                        BlacklistPasswordPolicyProviderFactory.CHECK_INTERVAL_SECONDS * 1000L);
 
         // all passwords in the deny list are in lower case
         Assert.assertFalse(blacklist.contains("1Password!"));
@@ -22,16 +33,60 @@ public class BlacklistPasswordPolicyProviderTest {
     @Test
     public void testAlwaysLowercaseInFile() {
         FileBasedPasswordBlacklist blacklist =
-                new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt");
-        blacklist.lazyInit();
+                new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt",
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY,
+                        BlacklistPasswordPolicyProviderFactory.CHECK_INTERVAL_SECONDS * 1000L);
         Assert.assertTrue(blacklist.contains("1Password!".toLowerCase()));
     }
 
     @Test
     public void testLowerCaseInFile() {
         FileBasedPasswordBlacklist blacklist =
-                new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt");
-        blacklist.lazyInit();
+                new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt",
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY,
+                        BlacklistPasswordPolicyProviderFactory.CHECK_INTERVAL_SECONDS * 1000L);
         Assert.assertTrue(blacklist.contains("pass1!word"));
     }
+
+    @Test
+    public void testReloadOnFileChange() throws java.io.IOException {
+        Path file = tempFolder.newFile("blacklist.txt").toPath();
+        Files.writeString(file, "oldpassword\n");
+
+        FileBasedPasswordBlacklist blacklist =
+                new FileBasedPasswordBlacklist(tempFolder.getRoot().toPath(), "blacklist.txt",
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 0);
+
+        Assert.assertTrue(blacklist.contains("oldpassword"));
+        Assert.assertFalse(blacklist.contains("newpassword"));
+
+        Files.writeString(file, "newpassword\n"); // Will truncate and rewrite the file.
+        Files.setLastModifiedTime(file, FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 1000));
+
+        Assert.assertFalse(blacklist.contains("oldpassword"));
+        Assert.assertTrue(blacklist.contains("newpassword"));
+    }
+
+    @Test
+    public void testReloadOnFileSizeChange() throws java.io.IOException {
+        Path file = tempFolder.newFile("blacklist.txt").toPath();
+        Files.writeString(file, "oldpassword\n");
+        FileTime originalMtime = Files.getLastModifiedTime(file);
+
+        FileBasedPasswordBlacklist blacklist =
+                new FileBasedPasswordBlacklist(tempFolder.getRoot().toPath(), "blacklist.txt",
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 0);
+
+        Assert.assertTrue(blacklist.contains("oldpassword"));
+        Assert.assertFalse(blacklist.contains("newpassword"));
+
+        // Rewrite the content while preserving the original mtime to simulate filesystems
+        // with coarse granularity where the timestamp remains unchanged between writes.
+        Files.writeString(file, "newpassword\nanotherpassword\n");
+        Files.setLastModifiedTime(file, originalMtime);
+
+        Assert.assertFalse(blacklist.contains("oldpassword"));
+        Assert.assertTrue(blacklist.contains("newpassword"));
+    }
+
 }

--- a/server-spi-private/src/test/java/org/keycloak/policy/BlacklistPasswordPolicyProviderTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/policy/BlacklistPasswordPolicyProviderTest.java
@@ -12,8 +12,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.keycloak.policy.BlacklistPasswordPolicyProviderFactory.FileBasedPasswordBlacklist;
-
 public class BlacklistPasswordPolicyProviderTest {
 
     @Rule
@@ -24,7 +22,7 @@ public class BlacklistPasswordPolicyProviderTest {
         FileBasedPasswordBlacklist blacklist =
                 new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt",
                         BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY,
-                        BlacklistPasswordPolicyProviderFactory.CHECK_INTERVAL_SECONDS * 1000L);
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_CHECK_INTERVAL_SECONDS * 1000L);
 
         // all passwords in the deny list are in lower case
         Assert.assertFalse(blacklist.contains("1Password!"));
@@ -35,7 +33,7 @@ public class BlacklistPasswordPolicyProviderTest {
         FileBasedPasswordBlacklist blacklist =
                 new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt",
                         BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY,
-                        BlacklistPasswordPolicyProviderFactory.CHECK_INTERVAL_SECONDS * 1000L);
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_CHECK_INTERVAL_SECONDS * 1000L);
         Assert.assertTrue(blacklist.contains("1Password!".toLowerCase()));
     }
 
@@ -44,23 +42,26 @@ public class BlacklistPasswordPolicyProviderTest {
         FileBasedPasswordBlacklist blacklist =
                 new FileBasedPasswordBlacklist(Paths.get("src/test/java/org/keycloak/policy"), "short_blacklist.txt",
                         BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY,
-                        BlacklistPasswordPolicyProviderFactory.CHECK_INTERVAL_SECONDS * 1000L);
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_CHECK_INTERVAL_SECONDS * 1000L);
         Assert.assertTrue(blacklist.contains("pass1!word"));
     }
 
     @Test
-    public void testReloadOnFileChange() throws java.io.IOException {
+    public void testReloadOnFileMtimeChange() throws Exception {
         Path file = tempFolder.newFile("blacklist.txt").toPath();
         Files.writeString(file, "oldpassword\n");
 
         FileBasedPasswordBlacklist blacklist =
                 new FileBasedPasswordBlacklist(tempFolder.getRoot().toPath(), "blacklist.txt",
-                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 0);
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 1); // Use 1 msec check interval for not to delay the test too much.
 
         Assert.assertTrue(blacklist.contains("oldpassword"));
         Assert.assertFalse(blacklist.contains("newpassword"));
 
-        Files.writeString(file, "newpassword\n"); // Will truncate and rewrite the file.
+        // Wait for the check interval to elapse.
+        // Rewrite the file, and bump the mtime by 1 sec to ensure a detectable change regardless of the filesystem's mtime granularity.
+        Thread.sleep(2);
+        Files.writeString(file, "newpassword\n");
         Files.setLastModifiedTime(file, FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 1000));
 
         Assert.assertFalse(blacklist.contains("oldpassword"));
@@ -68,25 +69,46 @@ public class BlacklistPasswordPolicyProviderTest {
     }
 
     @Test
-    public void testReloadOnFileSizeChange() throws java.io.IOException {
+    public void testReloadOnFileSizeChange() throws Exception {
         Path file = tempFolder.newFile("blacklist.txt").toPath();
         Files.writeString(file, "oldpassword\n");
         FileTime originalMtime = Files.getLastModifiedTime(file);
 
         FileBasedPasswordBlacklist blacklist =
                 new FileBasedPasswordBlacklist(tempFolder.getRoot().toPath(), "blacklist.txt",
-                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 0);
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 1); // Use 1 msec check interval for not to delay the test too much.
 
         Assert.assertTrue(blacklist.contains("oldpassword"));
         Assert.assertFalse(blacklist.contains("newpassword"));
 
+        // Wait for the check interval to elapse.
         // Rewrite the content while preserving the original mtime to simulate filesystems
         // with coarse granularity where the timestamp remains unchanged between writes.
+        Thread.sleep(2);
         Files.writeString(file, "newpassword\nanotherpassword\n");
         Files.setLastModifiedTime(file, originalMtime);
 
         Assert.assertFalse(blacklist.contains("oldpassword"));
         Assert.assertTrue(blacklist.contains("newpassword"));
+    }
+
+    @Test
+    public void testReloadCheckIntervalZero() throws Exception {
+        Path file = tempFolder.newFile("blacklist.txt").toPath();
+        Files.writeString(file, "oldpassword\n");
+
+        FileBasedPasswordBlacklist blacklist =
+                new FileBasedPasswordBlacklist(tempFolder.getRoot().toPath(), "blacklist.txt",
+                        BlacklistPasswordPolicyProviderFactory.DEFAULT_FALSE_POSITIVE_PROBABILITY, 0);
+
+        Assert.assertTrue(blacklist.contains("oldpassword"));
+
+        Files.writeString(file, "newpassword\n");
+        Files.setLastModifiedTime(file, FileTime.fromMillis(Files.getLastModifiedTime(file).toMillis() + 1000));
+
+        Thread.sleep(2);
+        Assert.assertTrue(blacklist.contains("oldpassword"));
+        Assert.assertFalse(blacklist.contains("newpassword"));
     }
 
 }


### PR DESCRIPTION
This PR adds optional support for automatically reloading the password blacklist file when it is modified, allowing the server to apply updates without a restart.

During password validation, the system checks the file modification timestamp and reloads the file if it has changed. This check is limited by a configurable interval: the check is done only if the specified number of seconds has passed since the last check. Otherwise, it skips the test and uses the current file.

The check interval is configured using new SPI option `--spi-password-policy--password-blacklist--check-interval-seconds` with default value of 60 seconds. When set to 0 reloading is disabled.

This PR implements option 1 with "lazy reloading" from https://github.com/keycloak/keycloak/issues/47163#issuecomment-4060150039. This approach avoids changes to the admin UI but requires the administrator to update the blacklist file atomically to prevent the system from loading an incomplete file.

Fixes #47163