### PR TITLE
Add offline session management to user Sessions tab

### DIFF
--- a/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_es.properties
+++ b/js/apps/admin-ui/maven-resources-community/theme/keycloak.v2/admin/messages/messages_es.properties
@@ -2040,6 +2040,7 @@ startTime=Hora de inicio
 logicHelp=La lógica dicta cómo se debe tomar la decisión de la política. Si es 'Positivo', el efecto resultante (permitir o denegar) obtenido durante la evaluación de esta política se usará para tomar una decisión. Si es 'Negativo', se negará el efecto resultante, es decir, un permiso se convierte en una denegación y viceversa.
 allowRegexComparison=Permitir comparación de patrones regex
 noSessionsForUser=Actualmente no hay sesiones activas para este usuario.
+noOfflineSessionsForUser=No hay sesiones sin conexión para este usuario.
 eventTypes.IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR.description=Error al vincular cuenta del proveedor de identidad
 implicitFlowHelp=Esto habilita el soporte para la autenticación basada en redirección de OpenID Connect sin código de autorización. En términos de las especificaciones de OpenID Connect u OAuth2, esto habilita el soporte del 'Flujo Implícito' para este cliente.
 user-events-cleared-error=No se pudieron borrar los eventos del usuario {{error}}

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -2281,6 +2281,7 @@ startTime=Start time
 logicHelp=The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
 allowRegexComparison=Allow regex pattern comparison
 noSessionsForUser=There are currently no active sessions for this user.
+noOfflineSessionsForUser=There are no offline sessions for this user.
 eventTypes.IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR.description=Identity provider link account error
 implicitFlowHelp=This enables support for OpenID Connect redirect based authentication without authorization code. In terms of OpenID Connect or OAuth2 specifications, this enables support of 'Implicit Flow' for this client.
 user-events-cleared-error=Could not clear the user events {{error}}

--- a/js/apps/admin-ui/src/user/UserSessions.tsx
+++ b/js/apps/admin-ui/src/user/UserSessions.tsx
@@ -14,6 +14,8 @@ export const UserSessions = () => {
   const { t } = useTranslation();
 
   const loader = () => adminClient.users.listSessions({ id, realm });
+  const offlineLoader = () =>
+    adminClient.users.listAllOfflineSessions({ id, realm });
 
   return (
     <PageSection variant="light" className="pf-v5-u-p-0">
@@ -22,6 +24,11 @@ export const UserSessions = () => {
         hiddenColumns={["username", "type"]}
         emptyInstructions={t("noSessionsForUser")}
         logoutUser={id}
+      />
+      <SessionsTable
+        loader={offlineLoader}
+        hiddenColumns={["username", "type"]}
+        emptyInstructions={t("noOfflineSessionsForUser")}
       />
     </PageSection>
   );

--- a/js/libs/keycloak-admin-client/src/resources/users.ts
+++ b/js/libs/keycloak-admin-client/src/resources/users.ts
@@ -440,6 +440,18 @@ export class Users extends Resource<{ realm?: string }> {
   });
 
   /**
+   * list all offline sessions associated with the user
+   */
+  public listAllOfflineSessions = this.makeRequest<
+    { id: string },
+    UserSessionRepresentation[]
+  >({
+    method: "GET",
+    path: "/{id}/offline-sessions",
+    urlParamKeys: ["id"],
+  });
+
+  /**
    * list offline sessions associated with the user and client
    */
   public listOfflineSessions = this.makeRequest<

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -453,6 +453,27 @@ public class UserResource {
     }
 
     /**
+     * Get offline sessions associated with the user
+     *
+     * @return
+     */
+    @Path("offline-sessions")
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
+    @Operation(summary = "Get offline sessions associated with the user")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = UserSessionRepresentation.class, type = SchemaType.ARRAY))),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public Stream<UserSessionRepresentation> getOfflineSessionsForUser() {
+        auth.users().requireView(user);
+        return new UserSessionManager(session).findOfflineSessionsStream(realm, user)
+                .map(ModelToRepresentation::toRepresentation);
+    }
+
+    /**
      * Get offline sessions associated with the user and client
      *
      * @return
@@ -688,6 +709,12 @@ public class UserResource {
                 .collect(Collectors.toList()) // collect to avoid concurrent modification as backchannelLogout removes the user sessions.
                 .forEach(userSession -> AuthenticationManager.backchannelLogout(session, realm, userSession,
                         session.getContext().getUri(), clientConnection, headers, true));
+
+        new UserSessionManager(session).findOfflineSessionsStream(realm, user)
+                .collect(Collectors.toList())
+                .forEach(offlineSession -> offlineSession.getAuthenticatedClientSessions().values().forEach(
+                        clientSession -> new UserSessionManager(session).revokeOfflineToken(user, clientSession.getClient())));
+
         adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).success();
     }
 


### PR DESCRIPTION
## Summary

Adds offline session management to the Admin Console user Sessions tab, addressing issues #47297 #46458.

## Changes

- **Backend**: New \`getOfflineSessionsForUser()\` endpoint that lists all offline sessions for a user
- **Backend**: Modified \`logout()\` method to revoke offline sessions along with online sessions
- **Frontend**: User Sessions tab now displays offline sessions in a separate section
- **Admin Client**: New \`listAllOfflineSessions()\` method to fetch offline sessions
- **Translations**: Added English and Spanish translations for the empty state message

## Behavior

- Offline sessions are displayed separately below online sessions
- Each offline session can be individually revoked with a 'Revoke' action
- The 'Logout all sessions' button now revokes both online and offline sessions
- Proper empty state message when no offline sessions exist

## Testing

- Tested with Docker Keycloak instance
- Verified offline sessions display and revoke functionality
- Verified translations display correctly