### PR TITLE
Allow Token Exchange of sender constrained tokens issued for the original client

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -89,3 +89,11 @@ exceeds 255 characters, it will be truncated during migration.
 DPoP (Demonstrating Proof of Possession) is no longer supported for implicit and hybrid flows. If a client has the *Require DPoP bound tokens* option enabled, authorization requests using implicit or hybrid response types will be rejected with an error.
 
 This change improves security by preventing the use of DPoP with flows that issue access tokens in the front channel, where the sender-constrained token model cannot be properly enforced.
+
+=== Token Exchange with Sender-constrained tokens allowed for scope changes
+
+Standard Token Exchange now accepts sender-constrained tokens when a client is requesting an exchange of their own token.
+This change allows token audience changes and up/down scoping and is applicable to both DPoP-bound tokens and X.509 certificate-bound tokens (mTLS).
+
+If you attempt to exchange a sender-constrained token using a different client, the request will be rejected with an `invalid_request` error.
+For more details, see the link:{securing_apps_token_exchange_link}[Token Exchange] guide.

--- a/docs/guides/securing-apps/dpop.adoc
+++ b/docs/guides/securing-apps/dpop.adoc
@@ -182,8 +182,12 @@ For granular control, you can use the **dpop-bind-enforcer** executor within Cli
 
 == DPoP with Standard Token Exchange
 
-* Standard Token Exchange does not support DPoP-bound tokens (as defined in RFC 7800) as the `subject_token` parameter. Only Bearer access tokens can be exchanged. If you attempt to use a DPoP-bound token as the subject token, the request will be rejected with an `invalid_request` error.
-* While DPoP-bound tokens cannot be used as `subject_token` to token exchange, you can obtain DPoP-bound tokens as **output**.
+Standard Token Exchange supports DPoP-bound tokens as `subject_token` under specific conditions:
+
+* The client performing the token exchange request *must be the same client* that the `subject_token` was issued for (the `azp` claim must match the requester client ID).
+* The client must include a valid DPoP proof in the exchange request, signed with the same key that was used to bind the original token. {project_name} verifies that the DPoP key thumbprint matches the `cnf.jkt` claim in the subject token.
+
+The exchanged token will also be DPoP-bound if a valid DPoP proof is included in the request.
 
 === When to Use Token Exchange with DPoP
 
@@ -192,5 +196,6 @@ Token exchange with DPoP is useful when:
 * You need to upgrade a Bearer token to a DPoP-bound token for increased security
 * You want to down-scope or change audiences while simultaneously adding DPoP binding
 * Your backend services require DPoP but the original token was issued as Bearer
+* You need to exchange a DPoP-bound token for a new one with different audiences or scopes while maintaining the DPoP binding
 
 </@tmpl.guide>

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -265,7 +265,9 @@ This use case can be replaced by refresh token grant.
 * The `subject_token` sent to the token exchange endpoint must have the requester client set as an audience in the `aud` claim. Otherwise, the request would be rejected. The only exception is, if client
 exchanges his own token, which was issued to it. Exchanging to itself might be useful to downscope/upscope the token or filter unneeded token audiences and so on.
 
-* Sender-constrained tokens (as defined in RFC 7800) cannot be used as `subject_token`. This includes DPoP-bound tokens and X.509 certificate-bound tokens. Standard Token Exchange only accepts Bearer access tokens as subject tokens. If you provide a sender-constrained token, the request will be rejected with an `invalid_request` error. However, you can obtain DPoP-bound tokens as **output** from token exchange by including a valid DPoP proof in the request. For more details, see <@links.securingapps id="dpop" />.
+* Sender-constrained tokens (as defined in RFC 7800) can be used as `subject_token` only when the requesting client is the same client that the token was originally issued for.
+The client must also provide valid proof of possession: a DPoP proof for DPoP-bound tokens, or the matching client certificate for mTLS-bound tokens.
+If the client does not match or the proof is missing/invalid, the request is rejected. For more details on DPoP, see <@links.securingapps id="dpop" />.
 
 * Consents - If the requester client has *Consent required* enabled, the token exchange is allowed only if the user is already granted consent to all requested scopes
 

--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -26,14 +26,17 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.services.util.DPoPUtil;
+import org.keycloak.services.util.MtlsHoKTokenUtil;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -162,8 +165,13 @@ public class ProtocolMapperUtils {
                         .filter(Objects::nonNull)
                         .filter(filter);
 
-        if (OIDCLoginProtocol.LOGIN_PROTOCOL.equals(ctx.getClientSession().getClient().getProtocol())) {
+        ClientModel client = ctx.getClientSession().getClient();
+        if (OIDCLoginProtocol.LOGIN_PROTOCOL.equals(client.getProtocol())) {
             protocolMapperStream = Stream.concat(protocolMapperStream, DPoPUtil.getTransientProtocolMapper());
+
+            if (OIDCAdvancedConfigWrapper.fromClientModel(client).isUseMtlsHokToken()) {
+                protocolMapperStream = Stream.concat(protocolMapperStream, MtlsHoKTokenUtil.getTransientProtocolMapper());
+            }
         }
 
         return protocolMapperStream.sorted(Comparator.comparing(ProtocolMapperUtils::compare));

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -30,6 +30,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.actiontoken.TokenUtils;
 import org.keycloak.common.Profile;
+import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.CollectionUtil;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -47,10 +48,13 @@ import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.rar.AuthorizationRequestContext;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.util.AuthorizationContextUtil;
+import org.keycloak.services.util.DPoPUtil;
+import org.keycloak.services.util.MtlsHoKTokenUtil;
 import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
@@ -135,13 +139,41 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
         UserSessionModel tokenSession = authResult.session();
         AccessToken token = authResult.token();
 
-        // Reject sender-constrained tokens (RFC 7800) as subject_token
         if (isSenderConstrainedToken(token)) {
-            event.detail(Details.REASON, "Sender-constrained tokens (RFC 7800) cannot be used as subject_token in Token Exchange");
-            event.error(Errors.INVALID_REQUEST);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
-                    "Sender-constrained tokens are not supported as subject_token. Use a Bearer token instead.",
-                    Response.Status.BAD_REQUEST);
+            // Reject sender-constrained tokens (RFC 7800) as subject_token if client does not match the authorized parties claim
+            if (!token.getIssuedFor().equals(client.getClientId())) {
+                event.detail(Details.REASON, "Sender-constrained token exchange rejected as the token was not issued for the requesting client");
+                event.error(Errors.INVALID_REQUEST);
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                      "Sender-constrained token exchange rejected as the token was not issued for the requesting client",
+                      Response.Status.BAD_REQUEST);
+            }
+
+            AccessToken.Confirmation cnf = token.getConfirmation();
+            // Validate mTLS
+            if (cnf.getCertThumbprint() != null) {
+                if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(token, session.getContext().getHttpRequest(), session)) {
+                    throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.BAD_REQUEST);
+                }
+            }
+            // Validate DPoP
+            if (Profile.isFeatureEnabled(Profile.Feature.DPOP) && cnf.getKeyThumbprint() != null) {
+                DPoP dPoP = session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE, DPoP.class);
+                if (dPoP == null) {
+                    event.detail(Details.REASON, "DPoP proof is missing");
+                    event.error(Errors.INVALID_DPOP_PROOF);
+                    throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                          "DPoP proof is missing", Response.Status.BAD_REQUEST);
+                }
+                try {
+                    DPoPUtil.validateBinding(token, dPoP);
+                } catch (VerificationException ex) {
+                    event.detail(Details.REASON, ex.getMessage());
+                    event.error(Errors.INVALID_DPOP_PROOF);
+                    throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                          ex.getMessage(), Response.Status.BAD_REQUEST);
+                }
+            }
         }
 
         event.user(tokenUser);

--- a/services/src/main/java/org/keycloak/services/util/MtlsHoKTokenUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/MtlsHoKTokenUtil.java
@@ -5,10 +5,25 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.http.HttpRequest;
+import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenResponseMapper;
+import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.TokenIntrospectionTokenMapper;
+import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
+import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.services.x509.X509ClientCertificateLookup;
 
@@ -22,8 +37,17 @@ public class MtlsHoKTokenUtil {
 
     private static final String DIGEST_ALG = "SHA-256";
 
-    public static final String CERT_VERIFY_ERROR_DESC = "Client certificate missing, or its thumbprint and one in the refresh token did NOT match";
+    public static final String CERT_VERIFY_ERROR_DESC = "Client certificate missing, or its thumbprint and one in the token did NOT match";
 
+    public static Stream<Map.Entry<ProtocolMapperModel, ProtocolMapper>> getTransientProtocolMapper() {
+        ProtocolMapperModel protocolMapperModel = new ProtocolMapperModel();
+        protocolMapperModel.setId(MtlsHoKProtocolMapper.PROVIDER_ID);
+        protocolMapperModel.setName("mtls-hok");
+        protocolMapperModel.setProtocolMapper(MtlsHoKProtocolMapper.PROVIDER_ID);
+        protocolMapperModel.setProtocol("openid-connect");
+        protocolMapperModel.setConfig(Map.of());
+        return Stream.of(Map.entry(protocolMapperModel, new MtlsHoKProtocolMapper()));
+    }
 
     public static AccessToken.Confirmation bindTokenWithClientCertificate(HttpRequest request, KeycloakSession session) {
         X509Certificate[] certs = getCertificateChain(request, session);
@@ -83,7 +107,7 @@ public class MtlsHoKTokenUtil {
         }
 
         if (!MessageDigest.isEqual(x5ts256.getBytes(), DERX509Base64UrlEncoded.getBytes())) {
-            logger.warnf("certificate's thumbprint and one in the refresh token did not match.");
+            logger.warnf("certificate's thumbprint and one in the token did not match.");
             return false;
         }
 
@@ -135,6 +159,53 @@ public class MtlsHoKTokenUtil {
             logger.tracef(":: certs[%d] Certfication Type of first x509 Client Certificate in Certificate Chain = %s", i, certs[i].getType());
             logger.tracef(":: certs[%d] Issuer DN of first x509 Client Certificate in Certificate Chain = %s", i, certs[i].getIssuerDN().getName());
             logger.tracef(":: certs[%d] Subject DN of first x509 Client Certificate in Certificate Chain = %s", i, certs[i].getSubjectDN().getName());
+        }
+    }
+
+    /**
+     * Protocol mapper that binds access tokens to the client's mTLS certificate
+     * by adding the "cnf" (confirmation) claim with a "x5t#S256" certificate
+     * thumbprint. This ensures sender-constrained tokens for all grant types,
+     * including token exchange.
+     */
+    public static class MtlsHoKProtocolMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper,
+          OIDCIDTokenMapper, UserInfoTokenMapper, TokenIntrospectionTokenMapper, OIDCAccessTokenResponseMapper {
+
+        public static final String PROVIDER_ID = "mtls-hok-protocol-mapper";
+
+        @Override
+        public String getId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getDisplayCategory() {
+            return TOKEN_MAPPER_CATEGORY;
+        }
+
+        @Override
+        public String getDisplayType() {
+            return "mtls-hok";
+        }
+
+        @Override
+        public String getHelpText() {
+            return "Binds access tokens to the client's mTLS certificate by adding the cnf claim with x5t#S256 thumbprint.";
+        }
+
+        @Override
+        public List<ProviderConfigProperty> getConfigProperties() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel,
+                                                KeycloakSession session, UserSessionModel userSession, ClientSessionContext clientSessionCtx) {
+            AccessToken.Confirmation confirmation = bindTokenWithClientCertificate(session.getContext().getHttpRequest(), session);
+            if (confirmation != null) {
+                token.setConfirmation(confirmation);
+            }
+            return token;
         }
     }
 }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/TokenExchangeRequest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.util.TokenUtil;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 
@@ -44,6 +45,11 @@ public class TokenExchangeRequest extends AbstractHttpPostRequest<TokenExchangeR
 
     public TokenExchangeRequest audience(String... audience) {
         this.audience = Arrays.stream(audience).toList();
+        return this;
+    }
+
+    public TokenExchangeRequest dpopProof(String dpopProof) {
+        header(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
         return this;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
@@ -70,6 +70,7 @@ import org.keycloak.representations.idm.ClientInitialAccessPresentation;
 import org.keycloak.representations.idm.ClientPoliciesRepresentation;
 import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
 import org.keycloak.representations.oidc.TokenMetadataRepresentation;
@@ -84,6 +85,8 @@ import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AdminApiUtil;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.broker.util.SimpleHttpDefault;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
+import org.keycloak.testsuite.updaters.ProtocolMappersUpdater;
 import org.keycloak.testsuite.util.AdminClientUtil;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPoliciesBuilder;
 import org.keycloak.testsuite.util.ClientPoliciesUtil.ClientPolicyBuilder;
@@ -1117,6 +1120,102 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
         }
 
         oauth.doLogout(response.getRefreshToken());
+    }
+
+    @Test
+    public void testDPoPTokenExchange() throws Exception {
+        ProtocolMapperRepresentation audMapper = new ProtocolMapperRepresentation();
+        audMapper.setName("dpop-test-audience-mapper");
+        audMapper.setProtocol("openid-connect");
+        audMapper.setProtocolMapper("oidc-audience-mapper");
+        audMapper.setConfig(Map.of("included.client.audience", "named-test-app","access.token.claim", "true"));
+
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CONFIDENTIAL_CLIENT_ID)
+                .setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
+                .update();
+             ProtocolMappersUpdater ignoredMappers = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CONFIDENTIAL_CLIENT_ID)
+                .protocolMappers().add(audMapper).update()) {
+            AccessTokenResponse tokenResponse = getDPoPBindAccessToken(rsaKeyPair);
+            String exchangeDpopProof = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST,
+                    oauth.getEndpoints().getToken(), (long) Time.currentTime(), Algorithm.PS256, jwsRsaHeader,
+                    rsaKeyPair.getPrivate(), tokenResponse.getAccessToken());
+
+            AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(tokenResponse.getAccessToken())
+                    .client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET)
+                    .audience("named-test-app").dpopProof(exchangeDpopProof)
+                    .send();
+
+            assertEquals(Status.OK.getStatusCode(), exchangeResponse.getStatusCode(), exchangeResponse.getErrorDescription());
+            assertEquals(TokenUtil.TOKEN_TYPE_DPOP, exchangeResponse.getTokenType());
+            AccessToken exchangedToken = oauth.verifyToken(exchangeResponse.getAccessToken());
+            assertEquals(jktRsa, exchangedToken.getConfirmation().getKeyThumbprint());
+            assertTrue(List.of(exchangedToken.getAudience()).contains("named-test-app"));
+
+            oauth.doLogout(tokenResponse.getRefreshToken());
+        }
+    }
+
+    @Test
+    public void testDPoPTokenExchangeMissingProof() throws Exception {
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CONFIDENTIAL_CLIENT_ID)
+                .setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
+                .update()) {
+            AccessTokenResponse tokenResponse = getDPoPBindAccessToken(rsaKeyPair);
+
+            AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(tokenResponse.getAccessToken())
+                    .client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET)
+                    .send();
+
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), exchangeResponse.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_REQUEST, exchangeResponse.getError());
+            assertTrue(exchangeResponse.getErrorDescription().contains("DPoP proof is missing"));
+
+            oauth.doLogout(tokenResponse.getRefreshToken());
+        }
+    }
+
+    @Test
+    public void testDPoPTokenExchangeDifferentClient() throws Exception {
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, "named-test-app")
+                .setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
+                .update()) {
+            AccessTokenResponse tokenResponse = getDPoPBindAccessToken(rsaKeyPair);
+            String dpopProof = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST,
+                    oauth.getEndpoints().getToken(), (long) Time.currentTime(), Algorithm.PS256, jwsRsaHeader,
+                    rsaKeyPair.getPrivate(), tokenResponse.getAccessToken());
+
+            AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(tokenResponse.getAccessToken())
+                    .client("named-test-app", "password")
+                    .dpopProof(dpopProof).send();
+
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), exchangeResponse.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_REQUEST, exchangeResponse.getError());
+            assertTrue(exchangeResponse.getErrorDescription().contains("not issued for the requesting client"));
+
+            oauth.doLogout(tokenResponse.getRefreshToken());
+        }
+    }
+
+    @Test
+    public void testDPoPTokenExchangeWrongKey() throws Exception {
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CONFIDENTIAL_CLIENT_ID)
+                .setAttribute(OIDCConfigAttributes.STANDARD_TOKEN_EXCHANGE_ENABLED, Boolean.TRUE.toString())
+                .update()) {
+            AccessTokenResponse tokenResponse = getDPoPBindAccessToken(rsaKeyPair);
+            String wrongDpopProof = generateSignedDPoPProof(UUID.randomUUID().toString(), HttpMethod.POST,
+                    oauth.getEndpoints().getToken(), (long) Time.currentTime(), Algorithm.ES256, jwsEcHeader,
+                    ecKeyPair.getPrivate(), tokenResponse.getAccessToken());
+
+            AccessTokenResponse exchangeResponse = oauth.tokenExchangeRequest(tokenResponse.getAccessToken())
+                    .client(TEST_CONFIDENTIAL_CLIENT_ID, TEST_CONFIDENTIAL_CLIENT_SECRET)
+                    .dpopProof(wrongDpopProof)
+                    .send();
+
+            assertEquals(Status.BAD_REQUEST.getStatusCode(), exchangeResponse.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_REQUEST, exchangeResponse.getError());
+
+            oauth.doLogout(tokenResponse.getRefreshToken());
+        }
     }
 
     private AccessTokenResponse getDPoPBindAccessToken(KeyPair rsaKeyPair) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
@@ -7,6 +7,7 @@ import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.client.Client;
@@ -37,9 +38,11 @@ import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.oidc.TokenMetadataRepresentation;
+import org.keycloak.services.util.MtlsHoKTokenUtil;
 import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.AssertEvents;
@@ -146,24 +149,35 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         testRealm.getUsers().add(user);
     }
 
-    // enable HoK Token as default
     @Before
-    public void enableHoKToken() {
-        // Enable MTLS HoK Token
-        for (String clientId : CLIENT_LIST) enableHoKToken(clientId);
+    public void configureClients() {
+        for (String clientId : CLIENT_LIST) {
+            ClientResource clientResource = AdminApiUtil.findClientByClientId(adminClient.realm("test"), clientId);
+            ClientRepresentation clientRep = clientResource.toRepresentation();
+            OIDCAdvancedConfigWrapper oidc = OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep);
+            // Enable MTLS HoK Token
+            oidc.setUseMtlsHoKToken(true);
+
+            if (clientId.equals("test-app")) {
+                // Enable token exchange
+                oidc.setStandardTokenExchangeEnabled(true);
+
+                ProtocolMapperRepresentation audMapper = new ProtocolMapperRepresentation();
+                audMapper.setName("oidc-audience-mapper");
+                audMapper.setProtocol("openid-connect");
+                audMapper.setProtocolMapper("oidc-audience-mapper");
+                audMapper.setConfig(Map.of(
+                      "included.client.audience", "named-test-app",
+                      "access.token.claim", "true"
+                ));
+                clientRep.setProtocolMappers(List.of(audMapper));
+            }
+            clientResource.update(clientRep);
+        }
     }
 
-    private void enableHoKToken(String clientId) {
-        // Enable MTLS HoK Token
-        ClientResource clientResource = AdminApiUtil.findClientByClientId(adminClient.realm("test"), clientId);
-        ClientRepresentation clientRep = clientResource.toRepresentation();
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseMtlsHoKToken(true);
-        clientResource.update(clientRep);
-    }
-    
-    // Authorization Code Flow 
+    // Authorization Code Flow
     // Bind HoK Token
-
     @Test
     public void accessTokenRequestWithClientCertificate() throws Exception {
         oauth.doLogin("test-user@localhost", "password");
@@ -307,7 +321,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         // Error Pattern
         assertEquals(401, response.getStatusCode());
         assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, response.getError());
-        assertEquals("Client certificate missing, or its thumbprint and one in the refresh token did NOT match", response.getErrorDescription());
+        assertEquals("Client certificate missing, or its thumbprint and one in the token did NOT match", response.getErrorDescription());
     }
 
     @Test
@@ -399,7 +413,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         // Error Pattern
         assertEquals(401, response.getStatusCode());
         assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, response.getError());
-        assertEquals("Client certificate missing, or its thumbprint and one in the refresh token did NOT match", response.getErrorDescription());
+        assertEquals("Client certificate missing, or its thumbprint and one in the token did NOT match", response.getErrorDescription());
     }
 
     private void expectSuccessfulResponseFromTokenEndpoint(AccessTokenResponse response, String sessionId, AccessToken token, RefreshToken refreshToken, EventRepresentation tokenEvent) {
@@ -743,6 +757,73 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         }
     }
 
+    @Test
+    public void testTokenExchangeV2() throws Exception {
+        // Obtain a HoK-bound access token with client certificate
+        oauth.doLogin("test-user@localhost", "password");
+        String code = oauth.parseLoginResponse().getCode();
+
+        oauth.client("test-app", "password");
+        AccessTokenResponse tokenResponse;
+        try (CloseableHttpClient client = MutualTLSUtils.newCloseableHttpClientWithDefaultKeyStoreAndTrustStore()) {
+            oauth.httpClient().set(client);
+            tokenResponse = oauth.doAccessTokenRequest(code);
+        } finally {
+            oauth.httpClient().reset();
+        }
+
+        assertEquals(200, tokenResponse.getStatusCode(), tokenResponse.getErrorDescription());
+        verifyHoKTokenDefaultCertThumbPrint(tokenResponse);
+
+        // Exchange the token for a new one with "named-test-app" as audience and assert that cnf is still present
+        AccessTokenResponse exchangeResponse;
+        try (CloseableHttpClient client = MutualTLSUtils.newCloseableHttpClientWithDefaultKeyStoreAndTrustStore()) {
+            oauth.httpClient().set(client);
+            exchangeResponse = oauth.tokenExchangeRequest(tokenResponse.getAccessToken())
+                  .audience("named-test-app")
+                  .send();
+        } finally {
+            oauth.httpClient().reset();
+        }
+
+        assertEquals(200, exchangeResponse.getStatusCode(), tokenResponse.getErrorDescription());
+        verifyHoKTokenCertThumbPrint(exchangeResponse, MutualTLSUtils.getThumbprintFromDefaultClientCert(), false);
+    }
+
+    @Test
+    public void testTokenExchangeV2WithMismatchedClientCertificate() throws Exception {
+        // Obtain a HoK-bound access token with the default client certificate
+        oauth.doLogin("test-user@localhost", "password");
+        String code = oauth.parseLoginResponse().getCode();
+
+        oauth.client("test-app", "password");
+        AccessTokenResponse tokenResponse;
+        try (CloseableHttpClient client = MutualTLSUtils.newCloseableHttpClientWithDefaultKeyStoreAndTrustStore()) {
+            oauth.httpClient().set(client);
+            tokenResponse = oauth.doAccessTokenRequest(code);
+        } finally {
+            oauth.httpClient().reset();
+        }
+
+        assertEquals(200, tokenResponse.getStatusCode(), tokenResponse.getErrorDescription());
+        verifyHoKTokenDefaultCertThumbPrint(tokenResponse);
+
+        // Attempt token exchange using a different client certificate — cnf thumbprint will not match
+        AccessTokenResponse exchangeResponse;
+        try (CloseableHttpClient client = MutualTLSUtils.newCloseableHttpClientWithOtherKeyStoreAndTrustStore()) {
+            oauth.httpClient().set(client);
+            exchangeResponse = oauth.tokenExchangeRequest(tokenResponse.getAccessToken())
+                  .audience("named-test-app")
+                  .send();
+        } finally {
+            oauth.httpClient().reset();
+        }
+
+        assertEquals(400, exchangeResponse.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, exchangeResponse.getError());
+        assertEquals(MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, exchangeResponse.getErrorDescription());
+    }
+
     private void verifyHoKTokenDefaultCertThumbPrint(AccessTokenResponse response) throws Exception {
         verifyHoKTokenCertThumbPrint(response, MutualTLSUtils.getThumbprintFromDefaultClientCert(), true);
     }
@@ -752,7 +833,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
     }
 
     private void verifyHoKTokenCertThumbPrint(AccessTokenResponse response, String certThumbPrint, boolean checkRefreshToken) {
-        JWSInput jws = null;
+        JWSInput jws;
         AccessToken at = null;
         try {
             jws = new JWSInput(response.getAccessToken());
@@ -760,6 +841,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         } catch (JWSInputException e) {
             Assertions.fail(e.toString());
         }
+        assertNotNull(at.getConfirmation());
         assertTrue(MessageDigest.isEqual(certThumbPrint.getBytes(), at.getConfirmation().getCertThumbprint().getBytes()));
 
         if (checkRefreshToken) {


### PR DESCRIPTION
Closes #47314

To workaround this issues in my deployments, I am registering a custom ProtocolMapper to add the missing confirmation claim. Based upon the code for DPoP, I have added an internal ProtocolMapper implementation. I assume there's probably a better/more correct way of solving this? The code is new to me, so help would be appreciated :slightly_smiling_face: 