### PR TITLE
fix: reject resource parameter when RESOURCE_INDICATORS feature is disabled #47122

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -16,6 +16,7 @@
  */
 
 package org.keycloak.protocol.oidc.endpoints;
+import org.keycloak.OAuthErrorException;
 
 import java.util.List;
 import java.util.Map;
@@ -191,6 +192,13 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             checker.checkPKCEParams();
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
             return redirectErrorToClient(parsedResponseMode, ex.getError(), ex.getErrorDescription());
+        }
+
+        // Reject 'resource' parameter if feature is disabled
+        if (request.getResource() != null && !Profile.isFeatureEnabled(Profile.Feature.RESOURCE_INDICATORS)) {
+            event.detail(Details.REASON, "resource_indicators_disabled");
+            event.error(Errors.INVALID_REQUEST);
+            return redirectErrorToClient(parsedResponseMode, OAuthErrorException.INVALID_REQUEST, "resource parameter not supported");
         }
 
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -21,6 +21,10 @@ import java.io.IOException;
 import java.util.Map;
 import javax.xml.namespace.QName;
 
+import org.keycloak.common.Profile;
+import org.keycloak.events.Errors;
+import org.keycloak.OAuthErrorException;
+
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.POST;
@@ -137,6 +141,14 @@ public class TokenEndpoint {
                 && !grantType.equals(PRE_AUTH_GRANT_TYPE)) {
             checkClient();
             checkParameterDuplicated();
+        }
+
+        // Reject 'resource' parameter if feature is disabled
+        String resource = formParams.getFirst(OIDCLoginProtocol.RESOURCE_PARAM);
+        if (resource != null && !Profile.isFeatureEnabled(Profile.Feature.RESOURCE_INDICATORS)) {
+            event.detail(Details.REASON, "resource_indicators_disabled");
+            event.error(Errors.INVALID_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "resource parameter not supported", Response.Status.BAD_REQUEST);
         }
 
         /*


### PR DESCRIPTION
As requested in #47122, this PR ensures that the resource parameter is rejected when the Resource Indicators feature is disabled.

Changes:
- Added validation in AuthorizationEndpoint to return an invalid_request redirect
- Added validation in TokenEndpoint to return an invalid_request error
- Added event logging for traceability

Fixes #47122