### PR TITLE
[quarkus-next] Fix operator controller stalling after JOSDK 5.3.0 eve…

### DIFF
--- a/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
+++ b/operator/src/main/java/org/keycloak/operator/controllers/KeycloakController.java
@@ -135,7 +135,7 @@ public class KeycloakController implements Reconciler<Keycloak> {
                     .endMetadata()
                     .withSpec(kc.getSpec())
                     .build();
-            return UpdateControl.patchResource(patchedKc);
+            return UpdateControl.<Keycloak>patchResource(patchedKc).rescheduleAfter(0L);
         }
 
         var existingDeployment = context.getSecondaryResource(StatefulSet.class).filter(ss -> ss.hasOwnerReferenceFor(kc)).orElse(null);


### PR DESCRIPTION
…nt filtering upgrade

Closes: #47473

This adds `.rescheduleAfter(0L)` to explicitly request immediate re-reconciliation after patching the spec.