### PR TITLE
Add OAuth 2.0 compliant redirect URI validation

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
@@ -94,8 +94,10 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
         protected boolean allowWildcardContextPath;
         @JsonProperty(SecureRedirectUrisEnforcerExecutorFactory.ALLOW_PERMITTED_DOMAINS)
         protected List<String> allowPermittedDomains = Collections.emptyList();
+        @JsonProperty(SecureRedirectUrisEnforcerExecutorFactory.OAUTH_2_0_COMPLIANT)
+        protected boolean oauth2_0compliant;
         @JsonProperty(SecureRedirectUrisEnforcerExecutorFactory.OAUTH_2_1_COMPLIANT)
-        protected boolean oauth2_1complient;
+        protected boolean oauth2_1compliant;
         @JsonProperty(SecureRedirectUrisEnforcerExecutorFactory.ALLOW_OPEN_REDIRECT)
         protected boolean allowOpenRedirect;
 
@@ -147,12 +149,20 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
             this.allowPermittedDomains = permittedDomains;
         }
 
-        public boolean isOAuth2_1Compliant() {
-            return oauth2_1complient;
+        public boolean isOAuth2_0Compliant() {
+            return oauth2_0compliant;
         }
 
-        public void setOAuth2_1Compliant(boolean oauth21complient) {
-            this.oauth2_1complient = oauth21complient;
+        public void setOAuth2_0Compliant(boolean oauth20compliant) {
+            this.oauth2_0compliant = oauth20compliant;
+        }
+
+        public boolean isOAuth2_1Compliant() {
+            return oauth2_1compliant;
+        }
+
+        public void setOAuth2_1Compliant(boolean oauth21compliant) {
+            this.oauth2_1compliant = oauth21compliant;
         }
 
         public boolean isAllowOpenRedirect() {
@@ -382,35 +392,37 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
                 }
             }
 
+            if (config.isOAuth2_0Compliant() || config.isOAuth2_1Compliant()) {
+                if (isIncludeUriFragment()) {
+                    logger.debugv("Invalid LoopbackAddress: URI fragment not allowed - input = {0}", uri.toString());
+                    return false;
+                }
+
+                if (isIncludeWildcard()) {
+                    logger.debugv("Invalid LoopbackAddress: Wildcard not allowed - input = {0}", uri.toString());
+                    return false;
+                }
+            }
+
             if (config.isOAuth2_1Compliant()) {
-                if (isIncludeUriFragment()) { // URL fragment is not allowed
-                    logger.debugv("Invalid LoopbackAddress: URI fragment not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
-                    return false;
-                }
-
-                if (isIncludeWildcard()) { // wildcard is not allowed
-                    logger.debugv("Invalid LoopbackAddress: Wildcard not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
-                    return false;
-                }
-
-                if ("localhost".equalsIgnoreCase(uri.getHost())) { // "localhost" is not allowed.
+                if ("localhost".equalsIgnoreCase(uri.getHost())) {
                     logger.debugv("Invalid LoopbackAddress: localhost not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
                     return false;
                 }
 
                 if (isRedirectUriParameter) {
-                    if (uri.getPort() < 0 || uri.getPort() > 65535) { // only 0 to 65535 are allowed. no port number is not allowed.
+                    if (uri.getPort() < 0 || uri.getPort() > 65535) {
                         logger.debugv("Invalid LoopbackAddress: invalid port number - OAuth 2.1 compliant - redirect_uri parameter - input = {0}", uri.toString());
                         return false;
                     }
                 } else {
-                    if (uri.getPort() > -1) { // any port number is not allowed
+                    if (uri.getPort() > -1) {
                         logger.debugv("Invalid LoopbackAddress: port number not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
                         return false;
                     }
                 }
 
-                if (!p.test(uri)) return false; // additional tests for OAuth 2.1 compliant
+                if (!p.test(uri)) return false;
             }
             return true;
         }
@@ -430,18 +442,20 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
                 }
             }
 
+            if (config.isOAuth2_0Compliant() || config.isOAuth2_1Compliant()) {
+                if (isIncludeUriFragment()) {
+                    logger.debugv("Invalid PrivateUseUriScheme: URI fragment not allowed - input = {0}", uri.toString());
+                    return false;
+                }
+
+                if (isIncludeWildcard()) {
+                    logger.debugv("Invalid PrivateUseUriScheme: Wildcard not allowed - input = {0}", uri.toString());
+                    return false;
+                }
+            }
+
             if (config.isOAuth2_1Compliant()) {
-                if (isIncludeUriFragment()) { // URL fragment is not allowed
-                    logger.debugv("Invalid PrivateUseUriScheme: URI fragment not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
-                    return false;
-                }
-
-                if (isIncludeWildcard()) { // wildcard is not allowed
-                    logger.debugv("Invalid PrivateUseUriScheme: Wildcard not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
-                    return false;
-                }
-
-                if (uri.getScheme() == null || !uri.getScheme().contains(".")) { // a single word scheme name is not allowed.
+                if (uri.getScheme() == null || !uri.getScheme().contains(".")) {
                     logger.debugv("Invalid PrivateUseUriScheme: a single word scheme name is not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
                     return false;
                 }
@@ -477,19 +491,21 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
                 }
             }
 
+            if (config.isOAuth2_0Compliant() || config.isOAuth2_1Compliant()) {
+                if (isIncludeUriFragment()) {
+                    logger.debugv("Invalid NormalUri: URI fragment not allowed - input = {0}", uri.toString());
+                    return false;
+                }
+
+                if (isIncludeWildcard()) {
+                    logger.debugv("Invalid NormalUri: Wildcard not allowed - input = {0}", uri.toString());
+                    return false;
+                }
+            }
+
             if (config.isOAuth2_1Compliant()) {
-                if (!isHttps()) { // only https scheme is allowed.
+                if (!isHttps()) {
                     logger.debugv("Invalid NormalUri: HTTP not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
-                    return false;
-                }
-
-                if (isIncludeUriFragment()) { // URL fragment is not allowed.
-                    logger.debugv("Invalid NormalUri: URI fragment not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
-                    return false;
-                }
-
-                if (isIncludeWildcard()) { // wildcard is not allowed.
-                    logger.debugv("Invalid NormalUri: Wildcard not allowed - OAuth 2.1 compliant - input = {0}", uri.toString());
                     return false;
                 }
             }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorFactory.java
@@ -36,6 +36,7 @@ public class SecureRedirectUrisEnforcerExecutorFactory implements ClientPolicyEx
     public static final String ALLOW_HTTP_SCHEME = "allow-http-scheme";
     public static final String ALLOW_WILDCARD_CONTEXT_PATH = "allow-wildcard-context-path";
     public static final String ALLOW_PERMITTED_DOMAINS = "allow-permitted-domains";
+    public static final String OAUTH_2_0_COMPLIANT = "oauth-2-0-compliant";
     public static final String OAUTH_2_1_COMPLIANT = "oauth-2-1-compliant";
 
     public static final String ALLOW_OPEN_REDIRECT = "allow-open-redirect";
@@ -138,6 +139,16 @@ public class SecureRedirectUrisEnforcerExecutorFactory implements ClientPolicyEx
                 "For example use pattern like this '(.*)\\.example\\.org' if you want clients to register redirect-uris only from domain 'example.org'." +
                 "Don't forget to use escaping of special characters like dots as otherwise dot is interpreted as any character in regex!")
             .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+            .add()
+
+            .property()
+            .name(OAUTH_2_0_COMPLIANT)
+            .label("OAuth 2.0 Compliant")
+            .helpText("If On, then the executor enforces OAuth 2.0 (RFC 6749) redirect URI rules. " +
+                "This means that URL fragments and wildcard redirect URIs are not allowed. " +
+                "This is less strict than 'OAuth 2.1 Compliant', which additionally disallows 'localhost' and requires HTTPS.")
+            .type(ProviderConfigProperty.BOOLEAN_TYPE)
+            .defaultValue(false)
             .add()
 
             .property()

--- a/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
@@ -43,6 +43,7 @@ import static org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnfo
 import static org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutorFactory.ALLOW_PERMITTED_DOMAINS;
 import static org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutorFactory.ALLOW_PRIVATE_USE_URI_SCHEME;
 import static org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutorFactory.ALLOW_WILDCARD_CONTEXT_PATH;
+import static org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutorFactory.OAUTH_2_0_COMPLIANT;
 import static org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutorFactory.OAUTH_2_1_COMPLIANT;
 
 import static org.junit.Assert.assertEquals;
@@ -76,6 +77,7 @@ public class SecureRedirectUrisEnforcerExecutorTest {
         assertFalse(configuration.isAllowPrivateUseUriScheme());
         assertFalse(configuration.isAllowHttpScheme());
         assertFalse(configuration.isAllowWildcardContextPath());
+        assertFalse(configuration.isOAuth2_0Compliant());
         assertFalse(configuration.isOAuth2_1Compliant());
         assertFalse(configuration.isAllowOpenRedirect());
 
@@ -336,6 +338,72 @@ public class SecureRedirectUrisEnforcerExecutorTest {
                 "https://keycloak.org/sso/silent-callback.html",
                 "https://example.org/auth/realms/master/broker/oidc/endpoint",
                 "https://192.168.8.1:12345/auth/realms/master/broker/oidc/endpoint"
+        ).forEach(i->checkSuccess(i, false));
+    }
+
+    @Test
+    public void failNormalUri_OAuth2_0Compliant() {
+        enable(OAUTH_2_0_COMPLIANT);
+        Stream.of(
+                "https://oauth.redirect:8443/auth/callback#fragment",
+                "https://example.org/path#frag",
+                "https://example.org/*"
+        ).forEach(i->checkFail(i, false, SecureRedirectUrisEnforcerExecutor.ERR_NORMALURI));
+    }
+
+    @Test
+    public void successNormalUri_OAuth2_0Compliant() {
+        enable(OAUTH_2_0_COMPLIANT);
+        // HTTP is still allowed (unlike OAuth 2.1) when allow-http-scheme is on
+        enable(ALLOW_HTTP_SCHEME);
+        Stream.of(
+                "https://example.org/redirect",
+                "http://example.org/redirect",
+                "https://example.org:8443/auth/callback"
+        ).forEach(i->checkSuccess(i, false));
+    }
+
+    @Test
+    public void failLoopbackAddress_OAuth2_0Compliant() {
+        enable(ALLOW_IPV4_LOOPBACK_ADDRESS, ALLOW_IPV6_LOOPBACK_ADDRESS, ALLOW_HTTP_SCHEME, OAUTH_2_0_COMPLIANT);
+        Stream.of(
+                "http://127.0.0.1/auth/admin#fragment",
+                "http://[::1]/auth/admin#fragment",
+                "http://127.0.0.1/*",
+                "http://[::1]/*"
+        ).forEach(i->checkFail(i, false, SecureRedirectUrisEnforcerExecutor.ERR_LOOPBACK));
+    }
+
+    @Test
+    public void successLoopbackAddress_OAuth2_0Compliant() {
+        enable(ALLOW_IPV4_LOOPBACK_ADDRESS, ALLOW_IPV6_LOOPBACK_ADDRESS, ALLOW_HTTP_SCHEME, OAUTH_2_0_COMPLIANT);
+        // localhost is still allowed (unlike OAuth 2.1)
+        Stream.of(
+                "http://localhost/auth/admin",
+                "http://localhost:8080/auth/admin",
+                "http://127.0.0.1:8080/auth/admin",
+                "http://127.0.0.1/auth/admin",
+                "http://[::1]:8080/auth/admin",
+                "http://[::1]/auth/admin"
+        ).forEach(i->checkSuccess(i, false));
+    }
+
+    @Test
+    public void failPrivateUseUriScheme_OAuth2_0Compliant() {
+        enable(ALLOW_PRIVATE_USE_URI_SCHEME, OAUTH_2_0_COMPLIANT);
+        Stream.of(
+                "myapp:/oauth.redirect#pinpoint",
+                "com.example.app:/oauth.redirect/*"
+        ).forEach(i->checkFail(i, false, SecureRedirectUrisEnforcerExecutor.ERR_PRIVATESCHEME));
+    }
+
+    @Test
+    public void successPrivateUseUriScheme_OAuth2_0Compliant() {
+        enable(ALLOW_PRIVATE_USE_URI_SCHEME, OAUTH_2_0_COMPLIANT);
+        // single-word scheme is still allowed (unlike OAuth 2.1)
+        Stream.of(
+                "com.example.app:/oauth2redirect/example-provider",
+                "myapp:/oauth.redirect"
         ).forEach(i->checkSuccess(i, false));
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SecureRedirectUrisEnforcerExecutorTest.java
@@ -474,7 +474,7 @@ public class SecureRedirectUrisEnforcerExecutorTest extends AbstractClientPolici
     }
 
     @Test
-    public void testSecureRedirectUrisEnforcerExecutor_OAuth2_1Complient() throws Exception {
+    public void testSecureRedirectUrisEnforcerExecutor_OAuth2_1Compliant() throws Exception {
         // register profiles
         String json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
                 (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
@@ -520,6 +520,62 @@ public class SecureRedirectUrisEnforcerExecutorTest extends AbstractClientPolici
         // authorization request - fail
         // redirect_uri not match with registered redirect uris
         testSecureRedirectUrisEnforcerExecutor_failAuthorizationRequest(alphaClientId, "com.example.app:/oauth3redirect/example-provider");
+    }
+
+    @Test
+    public void testSecureRedirectUrisEnforcerExecutor_OAuth2_0Compliant() throws Exception {
+        // register profiles - OAuth 2.0 compliant rejects fragments and wildcards
+        // but is less strict than OAuth 2.1 (allows localhost, HTTP, single-word schemes)
+        String json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Le Premier Profil")
+                        .addExecutor(SecureRedirectUrisEnforcerExecutorFactory.PROVIDER_ID,
+                                createSecureRedirectUrisEnforcerExecutorConfig(it->{
+                                    it.setAllowIPv4LoopbackAddress(true);
+                                    it.setAllowIPv6LoopbackAddress(true);
+                                    it.setAllowHttpScheme(true);
+                                    it.setOAuth2_0Compliant(true);}))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "La Premiere Politique", Boolean.TRUE)
+                        .addCondition(AnyClientConditionFactory.PROVIDER_ID,
+                                createAnyClientConditionConfig())
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // register - fail
+        // fragment in redirect URI not allowed per RFC 6749
+        testSecureRedirectUrisEnforcerExecutor_failRegisterByAdmin(List.of("https://example.com/callback#fragment"));
+
+        // register - fail
+        // wildcard in redirect URI not allowed
+        testSecureRedirectUrisEnforcerExecutor_failRegisterByAdmin(List.of("https://example.com/*"));
+
+        // register - success
+        // localhost is still allowed (unlike OAuth 2.1)
+        List<String> registerResultList = testSecureRedirectUrisEnforcerExecutor_successRegisterByAdmin(
+                List.of("http://localhost/auth/admin"));
+        String alphaClientId = registerResultList.get(0);
+        String alphaCid = registerResultList.get(1);
+
+        // update - fail
+        // fragment not allowed
+        testSecureRedirectUrisEnforcerExecutor_failUpdateByAdmin(alphaCid,
+                List.of("http://localhost/auth/admin#frag"));
+
+        // update - success
+        // HTTP scheme and localhost are allowed under OAuth 2.0 (unlike OAuth 2.1)
+        testSecureRedirectUrisEnforcerExecutor_successUpdateByAdmin(alphaCid,
+                List.of("http://localhost/auth/redirect", "http://127.0.0.1:8080/callback"));
+
+        // authorization request - fail
+        // redirect_uri not match with registered redirect uris
+        testSecureRedirectUrisEnforcerExecutor_failAuthorizationRequest(alphaClientId, "http://localhost/auth/other");
     }
 
     @Test


### PR DESCRIPTION
Enforce RFC 6749 Section 3.1.2 redirect URI rules (no fragments, no wildcards) via a new "OAuth 2.0 Compliant" client policy flag. This is less strict than the existing OAuth 2.1 flag, which additionally bans localhost and requires HTTPS.

Also fixes the "complient" typo in the existing OAuth 2.1 field and method names.

Closes #41164

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
