### PR TITLE
Add suppor for complex attribute notation in SCIM filters

### DIFF
--- a/scim/core/src/main/antlr4/org/keycloak/scim/filter/ScimFilterLexer.g4
+++ b/scim/core/src/main/antlr4/org/keycloak/scim/filter/ScimFilterLexer.g4
@@ -61,8 +61,8 @@ fragment ALPHA : [a-zA-Z];
 fragment DOT : '.';
 fragment COLON : ':';
 fragment SLASHSLASH : '//';
-fragment LBRACKET : '[';
-fragment RBRACKET : ']';
+LBRACKET : '[';
+RBRACKET : ']';
 
 // Whitespace
 WS : [ \t\r\n]+ -> skip;

--- a/scim/core/src/main/antlr4/org/keycloak/scim/filter/ScimFilterParser.g4
+++ b/scim/core/src/main/antlr4/org/keycloak/scim/filter/ScimFilterParser.g4
@@ -23,7 +23,14 @@ notExpression
 
 atom
     : LPAREN expression RPAREN
+    | valuePath
     | attributeExpression
+    ;
+
+// Value path for complex attribute filtering (RFC 7644 §3.4.2.2)
+// e.g., name[familyName eq "Smith" and givenName sw "Jo"]
+valuePath
+    : ATTRPATH LBRACKET expression RBRACKET
     ;
 
 // Attribute comparison expressions

--- a/scim/core/src/test/java/org/keycloak/scim/filter/FilterUtilsTest.java
+++ b/scim/core/src/test/java/org/keycloak/scim/filter/FilterUtilsTest.java
@@ -206,4 +206,51 @@ public class FilterUtilsTest {
         assertDoesNotThrow(() -> FilterUtils.parseFilter(
             "meta.lastModified le \"2024-12-31T23:59:59Z\""));
     }
+
+    @Test
+    public void testValuePathSimple() {
+        // Simple value path with single condition
+        assertDoesNotThrow(() -> FilterUtils.parseFilter("name[familyName eq \"Silva\"]"));
+        assertDoesNotThrow(() -> FilterUtils.parseFilter("emails[value co \"example.com\"]"));
+        assertDoesNotThrow(() -> FilterUtils.parseFilter("emails[type pr]"));
+    }
+
+    @Test
+    public void testValuePathWithLogicalOperators() {
+        // Value path with AND
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "name[familyName eq \"Silva\" and givenName sw \"Jo\"]"));
+
+        // Value path with OR
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "emails[type eq \"work\" or type eq \"home\"]"));
+
+        // Value path with NOT
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "emails[not (type eq \"work\")]"));
+    }
+
+    @Test
+    public void testValuePathCombinedWithRegularFilters() {
+        // Value path combined with regular attribute expressions
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "name[familyName eq \"Silva\"] and active eq true"));
+
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "userName sw \"J\" or emails[type eq \"work\" and value co \"example.com\"]"));
+    }
+
+    @Test
+    public void testValuePathWithParentheses() {
+        // Parentheses inside value path
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "emails[(type eq \"work\" or type eq \"home\") and value co \"example\"]"));
+    }
+
+    @Test
+    public void testValuePathWithSchemaPrefix() {
+        // Value path with schema-prefixed parent attribute
+        assertDoesNotThrow(() -> FilterUtils.parseFilter(
+            "urn:ietf:params:scim:schemas:core:2.0:User:name[familyName eq \"Silva\"]"));
+    }
 }

--- a/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateEvaluator.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateEvaluator.java
@@ -18,6 +18,7 @@ public class ScimJPAPredicateEvaluator extends ScimFilterParserBaseVisitor<JPAFi
 
     private final CriteriaBuilder cb;
     private final ScimJPAPredicateProvider predicateProvider;
+    private String parentPath;
 
     @SuppressWarnings("unchecked,rawtypes")
     public ScimJPAPredicateEvaluator(ScimResourceTypeProvider resourceTypeProvider, List schemas, CriteriaBuilder cb, Root<?> root) {
@@ -75,6 +76,9 @@ public class ScimJPAPredicateEvaluator extends ScimFilterParserBaseVisitor<JPAFi
 
     @Override
     public JPAFilterResult visitAtom(ScimFilterParser.AtomContext ctx) {
+        if (ctx.valuePath() != null) {
+            return visit(ctx.valuePath());
+        }
         if (ctx.attributeExpression() != null) {
             return visit(ctx.attributeExpression());
         }
@@ -82,19 +86,33 @@ public class ScimJPAPredicateEvaluator extends ScimFilterParserBaseVisitor<JPAFi
     }
 
     @Override
+    public JPAFilterResult visitValuePath(ScimFilterParser.ValuePathContext ctx) {
+        parentPath = ctx.ATTRPATH().getText();
+        try {
+            return visit(ctx.expression());
+        } finally {
+            parentPath = null;
+        }
+    }
+
+    @Override
     public JPAFilterResult visitPresentExpression(ScimFilterParser.PresentExpressionContext ctx) {
-        String scimAttrPath = ctx.ATTRPATH().getText();
+        String scimAttrPath = resolveAttrPath(ctx.ATTRPATH().getText());
         String operator = ctx.PR().getText().toLowerCase();
         return predicateProvider.createPredicate(scimAttrPath, operator, null);
     }
 
     @Override
     public JPAFilterResult visitComparisonExpression(ScimFilterParser.ComparisonExpressionContext ctx) {
-        String scimAttrPath = ctx.ATTRPATH().getText();
+        String scimAttrPath = resolveAttrPath(ctx.ATTRPATH().getText());
         String operator = ctx.compareOp().getText().toLowerCase();
         String value = extractValue(ctx.compValue());
 
         return predicateProvider.createPredicate(scimAttrPath, operator, value);
+    }
+
+    private String resolveAttrPath(String attrPath) {
+        return parentPath != null ? parentPath + "." + attrPath : attrPath;
     }
 
     private String extractValue(ScimFilterParser.CompValueContext ctx) {

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -513,6 +513,52 @@ public class FilterTest extends AbstractScimTest {
         assertSingleResult(response, alice.getUserName());
     }
 
+    // Tests for complex attribute (value path) filters
+
+    @Test
+    public void testComplexAttributeFilterByName() {
+        User bob = createUser("bob", "Robert", "Anderson", "bob@keycloak.org", true);
+        createUser("alice", "Alice", "Smith", "alice@keycloak.org", true);
+
+        // value path equivalent of: name.familyName eq "Anderson"
+        String filter = "name[familyName eq \"Anderson\"]";
+        ListResponse<User> response = client.users().getAll(filter);
+        assertSingleResult(response, bob.getUserName());
+
+        // value path equivalent of: name.givenName sw "Rob"
+        filter = "name[givenName sw \"Rob\"]";
+        response = client.users().getAll(filter);
+        assertSingleResult(response, bob.getUserName());
+    }
+
+    @Test
+    public void testComplexAttributeFilterWithLogicalOperators() {
+        User bob = createUser("bob", "Robert", "Anderson", "bob@keycloak.org", true);
+        User alice = createUser("alice", "Alice", "Anderson", "alice@keycloak.org", false);
+
+        // value path with AND: name[familyName eq "Anderson" and givenName eq "Alice"]
+        String filter = "name[familyName eq \"Anderson\" and givenName eq \"Alice\"]";
+        ListResponse<User> response = client.users().getAll(filter);
+        assertSingleResult(response, alice.getUserName());
+
+        // value path with OR: name[givenName eq "Robert" or givenName eq "Alice"]
+        filter = "name[givenName eq \"Robert\" or givenName eq \"Alice\"]";
+        response = client.users().getAll(filter);
+        assertThat(response, is(not(nullValue())));
+        assertThat(response.getTotalResults(), is(2));
+    }
+
+    @Test
+    public void testComplexAttributeCombinedWithRegularFilter() {
+        User bob = createUser("bob", "Robert", "Anderson", "bob@keycloak.org", true);
+        createUser("alice", "Alice", "Anderson", "alice@keycloak.org", false);
+
+        // value path combined with regular filter: name[familyName eq "Anderson"] and active eq true
+        String filter = "name[familyName eq \"Anderson\"] and active eq true";
+        ListResponse<User> response = client.users().getAll(filter);
+        assertSingleResult(response, bob.getUserName());
+    }
+
     // Tests for POST /.search endpoint
 
     @Test


### PR DESCRIPTION
Closes #47222

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
