### PR TITLE
Fix #47271: Use SecureRandom in OID4VC Nonce and Time Claim Generation

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -22,6 +22,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
+import java.security.SecureRandom;
 
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.KeycloakSession;
@@ -44,6 +45,8 @@ import org.jboss.logging.Logger;
 public class TimeClaimNormalizer {
 
     private static final Logger logger = Logger.getLogger(TimeClaimNormalizer.class);
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public enum Strategy {
         OFF,
@@ -95,7 +98,7 @@ public class TimeClaimNormalizer {
     }
 
     private Instant randomize(Instant original) {
-        long randomOffset = (long) (Math.random() * (randomizeWindowSeconds + 1));
+        long randomOffset = (long) (SECURE_RANDOM.nextDouble() * (randomizeWindowSeconds + 1));
         return original.minusSeconds(randomOffset);
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import jakarta.annotation.Nullable;
 
@@ -65,6 +65,8 @@ public class JwtCNonceHandler implements CNonceHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtCNonceHandler.class);
 
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     private final KeycloakSession keycloakSession;
 
     private final KeyWrapper signingKey;
@@ -83,7 +85,7 @@ public class JwtCNonceHandler implements CNonceHandler {
         audiences = Optional.ofNullable(audiences).orElseGet(Collections::emptyList);
         final long nowSeconds = Time.currentTime();
         final long expiresAt = nowSeconds + nonceLifetimeSeconds;
-        final int nonceLength = NONCE_DEFAULT_LENGTH + new Random().nextInt(NONCE_LENGTH_RANDOM_OFFSET);
+        final int nonceLength = NONCE_DEFAULT_LENGTH + SECURE_RANDOM.nextInt(NONCE_LENGTH_RANDOM_OFFSET);
         // this generated value itself is basically just a salt-value for the generated token, which itself is the nonce.
         final String strongSalt = Base64.getEncoder().encodeToString(RandomSecret.createRandomSecret(nonceLength));
 


### PR DESCRIPTION
Closes #47271

Replaced `Math.random()` and `java.util.Random` with instances of `java.security.SecureRandom` in `TimeClaimNormalizer.java` and `JwtCNonceHandler.java` to ensure security-sensitive claim generations are cryptographically random.