### PR TITLE
Show specific lockout message for Recovery Authentication Codes

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/RecoveryAuthnCodesFormAuthenticator.java
@@ -29,8 +29,6 @@ import org.keycloak.services.messages.Messages;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.storage.ReadOnlyException;
 
-import static org.keycloak.services.validation.Validation.FIELD_USERNAME;
-
 public class RecoveryAuthnCodesFormAuthenticator implements Authenticator, CredentialValidator<RecoveryAuthnCodesCredentialProvider> {
 
     public static final String GENERATED_RECOVERY_AUTHN_CODES_NOTE = "RecoveryAuthnCodes.generatedRecoveryAuthnCodes";
@@ -122,9 +120,21 @@ public class RecoveryAuthnCodesFormAuthenticator implements Authenticator, Crede
         }
         authnFlowContext.getEvent().user(authenticatedUser);
         authnFlowContext.getEvent().error(bruteForceError);
-        challengeResponse = createLoginForm(authnFlowContext, false, Messages.INVALID_USER, FIELD_USERNAME);
+        challengeResponse = createLoginForm(authnFlowContext, false, disabledByBruteForceError(bruteForceError),
+                disabledByBruteForceFieldError());
         authnFlowContext.forceChallenge(challengeResponse);
         return true;
+    }
+
+    protected String disabledByBruteForceError(String error) {
+        if (Errors.USER_TEMPORARILY_DISABLED.equals(error)) {
+            return Messages.ACCOUNT_TEMPORARILY_DISABLED_RECOVERY;
+        }
+        return Messages.ACCOUNT_PERMANENTLY_DISABLED_RECOVERY;
+    }
+
+    protected String disabledByBruteForceFieldError() {
+        return RecoveryAuthnCodesUtils.FIELD_RECOVERY_CODE_IN_BROWSER_FLOW;
     }
 
     protected String getDisabledByBruteForceEventError(AuthenticationFlowContext authnFlowContext, UserModel authenticatedUser) {

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -55,6 +55,10 @@ public class Messages {
 
     public static final String ACCOUNT_PERMANENTLY_DISABLED_TOTP = "accountPermanentlyDisabledMessageTotp";
 
+    public static final String ACCOUNT_TEMPORARILY_DISABLED_RECOVERY = "accountTemporarilyDisabledMessageRecovery";
+
+    public static final String ACCOUNT_PERMANENTLY_DISABLED_RECOVERY = "accountPermanentlyDisabledMessageRecovery";
+
     public static final String EXPIRED_CODE = "expiredCodeMessage";
 
     public static final String EXPIRED_ACTION = "expiredActionMessage";

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -236,6 +236,9 @@ accountPermanentlyDisabledMessage=Invalid username or password.
 # These properties are deliberately the same as "invalidTotpMessage", so by default, it is not possible to recognize the reason of failed authentication is temporarily disabled account
 accountTemporarilyDisabledMessageTotp=Invalid authenticator code.
 accountPermanentlyDisabledMessageTotp=Invalid authenticator code.
+# These properties are deliberately the same as "recovery-codes-error-invalid", so by default, it is not possible to recognize the reason of failed authentication is temporarily disabled account
+accountTemporarilyDisabledMessageRecovery=Invalid recovery authentication code
+accountPermanentlyDisabledMessageRecovery=Invalid recovery authentication code
 expiredCodeMessage=Login timeout. Please sign in again.
 expiredActionMessage=Action expired. Please continue with login now.
 expiredActionTokenNoSessionMessage=Action expired.


### PR DESCRIPTION
Update `RecoveryAuthnCodesFormAuthenticator` to display a specific
`USER_TEMPORARILY_DISABLED` message when brute force protection locks
a user out, instead of the generic `INVALID_USER` message.

This aligns the behavior with `OTPFormAuthenticator`, which already
correctly differentiates between invalid credentials and temporary
account lockout in its brute force handling.


Closes #46996