### PR TITLE
Fix #47341: client scope update fails if dynamic scope enabled before

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientScopeResource.java
@@ -125,6 +125,12 @@ public class ClientScopeResource {
     })
     public Response update(final ClientScopeRepresentation rep) {
         auth.clients().requireManageClientScopes();
+
+        if (!Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES) && rep.getAttributes() != null) {
+            rep.getAttributes().remove(ClientScopeModel.IS_DYNAMIC_SCOPE);
+            rep.getAttributes().remove(ClientScopeModel.DYNAMIC_SCOPE_REGEXP);
+        }
+
         ClientScopeResource.validateClientScope(session, rep);
         validateDynamicScopeUpdate(rep);
         try {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientScopeTest.java
@@ -757,6 +757,30 @@ public class ClientScopeTest extends AbstractClientScopeTest {
         createClientScope(protocol);
     }
 
+    @Test
+    public void updatePastDynamicClientScope() {
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("dynamic-scope-disabled");
+        scopeRep.setProtocol("openid-connect");
+        String scopeId = createClientScopeWithCleanup(scopeRep);
+
+        scopeRep = clientScopes().get(scopeId).toRepresentation();
+        scopeRep.getAttributes().put(ClientScopeModel.IS_DYNAMIC_SCOPE, "true");
+        scopeRep.getAttributes().put(ClientScopeModel.DYNAMIC_SCOPE_REGEXP, "dynamic-scope-disabled:*");
+        scopeRep.setDescription("updated description");
+
+        clientScopes().get(scopeId).update(scopeRep);
+
+        ClientScopeRepresentation updatedScopeRep = clientScopes().get(scopeId).toRepresentation();
+
+        String isDynamic = updatedScopeRep.getAttributes().get(ClientScopeModel.IS_DYNAMIC_SCOPE);
+        String regexp = updatedScopeRep.getAttributes().get(ClientScopeModel.DYNAMIC_SCOPE_REGEXP);
+
+        Assertions.assertEquals("updated description", updatedScopeRep.getDescription());
+        Assertions.assertTrue(isDynamic == null || isDynamic.isEmpty() || isDynamic.equals("false"));
+        Assertions.assertTrue(regexp == null || regexp.isEmpty());
+    }
+
     private void createClientScope(String protocol) {
         ClientScopeRepresentation clientScope = new ClientScopeRepresentation();
         clientScope.setName("test-client-scope");


### PR DESCRIPTION
When updating a client scope with the ClientScopeResource.java method update, check arguments before validating scopes. If dynamic scopes are not enabled, remove attributes referring to dynamic scopes when not null.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
