### PR TITLE
Fix NPE in OID4VCMapper when mapper configuration is missing

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapper.java
@@ -113,8 +113,11 @@ public abstract class OID4VCMapper implements ProtocolMapper, OID4VCEnvironmentP
     public List<String> getMetadataAttributePath() {
         final String claimName = mapperModel.getConfig().get(CLAIM_NAME);
         final String userAttributeName = mapperModel.getConfig().get(USER_ATTRIBUTE_KEY);
-        return ListUtils.union(getAttributePrefix(),
-                               List.of(Optional.ofNullable(claimName).orElse(userAttributeName)));
+        final String attributeName = Optional.ofNullable(claimName).orElse(userAttributeName);
+        if (attributeName == null) {
+            return getAttributePrefix();
+        }
+        return ListUtils.union(getAttributePrefix(), List.of(attributeName));
     }
 
     protected List<String> getAttributePrefix() {


### PR DESCRIPTION
Add null-safety check in `OID4VCMapper.getMetadataAttributePath()` to prevent
NullPointerException when a mapper's `claim.name` configuration property is
missing or empty.

Previously, accessing the `.well-known/openid-credential-issuer` endpoint
would throw an NPE if any protocol mapper had an empty or missing `claim.name`
property, making the entire metadata endpoint unusable.

> [!NOTE]
> This PR was created with the assistance of an AI coding agent.

Closes #47544