### PR TITLE
Fix stale empty state after deleting last resource on a page

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/Resources.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Resources.tsx
@@ -135,7 +135,14 @@ export const AuthorizationResources = ({
           resourceId: selectedResource?._id!,
         });
         addAlert(t("resourceDeletedSuccess"), AlertVariant.success);
-        refresh();
+
+        if (resources?.length === 1 && first > 0) {
+          // Go back one page. Changing 'first' will automatically re-trigger
+          // the useFetch hook, so we don't need to call refresh() here.
+          setFirst(first - max);
+        } else {
+          refresh();
+        }
       } catch (error) {
         addError("resourceDeletedError", error);
       }

--- a/js/apps/admin-ui/test/clients/authorization.spec.ts
+++ b/js/apps/admin-ui/test/clients/authorization.spec.ts
@@ -6,17 +6,24 @@ import {
   assertAxeViolations,
   assertNotificationMessage,
 } from "../utils/masthead.ts";
+import { confirmModal } from "../utils/modal.ts";
 import { goToClients, goToRealm } from "../utils/sidebar.ts";
 import {
   assertRowExists,
+  clickRowKebabItem,
   clickTableRowItem,
   searchItem,
 } from "../utils/table.ts";
 import {
   assertClipboardHasText,
   assertDownload,
+  assertEmptyStateNotVisible,
+  assertTableIsPopulated,
+  assertResource,
+  assertRowNotVisible,
   clickAuthenticationSaveButton,
   clickCopyButton,
+  clickNextPage,
   createAuthorizationScope,
   createPermission,
   createPolicy,
@@ -87,6 +94,44 @@ test.describe.serial("Client authentication subtab", () => {
     await clickSaveButton(page);
 
     await assertNotificationMessage(page, "Resource successfully updated");
+  });
+
+  test("Should navigate to previous page when last resource on current page is deleted", async ({
+    page,
+  }) => {
+    for (let i = 0; i < 15; i++) {
+      const paddedIndex = i.toString().padStart(2, "0");
+      await adminClient.createResource(clientId, {
+        name: `Z Paginated Resource ${paddedIndex}`,
+      });
+    }
+
+    try {
+      await goToResourcesSubTab(page);
+      await assertTableIsPopulated(page);
+
+      await clickNextPage(page);
+      await assertResource(page, "Z Paginated Resource 10");
+
+      for (let i = 10; i < 15; i++) {
+        const paddedIndex = i.toString().padStart(2, "0");
+        const resourceName = `Z Paginated Resource ${paddedIndex}`;
+
+        await clickRowKebabItem(page, resourceName, "Delete");
+        await confirmModal(page);
+        await assertRowNotVisible(page, resourceName);
+      }
+
+      await assertEmptyStateNotVisible(page);
+      await assertTableIsPopulated(page);
+    } finally {
+      for (let i = 0; i < 15; i++) {
+        const paddedIndex = i.toString().padStart(2, "0");
+        await adminClient.deleteResource(clientId, {
+          name: `Z Paginated Resource ${paddedIndex}`,
+        });
+      }
+    }
   });
 
   test("Should create a scope", async ({ page }) => {

--- a/js/apps/admin-ui/test/clients/authorization.ts
+++ b/js/apps/admin-ui/test/clients/authorization.ts
@@ -37,6 +37,22 @@ export async function createResource(
   await fillForm(page, resource);
 }
 
+export async function assertEmptyStateNotVisible(page: Page) {
+  await expect(page.getByTestId("empty-state")).toBeHidden();
+}
+
+export async function assertTableIsPopulated(page: Page) {
+  await expect(page.locator("tbody tr").first()).toBeVisible();
+}
+
+export async function assertRowNotVisible(page: Page, name: string) {
+  await expect(page.getByText(name, { exact: true })).toBeHidden();
+}
+
+export async function clickNextPage(page: Page) {
+  await page.getByLabel("Go to next page").first().click();
+}
+
 export async function fillForm(
   page: Page,
   resource:

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -614,6 +614,36 @@ class AdminClient {
     );
   }
 
+  async deleteResource(
+    clientId: string,
+    resource: { name: string; realm?: string },
+  ) {
+    await this.#login();
+    const { realm = this.#client.realmName, name } = resource;
+
+    const client = (await this.#client.clients.find({ clientId, realm }))[0];
+
+    if (!client?.id) {
+      throw new Error(`Client ${clientId} not found in realm ${realm}`);
+    }
+
+    const resources = await this.#client.clients.listResources({
+      id: client.id,
+      realm,
+      name,
+    });
+
+    const foundResource = resources.find((r) => r.name === name);
+
+    if (foundResource?._id) {
+      await this.#client.clients.delResource({
+        id: client.id,
+        realm,
+        resourceId: foundResource._id,
+      });
+    }
+  }
+
   async findUserByUsername(
     realm: string,
     username: string,


### PR DESCRIPTION
Closes #46089

The root cause was located in the deletion handler within js/apps/admin-ui/src/clients/authorization/Resources.tsx.

Previous Behavior: After a successful deletion API call, the UI called a refresh() function, which re-fetched the current (now empty) page offset.

New Behavior: The logic was updated to check the current state before refreshing. It now verifies if resources?.length === 1 (meaning we are deleting the last item) and first > 0 (meaning we are not on the first page). If true, it calls setFirst(first - max) to decrement the pagination offset. Changing this state automatically re-triggers the useFetch hook to load the previous page's data, eliminating the need for a manual refresh. If there are multiple items left on the page, the standard refresh() is used.

A new Playwright test was implemented in js/apps/admin-ui/test/clients/authorization.spec.ts.

The test creates 15 resources prefixed with "Z" to ensure they sort alphabetically to the end of the table, guaranteeing a spillover onto Page 2. Then, the test navigates to Page 2 and utilizes a while (true) loop to dynamically find and delete all "Z" prefixed resources present on that page. Once the final item is deleted, the test asserts that the empty state (assertEmptyStateNotVisible) does not render, and verifies that the UI automatically routed back to the previous page which is populated (assertTableIsPopulated).
