### PR TITLE
Fix #47153: Prevent NPE in IdentityBrokerService.updateFederatedIdentity when IdP link is missing

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -1134,6 +1134,11 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
     private void updateFederatedIdentity(BrokeredIdentityContext context, UserModel federatedUser) {
         FederatedIdentityModel federatedIdentityModel = this.session.users().getFederatedIdentity(this.realmModel, federatedUser, context.getIdpConfig().getAlias());
 
+        if (federatedIdentityModel == null) {
+            logger.warnf("Could not find federated identity for provider '%s' and user '%s' during update.", context.getIdpConfig().getAlias(), federatedUser.getUsername());
+            return;
+        }
+
         if (context.getIdpConfig().getSyncMode() == IdentityProviderSyncMode.FORCE) {
             setBasicUserAttributes(context, federatedUser);
 


### PR DESCRIPTION
Closes #47153

Added a null check for `federatedIdentityModel` in `IdentityBrokerService.updateFederatedIdentity` to prevent a `NullPointerException` when an IDP is recreated (e.g., via Terraform) and the user's legacy federated identity link points to the old internal IDP reference.