### PR TITLE
[OID4VCI] Secure-by-Default and Default Disablement of Pre-Authorized…

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -129,6 +129,7 @@ public class Profile {
         PERSISTENT_USER_SESSIONS("Persistent online user sessions across restarts and upgrades", Type.DEFAULT, FeatureUpdatePolicy.SHUTDOWN),
 
         OID4VC_VCI("Support for the OID4VCI protocol as part of OID4VC.", Type.EXPERIMENTAL),
+        OID4VC_VCI_PREAUTH_CODE("Support for credential offers with `pre-authorized_code` grant.", Type.EXPERIMENTAL, OID4VC_VCI),
 
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -349,7 +349,7 @@ public class OID4VCIssuerEndpoint {
     }
 
     /**
-     * Creates a Pre-Authorized offer that is bound to the calling user.
+     * Creates an authorization code grant offer that is bound to the calling user.
      */
     public Response createCredentialOffer(String credConfigId) {
         return createCredentialOffer(credConfigId, false, null);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -352,7 +352,7 @@ public class OID4VCIssuerEndpoint {
      * Creates a Pre-Authorized offer that is bound to the calling user.
      */
     public Response createCredentialOffer(String credConfigId) {
-        return createCredentialOffer(credConfigId, true, null);
+        return createCredentialOffer(credConfigId, false, null);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -402,7 +402,7 @@ public class OID4VCIssuerEndpoint {
      * | Type    | Mime-Type        | Notes                                     |
      * +---------+------------------+-------------------------------------------+
      * | uri     | application/json | JSON document that contains the offer uri |
-     * | uri+qr  | application/json | Same as 'uri' plus url encoded qr-code    |
+     * | uri_qr  | application/json | Same as 'uri' plus url encoded qr-code    |
      * | qr      | image/png        | Credential offer encoded as qr-code image |
      * +---------+------------------+---------+---------------------------------+
      * </p>
@@ -416,7 +416,7 @@ public class OID4VCIssuerEndpoint {
      * @param credentialConfigurationId  A valid credential configuration id
      * @param preAuthorized A flag whether the offer should be pre-authorized
      * @param targetUser    The username that the offer is authorized for
-     * @param expiresAt      The date/time when the offer expires (in Unix timestamp seconds)
+     * @param expiresAt     The date/time when the offer expires (in Unix timestamp seconds)
      * @param responseType  The response type, which can be 'uri', 'qr' or 'uri+qr'
      * @param width         The width of the QR code image
      * @param height        The height of the QR code image
@@ -426,7 +426,7 @@ public class OID4VCIssuerEndpoint {
     @Path(CREATE_CREDENTIAL_OFFER_PATH)
     public Response createCredentialOffer(
             @QueryParam("credential_configuration_id") String credentialConfigurationId,
-            @QueryParam("pre_authorized") @DefaultValue("true") Boolean preAuthorized,
+            @QueryParam("pre_authorized") @DefaultValue("false") Boolean preAuthorized,
             @QueryParam("target_user") String targetUser,
             @QueryParam("expire") Integer expiresAt,
             @QueryParam("type") @DefaultValue("uri") OfferResponseType responseType,

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
@@ -67,7 +67,7 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
         boolean preAuthorized = PRE_AUTH_GRANT_TYPE.equals(grantType);
         if (preAuthorized && !Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_PREAUTH_CODE)) {
             throw new CredentialOfferException(Errors.INVALID_REQUEST,
-                    "OID4VCI pre-authorized code grant offers not enabled. Requires --feature=oid4vc_vci_preauth_code");
+                    "OID4VCI pre-authorized code grant offers not enabled. Requires --feature=oid4vc-vci-preauth-code");
         }
 
         // Ensure at least one credential_configuration_id

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.keycloak.common.Profile;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.events.Errors;
 import org.keycloak.models.KeycloakSession;
@@ -61,6 +62,14 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
             String targetUsername,
             Integer expireAt) {
 
+        // Checks whether `--feature=oid4vc_vci_preauth_code` is enabled
+        //
+        boolean preAuthorized = PRE_AUTH_GRANT_TYPE.equals(grantType);
+        if (preAuthorized && !Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_PREAUTH_CODE)) {
+            throw new CredentialOfferException(Errors.INVALID_REQUEST,
+                    "OID4VCI pre-authorized code grant offers not enabled. Requires --feature=oid4vc_vci_preauth_code");
+        }
+
         // Ensure at least one credential_configuration_id
         //
         if (credentialConfigurationIds == null || credentialConfigurationIds.isEmpty()) {
@@ -96,7 +105,7 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
             return authDetails;
         });
 
-        if (PRE_AUTH_GRANT_TYPE.equals(grantType)) {
+        if (preAuthorized) {
             String code = "urn:oid4vci:code:" + SecretGenerator.getInstance().randomString(64);
             credOffer.addGrant(new PreAuthorizedCodeGrant().setPreAuthorizedCode(code));
         } else {

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -285,13 +285,15 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     private List<String> getGrantTypesSupported() {
 
         KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
-        List<String> supportedGrantTypes = new ArrayList<>(sessionFactory.getProviderFactoriesStream(OAuth2GrantType.class)
-                .map(ProviderFactory::getId)
-                .toList());
+        Stream<String> providerFactoryStream = sessionFactory
+                .getProviderFactoriesStream(OAuth2GrantType.class)
+                .map(ProviderFactory::getId);
 
         // Implicit not available as OAuth2GrantType implementation, but should be included.
         // It is served from OIDC authentication endpoint directly
-        supportedGrantTypes.add(OAuth2Constants.IMPLICIT);
+        List<String> supportedGrantTypes = Stream.concat(providerFactoryStream, Stream.of(OAuth2Constants.IMPLICIT))
+                .sorted().toList();
+
         return supportedGrantTypes;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -44,8 +44,8 @@ import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.RealmModel;
-import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.protocol.oidc.endpoints.TokenEndpoint;
 import org.keycloak.protocol.oidc.grants.OAuth2GrantType;
@@ -283,18 +283,15 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     }
 
     private List<String> getGrantTypesSupported() {
-        List<String> supportedGrantTypes = new ArrayList<>(session.getKeycloakSessionFactory().getProviderFactoriesStream(OAuth2GrantType.class)
+
+        KeycloakSessionFactory sessionFactory = session.getKeycloakSessionFactory();
+        List<String> supportedGrantTypes = new ArrayList<>(sessionFactory.getProviderFactoriesStream(OAuth2GrantType.class)
                 .map(ProviderFactory::getId)
                 .toList());
 
-        // Implicit not available as OAuth2GrantType implementation, but should be included. It is served from OIDC authentication endpoint directly
+        // Implicit not available as OAuth2GrantType implementation, but should be included.
+        // It is served from OIDC authentication endpoint directly
         supportedGrantTypes.add(OAuth2Constants.IMPLICIT);
-
-        // Remove the `pre-authorized_code` grant if not explicitly enabled
-        if (!Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_PREAUTH_CODE)) {
-            supportedGrantTypes.remove(PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE);
-        }
-
         return supportedGrantTypes;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -45,6 +45,7 @@ import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.protocol.oidc.endpoints.TokenEndpoint;
 import org.keycloak.protocol.oidc.grants.OAuth2GrantType;
@@ -282,13 +283,19 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
     }
 
     private List<String> getGrantTypesSupported() {
-        Stream<String> supportedGrantTypes = session.getKeycloakSessionFactory().getProviderFactoriesStream(OAuth2GrantType.class)
-                    .map(ProviderFactory::getId);
+        List<String> supportedGrantTypes = new ArrayList<>(session.getKeycloakSessionFactory().getProviderFactoriesStream(OAuth2GrantType.class)
+                .map(ProviderFactory::getId)
+                .toList());
 
         // Implicit not available as OAuth2GrantType implementation, but should be included. It is served from OIDC authentication endpoint directly
-        return Stream.concat(supportedGrantTypes, Stream.of(OAuth2Constants.IMPLICIT))
-                .sorted()
-                .collect(Collectors.toList());
+        supportedGrantTypes.add(OAuth2Constants.IMPLICIT);
+
+        // Remove the `pre-authorized_code` grant if not explicitly enabled
+        if (!Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_PREAUTH_CODE)) {
+            supportedGrantTypes.remove(PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE);
+        }
+
+        return supportedGrantTypes;
     }
 
     private List<String> getAcrValuesSupported(RealmModel realm) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantTypeFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantTypeFactory.java
@@ -61,7 +61,7 @@ public class PreAuthorizedCodeGrantTypeFactory implements OAuth2GrantTypeFactory
 
     @Override
     public boolean isSupported(Config.Scope config) {
-        return Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI);
+        return Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_PREAUTH_CODE);
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionPreAuthTest.java
@@ -1,0 +1,139 @@
+package org.keycloak.tests.oid4vc;
+
+
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.OID4VCCredentialOfferPage;
+import org.keycloak.tests.common.TestRealmUserConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.events.Details.GRANT_TYPE;
+import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
+import static org.keycloak.tests.oid4vc.OID4VCActionTest.getKcActionParameter;
+import static org.keycloak.tests.oid4vc.OID4VCActionTest.getNonceFromCredentialOfferUri;
+import static org.keycloak.tests.oid4vc.OID4VCActionTest.verifyVCActionCredentialResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled.class)
+public class OID4VCActionPreAuthTest extends OID4VCIssuerTestBase {
+
+    @InjectPage
+    OID4VCCredentialOfferPage credentialOfferPage;
+
+    @InjectUser(config = TestRealmUserConfig.class)
+    ManagedUser user;
+
+    OID4VCTestContext ctx;
+    OID4VCBasicWallet wallet;
+
+    @BeforeEach
+    void beforeEach() {
+        wallet = new OID4VCBasicWallet(keycloak, oauth);
+        ctx = new OID4VCTestContext(client, minimalJwtTypeCredentialScope);
+        user.admin().logout();
+    }
+
+    // Test successful scenario. Client redirects to Keycloak OIDC authentication request with "kc_action" parameter pointing to the
+    // credential-offer, which should be created on Keycloak side. Upon successful authentication of the user, the credential-offer page is displayed
+    // from where user can scan QR-code to his wallet and retrieve OID4 VC. Wallet uses "pre-authorization code"
+    @Test
+    public void testCredentialOfferAIASuccess_preAuthorizedCode() throws Exception {
+
+        var ctx = new OID4VCTestContext(client, minimalJwtTypeCredentialScope);
+
+        // Login as user. Check required-action displayed
+        oauth.client(client.getClientId(), "test-secret");
+        oauth.loginForm()
+                .kcAction(getKcActionParameter(client.getClientId(), minimalJwtTypeCredentialConfigurationIdName, true))
+                .open();
+        oauth.fillLoginForm(user.getUsername(), "password");
+
+        credentialOfferPage.assertCurrent();
+        String credentialOfferUri = credentialOfferPage.getCredentialOfferUri();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .details(Details.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED, String.valueOf(true))
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_USER_ID, user.getId())
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID, client.getClientId())
+                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
+
+        // Refresh screen. Should be still same credential-offer as before and test that there are not new events
+        driver.navigate().refresh();
+        credentialOfferPage.assertCurrent();
+        assertEquals(credentialOfferUri, credentialOfferPage.getCredentialOfferUri());
+
+        String credentialOfferNonce = getNonceFromCredentialOfferUri(credentialOfferUri);
+
+        // Pre-authorized code flow with credential exchange
+        CredentialOfferResponse credentialOfferResponse = oauth.oid4vc()
+                .credentialOfferRequest(credentialOfferNonce)
+                .send();
+        assertEquals(HttpStatus.SC_OK, credentialOfferResponse.getStatusCode());
+        CredentialsOffer credOffer = credentialOfferResponse.getCredentialsOffer();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .type(EventType.VERIFIABLE_CREDENTIAL_OFFER_REQUEST);
+
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode);
+        assertNull(credOffer.getIssuerState());
+
+        // Redeem Pre-Authorized Code for AccessToken
+        //
+        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
+        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken,"No accessToken");
+
+        assertNull(ctx.getAuthorizedCredentialIdentifier(),"Not expected to have credential identifier");
+
+        String credentialConfigId = ctx.getAuthorizedCredentialConfigurationId();
+        assertEquals(minimalJwtTypeCredentialConfigurationIdName, credentialConfigId);
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(GRANT_TYPE, PRE_AUTH_GRANT_TYPE)
+                .type(EventType.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED_GRANT);
+
+        // Credential request
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialConfigurationId(credentialConfigId)
+                .send().getCredentialResponse();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
+
+        verifyVCActionCredentialResponse(credResponse);
+
+        // Continue browser login inside the browser
+        credentialOfferPage.clickContinueButton();
+        String code = oauth.parseLoginResponse().getCode();
+        assertNotNull(code, "Authorization code should not be null");
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionTest.java
@@ -37,12 +37,10 @@ import static org.keycloak.events.Errors.REJECTED_BY_USER;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.MISSING_CREDENTIAL_CONFIG;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.UNKNOWN_CREDENTIAL_CONFIGURATION;
-import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
@@ -64,13 +62,12 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
         user.admin().logout();
     }
 
-
-    private String getKcActionParameter(String credentialConfigId, boolean preAuthorized) {
+    static String getKcActionParameter(String clientId, String credentialConfigId, boolean preAuthorized) {
         try {
             VerifiableCredentialOfferAction.CredentialOfferActionConfig cfg = new VerifiableCredentialOfferAction.CredentialOfferActionConfig();
             cfg.setCredentialConfigurationId(credentialConfigId);
-            cfg.setClientId(client.getClientId());
             cfg.setPreAuthorized(preAuthorized);
+            cfg.setClientId(clientId);
             String cfgAsString = cfg.asEncodedParameter();
             return VERIFIABLE_CREDENTIAL_OFFER_PROVIDER_ID + ":" + cfgAsString;
         } catch (IOException ioe) {
@@ -79,90 +76,16 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
         }
     }
 
-
-    // Test successful scenario. Client redirects to Keycloak OIDC authentication request with "kc_action" parameter pointing to the
-    // credential-offer, which should be created on Keycloak side. Upon successful authentication of the user, the credential-offer page is displayed
-    // from where user can scan QR-code to his wallet and retrieve OID4 VC. Wallet uses "pre-authorization code"
-    @Test
-    public void testCredentialOfferAIASuccess_preAuthorizedCode() throws Exception {
-        // Login as user. Check required-action displayed
-        oauth.client(client.getClientId(), "test-secret");
-        oauth.loginForm()
-                .kcAction(getKcActionParameter(minimalJwtTypeCredentialConfigurationIdName, true))
-                .open();
-        oauth.fillLoginForm(user.getUsername(), "password");
-
-        credentialOfferPage.assertCurrent();
-        String credentialOfferUri = credentialOfferPage.getCredentialOfferUri();
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
-                .details(Details.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED, String.valueOf(true))
-                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_USER_ID, user.getId())
-                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID, client.getClientId())
-                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
-
-        // Refresh screen. Should be still same credential-offer as before and test that there are not new events
-        driver.navigate().refresh();
-        credentialOfferPage.assertCurrent();
-        assertEquals(credentialOfferUri, credentialOfferPage.getCredentialOfferUri());
-
-        String credentialOfferNonce = getNonceFromCredentialOfferUri(credentialOfferUri);
-
-        // Pre-authorized code flow with credential exchange
-        CredentialOfferResponse credentialOfferResponse = oauth.oid4vc().credentialOfferRequest(credentialOfferNonce)
-                .send();
-        assertEquals(HttpStatus.SC_OK, credentialOfferResponse.getStatusCode());
-        CredentialsOffer credOffer = credentialOfferResponse.getCredentialsOffer();
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
-                .type(EventType.VERIFIABLE_CREDENTIAL_OFFER_REQUEST);
-
-        String preAuthCode = credOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthCode);
-        assertNull(credOffer.getIssuerState());
-
-        // Redeem Pre-Authorized Code for AccessToken
-        //
-        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
-        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
-
-        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
-        assertNotNull(accessToken,"No accessToken");
-
-        assertNull(ctx.getAuthorizedCredentialIdentifier(),"Not expected to have credential identifier");
-
-        String credentialConfigId = ctx.getAuthorizedCredentialConfigurationId();
-        assertEquals(minimalJwtTypeCredentialConfigurationIdName, credentialConfigId);
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .clientId(client.getClientId())
-                .details(GRANT_TYPE, PRE_AUTH_GRANT_TYPE)
-                .type(EventType.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED_GRANT);
-
-        // Credential request
-        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
-                .credentialConfigurationId(credentialConfigId)
-                .send().getCredentialResponse();
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .clientId(client.getClientId())
-                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
-                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
-
-        verifyCredentialResponse(credResponse);
-
-        // Continue browser login inside the browser
-        credentialOfferPage.clickContinueButton();
-        String code = oauth.parseLoginResponse().getCode();
-        assertNotNull(code, "Authorization code should not be null");
+    static String getNonceFromCredentialOfferUri(String credentialOfferUri) {
+        return credentialOfferUri.substring(credentialOfferUri.lastIndexOf("/") + 1);
     }
 
+    static void verifyVCActionCredentialResponse(CredentialResponse credResponse) {
+        CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
+        assertNotNull(credentialObj, "The first credential in the array should not be null");
+        IssuerSignedJWT issuerSignedJWT = SdJwtVP.of(credentialObj.getCredential().toString()).getIssuerSignedJWT();
+        assertEquals(minimalJwtTypeCredentialScopeName, issuerSignedJWT.getPayload().get(CLAIM_NAME_VCT).asText());
+    }
 
     // Test successful scenario with wallet using "authorization code" grant
     @Test
@@ -170,7 +93,7 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
         // Login as user. Check required-action displayed
         oauth.client(client.getClientId(), "test-secret");
         oauth.loginForm()
-                .kcAction(getKcActionParameter(minimalJwtTypeCredentialConfigurationIdName, false))
+                .kcAction(getKcActionParameter(client.getClientId(), minimalJwtTypeCredentialConfigurationIdName, false))
                 .open();
         oauth.fillLoginForm(user.getUsername(), "password");
 
@@ -249,7 +172,7 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
                 .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
                 .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
 
-        verifyCredentialResponse(credResponse);
+        verifyVCActionCredentialResponse(credResponse);
     }
 
 
@@ -259,7 +182,7 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
         // Login as user. Check required-action displayed
         oauth.client(client.getClientId(), "test-secret");
         oauth.loginForm()
-                .kcAction(getKcActionParameter(minimalJwtTypeCredentialConfigurationIdName, false))
+                .kcAction(getKcActionParameter(client.getClientId(), minimalJwtTypeCredentialConfigurationIdName, false))
                 .open();
         oauth.fillLoginForm(user.getUsername(), "password");
 
@@ -289,18 +212,6 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
                 .type(EventType.VERIFIABLE_CREDENTIAL_OFFER_REQUEST_ERROR);
     }
 
-    private String getNonceFromCredentialOfferUri(String credentialOfferUri) {
-        return credentialOfferUri.substring(credentialOfferUri.lastIndexOf("/") + 1);
-    }
-
-    private void verifyCredentialResponse(CredentialResponse credResponse) {
-        CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
-        assertNotNull(credentialObj, "The first credential in the array should not be null");
-        IssuerSignedJWT issuerSignedJWT = SdJwtVP.of(credentialObj.getCredential().toString()).getIssuerSignedJWT();
-        assertEquals(minimalJwtTypeCredentialScopeName, issuerSignedJWT.getPayload().get(CLAIM_NAME_VCT).asText());
-    }
-
-
     // Test for some error scenarios (incorrect values of "kc_action" referencing non-existent client scope etc).
     @Test
     public void testCredentialOfferErrors() {
@@ -323,7 +234,7 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
 
         // Test kc_action_parameter referencing incorrect credentialConfig
         oauth.loginForm()
-                .kcAction(getKcActionParameter("unknown-config-id", false))
+                .kcAction(getKcActionParameter(client.getClientId(), "unknown-config-id", false))
                 .open();
         authzCodeResponse = new AuthorizationEndpointResponse(oauth);
         assertNotNull(authzCodeResponse.getCode());

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAuthCodeOfferTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAuthCodeOfferTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * +----------+----------+---------+------------------------------------------------------+
  */
 @KeycloakIntegrationTest(config = VCTestServerConfig.class)
-public class OID4VCAuthorizationCodeOfferTest extends OID4VCIssuerTestBase {
+public class OID4VCAuthCodeOfferTest extends OID4VCIssuerTestBase {
 
     OID4VCBasicWallet wallet;
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAuthorizationCodeOfferTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAuthorizationCodeOfferTest.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.util.List;
 
 import org.keycloak.TokenVerifier;
-import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
@@ -12,7 +11,6 @@ import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.sdjwt.IssuerSignedJWT;
 import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -50,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * +----------+----------+---------+------------------------------------------------------+
  */
 @KeycloakIntegrationTest(config = VCTestServerConfig.class)
-public class OID4VCCredentialOfferMatrixTest extends OID4VCIssuerTestBase {
+public class OID4VCAuthorizationCodeOfferTest extends OID4VCIssuerTestBase {
 
     OID4VCBasicWallet wallet;
 
@@ -332,86 +330,6 @@ public class OID4VCCredentialOfferMatrixTest extends OID4VCIssuerTestBase {
         // Build and send AccessTokenRequest
         //
         AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode).send();
-        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
-        assertNotNull(accessToken, "No accessToken");
-
-        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
-        assertNotNull(authorizedIdentifier, "No authorized credential identifier");
-
-        // Send the CredentialRequest
-        //
-        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
-                .credentialIdentifier(authorizedIdentifier)
-                .send().getCredentialResponse();
-
-        verifyCredentialResponse(ctx, ctx.holder, credResponse);
-    }
-
-    @Test
-    public void testPreAuthOffer_DisabledUser() {
-
-        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
-
-        // Disable user
-        UserRepresentation userRep = testRealm.admin().users().search(ctx.holder).get(0);
-        UserResource userResource = testRealm.admin().users().get(userRep.getId());
-        userRep.setEnabled(false);
-        userResource.update(userRep);
-
-        try {
-            IllegalStateException error = assertThrows(IllegalStateException.class,
-                    () -> wallet.createPreAuthCredentialOffer(ctx, ctx.holder));
-            assertTrue(error.getMessage().contains("User 'alice' disabled"), error.getMessage());
-        } finally {
-            userRep.setEnabled(true);
-            userResource.update(userRep);
-        }
-    }
-
-    @Test
-    public void testPreAuthOffer_SelfIssued() throws Exception {
-
-        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
-
-        // Create Pre-Authorized CredentialOffer
-        //
-        CredentialsOffer credOffer = wallet.createPreAuthCredentialOffer(ctx, null);
-        String preAuthCode = credOffer.getPreAuthorizedCode();
-
-        // Redeem Pre-Authorized Code for AccessToken
-        //
-        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
-        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
-
-        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
-        assertNotNull(accessToken,"No accessToken");
-
-        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
-        assertNotNull(authorizedIdentifier,"No authorized credential identifier");
-
-        // Send the CredentialRequest
-        //
-        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
-                .credentialIdentifier(authorizedIdentifier)
-                .send().getCredentialResponse();
-
-        verifyCredentialResponse(ctx, ctx.issuer, credResponse);
-    }
-
-    @Test
-    public void testPreAuthOffer_Targeted() throws Exception {
-        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
-
-        // Create Pre-Authorized CredentialOffer
-        //
-        CredentialsOffer credOffer = wallet.createPreAuthCredentialOffer(ctx, ctx.holder);
-        String preAuthCode = credOffer.getPreAuthorizedCode();
-
-        // Redeem Pre-Authorized Code for AccessToken
-        //
-        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
-        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
-
         String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
         assertNotNull(accessToken, "No accessToken");
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -76,6 +76,7 @@ import org.keycloak.testframework.ui.annotations.InjectWebDriver;
 import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
 import org.keycloak.testsuite.util.oauth.AccessTokenRequest;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.util.AuthorizationDetailsParser;
 import org.keycloak.util.JsonSerialization;
 
@@ -265,7 +266,12 @@ public abstract class OID4VCIssuerTestBase {
         return oauthClient.accessTokenRequest(authCode).send();
     }
 
-    String getAuthorizationCode(OAuthClient oAuthClient, ClientRepresentation client, String username, String scope) {
+    protected String getAuthorizationCode(OAuthClient oAuthClient, ClientRepresentation client, String username, String scope) {
+        var authorizationEndpointResponse = getAuthorizationResponse(oAuthClient, client, username, scope);
+        return authorizationEndpointResponse.getCode();
+    }
+
+    protected AuthorizationEndpointResponse getAuthorizationResponse(OAuthClient oAuthClient, ClientRepresentation client, String username, String scope) {
         if (client != null) {
             if (client.getSecret() != null) {
                 oAuthClient.client(client.getClientId(), client.getSecret());
@@ -278,7 +284,7 @@ public abstract class OID4VCIssuerTestBase {
             oAuthClient.scope(scope);
         }
         var authorizationEndpointResponse = oAuthClient.doLogin(username, "password");
-        return authorizationEndpointResponse.getCode();
+        return authorizationEndpointResponse;
     }
 
     AccessTokenResponse getBearerToken(OAuthClient oauthClient, String authCode, OID4VCAuthorizationDetail... authDetail) {
@@ -329,6 +335,13 @@ public abstract class OID4VCIssuerTestBase {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
             return config.features(Profile.Feature.OID4VC_VCI);
+        }
+    }
+
+    static class VCTestServerWithPreAuthCodeEnabled implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_VCI_PREAUTH_CODE);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointPreAuthTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.oid4vc;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testsuite.util.AccountHelper;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled.class)
+public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest {
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @AfterEach
+    public void logout() {
+        AccountHelper.logout(testRealm.admin(), "john");
+    }
+
+    @Test
+    public void testPreAuthorizedCodeValidAfterOfferConsumed() {
+
+        String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
+        final String credentialConfigurationId = jwtTypeCredentialClientScope.getAttributes()
+                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
+
+        // 1. Fetch the Offer URI
+        CredentialOfferURI credentialOfferURI = oauth.oid4vc()
+                .credentialOfferUriRequest(credentialConfigurationId)
+                .preAuthorized(true)
+                .targetUser("john")
+                .bearerToken(token)
+                .send()
+                .getCredentialOfferURI();
+
+        assertNotNull(credentialOfferURI, "Credential offer URI should not be null");
+        String nonce = credentialOfferURI.getNonce();
+        assertNotNull(nonce, "Nonce should not be null");
+
+        // 2. Fetch the Offer JSON (this removes the nonce entry for replay protection)
+        CredentialsOffer credentialsOffer = oauth.oid4vc()
+                .credentialOfferRequest(nonce)
+                .bearerToken(token)
+                .send()
+                .getCredentialsOffer();
+
+        assertNotNull(credentialsOffer, "Credential offer should not be null");
+
+        String preAuthorizedCode = credentialsOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthorizedCode, "Pre-authorized code value should not be null");
+
+        // 3. Immediately perform the Token Request (Pre-Authorized Code Grant) using the valid code
+        CredentialIssuer credentialIssuer = oauth.oid4vc()
+                .issuerMetadataRequest()
+                .endpoint(credentialsOffer.getIssuerMetadataUrl())
+                .send()
+                .getMetadata();
+
+        OIDCConfigurationRepresentation openidConfig = oauth.wellknownRequest()
+                .url(credentialIssuer.getAuthorizationServers().get(0))
+                .send()
+                .getOidcConfiguration();
+
+        assertNotNull(openidConfig.getTokenEndpoint(), "Token endpoint should be present");
+
+        AccessTokenResponse accessTokenResponse = oauth.oid4vc()
+                .preAuthorizedCodeGrantRequest(preAuthorizedCode)
+                .send();
+
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode(), "Token request should succeed even after nonce is removed for replay protection");
+        assertNotNull(accessTokenResponse.getAccessToken(), "Access token should be present");
+        assertFalse(accessTokenResponse.getAccessToken().isEmpty(), "Access token should not be empty");
+    }
+
+    @Test
+    public void testCredentialIssuancePreAuth() {
+        String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
+
+        // 1. Retrieving the credential-offer-uri
+        final String credentialConfigurationId = jwtTypeCredentialClientScope.getAttributes()
+                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
+
+        CredentialOfferURI credOfferUri = oauth.oid4vc()
+                .credentialOfferUriRequest(credentialConfigurationId)
+                .preAuthorized(true)
+                .targetUser("john")
+                .bearerToken(token)
+                .send()
+                .getCredentialOfferURI();
+
+        assertNotNull(credOfferUri, "A valid offer uri should be returned");
+
+        // 2. Using the uri to get the actual credential offer
+        CredentialOfferResponse credentialOfferResponse = oauth.oid4vc()
+                .doCredentialOfferRequest(credOfferUri);
+        CredentialsOffer credentialsOffer = credentialOfferResponse.getCredentialsOffer();
+
+        assertNotNull(credentialsOffer, "A valid offer should be returned");
+
+        // 3. Get the issuer metadata
+        CredentialIssuer credentialIssuer = oauth.oid4vc()
+                .issuerMetadataRequest()
+                .endpoint(credentialsOffer.getIssuerMetadataUrl())
+                .send()
+                .getMetadata();
+
+        assertNotNull(credentialIssuer, "Issuer metadata should be returned");
+        assertEquals(1, credentialIssuer.getAuthorizationServers().size(), "We only expect one authorization server.");
+
+        // 4. Get the openid-configuration
+        OIDCConfigurationRepresentation openidConfig = oauth.wellknownRequest()
+                .url(credentialIssuer.getAuthorizationServers().get(0))
+                .send()
+                .getOidcConfiguration();
+
+        assertNotNull(openidConfig.getTokenEndpoint(), "A token endpoint should be included.");
+        assertTrue(openidConfig.getGrantTypesSupported().contains(PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE), "The pre-authorized code should be supported.");
+
+        // 5. Get an access token for the pre-authorized code
+        AccessTokenResponse accessTokenResponse = oauth.oid4vc()
+                .preAuthorizedCodeGrantRequest(credentialsOffer.getPreAuthorizedCode())
+                .endpoint(openidConfig.getTokenEndpoint())
+                .send();
+
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
+        String theToken = accessTokenResponse.getAccessToken();
+        assertNotNull(theToken, "Access token should be present");
+
+        // Extract credential_identifier from authorization_details in token response
+        List<OID4VCAuthorizationDetail> authDetailsResponse = accessTokenResponse.getOID4VCAuthorizationDetails();
+        assertNotNull(authDetailsResponse, "authorization_details should be present in the response");
+        assertFalse(authDetailsResponse.isEmpty(), "authorization_details should not be empty");
+
+        String credentialIdentifier = authDetailsResponse.get(0).getCredentialIdentifiers().get(0);
+        assertNotNull(credentialIdentifier, "Credential identifier should be present");
+
+        // 6. Get the credential using credential_identifier (required when authorization_details are present)
+        credentialsOffer.getCredentialConfigurationIds().stream()
+                .map(offeredCredentialId -> credentialIssuer.getCredentialsSupported().get(offeredCredentialId))
+                .map(credConfigId -> credentialIssuer.getCredentialsSupported().get(credConfigId))
+                .forEach(supportedCredential -> {
+                    try {
+                        requestCredentialWithIdentifier(
+                                theToken,
+                                credentialIssuer.getCredentialEndpoint(),
+                                credentialIdentifier,
+                                new CredentialResponseHandler(),
+                                jwtTypeCredentialClientScope
+                        );
+                    } catch (IOException e) {
+                        fail("Was not able to get the credential.");
+                    } catch (VerificationException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointPreAuthTest.java
@@ -56,61 +56,6 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
     }
 
     @Test
-    public void testPreAuthorizedCodeValidAfterOfferConsumed() {
-
-        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
-        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
-                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
-
-        // 1. Fetch the Offer URI
-        CredentialOfferURI credentialOfferURI = oauth.oid4vc()
-                .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(true)
-                .targetUser("john")
-                .bearerToken(token)
-                .send()
-                .getCredentialOfferURI();
-
-        assertNotNull(credentialOfferURI, "Credential offer URI should not be null");
-        String nonce = credentialOfferURI.getNonce();
-        assertNotNull(nonce, "Nonce should not be null");
-
-        // 2. Fetch the Offer JSON (this removes the nonce entry for replay protection)
-        CredentialsOffer credentialsOffer = oauth.oid4vc()
-                .credentialOfferRequest(nonce)
-                .bearerToken(token)
-                .send()
-                .getCredentialsOffer();
-
-        assertNotNull(credentialsOffer, "Credential offer should not be null");
-
-        String preAuthorizedCode = credentialsOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthorizedCode, "Pre-authorized code value should not be null");
-
-        // 3. Immediately perform the Token Request (Pre-Authorized Code Grant) using the valid code
-        CredentialIssuer credentialIssuer = oauth.oid4vc()
-                .issuerMetadataRequest()
-                .endpoint(credentialsOffer.getIssuerMetadataUrl())
-                .send()
-                .getMetadata();
-
-        OIDCConfigurationRepresentation openidConfig = oauth.wellknownRequest()
-                .url(credentialIssuer.getAuthorizationServers().get(0))
-                .send()
-                .getOidcConfiguration();
-
-        assertNotNull(openidConfig.getTokenEndpoint(), "Token endpoint should be present");
-
-        AccessTokenResponse accessTokenResponse = oauth.oid4vc()
-                .preAuthorizedCodeGrantRequest(preAuthorizedCode)
-                .send();
-
-        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode(), "Token request should succeed even after nonce is removed for replay protection");
-        assertNotNull(accessTokenResponse.getAccessToken(), "Access token should be present");
-        assertFalse(accessTokenResponse.getAccessToken().isEmpty(), "Access token should not be empty");
-    }
-
-    @Test
     public void testCredentialIssuancePreAuth() {
         String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
 
@@ -190,5 +135,60 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
                         throw new RuntimeException(e);
                     }
                 });
+    }
+
+    @Test
+    public void testPreAuthorizedCodeValidAfterOfferConsumed() {
+
+        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
+        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
+                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
+
+        // 1. Fetch the Offer URI
+        CredentialOfferURI credentialOfferURI = oauth.oid4vc()
+                .credentialOfferUriRequest(credentialConfigurationId)
+                .preAuthorized(true)
+                .targetUser("john")
+                .bearerToken(token)
+                .send()
+                .getCredentialOfferURI();
+
+        assertNotNull(credentialOfferURI, "Credential offer URI should not be null");
+        String nonce = credentialOfferURI.getNonce();
+        assertNotNull(nonce, "Nonce should not be null");
+
+        // 2. Fetch the Offer JSON (this removes the nonce entry for replay protection)
+        CredentialsOffer credentialsOffer = oauth.oid4vc()
+                .credentialOfferRequest(nonce)
+                .bearerToken(token)
+                .send()
+                .getCredentialsOffer();
+
+        assertNotNull(credentialsOffer, "Credential offer should not be null");
+
+        String preAuthorizedCode = credentialsOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthorizedCode, "Pre-authorized code value should not be null");
+
+        // 3. Immediately perform the Token Request (Pre-Authorized Code Grant) using the valid code
+        CredentialIssuer credentialIssuer = oauth.oid4vc()
+                .issuerMetadataRequest()
+                .endpoint(credentialsOffer.getIssuerMetadataUrl())
+                .send()
+                .getMetadata();
+
+        OIDCConfigurationRepresentation openidConfig = oauth.wellknownRequest()
+                .url(credentialIssuer.getAuthorizationServers().get(0))
+                .send()
+                .getOidcConfiguration();
+
+        assertNotNull(openidConfig.getTokenEndpoint(), "Token endpoint should be present");
+
+        AccessTokenResponse accessTokenResponse = oauth.oid4vc()
+                .preAuthorizedCodeGrantRequest(preAuthorizedCode)
+                .send();
+
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode(), "Token request should succeed even after nonce is removed for replay protection");
+        assertNotNull(accessTokenResponse.getAccessToken(), "Access token should be present");
+        assertFalse(accessTokenResponse.getAccessToken().isEmpty(), "Access token should not be empty");
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointPreAuthTest.java
@@ -58,8 +58,8 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
     @Test
     public void testPreAuthorizedCodeValidAfterOfferConsumed() {
 
-        String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
-        final String credentialConfigurationId = jwtTypeCredentialClientScope.getAttributes()
+        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
+        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
                 .get(CredentialScopeModel.VC_CONFIGURATION_ID);
 
         // 1. Fetch the Offer URI
@@ -112,10 +112,10 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
 
     @Test
     public void testCredentialIssuancePreAuth() {
-        String token = getBearerToken(oauth, client, jwtTypeCredentialClientScope.getName());
+        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
 
         // 1. Retrieving the credential-offer-uri
-        final String credentialConfigurationId = jwtTypeCredentialClientScope.getAttributes()
+        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
                 .get(CredentialScopeModel.VC_CONFIGURATION_ID);
 
         CredentialOfferURI credOfferUri = oauth.oid4vc()
@@ -180,10 +180,9 @@ public class OID4VCJWTIssuerEndpointPreAuthTest extends OID4VCIssuerEndpointTest
                     try {
                         requestCredentialWithIdentifier(
                                 theToken,
-                                credentialIssuer.getCredentialEndpoint(),
                                 credentialIdentifier,
                                 new CredentialResponseHandler(),
-                                jwtTypeCredentialClientScope
+                                jwtTypeCredentialScope
                         );
                     } catch (IOException e) {
                         fail("Was not able to get the credential.");

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -500,7 +500,18 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
     @Test
     public void testCredentialIssuance() {
-        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
+        AccessTokenResponse accessTokenResponse = getBearerTokenCodeFlow(oauth, client, "john", jwtTypeCredentialScope.getName());
+        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
+        String token = accessTokenResponse.getAccessToken();
+        assertNotNull(token, "Access token should be present");
+
+        // Extract credential_identifier from authorization_details in token response
+        List<OID4VCAuthorizationDetail> authDetailsResponse = accessTokenResponse.getOID4VCAuthorizationDetails();
+        assertNotNull(authDetailsResponse, "authorization_details should be present in the response");
+        assertFalse(authDetailsResponse.isEmpty(), "authorization_details should not be empty");
+
+        String credentialIdentifier = authDetailsResponse.get(0).getCredentialIdentifiers().get(0);
+        assertNotNull(credentialIdentifier, "Credential identifier should be present");
 
         // 1. Retrieving the credential-offer-uri
         final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
@@ -508,7 +519,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
         CredentialOfferURI credOfferUri = oauth.oid4vc()
                 .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(true)
+                .preAuthorized(false)
                 .targetUser("john")
                 .bearerToken(token)
                 .send()
@@ -522,6 +533,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         CredentialsOffer credentialsOffer = credentialOfferResponse.getCredentialsOffer();
 
         assertNotNull(credentialsOffer, "A valid offer should be returned");
+        List<String> credConfigIds = credentialsOffer.getCredentialConfigurationIds();
+        assertEquals(1, credConfigIds.size(), "We only expect one credential_configuration_id");
 
         // 3. Get the issuer metadata
         CredentialIssuer credentialIssuer = oauth.oid4vc()
@@ -540,34 +553,16 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .getOidcConfiguration();
 
         assertNotNull(openidConfig.getTokenEndpoint(), "A token endpoint should be included.");
-        assertTrue(openidConfig.getGrantTypesSupported().contains(PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE), "The pre-authorized code should be supported.");
+        assertFalse(openidConfig.getGrantTypesSupported().contains(PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE), "The pre-authorized code should not be supported.");
 
-        // 5. Get an access token for the pre-authorized code
-        AccessTokenResponse accessTokenResponse = oauth.oid4vc()
-                .preAuthorizedCodeGrantRequest(credentialsOffer.getPreAuthorizedCode())
-                .endpoint(openidConfig.getTokenEndpoint())
-                .send();
-
-        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode());
-        String theToken = accessTokenResponse.getAccessToken();
-        assertNotNull(theToken, "Access token should be present");
-
-        // Extract credential_identifier from authorization_details in token response
-        List<OID4VCAuthorizationDetail> authDetailsResponse = accessTokenResponse.getOID4VCAuthorizationDetails();
-        assertNotNull(authDetailsResponse, "authorization_details should be present in the response");
-        assertFalse(authDetailsResponse.isEmpty(), "authorization_details should not be empty");
-
-        String credentialIdentifier = authDetailsResponse.get(0).getCredentialIdentifiers().get(0);
-        assertNotNull(credentialIdentifier, "Credential identifier should be present");
-
-        // 6. Get the credential using credential_identifier (required when authorization_details are present)
-        credentialsOffer.getCredentialConfigurationIds().stream()
+        // 5. Get the credential using credential_identifier (required when authorization_details are present)
+        credConfigIds.stream()
                 .map(offeredCredentialId -> credentialIssuer.getCredentialsSupported().get(offeredCredentialId))
                 .map(credConfigId -> credentialIssuer.getCredentialsSupported().get(credConfigId))
                 .forEach(supportedCredential -> {
                     try {
                         requestCredentialWithIdentifier(
-                                theToken,
+                                token,
                                 credentialIdentifier,
                                 new CredentialResponseHandler(),
                                 jwtTypeCredentialScope
@@ -1219,7 +1214,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         // 1. Retrieving the create-credential-offer
         CredentialOfferURI credentialOfferURI = oauth.oid4vc()
                 .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(true)
+                .preAuthorized(false)
                 .targetUser("john")
                 .bearerToken(token)
                 .send()
@@ -1239,8 +1234,8 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
         assertNotNull(credentialsOffer, "Credential offer should not be null");
 
-        String preAuthorizedCode = credentialsOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthorizedCode, "Pre-authorized code value should not be null");
+        String issuerState = credentialsOffer.getIssuerState();
+        assertNotNull(issuerState, "Issuer state should not be null");
 
         // 3. Second access to the same credential offer URL - should fail with replay protection error
         CredentialOfferResponse response = oauth.oid4vc()
@@ -1262,7 +1257,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         // 1. Create first credential offer
         CredentialOfferURI credentialOfferURI1 = oauth.oid4vc()
                 .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(true)
+                .preAuthorized(false)
                 .targetUser("john")
                 .bearerToken(token)
                 .send()
@@ -1275,7 +1270,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         // 2. Create second credential offer (should have different nonce)
         CredentialOfferURI credentialOfferURI2 = oauth.oid4vc()
                 .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(true)
+                .preAuthorized(false)
                 .targetUser("john")
                 .bearerToken(token)
                 .send()
@@ -1375,7 +1370,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         assertFalse(accessTokenResponse.getAccessToken().isEmpty(), "Access token should not be empty");
     }
 
-    private String getCNonce() {
+    public String getCNonce() {
         UriBuilder builder = UriBuilder.fromUri(keycloakUrls.getBase());
         URI oid4vcUri = RealmsResource.protocolUrl(builder)
                 .build(testRealm.getName(), OID4VCLoginProtocolFactory.PROTOCOL_ID);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -1316,61 +1316,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         assertEquals(ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST.getValue(), response2.getError(), "Error type should be INVALID_CREDENTIAL_OFFER_REQUEST");
     }
 
-    @Test
-    public void testPreAuthorizedCodeValidAfterOfferConsumed() {
-        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
-        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
-                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
-
-        // 1. Fetch the Offer URI
-        CredentialOfferURI credentialOfferURI = oauth.oid4vc()
-                .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(true)
-                .targetUser("john")
-                .bearerToken(token)
-                .send()
-                .getCredentialOfferURI();
-
-        assertNotNull(credentialOfferURI, "Credential offer URI should not be null");
-        String nonce = credentialOfferURI.getNonce();
-        assertNotNull(nonce, "Nonce should not be null");
-
-        // 2. Fetch the Offer JSON (this removes the nonce entry for replay protection)
-        CredentialsOffer credentialsOffer = oauth.oid4vc()
-                .credentialOfferRequest(nonce)
-                .bearerToken(token)
-                .send()
-                .getCredentialsOffer();
-
-        assertNotNull(credentialsOffer, "Credential offer should not be null");
-
-        String preAuthorizedCode = credentialsOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthorizedCode, "Pre-authorized code value should not be null");
-
-        // 3. Immediately perform the Token Request (Pre-Authorized Code Grant) using the valid code
-        CredentialIssuer credentialIssuer = oauth.oid4vc()
-                .issuerMetadataRequest()
-                .endpoint(credentialsOffer.getIssuerMetadataUrl())
-                .send()
-                .getMetadata();
-
-        OIDCConfigurationRepresentation openidConfig = oauth.wellknownRequest()
-                .url(credentialIssuer.getAuthorizationServers().get(0))
-                .send()
-                .getOidcConfiguration();
-
-        assertNotNull(openidConfig.getTokenEndpoint(), "Token endpoint should be present");
-
-        AccessTokenResponse accessTokenResponse = oauth.oid4vc()
-                .preAuthorizedCodeGrantRequest(preAuthorizedCode)
-                .send();
-
-        assertEquals(HttpStatus.SC_OK, accessTokenResponse.getStatusCode(), "Token request should succeed even after nonce is removed for replay protection");
-        assertNotNull(accessTokenResponse.getAccessToken(), "Access token should be present");
-        assertFalse(accessTokenResponse.getAccessToken().isEmpty(), "Access token should not be empty");
-    }
-
-    public String getCNonce() {
+    private String getCNonce() {
         UriBuilder builder = UriBuilder.fromUri(keycloakUrls.getBase());
         URI oid4vcUri = RealmsResource.protocolUrl(builder)
                 .build(testRealm.getName(), OID4VCLoginProtocolFactory.PROTOCOL_ID);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPreAuthorizedCodeOfferTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPreAuthorizedCodeOfferTest.java
@@ -25,7 +25,6 @@ import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
 import org.keycloak.util.JsonSerialization;
 
 import org.apache.http.HttpStatus;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPreAuthorizedCodeOfferTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPreAuthorizedCodeOfferTest.java
@@ -1,0 +1,266 @@
+package org.keycloak.tests.oid4vc;
+
+import java.net.URI;
+import java.util.List;
+
+import org.keycloak.TokenVerifier;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.OID4VCCredentialOfferPage;
+import org.keycloak.tests.common.TestRealmUserConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
+import org.keycloak.util.JsonSerialization;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.events.Details.GRANT_TYPE;
+import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
+import static org.keycloak.tests.oid4vc.OID4VCActionTest.getKcActionParameter;
+import static org.keycloak.tests.oid4vc.OID4VCActionTest.getNonceFromCredentialOfferUri;
+import static org.keycloak.tests.oid4vc.OID4VCActionTest.verifyVCActionCredentialResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Credential Offer Validity Matrix
+ * <p>
+ * +----------+----------+---------+------------------------------------------------------+
+ * | Pre-Auth | Username | Valid   | Notes                                                |
+ * +----------+----------+---------+------------------------------------------------------+
+ * | no       | no       | yes     | Anonymous offer; any logged-in user may redeem.      |
+ * | no       | yes      | yes     | Offer restricted to a specific user.                 |
+ * +----------+----------+---------+------------------------------------------------------+
+ * | yes      | no       | no      | Pre-auth requires a target user.                     |
+ * | yes      | yes      | yes     | Pre-auth for a specific target user.                 |
+ * +----------+----------+---------+------------------------------------------------------+
+ */
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled.class)
+public class OID4VCPreAuthorizedCodeOfferTest extends OID4VCIssuerTestBase {
+
+    @InjectPage
+    OID4VCCredentialOfferPage credentialOfferPage;
+
+    @InjectUser(config = TestRealmUserConfig.class)
+    ManagedUser user;
+
+    OID4VCBasicWallet wallet;
+
+    @BeforeEach
+    void beforeEach() {
+        wallet = new OID4VCBasicWallet(keycloak, oauth);
+        user.admin().logout();
+        wallet.logout();
+    }
+
+    @Test
+    public void testRealmSetup() {
+        RealmRepresentation realmRep = testRealm.admin().toRepresentation();
+        assertEquals(shouldEnableOid4vci(realmRep), realmRep.isVerifiableCredentialsEnabled());
+        assertEquals(shouldEnableOid4vci(client), isOid4vciEnabled(client));
+    }
+
+    @Test
+    public void testPreAuthOffer_DisabledUser() {
+
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        // Disable user
+        UserRepresentation userRep = testRealm.admin().users().search(ctx.holder).get(0);
+        UserResource userResource = testRealm.admin().users().get(userRep.getId());
+        userRep.setEnabled(false);
+        userResource.update(userRep);
+
+        try {
+            IllegalStateException error = assertThrows(IllegalStateException.class,
+                    () -> wallet.createPreAuthCredentialOffer(ctx, ctx.holder));
+            assertTrue(error.getMessage().contains("User 'alice' disabled"), error.getMessage());
+        } finally {
+            userRep.setEnabled(true);
+            userResource.update(userRep);
+        }
+    }
+
+    @Test
+    public void testPreAuthOffer_SelfIssued() throws Exception {
+
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        // Create Pre-Authorized CredentialOffer
+        //
+        CredentialsOffer credOffer = wallet.createPreAuthCredentialOffer(ctx, null);
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+
+        // Redeem Pre-Authorized Code for AccessToken
+        //
+        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
+        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken,"No accessToken");
+
+        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(authorizedIdentifier,"No authorized credential identifier");
+
+        // Send the CredentialRequest
+        //
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(authorizedIdentifier)
+                .send().getCredentialResponse();
+
+        verifyCredentialResponse(ctx, ctx.issuer, credResponse);
+    }
+
+    @Test
+    public void testPreAuthOffer_Targeted() throws Exception {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        // Create Pre-Authorized CredentialOffer
+        //
+        CredentialsOffer credOffer = wallet.createPreAuthCredentialOffer(ctx, ctx.holder);
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+
+        // Redeem Pre-Authorized Code for AccessToken
+        //
+        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
+        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken, "No accessToken");
+
+        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(authorizedIdentifier, "No authorized credential identifier");
+
+        // Send the CredentialRequest
+        //
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(authorizedIdentifier)
+                .send().getCredentialResponse();
+
+        verifyCredentialResponse(ctx, ctx.holder, credResponse);
+    }
+
+    // Test successful scenario. Client redirects to Keycloak OIDC authentication request with "kc_action" parameter pointing to the
+    // credential-offer, which should be created on Keycloak side. Upon successful authentication of the user, the credential-offer page is displayed
+    // from where user can scan QR-code to his wallet and retrieve OID4 VC. Wallet uses "pre-authorization code"
+    @Test
+    public void testPreAuthOffer_AIASuccess() throws Exception {
+
+        var ctx = new OID4VCTestContext(client, minimalJwtTypeCredentialScope);
+
+        // Login as user. Check required-action displayed
+        oauth.client(client.getClientId(), "test-secret");
+        oauth.loginForm()
+                .kcAction(getKcActionParameter(client.getClientId(), minimalJwtTypeCredentialConfigurationIdName, true))
+                .open();
+        oauth.fillLoginForm(user.getUsername(), "password");
+
+        credentialOfferPage.assertCurrent();
+        String credentialOfferUri = credentialOfferPage.getCredentialOfferUri();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .details(Details.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED, String.valueOf(true))
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_USER_ID, user.getId())
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID, client.getClientId())
+                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
+
+        // Refresh screen. Should be still same credential-offer as before and test that there are not new events
+        driver.navigate().refresh();
+        credentialOfferPage.assertCurrent();
+        assertEquals(credentialOfferUri, credentialOfferPage.getCredentialOfferUri());
+
+        String credentialOfferNonce = getNonceFromCredentialOfferUri(credentialOfferUri);
+
+        // Pre-authorized code flow with credential exchange
+        CredentialOfferResponse credentialOfferResponse = oauth.oid4vc()
+                .credentialOfferRequest(credentialOfferNonce)
+                .send();
+        assertEquals(HttpStatus.SC_OK, credentialOfferResponse.getStatusCode());
+        CredentialsOffer credOffer = credentialOfferResponse.getCredentialsOffer();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .type(EventType.VERIFIABLE_CREDENTIAL_OFFER_REQUEST);
+
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode);
+        assertNull(credOffer.getIssuerState());
+
+        // Redeem Pre-Authorized Code for AccessToken
+        //
+        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
+        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken,"No accessToken");
+
+        assertNull(ctx.getAuthorizedCredentialIdentifier(),"Not expected to have credential identifier");
+
+        String credentialConfigId = ctx.getAuthorizedCredentialConfigurationId();
+        assertEquals(minimalJwtTypeCredentialConfigurationIdName, credentialConfigId);
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(GRANT_TYPE, PRE_AUTH_GRANT_TYPE)
+                .type(EventType.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED_GRANT);
+
+        // Credential request
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialConfigurationId(credentialConfigId)
+                .send().getCredentialResponse();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
+
+        verifyVCActionCredentialResponse(credResponse);
+
+        // Continue browser login inside the browser
+        credentialOfferPage.clickContinueButton();
+        String code = oauth.parseLoginResponse().getCode();
+        assertNotNull(code, "Authorization code should not be null");
+    }
+
+
+    // Private ---------------------------------------------------------------------------------------------------------
+
+    private void verifyCredentialResponse(OID4VCTestContext ctx, String expUser, CredentialResponse credResponse) throws Exception {
+
+        String scope = ctx.credentialScope.getName();
+        CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
+        assertNotNull(credentialObj, "The first credential in the array should not be null");
+
+        JsonWebToken jsonWebToken = TokenVerifier.create((String) credentialObj.getCredential(), JsonWebToken.class).getToken();
+        assertEquals("did:web:test.org", jsonWebToken.getIssuer());
+        Object vc = jsonWebToken.getOtherClaims().get("vc");
+        VerifiableCredential credential = JsonSerialization.mapper.convertValue(vc, VerifiableCredential.class);
+        assertEquals(List.of(scope), credential.getType());
+        assertEquals(URI.create("did:web:test.org"), credential.getIssuer());
+        assertEquals(expUser + "@email.cz", credential.getCredentialSubject().getClaims().get("email"));
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPreAuthorizedCodeOfferTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPreAuthorizedCodeOfferTest.java
@@ -5,38 +5,21 @@ import java.util.List;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.admin.client.resource.UserResource;
-import org.keycloak.events.Details;
-import org.keycloak.events.EventType;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.testframework.annotations.InjectUser;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
-import org.keycloak.testframework.events.EventAssertion;
-import org.keycloak.testframework.realm.ManagedUser;
-import org.keycloak.testframework.ui.annotations.InjectPage;
-import org.keycloak.testframework.ui.page.OID4VCCredentialOfferPage;
-import org.keycloak.tests.common.TestRealmUserConfig;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
-import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
 import org.keycloak.util.JsonSerialization;
 
-import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.keycloak.events.Details.GRANT_TYPE;
-import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
-import static org.keycloak.tests.oid4vc.OID4VCActionTest.getKcActionParameter;
-import static org.keycloak.tests.oid4vc.OID4VCActionTest.getNonceFromCredentialOfferUri;
-import static org.keycloak.tests.oid4vc.OID4VCActionTest.verifyVCActionCredentialResponse;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,18 +39,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled.class)
 public class OID4VCPreAuthorizedCodeOfferTest extends OID4VCIssuerTestBase {
 
-    @InjectPage
-    OID4VCCredentialOfferPage credentialOfferPage;
-
-    @InjectUser(config = TestRealmUserConfig.class)
-    ManagedUser user;
-
     OID4VCBasicWallet wallet;
 
     @BeforeEach
     void beforeEach() {
         wallet = new OID4VCBasicWallet(keycloak, oauth);
-        user.admin().logout();
         wallet.logout();
     }
 
@@ -157,94 +133,6 @@ public class OID4VCPreAuthorizedCodeOfferTest extends OID4VCIssuerTestBase {
 
         verifyCredentialResponse(ctx, ctx.holder, credResponse);
     }
-
-    // Test successful scenario. Client redirects to Keycloak OIDC authentication request with "kc_action" parameter pointing to the
-    // credential-offer, which should be created on Keycloak side. Upon successful authentication of the user, the credential-offer page is displayed
-    // from where user can scan QR-code to his wallet and retrieve OID4 VC. Wallet uses "pre-authorization code"
-    @Test
-    public void testPreAuthOffer_AIASuccess() throws Exception {
-
-        var ctx = new OID4VCTestContext(client, minimalJwtTypeCredentialScope);
-
-        // Login as user. Check required-action displayed
-        oauth.client(client.getClientId(), "test-secret");
-        oauth.loginForm()
-                .kcAction(getKcActionParameter(client.getClientId(), minimalJwtTypeCredentialConfigurationIdName, true))
-                .open();
-        oauth.fillLoginForm(user.getUsername(), "password");
-
-        credentialOfferPage.assertCurrent();
-        String credentialOfferUri = credentialOfferPage.getCredentialOfferUri();
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
-                .details(Details.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED, String.valueOf(true))
-                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_USER_ID, user.getId())
-                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID, client.getClientId())
-                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
-
-        // Refresh screen. Should be still same credential-offer as before and test that there are not new events
-        driver.navigate().refresh();
-        credentialOfferPage.assertCurrent();
-        assertEquals(credentialOfferUri, credentialOfferPage.getCredentialOfferUri());
-
-        String credentialOfferNonce = getNonceFromCredentialOfferUri(credentialOfferUri);
-
-        // Pre-authorized code flow with credential exchange
-        CredentialOfferResponse credentialOfferResponse = oauth.oid4vc()
-                .credentialOfferRequest(credentialOfferNonce)
-                .send();
-        assertEquals(HttpStatus.SC_OK, credentialOfferResponse.getStatusCode());
-        CredentialsOffer credOffer = credentialOfferResponse.getCredentialsOffer();
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
-                .type(EventType.VERIFIABLE_CREDENTIAL_OFFER_REQUEST);
-
-        String preAuthCode = credOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthCode);
-        assertNull(credOffer.getIssuerState());
-
-        // Redeem Pre-Authorized Code for AccessToken
-        //
-        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
-        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
-
-        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
-        assertNotNull(accessToken,"No accessToken");
-
-        assertNull(ctx.getAuthorizedCredentialIdentifier(),"Not expected to have credential identifier");
-
-        String credentialConfigId = ctx.getAuthorizedCredentialConfigurationId();
-        assertEquals(minimalJwtTypeCredentialConfigurationIdName, credentialConfigId);
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .clientId(client.getClientId())
-                .details(GRANT_TYPE, PRE_AUTH_GRANT_TYPE)
-                .type(EventType.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED_GRANT);
-
-        // Credential request
-        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
-                .credentialConfigurationId(credentialConfigId)
-                .send().getCredentialResponse();
-
-        EventAssertion.assertSuccess(events.poll())
-                .userId(user.getId())
-                .clientId(client.getClientId())
-                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
-                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
-
-        verifyVCActionCredentialResponse(credResponse);
-
-        // Continue browser login inside the browser
-        credentialOfferPage.clickContinueButton();
-        String code = oauth.parseLoginResponse().getCode();
-        assertNotNull(code, "Authorization code should not be null");
-    }
-
 
     // Private ---------------------------------------------------------------------------------------------------------
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/PreAuthorizedGrantTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 @EnableFeature(value = Profile.Feature.OID4VC_VCI, skipRestart = true)
+@EnableFeature(value = Profile.Feature.OID4VC_VCI_PREAUTH_CODE, skipRestart = true)
 public class PreAuthorizedGrantTest extends AbstractTestRealmKeycloakTest {
 
     private CloseableHttpClient httpClient;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCGrantFeatureTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCGrantFeatureTest.java
@@ -44,13 +44,13 @@ public class OID4VCGrantFeatureTest extends AbstractFeatureStateTest {
     }
 
     @Test
-    @EnableFeature(value = Profile.Feature.OID4VC_VCI, skipRestart = true)
+    @EnableFeature(value = Profile.Feature.OID4VC_VCI_PREAUTH_CODE, skipRestart = true)
     public void featureEnabled() {
         testFeatureAvailability(true);
     }
 
     @Test
-    @DisableFeature(value = Profile.Feature.OID4VC_VCI, skipRestart = true)
+    @DisableFeature(value = Profile.Feature.OID4VC_VCI_PREAUTH_CODE, skipRestart = true)
     public void featureDisabled() {
         testFeatureAvailability(false);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCTest.java
@@ -122,6 +122,7 @@ import static org.keycloak.testsuite.oid4vc.issuance.signing.OID4VCSdJwtIssuingE
  * Super class for all OID4VC tests. Provides convenience methods to ease the testing.
  */
 @EnableFeature(value = Profile.Feature.OID4VC_VCI, skipRestart = true)
+@EnableFeature(value = Profile.Feature.OID4VC_VCI_PREAUTH_CODE, skipRestart = true)
 public abstract class OID4VCTest extends AbstractTestRealmKeycloakTest {
 
 	private static final Logger LOGGER = Logger.getLogger(OID4VCTest.class);


### PR DESCRIPTION
closes #46396

This PR ...

* introduces --feature=oid4vc_vci_preauth_code
* rejects requests to the /create-credential-offer endpoint (when not enabled)
* removes the `pre-authorized_code` grant from the metadata
* adds a KeycloakServerConfig for PreAuth testing
* moves tests that use preauth to that server config
* uses `authorization_code` grant in places where preauth is not strictly necessary