### PR TITLE
Check refresh request resource param matches original resource param.

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -105,6 +105,7 @@ import org.keycloak.protocol.oidc.mappers.TokenIntrospectionTokenMapper;
 import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
 import org.keycloak.protocol.oidc.token.TokenPostProcessor;
 import org.keycloak.protocol.oidc.token.TokenPostProcessorContext;
+import org.keycloak.protocol.oidc.utils.OAuth2Code;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.rar.AuthorizationDetails;
 import org.keycloak.rar.AuthorizationRequestContext;
@@ -391,6 +392,8 @@ public class TokenManager {
         }
 
         storeRefreshTimingInformation(event, refreshToken, validation.newToken);
+
+        responseBuilder.requestRefreshToken(refreshToken);
 
         return responseBuilder;
     }
@@ -1148,6 +1151,9 @@ public class TokenManager {
         UserSessionModel userSession;
         ClientSessionContext clientSessionCtx;
 
+        OAuth2Code code;
+        RefreshToken requestRefreshToken;
+
         AccessToken accessToken;
         RefreshToken refreshToken;
         IDToken idToken;
@@ -1182,6 +1188,16 @@ public class TokenManager {
 
         public IDToken getIdToken() {
             return idToken;
+        }
+
+        public AccessTokenResponseBuilder code(OAuth2Code code) {
+            this.code = code;
+            return this;
+        }
+
+        public AccessTokenResponseBuilder requestRefreshToken(RefreshToken requestRefreshToken) {
+            this.requestRefreshToken = requestRefreshToken;
+            return this;
         }
 
         public AccessTokenResponseBuilder accessToken(AccessToken accessToken) {
@@ -1375,7 +1391,7 @@ public class TokenManager {
         }
 
         private void invokeTokenPostProcessors() {
-            TokenPostProcessorContext context = new TokenPostProcessorContext(refreshToken, accessToken, clientSessionCtx);
+            TokenPostProcessorContext context = new TokenPostProcessorContext(code, requestRefreshToken, refreshToken, accessToken, clientSessionCtx);
             session.getAllProviders(TokenPostProcessor.class).forEach(processor -> processor.process(context));
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -276,6 +276,7 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
                     s.getRefreshToken().setAuthorizationDetails(authDetailsResponse);
                 }
             }
+            s.code(codeData);
             return new TokenResponseContext(formParams, parseResult, clientSessionCtx, s);
         });
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/token/ResourceIndicatorsPostProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/token/ResourceIndicatorsPostProcessor.java
@@ -22,42 +22,47 @@ public class ResourceIndicatorsPostProcessor implements TokenPostProcessor {
     @Override
     public void process(TokenPostProcessorContext context) {
         String requestedResource = context.clientSessionCtx().getAttribute(OAuth2Constants.RESOURCE, String.class);
-        if (requestedResource == null) {
+        String grantType = context.clientSessionCtx().getAttribute(Constants.GRANT_TYPE, String.class);
+
+        boolean originalResourceParamRequired = false;
+        String originalResourceParam = null;
+        if (OAuth2Constants.AUTHORIZATION_CODE.equals(grantType)) {
+            originalResourceParam = context.code().getResource();
+            originalResourceParamRequired = true;
+        } else if (OAuth2Constants.REFRESH_TOKEN.equals(grantType)) {
+            originalResourceParam = (String) context.requestRefreshToken().getOtherClaims().get(OAuth2Constants.RESOURCE);
+            originalResourceParamRequired = true;
+        }
+
+        if (originalResourceParam == null && requestedResource == null) {
             return;
         }
 
-        String grantType = context.clientSessionCtx().getAttribute(Constants.GRANT_TYPE, String.class);
-
-        if (grantType.equals(OAuth2Constants.REFRESH_TOKEN)) {
-            if (isClientUrn(requestedResource)) {
-                if (findAudienceByClientUrn(requestedResource, context.refreshToken().getOriginalAudience()) == null) {
-                    throw new TokenInterceptorException(OAuthErrorException.INVALID_TARGET, ERROR_NOT_MATCHING);
-                }
-            } else {
-                if (find(requestedResource, context.refreshToken().getOriginalAudience()) == null) {
-                    throw new TokenInterceptorException(OAuthErrorException.INVALID_TARGET, ERROR_NOT_MATCHING);
-                }
-            }
-        } else {
-            String audienceToSet;
-
-            String originalResourceParam = context.clientSessionCtx().getClientSession().getNote(OAuth2Constants.RESOURCE);
-            if (originalResourceParam != null && !originalResourceParam.equals(requestedResource)) {
+        if (originalResourceParamRequired) {
+            if (originalResourceParam == null) {
                 throw new TokenInterceptorException(OAuthErrorException.INVALID_TARGET, ERROR_NOT_MATCHING);
             }
 
-            if (isClientUrn(requestedResource)) {
-                audienceToSet = findAudienceByClientUrn(requestedResource, context.accessToken().getAudience());
-            } else {
-                audienceToSet = findAudienceByClientAttribute(requestedResource, context.accessToken().getAudience());
+            if (requestedResource == null) {
+                requestedResource = originalResourceParam;
+            } else if (!requestedResource.equals(originalResourceParam)){
+                throw new TokenInterceptorException(OAuthErrorException.INVALID_TARGET, ERROR_NOT_MATCHING);
             }
-
-            if (audienceToSet == null) {
-                throw new TokenInterceptorException(OAuthErrorException.INVALID_TARGET, ERROR_INVALID_RESOURCE);
-            }
-
-            context.accessToken().audience(audienceToSet);
         }
+
+        String audienceToSet;
+        if (isClientUrn(requestedResource)) {
+            audienceToSet = findAudienceByClientUrn(requestedResource, context.accessToken().getAudience());
+        } else {
+            audienceToSet = findAudienceByClientAttribute(requestedResource, context.accessToken().getAudience());
+        }
+
+        if (audienceToSet == null) {
+            throw new TokenInterceptorException(OAuthErrorException.INVALID_TARGET, ERROR_INVALID_RESOURCE);
+        }
+
+        context.refreshToken().getOtherClaims().put(OAuth2Constants.RESOURCE, requestedResource);
+        context.accessToken().audience(audienceToSet);
     }
 
     private boolean isClientUrn(String resource) {
@@ -74,7 +79,7 @@ public class ResourceIndicatorsPostProcessor implements TokenPostProcessor {
             ClientModel client = session.clients().getClientByClientId(session.getContext().getRealm(), a);
             if (client != null) {
                 String clientResourceUrl = client.getAttribute(CLIENT_RESOURCE_URL_ATTRIBUTE);
-                if (clientResourceUrl.equals(resource)) {
+                if (resource.equals(clientResourceUrl)) {
                     return resource;
                 }
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/token/TokenPostProcessorContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/token/TokenPostProcessorContext.java
@@ -1,8 +1,9 @@
 package org.keycloak.protocol.oidc.token;
 
 import org.keycloak.models.ClientSessionContext;
+import org.keycloak.protocol.oidc.utils.OAuth2Code;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
 
-public record TokenPostProcessorContext(RefreshToken refreshToken, AccessToken accessToken, ClientSessionContext clientSessionCtx) {
+public record TokenPostProcessorContext(OAuth2Code code, RefreshToken requestRefreshToken, RefreshToken refreshToken, AccessToken accessToken, ClientSessionContext clientSessionCtx) {
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ResourceIndicatorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ResourceIndicatorsTest.java
@@ -14,8 +14,6 @@ import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.RealmConfigBuilder;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
-import org.keycloak.testframework.ui.annotations.InjectWebDriver;
-import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 
@@ -36,9 +34,6 @@ public class ResourceIndicatorsTest {
 
     @InjectOAuthClient(config = OAuthClientConfig.class)
     OAuthClient oauth;
-
-    @InjectWebDriver
-    ManagedWebDriver driver;
 
     @TestSetup
     public void loginUser() {
@@ -90,7 +85,7 @@ public class ResourceIndicatorsTest {
 
     @Test
     public void testAuthzDifferentResource() {
-        AuthorizationEndpointResponse authorizationEndpointResponse = oauth.loginForm().resource("urn:client:theservice2").doLoginWithCookie();
+        AuthorizationEndpointResponse authorizationEndpointResponse = oauth.loginForm().resource("urn:client:otherservice").doLoginWithCookie();
         Assertions.assertTrue(authorizationEndpointResponse.isRedirected());
 
         AccessTokenResponse accessTokenResponse = oauth.accessTokenRequest(authorizationEndpointResponse.getCode()).resource("urn:client:theservice").send();
@@ -120,7 +115,7 @@ public class ResourceIndicatorsTest {
         AccessTokenResponse tokenResponse = oauth.passwordGrantRequest("user", "pass").resource("https://theservice").send();
         Assertions.assertTrue(tokenResponse.isSuccess());
 
-        AccessTokenResponse refreshResponse = oauth.refreshRequest(tokenResponse.getRefreshToken()).resource("https://theservice").send();
+        AccessTokenResponse refreshResponse = oauth.refreshRequest(tokenResponse.getRefreshToken()).resource("https://otherservice").send();
         assertErrorResponse(refreshResponse,  INVALID_TARGET, ERROR_NOT_MATCHING);
     }
 
@@ -131,7 +126,16 @@ public class ResourceIndicatorsTest {
             realm.addClient("theservice").attribute("resource_url", "https://theservice");
             realm.clientRoles("theservice", "myrole");
 
-            realm.addUser("user").firstName("user").lastName("user").password("pass").email("the@email.localhost").clientRoles("theservice", "myrole");
+            realm.addClient("otherservice").attribute("resource_url", "https://otherservice");
+            realm.clientRoles("otherservice", "myrole");
+
+            realm.addClient("serviceWithoutResource");
+            realm.clientRoles("serviceWithoutResource", "myrole");
+
+            realm.addUser("user").firstName("user").lastName("user").password("pass").email("the@email.localhost")
+                    .clientRoles("theservice", "myrole")
+                    .clientRoles("otherservice", "myrole")
+                    .clientRoles("serviceWithoutResource", "myrole");
 
             return realm;
         }


### PR DESCRIPTION
Includes some NPE fixes (no client attribute) and refactors handling of verifying authz request resource param matching token request resource param.

Closes #47180

Signed-off-by: stianst <stianst@gmail.com>
