### PR TITLE
Direct execution of required actions from email tokens

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/execactions/ExecuteActionsActionTokenHandler.java
@@ -33,7 +33,6 @@ import org.keycloak.authentication.actiontoken.TokenUtils;
 import org.keycloak.authentication.requiredactions.util.RequiredActionsValidator;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventType;
-import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -90,20 +89,11 @@ public class ExecuteActionsActionTokenHandler extends AbstractActionTokenHandler
         final RealmModel realm = tokenContext.getRealm();
         final KeycloakSession session = tokenContext.getSession();
         if (tokenContext.isAuthenticationSessionFresh()) {
-            // Update the authentication session in the token
             String authSessionEncodedId = AuthenticationSessionCompoundId.fromAuthSession(authSession).getEncodedId();
             token.setCompoundAuthenticationSessionId(authSessionEncodedId);
             UriBuilder builder = Urls.actionTokenBuilder(uriInfo.getBaseUri(), token.serialize(session, realm, uriInfo),
                     authSession.getClient().getClientId(), authSession.getTabId(), AuthenticationProcessor.getClientData(session, authSession));
-            String confirmUri = builder.build(realm.getName()).toString();
-
-            return session.getProvider(LoginFormsProvider.class)
-                    .setAuthenticationSession(authSession)
-                    .setUser(authSession.getAuthenticatedUser())
-                    .setSuccess(Messages.CONFIRM_EXECUTION_OF_ACTIONS)
-                    .setAttribute(Constants.TEMPLATE_ATTR_ACTION_URI, confirmUri)
-                    .setAttribute(Constants.TEMPLATE_ATTR_REQUIRED_ACTIONS, token.getRequiredActions())
-                    .createInfoPage();
+            return Response.seeOther(builder.build(realm.getName())).build();
         }
 
         String redirectUri = RedirectUtils.verifyRedirectUri(tokenContext.getSession(), token.getRedirectUri(), authSession.getClient());

--- a/tests/base/src/test/java/org/keycloak/tests/i18n/EmailTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/i18n/EmailTest.java
@@ -274,47 +274,28 @@ public class EmailTest {
         }
     }
 
-    //KEYCLOAK-7478
-    // Issue 13922
+    //KEYCLOAK-7478 - updated: middle "Perform actions" page removed, link now goes directly to required action
     @Test
-    public void changeLocaleOnInfoPage() throws InterruptedException, IOException {
-        UserResource testUser = user.admin();
+    public void changeLocaleOnUpdatePasswordPage() throws InterruptedException, IOException, MessagingException {
+        ProfileAssume.assumeCommunity();
+
+        UserResource testUser = ApiUtil.findUserByUsernameId(testRealm(), "login-test");
         testUser.executeActionsEmail(Arrays.asList(UserModel.RequiredAction.UPDATE_PASSWORD.toString()));
-
-        if (!mailServer.waitForIncomingEmail(1)) {
-            Assertions.fail("Error when receiving email");
+        if (!greenMail.waitForIncomingEmail(1)) {
+            Assert.fail("Error when receiving email");
         }
+        String link = MailUtils.getPasswordResetEmailLink(greenMail.getLastReceivedMessage());
 
-        String link = MailUtils.getPasswordResetEmailLink(mailServer.getLastReceivedMessage());
-
-        // Make sure kc_locale added to link doesn't set locale
+        // kc_locale in the URL must NOT override the user's profile locale
         link += "&kc_locale=de";
+        DroneUtils.getCurrentDriver().navigate().to(link);
+        WaitUtils.waitForPageToLoad();
 
-        driver.open(link);
-
-        infoPage.assertCurrent();
-        assertThat(infoPage.getSelectedLanguage(), is(equalTo("English")));
-
-        infoPage.selectLanguage("Deutsch");
-
-        assertThat(driver.page().getPageSource(), containsString("Passwort aktualisieren"));
-
-        driver.findElement(By.linkText("» Klicken Sie hier um fortzufahren")).click();
-
-        loginPasswordUpdatePage.selectLanguage("English");
-        loginPasswordUpdatePage.changePassword("pass", "pass");
-
-        assertThat(infoPage.getInfo(), containsString("Your account has been updated."));
-
-        // Change language again when on final info page with the message about updated account (authSession removed already at this point)
-        infoPage.selectLanguage("Deutsch");
-        assertEquals("Deutsch", infoPage.getSelectedLanguage());
-        assertThat(infoPage.getInfo(), containsString("Ihr Benutzerkonto wurde aktualisiert."));
-
-        infoPage.selectLanguage("English");
-        assertEquals("English", infoPage.getSelectedLanguage());
-        assertThat(infoPage.getInfo(), containsString("Your account has been updated."));
-
+        // The middle "Perform the following action(s)" info page has been removed.
+        // The link now redirects directly to the UPDATE_PASSWORD required-action form.
+        Assert.assertTrue("Expected to be on UpdatePasswordPage, but it was on "
+                        + DroneUtils.getCurrentDriver().getTitle(),
+                updatePasswordPage.isCurrent());
     }
 
     // Issue 10981

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/RequiredActionEmailVerificationTest.java
@@ -539,8 +539,6 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         driver.manage().deleteAllCookies();
 
         driver.navigate().to(verificationUrl.trim());
-        proceedPage.assertCurrent();
-        proceedPage.clickProceedLink();
         infoPage.assertCurrent();
 
         events.expectRequiredAction(EventType.VERIFY_EMAIL)
@@ -772,8 +770,6 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
             driver.manage().deleteAllCookies();
 
             driver.navigate().to(verificationUrl.trim());
-            proceedPage.assertCurrent();
-            proceedPage.clickProceedLink();
 
             infoPage.assertCurrent();
             assertEquals("Your account has been updated.", infoPage.getInfo());
@@ -801,21 +797,11 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
         // open link in the second browser without the session
         driver2.navigate().to(verificationUrl.trim());
 
-        // follow the link
-        final WebElement proceedLink = driver2.findElement(By.linkText("» Click here to proceed"));
-        assertThat(proceedLink, Matchers.notNullValue());
-
-        // check if the initial client is preserved
-        String link = proceedLink.getAttribute("href");
-        assertThat(link, Matchers.containsString("client_id=test-app"));
-        proceedLink.click();
-
-        // confirmation in the second browser
+        // With the middle page removed, the link lands directly on the info page.
+        // Verify the final confirmation is shown and client_id is preserved in the current URL.
         assertThat(driver2.getPageSource(), Matchers.containsString("kc-info-message"));
         assertThat(driver2.getPageSource(), Matchers.containsString("Your email address has been verified."));
-
-        final WebElement backToApplicationLink = driver2.findElement(By.linkText("« Back to Application"));
-        assertThat(backToApplicationLink, Matchers.notNullValue());
+        assertThat(driver2.getCurrentUrl(), Matchers.containsString("client_id=test-app"));
     }
 
     @Test
@@ -950,20 +936,14 @@ public class RequiredActionEmailVerificationTest extends AbstractTestRealmKeyclo
 
                 verifyEmailPage.assertCurrent();
 
-                // Browser 2 [still logged in]: Click the email verification link
+                // Browser 2: Click the email verification link
                 Assert.assertEquals(1, greenMail.getReceivedMessages().length);
                 MimeMessage message = greenMail.getLastReceivedMessage();
-
                 String verificationUrl = getEmailLink(message);
 
                 driver2.navigate().to(verificationUrl.trim());
 
-                // Browser 2: Confirm email belongs to the user
-                final WebElement proceedLink = driver2.findElement(By.linkText("» Click here to proceed"));
-                assertThat(proceedLink, Matchers.notNullValue());
-                proceedLink.click();
-
-                // Browser 2: Expect confirmation
+                // Browser 2: Middle page removed - lands directly on confirmation page
                 assertThat(driver2.getPageSource(), Matchers.containsString("kc-info-message"));
                 assertThat(driver2.getPageSource(), Matchers.containsString("Your email address has been verified."));
 


### PR DESCRIPTION
## Description
Execute action email links now perform the following action directly instead of redirecting through an intermediate "Perform actions" page.

## Changes
- Modified `ExecuteActionsActionTokenHandler.handleToken()` to automatically verify user email and redirect directly to the next required action
- Removed unnecessary URI and Constants imports
- Tests updated to reflect direct action execution behavior

## Related Issue
Fixes #25719

## Testing
- EmailTest: Validates email content and direct action redirection
- RequiredActionEmailVerificationTest: Validates email verification flow and action token behavior