### PR TITLE
Fix #47202: Fix KEYCLOAK_LOCALE cookie setup for READ_ONLY federation users

### DIFF
--- a/services/src/main/java/org/keycloak/locale/DefaultLocaleUpdaterProvider.java
+++ b/services/src/main/java/org/keycloak/locale/DefaultLocaleUpdaterProvider.java
@@ -41,6 +41,7 @@ public class DefaultLocaleUpdaterProvider implements LocaleUpdaterProvider {
     public void updateUsersLocale(UserModel user, String locale) {
         final String previousLocale = user.getFirstAttribute("locale");
         if (!locale.equals(previousLocale)) {
+            updateLocaleCookie(locale);
             try {
                 EventBuilder event = new EventBuilder(session.getContext().getRealm(), session, session.getContext().getConnection())
                         .event(EventType.UPDATE_PROFILE)
@@ -49,7 +50,7 @@ public class DefaultLocaleUpdaterProvider implements LocaleUpdaterProvider {
                         .detail(Details.PREF_PREVIOUS + UserModel.LOCALE, previousLocale)
                         .detail(Details.PREF_UPDATED + UserModel.LOCALE, locale);
                 user.setSingleAttribute(UserModel.LOCALE, locale);
-                updateLocaleCookie(locale);
+
                 event.success();
             } catch (ReadOnlyException e) {
                 logger.debug("Attempt to store 'locale' attribute to read only user model. Ignoring exception", e);


### PR DESCRIPTION
Closes #47202

When federated users with `READ_ONLY` edit mode authenticate, updating the locale cookie was previously blocked by the `ReadOnlyException` thrown when trying to save the locale against the user model. This PR moves `updateLocaleCookie(locale)` outside the `try` block so the locale cookie is properly set in the user's session even if the user model cannot be updated.