### PR TITLE
Increase default page size in admin console from 10 to 20

### DIFF
--- a/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
+++ b/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
@@ -397,7 +397,7 @@ export function KeycloakDataTable<T>({
   const [defaultPageSize, setDefaultPageSize] = useStoredState(
     localStorage,
     "pageSize",
-    10,
+    20,
   );
 
   const [max, setMax] = useState(defaultPageSize);


### PR DESCRIPTION
Increases the default page size for tables in the admin console from 10 to 20.

The current default of 10 is below the visible fold on most modern screens, causing administrators to miss entries without realizing it. 20 is the next standard increment in PatternFly's pagination options and provides a better out-of-the-box experience for new users. Existing users who have already set a preference are unaffected as the value is persisted in localStorage.

Closes #47566

