### PR TITLE
Fix use of Optional to actually guard against NPE

### DIFF
--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java
@@ -166,7 +166,6 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
         return getDatastoreProvider().users();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <T extends Provider> T getProvider(Class<T> clazz) {
         List<String> key = List.of(clazz.getName());
@@ -174,6 +173,7 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
     }
 
     private <T extends Provider> T getOrCreateProvider(List<String> key, Supplier<ProviderFactory<T>> supplier) {
+        @SuppressWarnings("unchecked")
         T provider = (T) providers.get(key);
         // KEYCLOAK-11890 - Avoid using HashMap.computeIfAbsent() to implement logic in outer if() block below,
         // since per JDK-8071667 the remapping function should not modify the map during computation. While
@@ -188,7 +188,6 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
         return provider;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public <T extends Provider> T getProvider(Class<T> clazz, String id) {
         List<String> key = List.of(clazz.getName(), id);
@@ -207,11 +206,10 @@ public abstract class DefaultKeycloakSession implements KeycloakSession {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T extends Provider> T getComponentProvider(Class<T> clazz, String componentId, Function<KeycloakSessionFactory, ComponentModel> modelGetter) {
         List<String> key = List.of("component", clazz.getName(), componentId);
         final RealmModel realm = getContext().getRealm();
-        return getOrCreateProvider(key, () -> factory.getProviderFactory(clazz, Optional.ofNullable(realm.getId()).orElse(null), componentId, modelGetter));
+        return getOrCreateProvider(key, () -> factory.getProviderFactory(clazz, Optional.ofNullable(realm).map(RealmModel::getId).orElse(null), componentId, modelGetter));
     }
 
     @Override


### PR DESCRIPTION
closes #47572 

The use of Optional in [`DefaultKeycloakSession.getComponentProvider()`](https://github.com/keycloak/keycloak/blob/ed5a2e0f004fd6fecdf52c9cb24e0e6cdb35f8f6/services/src/main/java/org/keycloak/services/DefaultKeycloakSession.java#L214) was either completely useless or improperly coded (in that if the realm was null, then an NPE would have been thrown despite the use of the Optional).

I assumed the latter and fixed the use of the Optional accordingly.

While at it I've removed a couple of `@SuppressWarning` annotations which were no longer necessary and added one new one.