### PR TITLE
Fix duplicated resource on current and next page in Auth Resources

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/Resources.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/Resources.tsx
@@ -207,7 +207,7 @@ export const AuthorizationResources = ({
                   )}
                 </Tr>
               </Thead>
-              {resources.map((resource, rowIndex) => (
+              {resources.slice(0, max).map((resource, rowIndex) => (
                 <Tbody key={resource._id} isExpanded={resource.isExpanded}>
                   <Tr>
                     <Td

--- a/js/apps/admin-ui/test/clients/authorization.spec.ts
+++ b/js/apps/admin-ui/test/clients/authorization.spec.ts
@@ -296,12 +296,14 @@ test.describe.serial("Client authorization resources pagination", () => {
     await goToResourcesSubTab(page);
   });
 
-  test("Should not duplicate the 10th item on the 2nd page", async ({ page }) => {
-    await page.waitForSelector('table');
-    await expect(page.getByText('Resource-10', { exact: true })).toBeVisible();
-    await expect(page.getByText('Resource-11', { exact: true })).not.toBeVisible();
+  test("Should not duplicate the 10th item on the 2nd page", async ({
+    page,
+  }) => {
+    await page.waitForSelector("table");
+    await expect(page.getByText("Resource-10", { exact: true })).toBeVisible();
+    await expect(page.getByText("Resource-11", { exact: true })).toBeHidden();
     await page.locator('[aria-label="Go to next page"]').first().click();
-    await expect(page.getByText('Resource-11', { exact: true })).toBeVisible();
-    await expect(page.getByText('Resource-10', { exact: true })).not.toBeVisible();
+    await expect(page.getByText("Resource-11", { exact: true })).toBeVisible();
+    await expect(page.getByText("Resource-10", { exact: true })).toBeHidden();
   });
 });

--- a/js/apps/admin-ui/test/clients/authorization.spec.ts
+++ b/js/apps/admin-ui/test/clients/authorization.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import adminClient from "../utils/AdminClient.ts";
 import { clickSaveButton } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
@@ -258,5 +258,50 @@ test.describe.serial("Accessibility tests for client authorization", () => {
     page,
   }) => {
     await assertAxeViolations(page);
+  });
+});
+
+test.describe.serial("Client authorization resources pagination", () => {
+  const clientId = `client-authz-pagination-${crypto.randomUUID()}`;
+
+  test.beforeAll(async () => {
+    await adminClient.createClient({
+      protocol: "openid-connect",
+      clientId,
+      publicClient: false,
+      authorizationServicesEnabled: true,
+      serviceAccountsEnabled: true,
+      standardFlowEnabled: true,
+    });
+
+    for (let i = 1; i <= 11; i++) {
+      await adminClient.createResource(clientId, {
+        name: `Resource-${i.toString().padStart(2, "0")}`,
+        displayName: `Display Resource ${i}`,
+        type: "urn:pagination:test",
+      });
+    }
+  });
+
+  test.afterAll(async () => {
+    await adminClient.deleteClient(clientId);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToClients(page);
+    await searchItem(page, "Search for client", clientId);
+    await clickTableRowItem(page, clientId);
+    await goToAuthorizationTab(page);
+    await goToResourcesSubTab(page);
+  });
+
+  test("Should not duplicate the 10th item on the 2nd page", async ({ page }) => {
+    await page.waitForSelector('table');
+    await expect(page.getByText('Resource-10', { exact: true })).toBeVisible();
+    await expect(page.getByText('Resource-11', { exact: true })).not.toBeVisible();
+    await page.locator('[aria-label="Go to next page"]').first().click();
+    await expect(page.getByText('Resource-11', { exact: true })).toBeVisible();
+    await expect(page.getByText('Resource-10', { exact: true })).not.toBeVisible();
   });
 });


### PR DESCRIPTION
Closes: #46088

The data duplication issue in the Authorization Resources table occurred due to the pagination fetch logic. The useFetch hook is designed to request max + 1 items from the API to determine if a "Next" page exists. However, the UI was incorrectly rendering the entire returned array instead of limiting the display to the max value defined for the current page. As a result, the (N+1)-th item (which should only serve as a pagination indicator) was being displayed as the last item of the current page and then again as the first item of the next page.

To fix this issue, I implemented a .slice(0, max) on the resources array in Resources.tsx before mapping the data to the table rows. This ensures that even though N+1 items are fetched for background logic, only N items are rendered to the user, maintaining data uniqueness across paginated views.

For testing, I created 11 resources and verified that no duplication occurs when navigating between Page 1 and Page 2, and added a new Playwright E2E test in authorization.spec.ts that programmatically verifies the correct distribution of 11 resources across two pages.
