### PR TITLE
Fix LDAP vendor-dependent default values not visible in form (#47110)

### DIFF
--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsGeneral.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsGeneral.tsx
@@ -35,52 +35,52 @@ export const LdapSettingsGeneral = ({
   const setVendorDefaultValues = () => {
     switch (form.getValues("config.vendor[0]")) {
       case "ad":
-        form.setValue("config.usernameLDAPAttribute[0]", "cn");
-        form.setValue("config.rdnLDAPAttribute[0]", "cn");
-        form.setValue("config.uuidLDAPAttribute[0]", "objectGUID");
-        form.setValue("config.krbPrincipalAttribute[0]", "userPrincipalName");
+        form.setValue("config.usernameLDAPAttribute.0", "cn");
+        form.setValue("config.rdnLDAPAttribute.0", "cn");
+        form.setValue("config.uuidLDAPAttribute.0", "objectGUID");
+        form.setValue("config.krbPrincipalAttribute.0", "userPrincipalName");
         form.setValue(
-          "config.userObjectClasses[0]",
+          "config.userObjectClasses.0",
           "person, organizationalPerson, user",
         );
         break;
       case "rhds":
-        form.setValue("config.usernameLDAPAttribute[0]", "uid");
-        form.setValue("config.rdnLDAPAttribute[0]", "uid");
-        form.setValue("config.uuidLDAPAttribute[0]", "nsuniqueid");
-        form.setValue("config.krbPrincipalAttribute[0]", "krbPrincipalName");
+        form.setValue("config.usernameLDAPAttribute.0", "uid");
+        form.setValue("config.rdnLDAPAttribute.0", "uid");
+        form.setValue("config.uuidLDAPAttribute.0", "nsuniqueid");
+        form.setValue("config.krbPrincipalAttribute.0", "krbPrincipalName");
         form.setValue(
-          "config.userObjectClasses[0]",
+          "config.userObjectClasses.0",
           "inetOrgPerson, organizationalPerson",
         );
         break;
       case "tivoli":
-        form.setValue("config.usernameLDAPAttribute[0]", "uid");
-        form.setValue("config.rdnLDAPAttribute[0]", "uid");
-        form.setValue("config.uuidLDAPAttribute[0]", "uniqueidentifier");
-        form.setValue("config.krbPrincipalAttribute[0]", "krb5PrincipalName");
+        form.setValue("config.usernameLDAPAttribute.0", "uid");
+        form.setValue("config.rdnLDAPAttribute.0", "uid");
+        form.setValue("config.uuidLDAPAttribute.0", "uniqueidentifier");
+        form.setValue("config.krbPrincipalAttribute.0", "krb5PrincipalName");
         form.setValue(
-          "config.userObjectClasses[0]",
+          "config.userObjectClasses.0",
           "inetOrgPerson, organizationalPerson",
         );
         break;
       case "edirectory":
-        form.setValue("config.usernameLDAPAttribute[0]", "uid");
-        form.setValue("config.rdnLDAPAttribute[0]", "uid");
-        form.setValue("config.uuidLDAPAttribute[0]", "guid");
-        form.setValue("config.krbPrincipalAttribute[0]", "krb5PrincipalName");
+        form.setValue("config.usernameLDAPAttribute.0", "uid");
+        form.setValue("config.rdnLDAPAttribute.0", "uid");
+        form.setValue("config.uuidLDAPAttribute.0", "guid");
+        form.setValue("config.krbPrincipalAttribute.0", "krb5PrincipalName");
         form.setValue(
-          "config.userObjectClasses[0]",
+          "config.userObjectClasses.0",
           "inetOrgPerson, organizationalPerson",
         );
         break;
       case "other":
-        form.setValue("config.usernameLDAPAttribute[0]", "uid");
-        form.setValue("config.rdnLDAPAttribute[0]", "uid");
-        form.setValue("config.uuidLDAPAttribute[0]", "entryUUID");
-        form.setValue("config.krbPrincipalAttribute[0]", "krb5PrincipalName");
+        form.setValue("config.usernameLDAPAttribute.0", "uid");
+        form.setValue("config.rdnLDAPAttribute.0", "uid");
+        form.setValue("config.uuidLDAPAttribute.0", "entryUUID");
+        form.setValue("config.krbPrincipalAttribute.0", "krb5PrincipalName");
         form.setValue(
-          "config.userObjectClasses[0]",
+          "config.userObjectClasses.0",
           "inetOrgPerson, organizationalPerson",
         );
         break;


### PR DESCRIPTION
Draft PR: Fix LDAP vendor-dependent default values not visible in form (#47110)

Target branch: main (consider backport to 26.2.x if accepted)

Summary
- Fix UI state desync where changing "Vendor" in LDAP user-federation updates internal form values but does not update the rendered HTML inputs.
- Ensures programmatic updates to react-hook-form fields propagate to visible inputs.

Proposed changes
- Apply the patch from commit bcb95cd33148f43d0a51d2b862b0c0bc5dd2d229 (as referenced in issue #47110) with minimal cleanup and comments.
- Align registered field names with actual input definitions (fix array-notation mismatch).
- Add defensive code to call react-hook-form's setValue/trigger as needed after vendor change.

Tests
- Add a UI test (integration/selenium/playwright) that:
  1) Creates a realm and opens LDAP federation form
  2) Sets vendor to "Active Directory" and asserts default values for fields (e.g., User object classes)
  3) Changes vendor to "Other" and asserts the visible input values update to the new defaults
  4) Saves and re-opens to assert persisted values match

- Add a small unit test for the form helper (if present) to verify setValue is called when vendor changes.

Backport
- Backport to 26.2.x if customers report confusion or incorrect manual edits due to the UI mismatch. Otherwise target main and include in next minor.

Notes for reviewers
- Review commit bcb95cd... for side effects. Focus on:
  - Correctness of field name adjustments
  - Proper use of react-hook-form APIs (setValue, register, unregister)
  - No regressions for other federation vendors or fields
- Verify tests run in CI (quarkus dev profile) and UI test stability.

Suggested reviewers
- @pedro-igor (core-iam lead)
- UI owners: @keycloak/admin-ui-maintainer
- LDAP area: @keycloak/ldap-maintainer

References
- Issue: https://github.com/keycloak/keycloak/issues/47110
- Reporter commit: bcb95cd33148f43d0a51d2b862b0c0bc5dd2d229

Checklist before merge
- [ ] Patch applied and compiles
- [ ] New tests added and passing
- [ ] Reviewer approvals
- [ ] Backport decision recorded (if applicable)

