### PR TITLE
[OID4VCI] Initial public client for credential issuance

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -1,8 +1,10 @@
 package org.keycloak.tests.oid4vc;
 
+import java.time.Duration;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +41,10 @@ import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.PreAuthorizedCodeGrantRequest;
 import org.keycloak.util.JsonSerialization;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
@@ -390,8 +396,54 @@ public class OID4VCBasicWallet {
 
         public AuthorizationEndpointResponse send(String username, String password) {
             loginForm.open();
-            client.fillLoginForm(username, password);
-            return client.parseLoginResponse();
+            WebDriver driver = client.getDriver();
+            AuthPageState authPageState = waitForLoginOrError(driver);
+            switch (authPageState) {
+                case ERROR_REDIRECT -> {
+                    return new AuthorizationEndpointResponse(client);
+                }
+                case ERROR_PAGE -> {
+                    Map<String, String> params = new HashMap<>();
+                    params.put("error", "invalid_request");
+                    driver.findElements(By.id("kc-error-message")).stream()
+                            .map(d -> d.getText().trim().split("\\n")[0])
+                            .forEach(s -> params.put("error_description", s));
+                    return new AuthorizationEndpointResponse(params);
+                }
+                // AuthPageState.LOGIN
+                default -> {
+                    client.fillLoginForm(username, password);
+                    return new AuthorizationEndpointResponse(client);
+                }
+            }
+        }
+
+        enum AuthPageState {LOGIN, ERROR_REDIRECT, ERROR_PAGE}
+
+        private AuthPageState waitForLoginOrError(WebDriver driver) {
+            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+            return wait.until(d -> {
+                String url = d.getCurrentUrl();
+
+                // Error via redirect (some flows)
+                if (url != null && (url.contains("error=") || url.contains("error_description="))) {
+                    return AuthPageState.ERROR_REDIRECT;
+                }
+
+                // Error page rendered by Keycloak
+                if (!d.findElements(By.id("kc-error-message")).isEmpty()) {
+                    return AuthPageState.ERROR_PAGE;
+                }
+
+                // Login form present
+                if (!d.findElements(By.id("username")).isEmpty()
+                        || !d.findElements(By.name("username")).isEmpty()) {
+                    return AuthPageState.LOGIN;
+                }
+
+                return null; // keep waiting
+            });
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -1,7 +1,7 @@
 package org.keycloak.tests.oid4vc;
 
-import java.time.Duration;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -413,7 +413,7 @@ public class OID4VCBasicWallet {
                 // AuthPageState.LOGIN
                 default -> {
                     client.fillLoginForm(username, password);
-                    return new AuthorizationEndpointResponse(client);
+                    return client.parseLoginResponse();
                 }
             }
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -100,7 +100,8 @@ public abstract class OID4VCIssuerTestBase {
 
     protected final Logger log = Logger.getLogger(getClass());
 
-    public static final String OID4VCI_CLIENT_ID = "oid4vci-client";
+    public static final String CLIENT_ID = "oid4vci-test";
+    public static final String PUBLIC_CLIENT_ID = "oid4vci-test-pub";
     public static final URI ISSUER_DID = URI.create("did:web:test.org");
     public static final String TEST_CREDENTIAL_MAPPERS_FILE = "/oid4vc/test-credential-mappers.json";
 
@@ -118,12 +119,16 @@ public abstract class OID4VCIssuerTestBase {
     protected CredentialScopeRepresentation sdJwtTypeCredentialScope;
 
     protected ClientRepresentation client;
+    protected ClientRepresentation pubClient;
 
     @InjectRealm(config = VCTestRealmConfig.class)
     protected ManagedRealm testRealm;
 
-    @InjectClient(ref = "oid4vci-client", config = OID4VCIClient.class)
+    @InjectClient(ref = "oid4vci-client", config = ConfidentialOID4VCIClient.class)
     protected ManagedClient managedClient;
+
+    @InjectClient(ref = PUBLIC_CLIENT_ID, config = PublicOID4VCIClient.class)
+    ManagedClient managedPublicClient;
 
     @InjectOAuthClient
     protected OAuthClient oauth;
@@ -153,10 +158,11 @@ public abstract class OID4VCIssuerTestBase {
     @BeforeEach
     void beforeEachInternal() {
         client = managedClient.admin().toRepresentation();
+        pubClient = managedPublicClient.admin().toRepresentation();
         jwtTypeCredentialScope = requireExistingCredentialScope(jwtTypeCredentialScopeName);
         minimalJwtTypeCredentialScope = requireExistingCredentialScope(minimalJwtTypeCredentialScopeName);
         sdJwtTypeCredentialScope = requireExistingCredentialScope(sdJwtTypeCredentialScopeName);
-        oauth.client(OID4VCI_CLIENT_ID, "test-secret");
+        oauth.client(CLIENT_ID, "test-secret");
         enableVerifiableCredentialEvents(testRealm);
     }
 
@@ -353,7 +359,7 @@ public abstract class OID4VCIssuerTestBase {
             realm.addRole(CREDENTIAL_OFFER_CREATE);
 
             // Allow the default client scopes to be added as well
-            realm.attribute(CREATE_DEFAULT_CLIENT_SCOPES, String.valueOf(true));
+            realm.attribute(CREATE_DEFAULT_CLIENT_SCOPES, "true");
 
             realm.addClientScope(createCredentialScope(
                     sdJwtTypeCredentialScopeName,
@@ -488,19 +494,33 @@ public abstract class OID4VCIssuerTestBase {
         }
     }
 
-    public static class OID4VCIClient implements ClientConfig {
+    public static class ConfidentialOID4VCIClient implements ClientConfig {
 
         @Override
         public ClientConfigBuilder configure(ClientConfigBuilder client) {
-            client.clientId(OID4VCI_CLIENT_ID)
+            client.clientId(CLIENT_ID)
                     .serviceAccountsEnabled(true)
                     .directAccessGrantsEnabled(true)
-                    .attribute(OID4VCI_ENABLED_ATTRIBUTE_KEY, "true")
                     .defaultClientScopes("basic", "profile", "roles")
                     .optionalClientScopes(jwtTypeCredentialScopeName, minimalJwtTypeCredentialScopeName, sdJwtTypeCredentialScopeName, "email")
+                    .attribute(OID4VCI_ENABLED_ATTRIBUTE_KEY, "true")
                     .redirectUris("*")
                     .secret("test-secret");
+            return client;
+        }
+    }
 
+    public static class PublicOID4VCIClient implements ClientConfig {
+
+        @Override
+        public ClientConfigBuilder configure(ClientConfigBuilder client) {
+            client.clientId(PUBLIC_CLIENT_ID)
+                    .publicClient(true)
+                    .defaultClientScopes("basic", "profile", "roles")
+                    .optionalClientScopes(jwtTypeCredentialScopeName, minimalJwtTypeCredentialScopeName, sdJwtTypeCredentialScopeName, "email")
+                    .redirectUris("http://127.0.0.1:8500/callback/oauth")
+                    .attribute(OID4VCI_ENABLED_ATTRIBUTE_KEY, "true")
+                    .attribute("pkce.code.challenge.method", "S256");  // require PKCE
             return client;
         }
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -162,7 +162,7 @@ public abstract class OID4VCIssuerTestBase {
         jwtTypeCredentialScope = requireExistingCredentialScope(jwtTypeCredentialScopeName);
         minimalJwtTypeCredentialScope = requireExistingCredentialScope(minimalJwtTypeCredentialScopeName);
         sdJwtTypeCredentialScope = requireExistingCredentialScope(sdJwtTypeCredentialScopeName);
-        oauth.client(CLIENT_ID, "test-secret");
+        oauth.client(CLIENT_ID, client.getSecret());
         enableVerifiableCredentialEvents(testRealm);
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -1078,7 +1078,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         );
 
         optionalScope = registerOptionalClientScope(optionalScope);
-        ClientRepresentation testClient = testRealm.admin().clients().findByClientId(OID4VCI_CLIENT_ID).get(0);
+        ClientRepresentation testClient = testRealm.admin().clients().findByClientId(CLIENT_ID).get(0);
         testRealm.admin().clients().get(testClient.getId()).addOptionalClientScope(optionalScope.getId());
 
         final String scopeName = optionalScope.getName();
@@ -1135,7 +1135,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         );
 
         oid4vciScope = registerOptionalClientScope(oid4vciScope);
-        ClientRepresentation testClient = testRealm.admin().clients().findByClientId(OID4VCI_CLIENT_ID).get(0);
+        ClientRepresentation testClient = testRealm.admin().clients().findByClientId(CLIENT_ID).get(0);
         ClientResource clientResource = testRealm.admin().clients().get(testClient.getId());
 
         try {
@@ -1190,7 +1190,7 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
         });
 
         try {
-            ClientRepresentation testClient = testRealm.admin().clients().findByClientId(OID4VCI_CLIENT_ID).get(0);
+            ClientRepresentation testClient = testRealm.admin().clients().findByClientId(CLIENT_ID).get(0);
             ClientResource clientResource = testRealm.admin().clients().get(testClient.getId());
 
             try {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPublicClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPublicClientTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.oid4vc;
+
+import java.net.URI;
+import java.util.List;
+
+import org.keycloak.TokenVerifier;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
+import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestServerConfig;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.PkceGenerator;
+import org.keycloak.util.JsonSerialization;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+/**
+ * An external wallet would generally not be trusted to keep the client_secret
+ * oid4vci clients should be configured as public with pkce enabled
+ */
+@KeycloakIntegrationTest(config = VCTestServerConfig.class)
+public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
+
+    OID4VCBasicWallet wallet;
+
+    @BeforeEach
+    void beforeEach() {
+        wallet = new OID4VCBasicWallet(keycloak, oauth);
+
+        // Reconfigure OAuthClient
+        oauth.client(pubClient.getClientId(), null);
+    }
+
+    @AfterEach
+    void afterEach() {
+        wallet.logout();
+    }
+
+    @Test
+    public void testCredentialFromPublicClient() throws Exception {
+
+        var ctx = new OID4VCTestContext(pubClient, jwtTypeCredentialScope);
+
+        PkceGenerator pkce = PkceGenerator.s256();
+
+        CredentialIssuer issuerMetadata = wallet.getIssuerMetadata(ctx);
+
+        OID4VCAuthorizationDetail authDetail = new OID4VCAuthorizationDetail();
+        authDetail.setType(OPENID_CREDENTIAL);
+        authDetail.setCredentialConfigurationId(ctx.credConfigId);
+        authDetail.setLocations(List.of(issuerMetadata.getCredentialIssuer()));
+
+        // Send AuthorizationRequest
+        //
+        AuthorizationEndpointResponse authResponse = wallet
+                .authorizationRequest()
+                .scope(ctx.credScopeName)
+                .authorizationDetails(authDetail)
+                .codeChallenge(pkce)
+                .send(ctx.holder, "password");
+        String authCode = authResponse.getCode();
+
+        // Build and send AccessTokenRequest
+        //
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
+                .codeVerifier(pkce)
+                .send();
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken, "No accessToken");
+
+        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(authorizedIdentifier, "No authorized credential identifier");
+
+        // Send the CredentialRequest
+        //
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(authorizedIdentifier)
+                .send().getCredentialResponse();
+
+        verifyCredentialResponse(ctx, ctx.holder, credResponse);
+    }
+
+    @Test
+    public void testCredentialFromPreAuthCode() throws Exception {
+
+        var ctx = new OID4VCTestContext(pubClient, jwtTypeCredentialScope);
+
+        // Create Pre-Authorized CredentialOffer
+        //
+        CredentialsOffer credOffer = wallet.createPreAuthCredentialOffer(ctx, ctx.holder);
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+
+        // Redeem Pre-Authorized Code for AccessToken
+        //
+        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
+        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken, "No accessToken");
+
+        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(authorizedIdentifier, "No authorized credential identifier");
+
+        // Send the CredentialRequest
+        //
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(authorizedIdentifier)
+                .send().getCredentialResponse();
+
+        verifyCredentialResponse(ctx, ctx.holder, credResponse);
+    }
+
+    @Test
+    public void testAuthorizationRequestNoPkce() throws Exception {
+
+        var ctx = new OID4VCTestContext(pubClient, jwtTypeCredentialScope);
+
+        // Send AuthorizationRequest
+        //
+        AuthorizationEndpointResponse authResponse = wallet
+                .authorizationRequest()
+                .scope(ctx.credScopeName)
+                .send(ctx.holder, "password");
+
+        assertEquals("invalid_request", authResponse.getError());
+        assertEquals("Missing parameter: code_challenge_method", authResponse.getErrorDescription());
+    }
+
+    // Private ---------------------------------------------------------------------------------------------------------
+
+    private void verifyCredentialResponse(OID4VCTestContext ctx, String expUser, CredentialResponse credResponse) throws Exception {
+
+        String scope = ctx.credentialScope.getName();
+        CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
+        assertNotNull(credentialObj, "The first credential in the array should not be null");
+
+        JsonWebToken jsonWebToken = TokenVerifier.create((String) credentialObj.getCredential(), JsonWebToken.class).getToken();
+        assertEquals("did:web:test.org", jsonWebToken.getIssuer());
+        Object vc = jsonWebToken.getOtherClaims().get("vc");
+        VerifiableCredential credential = JsonSerialization.mapper.convertValue(vc, VerifiableCredential.class);
+        assertEquals(List.of(scope), credential.getType());
+        assertEquals(URI.create("did:web:test.org"), credential.getIssuer());
+        assertEquals(expUser + "@email.cz", credential.getCredentialSubject().getClaims().get("email"));
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
@@ -33,11 +33,20 @@ public class OID4VCTestContext {
     static final AttachmentKey<AccessTokenResponse> ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(AccessTokenResponse.class);
     static final AttachmentKey<CredentialResponse> CREDENTIAL_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(CredentialResponse.class);
 
+<<<<<<< HEAD
     public String clientId;
     public String issuer;      // Issuing username (i.e. agent who creates credential offers)
     public String holder;      // Holder who requests the credential
     public String credConfigId;
     public String credScopeName;
+=======
+    ClientRepresentation client;
+    String issuer;      // Issuing username (i.e. agent who creates credential offers)
+    String holder;      // Holder who requests the credential
+    String credConfigId;
+    String credScopeName;
+    CredentialScopeRepresentation credentialScope;
+>>>>>>> 4d538fbe97 ([OID4CVI] Review and fix issuance on public clients)
 
     public ClientRepresentation client;
     public CredentialScopeRepresentation credentialScope;
@@ -46,7 +55,6 @@ public class OID4VCTestContext {
 
     public OID4VCTestContext(ClientRepresentation client, CredentialScopeRepresentation credentialScope) {
         this.client = client;
-        this.clientId = client.getClientId();
         this.issuer = "john";
         this.holder = "alice";
         this.credentialScope = credentialScope;

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
@@ -33,20 +33,11 @@ public class OID4VCTestContext {
     static final AttachmentKey<AccessTokenResponse> ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(AccessTokenResponse.class);
     static final AttachmentKey<CredentialResponse> CREDENTIAL_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(CredentialResponse.class);
 
-<<<<<<< HEAD
     public String clientId;
     public String issuer;      // Issuing username (i.e. agent who creates credential offers)
     public String holder;      // Holder who requests the credential
     public String credConfigId;
     public String credScopeName;
-=======
-    ClientRepresentation client;
-    String issuer;      // Issuing username (i.e. agent who creates credential offers)
-    String holder;      // Holder who requests the credential
-    String credConfigId;
-    String credScopeName;
-    CredentialScopeRepresentation credentialScope;
->>>>>>> 4d538fbe97 ([OID4CVI] Review and fix issuance on public clients)
 
     public ClientRepresentation client;
     public CredentialScopeRepresentation credentialScope;

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCPublicClientPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCPublicClientPreAuthTest.java
@@ -15,40 +15,38 @@
  * limitations under the License.
  */
 
-package org.keycloak.tests.oid4vc;
+package org.keycloak.tests.oid4vc.preauth;
 
 import java.net.URI;
 import java.util.List;
 
 import org.keycloak.TokenVerifier;
-import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
-import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
-import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestServerConfig;
+import org.keycloak.tests.oid4vc.OID4VCBasicWallet;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
-import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
-import org.keycloak.testsuite.util.oauth.PkceGenerator;
 import org.keycloak.util.JsonSerialization;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
  * An external wallet would generally not be trusted to keep the client_secret
  * oid4vci clients should be configured as public with pkce enabled
  */
-@KeycloakIntegrationTest(config = VCTestServerConfig.class)
-public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithPreAuthCodeEnabled.class)
+public class OID4VCPublicClientPreAuthTest extends OID4VCIssuerTestBase {
 
     OID4VCBasicWallet wallet;
 
@@ -66,34 +64,20 @@ public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
     }
 
     @Test
-    public void testCredentialFromPublicClient() throws Exception {
+    public void testCredentialFromPreAuthCode() throws Exception {
 
         var ctx = new OID4VCTestContext(pubClient, jwtTypeCredentialScope);
 
-        PkceGenerator pkce = PkceGenerator.s256();
-
-        CredentialIssuer issuerMetadata = wallet.getIssuerMetadata(ctx);
-
-        OID4VCAuthorizationDetail authDetail = new OID4VCAuthorizationDetail();
-        authDetail.setType(OPENID_CREDENTIAL);
-        authDetail.setCredentialConfigurationId(ctx.credConfigId);
-        authDetail.setLocations(List.of(issuerMetadata.getCredentialIssuer()));
-
-        // Send AuthorizationRequest
+        // Create Pre-Authorized CredentialOffer
         //
-        AuthorizationEndpointResponse authResponse = wallet
-                .authorizationRequest()
-                .scope(ctx.credScopeName)
-                .authorizationDetails(authDetail)
-                .codeChallenge(pkce)
-                .send(ctx.holder, "password");
-        String authCode = authResponse.getCode();
+        CredentialsOffer credOffer = wallet.createPreAuthCredentialOffer(ctx, ctx.holder);
+        String preAuthCode = credOffer.getPreAuthorizedCode();
 
-        // Build and send AccessTokenRequest
+        // Redeem Pre-Authorized Code for AccessToken
         //
-        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
-                .codeVerifier(pkce)
-                .send();
+        AccessTokenResponse tokenResponse = wallet.preAuthAccessTokenRequest(ctx, preAuthCode).send();
+        assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
+
         String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
         assertNotNull(accessToken, "No accessToken");
 
@@ -107,22 +91,6 @@ public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
                 .send().getCredentialResponse();
 
         verifyCredentialResponse(ctx, ctx.holder, credResponse);
-    }
-
-    @Test
-    public void testAuthorizationRequestNoPkce() throws Exception {
-
-        var ctx = new OID4VCTestContext(pubClient, jwtTypeCredentialScope);
-
-        // Send AuthorizationRequest
-        //
-        AuthorizationEndpointResponse authResponse = wallet
-                .authorizationRequest()
-                .scope(ctx.credScopeName)
-                .send(ctx.holder, "password");
-
-        assertEquals("invalid_request", authResponse.getError());
-        assertEquals("Missing parameter: code_challenge_method", authResponse.getErrorDescription());
     }
 
     // Private ---------------------------------------------------------------------------------------------------------

--- a/tests/utils-shared/pom.xml
+++ b/tests/utils-shared/pom.xml
@@ -31,11 +31,20 @@
     <packaging>jar</packaging>
     <description>Keycloak Testsuite Utilities shared between legacy and new testsuites</description>
 
+    <properties>
+        <selenium.version>4.28.1</selenium.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-api</artifactId>
-            <version>4.25.0</version>
+            <version>${selenium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-support</artifactId>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
@@ -306,6 +306,10 @@ public abstract class AbstractOAuthClient<T> {
         return client();
     }
 
+    public WebDriver getDriver() {
+        return driver;
+    }
+
     public HttpClientManager httpClient() {
         return httpClientManager;
     }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AuthorizationEndpointResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AuthorizationEndpointResponse.java
@@ -35,6 +35,10 @@ public class AuthorizationEndpointResponse {
         }
     }
 
+    public AuthorizationEndpointResponse(Map<String, String> params) {
+        this.params = params;
+    }
+
     private boolean isFragment(AbstractOAuthClient<?> client) {
         try {
             OIDCResponseType responseType = OIDCResponseType.parse(client.config().getResponseType());


### PR DESCRIPTION
closes #47280

This PR ...

* adds a public client `test-app-pub` to testrealm.json
* adds a comprehensive test using the new OAuthClient APIs (i.e. OID4VCPublicClientTest)
* adds support for error page/redirect to the AuthorizationRequest
* removes dependency on `OID4VCIssuerEndpointTest.getCredentialOfferUriUrl()`
