### PR TITLE
fix: allowing nested } if matched with {

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
+++ b/common/src/main/java/org/keycloak/common/util/StringPropertyReplacer.java
@@ -131,6 +131,7 @@ public final class StringPropertyReplacer
         return new InputStream() {
             private ByteArrayInputStream buffer;
             private boolean closed;
+            private int curlyBraceDepth;
 
             @Override
             public int read() throws IOException {
@@ -147,8 +148,14 @@ public final class StringPropertyReplacer
                 }
                 // if no buffer, scan for } or ${
                 int c = source.read();
-                if (c == '}' && readUntilCurlyBrace) {
-                    return -2;
+                if (readUntilCurlyBrace) {
+                    if (c == '}') {
+                        if (curlyBraceDepth-- == 0) {
+                            return -2;
+                        }
+                    } else if (c == '{') {
+                        curlyBraceDepth++;
+                    }
                 }
                 if (c != '$') {
                     return c;

--- a/common/src/test/java/org/keycloak/common/util/StringPropertyReplacerTest.java
+++ b/common/src/test/java/org/keycloak/common/util/StringPropertyReplacerTest.java
@@ -41,6 +41,11 @@ public class StringPropertyReplacerTest {
         System.setProperty("prop2", "val2");
         Assert.assertEquals("foo-val2", replaceProperties("foo-${prop2:def}"));
 
+        // nesting curly braces
+        Assert.assertEquals("This is a default text with a {0} substitute", replaceProperties("${prop3:This is a default text with a {0} substitute}"));
+        // stops at first unmatched, then the rest is regular text - matches the original implementation
+        Assert.assertEquals("This is a default text with a {0} substitute}", replaceProperties("${prop3:This is a default text with a {0}} substitute}"));
+
         // It looks for the property "prop3", then fallback to "prop4", then fallback to "prop5" and finally default value.
         // This syntax is supported by Quarkus (and underlying Microprofile)
         Assert.assertEquals("foo-def", replaceProperties("foo-${prop3:${prop4:${prop5:def}}}"));


### PR DESCRIPTION
restores the old implementations handling of nested curly braces

closes: #47201

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
