### PR TITLE
Client API v2: add schema properties descriptions from @JsonPropertyDescription in order to improve CLI client help

### DIFF
--- a/js/libs/keycloak-admin-client/openapi.yaml
+++ b/js/libs/keycloak-admin-client/openapi.yaml
@@ -7,10 +7,14 @@ components:
       properties:
         method:
           type: string
+          description: Which authentication method is used for this client
         secret:
           type: string
+          description: Secret used to authenticate this client with Secret authentication
         certificate:
           type: string
+          description: Public key used to authenticate this client with Signed JWT
+            authentication
     BaseClientRepresentation:
       description: Base client representation with common properties for all client
         types
@@ -18,24 +22,32 @@ components:
       properties:
         clientId:
           type: string
+          description: ID uniquely identifying this client
         displayName:
           type: string
+          description: Human readable name of the client
         description:
           type: string
+          description: Human readable description of the client
         enabled:
           type: boolean
+          description: Whether this client is enabled
         appUrl:
           type: string
+          description: URL to the application's homepage that is represented by this
+            client
         redirectUris:
           type: array
           uniqueItems: true
           items:
             type: string
+          description: URIs that the browser can redirect to after login
         roles:
           type: array
           uniqueItems: true
           items:
             type: string
+          description: Roles associated with this client
         protocol:
           type: string
       discriminator:
@@ -61,18 +73,22 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/Flow"
+          description: Login flows that are enabled for this client
         auth:
           $ref: "#/components/schemas/Auth"
+          description: Authentication configuration for this client
         webOrigins:
           type: array
           uniqueItems: true
           items:
             type: string
+          description: Web origins that are allowed to make requests to this client
         serviceAccountRoles:
           type: array
           uniqueItems: true
           items:
             type: string
+          description: Roles assigned to the service account
         protocol:
           type: string
       allOf:
@@ -83,28 +99,43 @@ components:
       properties:
         nameIdFormat:
           type: string
+          description: "Name ID format to use for the subject (e.g., 'username', 'email',\
+            \ 'transient', 'persistent')"
         forceNameIdFormat:
           type: boolean
+          description: Force the specified Name ID format even if the client requests
+            a different one
         includeAuthnStatement:
           type: boolean
+          description: Include AuthnStatement in the SAML response
         signDocuments:
           type: boolean
+          description: Sign SAML documents on the server side
         signAssertions:
           type: boolean
+          description: Sign SAML assertions
         clientSignatureRequired:
           type: boolean
+          description: Require client to sign SAML requests
         forcePostBinding:
           type: boolean
+          description: Force POST binding for SAML responses
         frontChannelLogout:
           type: boolean
+          description: Use front-channel logout (browser redirect)
         signatureAlgorithm:
           type: string
+          description: "Signature algorithm for signing SAML documents (e.g., 'RSA_SHA256',\
+            \ 'RSA_SHA512')"
         signatureCanonicalizationMethod:
           type: string
+          description: Canonicalization method for XML signatures
         signingCertificate:
           type: string
+          description: "X.509 certificate for signing (PEM format, without headers)"
         allowEcpFlow:
           type: boolean
+          description: Allow ECP (Enhanced Client or Proxy) flow
         protocol:
           type: string
       allOf:

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OpenApiDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/OpenApiDistTest.java
@@ -123,5 +123,10 @@ public class OpenApiDistTest {
           .body("paths.'/admin/api/{realmName}/clients/{version}'.get.responses.'200'.content.'application/json'.schema.items.'$ref'", equalTo("#/components/schemas/BaseClientRepresentation"))
           .body("paths.'/admin/api/{realmName}/clients/{version}/{id}'.get.responses.'200'.content.'application/json'.schema.'$ref'", equalTo("#/components/schemas/BaseClientRepresentation"))
           .body("paths.'/admin/api/{realmName}/clients/{version}/{id}'.put.requestBody.content.'application/json'.schema.'$ref'", equalTo("#/components/schemas/BaseClientRepresentation"));
+
+      // @JsonPropertyDescription values must be propagated to schema property descriptions
+      response
+          .body("components.schemas.SAMLClientRepresentation.properties.nameIdFormat.description", containsString("Name ID format"))
+          .body("components.schemas.Auth.properties.secret.description", containsString("authenticate"));
     }
 }

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/internal/openapi/OASModelFilter.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/internal/openapi/OASModelFilter.java
@@ -11,6 +11,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,12 +25,14 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.services.PatchTypeNames.JSON_MERGE;
+import static org.keycloak.utils.StringUtil.isNullOrEmpty;
 
 public class OASModelFilter implements OASFilter {
 
@@ -80,6 +83,8 @@ public class OASModelFilter implements OASFilter {
                 }
             });
         });
+
+        addDescriptionsToSchemasProperties(openAPI);
     }
 
     /**
@@ -87,7 +92,7 @@ public class OASModelFilter implements OASFilter {
      * from all remaining schemas.
      */
     private void removeSchemaAndRefs(OpenAPI openAPI, String schemaName) {
-        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+        if (hasNoSchemas(openAPI)) {
             return;
         }
 
@@ -176,7 +181,7 @@ public class OASModelFilter implements OASFilter {
      * hierarchies with inheritance.
      */
     private void addDiscriminatorsToParentSchemas(OpenAPI openAPI, Map<String, Set<Schema>> discriminatorPropertiesToBeAdded) {
-        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+        if (hasNoSchemas(openAPI)) {
             return;
         }
 
@@ -299,5 +304,41 @@ public class OASModelFilter implements OASFilter {
         sortedPathItem.setParameters(pathItem.getParameters());
 
         return sortedPathItem;
+    }
+
+    private void addDescriptionsToSchemasProperties(OpenAPI openAPI) {
+        if (hasNoSchemas(openAPI)) {
+            return;
+        }
+
+        openAPI.getComponents().getSchemas().forEach((schemaName, schema) -> {
+            if (schema.getProperties() != null) {
+                ClassInfo classInfo = simpleNameToClassInfoMap.get(schemaName);
+                if (classInfo == null) {
+                    log.debugf("No Java class found for schema '%s' — property descriptions from  the '%s' annotation will not be added", schemaName, JsonPropertyDescription.class.getName());
+                } else {
+                    schema.getProperties().forEach((propertyName, propertySchema) -> {
+                        if (isNullOrEmpty(propertySchema.getDescription())) {
+                            propertySchema.setDescription(findJsonPropertyDescription(classInfo, propertyName));
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    private String findJsonPropertyDescription(ClassInfo classInfo, String fieldName) {
+        FieldInfo field = classInfo.field(fieldName);
+        if (field != null) {
+            AnnotationInstance annotation = field.annotation(JsonPropertyDescription.class);
+            if (annotation != null && annotation.value() != null && !annotation.value().asString().isBlank()) {
+                return annotation.value().asString();
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasNoSchemas(OpenAPI openAPI) {
+        return openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null;
     }
 }


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/47299

We propagate Java representation properties description placed in `JsonPropertyDescription` to the schema property description. This will enable CLI client to show correct description for CLI command arguments.
