### PR TITLE
[Keycloak 26.5] Stricter access control when fetching user profile configuration and metadata

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_5_6.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_5_6.adoc
@@ -9,3 +9,11 @@ In minor or patch releases, {project_name} will only introduce breaking changes 
 In order to improve security, the access control for managing permission tickets has been made stricter where
 only users (or service accounts) granted with the `uma-protection` role can manage permission tickets for a given
 resource server. The only exception is the resource server itself, which can manage its permission tickets without the `uma-protection` role.
+
+=== Stricter access control for fetching user profile configuration and metadata
+
+In order to improve security, the access control for fetching user profile configuration and metadata from a realm has been made stricter,
+and it is no longer possible to fetch this information if the administrator is granted with any administrative role.
+
+Instead, the administrator must have explicit permissions to view or manage users, or by
+having the `view-realm`, or `manage-realm`, or `view-users`, or `manage-users`, or `query-users` roles.

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserProfileResource.java
@@ -19,6 +19,7 @@ package org.keycloak.services.resources.admin;
 import java.util.Collections;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
@@ -77,8 +78,11 @@ public class UserProfileResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public UPConfig getConfiguration() {
-        auth.requireAnyAdminRole();
-        return session.getProvider(UserProfileProvider.class).getConfiguration();
+        if (auth.realm().canViewRealm() || auth.users().canQuery()) {
+            return session.getProvider(UserProfileProvider.class).getConfiguration();
+        } else {
+            throw new ForbiddenException();
+        }
     }
 
     @GET
@@ -91,9 +95,12 @@ public class UserProfileResource {
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public UserProfileMetadata getMetadata() {
-        auth.requireAnyAdminRole();
-        UserProfile profile = session.getProvider(UserProfileProvider.class).create(UserProfileContext.USER_API, Collections.emptyMap());
-        return createUserProfileMetadata(session, profile);
+        if (auth.realm().canViewRealm() || auth.users().canQuery()) {
+            UserProfile profile = session.getProvider(UserProfileProvider.class).create(UserProfileContext.USER_API, Collections.emptyMap());
+            return createUserProfileMetadata(session, profile);
+        } else {
+            throw new ForbiddenException();
+        }
     }
 
     @PUT

--- a/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
@@ -20,6 +20,8 @@ package org.keycloak.tests.admin;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.Response;
 
@@ -470,6 +472,19 @@ public class PermissionsTest extends AbstractPermissionsTest {
         invoke(realm -> realm.flows().getRequiredActions(), clients.get(AdminRoles.QUERY_USERS), true);
         invoke(realm -> clients.get(AdminRoles.VIEW_USERS).realm(REALM_NAME).users().get(user.getId()).getConfiguredUserStorageCredentialTypes(),
                 clients.get(AdminRoles.VIEW_USERS), true);
+        for (String role : Stream.of(AdminRoles.ALL_REALM_ROLES)
+                .filter(Predicate.not(AdminRoles.VIEW_REALM::equals)
+                .and(Predicate.not(AdminRoles.MANAGE_REALM::equals)
+                .and(Predicate.not(AdminRoles.VIEW_USERS::equals)
+                .and(Predicate.not(AdminRoles.MANAGE_USERS::equals)
+                .and(Predicate.not(AdminRoles.QUERY_USERS::equals)))))).toList()) {
+            invoke(realm -> realm.users().userProfile().getConfiguration(), clients.get(role), false);
+            invoke(realm -> realm.users().userProfile().getMetadata(), clients.get(role), false);
+        }
+        for (String role : Stream.of(AdminRoles.VIEW_REALM, AdminRoles.MANAGE_REALM, AdminRoles.VIEW_USERS, AdminRoles.MANAGE_USERS, AdminRoles.QUERY_USERS).toList()) {
+            invoke(realm -> realm.users().userProfile().getConfiguration(), clients.get(role), true);
+            invoke(realm -> realm.users().userProfile().getMetadata(), clients.get(role), true);
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #45493

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
