### PR TITLE
Fix BruteForceProtector failure counter not resetting when failures are spaced apart > maxDelta

### DIFF
--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -143,7 +143,7 @@ public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtect
     }
 
     @Override
-    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
+    public void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
         // remove the user from concurrent login attemps once it's processed
         enlistRemoval(session, userId);
         super.failure(session, realm, userId, remoteAddr, failureTime, categories);

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -80,12 +80,11 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
         this.factory = factory;
     }
 
-    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
+    public void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
         UserLoginFailureModel userLoginFailure = getUserFailureModel(session, realm, userId);
         if (userLoginFailure == null) {
             userLoginFailure = session.loginFailures().addUserLoginFailure(realm, userId);
         }
-        userLoginFailure.setLastIPFailure(remoteAddr);
         long last = userLoginFailure.getLastFailure();
         long deltaTime = 0;
         if (last > 0) {
@@ -94,10 +93,11 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
 
         if (!(realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) && deltaTime > 0) {
             // if last failure was more than MAX_DELTA clear failures
-            if (deltaTime > (long) realm.getMaxDeltaTimeSeconds() * 1000L) {
+            if (deltaTime > realm.getMaxDeltaTimeSeconds() * 1000L) {
                 userLoginFailure.clearFailures();
             }
         }
+        userLoginFailure.setLastIPFailure(remoteAddr);
         userLoginFailure.setLastFailure(failureTime);
         userLoginFailure.incrementFailures();
         logger.debugf("new num failures: %s", userLoginFailure.getNumFailures());
@@ -105,9 +105,9 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
         long waitSeconds = 0L;
         if (!(realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0)) {
             if (RealmRepresentation.BruteForceStrategy.MULTIPLE.equals(realm.getBruteForceStrategy())) {
-                waitSeconds = (long) realm.getWaitIncrementSeconds() *  ((long) userLoginFailure.getNumFailures() / realm.getFailureFactor());
+                waitSeconds = realm.getWaitIncrementSeconds() *  ((long) userLoginFailure.getNumFailures() / realm.getFailureFactor());
             } else {
-                waitSeconds = (long) realm.getWaitIncrementSeconds() * ((long) 1 + userLoginFailure.getNumFailures() - realm.getFailureFactor());
+                waitSeconds = realm.getWaitIncrementSeconds() * ((long) 1 + userLoginFailure.getNumFailures() - realm.getFailureFactor());
             }
         }
 

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -91,7 +91,6 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
         if (last > 0) {
             deltaTime = failureTime - last;
         }
-        userLoginFailure.setLastFailure(failureTime);
 
         if (!(realm.isPermanentLockout() && realm.getMaxTemporaryLockouts() == 0) && deltaTime > 0) {
             // if last failure was more than MAX_DELTA clear failures
@@ -99,6 +98,7 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
                 userLoginFailure.clearFailures();
             }
         }
+        userLoginFailure.setLastFailure(failureTime);
         userLoginFailure.incrementFailures();
         logger.debugf("new num failures: %s", userLoginFailure.getNumFailures());
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -553,6 +553,79 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
     }
 
     @Test
+    public void testRepeatedFailureResetForTemporaryLockout() {
+        RealmRepresentation realm = testRealm().toRepresentation();
+        try {
+            // Using a large maxDeltaTimeSeconds to prevent cache expiration happening due to
+            // Infinispan cache expiration in dev environment, between the two failure() calls inside the server lambda.
+            realm.setMaxDeltaTimeSeconds(3600);
+            testRealm().update(realm);
+
+            UserRepresentation user = findUser("test-user@localhost");
+            String userId = user.getId();
+            String realmId = realm.getId();
+
+            // Calling failure() directly on the server side with custom failureTime values, this ensures 
+            // bypassing the async executor so both calls share the same session/transaction. 
+            // This allows to observing the entity state without cache expiration.
+            testingClient.server().run(session -> {
+
+                RealmModel realmModel = session.realms().getRealm(realmId);
+                BruteForceProtector protector = session.getProvider(BruteForceProtector.class);
+
+                // Find the protected failure() method via reflection, 
+                // trying to cover cases where the method is declared in a parent class.
+                java.lang.reflect.Method failureMethod = null;
+                for (Class<?> clazz = protector.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+                    try {
+                        failureMethod = clazz.getDeclaredMethod("failure",
+                                org.keycloak.models.KeycloakSession.class,
+                                RealmModel.class, String.class, String.class, long.class, String.class);
+                        failureMethod.setAccessible(true);
+                        break;
+                    } catch (NoSuchMethodException e) {
+                        // Trying parent class in next iterations
+                    }
+                }
+                Assert.assertNotNull("Could not find failure() method via reflection", failureMethod);
+
+                // Now attempting Failure 1
+                long T1 = org.keycloak.common.util.Time.currentTimeMillis();
+                try {
+                    failureMethod.invoke(protector, session, realmModel, userId, "127.0.0.1", T1, null);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                UserLoginFailureModel lf = session.loginFailures()
+                        .getUserLoginFailure(realmModel, userId);
+                Assert.assertNotNull(lf);
+                Assert.assertEquals(1, lf.getNumFailures());
+
+                // Now attempting Failure 2 with delta > maxDeltaTimeSeconds (3600s)
+                long T2 = T1 + 3601 * 1000L;
+                try {
+                    failureMethod.invoke(protector, session, realmModel, userId, "127.0.0.1", T2, null);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                lf = session.loginFailures().getUserLoginFailure(realmModel, userId);
+
+                // Counter should have been cleared then re-incremented
+                Assert.assertEquals("numFailures should be 1 after counter reset", 1, lf.getNumFailures());
+
+                // The Core Test Assertion: setLastFailure must run AFTER clearFailures so lastFailure is not wiped to 0.
+                // If setLastFailure runs before clearFailures (the behavior causing the bug), clearFailures() sets lastFailure to 0, 
+                // then subsequent failures lose the ability to compute the correct delta time.
+                Assert.assertTrue("lastFailure must be preserved after counter reset, got: "
+                        + lf.getLastFailure(), lf.getLastFailure() > 0);
+            });
+        } finally {
+            realm.setMaxDeltaTimeSeconds(20);
+            testRealm().update(realm);
+        }
+    }
+
+    @Test
     public void testCacheExpiryForTemporaryLockout() {
         RealmRepresentation realm = managedRealm.admin().toRepresentation();
         loginInvalidPassword();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -42,6 +42,7 @@ import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.BruteForceProtector;
+import org.keycloak.services.managers.DefaultBruteForceProtector;
 import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
@@ -554,12 +555,12 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
 
     @Test
     public void testRepeatedFailureResetForTemporaryLockout() {
-        RealmRepresentation realm = testRealm().toRepresentation();
+        RealmRepresentation realm = managedRealm.admin().toRepresentation();
         try {
             // Using a large maxDeltaTimeSeconds to prevent cache expiration happening due to
             // Infinispan cache expiration in dev environment, between the two failure() calls inside the server lambda.
             realm.setMaxDeltaTimeSeconds(3600);
-            testRealm().update(realm);
+            managedRealm.admin().update(realm);
 
             UserRepresentation user = findUser("test-user@localhost");
             String userId = user.getId();
@@ -571,57 +572,35 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
             testingClient.server().run(session -> {
 
                 RealmModel realmModel = session.realms().getRealm(realmId);
-                BruteForceProtector protector = session.getProvider(BruteForceProtector.class);
-
-                // Find the protected failure() method via reflection, 
-                // trying to cover cases where the method is declared in a parent class.
-                java.lang.reflect.Method failureMethod = null;
-                for (Class<?> clazz = protector.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
-                    try {
-                        failureMethod = clazz.getDeclaredMethod("failure",
-                                org.keycloak.models.KeycloakSession.class,
-                                RealmModel.class, String.class, String.class, long.class, String.class);
-                        failureMethod.setAccessible(true);
-                        break;
-                    } catch (NoSuchMethodException e) {
-                        // Trying parent class in next iterations
-                    }
-                }
-                Assert.assertNotNull("Could not find failure() method via reflection", failureMethod);
+                DefaultBruteForceProtector protector = (DefaultBruteForceProtector)session.getProvider(BruteForceProtector.class);
 
                 // Now attempting Failure 1
                 long T1 = org.keycloak.common.util.Time.currentTimeMillis();
-                try {
-                    failureMethod.invoke(protector, session, realmModel, userId, "127.0.0.1", T1, null);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                protector.failure(session, realmModel, userId, "127.0.0.1", T1, null);
                 UserLoginFailureModel lf = session.loginFailures()
                         .getUserLoginFailure(realmModel, userId);
-                Assert.assertNotNull(lf);
-                Assert.assertEquals(1, lf.getNumFailures());
+                Assertions.assertNotNull(lf);
+                Assertions.assertEquals(1, lf.getNumFailures());
 
                 // Now attempting Failure 2 with delta > maxDeltaTimeSeconds (3600s)
                 long T2 = T1 + 3601 * 1000L;
-                try {
-                    failureMethod.invoke(protector, session, realmModel, userId, "127.0.0.1", T2, null);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                protector.failure(session, realmModel, userId, "127.0.0.1", T2, null);
                 lf = session.loginFailures().getUserLoginFailure(realmModel, userId);
 
                 // Counter should have been cleared then re-incremented
-                Assert.assertEquals("numFailures should be 1 after counter reset", 1, lf.getNumFailures());
+                Assertions.assertEquals(1, lf.getNumFailures(), "numFailures should be 1 after counter reset");
+                
+                Assertions.assertEquals("127.0.0.1", lf.getLastIPFailure(), "last ip should be retained");
 
                 // The Core Test Assertion: setLastFailure must run AFTER clearFailures so lastFailure is not wiped to 0.
                 // If setLastFailure runs before clearFailures (the behavior causing the bug), clearFailures() sets lastFailure to 0, 
                 // then subsequent failures lose the ability to compute the correct delta time.
-                Assert.assertTrue("lastFailure must be preserved after counter reset, got: "
-                        + lf.getLastFailure(), lf.getLastFailure() > 0);
+                Assertions.assertTrue(lf.getLastFailure() > 0, "lastFailure must be preserved after counter reset, got: "
+                        + lf.getLastFailure());
             });
         } finally {
             realm.setMaxDeltaTimeSeconds(20);
-            testRealm().update(realm);
+            managedRealm.admin().update(realm);
         }
     }
 


### PR DESCRIPTION
## Problem ( from Issue #46634 )
When login failures are spaced more than maxDeltaTimeSeconds apart, the brute force counter should reset each time. Instead only the first reset works, after that the counter starts accumulating again and the user gets locked out.

I traced it to the ordering inside `DefaultBruteForceProtector.failure()`: `setLastFailure(failureTime)` runs before the `clearFailures()` call which zeros out everything on the UserFailureModel entity including `lastFailure` which was just set a few lines earlier. 

So after the first reset, lastFailure is 0. When the next failure comes in, getLastFailure() returns 0, deltaTime ends up as 0, and the deltacheck is never entered thus leading to no reset happening and the counter just keeps going up.

## Solution
I moved `setLastFailure(failureTime)` to after the `clearFailures()` block so the timestamp survives the reset and the next failure can compute the correct time difference delta.

For the test I had some difficulty reproducing this through the normal login flow because the `setTimeOffset()` (which is used in the other tests) also advances Infinispan's clock, which causes the login failure cache entry to expire between calls and masks the bug entirely. 

So I called `failure()` directly via reflection with controlled timestamps in the same transaction instead (I'm open to any discussions or recommendations for any alternative approach here if needed)

Closes #46634

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
