### PR TITLE
Draft: Add optional JWKS URL to Kubernetes Identity Provider

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/KubernetesSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/KubernetesSettings.tsx
@@ -24,6 +24,12 @@ export const KubernetesSettings = () => {
         labelIcon={t("kubernetesIssuerUrlHelp")}
         label={t("kubernetesIssuerUrl")}
       />
+      <TextControl
+        name="config.jwksUrl"
+        label={t("jwksUrl")}
+        labelIcon={t("jwksUrlHelp")}
+        type="url"
+      />
       <FormGroupField label="fedClientAssertionMaxExp">
         <Controller
           name="config.fedClientAssertionMaxExp"

--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProvider.java
@@ -10,8 +10,10 @@ import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.keys.PublicKeyLoader;
 import org.keycloak.keys.PublicKeyStorageProvider;
 import org.keycloak.keys.PublicKeyStorageUtils;
+import org.keycloak.keys.loader.OIDCIdentityProviderPublicKeyLoader;
 import org.keycloak.models.KeycloakSession;
 
 import org.jboss.logging.Logger;
@@ -48,7 +50,14 @@ public class KubernetesIdentityProvider implements ClientAssertionIdentityProvid
 
             String modelKey = PublicKeyStorageUtils.getIdpModelCacheKey(validator.getContext().getRealm().getId(), config.getInternalId());
             PublicKeyStorageProvider keyStorage = session.getProvider(PublicKeyStorageProvider.class);
-            KeyWrapper publicKey = keyStorage.getPublicKey(modelKey, kid, alg, new KubernetesJwksEndpointLoader(session, config.getIssuer()));
+
+            PublicKeyLoader loader;
+            if (config.isUseJwksUrl()) {
+                loader = new OIDCIdentityProviderPublicKeyLoader(session, config);
+            } else {
+                loader = new KubernetesJwksEndpointLoader(session, config.getIssuer());
+            }
+            KeyWrapper publicKey = keyStorage.getPublicKey(modelKey, kid, alg, loader);
 
             SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, alg);
             if (signatureProvider == null) {

--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java
@@ -1,13 +1,18 @@
 package org.keycloak.broker.kubernetes;
 
 
+import com.google.common.base.Strings;
+
+import org.keycloak.broker.jwtauthorizationgrant.JWTAuthorizationGrantConfig;
 import org.keycloak.broker.oidc.IssuerValidation;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.RealmModel;
 
+import static org.keycloak.broker.oidc.OIDCIdentityProviderConfig.USE_JWKS_URL;
 
-public class KubernetesIdentityProviderConfig extends IdentityProviderModel implements IssuerValidation {
+
+public class KubernetesIdentityProviderConfig extends IdentityProviderModel implements IssuerValidation, JWTAuthorizationGrantConfig {
 
     public KubernetesIdentityProviderConfig() {
     }
@@ -42,5 +47,10 @@ public class KubernetesIdentityProviderConfig extends IdentityProviderModel impl
     public void validate(RealmModel realm) {
         super.validate(realm);
         validateIssuer(realm, IdentityProviderType.CLIENT_ASSERTION);
+    }
+
+    @Override
+    public boolean isUseJwksUrl() {
+        return !Strings.isNullOrEmpty(getJwksUrl());
     }
 }


### PR DESCRIPTION
 Relates to #47439

Adds an optional **JWKS URL** field to the Kubernetes Identity Provider.
When configured, Keycloak fetches signing keys directly from that URL and skips OIDC Discovery (`/.well-known/openid-configuration`). When left empty, existing behaviour is fully preserved.

## Approach

The implementation is intentionally minimal and builds entirely on existing infrastructure:
  - `KubernetesIdentityProviderConfig` now implements `JWTAuthorizationGrantConfig`, which provides `getJwksUrl()` and satisfies the interface already expected by `OIDCIdentityProviderPublicKeyLoader`. `isUseJwksUrl()` is derived from whether the URL field is non-empty - no separate enable/disable toggle is needed.
  - `OIDCIdentityProviderPublicKeyLoader` is reused for the direct-fetch path, so the existing public key cache and `kid`-triggered refresh logic work without any modifications.
  - `USE_JWKS_URL` config key is shared with `OIDCIdentityProviderConfig`, keeping the config model consistent across Identity Provider types.
  - The branching point is a single `if/else` in `verifySignature()`; no other validation or claim-handling logic is touched.

## What this does NOT change

  - Issuer (`iss`) claim validation is unchanged - the issuer field retains its role as the identity anchor regardless of which
    key-loading path is used.
  - All existing behaviour when JWKS URL is left empty is unchanged.

## Status
  **Draft / proof-of-concept** - opening early for feedback on the approach.