### PR TITLE
Chage identity brokering API V2 to only allow confidential clients

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -44,6 +44,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.RequiredActionContext;
@@ -101,11 +102,13 @@ import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.protocol.saml.SamlSessionUtils;
 import org.keycloak.protocol.saml.preprocessor.SamlAuthenticationPreprocessor;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ErrorResponse;
@@ -117,10 +120,12 @@ import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
 import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.services.managers.ClientSessionCode;
+import org.keycloak.services.managers.GrantTypeEndpointRestrictionValidator;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.AuthenticationFlowURLHelper;
 import org.keycloak.services.util.BrowserHistoryHelper;
 import org.keycloak.services.util.CacheControlUtil;
+import org.keycloak.services.util.DPoPUtil;
 import org.keycloak.services.util.DefaultClientSessionContext;
 import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.services.validation.Validation;
@@ -475,8 +480,111 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
     @GET
     @NoCache
     @Path("{provider_alias}/token")
-    public Response retrieveToken(@PathParam("provider_alias") String providerAlias) {
-        return getToken(providerAlias);
+    public Response retrieveTokenV1(@PathParam("provider_alias") String providerAlias) {
+        return getTokenV1(providerAlias);
+    }
+
+    @POST
+    @NoCache
+    @Path("{provider_alias}/token")
+    public Response retrieveTokenV2(@PathParam("provider_alias") String providerAlias) {
+        return getTokenV2(providerAlias);
+    }
+
+    private Response getTokenV2(String providerAlias) {
+        this.event.event(EventType.IDENTITY_PROVIDER_RETRIEVE_TOKEN)
+                .detail(Details.IDENTITY_PROVIDER, providerAlias);
+
+        Cors cors = Cors.builder().auth().allowedMethods("POST").auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS);
+
+        // check profile is enabled
+        if (!Profile.isFeatureEnabled(Profile.Feature.IDENTITY_BROKERING_API_V2)) {
+            event.detail(Details.REASON, "Identity Brokering API feature not enabled");
+            event.error(Errors.IDENTITY_PROVIDER_ERROR);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Identity Brokering API feature not enabled", Response.Status.BAD_REQUEST);
+        }
+
+        // authenticate client
+        AuthorizeClientUtil.ClientAuthResult clientAuth = AuthorizeClientUtil.authorizeClient(session, event, cors);
+        ClientModel client = clientAuth.getClient();
+        cors.allowedOrigins(session, client);
+        event.client(client);
+        session.getContext().setClient(client);
+        if (client.isPublicClient()) {
+            event.detail(Details.REASON, "public clients not allowed");
+            event.error(Errors.NOT_ALLOWED);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "public clients not allowed", Response.Status.FORBIDDEN);
+        }
+
+        // check the client is allowed to retrieve tokens to this provider
+        OIDCAdvancedConfigWrapper oidcClient = OIDCAdvancedConfigWrapper.fromClientModel(client);
+        if (!oidcClient.getExternalTokenEnabled() || !oidcClient.getExternalAllowedIdentityProviders().contains(providerAlias)) {
+            event.detail(Details.REASON, "Client not allowed to retrieve token for the provider");
+            event.error(Errors.NOT_ALLOWED);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Client not allowed to retrieve token for the provider", Response.Status.FORBIDDEN);
+        }
+
+        // validate the token
+        String tokenString = session.getContext().getHttpRequest().getDecodedFormParameters().getFirst(OAuth2Constants.TOKEN);
+        AuthenticationManager.AuthResult authResult = AuthenticationManager.verifyIdentityToken(
+                session, realmModel, session.getContext().getUri(), clientConnection, true, true, null, false, tokenString, headers,
+                verifier -> {
+                    DPoPUtil.withDPoPVerifier(verifier, realmModel, new DPoPUtil.Validator(session).request(request).uriInfo(session.getContext().getUri()).accessToken(tokenString));
+                    verifier.withChecks(GrantTypeEndpointRestrictionValidator.check(session));
+                });
+        if (authResult == null) {
+            event.error(Errors.INVALID_TOKEN);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_TOKEN, "Invalid token", Response.Status.BAD_REQUEST);
+        }
+        AccessToken token = authResult.token();
+        event.user(authResult.user());
+
+        // check the request client is in the audience
+        if (!client.getClientId().equals(token.getIssuedFor()) && !token.hasAudience(client.getClientId())) {
+            event.detail(Details.REASON, "client is not within the token audience");
+            event.error(Errors.NOT_ALLOWED);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.UNAUTHORIZED_CLIENT, "Client is not within the token audience", Response.Status.FORBIDDEN);
+        }
+
+        // retrieve the provider model
+        IdentityProviderModel model = session.identityProviders().getByAlias(providerAlias);
+        if (model == null || !model.isEnabled()) {
+            event.detail(Details.REASON, "Invalid identity provider");
+            event.error(Errors.IDENTITY_PROVIDER_ERROR);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid identity provider", Response.Status.BAD_REQUEST);
+        }
+
+        // retrieve the provider
+        UserAuthenticationIdentityProvider<?> identityProvider = getIdentityProvider(session, model, UserAuthenticationIdentityProvider.class);
+        if (identityProvider == null) {
+            event.detail(Details.REASON, "Invalid identity provider");
+            event.error(Errors.IDENTITY_PROVIDER_ERROR);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "Invalid identity provider", Response.Status.BAD_REQUEST);
+        }
+
+        // retrieve the identity associated to the user
+        FederatedIdentityModel identity = this.session.users().getFederatedIdentity(realmModel, authResult.user(), providerAlias);
+        if (identity == null) {
+            event.detail(Details.REASON, "User not associated to identity provider");
+            event.error(Errors.IDENTITY_PROVIDER_ERROR);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "User not associated to identity provider", Response.Status.BAD_REQUEST);
+        }
+
+        // obtain the session from the token
+        UserSessionModel userSession = UserSessionUtil.findValidSessionForAccessToken(
+                session, realmModel, token, authResult.client(), (invalidUserSession -> {}))
+                .getUserSession();
+
+        // now it is OK to retrieve the token from the session or the database
+        try {
+            Response response = identityProvider.retrieveToken(session, identity, userSession, authResult.user());
+            event.success();
+            return cors.add(Response.fromResponse(response));
+        } catch (Exception e) {
+            event.detail(Details.REASON, e.getMessage());
+            event.error(Errors.INVALID_REQUEST);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
+        }
     }
 
     private boolean canReadBrokerToken(AccessToken token) {
@@ -485,10 +593,11 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
         return brokerRoles != null && brokerRoles.isUserInRole(Constants.READ_TOKEN_ROLE);
     }
 
-    private Response getToken(String providerAlias) {
+    private Response getTokenV1(String providerAlias) {
         this.event.event(EventType.IDENTITY_PROVIDER_RETRIEVE_TOKEN)
                 .detail(Details.IDENTITY_PROVIDER, providerAlias);
-        if (!Profile.isAnyVersionOfFeatureEnabled(Profile.Feature.IDENTITY_BROKERING_API_V1)) {
+
+        if (!Profile.isFeatureEnabled(Profile.Feature.IDENTITY_BROKERING_API_V1)) {
             event.detail(Details.REASON, "Identity Brokering API feature not enabled");
             event.error(Errors.IDENTITY_PROVIDER_ERROR);
             return badRequest("Identity Brokering API feature not enabled");
@@ -513,19 +622,25 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
             this.event.user(user);
             this.session.getContext().setClient(clientModel);
 
-            OIDCAdvancedConfigWrapper oidcClient = OIDCAdvancedConfigWrapper.fromClientModel(clientModel);
             ClientModel brokerClient = realmModel.getClientByClientId(Constants.BROKER_SERVICE_CLIENT_ID);
+            if (brokerClient == null) {
+                event.detail(Details.REASON, "Realm has not migrated to support the broker token exchange service");
+                event.error(Errors.IDENTITY_PROVIDER_ERROR);
+                return corsResponse(forbidden("Realm has not migrated to support the broker token exchange service"), clientModel);
+            }
 
-            boolean isBrokerAuthorized = Profile.isFeatureEnabled(Profile.Feature.IDENTITY_BROKERING_API_V1)
-                    && brokerClient != null && canReadBrokerToken(token);
-            boolean isClientAuthorized = Profile.isFeatureEnabled(Profile.Feature.IDENTITY_BROKERING_API_V2)
-                    && oidcClient.getExternalTokenEnabled()
-                    && oidcClient.getExternalAllowedIdentityProviders().contains(providerAlias);
-
-            if (!isBrokerAuthorized && !isClientAuthorized) {
-                this.event.detail(Details.REASON, "Not authorized");
-                this.event.error(Errors.UNAUTHORIZED_CLIENT);
+            if (!canReadBrokerToken(token)) {
+                event.detail(Details.REASON, "Client not authorized to retrieve tokens for provider");
+                event.error(Errors.UNAUTHORIZED_CLIENT);
                 return corsResponse(forbidden("Client [" + clientModel.getClientId() + "] not authorized to retrieve tokens from identity provider [" + providerAlias + "]."), clientModel);
+            }
+
+            UserAuthenticationIdentityProvider<?> identityProvider = getIdentityProvider(session, providerAlias);
+            IdentityProviderModel identityProviderConfig = getIdentityProviderConfig(providerAlias);
+            if (Booleans.isFalse(identityProviderConfig.isStoreToken())) {
+                event.detail(Details.REASON, "Identity Provider does not support this operation");
+                event.error(Errors.IDENTITY_PROVIDER_ERROR);
+                return corsResponse(badRequest("Identity Provider [" + providerAlias + "] does not support this operation."), clientModel);
             }
 
             FederatedIdentityModel identity = this.session.users().getFederatedIdentity(this.realmModel, user, providerAlias);
@@ -534,23 +649,15 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
                 this.event.error(Errors.IDENTITY_PROVIDER_ERROR);
                 return corsResponse(badRequest("User [" + user.getId() + "] is not associated with identity provider [" + providerAlias + "]."), clientModel);
             }
-
-            UserAuthenticationIdentityProvider<?> identityProvider = getIdentityProvider(session, providerAlias);
-            IdentityProviderModel identityProviderConfig = getIdentityProviderConfig(providerAlias);
+            if (identity.getToken() == null) {
+                this.event.detail(Details.REASON, "No token stored for user in this provider");
+                this.event.error(Errors.IDENTITY_PROVIDER_ERROR);
+                return corsResponse(notFound("No token stored for user [" + authResult.user().getId() + "] with associated identity provider [" + providerAlias + "]."), clientModel);
+            }
 
             String oldToken = identity.getToken();
             try {
-                Response response;
-                if (isBrokerAuthorized) {
-                    // use old method for V1
-                    response = corsResponse(identityProvider.retrieveToken(session, identity), clientModel);
-                } else {
-                    // user new method for V2
-                    UserSessionModel userSession = UserSessionUtil.findValidSessionForAccessToken(
-                            session, realmModel, token, clientModel, (invalidUserSession -> {}))
-                            .getUserSession();
-                    response = corsResponse(identityProvider.retrieveToken(session, identity, userSession, user), clientModel);
-                }
+                Response response = corsResponse(identityProvider.retrieveToken(session, identity), clientModel);
                 this.event.success();
                 return response;
             } catch (WebApplicationException e) {

--- a/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenTest.java
@@ -87,7 +87,7 @@ public interface InterfaceIdentityProviderStoreTokenTest {
         });
 
         AbstractHttpResponse externalTokens = doFetchExternalIdpToken(internalTokens.getAccessToken());
-        Assertions.assertEquals(502, externalTokens.getStatusCode());
+        Assertions.assertFalse(externalTokens.isSuccess());
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenV1Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenV1Test.java
@@ -26,6 +26,20 @@ public interface InterfaceIdentityProviderStoreTokenV1Test extends InterfaceIden
     }
 
     @Test
+    default void testIdentityBrokeringAPIV2Disabled() {
+        OAuthClient oauth = getOAuthClient();
+
+        oauth.openLoginForm();
+        loginWithIdP();
+
+        AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
+        Assertions.assertTrue(internalTokens.isSuccess());
+
+        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, internalTokens.getAccessToken());
+        Assertions.assertFalse(externalTokens.isSuccess());
+    }
+
+    @Test
     default void testOIDCIdentityProviderStoreTokenManualRoleGrant() {
         ManagedRealm realm = getRealm();
         OAuthClient oauth = getOAuthClient();

--- a/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenV2Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceIdentityProviderStoreTokenV2Test.java
@@ -1,5 +1,6 @@
 package org.keycloak.tests.broker;
 
+import org.keycloak.OAuthErrorException;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.RealmModel;
@@ -7,6 +8,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 import org.keycloak.models.jpa.JpaRealmProviderFactory;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.realm.ClientConfig;
 import org.keycloak.testframework.realm.ClientConfigBuilder;
@@ -35,7 +37,69 @@ public interface InterfaceIdentityProviderStoreTokenV2Test extends InterfaceIden
 
     @Override
     default AbstractHttpResponse doFetchExternalIdpToken(String token) {
-        return getOAuthClient().doFetchExternalIdpToken(IDP_ALIAS, token);
+        return getOAuthClient().doFetchExternalIdpTokenPost(IDP_ALIAS, token);
+    }
+
+    @Test
+    default void testIdentityBrokeringAPIV1Disabled() {
+        OAuthClient oauth = getOAuthClient();
+
+        oauth.openLoginForm();
+        loginWithIdP();
+
+        AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
+        Assertions.assertTrue(internalTokens.isSuccess());
+
+        AbstractHttpResponse externalTokens = oauth.doFetchExternalIdpTokenString(IDP_ALIAS, internalTokens.getAccessToken());
+        Assertions.assertFalse(externalTokens.isSuccess());
+    }
+
+    @Test
+    default void testPublicClient() {
+        ManagedRealm realm = getRealm();
+        OAuthClient oauth = getOAuthClient();
+
+        oauth.openLoginForm();
+        loginWithIdP();
+
+        AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
+        Assertions.assertTrue(internalTokens.isSuccess());
+
+        ClientResource clientResource = AdminApiUtil.findClientByClientId(realm.admin(), "test-app");
+        ClientRepresentation clientRep = clientResource.toRepresentation();
+        realm.cleanup().add(r -> {
+            clientRep.setPublicClient(false);
+            clientResource.update(clientRep);
+        });
+        clientRep.setPublicClient(true);
+        clientResource.update(clientRep);
+        AbstractHttpResponse externalTokens = doFetchExternalIdpToken(internalTokens.getAccessToken());
+        Assertions.assertEquals(403, externalTokens.getStatusCode());
+        Assertions.assertEquals(OAuthErrorException.INVALID_CLIENT, ((AccessTokenResponse) externalTokens).getError());
+    }
+
+    @Test
+    default void testDifferentAudience() {
+        ManagedRealm realm = getRealm();
+        OAuthClient oauth = getOAuthClient();
+
+        oauth.openLoginForm();
+        loginWithIdP();
+
+        AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
+        Assertions.assertTrue(internalTokens.isSuccess());
+
+        realm.admin().clients().create(ClientConfigBuilder.create()
+                .clientId("test-app-other")
+                .attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_ENABLED, Boolean.TRUE.toString())
+                .attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_IDP, IDP_ALIAS)
+                .secret("test-secret")
+                .build());
+        realm.cleanup().add(r -> oauth.client("test-app", "test-secret"));
+        AccessTokenResponse externalTokens = oauth.client("test-app-other", "test-secret").doFetchExternalIdpTokenPost(IDP_ALIAS, internalTokens.getAccessToken());
+        Assertions.assertEquals(403, externalTokens.getStatusCode());
+        Assertions.assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, externalTokens.getError());
+        Assertions.assertEquals("Client is not within the token audience", externalTokens.getErrorDescription());
     }
 
     @Test
@@ -50,7 +114,7 @@ public interface InterfaceIdentityProviderStoreTokenV2Test extends InterfaceIden
         Assertions.assertTrue(tokenResponse.isSuccess());
 
         // external access enabled initially
-        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, tokenResponse.getAccessToken());
+        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, tokenResponse.getAccessToken());
         Assertions.assertTrue(tokenResponse.isSuccess());
         checkSuccessfulTokenResponse(externalTokens);
 
@@ -58,22 +122,22 @@ public interface InterfaceIdentityProviderStoreTokenV2Test extends InterfaceIden
         ClientResource clientResource = AdminApiUtil.findClientByClientId(realm.admin(), "test-app");
         ManagedClient client = new ManagedClient(clientResource.toRepresentation(), clientResource);
         client.updateWithCleanup(c-> c.attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_ENABLED, Boolean.FALSE.toString()));
-        externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, tokenResponse.getAccessToken());
+        externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, tokenResponse.getAccessToken());
         Assertions.assertEquals(403, externalTokens.getStatusCode());
 
         // external access disabled but idp selected
         client.updateWithCleanup(c-> c.attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_ENABLED, Boolean.FALSE.toString()).attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_IDP, IDP_ALIAS));
-        externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, tokenResponse.getAccessToken());
+        externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, tokenResponse.getAccessToken());
         Assertions.assertEquals(403, externalTokens.getStatusCode());
 
         // external access enabled but idp different
         client.updateWithCleanup(c-> c.attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_ENABLED, Boolean.TRUE.toString()).attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_IDP, "other-idp"));
-        externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, tokenResponse.getAccessToken());
+        externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, tokenResponse.getAccessToken());
         Assertions.assertEquals(403, externalTokens.getStatusCode());
 
         // enable again
         client.updateWithCleanup(c-> c.attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_ENABLED, Boolean.TRUE.toString()).attribute(OIDCConfigAttributes.EXTERNAL_TOKEN_IDP, IDP_ALIAS));
-        externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, tokenResponse.getAccessToken());
+        externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, tokenResponse.getAccessToken());
         Assertions.assertTrue(tokenResponse.isSuccess());
         checkSuccessfulTokenResponse(externalTokens);
     }
@@ -92,7 +156,7 @@ public interface InterfaceIdentityProviderStoreTokenV2Test extends InterfaceIden
         AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
         Assertions.assertTrue(internalTokens.isSuccess());
 
-        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, internalTokens.getAccessToken());
         Assertions.assertTrue(externalTokens.isSuccess());
         checkSuccessfulTokenResponse(externalTokens);
 
@@ -112,7 +176,7 @@ public interface InterfaceIdentityProviderStoreTokenV2Test extends InterfaceIden
 
             internalTokens = oauth.doRefreshTokenRequest(internalTokens.getRefreshToken());
             Assertions.assertEquals(200, internalTokens.getStatusCode());
-            AccessTokenResponse externalTokens2 = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+            AccessTokenResponse externalTokens2 = oauth.doFetchExternalIdpTokenPost(IDP_ALIAS, internalTokens.getAccessToken());
             Assertions.assertEquals(200, externalTokens2.getStatusCode());
 
             // Check that we now have a different access and refresh token

--- a/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceOIDCIdentityProviderStoreTokenTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/InterfaceOIDCIdentityProviderStoreTokenTest.java
@@ -19,6 +19,7 @@ import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.RealmConfigBuilder;
 import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
 import org.keycloak.testsuite.util.IdentityProviderBuilder;
+import org.keycloak.testsuite.util.oauth.AbstractHttpResponse;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.junit.jupiter.api.Assertions;
@@ -49,7 +50,7 @@ public interface InterfaceOIDCIdentityProviderStoreTokenTest extends InterfaceId
         AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
         Assertions.assertTrue(internalTokens.isSuccess());
 
-        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+        AbstractHttpResponse externalTokens = doFetchExternalIdpToken(internalTokens.getAccessToken());
         Assertions.assertEquals(200, externalTokens.getStatusCode());
         checkSuccessfulTokenResponse(externalTokens);
 
@@ -60,16 +61,17 @@ public interface InterfaceOIDCIdentityProviderStoreTokenTest extends InterfaceId
             return session.getProvider(UserProvider.class, JpaRealmProviderFactory.PROVIDER_ID).getFederatedIdentity(r, user, IDP_ALIAS).getToken();
         }, String.class);
 
-        getTimeOffSet().set(externalTokens.getExpiresIn() - IdentityProviderModel.DEFAULT_MIN_VALIDITY_TOKEN + 1);
+        getTimeOffSet().set(((AccessTokenResponse) externalTokens).getExpiresIn() - IdentityProviderModel.DEFAULT_MIN_VALIDITY_TOKEN + 1);
 
         internalTokens = oauth.doRefreshTokenRequest(internalTokens.getRefreshToken());
         Assertions.assertEquals(200, internalTokens.getStatusCode());
-        AccessTokenResponse externalTokens2 = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+        AbstractHttpResponse externalTokens2 = doFetchExternalIdpToken(internalTokens.getAccessToken());
         Assertions.assertEquals(200, externalTokens2.getStatusCode());
         checkSuccessfulTokenResponse(externalTokens);
 
         // Check that we now have a different access and refresh token
-        Assertions.assertNotEquals(externalTokens.getAccessToken(), externalTokens2.getAccessToken());
+        Assertions.assertNotEquals(((AccessTokenResponse) externalTokens).getAccessToken(),
+                ((AccessTokenResponse) externalTokens2).getAccessToken());
 
         String newTokenFromDatabase = getRunOnServer().fetch(session -> {
             RealmModel r = session.realms().getRealmByName(realmName);
@@ -94,11 +96,11 @@ public interface InterfaceOIDCIdentityProviderStoreTokenTest extends InterfaceId
         AccessTokenResponse internalTokens = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
         Assertions.assertTrue(internalTokens.isSuccess());
 
-        AccessTokenResponse externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+        AbstractHttpResponse externalTokens = doFetchExternalIdpToken(internalTokens.getAccessToken());
         Assertions.assertEquals(200, externalTokens.getStatusCode());
         checkSuccessfulTokenResponse(externalTokens);
 
-        getTimeOffSet().set(externalTokens.getExpiresIn() + 10);
+        getTimeOffSet().set(((AccessTokenResponse) externalTokens).getExpiresIn() + 10);
 
         IdentityProviderResource resource = realm.admin().identityProviders().get(IDP_ALIAS);
         IdentityProviderRepresentation idp = resource.toRepresentation();
@@ -107,7 +109,7 @@ public interface InterfaceOIDCIdentityProviderStoreTokenTest extends InterfaceId
 
         internalTokens = oauth.doRefreshTokenRequest(internalTokens.getRefreshToken());
         Assertions.assertEquals(200, internalTokens.getStatusCode());
-        AccessTokenResponse error = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+        AbstractHttpResponse error = doFetchExternalIdpToken(internalTokens.getAccessToken());
         Assertions.assertFalse(error.isSuccess());
 
         logout();
@@ -142,19 +144,20 @@ public interface InterfaceOIDCIdentityProviderStoreTokenTest extends InterfaceId
         Assertions.assertTrue(internalTokensPasswordGrant.isSuccess());
 
         //external token from direct grant
-        AccessTokenResponse externalTokensPasswordGrant = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokensPasswordGrant.getAccessToken());
+        AbstractHttpResponse externalTokensPasswordGrant = doFetchExternalIdpToken(internalTokensPasswordGrant.getAccessToken());
         Assertions.assertEquals(200, externalTokensPasswordGrant.getStatusCode());
 
-        getTimeOffSet().set(externalTokensPasswordGrant.getExpiresIn() - IdentityProviderModel.DEFAULT_MIN_VALIDITY_TOKEN + 1);
+        getTimeOffSet().set(((AccessTokenResponse) externalTokensPasswordGrant).getExpiresIn() - IdentityProviderModel.DEFAULT_MIN_VALIDITY_TOKEN + 1);
 
         //test refresh with external token from direct grant
         internalTokensPasswordGrant = oauth.doRefreshTokenRequest(internalTokensPasswordGrant.getRefreshToken());
         Assertions.assertEquals(200, internalTokensPasswordGrant.getStatusCode());
-        AccessTokenResponse externalTokensPasswordGrant2 = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+        AbstractHttpResponse externalTokensPasswordGrant2 = doFetchExternalIdpToken(internalTokens.getAccessToken());
         Assertions.assertEquals(200, externalTokensPasswordGrant2.getStatusCode());
 
         // Check that now we have a different token
-        Assertions.assertNotEquals(externalTokensPasswordGrant.getAccessToken(), externalTokensPasswordGrant2.getAccessToken());
+        Assertions.assertNotEquals(((AccessTokenResponse) externalTokensPasswordGrant).getAccessToken(),
+                ((AccessTokenResponse) externalTokensPasswordGrant2).getAccessToken());
 
         if (!isIdentityBrokeringAPIV1()) {
             //disable the store token
@@ -163,11 +166,11 @@ public interface InterfaceOIDCIdentityProviderStoreTokenTest extends InterfaceId
             });
 
             //success because external token are in the user session after the broker login
-            AccessTokenResponse externalTokens = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokens.getAccessToken());
+            AbstractHttpResponse externalTokens = doFetchExternalIdpToken(internalTokens.getAccessToken());
             Assertions.assertEquals(200, externalTokens.getStatusCode());
 
             //fail because external token are not in the user session
-            externalTokensPasswordGrant = oauth.doFetchExternalIdpToken(IDP_ALIAS, internalTokensPasswordGrant.getAccessToken());
+            externalTokensPasswordGrant = doFetchExternalIdpToken(internalTokensPasswordGrant.getAccessToken());
             Assertions.assertEquals(400, externalTokensPasswordGrant.getStatusCode());
         }
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
@@ -244,6 +244,10 @@ public abstract class AbstractOAuthClient<T> {
         }.send();
     }
 
+    public AccessTokenResponse doFetchExternalIdpTokenPost(String providerAlias, String accessToken) {
+        return new FetchExternalIdpTokenPostRequest(providerAlias, accessToken, this).send();
+    }
+
     public CibaClient ciba() {
         return new CibaClient(this);
     }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/FetchExternalIdpTokenPostRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/FetchExternalIdpTokenPostRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.keycloak.OAuth2Constants;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class FetchExternalIdpTokenPostRequest extends AbstractHttpPostRequest<FetchExternalIdpTokenPostRequest, AccessTokenResponse> {
+
+    private final String providerAlias;
+    private final String accessToken;
+
+    FetchExternalIdpTokenPostRequest(String providerAlias, String accessToken, AbstractOAuthClient<?> client) {
+        super(client);
+        this.providerAlias = providerAlias;
+        this.accessToken = accessToken;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return UriBuilder.fromUri(client.baseUrl).path("/realms/{realm-name}/broker/{provider_alias}/token").buildFromMap(Map.of("realm-name", client.config.getRealm(), "provider_alias", providerAlias)).toString();
+    }
+
+    @Override
+    protected void initRequest() {
+        parameter(OAuth2Constants.TOKEN, accessToken);
+
+        if (client.config.getOrigin() != null) {
+            header("Origin", client.config.getOrigin());
+        }
+    }
+
+    @Override
+    protected AccessTokenResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new AccessTokenResponse(response);
+    }
+}


### PR DESCRIPTION
Closes #47256

Adding a POST method for identity brokering API V2 retrieve token. The token is passed using the `token` parameter. I have also modified the V1 to be almost the same as it was before (just the event handling is maintained that was missing before). The V2 alternative is doing almost the same that standard token exchange or introspection endpoint is doing now. The response is also a common `CorsErrorResponseException` with `error` and `errorDescription` like in OAUth2 spec. Tests added in the V2 accordingly.

After working on this, I think that now the new POST endpoint is very similar to a grant request (for example like TE is doing for internal to external). And I don't know if the endpoint is more suitable in the protocol part than in the admin API. So I also thought about moving the endpoint to a custom grant in keycloak, but, for the moment, the PR is just using POST instead of GET as described in the issue.
