### PR TITLE
Update authentication section in the Server Admin Guide Features section

### DIFF
--- a/docs/documentation/server_admin/topics/overview/features.adoc
+++ b/docs/documentation/server_admin/topics/overview/features.adoc
@@ -14,7 +14,8 @@
 * Admin Console for central management of users, roles, role mappings, clients and configuration.
 * Account Console that allows users to centrally manage their account.
 * Theme support - Customize all user facing pages to integrate with your applications and branding.
-* Two-factor Authentication - Support for TOTP/HOTP via Google Authenticator or FreeOTP.
+* Flexible Authentication - Authenticate user with various mechanisms including passkey, password or X.509 certificates. Step-up authentication support
+* Two-factor Authentication - Support for passkey, recovery codes and TOTP/HOTP via Google Authenticator or FreeOTP.
 * Login flows - optional user self-registration, recover password, verify email, require password update, etc.
 * Session management - Admins and users themselves can view and manage user sessions.
 * Token mappers - Map user attributes, roles, etc. how you want into tokens and statements.


### PR DESCRIPTION
closes #47393

There are some other things missing in the "Features" section (EG. Organization, groups). In this PR, I handled only "Authentication" parts as I've noticed some interesting stuff (EG. Passkeys) is completely missing from there.
