### PR TITLE
Allow read-only view of IDP mapper config with view-identity-providers role

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -897,6 +897,7 @@ noPasswordPoliciesInstructions=You haven't added any password policies to this r
 testAuthentication=Test authentication
 groupNameLdapAttributeHelp=Name of LDAP attribute that is used in group objects for the name and RDN of group. It is typically 'cn'. In this case, a typical group/role object may have DN such as 'cn\=Group1,ouu\=groups,dc\=example,dc\=org'.
 deleteError=Could not delete the provider {{error}}
+deleteErrorIdentityProvider=Could not delete identity provider mapper\: '{{error}}'
 attributeDisplayName=Display name
 pkceEnabled=Use PKCE
 pkceRequired=Require PKCE

--- a/js/apps/admin-ui/src/identity-providers/routes/EditMapper.tsx
+++ b/js/apps/admin-ui/src/identity-providers/routes/EditMapper.tsx
@@ -17,7 +17,7 @@ export const IdentityProviderEditMapperRoute: AppRouteObject = {
   element: <AddMapper />,
   breadcrumb: (t) => t("editIdPMapper"),
   handle: {
-    access: "manage-identity-providers",
+    access: "view-identity-providers",
   },
 };
 


### PR DESCRIPTION
- The api had already been correct but the frontend used to require `manage-identity-providers` role.
- I adjusted it to behave similar to dedicated client scope mappings, i.e. save+cancel buttons are visible but greyed out and the delete action is also available but will result in an error.
- As the error message key `deleteErrorIdentityProvider` had been missing in the translations I added it as well

You might argue that not displaying the delete action at all would be better but I implemented this in favor of consistency with the other dialogs.

Closes #36226