### PR TITLE
Use monospaced font for workflow editor.

### DIFF
--- a/js/apps/admin-ui/src/components/form/CodeEditor.tsx
+++ b/js/apps/admin-ui/src/components/form/CodeEditor.tsx
@@ -26,7 +26,8 @@ const CodeEditor = ({
         padding={15}
         minHeight={height}
         style={{
-          font: "var(--pf-global--FontFamily--monospace)",
+          fontFamily: '"Liberation Mono", "Courier New", Courier, monospace',
+          fontSize: "16px",
         }}
         onChange={(event) => onChange?.(event.target.value)}
         value={value}

--- a/js/apps/admin-ui/src/components/form/CodeEditor.tsx
+++ b/js/apps/admin-ui/src/components/form/CodeEditor.tsx
@@ -26,7 +26,8 @@ const CodeEditor = ({
         padding={15}
         minHeight={height}
         style={{
-          fontFamily: '"Liberation Mono", "Courier New", Courier, monospace',
+          fontFamily:
+            'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
           fontSize: "16px",
         }}
         onChange={(event) => onChange?.(event.target.value)}


### PR DESCRIPTION
Fixes #47454

Monospaced font is nicer for editing YAML.

ui-monospace → SF Mono on macOS/iOS (Safari)
SFMono-Regular → SF Mono on macOS (Chrome/Firefox)
Menlo → macOS fallback
Consolas → Windows
Liberation Mono → Linux
monospace → final fallback