### PR TITLE
fix: reusing the apache builder to retain retry config (#47402)

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelHttpClientBuilder.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/tracing/OTelHttpClientBuilder.java
@@ -31,7 +31,7 @@ public class OTelHttpClientBuilder extends HttpClientBuilder {
     }
 
     @Override
-    protected org.apache.http.impl.client.HttpClientBuilder getApacheHttpClientBuilder() {
+    protected org.apache.http.impl.client.HttpClientBuilder createApacheHttpClientBuilder() {
         return ApacheHttpClientTelemetry.builder(provider.getOpenTelemetry()).build().newHttpClientBuilder();
     }
 

--- a/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
@@ -93,6 +93,11 @@ public class HttpClientBuilder {
     protected boolean disableCookies = false;
     protected ProxyMappings proxyMappings;
     protected boolean expectContinueEnabled = false;
+    protected org.apache.http.impl.client.HttpClientBuilder apacheBuilder = createApacheHttpClientBuilder();
+
+    protected org.apache.http.impl.client.HttpClientBuilder createApacheHttpClientBuilder() {
+        return HttpClients.custom();
+    }
 
     /**
      * Socket inactivity timeout
@@ -281,7 +286,7 @@ public class HttpClientBuilder {
     }
 
     protected org.apache.http.impl.client.HttpClientBuilder getApacheHttpClientBuilder() {
-        return HttpClients.custom();
+        return apacheBuilder;
     }
 
     private SSLContext createSslContext(

--- a/services/src/test/java/org/keycloak/connections/httpclient/HttpClientBuilderTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/HttpClientBuilderTest.java
@@ -1,12 +1,16 @@
 package org.keycloak.connections.httpclient;
 
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
+import static org.junit.Assert.assertNotNull;
 
 public class HttpClientBuilderTest {
 
@@ -18,6 +22,23 @@ public class HttpClientBuilderTest {
 
         Assert.assertEquals("Default socket timeout is -1 and can be converted by TimeUnit", -1, requestConfig.getSocketTimeout());
         Assert.assertEquals("Default connect timeout is -1 and can be converted by TimeUnit", -1, requestConfig.getConnectTimeout());
+    }
+
+    @Test
+    public void testRepeatedApacheBuilderUse() throws Exception {
+        HttpClientBuilder httpClientBuilder = new HttpClientBuilder();
+        httpClientBuilder.getApacheHttpClientBuilder().setRetryHandler(new HttpRequestRetryHandler() {
+
+            @Override
+            public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
+                return true;
+            }
+        });
+        var builder = httpClientBuilder.getApacheHttpClientBuilder(); // should not clear the retry handler
+
+        Field retryHandler = builder.getClass().getDeclaredField("retryHandler");
+        retryHandler.setAccessible(true);
+        assertNotNull(retryHandler.get(builder));
     }
 
     @Test
@@ -53,4 +74,5 @@ public class HttpClientBuilderTest {
         defaultConfig.setAccessible(true);
         return (RequestConfig) defaultConfig.get(httpClient);
     }
+
 }


### PR DESCRIPTION
closes: #47379


(cherry picked from commit 0780d567301719efa51095817af7854551da39c4)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
