### PR TITLE
Fix device user code input styling in keycloak.v2 login theme

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/OAuth2DeviceVerificationPage.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/pages/OAuth2DeviceVerificationPage.java
@@ -27,11 +27,12 @@ import org.openqa.selenium.support.FindBy;
 public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
 
     private static final String CONSENT_DENIED_MESSAGE = "Consent denied for connecting the device.";
-    
-    @FindBy(id = "device-user-code")
+    public static final String DEVICE_USER_CODE = "device_user_code";
+
+    @FindBy(name = DEVICE_USER_CODE)
     private WebElement userCodeInput;
 
-    @FindBy(css = "input[type=\"submit\"]")
+    @FindBy(css = "button[type=\"submit\"]")
     private WebElement submitButton;
 
     @FindBy(className = "pf-v5-c-alert")
@@ -53,7 +54,7 @@ public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
     public boolean isCurrent() {
         if (driver.getTitle().startsWith("Sign in to ")) {
             try {
-                driver.findElement(By.id("device-user-code"));
+                driver.findElement(By.id(DEVICE_USER_CODE));
                 return true;
             } catch (Throwable t) {
             }
@@ -106,7 +107,7 @@ public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
     private boolean isInvalidUserCodePage() {
         if (driver.getTitle().startsWith("Sign in to ")) {
             try {
-                driver.findElement(By.id("device-user-code"));
+                driver.findElement(By.id(DEVICE_USER_CODE));
                 return driver.findElement(By.id("kc-page-title")).getText().equals("Device Login")
                         && driver.findElement(By.className("pf-m-danger")).getText().equals("Invalid code, please try again.");
             } catch (Throwable t) {
@@ -118,7 +119,7 @@ public class OAuth2DeviceVerificationPage extends LanguageComboboxAwarePage {
     private boolean isExpiredUserCodePage() {
         if (driver.getTitle().startsWith("Sign in to ")) {
             try {
-                driver.findElement(By.id("device-user-code"));
+                driver.findElement(By.id(DEVICE_USER_CODE));
                 return driver.findElement(By.id("kc-page-title")).getText().equals("Device Login")
                         && driver.findElement(By.className("pf-m-danger")).getText().equals("The code has expired. Please go back to your device and try connecting again.");
             } catch (Throwable t) {

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-oauth2-device-verify-user-code.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-oauth2-device-verify-user-code.ftl
@@ -1,0 +1,17 @@
+<#import "template.ftl" as layout>
+<#import "field.ftl" as field>
+<#import "buttons.ftl" as buttons>
+<@layout.registrationLayout; section>
+<!-- template: login-oauth2-device-verify-user-code.ftl -->
+    <#if section = "header">
+        ${msg("oauth2DeviceVerificationTitle")}
+    <#elseif section = "form">
+        <form id="kc-user-verify-device-user-code-form" class="${properties.kcFormClass!}" action="${url.oauth2DeviceVerificationAction}" method="post">
+            <@field.input name="device_user_code" label=msg("verifyOAuth2DeviceUserCode") autofocus=true />
+
+            <@buttons.actionGroup>
+                <@buttons.button id="kc-login" label="doSubmit" class=["kcButtonPrimaryClass", "kcButtonBlockClass"] />
+            </@buttons.actionGroup>
+        </form>
+    </#if>
+</@layout.registrationLayout>

--- a/themes/src/main/resources/theme/keycloak.v2/login/login-passkeys-conditional-authenticate.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/login-passkeys-conditional-authenticate.ftl
@@ -1,0 +1,136 @@
+<#import "template.ftl" as layout>
+<#import "field.ftl" as field>
+<#import "buttons.ftl" as buttons>
+<@layout.registrationLayout displayInfo=(realm.registrationAllowed && !registrationDisabled??); section>
+<!-- template: login-passkeys-conditional-authenticate.ftl -->
+    <#if section = "title">
+     title
+    <#elseif section = "header">
+        ${msg("passkey-login-title")}
+    <#elseif section = "form">
+        <form id="webauth" action="${url.loginAction}" method="post">
+            <input type="hidden" id="clientDataJSON" name="clientDataJSON"/>
+            <input type="hidden" id="authenticatorData" name="authenticatorData"/>
+            <input type="hidden" id="signature" name="signature"/>
+            <input type="hidden" id="credentialId" name="credentialId"/>
+            <input type="hidden" id="userHandle" name="userHandle"/>
+            <input type="hidden" id="error" name="error"/>
+        </form>
+
+        <div class="${properties.kcFormGroupClass!} no-bottom-margin">
+            <#if authenticators??>
+                <form id="authn_select" class="${properties.kcFormClass!}">
+                    <#list authenticators.authenticators as authenticator>
+                        <input type="hidden" name="authn_use_chk" value="${authenticator.credentialId}"/>
+                    </#list>
+                </form>
+
+                <#if shouldDisplayAuthenticators?? && shouldDisplayAuthenticators>
+                    <#if authenticators.authenticators?size gt 1>
+                        <p class="${properties.kcSelectAuthListItemTitle!}">${msg("passkey-available-authenticators")}</p>
+                    </#if>
+
+                    <div class="${properties.kcFormClass!}">
+                        <#list authenticators.authenticators as authenticator>
+                            <div id="kc-webauthn-authenticator-item-${authenticator?index}" class="${properties.kcSelectAuthListItemClass!}">
+                                <div class="${properties.kcSelectAuthListItemIconClass!}">
+                                    <i class="${(properties['${authenticator.transports.iconClass}'])!'${properties.kcWebAuthnDefaultIcon!}'} ${properties.kcSelectAuthListItemIconPropertyClass!}"></i>
+                                </div>
+                                <div class="${properties.kcSelectAuthListItemBodyClass!}">
+                                    <div id="kc-webauthn-authenticator-label-${authenticator?index}"
+                                         class="${properties.kcSelectAuthListItemHeadingClass!}">
+                                        ${authenticator.label}
+                                    </div>
+
+                                    <#if authenticator.transports?? && authenticator.transports.displayNameProperties?has_content>
+                                        <div id="kc-webauthn-authenticator-transport-${authenticator?index}"
+                                            class="${properties.kcSelectAuthListItemDescriptionClass!}">
+                                            <#list authenticator.transports.displayNameProperties as nameProperty>
+                                                <span>${msg(nameProperty)}</span>
+                                                <#if nameProperty?has_next>
+                                                    <span>, </span>
+                                                </#if>
+                                            </#list>
+                                        </div>
+                                    </#if>
+
+                                    <div class="${properties.kcSelectAuthListItemDescriptionClass!}">
+                                        <span id="kc-webauthn-authenticator-createdlabel-${authenticator?index}">
+                                            ${msg('passkey-createdAt-label')}
+                                        </span>
+                                        <span id="kc-webauthn-authenticator-created-${authenticator?index}">
+                                            ${authenticator.createdAt}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="${properties.kcSelectAuthListItemFillClass!}"></div>
+                            </div>
+                        </#list>
+                    </div>
+                </#if>
+            </#if>
+
+            <div id="kc-form">
+                <div id="kc-form-wrapper">
+                    <#if realm.password>
+                        <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post" style="display:none">
+                            <#if !usernameHidden??>
+                                <@field.input name="username" label=msg("passkey-autofill-select") value=login.username!'' autofocus=true autocomplete="username webauthn" />
+                            </#if>
+                        </form>
+                    </#if>
+                    <div id="kc-form-passkey-button" class="${properties.kcFormButtonsClass!}" style="display:none">
+                        <input id="authenticateWebAuthnButton" type="button" autofocus="autofocus"
+                            value="${msg("passkey-doAuthenticate")}"
+                            class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script type="module">
+            <#outputformat "JavaScript">
+            import { authenticateByWebAuthn } from "${url.resourcesPath}/js/webauthnAuthenticate.js";
+            import { initAuthenticate } from "${url.resourcesPath}/js/passkeysConditionalAuth.js";
+
+            const authButton = document.getElementById('authenticateWebAuthnButton');
+            const input = {
+                isUserIdentified : ${isUserIdentified},
+                challenge : ${challenge?c},
+                userVerification : ${userVerification?c},
+                rpId : ${rpId?c},
+                createTimeout : ${createTimeout?c},
+                errmsg : ${msg("webauthn-unsupported-browser-text")?c}
+            };
+            authButton.addEventListener("click", () => {
+                authenticateByWebAuthn(input);
+            }, { once: true });
+
+            const args = {
+                isUserIdentified : ${isUserIdentified},
+                challenge : ${challenge?c},
+                userVerification : ${userVerification?c},
+                rpId : ${rpId?c},
+                createTimeout : ${createTimeout?c},
+                errmsg : ${msg("passkey-unsupported-browser-text")?c}
+            };
+
+            document.addEventListener("DOMContentLoaded", (event) => initAuthenticate(args, (available) => {
+                if (available) {
+                    document.getElementById("kc-form-login").style.display = "block";
+                } else {
+                    document.getElementById("kc-form-passkey-button").style.display = 'block';
+                }
+            }));
+            </#outputformat>
+        </script>
+
+    <#elseif section = "info">
+        <#if realm.registrationAllowed && !registrationDisabled??>
+            <div id="kc-registration">
+                <span>${msg("noAccount")} <a tabindex="6" href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+            </div>
+        </#if>
+    </#if>
+
+</@layout.registrationLayout>


### PR DESCRIPTION
Fixes #46463

When entering a code for the OAuth 2.0 Device Authorization Grant on the device verification page, the input field was not rendered with the expected PatternFly styling in the keycloak.v2 login theme.

This change adds the missing keycloak.v2 template for the device user code page so the code input is rendered like the other PatternFly-styled login form fields.

<img width="1918" height="986" alt="image" src="https://github.com/user-attachments/assets/46a44372-6080-4a29-9a80-0611a4d92180" />
