### PR TITLE
Add externalId attribute to group resource type

### DIFF
--- a/scim/core/src/main/java/org/keycloak/scim/resource/schema/attribute/Attribute.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/schema/attribute/Attribute.java
@@ -64,6 +64,9 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
     private String returned = RETURNED_DEFAULT;
     private boolean multivalued;
     private Class<?> complexType;
+    private boolean required;
+    private boolean caseExact;
+    private String uniqueness;
 
     private Attribute(String name, AttributeMapper<M, R> mapper, String parentName, String alias) {
         this.name = name;
@@ -159,6 +162,30 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
         return complexType;
     }
 
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setCaseExact(boolean caseExact) {
+        this.caseExact = caseExact;
+    }
+
+    public boolean isCaseExact() {
+        return caseExact;
+    }
+
+    public void setUniqueness(String uniqueness) {
+        this.uniqueness = uniqueness;
+    }
+
+    public String getUniqueness() {
+        return uniqueness;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof Attribute<?, ?> attribute)) return false;
@@ -244,13 +271,17 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
         private TriConsumer<M, String, ?> modelSetter;
         private BiConsumer<R, ?> representationSetter;
         List<Attribute<M, R>> attributes = new ArrayList<>();
-        private Function<Attribute<M, R>, String> modelAttributeResolver;
+        // by default, resolve model attribute name as the same as the scim attribute name
+        private Function<Attribute<M, R>, String> modelAttributeResolver = Attribute::getName;
         private String type;
         private String mutability;
         private String returned;
         private boolean multivalued;
         private TriConsumer<M, String, Set<?>> modelRemover;
         private TriConsumer<M, String, Set<?>> modelAdder;
+        private boolean required;
+        private boolean caseExact = true;
+        private String uniqueness = "none";
 
         private Builder(String name, Class<?> complexType) {
             Objects.requireNonNull(name, "name cannot be null");
@@ -284,7 +315,7 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
             String subName = this.name + "." + name;
             Attribute<M, R> attribute = assembleAttribute(subName, this.name, alias,
                     new AttributeMapper<>(modelSetter, new ComplexAttributeSetter<>(this.name, name, complexType)),
-                    modelAttributeResolver, "string", null, returned, false, null);
+                    modelAttributeResolver, "string", null, returned, false, false, true, null, null);
             attributes.add(attribute);
             return this;
         }
@@ -322,7 +353,7 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
         public List<Attribute<M, R>> build() {
             Attribute<M, R> attribute = assembleAttribute(name, null, null,
                     new AttributeMapper<>(modelSetter, representationSetter, modelRemover, modelAdder),
-                    modelAttributeResolver, type, mutability, returned, multivalued, complexType);
+                    modelAttributeResolver, type, mutability, returned, multivalued, required, caseExact, uniqueness, complexType);
             if (attributes.isEmpty()) {
                 // do not add the root attribute if there are subattributes
                 attributes.add(attribute);
@@ -334,7 +365,11 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
                                                    AttributeMapper<M, R> mapper,
                                                    Function<Attribute<M, R>, String> modelAttributeResolver,
                                                    String type, String mutability, String returned,
-                                                   boolean multivalued, Class<?> complexType) {
+                                                   boolean multivalued,
+                                                   boolean required,
+                                                   boolean caseExact,
+                                                   String uniqueness,
+                                                   Class<?> complexType) {
             Attribute<M, R> attribute = new Attribute<>(name, mapper, parentName, alias);
             attribute.setModelAttributeResolver(modelAttributeResolver);
             attribute.setType(type);
@@ -344,6 +379,9 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
             }
             attribute.setMultivalued(multivalued);
             attribute.setComplexType(complexType);
+            attribute.setRequired(required);
+            attribute.setCaseExact(caseExact);
+            attribute.setUniqueness(uniqueness == null ? "none" : uniqueness);
             return attribute;
         }
 
@@ -359,6 +397,26 @@ public class Attribute<M extends Model, R extends ResourceTypeRepresentation> {
 
         public <C> Builder<M, R> withModelAdder(TriConsumer<M, String, Set<C>> adder) {
             this.modelAdder = (m, s, objects) -> adder.accept(m, s, (Set<C>) objects);
+            return this;
+        }
+
+        public Builder<M, R> required() {
+            this.required = true;
+            return this;
+        }
+
+        public Builder<M, R> notCaseExact() {
+            this.caseExact = false;
+            return this;
+        }
+
+        public Builder<M, R> serverUnique() {
+            this.uniqueness = "server";
+            return this;
+        }
+
+        public Builder<M, R> globalUnique() {
+            this.uniqueness = "global";
             return this;
         }
     }

--- a/scim/model/src/main/java/org/keycloak/scim/model/config/ServiceProviderConfigResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/config/ServiceProviderConfigResourceTypeProvider.java
@@ -10,6 +10,7 @@ import org.keycloak.models.Model;
 import org.keycloak.scim.protocol.ForbiddenException;
 import org.keycloak.scim.protocol.request.SearchRequest;
 import org.keycloak.scim.resource.config.ServiceProviderConfig;
+import org.keycloak.scim.resource.config.ServiceProviderConfig.AuthenticationScheme;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.BulkSupport;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.FilterSupport;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.Supported;
@@ -36,9 +37,29 @@ public class ServiceProviderConfigResourceTypeProvider implements SingletonResou
         config.setChangePassword(Supported.FALSE);
         config.setCreatedTimestamp(Time.currentTimeMillis());
         config.setSort(Supported.FALSE);
-        config.setFilter(new FilterSupport());
+        config.setFilter(getFilterSupport());
+        config.setAuthenticationSchemes(getAuthenticationSchemes());
 
         return config;
+    }
+
+    private FilterSupport getFilterSupport() {
+        FilterSupport filter = new FilterSupport();
+
+        filter.setSupported(true);
+
+        return filter;
+    }
+
+    private List<AuthenticationScheme> getAuthenticationSchemes() {
+        AuthenticationScheme scheme = new AuthenticationScheme();
+
+        scheme.setName("OAuth Bearer Token");
+        scheme.setDescription("Authentication scheme using the OAuth Bearer Token standard");
+        scheme.setSpecUri("https://tools.ietf.org/html/rfc6750");
+        scheme.setType("oauthbearertoken");
+
+        return List.of(scheme);
     }
 
     @Override

--- a/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/filter/ScimJPAPredicateProvider.java
@@ -133,6 +133,11 @@ public class ScimJPAPredicateProvider {
             basePredicate = cb.equal(join.get("name"), modelAttributeName);
         }
 
+        if (value != null && !attrInfo.isCaseExact() && "string".equals(attrInfo.getType())) {
+            value = value.toString().toLowerCase();
+            expression = cb.lower((Expression<String>) expression);
+        }
+
         Predicate predicate = operatorMap.get(operation).apply(cb, expression, value);
         return (basePredicate != null) ? cb.and(basePredicate, predicate) : predicate;
     }

--- a/scim/model/src/main/java/org/keycloak/scim/model/group/GroupCoreModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/group/GroupCoreModelSchema.java
@@ -35,28 +35,31 @@ public final class GroupCoreModelSchema extends AbstractModelSchema<GroupModel, 
 
     @Override
     protected Set<String> getModelAttributeNames() {
-        return Set.of("name");
+        return Set.of("name", "externalId");
     }
 
     @Override
     protected String getAttributeValue(GroupModel model, String name) {
-        if (name.equals("name")) {
-            return model.getName();
-        }
-        return null;
+        return switch (name) {
+            case "name" -> model.getName();
+            case "externalId" -> model.getFirstAttribute("externalId");
+            default -> null;
+        };
     }
 
     @Override
     protected String getAttributeSchemaName(String name) {
-        if (name.equals("name")) {
-            return "displayName";
-        }
-        return null;
+        return switch (name) {
+            case "name" -> "displayName";
+            case "externalId" -> name;
+            default -> null;
+        };
     }
 
     @Override
     protected Map<String, Attribute<GroupModel, Group>> doGetAttributes() {
         List<Attribute<GroupModel, Group>> attributes = new ArrayList<>(Attribute.<GroupModel, Group>simple("displayName")
+                    .notCaseExact()
                     .modelAttributeResolver((attribute) -> {
                         if (attribute.getName().equals("displayName")) {
                             return "name";
@@ -65,6 +68,11 @@ public final class GroupCoreModelSchema extends AbstractModelSchema<GroupModel, 
                     })
                     .withModelSetter(GroupModel::setName)
                     .build());
+        attributes.addAll(Attribute.<GroupModel, Group>simple("externalId")
+                .immutable()
+                .string()
+                .withModelSetter(GroupModel::setSingleAttribute)
+                .build());
         attributes.addAll(Attribute.<GroupModel, Group>simple("meta.created")
                 .timestamp()
                 .immutable()

--- a/scim/model/src/main/java/org/keycloak/scim/model/schema/SchemaResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/schema/SchemaResourceTypeProvider.java
@@ -87,6 +87,10 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
                         p.setName(k);
                         p.setType("complex");
                         p.setMultiValued(false);
+                        p.setMutability("readWrite");
+                        p.setCaseExact(false);
+                        p.setRequired(false);
+                        p.setUniqueness("none");
                         return p;
                     });
 
@@ -95,6 +99,8 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
                     subAttr.setType(attribute.getType());
                     subAttr.setMultiValued(false);
                     subAttr.setReturned(attribute.getReturned());
+                    subAttr.setMutability(attribute.isImmutable() ? "immutable" : "readWrite");
+                    subAttr.setUniqueness(attribute.getUniqueness());
 
                     List<Attribute> subAttributes = parent.getSubAttributes();
                     if (subAttributes == null) {
@@ -109,6 +115,10 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
                         p.setName(k);
                         p.setType("complex");
                         p.setMultiValued(attribute.isMultivalued());
+                        p.setMutability(attribute.isImmutable() ? "immutable" : "readWrite");
+                        p.setRequired(attribute.isRequired());
+                        p.setCaseExact(attribute.isCaseExact());
+                        p.setUniqueness(attribute.getUniqueness());
                         return p;
                     });
 
@@ -117,6 +127,10 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
                     subAttr.setType(attribute.getType());
                     subAttr.setMultiValued(false);
                     subAttr.setReturned(attribute.getReturned());
+                    subAttr.setMutability(attribute.isImmutable() ? "immutable" : "readWrite");
+                    subAttr.setRequired(attribute.isRequired());
+                    subAttr.setCaseExact(attribute.isCaseExact());
+                    subAttr.setUniqueness(attribute.getUniqueness());
 
                     List<Attribute> subAttributes = parent.getSubAttributes();
                     if (subAttributes == null) {
@@ -132,6 +146,10 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
                         attr.setType(attribute.getType());
                         attr.setMultiValued(attribute.isMultivalued());
                         attr.setReturned(attribute.getReturned());
+                        attr.setMutability(attribute.isImmutable() ? "immutable" : "readWrite");
+                        attr.setRequired(attribute.isRequired());
+                        attr.setCaseExact(attribute.isCaseExact());
+                        attr.setUniqueness(attribute.getUniqueness());
                         return attr;
                     });
                 }
@@ -143,6 +161,10 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
                     attr.setType(attribute.getType());
                     attr.setMultiValued(attribute.isMultivalued());
                     attr.setReturned(attribute.getReturned());
+                    attr.setMutability(attribute.isImmutable() ? "immutable" : "readWrite");
+                    attr.setRequired(attribute.isRequired());
+                    attr.setCaseExact(attribute.isCaseExact());
+                    attr.setUniqueness(attribute.getUniqueness());
                     return attr;
                 });
             }

--- a/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/user/UserCoreModelSchema.java
@@ -46,11 +46,16 @@ public final class UserCoreModelSchema extends AbstractUserModelSchema {
         List<Attribute<UserModel, User>> attributes = new ArrayList<>();
 
         attributes.addAll(Attribute.<UserModel, User>simple("userName")
+                .required()
+                .notCaseExact()
+                .serverUnique()
                 .modelAttributeResolver(this::createModelAttributeResolver)
                 .withModelSetter(UserModel::setSingleAttribute)
                 .build());
         attributes.addAll(Attribute.<UserModel, User>complex("emails", Email.class)
                 .modelAttributeResolver(this::createModelAttributeResolver)
+                .notCaseExact()
+                .globalUnique()
                 .multivalued()
                 .withModelSetter((TriConsumer<UserModel, String, Set<Email>>) (model, name, values) -> {
                     for (Email value : values) {

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/FilterTest.java
@@ -785,10 +785,10 @@ public class FilterTest extends AbstractScimTest {
         Instant before = Instant.now();
 
         Group group = new Group();
-        group.setDisplayName("groupA");
+        group.setDisplayName(KeycloakModelUtils.generateId());
         group = client.groups().create(group);
         groupIdsToRemove.add(group.getId());
-        final String displayName = group.getDisplayName();
+        String displayName = group.getDisplayName();
 
         Instant after = Instant.now();
 

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/GroupTest.java
@@ -8,7 +8,9 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.scim.client.ResourceFilter;
 import org.keycloak.scim.protocol.request.PatchRequest;
+import org.keycloak.scim.protocol.response.ListResponse;
 import org.keycloak.scim.resource.group.Group;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.events.AdminEventAssertion;
@@ -17,7 +19,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -28,6 +32,7 @@ public class GroupTest extends AbstractScimTest {
     public void testCreate() {
         Group expected = new Group();
         expected.setDisplayName(KeycloakModelUtils.generateId());
+        expected.setExternalId(KeycloakModelUtils.generateId());
         expected = client.groups().create(expected);
         assertNotNull(expected);
 
@@ -39,6 +44,7 @@ public class GroupTest extends AbstractScimTest {
         Group actual = client.groups().get(expected.getId());
         assertNotNull(actual);
         assertEquals(expected.getDisplayName(), actual.getDisplayName());
+        assertEquals(expected.getExternalId(), actual.getExternalId());
     }
 
     @Test
@@ -71,6 +77,7 @@ public class GroupTest extends AbstractScimTest {
 
         expected = client.groups().get(expected.getId());
         expected.setDisplayName("Updated " + expected.getDisplayName());
+        expected.setExternalId(KeycloakModelUtils.generateId());
         adminEvents.clear();
         client.groups().update(expected);
 
@@ -81,6 +88,7 @@ public class GroupTest extends AbstractScimTest {
 
         Group actual = client.groups().get(expected.getId());
         assertEquals(expected.getDisplayName(), actual.getDisplayName());
+        assertEquals(expected.getExternalId(), actual.getExternalId());
     }
 
     @Test
@@ -92,9 +100,11 @@ public class GroupTest extends AbstractScimTest {
 
         expected = client.groups().get(expected.getId());
         expected.setDisplayName("Updated " + expected.getDisplayName());
+        expected.setExternalId(KeycloakModelUtils.generateId());
         adminEvents.clear();
         client.groups().patch(expected.getId(), PatchRequest.create()
                 .replace("displayName", expected.getDisplayName())
+                .replace("externalId", expected.getExternalId())
                 .build());
 
         AdminEventAssertion.assertSuccess(adminEvents.poll())
@@ -104,6 +114,7 @@ public class GroupTest extends AbstractScimTest {
 
         Group actual = client.groups().get(expected.getId());
         assertEquals(expected.getDisplayName(), actual.getDisplayName());
+        assertEquals(expected.getExternalId(), actual.getExternalId());
     }
 
     @Test
@@ -176,5 +187,30 @@ public class GroupTest extends AbstractScimTest {
         Group group = client.groups().get(rep.getId());
         assertNotNull(group);
         assertEquals(rep.getName(), group.getDisplayName());
+    }
+
+    @Test
+    public void testSearchByExternalId() {
+        Group group = new Group();
+        group.setDisplayName(KeycloakModelUtils.generateId());
+        group.setExternalId(KeycloakModelUtils.generateId());
+        group = client.groups().create(group);
+
+        Group group2 = new Group();
+        group2.setDisplayName(KeycloakModelUtils.generateId());
+        group2.setExternalId(KeycloakModelUtils.generateId());
+        group2 = client.groups().create(group2);
+
+        String filter = ResourceFilter.filter().eq("externalId", group.getExternalId()).build();
+        ListResponse<Group> response = client.groups().getAll(filter);
+        assertFalse(response.getResources().isEmpty());
+        assertThat(response.getTotalResults(), is(1));
+        assertThat(response.getResources().get(0).getExternalId(), is(group.getExternalId()));
+
+        filter = ResourceFilter.filter().eq("externalId", group2.getExternalId()).build();
+        response = client.groups().getAll(filter);
+        assertFalse(response.getResources().isEmpty());
+        assertThat(response.getTotalResults(), is(1));
+        assertThat(response.getResources().get(0).getExternalId(), is(group2.getExternalId()));
     }
 }

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/SchemaTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/SchemaTest.java
@@ -50,27 +50,42 @@ public class SchemaTest extends AbstractScimTest {
         assertFalse(schema.getAttributes().isEmpty());
 
         // Verify ALL expected attributes are present (extracted from UserCoreModelSchema)
-        // UserCoreModelSchema has: userName, emails[0].value, name.*, externalId, nickName, locale, active
-        // These should map to top-level attributes: userName, emails, name, externalId, nickName, locale, active
         Set<String> attributeNames = schema.getAttributes().stream()
                 .map(Schema.Attribute::getName)
                 .collect(Collectors.toSet());
 
-        assertEquals(14, attributeNames.size(), "User schema should have exactly 7 attributes");
-        assertTrue(attributeNames.contains("userName"));
-        assertTrue(attributeNames.contains("emails"));
-        assertTrue(attributeNames.contains("name"));
-        assertTrue(attributeNames.contains("externalId"));
-        assertTrue(attributeNames.contains("nickName"));
-        assertTrue(attributeNames.contains("locale"));
-        assertTrue(attributeNames.contains("active"));
-        assertTrue(attributeNames.contains("profileUrl"));
-        assertTrue(attributeNames.contains("preferredLanguage"));
-        assertTrue(attributeNames.contains("displayName"));
-        assertTrue(attributeNames.contains("timezone"));
-        assertTrue(attributeNames.contains("groups"));
-        assertTrue(attributeNames.contains("title"));
-        assertTrue(attributeNames.contains("userType"));
+        assertEquals(14, attributeNames.size(), "User schema should have exactly 14 attributes");
+
+        assertAttribute(findAttribute(schema, "userName"), "string", false, true, false, "readWrite", "server");
+        assertAttribute(findAttribute(schema, "emails"), "complex", true, false, false, "readWrite", "global");
+        assertAttribute(findAttribute(schema, "name"), "complex", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "displayName"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "title"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "externalId"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "userType"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "nickName"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "locale"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "timezone"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "preferredLanguage"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "profileUrl"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "active"), "boolean", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "groups"), "complex", true, false, true, "readWrite", "none");
+
+        // Verify name sub-attributes
+        Schema.Attribute name = findAttribute(schema, "name");
+        assertNotNull(name.getSubAttributes(), "name should have sub-attributes");
+        Set<String> nameSubAttrNames = name.getSubAttributes().stream()
+                .map(Schema.Attribute::getName)
+                .collect(Collectors.toSet());
+        assertTrue(nameSubAttrNames.contains("givenName"));
+        assertTrue(nameSubAttrNames.contains("familyName"));
+        assertTrue(nameSubAttrNames.contains("middleName"));
+        assertTrue(nameSubAttrNames.contains("honorificPrefix"));
+        assertTrue(nameSubAttrNames.contains("honorificSuffix"));
+        assertTrue(nameSubAttrNames.contains("formatted"));
+        for (Schema.Attribute subAttr : name.getSubAttributes()) {
+            assertSubAttribute(subAttr, "string", false, "readWrite");
+        }
     }
 
     @Test
@@ -83,15 +98,14 @@ public class SchemaTest extends AbstractScimTest {
         assertEquals("Group", schema.getDescription());
         assertNotNull(schema.getAttributes());
 
-        // Verify ALL expected attributes are present (extracted from GroupCoreModelSchema)
-        // GroupCoreModelSchema currently only has: displayName
-        // Note: members is not yet supported in GroupCoreModelSchema attribute mappers
         Set<String> attributeNames = schema.getAttributes().stream()
                 .map(Schema.Attribute::getName)
                 .collect(Collectors.toSet());
 
-        assertEquals(1, attributeNames.size(), "Group schema should have exactly 1 attribute");
-        assertTrue(attributeNames.contains("displayName"));
+        assertEquals(2, attributeNames.size(), "Group schema should have exactly 2 attributes");
+
+        assertAttribute(findAttribute(schema, "displayName"), "string", false, false, false, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "externalId"), "string", false, false, true, "immutable", "none");
     }
 
     @Test
@@ -104,145 +118,31 @@ public class SchemaTest extends AbstractScimTest {
         assertEquals("Enterprise User", schema.getDescription());
         assertNotNull(schema.getAttributes());
 
-        // Verify ALL expected attributes are present (extracted from UserEnterpriseModelSchema)
-        // UserEnterpriseModelSchema has: employeeNumber, costCenter, organization, division, department, manager.*
-        // These should map to: employeeNumber, costCenter, organization, division, department, manager
         Set<String> attributeNames = schema.getAttributes().stream()
                 .map(Schema.Attribute::getName)
                 .collect(Collectors.toSet());
 
         assertEquals(6, attributeNames.size(), "Enterprise User schema should have exactly 6 attributes");
-        assertTrue(attributeNames.contains("employeeNumber"));
-        assertTrue(attributeNames.contains("costCenter"));
-        assertTrue(attributeNames.contains("organization"));
-        assertTrue(attributeNames.contains("division"));
-        assertTrue(attributeNames.contains("department"));
-        assertTrue(attributeNames.contains("manager"));
-    }
 
-    @Test
-    public void testAttributeProperties() {
-        Schema schema = client.schemas().get(Scim.USER_CORE_SCHEMA);
+        // Simple string attributes
+        assertAttribute(findAttribute(schema, "employeeNumber"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "costCenter"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "organization"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "division"), "string", false, false, true, "readWrite", "none");
+        assertAttribute(findAttribute(schema, "department"), "string", false, false, true, "readWrite", "none");
 
-        // Test STRING type (userName)
-        Schema.Attribute userNameAttr = findAttribute(schema, "userName");
-        assertNotNull(userNameAttr, "userName attribute should exist");
-        assertEquals("string", userNameAttr.getType());
-        assertEquals(false, userNameAttr.getMultiValued());
-
-        // Test BOOLEAN type (active)
-        Schema.Attribute activeAttr = findAttribute(schema, "active");
-        assertNotNull(activeAttr, "active attribute should exist");
-        assertEquals("boolean", activeAttr.getType());
-        assertEquals(false, activeAttr.getMultiValued());
-
-        // Test COMPLEX multi-valued (emails)
-        Schema.Attribute emailsAttr = findAttribute(schema, "emails");
-        assertNotNull(emailsAttr, "emails attribute should exist");
-        assertEquals("complex", emailsAttr.getType());
-        assertEquals(true, emailsAttr.getMultiValued());
-
-        // Test COMPLEX single-valued (name)
-        Schema.Attribute nameAttr = findAttribute(schema, "name");
-        assertNotNull(nameAttr, "name attribute should exist");
-        assertEquals("complex", nameAttr.getType());
-        assertEquals(false, nameAttr.getMultiValued());
-
-        // Test STRING attributes (externalId, nickName, locale)
-        Schema.Attribute externalIdAttr = findAttribute(schema, "externalId");
-        assertNotNull(externalIdAttr, "externalId attribute should exist");
-        assertEquals("string", externalIdAttr.getType());
-        assertEquals(false, externalIdAttr.getMultiValued());
-
-        Schema.Attribute nickNameAttr = findAttribute(schema, "nickName");
-        assertNotNull(nickNameAttr, "nickName attribute should exist");
-        assertEquals("string", nickNameAttr.getType());
-        assertEquals(false, nickNameAttr.getMultiValued());
-
-        Schema.Attribute localeAttr = findAttribute(schema, "locale");
-        assertNotNull(localeAttr, "locale attribute should exist");
-        assertEquals("string", localeAttr.getType());
-        assertEquals(false, localeAttr.getMultiValued());
-    }
-
-    @Test
-    public void testReferenceTypes() {
-        // Test EnterpriseUser manager is a complex attribute
-        Schema enterpriseUserSchema = client.schemas().get(Scim.ENTERPRISE_USER_SCHEMA);
-        Schema.Attribute managerAttr = findAttribute(enterpriseUserSchema, "manager");
-        assertNotNull(managerAttr, "manager attribute should exist");
-        assertEquals("complex", managerAttr.getType());
-        assertEquals(false, managerAttr.getMultiValued());
-
-        // TODO: referenceTypes are not yet tracked in the model schema Attribute.
-        // Once Attribute supports reference types, add assertions for:
-        //   managerAttr.getReferenceTypes() containing "User"
-
-        // Note: Group.members is not yet supported in GroupCoreModelSchema,
-        // so reference type testing for members is omitted
-    }
-
-    @Test
-    public void testEnterpriseUserAttributeTypes() {
-        Schema schema = client.schemas().get(Scim.ENTERPRISE_USER_SCHEMA);
-
-        // All enterprise user attributes (except manager) should be string type
-        String[] stringAttributes = {"employeeNumber", "costCenter", "organization", "division", "department"};
-        for (String attrName : stringAttributes) {
-            Schema.Attribute attr = findAttribute(schema, attrName);
-            assertNotNull(attr, attrName + " attribute should exist");
-            assertEquals("string", attr.getType(), attrName + " should be string type");
-            assertEquals(false, attr.getMultiValued(), attrName + " should not be multi-valued");
+        // Manager is a complex attribute with sub-attributes
+        assertAttribute(findAttribute(schema, "manager"), "complex", false, false, false, "readWrite", "none");
+        Schema.Attribute manager = findAttribute(schema, "manager");
+        assertNotNull(manager.getSubAttributes(), "manager should have sub-attributes");
+        Set<String> managerSubAttrNames = manager.getSubAttributes().stream()
+                .map(Schema.Attribute::getName)
+                .collect(Collectors.toSet());
+        assertTrue(managerSubAttrNames.contains("value"));
+        assertTrue(managerSubAttrNames.contains("displayName"));
+        for (Schema.Attribute subAttr : manager.getSubAttributes()) {
+            assertSubAttribute(subAttr, "string", false, "readWrite");
         }
-
-        // Manager is complex type with User reference
-        Schema.Attribute managerAttr = findAttribute(schema, "manager");
-        assertNotNull(managerAttr, "manager attribute should exist");
-        assertEquals("complex", managerAttr.getType());
-        assertEquals(false, managerAttr.getMultiValued());
-    }
-
-    @Test
-    public void testGroupAttributeTypes() {
-        Schema schema = client.schemas().get(Scim.GROUP_CORE_SCHEMA);
-
-        // displayName should be string
-        Schema.Attribute displayNameAttr = findAttribute(schema, "displayName");
-        assertNotNull(displayNameAttr, "displayName attribute should exist");
-        assertEquals("string", displayNameAttr.getType());
-        assertEquals(false, displayNameAttr.getMultiValued());
-
-        // Note: members is not yet supported in GroupCoreModelSchema attribute mappers
-    }
-
-    @Test
-    public void testPathExtractionLogic() {
-        // This test verifies that the path extraction logic works correctly
-        // Multiple SCIM paths should map to the same top-level attribute
-
-        Schema userSchema = client.schemas().get(Scim.USER_CORE_SCHEMA);
-
-        // UserCoreModelSchema has multiple paths for 'name':
-        // - name.givenName, name.familyName, name.middleName, name.honorificPrefix, name.honorificSuffix
-        // All should map to a single 'name' attribute
-        Schema.Attribute nameAttr = findAttribute(userSchema, "name");
-        assertNotNull(nameAttr, "name attribute should exist (from multiple name.* paths)");
-        assertEquals("complex", nameAttr.getType());
-        assertEquals(false, nameAttr.getMultiValued());
-
-        // emails[0].value should map to 'emails' attribute
-        Schema.Attribute emailsAttr = findAttribute(userSchema, "emails");
-        assertNotNull(emailsAttr, "emails attribute should exist (from emails[0].value path)");
-        assertEquals("complex", emailsAttr.getType());
-        assertEquals(true, emailsAttr.getMultiValued());
-
-        // EnterpriseUser has manager.value and manager.displayName
-        // Both should map to a single 'manager' attribute
-        Schema enterpriseSchema = client.schemas().get(Scim.ENTERPRISE_USER_SCHEMA);
-        Schema.Attribute managerAttr = findAttribute(enterpriseSchema, "manager");
-        assertNotNull(managerAttr, "manager attribute should exist (from manager.* paths)");
-        assertEquals("complex", managerAttr.getType());
-        assertEquals(false, managerAttr.getMultiValued());
     }
 
     @Test
@@ -283,5 +183,23 @@ public class SchemaTest extends AbstractScimTest {
                 .filter(attr -> name.equals(attr.getName()))
                 .findFirst()
                 .orElse(null);
+    }
+
+    private void assertAttribute(Schema.Attribute attribute, String type, boolean multiValued,
+                                  boolean required, boolean caseExact, String mutability, String uniqueness) {
+        assertNotNull(attribute, "attribute should not be null");
+        assertEquals(type, attribute.getType(), attribute.getName() + " type");
+        assertEquals(multiValued, attribute.getMultiValued(), attribute.getName() + " multiValued");
+        assertEquals(required, attribute.getRequired(), attribute.getName() + " required");
+        assertEquals(caseExact, attribute.getCaseExact(), attribute.getName() + " caseExact");
+        assertEquals(mutability, attribute.getMutability(), attribute.getName() + " mutability");
+        assertEquals(uniqueness, attribute.getUniqueness(), attribute.getName() + " uniqueness");
+    }
+
+    private void assertSubAttribute(Schema.Attribute subAttribute, String type, boolean multiValued, String mutability) {
+        assertNotNull(subAttribute, "sub-attribute should not be null");
+        assertEquals(type, subAttribute.getType(), subAttribute.getName() + " sub-attribute type");
+        assertEquals(multiValued, subAttribute.getMultiValued(), subAttribute.getName() + " sub-attribute multiValued");
+        assertEquals(mutability, subAttribute.getMutability(), subAttribute.getName() + " sub-attribute mutability");
     }
 }

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/ServiceProviderConfigTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/ServiceProviderConfigTest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.keycloak.scim.resource.config.ServiceProviderConfig;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.AuthenticationScheme;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.BulkSupport;
+import org.keycloak.scim.resource.config.ServiceProviderConfig.FilterSupport;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.Supported;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 
@@ -37,8 +38,15 @@ public class ServiceProviderConfigTest extends AbstractScimTest {
         assertTrue(patch.getSupported());
         List<AuthenticationScheme> authenticationSchemes = config.getAuthenticationSchemes();
         assertNotNull(authenticationSchemes);
-        // TODO: support at least bearer token authentication scheme
-        assertTrue(authenticationSchemes.isEmpty());
+        assertEquals(1, authenticationSchemes.size());
+        AuthenticationScheme bearerScheme = authenticationSchemes.get(0);
+        assertEquals("OAuth Bearer Token", bearerScheme.getName());
+        assertEquals("Authentication scheme using the OAuth Bearer Token standard", bearerScheme.getDescription());
+        assertEquals("https://tools.ietf.org/html/rfc6750", bearerScheme.getSpecUri());
+        assertEquals("oauthbearertoken", bearerScheme.getType());
+        FilterSupport filter = config.getFilter();
+        assertNotNull(filter);
+        assertTrue(filter.getSupported());
         Set<String> schemas = config.getSchemas();
         assertNotNull(schemas);
         assertEquals(1, schemas.size());


### PR DESCRIPTION
Closes #47481

* Missing `externalId` attribute in the group resource type
* Updating service provider config to advertise missing configurations
* Updating schema endpoint and attribute mapping to adverstize additional metadata such as `uniqueness`, `required`, and `caseExact`

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
