### PR TITLE
is-45364 Proposal for getClientApi() helper method

### DIFF
--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
@@ -2,8 +2,10 @@ package org.keycloak.tests.admin.client.v2;
 
 import jakarta.ws.rs.core.HttpHeaders;
 
+import org.keycloak.admin.api.client.ClientApi;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.services.client.ClientServiceHelper;
+import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 
@@ -14,6 +16,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractClientApiV2Test {
+    protected abstract Keycloak getAdminClient();
+    protected abstract ManagedRealm getTestRealm();
     protected static ObjectMapper mapper;
 
     public String getRealmName() {
@@ -25,6 +29,10 @@ public abstract class AbstractClientApiV2Test {
     }
     public String getClientApiUrl(String clientId) {
         return "http://localhost:8080/admin/api/%s/clients/v2/%s".formatted(getRealmName(), clientId);
+    }
+
+    public ClientApi getClientApi(String clientId) {
+        return getAdminClient().clients(getTestRealm().getName()).v2().client(clientId);
     }
 
     @BeforeAll

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AdminEventV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AdminEventV2Test.java
@@ -86,6 +86,16 @@ public class AdminEventV2Test extends AbstractClientApiV2Test {
     @InjectRunOnServer
     RunOnServerClient runOnServer;
 
+    @Override
+    protected Keycloak getAdminClient() {
+        return this.adminClient;
+    }
+
+    @Override
+    protected ManagedRealm getTestRealm() {
+        return this.masterRealm;
+    }
+
     @BeforeEach
     public void setupAndClearEvents() {
         runOnServer.run(session -> {

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2AuthorizationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2AuthorizationTest.java
@@ -24,6 +24,7 @@ import org.keycloak.representations.idm.authorization.UserPolicyRepresentation;
 import org.keycloak.services.PatchTypeNames;
 import org.keycloak.services.client.ClientServiceHelper;
 import org.keycloak.testframework.admin.AdminClientFactory;
+import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectAdminClientFactory;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
@@ -66,6 +67,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ClientApiV2AuthorizationTest extends AbstractClientApiV2Test {
     private static final String FGAP_USER_ID = "00000000000000000000";
 
+    @InjectAdminClient
+    Keycloak adminClient;
+
     @InjectHttpClient
     CloseableHttpClient client;
 
@@ -77,6 +81,16 @@ public class ClientApiV2AuthorizationTest extends AbstractClientApiV2Test {
 
     @InjectClient(attachTo = Constants.ADMIN_PERMISSIONS_CLIENT_ID)
     ManagedClient adminPermissionClient;
+
+    @Override
+    protected Keycloak getAdminClient() {
+        return this.adminClient;
+    }
+
+    @Override
+    protected ManagedRealm getTestRealm() {
+        return this.testRealm;
+    }
 
     @Override
     public String getRealmName() {

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2DisabledTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2DisabledTest.java
@@ -1,13 +1,19 @@
 package org.keycloak.tests.admin.client.v2;
 
-import org.keycloak.testframework.annotations.InjectHttpClient;
-import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import jakarta.ws.rs.NotFoundException;
 
-import org.apache.http.client.methods.HttpGet;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Vaclav Muzikar <vmuzikar@redhat.com>
@@ -17,11 +23,29 @@ public class ClientApiV2DisabledTest extends AbstractClientApiV2Test {
     @InjectHttpClient
     CloseableHttpClient client;
 
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectRealm(attachTo = "master", ref = "master")
+    ManagedRealm masterRealm;
+
+    @Override
+    protected Keycloak getAdminClient() {
+        return this.adminClient;
+    }
+
+    @Override
+    protected ManagedRealm getTestRealm() {
+        return this.masterRealm;
+    }
+
     @Test
-    public void getClient() throws Exception {
-        HttpGet request = new HttpGet(getClientsApiUrl() + "/realms/master/clients/account");
-        try (var response = client.execute(request)) {
-            assertEquals(404, response.getStatusLine().getStatusCode());
-        }
+    public void getClient() {
+        NotFoundException ex = assertThrows(
+            NotFoundException.class,
+            () -> getClientApi("account").getClient()
+        );
+
+        assertTrue(ex.getMessage().contains("HTTP 404 Not Found"));
     }
 }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -100,9 +100,19 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
     @InjectClient(realmRef = "master")
     ManagedClient testClient;
 
+    @Override
+    protected Keycloak getAdminClient() {
+        return this.adminClient;
+    }
+
+    @Override
+    protected ManagedRealm getTestRealm() {
+        return this.testRealm;
+    }
+
     @Test
     public void getClient() {
-        var client = adminClient.clients(testRealm.getName()).v2().client("account").getClient();
+        var client = getClientApi("account").getClient();
         assertEquals("account", client.getClientId());
     }
 

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientPoliciesV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientPoliciesV2Test.java
@@ -50,7 +50,9 @@ import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExec
 import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.server.KeycloakServerConfig;
@@ -109,6 +111,19 @@ public class ClientPoliciesV2Test extends AbstractClientApiV2Test {
 
     @InjectRunOnServer
     RunOnServerClient runOnServer;
+
+    @InjectRealm
+    ManagedRealm testRealm;
+
+    @Override
+    protected Keycloak getAdminClient() {
+        return this.adminClient;
+    }
+
+    @Override
+    protected ManagedRealm getTestRealm() {
+        return this.testRealm;
+    }
 
     @AfterEach
     public void cleanup() {

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/InteropTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/InteropTest.java
@@ -34,7 +34,9 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.server.KeycloakServerConfig;
 import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.util.ApiUtil;
@@ -75,6 +77,19 @@ public class InteropTest extends AbstractClientApiV2Test {
 
     @InjectAdminClient
     Keycloak adminClient;
+
+    @InjectRealm
+    ManagedRealm testRealm;
+
+    @Override
+    protected Keycloak getAdminClient() {
+        return this.adminClient;
+    }
+
+    @Override
+    protected ManagedRealm getTestRealm() {
+        return this.testRealm;
+    }
 
     /**
      * Test: Create a client using v1 API, then assert/read using v2 API.


### PR DESCRIPTION
As discussed here: https://github.com/keycloak/keycloak/pull/46973#discussion_r2986463804

Here is my proposal for the helper method. 

This was the only option, to still have the option to overwrite the Injection in the child class.

Abstract class:
```
    protected abstract Keycloak getAdminClient();
    protected abstract ManagedRealm getTestRealm();

    public ClientApi getClientApi(String clientId) {
        return getAdminClient().clients(getTestRealm().getName()).v2().client(clientId);
    }
```

Child class:

```
......
    @InjectRealm(config = NoAccessRealmConfig.class)
    ManagedRealm testRealm;

    @Override
    protected Keycloak getAdminClient() {
        return this.adminClient;
    }

    @Override
    protected ManagedRealm getTestRealm() {
        return this.testRealm;
    }

    @Test
    public void getClient() {
        var client = getClientApi("account").getClient();
        assertEquals("account", client.getClientId());
    }
```

CC: @mabartos && @vmuzikar 