### PR TITLE
CVE-2026-3429 Improper Access Control for LoA During Credential Deletion for the case of client overriden flow

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/AuthenticationFlowResolver.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/AuthenticationFlowResolver.java
@@ -49,14 +49,9 @@ public class AuthenticationFlowResolver {
             }
         }
 
-        String clientFlow = client.getAuthenticationFlowBindingOverride(AuthenticationFlowBindings.BROWSER_BINDING);
-        if (clientFlow != null) {
-            flow = authSession.getRealm().getAuthenticationFlowById(clientFlow);
-            if (flow != null) {
-                return flow;
-            }
-            logger.warnf("Client %s has browser flow override, but this flow '%s' does not exist, " +
-                    "fallback to browser flow", client.getClientId(), clientFlow);
+        flow = resolveBindingOverrideFlowForClient(client, AuthenticationFlowBindings.BROWSER_BINDING);
+        if (flow != null) {
+            return flow;
         }
         return authSession.getRealm().getBrowserFlow();
     }
@@ -76,15 +71,23 @@ public class AuthenticationFlowResolver {
             }
         }
 
-        String clientFlow = client.getAuthenticationFlowBindingOverride(AuthenticationFlowBindings.DIRECT_GRANT_BINDING);
+        flow = resolveBindingOverrideFlowForClient(client, AuthenticationFlowBindings.DIRECT_GRANT_BINDING);
+        if (flow != null) {
+            return flow;
+        }
+        return authSession.getRealm().getDirectGrantFlow();
+    }
+
+    public static AuthenticationFlowModel resolveBindingOverrideFlowForClient(ClientModel client, String flowBindingType) {
+        String clientFlow = client.getAuthenticationFlowBindingOverride(flowBindingType);
         if (clientFlow != null) {
-            flow = authSession.getRealm().getAuthenticationFlowById(clientFlow);
+            AuthenticationFlowModel flow = client.getRealm().getAuthenticationFlowById(clientFlow);
             if (flow != null) {
                 return flow;
             }
-            logger.warnf("Client %s has direct grant flow override, but this flow '%s' does not exist, " +
-                    "fallback to direct grant flow", client.getClientId(), clientFlow);
+            logger.warnf("Client %s has %s flow override, but configured override flow '%s' does not exist, " +
+                    "fallback to realm %s flow", client.getClientId(), flowBindingType, clientFlow, flowBindingType);
         }
-        return authSession.getRealm().getDirectGrantFlow();
+        return null;
     }
 }

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/util/CredentialDeleteHelper.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/util/CredentialDeleteHelper.java
@@ -32,9 +32,13 @@ import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.credential.CredentialTypeMetadata;
 import org.keycloak.credential.CredentialTypeMetadataContext;
+import org.keycloak.models.AuthenticationFlowBindings;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.AuthenticationFlowResolver;
 
 import org.jboss.logging.Logger;
 
@@ -107,7 +111,7 @@ public class CredentialDeleteHelper {
     }
 
     private static void checkAuthenticatedLoASufficientForCredentialRemove(KeycloakSession session, String credentialType, Supplier<Integer> currentLoAProvider) {
-        int requestedLoaForCredentialRemove = getRequestedLoaForCredential(session, session.getContext().getRealm(), credentialType);
+        int requestedLoaForCredentialRemove = getRequestedLoaForCredential(session, credentialType);
 
         int currentAuthenticatedLevel = currentLoAProvider.get();
         if (currentAuthenticatedLevel < requestedLoaForCredentialRemove) {
@@ -115,8 +119,15 @@ public class CredentialDeleteHelper {
         }
     }
 
-    private static int getRequestedLoaForCredential(KeycloakSession session, RealmModel realm, String credentialType) {
-        Map<String, Integer> credentialTypesToLoa = LoAUtil.getCredentialTypesToLoAMap(session, realm, realm.getBrowserFlow());
+    private static int getRequestedLoaForCredential(KeycloakSession session, String credentialType) {
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel client = session.getContext().getClient();
+        AuthenticationFlowModel authFlow = AuthenticationFlowResolver.resolveBindingOverrideFlowForClient(client, AuthenticationFlowBindings.BROWSER_BINDING);
+        if (authFlow == null) {
+            authFlow = realm.getBrowserFlow();
+        }
+
+        Map<String, Integer> credentialTypesToLoa = LoAUtil.getCredentialTypesToLoAMap(session, realm, authFlow);
         return credentialTypesToLoa.getOrDefault(credentialType, NO_LOA);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/LevelOfAssuranceFlowTest.java
@@ -55,11 +55,13 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.representations.ClaimsRepresentation;
 import org.keycloak.representations.IDToken;
+import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testsuite.AbstractAuthenticationTest;
 import org.keycloak.testsuite.AbstractChangeImportedUserPasswordsTest;
 import org.keycloak.testsuite.Assert;
 import org.keycloak.testsuite.AssertEvents;
@@ -838,6 +840,38 @@ public class LevelOfAssuranceFlowTest extends AbstractChangeImportedUserPassword
                 Assert.assertEquals(204, response.getStatus());
             }
             Assert.assertNull(accountRestClient.getCredentialByUserLabel("totp2-label"));
+        }
+    }
+
+    // Test that LoA enforcement works for the case when there is "AuthenticationFlowBindingOverride" with the enforced LoA flow for the particular client
+    @Test
+    public void testWithMultipleOTPCodes_clientSpecificAuthenticationFlow() throws Exception {
+        List<AuthenticationFlowRepresentation> flows = testRealm().flows().getFlows();
+
+        // Set default browser flow for realm
+        RealmRepresentation realm = testRealm().toRepresentation();
+        realm.setBrowserFlow(DefaultAuthenticationFlows.BROWSER_FLOW);
+        testRealm().update(realm);
+
+        // Override step-up flow just for the client
+        AuthenticationFlowRepresentation stepUpFlowRepresentation = AbstractAuthenticationTest.findFlowByAlias(FLOW_ALIAS, flows);
+        ClientResource testClient = ApiUtil.findClientByClientId(testRealm(), CLIENT_ID);
+        ClientRepresentation testClientRep = testClient.toRepresentation();
+        testClientRep.setAuthenticationFlowBindingOverrides(
+                Map.of(DefaultAuthenticationFlows.BROWSER_FLOW, stepUpFlowRepresentation.getId())
+        );
+        testClient.update(testClientRep);
+
+        try {
+            testWithMultipleOTPCodes();
+        } finally {
+            // Revert
+            testClientRep.setAuthenticationFlowBindingOverrides(
+                    Map.of(DefaultAuthenticationFlows.BROWSER_FLOW, "")
+            );
+            testClient.update(testClientRep);
+            realm.setBrowserFlow(FLOW_ALIAS);
+            testRealm().update(realm);
         }
     }
 


### PR DESCRIPTION
closes #47069

Signed-off-by: mposolda <mposolda@gmail.com>
(cherry picked from commit 68f5779230d08825e6a4b4e23471fade16434178)
