### PR TITLE
Fix NPE in ClientSecretRotationContext when client policy with client-updater-context exists

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/ClientSecretRotationContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/ClientSecretRotationContext.java
@@ -3,6 +3,7 @@ package org.keycloak.services.clientpolicy.context;
 import org.keycloak.models.ClientModel;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
+import org.keycloak.services.resources.admin.AdminAuth;
 import org.keycloak.utils.StringUtil;
 
 public class ClientSecretRotationContext extends AdminClientUpdateContext {
@@ -10,8 +11,8 @@ public class ClientSecretRotationContext extends AdminClientUpdateContext {
     private final String currentSecret;
 
     public ClientSecretRotationContext(ClientRepresentation proposedClientRepresentation,
-                                       ClientModel targetClient, String currentSecret) {
-        super(proposedClientRepresentation, targetClient, null);
+                                       ClientModel targetClient, String currentSecret, AdminAuth adminAuth) {
+        super(proposedClientRepresentation, targetClient, adminAuth);
         this.currentSecret = currentSecret;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -301,7 +301,7 @@ public class ClientResource {
 
             ClientRepresentation representation = ModelToRepresentation.toRepresentation(client, session);
             ClientSecretRotationContext secretRotationContext = new ClientSecretRotationContext(
-                representation, client, client.getSecret());
+                representation, client, client.getSecret(), auth.adminAuth());
 
             String secret = KeycloakModelUtils.generateSecret(client);
 


### PR DESCRIPTION
Closes #47063

## Problem

When a Client Policy using the `client-updater-context` condition is active, regenerating a client secret from the Admin UI throws a `NullPointerException`:

```
Cannot invoke "org.keycloak.services.resources.admin.AdminAuth.getToken()" because "this.adminAuth" is null
```

## Root Cause

`ClientSecretRotationContext` passes `null` for the `AdminAuth` parameter to its parent `AdminClientUpdateContext` constructor:

```java
public ClientSecretRotationContext(..., String currentSecret) {
    super(proposedClientRepresentation, targetClient, null);  // null adminAuth
    ...
}
```

When `ClientUpdaterContextCondition.applyPolicy()` evaluates the `UPDATED` event, it casts the context to `ClientCRUDContext` and calls `getToken()`, which delegates to `adminAuth.getToken()` — but `adminAuth` is `null`.

This is inconsistent with how all other admin CRUD contexts are constructed in `ClientResource`. For example, the normal client update path at `ClientResource.updateClient()` correctly passes `auth.adminAuth()`:

```java
session.clientPolicy().triggerOnEvent(new AdminClientUpdateContext(rep, client, auth.adminAuth()));
```

## Fix

- Add `AdminAuth` parameter to `ClientSecretRotationContext` constructor, pass it to the parent instead of `null`
- Pass `auth.adminAuth()` from `ClientResource.regenerateSecret()` when constructing the context

This is consistent with how all other admin CRUD contexts are built in `ClientResource`.

**AI agent disclosure**: An AI coding assistant was used to help locate the root cause and draft this fix.