### PR TITLE
Added implementation for CLI option for database connection timeout and provide it into quarkus.datasource.jdbc.login-timeout 

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -319,4 +319,4 @@ In the current version {project_name} will log a warning if the database is not 
 
 The following features have been removed from this release.
 
-=== <TODO
+=== <TODO>

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -283,6 +283,19 @@ As an alternative to specifying a truststore file with `db-tls-trust-store-file`
 
 See the https://www.keycloak.org/server/db#_secure_the_database_connection[Secure the database connection] section of the database guide for more details and examples.
 
+=== New `--db-connect-timeout` option for database connection timeout
+
+A new CLI option `--db-connect-timeout` has been introduced to configure the database connection timeout from a single place across all supported database vendors.
+
+Previously, the connection timeout could only be configured vendor-specifically via `db-url` or `db-url-properties`, using different property names and units per driver.
+
+The new option:
+
+* Translates the value to the correct vendor-specific JDBC driver property (in milliseconds or seconds depending on the driver).
+* Also sets `quarkus.datasource.jdbc.login-timeout` at the Quarkus pool level.
+* Defaults to `10s` (10 seconds), consistent with the previous per-driver defaults.
+* Does not override a timeout already set explicitly in `db-url` or `db-url-properties`.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -260,11 +260,6 @@ As part of this change, the database configuration documentation has been update
 The previously documented `utf8mb3` (or `utf8`) character set has been removed from the documentation due to its limitations in storing certain Unicode characters.
 * Previously recommended JDBC driver settings for Oracle, MySQL, and MariaDB have been removed from the documentation, as current versions of these databases use appropriate default values.
 
-=== Automatic database connection timeout defaults
-
-To improve failover behavior and startup resilience during network issues, {project_name} now sets a default database connection timeout of 10 seconds.
-See https://www.keycloak.org/server/db[Configuring the database] for the list of databases, and on how to change this default.
-
 === New CLI options for database TLS configuration
 
 New CLI options are now available to configure TLS encryption for database connections in a vendor-independent way:
@@ -283,18 +278,10 @@ As an alternative to specifying a truststore file with `db-tls-trust-store-file`
 
 See the https://www.keycloak.org/server/db#_secure_the_database_connection[Secure the database connection] section of the database guide for more details and examples.
 
-=== New `--db-connect-timeout` option for database connection timeout
+=== New `--db-connect-timeout` option for database connection and login timeout
 
-A new CLI option `--db-connect-timeout` has been introduced to configure the database connection timeout from a single place across all supported database vendors.
-
-Previously, the connection timeout could only be configured vendor-specifically via `db-url` or `db-url-properties`, using different property names and units per driver.
-
-The new option:
-
-* Translates the value to the correct vendor-specific JDBC driver property (in milliseconds or seconds depending on the driver).
-* Also sets `quarkus.datasource.jdbc.login-timeout` at the Quarkus pool level.
-* Defaults to `10s` (10 seconds), consistent with the previous per-driver defaults.
-* Does not override a timeout already set explicitly in `db-url` or `db-url-properties`.
+A new CLI option `--db-connect-timeout` sets the JDBC driver connection timeout and login timeout.
+It defaults to `10s` to improve failover behavior and startup resilience during network issues.
 
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
@@ -332,4 +319,4 @@ In the current version {project_name} will log a warning if the database is not 
 
 The following features have been removed from this release.
 
-=== <TODO>
+=== <TODO

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -281,57 +281,14 @@ For example:
 
 <@kc.start parameters="--db mssql --db-url-properties=';sendStringParametersAsUnicode=true'"/>
 
-== Automatic database connection timeout
+== Database connection and login timeout
 
 When {project_name} connects to the database, network problems can occur, especially during failovers or switchovers.
-To improve resilience and ensure faster recovery, {project_name} automatically sets a default connection timeout of 10 seconds for all supported database vendors when using the standard JDBC driver.
-
-This timeout is controlled by a single CLI option:
+To improve failover behavior and startup resilience during network issues, {project_name} sets a default connection timeout of 10s for all supported database vendors when using the standard JDBC driver.
 
 `db-connect-timeout`::
-Sets the connection timeout for the database.
-The value is translated to the vendor-specific JDBC driver property (in milliseconds or seconds depending on the vendor) and also sets the Quarkus pool-level login timeout (`quarkus.datasource.jdbc.login-timeout`).
-Default: `10s` (10 seconds).
-
-The following table shows how the value is translated per vendor:
-
-[%autowidth]
-|===
-|Database |JDBC driver property |Unit
-
-|MySQL
-|`connectTimeout`
-|milliseconds
-
-|MariaDB
-|`connectTimeout`
-|milliseconds
-
-|TiDB
-|`connectTimeout`
-|milliseconds
-
-|Oracle Database
-|`oracle.net.CONNECT_TIMEOUT`
-|milliseconds
-
-|PostgreSQL
-|`connectTimeout`
-|seconds
-
-|Microsoft SQL Server
-|`loginTimeout`
-|seconds
-
-|===
-
-In addition, {project_name} always sets `quarkus.datasource.jdbc.login-timeout` (in seconds) to the same value, regardless of the database vendor.
-
-{project_name} applies these defaults automatically, but only when all the following conditions are met:
-
-* The database vendor is configured via `--db`.
-* {project_name} is using the standard JDBC driver for that vendor.
-* The timeout property has not already been set explicitly by the user in `db-url` or `db-url-properties`.
+Sets the JDBC driver connection timeout and login timeout.
+Default: `10s`.
 
 == Preparing for PostgreSQL
 

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -284,74 +284,54 @@ For example:
 == Automatic database connection timeout
 
 When {project_name} connects to the database, network problems can occur, especially during failovers or switchovers.
-To improve resilience and ensure faster recovery, {project_name} automatically sets a default connection timeout of 10 seconds for selected database vendors when using the standard JDBC driver.
+To improve resilience and ensure faster recovery, {project_name} automatically sets a default connection timeout of 10 seconds for all supported database vendors when using the standard JDBC driver.
 
-The following table lists the affected vendors, the JDBC driver property used, and the default value applied by {project_name}:
+This timeout is controlled by a single CLI option:
+
+`db-connect-timeout`::
+Sets the connection timeout for the database.
+The value is translated to the vendor-specific JDBC driver property (in milliseconds or seconds depending on the vendor) and also sets the Quarkus pool-level login timeout (`quarkus.datasource.jdbc.login-timeout`).
+Default: `10s` (10 seconds).
+
+The following table shows how the value is translated per vendor:
 
 [%autowidth]
 |===
-|Database |JDBC driver property |Default value |Unit
+|Database |JDBC driver property |Unit
 
 |MySQL
 |`connectTimeout`
-|`10000`
 |milliseconds
 
 |MariaDB
 |`connectTimeout`
-|`10000`
+|milliseconds
+
+|TiDB
+|`connectTimeout`
+|milliseconds
+
+|Oracle Database
+|`oracle.net.CONNECT_TIMEOUT`
 |milliseconds
 
 |PostgreSQL
 |`connectTimeout`
-|`10`
 |seconds
-
-|Oracle Database
-|`oracle.net.CONNECT_TIMEOUT`
-|`10000`
-|milliseconds
 
 |Microsoft SQL Server
 |`loginTimeout`
-|`10`
 |seconds
 
 |===
 
-{project_name} applies these defaults automatically, but only when all of the following conditions are met:
+In addition, {project_name} always sets `quarkus.datasource.jdbc.login-timeout` (in seconds) to the same value, regardless of the database vendor.
+
+{project_name} applies these defaults automatically, but only when all the following conditions are met:
 
 * The database vendor is configured via `--db`.
 * {project_name} is using the standard JDBC driver for that vendor.
 * The timeout property has not already been set explicitly by the user in `db-url` or `db-url-properties`.
-
-=== Overriding the default connection timeout
-
-To use a different connection timeout, set the relevant JDBC driver property explicitly via `db-url` or `db-url-properties`.
-
-For MySQL:
-
-<@kc.start parameters="--db mysql --db-url-properties='?connectTimeout=30000'"/>
-
-For MariaDB:
-
-<@kc.start parameters="--db mariadb --db-url-properties='?connectTimeout=30000'"/>
-
-For Microsoft SQL Server:
-
-<@kc.start parameters="--db mssql --db-url-properties=';loginTimeout=20'"/>
-
-For PostgreSQL:
-
-<@kc.start parameters="--db postgres --db-url-properties='?connectTimeout=30'"/>
-
-[NOTE]
-====
-When using `db-url-properties`, prepend the correct delimiter for your vendor's JDBC URL format:
-
-* PostgreSQL, MySQL, and MariaDB: use `?` as the first property delimiter, or `&` for subsequent properties.
-* Microsoft SQL Server: use `;` as the property delimiter.
-====
 
 == Preparing for PostgreSQL
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -125,12 +125,8 @@ public class DatabaseOptions {
 
     public static final Option<String> DB_CONNECT_TIMEOUT = new OptionBuilder<>("db-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .description("Sets the default database connection timeout. " +
-                    "The value is applied to the JDBC driver (vendor-specific property) and also sets " +
-                    "'quarkus.datasource.jdbc.login-timeout'. " +
-                    "If the timeout is already set explicitly in 'db-url' or 'db-url-properties', it is not overridden. " +
-                    DURATION_DESCRIPTION)
-            .defaultValue("10")
+            .description("Sets the JDBC driver connection timeout and login timeout. " + DURATION_DESCRIPTION)
+            .defaultValue("10s")
             .build();
 
     public static final Option<String> DB_TLS_MODE = new OptionBuilder<>("db-tls-mode", String.class)
@@ -203,8 +199,6 @@ public class DatabaseOptions {
     public static final Option<String> DB_PROPERTY_ORACLE_TRUST_STORE_TYPE = new OptionBuilder<>("db-property-javax.net.ssl.trustStoreType", String.class)
             .hidden()
             .build();
-
-
     public static final Option<String> DB_MSSQL_SEND_STRING_PARAMETER_AS_UNICODE = new OptionBuilder<>("db-mssql-send-string-parameter-as-unicode", String.class)
             .category(OptionCategory.DATABASE)
             .defaultValue("false")

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -206,32 +206,26 @@ public class DatabaseOptions {
             .build();
     public static final Option<String> DB_MYSQL_CONNECT_TIMEOUT = new OptionBuilder<>("db-mysql-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .defaultValue("10000") // 10 seconds in milliseconds
             .hidden()
             .build();
     public static final Option<String> DB_MARIADB_CONNECT_TIMEOUT = new OptionBuilder<>("db-mariadb-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .defaultValue("10000") // 10 seconds in milliseconds
             .hidden()
             .build();
     public static final Option<String> DB_ORACLE_CONNECT_TIMEOUT = new OptionBuilder<>("db-oracle-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .defaultValue("10000") // 10 seconds in milliseconds
             .hidden()
             .build();
     public static final Option<String> DB_MSSQL_CONNECT_TIMEOUT = new OptionBuilder<>("db-mssql-login-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .defaultValue("10") // 10 seconds, unit is SECONDS
             .hidden()
             .build();
     public static final Option<String> DB_POSTGRES_CONNECT_TIMEOUT = new OptionBuilder<>("db-postgres-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .defaultValue("10") // 10 seconds, unit is SECONDS
             .hidden()
             .build();
     public static final Option<String> DB_TIDB_CONNECT_TIMEOUT = new OptionBuilder<>("db-tidb-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
-            .defaultValue("10000") // 10 seconds in milliseconds
             .hidden()
             .build();
     public static final class Datasources {

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -123,6 +123,16 @@ public class DatabaseOptions {
             .hidden()
             .build();
 
+    public static final Option<String> DB_CONNECT_TIMEOUT = new OptionBuilder<>("db-connect-timeout", String.class)
+            .category(OptionCategory.DATABASE)
+            .description("Sets the default database connection timeout. " +
+                    "The value is applied to the JDBC driver (vendor-specific property) and also sets " +
+                    "'quarkus.datasource.jdbc.login-timeout'. " +
+                    "If the timeout is already set explicitly in 'db-url' or 'db-url-properties', it is not overridden. " +
+                    DURATION_DESCRIPTION)
+            .defaultValue("10")
+            .build();
+
     public static final Option<String> DB_TLS_MODE = new OptionBuilder<>("db-tls-mode", String.class)
             .category(OptionCategory.DATABASE)
             .expectedValues(Arrays.stream(DatabaseTlsMode.values()).map(DatabaseTlsMode::toCliValue).toList())

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -64,14 +64,11 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.
 public final class DatabasePropertyMappers implements PropertyMapperGrouping {
     public static final String PG_TARGET_SERVER_TYPE = "quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType";
     public static final String MSSQL_SEND_STRING_PARAMETER_AS_UNICODE = "quarkus.datasource.jdbc.additional-jdbc-properties.sendStringParametersAsUnicode";
-    public static final String MYSQL_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
-    public static final String MARIADB_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
+    // Shared constant for drivers that use "connectTimeout" as the JDBC property name (MySQL, MariaDB, PostgreSQL, TiDB)
+    public static final String CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
     public static final String ORACLEDB_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.oracle.net.CONNECT_TIMEOUT";
     public static final String MSSQL_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.loginTimeout";
-    private static final String POSTGRES_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
-    private static final String TIDB_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
     public static final String JDBC_LOGIN_TIMEOUT = "quarkus.datasource.jdbc.login-timeout";
-    //quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout"
 
     private static final Logger log = Logger.getLogger(DatabasePropertyMappers.class);
 
@@ -114,49 +111,42 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 fromOption(DatabaseOptions.DB_CONNECT_TIMEOUT)
                         .to(JDBC_LOGIN_TIMEOUT)
                         .validator(DatabasePropertyMappers::validateConnectTimeout)
-                        .transformer((value, context) -> String.valueOf(DurationConverter.parseDuration(value).getSeconds()))
                         .paramLabel("timeout")
                         .build(),
                 fromOption(DatabaseOptions.DB_MYSQL_CONNECT_TIMEOUT)
-                        .to(MYSQL_CONNECT_TIMEOUT)
+                        .to(CONNECT_TIMEOUT)
                         .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
-                                -> value == null ? null
-                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
+                                -> durationToMillis(value))
                         .isEnabled(DatabasePropertyMappers::isMysqlConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_MARIADB_CONNECT_TIMEOUT)
-                        .to(MARIADB_CONNECT_TIMEOUT)
+                        .to(CONNECT_TIMEOUT)
                         .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
-                                -> value == null ? null
-                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
+                                -> durationToMillis(value))
                         .isEnabled(DatabasePropertyMappers::isMariadbConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_ORACLE_CONNECT_TIMEOUT)
                         .to(ORACLEDB_CONNECT_TIMEOUT)
                         .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
-                                -> value == null ? null
-                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
+                                -> durationToMillis(value))
                         .isEnabled(DatabasePropertyMappers::isOracleConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_MSSQL_CONNECT_TIMEOUT)
                         .to(MSSQL_CONNECT_TIMEOUT)
                         .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
-                                -> value == null ? null
-                                : String.valueOf(DurationConverter.parseDuration(value).getSeconds()))
+                                -> durationToSeconds(value))
                         .isEnabled(DatabasePropertyMappers::isMssqlLoginTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_POSTGRES_CONNECT_TIMEOUT)
-                        .to(POSTGRES_CONNECT_TIMEOUT)
+                        .to(CONNECT_TIMEOUT)
                         .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
-                                -> value == null ? null
-                                : String.valueOf(DurationConverter.parseDuration(value).getSeconds()))
+                                -> durationToSeconds(value))
                         .isEnabled(DatabasePropertyMappers::isPostgresConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_TIDB_CONNECT_TIMEOUT)
-                        .to(TIDB_CONNECT_TIMEOUT)
+                        .to(CONNECT_TIMEOUT)
                         .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
-                                -> value == null ? null
-                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
+                                -> durationToMillis(value))
                         .isEnabled(DatabasePropertyMappers::isTidbConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_URL_HOST)
@@ -252,7 +242,7 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 setInputTlsJdbcProperty(DB_PROPERTY_TRUST_CERTIFICATE_KEY_STORE_PASSWORD, DB_TLS_TRUST_STORE_PASSWORD, "trustCertificateKeyStorePassword", EnumSet.of(Database.Vendor.MYSQL, Database.Vendor.TIDB)),
                 setInputTlsJdbcProperty(DB_PROPERTY_SERVER_SSL_CERT, DB_TLS_TRUST_STORE_FILE, "serverSslCert", EnumSet.of(Database.Vendor.MARIADB)),
 
-                // PosgreSQL
+                // PostgreSQL
                 setTlsJdbcProperty(DatabaseOptions.DB_PROPERTY_SSLMODE, "sslmode", Map.of(Database.Vendor.POSTGRES, "verify-full")),
                 fromOption(DB_PROPERTY_SSLFACTORY)
                         .mapFrom(DB)
@@ -380,6 +370,14 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
         return !dbUrl.contains(timeoutProperty) && !dbUrlProperties.contains(timeoutProperty);
     }
 
+    private static String durationToMillis(String value) {
+        return String.valueOf(DurationConverter.parseDuration(value).toMillis());
+    }
+
+    private static String durationToSeconds(String value) {
+        return String.valueOf(DurationConverter.parseDuration(value).getSeconds());
+    }
+
     /**
      * Starting with H2 version 2.x, marking "VALUE" as a non-keyword is necessary as some columns are named "VALUE" in the Keycloak schema.
      * <p />
@@ -422,7 +420,7 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
         String url = Database.getDefaultUrl(name, value).orElse(null);
         if (isDevModeDatabase(value)) {
             String key = Optional.ofNullable(name).map(
-                    n -> DatabaseOptions.Datasources.getNamedKey(DatabaseOptions.DB_URL_PROPERTIES, n).orElseThrow())
+                            n -> DatabaseOptions.Datasources.getNamedKey(DatabaseOptions.DB_URL_PROPERTIES, n).orElseThrow())
                     .orElse(DatabaseOptions.DB_URL_PROPERTIES.getKey());
             String urlProps = Configuration.getKcConfigValue(key).getValue();
             if (urlProps != null) {
@@ -653,8 +651,8 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
     private static void validateConnectTimeout(String value) {
         try {
             Duration duration = DurationConverter.parseDuration(value);
-            if (duration == null || duration.isNegative() || duration.isZero()) {
-                throw new PropertyException("Invalid duration '%s' for option '%s'. Duration must be positive."
+            if (duration == null || duration.isNegative()) {
+                throw new PropertyException("Invalid duration '%s' for option '%s'. Duration must be non-negative."
                         .formatted(value, DatabaseOptions.DB_CONNECT_TIMEOUT.getKey()));
             }
         } catch (IllegalArgumentException e) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -64,7 +64,6 @@ import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.
 public final class DatabasePropertyMappers implements PropertyMapperGrouping {
     public static final String PG_TARGET_SERVER_TYPE = "quarkus.datasource.jdbc.additional-jdbc-properties.targetServerType";
     public static final String MSSQL_SEND_STRING_PARAMETER_AS_UNICODE = "quarkus.datasource.jdbc.additional-jdbc-properties.sendStringParametersAsUnicode";
-    // Shared constant for drivers that use "connectTimeout" as the JDBC property name (MySQL, MariaDB, PostgreSQL, TiDB)
     public static final String CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
     public static final String ORACLEDB_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.oracle.net.CONNECT_TIMEOUT";
     public static final String MSSQL_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.loginTimeout";
@@ -375,7 +374,7 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
     }
 
     private static String durationToSeconds(String value) {
-        return String.valueOf(DurationConverter.parseDuration(value).getSeconds());
+        return String.valueOf(DurationConverter.parseDuration(value).toSeconds());
     }
 
     /**

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -1,5 +1,6 @@
 package org.keycloak.quarkus.runtime.configuration.mappers;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -10,11 +11,13 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.keycloak.common.util.DurationConverter;
 import org.keycloak.config.CachingOptions;
 import org.keycloak.config.CachingOptions.Stack;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.Option;
 import org.keycloak.config.OptionBuilder;
+import org.keycloak.config.OptionsUtil;
 import org.keycloak.config.TransactionOptions;
 import org.keycloak.config.database.Database;
 import org.keycloak.quarkus.runtime.cli.Picocli;
@@ -67,6 +70,8 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
     public static final String MSSQL_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.loginTimeout";
     private static final String POSTGRES_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
     private static final String TIDB_CONNECT_TIMEOUT = "quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout";
+    public static final String JDBC_LOGIN_TIMEOUT = "quarkus.datasource.jdbc.login-timeout";
+    //quarkus.datasource.jdbc.additional-jdbc-properties.connectTimeout"
 
     private static final Logger log = Logger.getLogger(DatabasePropertyMappers.class);
 
@@ -106,28 +111,52 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                         .to(MSSQL_SEND_STRING_PARAMETER_AS_UNICODE)
                         .isEnabled(DatabasePropertyMappers::isMssqlSendStringParametersAsUnicode)
                         .build(),
+                fromOption(DatabaseOptions.DB_CONNECT_TIMEOUT)
+                        .to(JDBC_LOGIN_TIMEOUT)
+                        .validator(DatabasePropertyMappers::validateConnectTimeout)
+                        .transformer((value, context) -> String.valueOf(DurationConverter.parseDuration(value).getSeconds()))
+                        .paramLabel("timeout")
+                        .build(),
                 fromOption(DatabaseOptions.DB_MYSQL_CONNECT_TIMEOUT)
                         .to(MYSQL_CONNECT_TIMEOUT)
+                        .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
+                                -> value == null ? null
+                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
                         .isEnabled(DatabasePropertyMappers::isMysqlConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_MARIADB_CONNECT_TIMEOUT)
                         .to(MARIADB_CONNECT_TIMEOUT)
+                        .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
+                                -> value == null ? null
+                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
                         .isEnabled(DatabasePropertyMappers::isMariadbConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_ORACLE_CONNECT_TIMEOUT)
                         .to(ORACLEDB_CONNECT_TIMEOUT)
+                        .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
+                                -> value == null ? null
+                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
                         .isEnabled(DatabasePropertyMappers::isOracleConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_MSSQL_CONNECT_TIMEOUT)
                         .to(MSSQL_CONNECT_TIMEOUT)
+                        .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
+                                -> value == null ? null
+                                : String.valueOf(DurationConverter.parseDuration(value).getSeconds()))
                         .isEnabled(DatabasePropertyMappers::isMssqlLoginTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_POSTGRES_CONNECT_TIMEOUT)
                         .to(POSTGRES_CONNECT_TIMEOUT)
+                        .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
+                                -> value == null ? null
+                                : String.valueOf(DurationConverter.parseDuration(value).getSeconds()))
                         .isEnabled(DatabasePropertyMappers::isPostgresConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_TIDB_CONNECT_TIMEOUT)
                         .to(TIDB_CONNECT_TIMEOUT)
+                        .mapFrom(DatabaseOptions.DB_CONNECT_TIMEOUT, (name, value, context)
+                                -> value == null ? null
+                                : String.valueOf(DurationConverter.parseDuration(value).toMillis()))
                         .isEnabled(DatabasePropertyMappers::isTidbConnectTimeoutEnabled)
                         .build(),
                 fromOption(DatabaseOptions.DB_URL_HOST)
@@ -619,6 +648,19 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 getNamedKey(DB_TLS_TRUST_STORE_FILE, datasource);
         return option.map(Configuration::getKcConfigValue)
                 .map(ConfigValue::getValue);
+    }
+
+    private static void validateConnectTimeout(String value) {
+        try {
+            Duration duration = DurationConverter.parseDuration(value);
+            if (duration == null || duration.isNegative() || duration.isZero()) {
+                throw new PropertyException("Invalid duration '%s' for option '%s'. Duration must be positive."
+                        .formatted(value, DatabaseOptions.DB_CONNECT_TIMEOUT.getKey()));
+            }
+        } catch (IllegalArgumentException e) {
+            throw new PropertyException("Invalid duration format '%s' for option '%s'. %s"
+                    .formatted(value, DatabaseOptions.DB_CONNECT_TIMEOUT.getKey(), OptionsUtil.DURATION_DESCRIPTION));
+        }
     }
 
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -298,8 +298,8 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertThat(nonRunningPicocli.getErrString(),
                 containsString(Help.defaultColorScheme(nonRunningPicocli.getColorMode())
                         .errorText("Unknown option: '--db-pasword'").toString()));
-        assertThat(nonRunningPicocli.getErrString(),
-                containsString("Possible solutions: --db-url, --db-connect-timeout, --db-url-host, --db-url-database, --db-url-port, --db-url-properties, --db-username, --db-password, --db-schema, --db-pool-initial-size, --db-pool-min-size, --db-pool-max-size, --db-pool-max-lifetime, --db-debug-jpql"));
+        assertThat(nonRunningPicocli.getErrString(), containsString(
+                "Possible solutions: --db-url, --db-connect-timeout, --db-url-host, --db-url-database, --db-url-port, --db-url-properties, --db-username, --db-password, --db-schema, --db-pool-initial-size, --db-pool-min-size, --db-pool-max-size, --db-pool-max-lifetime, --db-debug-jpql, --db-log-slow-queries-threshold, --db-tls-mode, --db-tls-trust-store-file, --db-tls-trust-store-type, --db-tls-trust-store-password, --db-driver, --db, --db-url-full-<datasource>, --db-url-host-<datasource>, --db-url-database-<datasource>, --db-url-port-<datasource>, --db-url-properties-<datasource>, --db-username-<datasource>, --db-password-<datasource>, --db-schema-<datasource>, --db-pool-initial-size-<datasource>, --db-pool-min-size-<datasource>, --db-pool-max-size-<datasource>, --db-debug-jpql-<datasource>, --db-log-slow-queries-threshold-<datasource>, --db-tls-mode-<datasource>, --db-tls-trust-store-file-<datasource>, --db-tls-trust-store-type-<datasource>, --db-tls-trust-store-password-<datasource>, --db-enabled-<datasource>, --db-driver-<datasource>, --db-kind-<datasource>"));
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -298,8 +298,8 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertThat(nonRunningPicocli.getErrString(),
                 containsString(Help.defaultColorScheme(nonRunningPicocli.getColorMode())
                         .errorText("Unknown option: '--db-pasword'").toString()));
-        assertThat(nonRunningPicocli.getErrString(), containsString(
-                "Possible solutions: --db-url, --db-url-host, --db-url-database, --db-url-port, --db-url-properties, --db-username, --db-password, --db-schema, --db-pool-initial-size, --db-pool-min-size, --db-pool-max-size, --db-pool-max-lifetime, --db-debug-jpql, --db-log-slow-queries-threshold, --db-tls-mode, --db-tls-trust-store-file, --db-tls-trust-store-type, --db-tls-trust-store-password, --db-driver, --db, --db-url-full-<datasource>, --db-url-host-<datasource>, --db-url-database-<datasource>, --db-url-port-<datasource>, --db-url-properties-<datasource>, --db-username-<datasource>, --db-password-<datasource>, --db-schema-<datasource>, --db-pool-initial-size-<datasource>, --db-pool-min-size-<datasource>, --db-pool-max-size-<datasource>, --db-debug-jpql-<datasource>, --db-log-slow-queries-threshold-<datasource>, --db-tls-mode-<datasource>, --db-tls-trust-store-file-<datasource>, --db-tls-trust-store-type-<datasource>, --db-tls-trust-store-password-<datasource>, --db-enabled-<datasource>, --db-driver-<datasource>, --db-kind-<datasource>"));
+        assertThat(nonRunningPicocli.getErrString(),
+                containsString("Possible solutions: --db-url, --db-connect-timeout, --db-url-host, --db-url-database, --db-url-port, --db-url-properties, --db-username, --db-password, --db-schema, --db-pool-initial-size, --db-pool-min-size, --db-pool-max-size, --db-pool-max-lifetime, --db-debug-jpql"));
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -30,8 +30,10 @@ import java.util.stream.StreamSupport;
 import org.keycloak.Config;
 import org.keycloak.config.CachingOptions;
 import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.cli.command.Start;
 import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 import org.keycloak.quarkus.runtime.configuration.mappers.HttpPropertyMappers;
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMappers;
 import org.keycloak.quarkus.runtime.vault.FilesKeystoreVaultProviderFactory;
 import org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory;
 import org.keycloak.spi.infinispan.CacheEmbeddedConfigProviderSpi;
@@ -837,62 +839,117 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void testDefaultDatabaseConnectTimeouts() {
-        // MySQL: connectTimeout in milliseconds
+        //MySQL:
         ConfigArgsConfigSource.setCliArgs("--db=mysql");
         SmallRyeConfig config = createConfig();
         assertTrue(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
         assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+        createConfigFromCliArguments("--db=mysql", "--db-url-properties=?connectTimeout=5000");
+        assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
+        createConfigFromCliArguments("--db=mysql", "--db-url=jdbc:mysql://localhost:3306/keycloak?connectTimeout=5000");
+        assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
 
-        // MySQL: custom timeout in milliseconds
-        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-connect-timeout=30s");
-        config = createConfig();
+        config = createConfigFromCliArguments("--db=mysql", "--db-connect-timeout=30s");
         assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
         assertEquals("30s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        // MySQL: connectTimeout already set in db-url-properties -> disabled
-        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-url-properties=?connectTimeout=5000");
-        config = createConfig();
-        assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
-
-        // MySQL: connectTimeout already set in db-url -> disabled
-        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-url=jdbc:mysql://localhost/keycloak?connectTimeout=5000");
-        config = createConfig();
-        assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
-
-        // MariaDB: connectTimeout in milliseconds
+        // MariaDB:
         ConfigArgsConfigSource.setCliArgs("--db=mariadb");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        // Oracle: connectTimeout in milliseconds
+        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-url=jdbc:mariadb://localhost:3306/keycloak?connectTimeout=5000");
+        config = createConfig();
+        assertFalse(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
+
+        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-url-properties=?connectTimeout=5000");
+        config = createConfig();
+        assertFalse(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
+
+        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
+        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("30s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+
+        // Oracle:
         ConfigArgsConfigSource.setCliArgs("--db=oracle");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.ORACLEDB_CONNECT_TIMEOUT).getValue());
+        assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        // MSSQL: loginTimeout in seconds
+        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-url-properties=?oracle.net.CONNECT_TIMEOUT=5000");
+        config = createConfig();
+        assertFalse(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
+        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-url=jdbc:oracle:thin:@//localhost:1521/keycloak?oracle.net.CONNECT_TIMEOUT=5000");
+        config = createConfig();
+        assertFalse(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
+
+        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
+        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.ORACLEDB_CONNECT_TIMEOUT).getValue());
+        assertEquals("30s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+
+        // MSSQL:
         ConfigArgsConfigSource.setCliArgs("--db=mssql");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
         assertEquals("10", config.getConfigValue(DatabasePropertyMappers.MSSQL_CONNECT_TIMEOUT).getValue());
-
-        // PostgreSQL: connectTimeout in seconds
-        ConfigArgsConfigSource.setCliArgs("--db=postgres");
-        config = createConfig();
-        assertTrue(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
-        assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
         assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        // PostgreSQL: connectTimeout already set in db-url-properties -> disabled
-        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url-properties=?connectTimeout=5");
+        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url-properties=;loginTimeout=20");
         config = createConfig();
+        assertFalse(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
+
+        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url=jdbc:sqlserver://localhost:1433;databaseName=keycloak;loginTimeout=20");
+        config = createConfig();
+        assertFalse(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
+        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.MSSQL_CONNECT_TIMEOUT).getValue());
+        assertEquals("30s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+
+        // PostgreSQL:
+        resetConfiguration();
+        ConfigArgsConfigSource.setCliArgs("--db=postgres");
+        createConfig();
+        PropertyMappers.sanitizeDisabledMappers(new Start());
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
+        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+
+        resetConfiguration();
+        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url-properties=?connectTimeout=5");
+        createConfig();
+        PropertyMappers.sanitizeDisabledMappers(new Start());
         assertFalse(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
 
-        // custom JDBC driver -> disabled
-        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-driver=software.amazon.jdbc.Driver");
-        config = createConfig();
+        resetConfiguration();
+        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url=jdbc:postgresql://localhost:5432/keycloak?connectTimeout=5");
+        createConfig();
+        PropertyMappers.sanitizeDisabledMappers(new Start());
         assertFalse(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
+
+        resetConfiguration();
+        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-driver=software.amazon.jdbc.Driver");
+        createConfig();
+        PropertyMappers.sanitizeDisabledMappers(new Start());
+        assertFalse(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
+
+        resetConfiguration();
+        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-connect-timeout=30s");
+        createConfig();
+        PropertyMappers.sanitizeDisabledMappers(new Start());
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("30s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
     }
 }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -838,38 +838,50 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void testDefaultDatabaseConnectTimeouts() {
-
+        //MySQL:
         ConfigArgsConfigSource.setCliArgs("--db=mysql");
         SmallRyeConfig config = createConfig();
         assertTrue(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.MYSQL_CONNECT_TIMEOUT).getValue());
+        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-url-properties=?connectTimeout=5000");
-        config = createConfig();
+        // used createConfigFromCliArguments() so config,static state are both refreshed and resets the static state.
+        createConfigFromCliArguments("--db=mysql", "--db-url-properties=?connectTimeout=5000");
         assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
 
-        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-url=jdbc:mysql://localhost:3306/keycloak?connectTimeout=5000");
-        config = createConfig();
+        createConfigFromCliArguments("--db=mysql", "--db-url=jdbc:mysql://localhost:3306/keycloak?connectTimeout=5000");
         assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
+
+        config = createConfigFromCliArguments("--db=mysql", "--db-connect-timeout=30s");
+        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.MYSQL_CONNECT_TIMEOUT).getValue());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=mariadb");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.MARIADB_CONNECT_TIMEOUT).getValue());
+        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-url=jdbc:mariadb://localhost:3306/keycloak?connectTimeout=5000");
         config = createConfig();
         assertFalse(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
 
-        // MariaDB: connectTimeout
+        // MariaDB:
         ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-url-properties=?connectTimeout=5000");
         config = createConfig();
         assertFalse(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
+        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
+        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.MARIADB_CONNECT_TIMEOUT).getValue());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
+        // Oracle:
         ConfigArgsConfigSource.setCliArgs("--db=oracle");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.ORACLEDB_CONNECT_TIMEOUT).getValue());
+        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-url-properties=?oracle.net.CONNECT_TIMEOUT=5000");
         config = createConfig();
@@ -879,10 +891,18 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         config = createConfig();
         assertFalse(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
 
+        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
+        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.ORACLEDB_CONNECT_TIMEOUT).getValue());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+
+        // MSSQL:
         ConfigArgsConfigSource.setCliArgs("--db=mssql");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
         assertEquals("10", config.getConfigValue(DatabasePropertyMappers.MSSQL_CONNECT_TIMEOUT).getValue());
+        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
         ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url-properties=;loginTimeout=20");
         config = createConfig();
@@ -891,5 +911,11 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url=jdbc:sqlserver://localhost:1433;databaseName=keycloak;loginTimeout=20");
         config = createConfig();
         assertFalse(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
+        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertTrue(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.MSSQL_CONNECT_TIMEOUT).getValue());
+        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
     }
-}
+    }
+

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -882,7 +882,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db=postgres");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
-        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
         assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
         // PostgreSQL: connectTimeout already set in db-url-properties -> disabled

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -326,7 +326,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url=jdbc:postgresql://localhost/keycloak", "--db-username=postgres");
         SmallRyeConfig config = createConfig();
         assertEquals("org.hibernate.dialect.PostgreSQLDialect",
-            config.getConfigValue("kc.db-dialect").getValue());
+                config.getConfigValue("kc.db-dialect").getValue());
         assertEquals("jdbc:postgresql://localhost/keycloak", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("postgresql", config.getConfigValue("quarkus.datasource.db-kind").getValue());
         assertEquals("postgres", config.getConfigValue("quarkus.datasource.username").getValue());
@@ -370,6 +370,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertEquals("jdbc:mariadb://localhost/keycloak", config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertEquals("mariadb", config.getConfigValue("quarkus.datasource.db-kind").getValue());
     }
+
     @Test
     public void testDatabaseProperties() {
         System.setProperty("kc.db-url-properties", ";;test=test;test1=test1");
@@ -455,7 +456,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void testNestedDatabaseProperties() {
         SmallRyeConfig config = createConfig();
-        assertEquals("jdbc:h2:file:"+Environment.getHomeDir().orElseThrow()+"/data/keycloakdb", config.getConfigValue("quarkus.datasource.foo").getValue());
+        assertEquals("jdbc:h2:file:" + Environment.getHomeDir().orElseThrow() + "/data/keycloakdb", config.getConfigValue("quarkus.datasource.foo").getValue());
 
         Assert.assertEquals("foo-def-suffix", config.getConfigValue("quarkus.datasource.bar").getValue());
 
@@ -598,7 +599,7 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void testKeystoreConfigSourcePropertyMapping() {
         SmallRyeConfig config = createConfig();
-        assertEquals(config.getConfigValue("smallrye.config.source.keystore.kc-default.password").getValue(),config.getConfigValue("kc.config-keystore-password").getValue());
+        assertEquals(config.getConfigValue("smallrye.config.source.keystore.kc-default.password").getValue(), config.getConfigValue("kc.config-keystore-password").getValue());
         // Properties are loaded from the file - secret can be obtained only if the mapping works correctly
         ConfigValue secret = config.getConfigValue("my.secret");
         assertEquals("secret", secret.getValue());
@@ -653,8 +654,8 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     public void testCacheMaxCount() {
         int maxCount = 500;
         Set<String> maxCountCaches = Stream.of(CachingOptions.LOCAL_MAX_COUNT_CACHES, CachingOptions.CLUSTERED_MAX_COUNT_CACHES)
-              .flatMap(Arrays::stream)
-              .collect(Collectors.toSet());
+                .flatMap(Arrays::stream)
+                .collect(Collectors.toSet());
 
         StringBuilder sb = new StringBuilder();
         for (String cache : maxCountCaches) {
@@ -775,14 +776,12 @@ public class ConfigurationTest extends AbstractConfigurationTest {
                                                 String trustStoreTypeProperty) {
         var config = createConfigFromCliArguments("--db=" + dbKind, "--db-url-host=myhost", "--db-tls-mode=disabled");
 
-
         assertEquals(dbUrl, config.getConfigValue("quarkus.datasource.jdbc.url").getValue());
         assertNullAllAdditionalJdbcProperty(config, null, tlsJdbcProperties.keySet());
         assertNullAllAdditionalJdbcProperty(config, null, withJavaTrustStoreJdbcProperties.keySet());
         assertNullAdditionalJdbcProperty(config, null, truststoreFileProperty);
         assertNullAdditionalJdbcProperty(config, null, trustStorePasswordProperty);
         assertNullAdditionalJdbcProperty(config, null, trustStoreTypeProperty);
-
 
         // oracle has a different protocol for TLS
         if ("oracle".equals(dbKind)) {
@@ -838,82 +837,62 @@ public class ConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void testDefaultDatabaseConnectTimeouts() {
-        //MySQL:
+        // MySQL: connectTimeout in milliseconds
         ConfigArgsConfigSource.setCliArgs("--db=mysql");
         SmallRyeConfig config = createConfig();
         assertTrue(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
-        assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.MYSQL_CONNECT_TIMEOUT).getValue());
-        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+        assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        // used createConfigFromCliArguments() so config,static state are both refreshed and resets the static state.
-        createConfigFromCliArguments("--db=mysql", "--db-url-properties=?connectTimeout=5000");
+        // MySQL: custom timeout in milliseconds
+        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-connect-timeout=30s");
+        config = createConfig();
+        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("30s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+
+        // MySQL: connectTimeout already set in db-url-properties -> disabled
+        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-url-properties=?connectTimeout=5000");
+        config = createConfig();
         assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
 
-        createConfigFromCliArguments("--db=mysql", "--db-url=jdbc:mysql://localhost:3306/keycloak?connectTimeout=5000");
+        // MySQL: connectTimeout already set in db-url -> disabled
+        ConfigArgsConfigSource.setCliArgs("--db=mysql", "--db-url=jdbc:mysql://localhost/keycloak?connectTimeout=5000");
+        config = createConfig();
         assertFalse(DatabasePropertyMappers.isMysqlConnectTimeoutEnabled());
 
-        config = createConfigFromCliArguments("--db=mysql", "--db-connect-timeout=30s");
-        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.MYSQL_CONNECT_TIMEOUT).getValue());
-        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+        // MariaDB: connectTimeout in milliseconds
         ConfigArgsConfigSource.setCliArgs("--db=mariadb");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
-        assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.MARIADB_CONNECT_TIMEOUT).getValue());
-        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+        assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
 
-        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-url=jdbc:mariadb://localhost:3306/keycloak?connectTimeout=5000");
-        config = createConfig();
-        assertFalse(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
-
-        // MariaDB:
-        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-url-properties=?connectTimeout=5000");
-        config = createConfig();
-        assertFalse(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
-        ConfigArgsConfigSource.setCliArgs("--db=mariadb", "--db-connect-timeout=30s");
-        config = createConfig();
-        assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
-        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.MARIADB_CONNECT_TIMEOUT).getValue());
-        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
-
-        // Oracle:
+        // Oracle: connectTimeout in milliseconds
         ConfigArgsConfigSource.setCliArgs("--db=oracle");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
         assertEquals("10000", config.getConfigValue(DatabasePropertyMappers.ORACLEDB_CONNECT_TIMEOUT).getValue());
-        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-url-properties=?oracle.net.CONNECT_TIMEOUT=5000");
-        config = createConfig();
-        assertFalse(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
-
-        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-url=jdbc:oracle:thin:@//localhost:1521/keycloak?oracle.net.CONNECT_TIMEOUT=5000");
-        config = createConfig();
-        assertFalse(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
-
-        ConfigArgsConfigSource.setCliArgs("--db=oracle", "--db-connect-timeout=30s");
-        config = createConfig();
-        assertTrue(DatabasePropertyMappers.isOracleConnectTimeoutEnabled());
-        assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.ORACLEDB_CONNECT_TIMEOUT).getValue());
-        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
-
-        // MSSQL:
+        // MSSQL: loginTimeout in seconds
         ConfigArgsConfigSource.setCliArgs("--db=mssql");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
         assertEquals("10", config.getConfigValue(DatabasePropertyMappers.MSSQL_CONNECT_TIMEOUT).getValue());
-        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url-properties=;loginTimeout=20");
+        // PostgreSQL: connectTimeout in seconds
+        ConfigArgsConfigSource.setCliArgs("--db=postgres");
         config = createConfig();
-        assertFalse(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
+        assertTrue(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
+        assertEquals("10", config.getConfigValue(DatabasePropertyMappers.CONNECT_TIMEOUT).getValue());
+        assertEquals("10s", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
 
-        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-url=jdbc:sqlserver://localhost:1433;databaseName=keycloak;loginTimeout=20");
+        // PostgreSQL: connectTimeout already set in db-url-properties -> disabled
+        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-url-properties=?connectTimeout=5");
         config = createConfig();
-        assertFalse(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
-        ConfigArgsConfigSource.setCliArgs("--db=mssql", "--db-connect-timeout=30s");
+        assertFalse(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
+
+        // custom JDBC driver -> disabled
+        ConfigArgsConfigSource.setCliArgs("--db=postgres", "--db-driver=software.amazon.jdbc.Driver");
         config = createConfig();
-        assertTrue(DatabasePropertyMappers.isMssqlLoginTimeoutEnabled());
-        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.MSSQL_CONNECT_TIMEOUT).getValue());
-        assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
+        assertFalse(DatabasePropertyMappers.isPostgresConnectTimeoutEnabled());
     }
-    }
+}

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -855,7 +855,6 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         config = createConfigFromCliArguments("--db=mysql", "--db-connect-timeout=30s");
         assertEquals("30000", config.getConfigValue(DatabasePropertyMappers.MYSQL_CONNECT_TIMEOUT).getValue());
         assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
-
         ConfigArgsConfigSource.setCliArgs("--db=mariadb");
         config = createConfig();
         assertTrue(DatabasePropertyMappers.isMariadbConnectTimeoutEnabled());
@@ -918,4 +917,3 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertEquals("30", config.getConfigValue(DatabasePropertyMappers.JDBC_LOGIN_TIMEOUT).getValue());
     }
     }
-

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -35,12 +35,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -34,6 +34,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -36,6 +36,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -37,12 +37,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -30,12 +30,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -29,6 +29,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -30,12 +30,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -29,6 +29,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -30,12 +30,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -29,6 +29,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -30,12 +30,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -29,6 +29,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -78,12 +78,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -77,6 +77,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -147,6 +147,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -148,12 +148,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -125,6 +125,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -126,12 +126,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -149,12 +149,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -148,6 +148,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -121,6 +121,13 @@ Config:
 
 Database:
 
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -122,12 +122,9 @@ Config:
 Database:
 
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -145,12 +145,9 @@ Config:
 Database:
 
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -144,6 +144,13 @@ Config:
 
 Database:
 
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -124,6 +124,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -125,12 +125,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -147,6 +147,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -148,12 +148,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -123,12 +123,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -122,6 +122,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -146,12 +146,9 @@ Database:
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
 --db-connect-timeout <timeout>
-                     Sets the default database connection timeout. The value is applied to the JDBC
-                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
-                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
-                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
-                       value, an integer number of seconds, or an integer followed by one of [ms,
-                       h, m, s, d]. Default: 10.
+                     Sets the JDBC driver connection timeout and login timeout. May be an ISO 8601
+                       duration value, an integer number of seconds, or an integer followed by one
+                       of [ms, h, m, s, d]. Default: 10s.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -145,6 +145,13 @@ Database:
                        deprecated, you should explicitly specify the db instead. Possible values
                        are: dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.
                        Default: dev-file.
+--db-connect-timeout <timeout>
+                     Sets the default database connection timeout. The value is applied to the JDBC
+                       driver (vendor-specific property) and also sets 'quarkus.datasource.jdbc.
+                       login-timeout'. If the timeout is already set explicitly in 'db-url' or
+                       'db-url-properties', it is not overridden. May be an ISO 8601 duration
+                       value, an integer number of seconds, or an integer followed by one of [ms,
+                       h, m, s, d]. Default: 10.
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.


### PR DESCRIPTION

Closes #47140

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
