### PR TITLE
[OID4VCI] Fix NullPointerException in OID4VCI mapper metadata generation

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCGeneratedIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCGeneratedIdMapper.java
@@ -86,6 +86,9 @@ public class OID4VCGeneratedIdMapper extends OID4VCMapper {
     public void setClaim(Map<String, Object> claims, UserSessionModel userSessionModel) {
         // Assign a generated ID
         List<String> attributePath = getMetadataAttributePath();
+        if (attributePath.isEmpty()) {
+            return;
+        }
         String propertyName = attributePath.get(attributePath.size() - 1);
         claims.put(propertyName, String.format("urn:uuid:%s", UUID.randomUUID()));
     }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCMapper.java
@@ -113,8 +113,14 @@ public abstract class OID4VCMapper implements ProtocolMapper, OID4VCEnvironmentP
     public List<String> getMetadataAttributePath() {
         final String claimName = mapperModel.getConfig().get(CLAIM_NAME);
         final String userAttributeName = mapperModel.getConfig().get(USER_ATTRIBUTE_KEY);
-        return ListUtils.union(getAttributePrefix(),
-                               List.of(Optional.ofNullable(claimName).orElse(userAttributeName)));
+        String attributeName = Optional.ofNullable(claimName)
+                .orElse(userAttributeName);
+
+        if (attributeName == null) {
+            return Collections.emptyList();
+        }
+        
+        return ListUtils.union(getAttributePrefix(), List.of(attributeName));
     }
 
     protected List<String> getAttributePrefix() {
@@ -168,12 +174,15 @@ public abstract class OID4VCMapper implements ProtocolMapper, OID4VCEnvironmentP
      */
     public void setClaimWithMetadataPrefix(Map<String, Object> claimsOrig, Map<String, Object> claimsWithPrefix) {
         List<String> attributePath = getMetadataAttributePath();
+        if (attributePath.isEmpty()) {
+            return;
+        }
         String propertyName = attributePath.get(attributePath.size() - 1);
         if (claimsOrig.get(propertyName) != null) {
             Object claimValue = claimsOrig.get(propertyName);
             Map<String, Object> current = claimsWithPrefix;
 
-            for (int i = 0; i < attributePath.size() ; i++) {
+            for (int i = 0; i < attributePath.size(); i++) {
                 String currentSnippetName = attributePath.get(i);
                 if (i < attributePath.size() - 1) {
                     Map<String, Object> obj = (Map<String, Object>) current.get(currentSnippetName);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCStaticClaimMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCStaticClaimMapper.java
@@ -69,6 +69,9 @@ public class OID4VCStaticClaimMapper extends OID4VCMapper {
     @Override
     public void setClaim(Map<String, Object> claims, UserSessionModel userSessionModel) {
         List<String> attributePath = getMetadataAttributePath();
+        if (attributePath.isEmpty()) {
+            return;
+        }
         String propertyName = attributePath.get(attributePath.size() - 1);
         String staticValue = mapperModel.getConfig().get(STATIC_CLAIM_KEY);
         claims.put(propertyName, staticValue);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCSubjectIdMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCSubjectIdMapper.java
@@ -128,6 +128,9 @@ public class OID4VCSubjectIdMapper extends OID4VCMapper {
     public void setClaim(Map<String, Object> claims, UserSessionModel userSessionModel) {
         UserModel userModel = userSessionModel.getUser();
         List<String> attributePath = getMetadataAttributePath();
+        if (attributePath.isEmpty()) {
+            return;
+        }
         String propertyName = attributePath.get(attributePath.size() - 1);
         String userAttributeName = mapperModel.getConfig().get(OID4VCMapper.USER_ATTRIBUTE_KEY);
         Consumer<String> userIdConsumer = (val) -> claims.put(propertyName, val);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCTargetRoleMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCTargetRoleMapper.java
@@ -152,6 +152,9 @@ public class OID4VCTargetRoleMapper extends OID4VCMapper {
 	public void setClaim(Map<String, Object> claims,
 						 UserSessionModel userSessionModel) {
 		List<String> attributePath = getMetadataAttributePath();
+		if (attributePath.isEmpty()) {
+			return;
+		}
 		String propertyName = attributePath.get(attributePath.size() - 1);
 		String client = mapperModel.getConfig().get(CLIENT_CONFIG_KEY);
 		ClientModel clientModel = userSessionModel.getRealm().getClientByClientId(client);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCUserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/mappers/OID4VCUserAttributeMapper.java
@@ -88,6 +88,9 @@ public class OID4VCUserAttributeMapper extends OID4VCMapper {
     public void setClaim(Map<String, Object> claims, UserSessionModel userSessionModel) {
         String claimName = mapperModel.getConfig().get(CLAIM_NAME);
         String userAttribute = mapperModel.getConfig().get(USER_ATTRIBUTE_KEY);
+        if (claimName == null && userAttribute == null) {
+            return;
+        }
         boolean aggregateAttributes = Optional.ofNullable(mapperModel.getConfig().get(AGGREGATE_ATTRIBUTES_KEY))
                 .map(Boolean::parseBoolean).orElse(false);
         Collection<String> attributes =
@@ -96,7 +99,7 @@ public class OID4VCUserAttributeMapper extends OID4VCMapper {
         attributes.removeAll(Collections.singleton(null));
         if (!attributes.isEmpty()) {
             JsonUtils.mapClaim(
-                    JsonUtils.splitClaimPath(claimName),
+                    JsonUtils.splitClaimPath(Optional.ofNullable(claimName).orElse(userAttribute)),
                     String.join(",", attributes),
                     claims,
                     false
@@ -143,7 +146,14 @@ public class OID4VCUserAttributeMapper extends OID4VCMapper {
         String claimName = mapperModel.getConfig().get(CLAIM_NAME);
         final String userAttributeName = mapperModel.getConfig().get(USER_ATTRIBUTE_KEY);
         // Split claim name into path segments for metadata endpoint.
-        final List<String> claimPath = Optional.ofNullable(claimName).map(JsonUtils::splitClaimPath).orElse(List.of(userAttributeName));
+        final List<String> claimPath = Optional.ofNullable(claimName)
+                .map(JsonUtils::splitClaimPath)
+                .orElse(Optional.ofNullable(userAttributeName)
+                        .map(List::of)
+                        .orElse(Collections.emptyList()));
+        if (claimPath.isEmpty()) {
+            return Collections.emptyList();
+        }
         return ListUtils.union(getAttributePrefix(), claimPath);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/Claim.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/Claim.java
@@ -77,9 +77,14 @@ public class Claim {
                 return Optional.empty();
             }
 
-            claim.setName(String.join(".", mapper.getMetadataAttributePath()));
+            List<String> attributePath = mapper.getMetadataAttributePath();
+            if (attributePath == null || attributePath.isEmpty()) {
+                return Optional.empty();
+            }
 
-            claim.setPath(mapper.getMetadataAttributePath());
+            claim.setName(String.join(".", attributePath));
+
+            claim.setPath(attributePath);
             claim.setMandatory(protocolMapper.isMandatory());
 
             String displayString = protocolMapper.getDisplay();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIMapperEmptyConfigTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIMapperEmptyConfigTest.java
@@ -1,0 +1,157 @@
+package org.keycloak.tests.oid4vc;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+public class OID4VCIMapperEmptyConfigTest extends OID4VCIssuerTestBase {
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @Test
+    public void testEmptyMapperConfigDoesNotCauseNPE() {
+        String scopeName = "empty-config-scope-" + UUID.randomUUID();
+        
+        ClientScopeRepresentation scope = new ClientScopeRepresentation();
+        scope.setName(scopeName);
+        scope.setProtocol("oid4vc");
+        
+        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
+        emptyMapper.setName("empty-mapper");
+        emptyMapper.setProtocol("oid4vc");
+        emptyMapper.setProtocolMapper("oid4vc-subject-id-mapper");
+        emptyMapper.setConfig(Map.of()); // Empty config
+        
+        scope.setProtocolMappers(List.of(emptyMapper));
+        
+        testRealm.admin().clientScopes().create(scope).close();
+
+        runOnServer.run(session -> {
+            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
+            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
+            
+            // The empty mapper should be ignored and not present in the claims
+            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
+                    .map(config -> config.getCredentialMetadata())
+                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
+                    .flatMap(metadata -> metadata.getClaims().stream())
+                    .anyMatch(claim -> "empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
+            
+            assertFalse(foundEmptyMapper, "Mapper with empty config should not be included in metadata");
+        });
+    }
+
+    @Test
+    public void testUserAttributeMapperEmptyConfig() {
+        String scopeName = "user-attr-empty-config-scope-" + UUID.randomUUID();
+
+        ClientScopeRepresentation scope = new ClientScopeRepresentation();
+        scope.setName(scopeName);
+        scope.setProtocol("oid4vc");
+
+        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
+        emptyMapper.setName("user-attr-empty-mapper");
+        emptyMapper.setProtocol("oid4vc");
+        emptyMapper.setProtocolMapper("oid4vc-user-attribute-mapper");
+        emptyMapper.setConfig(Map.of()); // Empty config
+
+        scope.setProtocolMappers(List.of(emptyMapper));
+
+        testRealm.admin().clientScopes().create(scope).close();
+
+        runOnServer.run(session -> {
+            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
+            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
+
+            // The empty mapper should be ignored and not present in the claims
+            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
+                    .map(config -> config.getCredentialMetadata())
+                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
+                    .flatMap(metadata -> metadata.getClaims().stream())
+                    .anyMatch(claim -> "user-attr-empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
+
+            assertFalse(foundEmptyMapper, "User attribute mapper with empty config should not be included in metadata");
+        });
+    }
+
+    @Test
+    public void testStaticClaimMapperEmptyConfig() {
+        String scopeName = "static-claim-empty-config-scope-" + UUID.randomUUID();
+
+        ClientScopeRepresentation scope = new ClientScopeRepresentation();
+        scope.setName(scopeName);
+        scope.setProtocol("oid4vc");
+
+        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
+        emptyMapper.setName("static-claim-empty-mapper");
+        emptyMapper.setProtocol("oid4vc");
+        emptyMapper.setProtocolMapper("oid4vc-static-claim-mapper");
+        emptyMapper.setConfig(Map.of()); // Empty config
+
+        scope.setProtocolMappers(List.of(emptyMapper));
+
+        testRealm.admin().clientScopes().create(scope).close();
+
+        runOnServer.run(session -> {
+            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
+            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
+
+            // The empty mapper should be ignored and not present in the claims
+            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
+                    .map(config -> config.getCredentialMetadata())
+                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
+                    .flatMap(metadata -> metadata.getClaims().stream())
+                    .anyMatch(claim -> "static-claim-empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
+
+            assertFalse(foundEmptyMapper, "Static claim mapper with empty config should not be included in metadata");
+        });
+    }
+
+    @Test
+    public void testIssuedAtTimeClaimMapperEmptyConfig() {
+        String scopeName = "iat-claim-empty-config-scope-" + UUID.randomUUID();
+
+        ClientScopeRepresentation scope = new ClientScopeRepresentation();
+        scope.setName(scopeName);
+        scope.setProtocol("oid4vc");
+
+        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
+        emptyMapper.setName("iat-claim-empty-mapper");
+        emptyMapper.setProtocol("oid4vc");
+        emptyMapper.setProtocolMapper("oid4vc-issued-at-time-claim-mapper");
+        emptyMapper.setConfig(Map.of()); // Empty config
+
+        scope.setProtocolMappers(List.of(emptyMapper));
+
+        testRealm.admin().clientScopes().create(scope).close();
+
+        runOnServer.run(session -> {
+            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
+            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
+
+            // The empty mapper should be ignored and not present in the claims
+            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
+                    .map(config -> config.getCredentialMetadata())
+                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
+                    .flatMap(metadata -> metadata.getClaims().stream())
+                    .anyMatch(claim -> "iat-claim-empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
+
+            assertFalse(foundEmptyMapper, "IAT claim mapper with empty config should not be included in metadata");
+        });
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIMapperEmptyConfigTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIMapperEmptyConfigTest.java
@@ -4,13 +4,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
-import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
-import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,138 +18,53 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
 public class OID4VCIMapperEmptyConfigTest extends OID4VCIssuerTestBase {
 
-    @InjectRunOnServer
-    RunOnServerClient runOnServer;
-
     @Test
     public void testEmptyMapperConfigDoesNotCauseNPE() {
-        String scopeName = "empty-config-scope-" + UUID.randomUUID();
-        
-        ClientScopeRepresentation scope = new ClientScopeRepresentation();
-        scope.setName(scopeName);
-        scope.setProtocol("oid4vc");
-        
-        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
-        emptyMapper.setName("empty-mapper");
-        emptyMapper.setProtocol("oid4vc");
-        emptyMapper.setProtocolMapper("oid4vc-subject-id-mapper");
-        emptyMapper.setConfig(Map.of()); // Empty config
-        
-        scope.setProtocolMappers(List.of(emptyMapper));
-        
-        testRealm.admin().clientScopes().create(scope).close();
-
-        runOnServer.run(session -> {
-            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
-            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
-            
-            // The empty mapper should be ignored and not present in the claims
-            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
-                    .map(config -> config.getCredentialMetadata())
-                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
-                    .flatMap(metadata -> metadata.getClaims().stream())
-                    .anyMatch(claim -> "empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
-            
-            assertFalse(foundEmptyMapper, "Mapper with empty config should not be included in metadata");
-        });
+        assertMapperIsIgnored("oid4vc-subject-id-mapper", "empty-mapper");
     }
 
     @Test
     public void testUserAttributeMapperEmptyConfig() {
-        String scopeName = "user-attr-empty-config-scope-" + UUID.randomUUID();
-
-        ClientScopeRepresentation scope = new ClientScopeRepresentation();
-        scope.setName(scopeName);
-        scope.setProtocol("oid4vc");
-
-        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
-        emptyMapper.setName("user-attr-empty-mapper");
-        emptyMapper.setProtocol("oid4vc");
-        emptyMapper.setProtocolMapper("oid4vc-user-attribute-mapper");
-        emptyMapper.setConfig(Map.of()); // Empty config
-
-        scope.setProtocolMappers(List.of(emptyMapper));
-
-        testRealm.admin().clientScopes().create(scope).close();
-
-        runOnServer.run(session -> {
-            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
-            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
-
-            // The empty mapper should be ignored and not present in the claims
-            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
-                    .map(config -> config.getCredentialMetadata())
-                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
-                    .flatMap(metadata -> metadata.getClaims().stream())
-                    .anyMatch(claim -> "user-attr-empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
-
-            assertFalse(foundEmptyMapper, "User attribute mapper with empty config should not be included in metadata");
-        });
+        assertMapperIsIgnored("oid4vc-user-attribute-mapper", "user-attr-empty-mapper");
     }
 
     @Test
     public void testStaticClaimMapperEmptyConfig() {
-        String scopeName = "static-claim-empty-config-scope-" + UUID.randomUUID();
-
-        ClientScopeRepresentation scope = new ClientScopeRepresentation();
-        scope.setName(scopeName);
-        scope.setProtocol("oid4vc");
-
-        ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
-        emptyMapper.setName("static-claim-empty-mapper");
-        emptyMapper.setProtocol("oid4vc");
-        emptyMapper.setProtocolMapper("oid4vc-static-claim-mapper");
-        emptyMapper.setConfig(Map.of()); // Empty config
-
-        scope.setProtocolMappers(List.of(emptyMapper));
-
-        testRealm.admin().clientScopes().create(scope).close();
-
-        runOnServer.run(session -> {
-            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
-            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
-
-            // The empty mapper should be ignored and not present in the claims
-            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
-                    .map(config -> config.getCredentialMetadata())
-                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
-                    .flatMap(metadata -> metadata.getClaims().stream())
-                    .anyMatch(claim -> "static-claim-empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
-
-            assertFalse(foundEmptyMapper, "Static claim mapper with empty config should not be included in metadata");
-        });
+        assertMapperIsIgnored("oid4vc-static-claim-mapper", "static-claim-empty-mapper");
     }
 
     @Test
     public void testIssuedAtTimeClaimMapperEmptyConfig() {
-        String scopeName = "iat-claim-empty-config-scope-" + UUID.randomUUID();
+        assertMapperIsIgnored("oid4vc-issued-at-time-claim-mapper", "iat-claim-empty-mapper");
+    }
+
+    private void assertMapperIsIgnored(String mapperType, String mapperName) {
+        String scopeName = mapperName + "-scope-" + UUID.randomUUID();
 
         ClientScopeRepresentation scope = new ClientScopeRepresentation();
         scope.setName(scopeName);
         scope.setProtocol("oid4vc");
 
         ProtocolMapperRepresentation emptyMapper = new ProtocolMapperRepresentation();
-        emptyMapper.setName("iat-claim-empty-mapper");
+        emptyMapper.setName(mapperName);
         emptyMapper.setProtocol("oid4vc");
-        emptyMapper.setProtocolMapper("oid4vc-issued-at-time-claim-mapper");
+        emptyMapper.setProtocolMapper(mapperType);
         emptyMapper.setConfig(Map.of()); // Empty config
 
         scope.setProtocolMappers(List.of(emptyMapper));
 
         testRealm.admin().clientScopes().create(scope).close();
 
-        runOnServer.run(session -> {
-            CredentialIssuer credentialIssuer = new OID4VCIssuerWellKnownProvider(session).getIssuerMetadata();
-            assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
+        CredentialIssuer credentialIssuer = oauth.oid4vc().doIssuerMetadataRequest().getMetadata();
+        assertNotNull(credentialIssuer, "Credential Issuer metadata should be available");
 
-            // The empty mapper should be ignored and not present in the claims
-            boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
-                    .map(config -> config.getCredentialMetadata())
-                    .filter(metadata -> metadata != null && metadata.getClaims() != null)
-                    .flatMap(metadata -> metadata.getClaims().stream())
-                    .anyMatch(claim -> "iat-claim-empty-mapper".equals(claim.getName()) || claim.getName().isEmpty());
+        // The empty mapper should be ignored and not present in the claims
+        boolean foundEmptyMapper = credentialIssuer.getCredentialsSupported().values().stream()
+                .map(SupportedCredentialConfiguration::getCredentialMetadata)
+                .filter(metadata -> metadata != null && metadata.getClaims() != null)
+                .flatMap(metadata -> metadata.getClaims().stream())
+                .anyMatch(claim -> mapperName.equals(claim.getName()) || (claim.getName() != null && claim.getName().isEmpty()));
 
-            assertFalse(foundEmptyMapper, "IAT claim mapper with empty config should not be included in metadata");
-        });
+        assertFalse(foundEmptyMapper, "Mapper " + mapperName + " of type " + mapperType + " with empty config should not be included in metadata");
     }
 }


### PR DESCRIPTION
This PR fixes a NullPointerException in `OID4VCMapper` caused by missing or empty mapper configurations.

### Changes
- Skip mappers with invalid or empty metadata attribute paths in `Claim.parse`
- Add defensive checks across OID4VC mappers to safely handle empty paths during credential issuance
- Add integration tests to verify the fix and ensure invalid mappers are ignored

### Impact
- Prevents runtime failures during issuer metadata generation
- Improves robustness of mapper handling
- Ensures only valid mappers are exposed in metadata

Closes #47544

