### PR TITLE
fix: validate resource parameter format in authorization endpoint when RESOURCE_INDICATORS is enabled #47119

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -21,6 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.keycloak.OAuthErrorException;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -192,6 +198,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
             return redirectErrorToClient(parsedResponseMode, ex.getError(), ex.getErrorDescription());
         }
+
+        Response resourceError = checkResourceParameter();
+        if (resourceError != null) return resourceError;
 
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
         String dpopJkt = session.getAttribute(PAR_DPOP_PROOF_JKT, String.class);
@@ -456,5 +465,25 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         paramAction.accept(OIDCLoginProtocol.RESOURCE_PARAM, request.getResource());
         paramAction.accept(OIDCLoginProtocol.STATE_PARAM, request.getState());
         paramAction.accept(OIDCLoginProtocol.DPOP_JKT, request.getDpopJkt());
+    }
+    private Response checkResourceParameter() {
+        if (Profile.isFeatureEnabled(Profile.Feature.RESOURCE_INDICATORS)) {
+            MultivaluedMap<String, String> queryParams = session.getContext().getUri().getQueryParameters();
+            List<String> resources = queryParams.get(OIDCLoginProtocol.RESOURCE_PARAM);
+
+            if (resources == null || resources.isEmpty()) return null;
+
+            for (String r : resources) {
+                try {
+                    URI uri = new URI(r);
+                    if (!uri.isAbsolute() || uri.getRawFragment() != null) {
+                        return redirectErrorToClient(parsedResponseMode, OAuthErrorException.INVALID_TARGET, "Invalid resource parameter");
+                    }
+                } catch (URISyntaxException e) {
+                    return redirectErrorToClient(parsedResponseMode, OAuthErrorException.INVALID_TARGET, "Malformed resource parameter");
+                }
+            }
+        }
+        return null;
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ResourceIndicatorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ResourceIndicatorsTest.java
@@ -42,6 +42,30 @@ public class ResourceIndicatorsTest {
     }
 
     @Test
+    public void testAuthzInvalidResourceRelative() {
+        // Test with a relative URI (triggers !uri.isAbsolute() check)
+        AuthorizationEndpointResponse response = oauth.loginForm()
+                .resource("/relative-path")
+                .doLoginWithCookie();
+        
+        Assertions.assertTrue(response.isRedirected());
+        Assertions.assertEquals(INVALID_TARGET, response.getError());
+        Assertions.assertEquals("Invalid resource parameter", response.getErrorDescription());
+    }
+
+    @Test
+    public void testAuthzInvalidResourceWithFragment() {
+        // Test with a fragment (triggers uri.getRawFragment() != null check)
+        AuthorizationEndpointResponse response = oauth.loginForm()
+                .resource("https://theservice#fragment")
+                .doLoginWithCookie();
+        
+        Assertions.assertTrue(response.isRedirected());
+        Assertions.assertEquals(INVALID_TARGET, response.getError());
+        Assertions.assertEquals("Invalid resource parameter", response.getErrorDescription());
+    }
+
+    @Test
     public void testValidResourceByClientUrn() {
         AccessTokenResponse tokenResponse = oauth.passwordGrantRequest("user", "pass").resource("urn:client:theservice").send();
         assertValidResponse(tokenResponse, "theservice");


### PR DESCRIPTION
Fixes #47119

## Summary

This PR adds validation for the `resource` parameter in the Authorization Endpoint when the `RESOURCE_INDICATORS` feature is enabled.

## Changes

- Added validation for the `resource` parameter in `AuthorizationEndpoint`.
- Reads `resource` values directly from raw query parameters using `session.getContext().getUri().getQueryParameters()`.
- Validates each resource value to ensure it:
  - Is a valid absolute URI.
  - Does not contain a fragment (`#`), as required by RFC 8707.
- Returns an `invalid_target` error using `redirectErrorToClient` when validation fails.

## Rationale

The previous approach relied on `request.getResource()`, which may not always contain the raw query parameter values for standard OIDC requests. 

This change ensures consistent and reliable validation by reading directly from the request URI.

## Testing

Verified the following scenarios:

- ❌ Invalid resource (`/bad`) → rejected with `invalid_target`
- ❌ Resource with fragment (`http://example.com#bad`) → rejected with `invalid_target`
- ✅ Valid resource (`http://example.com`) → request proceeds normally

## Notes

- Validation is only applied when the `RESOURCE_INDICATORS` feature is enabled.
- Follows RFC 8707 requirements for resource indicators.