### PR TITLE
[OID4VCI] Exclude @context from credential definition for non-JSON-LD formats

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/JwtCredentialBuilder.java
@@ -111,6 +111,9 @@ public class JwtCredentialBuilder implements CredentialBuilder {
     @Override
     public void contributeToMetadata(SupportedCredentialConfiguration credentialConfig, CredentialScopeModel credentialScope) {
         CredentialDefinition credentialDefinition = CredentialDefinition.parse(credentialScope);
+        // @context must not be included for jwt_vc_json format per OID4VCI spec;
+        // it is only valid for ldp_vc format.
+        credentialDefinition.setContext(null);
         credentialConfig.setCredentialDefinition(credentialDefinition);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/LDCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/LDCredentialBuilder.java
@@ -18,7 +18,10 @@
 package org.keycloak.protocol.oid4vc.issuance.credentialbuilder;
 
 import org.keycloak.VCFormat;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialBuildConfig;
+import org.keycloak.protocol.oid4vc.model.CredentialDefinition;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 
 
@@ -36,6 +39,12 @@ public class LDCredentialBuilder implements CredentialBuilder {
     @Override
     public String getSupportedFormat() {
         return VCFormat.LDP_VC;
+    }
+
+    @Override
+    public void contributeToMetadata(SupportedCredentialConfiguration credentialConfig, CredentialScopeModel credentialScope) {
+        CredentialDefinition credentialDefinition = CredentialDefinition.parse(credentialScope);
+        credentialConfig.setCredentialDefinition(credentialDefinition);
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
@@ -568,12 +568,9 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerTestBase {
                 assertEquals(credentialDefinitionTypes.size(), supportedConfig.getCredentialDefinition().getType().size());
             }
 
-            List<String> credentialDefinitionContexts = credScope.getVcContexts();
-            if (!credentialDefinitionContexts.isEmpty()) {
-                assertEquals(credentialDefinitionContexts.size(), supportedConfig.getCredentialDefinition().getContext().size());
-                MatcherAssert.assertThat(supportedConfig.getCredentialDefinition().getContext(),
-                        Matchers.containsInAnyOrder(credentialDefinitionTypes.toArray()));
-            }
+            // @context must not be present for jwt_vc_json format per OID4VCI spec
+            assertNull(supportedConfig.getCredentialDefinition().getContext(),
+                    "jwt_vc_json credentials should not have @context in credential_definition");
         }
 
         List<String> signingAlgsSupported = supportedConfig.getCredentialSigningAlgValuesSupported();


### PR DESCRIPTION
Conditionally include `@context` in `credential_definition` only when the
credential format is `ldp_vc`, as per the OID4VCI specification.

Previously, `@context` was included in credential definitions for all formats
including `jwt_vc_json`, which violates the spec and may cause interoperability
issues with conformant verifiers.


Closes #47045