### PR TITLE
Pin actions/checkout by commit SHA in translation-notify.yml

### DIFF
--- a/.github/workflows/translation-notify.yml
+++ b/.github/workflows/translation-notify.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install Yq
         run: sudo snap install yq


### PR DESCRIPTION
Pin `actions/checkout` by commit SHA instead of tag reference in `translation-notify.yml` to align with the convention used across all other workflows in the repository.

This change replaces the tag-based reference (`actions/checkout@v4`) with the commit SHA that other workflow files already use, improving supply chain security by preventing potential tag manipulation.

> [!NOTE]
> This PR was created with the assistance of an AI coding agent.

Closes #47085