### PR TITLE
Configurable emptiness of user events metrics tags

### DIFF
--- a/docs/documentation/release_notes/topics/26_7_0.adoc
+++ b/docs/documentation/release_notes/topics/26_7_0.adoc
@@ -134,3 +134,10 @@ NIST is going to fully https://www.nist.gov/news-events/news/2022/12/nist-retire
 Consider SHA1 hashing retired in all uses within {project_name}. Users should configure other secure hashing functions as soon as possible (for example SHA2, SHA3).
 ====
 
+== Option to replace empty metric tags in user event metrics
+
+By default, user event metrics may contain empty label values (e.g. `idp=""`), which some monitoring systems reject as non-compliant with the Prometheus Remote-Write specification.
+
+A new option `event-metrics-user-allow-empty-tags` allows replacing empty tag values with `none`.
+
+For more information, see the https://www.keycloak.org/observability/event-metrics[Monitoring user activities with event metrics] guide.

--- a/docs/guides/observability/event-metrics.adoc
+++ b/docs/guides/observability/event-metrics.adoc
@@ -41,6 +41,17 @@ The following example limits the events collected to `LOGIN` and `LOGOUT` events
 
 <@kc.start parameters="... --event-metrics-user-events=login,logout ..."/>
 
+== Handling empty metric tags
+
+By default, {project_name} allows empty metric tag values (e.g. `idp=""`).
+Some monitoring systems reject metrics with empty labels as they do not comply with the https://prometheus.io/docs/specs/prw/remote_write_spec/#labels[Prometheus Remote-Write specification].
+
+To replace empty tag values with `none`, set the `event-metrics-user-allow-empty-tags` option to `false`:
+
+<@kc.start parameters="... --event-metrics-user-allow-empty-tags=false ..."/>
+
+With this setting, a metric like `keycloak_user_events_total{event="login",error="",idp=""}` becomes `keycloak_user_events_total{event="login",error="none",idp="none"}`.
+
 See <@links.observability id="metrics-for-troubleshooting-keycloak"/> for a description of the metrics collected.
 
 </@tmpl.guide>

--- a/quarkus/config-api/src/main/java/org/keycloak/config/EventOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/EventOptions.java
@@ -26,4 +26,11 @@ public class EventOptions {
             .deprecatedMetadata(DeprecatedMetadata.deprecateValues("Use `remove_credential` instead of `remove_totp`, and `update_credential` instead of `update_totp` and `update_password`.", "remove_totp", "update_totp", "update_password"))
             .build();
 
+    public static final Option<Boolean> USER_EVENT_METRICS_ALLOW_EMPTY_TAGS = new OptionBuilder<>("event-metrics-user-allow-empty-tags", Boolean.class)
+            .category(OptionCategory.EVENTS)
+            .description("If set to 'false', empty metric tag values are replaced with 'none' to comply with the Prometheus Remote-Write specification. By default, empty tags are allowed for backward compatibility.")
+            .buildTime(false)
+            .defaultValue(Boolean.TRUE)
+            .deprecatedValues("The default will change to 'false' in Keycloak 27.0.0. Empty tags will be replaced with 'none' by default.", Boolean.TRUE)
+            .build();
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/EventPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/EventPropertyMappers.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.keycloak.common.Profile;
 import org.keycloak.events.EventType;
 
+import static org.keycloak.config.EventOptions.USER_EVENT_METRICS_ALLOW_EMPTY_TAGS;
 import static org.keycloak.config.EventOptions.USER_EVENT_METRICS_ENABLED;
 import static org.keycloak.config.EventOptions.USER_EVENT_METRICS_EVENTS;
 import static org.keycloak.config.EventOptions.USER_EVENT_METRICS_TAGS;
@@ -14,7 +15,6 @@ import static org.keycloak.quarkus.runtime.configuration.Configuration.isTrue;
 import static org.keycloak.quarkus.runtime.configuration.mappers.MetricsPropertyMappers.METRICS_ENABLED_MSG;
 import static org.keycloak.quarkus.runtime.configuration.mappers.MetricsPropertyMappers.metricsEnabled;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
-
 
 final class EventPropertyMappers implements PropertyMapperGrouping {
 
@@ -33,6 +33,10 @@ final class EventPropertyMappers implements PropertyMapperGrouping {
                 fromOption(USER_EVENT_METRICS_EVENTS.toBuilder().expectedValues(expectedUserMetricEvents()).build())
                         .to("kc.spi-events-listener--micrometer-user-event-metrics--events")
                         .paramLabel("events")
+                        .isEnabled(EventPropertyMappers::userEventsMetricsTags, "user event metrics are enabled")
+                        .build(),
+                fromOption(USER_EVENT_METRICS_ALLOW_EMPTY_TAGS)
+                        .to("kc.spi-events-listener--micrometer-user-event-metrics--allow-empty-tags")
                         .isEnabled(EventPropertyMappers::userEventsMetricsTags, "user event metrics are enabled")
                         .build()
         );

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/metrics/events/MicrometerUserEventMetricsEventListenerProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/metrics/events/MicrometerUserEventMetricsEventListenerProvider.java
@@ -30,6 +30,7 @@ import org.keycloak.events.EventListenerTransaction;
 import org.keycloak.events.EventType;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.utils.StringUtil;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
@@ -45,20 +46,23 @@ public class MicrometerUserEventMetricsEventListenerProvider implements EventLis
     private static final String CLIENT_ID_TAG = "client.id";
     private static final String ERROR_TAG = "error";
     private static final String EVENT_TAG = "event";
+    public static final String NONE_TAG_VALUE = "none";
 
     private final boolean withIdp;
     private final boolean withRealm;
     private final boolean withClientId;
+    private final boolean allowEmptyTags;
     private final HashSet<String> events;
 
     private final EventListenerTransaction tx =
             new EventListenerTransaction(null, this::countEvent);
     private final Meter.MeterProvider<Counter> meterProvider;
 
-    public MicrometerUserEventMetricsEventListenerProvider(KeycloakSession session, boolean withIdp, boolean withRealm, boolean withClientId, HashSet<String> events, Meter.MeterProvider<Counter> meterProvider) {
+    public MicrometerUserEventMetricsEventListenerProvider(KeycloakSession session, boolean withIdp, boolean withRealm, boolean withClientId, boolean allowEmptyTags, HashSet<String> events, Meter.MeterProvider<Counter> meterProvider) {
         this.withIdp = withIdp;
         this.withRealm = withRealm;
         this.withClientId = withClientId;
+        this.allowEmptyTags = allowEmptyTags;
         this.events = events;
         this.meterProvider = meterProvider;
         session.getTransactionManager().enlistAfterCompletion(tx);
@@ -114,19 +118,23 @@ public class MicrometerUserEventMetricsEventListenerProvider implements EventLis
 
     private String getClientId(Event event) {
         // Don't use the clientId as a tag value of the event CLIENT_NOT_FOUND as it would lead to a metrics cardinality explosion
-        return Errors.CLIENT_NOT_FOUND.equals(event.getError()) ? "unknown" : event.getClientId();
+        return Errors.CLIENT_NOT_FOUND.equals(event.getError()) ? NONE_TAG_VALUE : event.getClientId();
     }
 
     private String getError(Event event) {
         String error = event.getError();
         if (error == null && event.getType().name().endsWith("_ERROR")) {
-            error = "unknown";
+            error = NONE_TAG_VALUE;
         }
         return error;
     }
 
     private void addTag(List<Tag> tags, String tagName, String value) {
-        tags.add(Tag.of(tagName, value != null ? value : ""));
+        if (StringUtil.isBlank(value)) {
+            tags.add(Tag.of(tagName, allowEmptyTags ? "" : NONE_TAG_VALUE));
+        } else {
+            tags.add(Tag.of(tagName, value));
+        }
     }
 
     public static String format(EventType type) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/metrics/events/MicrometerUserEventMetricsEventListenerProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/metrics/events/MicrometerUserEventMetricsEventListenerProviderFactory.java
@@ -20,6 +20,7 @@ package org.keycloak.quarkus.runtime.services.metrics.events;
 import java.util.HashSet;
 
 import org.keycloak.Config;
+import org.keycloak.config.EventOptions;
 import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.EventListenerProviderFactory;
 import org.keycloak.models.KeycloakSession;
@@ -37,19 +38,21 @@ public class MicrometerUserEventMetricsEventListenerProviderFactory implements E
     private static final String ID = "micrometer-user-event-metrics";
     private static final String TAGS_OPTION = "tags";
     private static final String EVENTS_OPTION = "events";
+    private static final String ALLOW_EMPTY_TAGS_OPTION = "allow-empty-tags";
     private static final String DESCRIPTION_OF_EVENT_METER = "Keycloak user events";
     // Micrometer naming convention that separates lowercase words with a . (dot) character.
     private static final String KEYCLOAK_METER_NAME_PREFIX = "keycloak.";
     private static final String USER_EVENTS_METER_NAME = KEYCLOAK_METER_NAME_PREFIX + "user";
 
     private boolean withIdp, withRealm, withClientId;
+    private boolean allowEmptyTags;
 
     private HashSet<String> events;
     private Meter.MeterProvider<Counter> meterProvider;
 
     @Override
     public EventListenerProvider create(KeycloakSession session) {
-        return new MicrometerUserEventMetricsEventListenerProvider(session, withIdp, withRealm, withClientId, events, meterProvider);
+        return new MicrometerUserEventMetricsEventListenerProvider(session, withIdp, withRealm, withClientId, allowEmptyTags, events, meterProvider);
     }
 
     @Override
@@ -77,6 +80,7 @@ public class MicrometerUserEventMetricsEventListenerProviderFactory implements E
             }
         }
 
+        allowEmptyTags = config.getBoolean(ALLOW_EMPTY_TAGS_OPTION, EventOptions.USER_EVENT_METRICS_ALLOW_EMPTY_TAGS.getDefaultValue().orElse(true));
     }
 
     @Override

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -540,6 +540,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-enabled <true|false>
                      Create metrics based on user events. Default: false. Available only when
                        metrics are enabled and feature user-event-metrics is enabled.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -540,6 +540,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-enabled <true|false>
                      Create metrics based on user events. Default: false. Available only when
                        metrics are enabled and feature user-event-metrics is enabled.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -942,6 +942,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-enabled <true|false>
                      Create metrics based on user events. Default: false. Available only when
                        metrics are enabled and feature user-event-metrics is enabled.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -943,6 +943,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-enabled <true|false>
                      Create metrics based on user events. Default: false. Available only when
                        metrics are enabled and feature user-event-metrics is enabled.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -853,6 +853,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-events <events>
                      Comma-separated list of events to be collected for user event metrics. This
                        option can be used to reduce the number of metrics created as by default all

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -942,6 +942,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-enabled <true|false>
                      Create metrics based on user events. Default: false. Available only when
                        metrics are enabled and feature user-event-metrics is enabled.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -940,6 +940,11 @@ Tracing:
 
 Events:
 
+--event-metrics-user-allow-empty-tags <true|false>
+                     If set to 'false', empty metric tag values are replaced with 'none' to comply
+                       with the Prometheus Remote-Write specification. By default, empty tags are
+                       allowed for backward compatibility. Default: true. Available only when user
+                       event metrics are enabled.
 --event-metrics-user-enabled <true|false>
                      Create metrics based on user events. Default: false. Available only when
                        metrics are enabled and feature user-event-metrics is enabled.

--- a/tests/base/src/test/java/org/keycloak/tests/events/EventMetricsProviderNoEmptyTagsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/events/EventMetricsProviderNoEmptyTagsTest.java
@@ -1,0 +1,81 @@
+package org.keycloak.tests.events;
+
+import org.keycloak.events.Details;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventType;
+import org.keycloak.models.RealmModel;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import io.micrometer.core.instrument.Metrics;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest(config = EventMetricsProviderNoEmptyTagsTest.EventMetricsServerConfig.class)
+public class EventMetricsProviderNoEmptyTagsTest {
+
+    @InjectRealm
+    ManagedRealm realm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    private final static String CLIENT_ID = "CLIENT_ID";
+
+    @Test
+    public void shouldReplaceEmptyTagsWithUnknown() {
+        String realmName = realm.getName();
+
+        runOnServer.run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+
+            EventBuilder eventBuilder = new EventBuilder(realm, session);
+            eventBuilder.event(EventType.LOGIN)
+                    .client(CLIENT_ID);
+            eventBuilder.success();
+        });
+
+        runOnServer.run(session -> {
+            MatcherAssert.assertThat("Empty tags should be replaced with 'none'",
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "none", "realm", realmName, "client.id", CLIENT_ID, "idp", "none").count(), Matchers.equalTo(1.0));
+        });
+    }
+
+    @Test
+    public void shouldKeepNonEmptyTagsUnchanged() {
+        String realmName = realm.getName();
+
+        runOnServer.run(session -> {
+            RealmModel realm = session.getContext().getRealm();
+
+            EventBuilder eventBuilder = new EventBuilder(realm, session);
+            eventBuilder.event(EventType.LOGIN)
+                    .client(CLIENT_ID)
+                    .detail(Details.IDENTITY_PROVIDER, "my-idp");
+            eventBuilder.error("my-error");
+        });
+
+        runOnServer.run(session -> {
+            MatcherAssert.assertThat("Non-empty tags should remain unchanged",
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "my-error", "realm", realmName, "client.id", CLIENT_ID, "idp", "my-idp").count(), Matchers.equalTo(1.0));
+        });
+    }
+
+    public static class EventMetricsServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.option("metrics-enabled", "true")
+                    .option("event-metrics-user-enabled", "true")
+                    .option("event-metrics-user-tags", "realm,idp,clientId")
+                    .option("event-metrics-user-allow-empty-tags", "false");
+        }
+    }
+
+}

--- a/tests/base/src/test/java/org/keycloak/tests/events/EventMetricsProviderWithTagsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/events/EventMetricsProviderWithTagsTest.java
@@ -84,7 +84,7 @@ public class EventMetricsProviderWithTagsTest {
             MatcherAssert.assertThat("Searching for login error metric",
                     Metrics.globalRegistry.counter("keycloak.user", "event", "login", "error", "ERROR", "realm", realmName, "client.id", CLIENT_ID, "idp", "IDENTITY_PROVIDER").count() == 1);
             MatcherAssert.assertThat("Searching for refresh with unknown client",
-                    Metrics.globalRegistry.counter("keycloak.user", "event", "refresh_token", "error", "client_not_found", "realm", realmName, "client.id", "unknown", "idp", "").count() == 1);
+                    Metrics.globalRegistry.counter("keycloak.user", "event", "refresh_token", "error", "client_not_found", "realm", realmName, "client.id", "none", "idp", "").count() == 1);
         });
     }
 


### PR DESCRIPTION
- Closes #45582
- Ads placeholder 'unknown' the tags that are empty if the option deny to have tags empty
- Should not provide any breaking change, and users would need to opt-in to comply with the Prometheus Remote-Write spec
- AFAIK, there's no standard way of managing the emptiness of these tags
- For Keycloak 27.0.0, we could change the default value to 'false' and just returning the 'unknown' if the tag supposed to be empty - but till that time, there might be some changes on the prometheus side to not having such requiremens for the RW spec
- Most likely not part of the Keycloak 26.6.0 release

cc: @ahus1 @ltronky @Pepo48 @pruivo @ryanemerson 