### PR TITLE
Implementing locale based theme-description translation

### DIFF
--- a/docs/guides/ui-customization/localization.adoc
+++ b/docs/guides/ui-customization/localization.adoc
@@ -30,6 +30,10 @@ of the realm.
 
 Texts of these message bundles can be overwritten by realm-specific values, which are manageable by the UI and API.
 
+Each theme can have a locale specific description in the message key `theme.<theme-name>.<type>.description`.
+For example, use the key `theme.keycloak.v3.account.description` to provide a description for the `keycloak.v3` theme for the Account Console.
+As usual, the English message will be the fallback for all other languages.
+
 == Adding a language to a theme
 
 .Procedure

--- a/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/messages/messages_en.properties
+++ b/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/messages/messages_en.properties
@@ -236,3 +236,4 @@ invalid_request_object=Invalid request object
 request_not_supported=Request not supported
 request_uri_not_supported=Request uri not supported
 registration_not_supported=Registration not supported
+theme.keycloak.v3.account.description=Refined, v3 is more cohesive and dynamic. (Default for Account)

--- a/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/theme.properties
+++ b/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/theme.properties
@@ -2,7 +2,5 @@ parent=base
 deprecatedMode=false
 darkMode=true
 
-description=Refined, v3 is more cohesive and dynamic. (Default for Account)
-
 kcDarkModeClass=pf-v5-theme-dark
 contentHashPattern=assets/.*

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3773,6 +3773,7 @@ eventTypes.USER_SESSION_DELETED_ERROR.name=User session deleted error
 eventTypes.USER_SESSION_DELETED_ERROR.description=User session deleted error
 hideOnLoginWhenOrgNotResolved=Hide on login page when organization not resolved
 hideOnLoginWhenOrgNotResolvedHelp=If enabled, the identity provider will be hidden on the login page when the organization cannot be resolved based on the user's email domain. Otherwise, the identity provider will be shown on the login page regardless of whether the organization is resolved or not. If 'Hide on login page' is also enabled, the identity provider will always be hidden on the login page.
+theme.keycloak.v2.admin.description=Cleaner and more modern, v2 supports automatic light/dark mode switching. (Default for Admin)
 
 # Roles
 role_admin=Admin

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/theme.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/theme.properties
@@ -1,7 +1,5 @@
 parent=base
 darkMode=true
 
-description=Cleaner and more modern, v2 supports automatic light/dark mode switching. (Default for Admin)
-
 kcDarkModeClass=pf-v5-theme-dark
 contentHashPattern=assets/.*

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -266,14 +266,13 @@ public class ServerInfoAdminResource {
     private String getThemeDescription(Theme theme) throws IOException {
         Locale locale = session.getContext().resolveLocale(null);
 
-        String description = theme.getProperties().getProperty("description");
         Properties enhancedMessages = theme.getEnhancedMessages(session.getContext().getRealm(), locale);
         if (enhancedMessages == null) {
-            return description;
+            return null;
         }
 
         String descriptionKey = "theme." + theme.getName() + "." + theme.getType().name().toLowerCase(Locale.ROOT) + ".description";
-        return enhancedMessages.getProperty(descriptionKey, description);
+        return enhancedMessages.getProperty(descriptionKey);
     }
 
     private LinkedList<String> filterThemes(Theme.Type type, LinkedList<String> themeNames) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -26,7 +26,9 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -262,7 +264,16 @@ public class ServerInfoAdminResource {
     }
 
     private String getThemeDescription(Theme theme) throws IOException {
-        return theme.getProperties().getProperty("description");
+        Locale locale = session.getContext().resolveLocale(null);
+
+        String description = theme.getProperties().getProperty("description");
+        Properties enhancedMessages = theme.getEnhancedMessages(session.getContext().getRealm(), locale);
+        if (enhancedMessages == null) {
+            return description;
+        }
+
+        String descriptionKey = "theme." + theme.getName() + "." + theme.getType().name().toLowerCase(Locale.ROOT) + ".description";
+        return enhancedMessages.getProperty(descriptionKey, description);
     }
 
     private LinkedList<String> filterThemes(Theme.Type type, LinkedList<String> themeNames) {

--- a/themes/src/main/resources/theme/keycloak.v2/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/login/messages/messages_en.properties
@@ -1,0 +1,1 @@
+theme.keycloak.v2.login.description=Cleaner and more modern, v2 supports automatic light/dark mode switching. (Default for Login)

--- a/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
@@ -1,8 +1,6 @@
 parent=base
 import=common/keycloak
 
-description=Cleaner and more modern, v2 supports automatic light/dark mode switching. (Default for Login)
-
 styles=css/styles.css
 stylesCommon=vendor/patternfly-v5/patternfly.min.css vendor/patternfly-v5/patternfly-addons.css
 

--- a/themes/src/main/resources/theme/keycloak/email/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak/email/messages/messages_en.properties
@@ -1,0 +1,1 @@
+theme.keycloak.email.description=High contrast, sharp, utilitarian, basic. (Default for Email)

--- a/themes/src/main/resources/theme/keycloak/email/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/email/theme.properties
@@ -1,3 +1,1 @@
 parent=base
-
-description=High contrast, sharp, utilitarian, basic. (Default for Email)

--- a/themes/src/main/resources/theme/keycloak/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak/login/messages/messages_en.properties
@@ -1,0 +1,1 @@
+theme.keycloak.login.description=High contrast, sharp, utilitarian, basic.

--- a/themes/src/main/resources/theme/keycloak/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/login/theme.properties
@@ -1,8 +1,6 @@
 parent=base
 import=common/keycloak
 
-description=High contrast, sharp, utilitarian, basic.
-
 styles=css/login.css
 stylesCommon=vendor/patternfly-v4/patternfly.min.css vendor/patternfly-v3/css/patternfly.min.css vendor/patternfly-v3/css/patternfly-additions.min.css lib/pficon/pficon.css
 

--- a/themes/src/main/resources/theme/keycloak/welcome/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/keycloak/welcome/messages/messages_en.properties
@@ -1,0 +1,1 @@
+theme.keycloak.welcome.description=High contrast, sharp, utilitarian, basic.

--- a/themes/src/main/resources/theme/keycloak/welcome/theme.properties
+++ b/themes/src/main/resources/theme/keycloak/welcome/theme.properties
@@ -1,7 +1,5 @@
 import=common/keycloak
 
-description=High contrast, sharp, utilitarian, basic.
-
 stylesCommon=vendor/patternfly-v5/patternfly.min.css vendor/patternfly-v5/patternfly-addons.css
 styles=css/welcome.css
 


### PR DESCRIPTION
This PR adds handling of locale based theme descriptions.

Implementation checks if the locale-enhanced properties contain a translated description. If not, it falls back to **EN**. In the case `getEnhancedMessages(RealmModel realm, Locale locale)` is ran via `ClassLoaderTheme.java` with a null locale, the default theme description is displayed.

Below is an example. In it, I added translations to the `themes/src/main/resources-community/theme/base/*/messages/messages_nl.properties` files and switched the locale to **NL**. The theme descriptions change to Dutch.

![output](https://github.com/user-attachments/assets/4c71ef2c-ca4b-4212-a9d1-2c5b8c771dab)

Closes #47038