### PR TITLE
fix(oid4vci): use SecureRandom for nonce and time claim generation

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
+++ b/common/src/main/java/org/keycloak/common/util/SecretGenerator.java
@@ -59,6 +59,10 @@ public class SecretGenerator {
         return id;
     }
 
+    public static int nextInt(int bound) {
+        return SECURE_RANDOM.nextInt(bound);
+    }
+
     public String randomString() {
         return randomString(SECRET_LENGTH_256_BITS, ALPHANUM);
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizer.java
@@ -23,6 +23,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -59,10 +60,10 @@ public class TimeClaimNormalizer {
     }
 
     private final Strategy strategy;
-    private final long randomizeWindowSeconds;
+    private final int randomizeWindowSeconds;
     private final RoundUnit roundUnit;
 
-    public static final long DEFAULT_RANDOMIZE_WINDOW = 86400; // 24h default
+    public static final int DEFAULT_RANDOMIZE_WINDOW = 86400; // 24h default
     public static final Strategy DEFAULT_STRATEGY = Strategy.OFF;
     public static final RoundUnit DEFAULT_ROUND_UNIT = RoundUnit.SECOND;
 
@@ -76,7 +77,7 @@ public class TimeClaimNormalizer {
         this.roundUnit = parseRoundUnit(realm.getAttribute(OID4VCIConstants.TIME_ROUND_UNIT));
     }
 
-    TimeClaimNormalizer(Strategy strategy, Long randomizeWindowSeconds, RoundUnit roundUnit) {
+    TimeClaimNormalizer(Strategy strategy, Integer randomizeWindowSeconds, RoundUnit roundUnit) {
         this.strategy = strategy == null ? DEFAULT_STRATEGY : strategy;
         this.randomizeWindowSeconds =
                 randomizeWindowSeconds == null ? DEFAULT_RANDOMIZE_WINDOW : randomizeWindowSeconds;
@@ -95,7 +96,7 @@ public class TimeClaimNormalizer {
     }
 
     private Instant randomize(Instant original) {
-        long randomOffset = (long) (Math.random() * (randomizeWindowSeconds + 1));
+        int randomOffset = SecretGenerator.nextInt(randomizeWindowSeconds + 1);
         return original.minusSeconds(randomOffset);
     }
 
@@ -122,12 +123,12 @@ public class TimeClaimNormalizer {
         }
     }
 
-    private static long parseRandomizeWindow(String value) {
+    private static int parseRandomizeWindow(String value) {
         if (StringUtil.isBlank(value)) {
             return DEFAULT_RANDOMIZE_WINDOW;
         }
         try {
-            long window = Long.parseLong(value.trim());
+            int window = Integer.parseInt(value.trim());
             if (window <= 0) {
                 logger.warnf("Randomization window is zero or negative (%d), will be using default value", window);
                 return DEFAULT_RANDOMIZE_WINDOW;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Random;
 
 import jakarta.annotation.Nullable;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.crypto.Algorithm;
@@ -82,7 +82,7 @@ public class JwtCNonceHandler implements CNonceHandler {
         audiences = Optional.ofNullable(audiences).orElseGet(Collections::emptyList);
         final long nowSeconds = Time.currentTime();
         final long expiresAt = nowSeconds + nonceLifetimeSeconds;
-        final int nonceLength = NONCE_DEFAULT_LENGTH + new Random().nextInt(NONCE_LENGTH_RANDOM_OFFSET);
+        final int nonceLength = NONCE_DEFAULT_LENGTH + SecretGenerator.nextInt(NONCE_LENGTH_RANDOM_OFFSET);
         // this generated value itself is basically just a salt-value for the generated token, which itself is the nonce.
         final String strongSalt = Base64.getEncoder().encodeToString(RandomSecret.createRandomSecret(nonceLength));
 

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/TimeClaimNormalizerTest.java
@@ -34,14 +34,14 @@ public class TimeClaimNormalizerTest {
     @Test
     public void offStrategy_keepsOriginal() {
         Instant orig = Instant.parse("2025-01-02T03:04:05Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.OFF, 0L, TimeClaimNormalizer.RoundUnit.DAY);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.OFF, 0, TimeClaimNormalizer.RoundUnit.DAY);
         assertThat(n.normalize(orig), is(orig));
     }
 
     @Test
     public void roundDay_truncatesToStartOfDayUtc() {
         Instant orig = Instant.parse("2025-01-02T23:59:59Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.DAY);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0, TimeClaimNormalizer.RoundUnit.DAY);
         Instant normalized = n.normalize(orig);
         assertThat(normalized, is(Instant.parse("2025-01-02T00:00:00Z")));
     }
@@ -49,7 +49,7 @@ public class TimeClaimNormalizerTest {
     @Test
     public void roundHour_truncatesToHour() {
         Instant orig = Instant.parse("2025-01-02T03:59:59Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.HOUR);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0, TimeClaimNormalizer.RoundUnit.HOUR);
         Instant normalized = n.normalize(orig);
         assertThat(normalized, is(Instant.parse("2025-01-02T03:00:00Z")));
     }
@@ -57,7 +57,7 @@ public class TimeClaimNormalizerTest {
     @Test
     public void roundMinute_truncatesToMinute() {
         Instant orig = Instant.parse("2025-01-02T03:04:59Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.MINUTE);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0, TimeClaimNormalizer.RoundUnit.MINUTE);
         Instant normalized = n.normalize(orig);
         assertThat(normalized, is(Instant.parse("2025-01-02T03:04:00Z")));
     }
@@ -65,7 +65,7 @@ public class TimeClaimNormalizerTest {
     @Test
     public void roundSecond_truncatesToSecond() {
         Instant orig = Instant.parse("2025-01-02T03:04:05.987654Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0L, TimeClaimNormalizer.RoundUnit.SECOND);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.ROUND, 0, TimeClaimNormalizer.RoundUnit.SECOND);
         Instant normalized = n.normalize(orig);
         assertThat(normalized, is(Instant.parse("2025-01-02T03:04:05Z")));
     }
@@ -81,7 +81,7 @@ public class TimeClaimNormalizerTest {
     @Test
     public void randomize_withinWindow_doesNotShiftIntoFuture() {
         Instant orig = Instant.parse("2025-01-02T22:00:00Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600, TimeClaimNormalizer.RoundUnit.DAY);
 
         Instant normalized = n.normalize(orig);
 
@@ -91,7 +91,7 @@ public class TimeClaimNormalizerTest {
     @Test
     public void randomize_withinWindow_alwaysBeforeOrEqualOriginal() {
         Instant orig = Instant.parse("2025-01-02T22:00:00Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600, TimeClaimNormalizer.RoundUnit.DAY);
         Instant normalized = n.normalize(orig);
         assertFalse("Normalized time should not be after original time", normalized.isAfter(orig));
         // should be within the randomization window
@@ -102,7 +102,7 @@ public class TimeClaimNormalizerTest {
     @Test
     public void randomize_alwaysRandomizesWithinWindow() {
         Instant orig = Instant.parse("2025-01-02T22:00:00Z");
-        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600L, TimeClaimNormalizer.RoundUnit.DAY);
+        TimeClaimNormalizer n = new TimeClaimNormalizer(TimeClaimNormalizer.Strategy.RANDOMIZE, 3600, TimeClaimNormalizer.RoundUnit.DAY);
 
         Instant normalized = n.normalize(orig);
 


### PR DESCRIPTION
This PR addresses insecure use of `java.util.Random` and `Math.random()` by introducing `SecureRandom` for nonce and time claim generation in OID4VC.

**Key changes:**

- replace non-cryptographic PRNG usage (java.util.Random, Math.random)
- use SecureRandom in JwtCNonceHandler for nonce length generation
- use SecureRandom in TimeClaimNormalizer for time claim randomization
- introduce centralized secure random utility (SecretGenerator)
- ensure uniform and unpredictable randomness in security-sensitive flows

Closes #47271