### PR TITLE
implement multi domain support for organisation IDP

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/OrganizationDomainRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/OrganizationDomainRepresentation.java
@@ -26,6 +26,7 @@ public class OrganizationDomainRepresentation {
 
     private String name;
     private boolean verified;
+    private String idpId;
 
     public OrganizationDomainRepresentation() {
         // for reflection
@@ -49,6 +50,14 @@ public class OrganizationDomainRepresentation {
 
     public void setVerified(boolean verified) {
         this.verified = verified;
+    }
+
+    public String getIdpId() {
+        return this.idpId;
+    }
+
+    public void setIdpId(String idpId) {
+        this.idpId = idpId;
     }
 
     @Override

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationDomainsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationDomainsResource.java
@@ -17,46 +17,33 @@
 
 package org.keycloak.admin.client.resource;
 
+import java.util.List;
+
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 
-public interface OrganizationResource {
+public interface OrganizationDomainsResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    OrganizationRepresentation toRepresentation();
+    List<OrganizationDomainRepresentation> getDomains();
 
-    @PUT
+    @Path("{name}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    OrganizationDomainRepresentation getDomain(@PathParam("name") String name);
+
+    @Path("{name}")
+    @PATCH
     @Consumes(MediaType.APPLICATION_JSON)
-    Response update(OrganizationRepresentation organization);
-
-    @DELETE
-    Response delete();
-
-    @Path("members")
-    OrganizationMembersResource members();
-
-    /**
-     * @since Keycloak server 26.5.0.
-     * @return {@link OrganizationInvitationsResource} to manage organization invitations
-     */
-    @Path("invitations")
-    OrganizationInvitationsResource invitations();
-
-    @Path("identity-providers")
-    OrganizationIdentityProvidersResource identityProviders();
-
-    @Path("groups")
-    OrganizationGroupsResource groups();
-
-    @Path("domains")
-    OrganizationDomainsResource domains();
+    @Produces(MediaType.APPLICATION_JSON)
+    Response updateDomain(@PathParam("name") String name, OrganizationDomainRepresentation representation);
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationIdentityProviderResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationIdentityProviderResource.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 
 public interface OrganizationIdentityProviderResource {
 
@@ -66,4 +67,16 @@ public interface OrganizationIdentityProviderResource {
                                         @QueryParam("max") Integer max,
                                         @QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation,
                                         @QueryParam("subGroupsCount") @DefaultValue("false") boolean subGroupsCount);
+
+    /**
+     * Returns organization domains for the identity provider with the specified alias.
+     * Only returns domains if the identity provider is associated with the organization.
+     *
+     * @return a list of organization domains associated with the organization
+     * @since Keycloak server 26.6.0
+     */
+    @Path("domains")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationDomainRepresentation> getDomains();
 }

--- a/js/apps/admin-ui/src/organizations/DetailOrganization.tsx
+++ b/js/apps/admin-ui/src/organizations/DetailOrganization.tsx
@@ -54,6 +54,21 @@ export default function DetailOrganization() {
   const save = async (org: OrganizationFormType) => {
     try {
       const organization = convertToOrg(org);
+      const currentOrg = await adminClient.organizations.findOne({ id });
+
+      const currentDomainsMap = new Map(
+        currentOrg?.domains?.map((d) => [d.name, d]) ?? [],
+      );
+
+      //We want to keep current domain idpId and verified status
+      organization.domains?.forEach((domain) => {
+        const currentDomain = currentDomainsMap.get(domain.name!);
+        if (currentDomain) {
+          domain.idpId = currentDomain.idpId;
+          domain.verified = currentDomain.verified;
+        }
+      });
+
       await adminClient.organizations.updateById({ id }, organization);
       addAlert(t("organizationSaveSuccess"));
     } catch (error) {

--- a/js/apps/admin-ui/src/organizations/IdentityProviderSelect.tsx
+++ b/js/apps/admin-ui/src/organizations/IdentityProviderSelect.tsx
@@ -31,6 +31,7 @@ import useToggle from "../utils/useToggle";
 type IdentityProviderSelectProps = Omit<ComponentProps, "convertToName"> & {
   variant?: "typeaheadMulti" | "typeahead";
   isRequired?: boolean;
+  orgId: string;
 };
 
 export const IdentityProviderSelect = ({
@@ -41,6 +42,7 @@ export const IdentityProviderSelect = ({
   isRequired,
   variant = "typeahead",
   isDisabled,
+  orgId,
 }: IdentityProviderSelectProps) => {
   const { adminClient } = useAdminClient();
 
@@ -66,13 +68,14 @@ export const IdentityProviderSelect = ({
     async () => {
       const params: IdentityProvidersQuery = {
         max: 20,
-        realmOnly: true,
       };
       if (search) {
         params.search = search;
       }
 
-      return await adminClient.identityProviders.find(params);
+      var allIdentityProviders  = await adminClient.identityProviders.find(params);
+      //Filter IDP to keep the IDP which are either not linked to an org yet or linked to the current organisation
+      return allIdentityProviders.filter( (idp) => !idp.organizationId || idp.organizationId === orgId);
     },
     setIdps,
     [search],

--- a/js/apps/admin-ui/src/organizations/IdentityProviders.tsx
+++ b/js/apps/admin-ui/src/organizations/IdentityProviders.tsx
@@ -8,6 +8,8 @@ import {
 import {
   Button,
   ButtonVariant,
+  Chip,
+  ChipGroup,
   PageSection,
   Switch,
   ToolbarItem,
@@ -25,6 +27,52 @@ import { useRealm } from "../context/realm-context/RealmContext";
 import useToggle from "../utils/useToggle";
 import { LinkIdentityProviderModal } from "./LinkIdentityProviderModal";
 import { EditOrganizationParams } from "./routes/EditOrganization";
+
+type DomainCellProps = {
+  row: IdentityProviderRepresentation;
+  orgId: string;
+};
+
+const DomainCell = ({ row, orgId }: DomainCellProps) => {
+  const { adminClient } = useAdminClient();
+  const { t } = useTranslation();
+  const [domains, setDomains] = useState<string[]>([]);
+
+  useFetch(
+    async () => {
+      const configDomain = row.config?.["kc.org.domain"];
+      if (configDomain === "ANY") {
+        return ["ANY"];
+      }
+      const orgDomains =
+        await adminClient.organizations.getOrganizationDomainsByIdp({
+          orgId,
+          alias: row.alias!,
+        });
+      return orgDomains.map((domain) => domain.name!)
+    },
+    (result) => setDomains(result),
+    [row.alias],
+  );
+
+  if (domains.length === 0) {
+    return null;
+  }
+
+  return (
+    <ChipGroup
+      numChips={2}
+      expandedText={t("hide")}
+      collapsedText={t("showRemaining")}
+    >
+      {domains.map((name) => (
+        <Chip key={name} isReadOnly>
+          {name}
+        </Chip>
+      ))}
+    </ChipGroup>
+  );
+};
 
 type ShownOnLoginPageCheckProps = {
   row: IdentityProviderRepresentation;
@@ -208,8 +256,11 @@ export const IdentityProviders = () => {
                 ),
               },
               {
-                name: "config['kc.org.domain']",
+                name: "domain",
                 displayKey: "domain",
+                cellRenderer: (row) => (
+                  <DomainCell row={row} orgId={orgId!} />
+                ),
               },
               {
                 name: "providerId",

--- a/js/apps/admin-ui/src/organizations/LinkIdentityProviderModal.tsx
+++ b/js/apps/admin-ui/src/organizations/LinkIdentityProviderModal.tsx
@@ -88,6 +88,16 @@ export const LinkIdentityProviderModal = ({
           alias: data.alias[0],
         });
       }
+
+      // Unless user selected ANY we update the domain link to the IDP
+      const domain = config["kc.org.domain"]
+      if (domain !== undefined && domain !== "ANY") {
+        await adminClient.organizations.updateDomain(
+          { orgId, domainName: domain },
+          { idpId: foundIdentityProvider.internalId },
+        );
+      }
+
       addAlert(
         t(!identityProvider ? "linkSuccessful" : "linkUpdatedSuccessful"),
       );
@@ -133,6 +143,7 @@ export const LinkIdentityProviderModal = ({
             defaultValue={[]}
             isRequired
             isDisabled={!!identityProvider}
+            orgId={orgId}
           />
           <SelectControl
             name={convertAttributeNameToForm("config.kc.org.domain")}

--- a/js/apps/admin-ui/test/organization/idp.spec.ts
+++ b/js/apps/admin-ui/test/organization/idp.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../utils/table.ts";
 import {
   clickAddIdentityProvider,
+  clickUnlinkIdentityProvider,
   fillForm,
   goToIdentityProviders,
 } from "./idp.ts";
@@ -53,5 +54,50 @@ test.describe.serial("Identity providers", () => {
       "Identity provider successfully linked to organization",
     );
     await assertRowExists(page, "bitbucket");
+  });
+});
+
+test.describe.serial("Identity providers - multi domain", () => {
+  const realmName = `org-idp-domains-${uuid()}`;
+  const orgName = "multi-domain-org";
+
+  test.beforeAll(async () => {
+    await adminClient.createRealm(realmName, { organizationsEnabled: true });
+    await adminClient.createOrganization({
+      realm: realmName,
+      name: orgName,
+      domains: [
+        { name: "alpha.com", verified: false },
+        { name: "beta.com", verified: false },
+        { name: "gamma.com", verified: false },
+      ],
+    });
+    await adminClient.createIdentityProvider("BitBucket", "bitbucket", realmName);
+    const orgId = await adminClient.findOrg(orgName, realmName);
+    await adminClient.linkIdpToOrg(orgId, "bitbucket", realmName);
+    const idp = await adminClient.getIdentityProvider("bitbucket", realmName);
+    await adminClient.updateOrgDomain(orgId, "alpha.com", { idpId: idp!.internalId }, realmName);
+    await adminClient.updateOrgDomain(orgId, "beta.com", { idpId: idp!.internalId }, realmName);
+  });
+
+  test.afterAll(() => adminClient.deleteRealm(realmName));
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToRealm(page, realmName);
+    await goToOrganizations(page);
+    await clickTableRowItem(page, orgName);
+    await goToIdentityProviders(page);
+  });
+
+  test("unlink multi domain idp and verify idp list is empty", async ({ page }) => {
+    await assertRowExists(page, "bitbucket");
+    await clickUnlinkIdentityProvider(page, "bitbucket");
+    await confirmModal(page);
+    await assertNotificationMessage(
+      page,
+      "Identity provider has been unlinked",
+    );
+    await assertEmptyTable(page);
   });
 });

--- a/js/apps/admin-ui/test/organization/idp.ts
+++ b/js/apps/admin-ui/test/organization/idp.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 import { selectItem } from "../utils/form.ts";
+import { clickRowKebabItem } from "../utils/table.ts";
 
 export async function goToIdentityProviders(page: Page) {
   await page.getByTestId("identityProvidersTab").click();
@@ -9,6 +10,17 @@ export async function clickAddIdentityProvider(page: Page) {
   await page
     .getByTestId("no-identity-provider-in-this-organization-empty-action")
     .click();
+}
+
+export async function clickUnlinkIdentityProvider(
+  page: Page,
+  alias: string,
+) {
+  await clickRowKebabItem(page, alias, "Unlink provider");
+}
+
+export async function clickLinkIdentityProviderFromToolbar(page: Page) {
+  await page.getByRole("button", { name: "Link identity provider" }).click();
 }
 
 export async function fillForm(

--- a/js/apps/admin-ui/test/utils/AdminClient.ts
+++ b/js/apps/admin-ui/test/utils/AdminClient.ts
@@ -3,6 +3,7 @@ import type ClientRepresentation from "@keycloak/keycloak-admin-client/lib/defs/
 import type ClientScopeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation.js";
 import type ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation.js";
 import type OrganizationRepresentation from "@keycloak/keycloak-admin-client/lib/defs/organizationRepresentation.js";
+import type OrganizationDomainRepresentation from "@keycloak/keycloak-admin-client/lib/defs/organizationDomainRepresentation.js";
 import type PolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/policyRepresentation.js";
 import type ResourceRepresentation from "@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation.js";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation.js";
@@ -333,6 +334,16 @@ class AdminClient {
     });
   }
 
+  async getIdentityProvider(
+    alias: string,
+    realm: string = this.#client.realmName,
+  ) {
+    await this.#login();
+    return this.#withRealm(realm, async () => {
+      return this.#client.identityProviders.findOne({ alias });
+    });
+  }
+
   async deleteIdentityProvider(idpAlias: string) {
     await this.#login();
     await this.#client.identityProviders.del({
@@ -373,6 +384,41 @@ class AdminClient {
   ) {
     await this.#login();
     await this.#client.organizations.create(org);
+  }
+
+  async findOrg(
+    name: string,
+    realm: string = this.#client.realmName,
+  ): Promise<string> {
+    await this.#login();
+    return this.#withRealm(realm, async () => {
+      const found = await this.#client.organizations.find({ search: name });
+      if (found.length === 0) throw new Error(`Organization not found: ${name}`);
+      return found[0].id!;
+    });
+  }
+
+  async linkIdpToOrg(
+    orgId: string,
+    alias: string,
+    realm: string = this.#client.realmName,
+  ): Promise<void> {
+    await this.#login();
+    await this.#withRealm(realm, async () => {
+      await this.#client.organizations.linkIdp({ orgId, alias });
+    });
+  }
+
+  async updateOrgDomain(
+    orgId: string,
+    domainName: string,
+    data: Partial<OrganizationDomainRepresentation>,
+    realm: string = this.#client.realmName,
+  ): Promise<void> {
+    await this.#login();
+    await this.#withRealm(realm, async () => {
+      await this.#client.organizations.updateDomain({ orgId, domainName }, data);
+    });
   }
 
   async deleteOrganization(

--- a/js/libs/keycloak-admin-client/src/defs/organizationDomainRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/organizationDomainRepresentation.ts
@@ -1,4 +1,5 @@
 export default interface OrganizationDomainRepresentation {
   name?: string;
   verified?: boolean;
+  idpId?: string;
 }

--- a/js/libs/keycloak-admin-client/src/resources/agent.ts
+++ b/js/libs/keycloak-admin-client/src/resources/agent.ts
@@ -11,7 +11,7 @@ import { stringifyQueryParams } from "../utils/stringifyQueryParams.js";
 // constants
 const SLASH = "/";
 
-type Method = "GET" | "POST" | "PUT" | "DELETE";
+type Method = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 // interface
 export interface RequestArgs {

--- a/js/libs/keycloak-admin-client/src/resources/organizations.ts
+++ b/js/libs/keycloak-admin-client/src/resources/organizations.ts
@@ -1,6 +1,7 @@
 import type { KeycloakAdminClient } from "../client.js";
 import IdentityProviderRepresentation from "../defs/identityProviderRepresentation.js";
 import type OrganizationRepresentation from "../defs/organizationRepresentation.js";
+import type OrganizationDomainRepresentation from "../defs/organizationDomainRepresentation.js";
 import type OrganizationInvitationRepresentation from "../defs/organizationInvitationRepresentation.js";
 import UserRepresentation from "../defs/userRepresentation.js";
 import Resource from "./resource.js";
@@ -166,6 +167,44 @@ export class Organizations extends Resource<{ realm?: string }> {
       urlParamKeys: ["orgId", "alias"],
     },
   );
+
+  public getOrganizationDomainsByIdp = this.makeRequest<
+    { orgId: string; alias: string },
+    OrganizationDomainRepresentation[]
+  >({
+    method: "GET",
+    path: "/{orgId}/identity-providers/{alias}/domains",
+    urlParamKeys: ["orgId", "alias"],
+  });
+
+  // Organization Domains Management
+  public listDomains = this.makeRequest<
+    { orgId: string },
+    OrganizationDomainRepresentation[]
+  >({
+    method: "GET",
+    path: "/{orgId}/domains",
+    urlParamKeys: ["orgId"],
+  });
+
+  public getDomain = this.makeRequest<
+    { orgId: string; domainName: string },
+    OrganizationDomainRepresentation
+  >({
+    method: "GET",
+    path: "/{orgId}/domains/{domainName}",
+    urlParamKeys: ["orgId", "domainName"],
+  });
+
+  public updateDomain = this.makeUpdateRequest<
+    { orgId: string; domainName: string },
+    OrganizationDomainRepresentation,
+    OrganizationDomainRepresentation
+  >({
+    method: "PATCH",
+    path: "/{orgId}/domains/{domainName}",
+    urlParamKeys: ["orgId", "domainName"],
+  });
 
   // Organization Invitations Management
   public listInvitations = this.makeRequest<

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_6_0_OrgDomainIdpMigration.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate26_6_0_OrgDomainIdpMigration.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.connections.jpa.updater.liquibase.custom;
+
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.CustomChangeException;
+import liquibase.statement.core.RawParameterizedSqlStatement;
+
+public class JpaUpdate26_6_0_OrgDomainIdpMigration extends CustomKeycloakTask {
+
+    @Override
+    protected void generateStatementsImpl() throws CustomChangeException {
+        String orgDomainTable = getTableName("ORG_DOMAIN");
+        String identityProviderTable = getTableName("IDENTITY_PROVIDER");
+        String identityProviderConfigTable = getTableName("IDENTITY_PROVIDER_CONFIG");
+
+        if (database instanceof PostgresDatabase) {
+            generateUpdateQueryForPostgreSQL(orgDomainTable, identityProviderTable, identityProviderConfigTable);
+            return;
+        }
+
+        if (database instanceof MySQLDatabase) {
+            // and MariaDB
+            generateUpdateQueryForMySQL(orgDomainTable, identityProviderTable, identityProviderConfigTable);
+            return;
+        }
+
+        if (database instanceof MSSQLDatabase) {
+            generateUpdateQueryForMSSQL(orgDomainTable, identityProviderTable, identityProviderConfigTable);
+            return;
+        }
+
+        if (database instanceof OracleDatabase) {
+            generateUpdateQueryForOracle(orgDomainTable, identityProviderTable, identityProviderConfigTable);
+            return;
+        }
+
+        // H2 and others, very slow with O(n^2) complexity
+        // It is standard SQL queries, it *must* be compatible with all vendors (fingers crossed)
+        generateUpdateQueryUsingStandardSQL(orgDomainTable, identityProviderTable, identityProviderConfigTable);
+    }
+
+    @Override
+    protected String getTaskId() {
+        return "Migrate IDP_ID in ORG_DOMAIN table based on IDP config";
+    }
+
+    private void generateUpdateQueryUsingStandardSQL(String orgDomainTable, String identityProviderTable, String identityProviderConfigTable) {
+        statements.add(new RawParameterizedSqlStatement("""
+                UPDATE %s od
+                SET od.idp_id = (
+                    SELECT ip.internal_id 
+                    FROM %s ip
+                    INNER JOIN %s ipc ON ipc.name = 'kc.org.domain' AND ipc.value = od.name
+                    WHERE ip.organization_id = od.org_id
+                )
+                WHERE od.idp_id IS NULL"""
+                .formatted(orgDomainTable, identityProviderTable, identityProviderConfigTable)));
+    }
+
+    private void generateUpdateQueryForOracle(String orgDomainTable, String identityProviderTable, String identityProviderConfigTable) {
+        statements.add(new RawParameterizedSqlStatement("""
+                MERGE INTO %s od
+                USING (
+                    SELECT ip.internal_id, ipc.value as domain_name, ip.organization_id
+                    FROM %s ip
+                    INNER JOIN %s ipc ON ipc.name = 'kc.org.domain' AND ipc.identity_provider_id = ip.internal_id
+                ) ip_data ON (od.name = ip_data.domain_name AND od.org_id = ip_data.organization_id)
+                WHEN MATCHED THEN
+                UPDATE SET od.idp_id = ip_data.internal_id"""
+                .formatted(orgDomainTable, identityProviderTable, identityProviderConfigTable)));
+    }
+
+    private void generateUpdateQueryForMSSQL(String orgDomainTable, String identityProviderTable, String identityProviderConfigTable) {
+        statements.add(new RawParameterizedSqlStatement("""
+                UPDATE od
+                SET od.idp_id = ip.internal_id
+                FROM %s od
+                INNER JOIN %s ip ON ip.organization_id = od.org_id
+                INNER JOIN %s ipc ON ipc.name = 'kc.org.domain' AND ipc.value = od.name AND ipc.identity_provider_id = ip.internal_id
+                WHERE od.idp_id IS NULL"""
+                .formatted(orgDomainTable, identityProviderTable, identityProviderConfigTable)));
+    }
+
+    private void generateUpdateQueryForMySQL(String orgDomainTable, String identityProviderTable, String identityProviderConfigTable) {
+        statements.add(new RawParameterizedSqlStatement("""
+                UPDATE %s od
+                INNER JOIN %s ip ON ip.organization_id = od.org_id
+                INNER JOIN %s ipc ON ipc.name = 'kc.org.domain' AND ipc.value = od.name AND ipc.identity_provider_id = ip.internal_id
+                SET od.idp_id = ip.internal_id
+                WHERE od.idp_id IS NULL"""
+                .formatted(orgDomainTable, identityProviderTable, identityProviderConfigTable)));
+    }
+
+    private void generateUpdateQueryForPostgreSQL(String orgDomainTable, String identityProviderTable, String identityProviderConfigTable) {
+        statements.add(new RawParameterizedSqlStatement("""
+                UPDATE %s od
+                SET idp_id = ip.internal_id
+                FROM %s ip
+                INNER JOIN %s ipc ON ipc.name = 'kc.org.domain' AND ipc.identity_provider_id = ip.internal_id
+                WHERE ip.organization_id = od.org_id AND ipc.value = od.name"""
+                .formatted(orgDomainTable, identityProviderTable, identityProviderConfigTable)));
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationDomainEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationDomainEntity.java
@@ -56,6 +56,10 @@ public class OrganizationDomainEntity {
     @JoinColumn(name = "ORG_ID")
     private OrganizationEntity organization;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "IDP_ID")
+    private IdentityProviderEntity identityProvider;
+
     public String getId() {
         return id;
     }
@@ -86,6 +90,14 @@ public class OrganizationDomainEntity {
 
     public void setOrganization(OrganizationEntity organization) {
         this.organization = organization;
+    }
+
+    public IdentityProviderEntity getIdentityProvider() {
+        return this.identityProvider;
+    }
+
+    public void setIdentityProvider(IdentityProviderEntity identityProvider) {
+        this.identityProvider = identityProvider;
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -664,9 +664,14 @@ public class JpaOrganizationProvider implements OrganizationProvider {
             return false;
         }
 
-        // clear the organization id and any domain assigned to the IDP.
+        // clear the organization id and any domain associated with the IDP.
         identityProvider.setOrganizationId(null);
+        organizationEntity.getDomains().stream()
+                .filter(domain -> domain.getIdentityProvider() !=null &&
+                        domain.getIdentityProvider().getInternalId().equalsIgnoreCase(identityProvider.getInternalId()))
+                .forEach(domain -> domain.setIdentityProvider(null));
         identityProvider.getConfig().remove(ORGANIZATION_DOMAIN_ATTRIBUTE);
+
         session.identityProviders().update(identityProvider);
 
         return true;

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -26,6 +26,9 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.persistence.EntityManager;
+
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
@@ -35,6 +38,7 @@ import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.jpa.JpaModel;
+import org.keycloak.models.jpa.entities.IdentityProviderEntity;
 import org.keycloak.models.jpa.entities.OrganizationDomainEntity;
 import org.keycloak.models.jpa.entities.OrganizationEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -183,21 +187,26 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
                 .map(this::validateDomain)
                 .collect(Collectors.toMap(OrganizationDomainModel::getName, Function.identity()));
 
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+
         for (OrganizationDomainEntity domainEntity : new HashSet<>(this.entity.getDomains())) {
-            // update the existing domain (for now, only the verified flag can be changed).
+            // update the existing domain
             if (modelMap.containsKey(domainEntity.getName())) {
-                domainEntity.setVerified(modelMap.get(domainEntity.getName()).isVerified());
+                OrganizationDomainModel model = modelMap.get(domainEntity.getName());
+                domainEntity.setVerified(model.isVerified());
+                
+                // Update identity provider reference
+                if (model.getIdpId() != null) {
+                    IdentityProviderEntity idpEntity = em.getReference(IdentityProviderEntity.class, model.getIdpId());
+                    domainEntity.setIdentityProvider(idpEntity);
+                } else {
+                    domainEntity.setIdentityProvider(null);
+                }
+                
                 modelMap.remove(domainEntity.getName());
             } else {
                 // remove domain that is not found in the new set.
                 this.entity.removeDomain(domainEntity);
-                // check if any idp is assigned to the removed domain, and unset the domain if that's the case.
-                getIdentityProviders()
-                        .filter(idp -> Objects.equals(domainEntity.getName(), idp.getConfig().get(ORGANIZATION_DOMAIN_ATTRIBUTE)))
-                        .forEach(idp -> {
-                            idp.getConfig().remove(ORGANIZATION_DOMAIN_ATTRIBUTE);
-                            session.identityProviders().update(idp);
-                        });
             }
         }
 
@@ -208,6 +217,12 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
             domainEntity.setName(model.getName());
             domainEntity.setVerified(model.isVerified());
             domainEntity.setOrganization(this.entity);
+
+            if (model.getIdpId() != null) {
+                IdentityProviderEntity idpEntity = em.getReference(IdentityProviderEntity.class, model.getIdpId());
+                domainEntity.setIdentityProvider(idpEntity);
+            }
+            
             this.entity.addDomain(domainEntity);
         }
     }
@@ -263,7 +278,8 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
     }
 
     private OrganizationDomainModel toModel(OrganizationDomainEntity entity) {
-        return new OrganizationDomainModel(entity.getName(), entity.isVerified());
+        String idpId = entity.getIdentityProvider() != null ? entity.getIdentityProvider().getInternalId() : null;
+        return new OrganizationDomainModel(entity.getName(), entity.isVerified(), idpId);
     }
 
     /**

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.6.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.6.0.xml
@@ -120,4 +120,19 @@
         </addColumn>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.6.0-org-domain-idp-column">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <not>
+                <columnExists tableName="ORG_DOMAIN" columnName="IDP_ID"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="ORG_DOMAIN">
+            <column name="IDP_ID" type="VARCHAR(36)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.6.0-org-domain-idp-migration">
+        <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate26_6_0_OrgDomainIdpMigration"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -1444,6 +1444,7 @@ public class ModelToRepresentation {
         OrganizationDomainRepresentation representation = new OrganizationDomainRepresentation();
         representation.setName(model.getName());
         representation.setVerified(model.isVerified());
+        representation.setIdpId(model.getIdpId());
         return representation;
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -1753,6 +1753,6 @@ public class RepresentationToModel {
     }
 
     public static OrganizationDomainModel toModel(OrganizationDomainRepresentation domainRepresentation) {
-        return new OrganizationDomainModel(domainRepresentation.getName(), domainRepresentation.isVerified());
+        return new OrganizationDomainModel(domainRepresentation.getName(), domainRepresentation.isVerified(), domainRepresentation.getIdpId());
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationDomainModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationDomainModel.java
@@ -34,14 +34,20 @@ public class OrganizationDomainModel implements Serializable {
 
     private final String name;
     private final boolean verified;
+    private final String idpId;
 
     public OrganizationDomainModel(String name) {
-        this(name, false);
+        this(name, false, null);
     }
 
     public OrganizationDomainModel(String name, boolean verified) {
+        this(name, verified, null);
+    }
+
+    public OrganizationDomainModel(String name, boolean verified, String idpId) {
         this.name = name == null ? null : name.trim().toLowerCase();
         this.verified = verified;
+        this.idpId = idpId;
     }
 
     public String getName() {
@@ -50,6 +56,10 @@ public class OrganizationDomainModel implements Serializable {
 
     public boolean isVerified() {
         return this.verified;
+    }
+
+    public String getIdpId() {
+        return this.idpId;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationDomainResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationDomainResource.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.organization.admin.resource;
+
+import java.util.stream.Stream;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationDomainModel;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.NoCache;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+public class OrganizationDomainResource {
+
+    private final KeycloakSession session;
+    private final OrganizationModel organization;
+    private final AdminEventBuilder adminEvent;
+
+    public OrganizationDomainResource(KeycloakSession session, OrganizationModel organization, AdminEventBuilder adminEvent) {
+        this.session = session;
+        this.organization = organization;
+        this.adminEvent = adminEvent.resource(ResourceType.ORGANIZATION);
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Returns the organization domains")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationDomainRepresentation.class, type = SchemaType.ARRAY)))
+    })
+    public Stream<OrganizationDomainRepresentation> getDomains() {
+        return organization.getDomains().map(ModelToRepresentation::toRepresentation);
+    }
+
+    @Path("{name}")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Returns a specific domain of the organization")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationDomainRepresentation.class))),
+        @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public Response getDomain(
+            @Parameter(description = "The domain name") @PathParam("name") String name) {
+        OrganizationDomainRepresentation domain = organization.getDomains()
+                .filter(d -> d.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .map(ModelToRepresentation::toRepresentation)
+                .orElse(null);
+        
+        if (domain == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+        
+        return Response.ok(domain).build();
+    }
+
+    @Path("{name}")
+    @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Partially updates a domain of the organization",
+            description = "Updates a domain using a subset of the representation. Only the provided fields are updated.")
+    @RequestBody(description = "Subset of the domain representation", required = true)
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "Updated", content = @Content(schema = @Schema(implementation = OrganizationDomainRepresentation.class))),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
+        @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public Response updateDomain(
+            @Parameter(description = "The domain name") @PathParam("name") String name,
+            OrganizationDomainRepresentation representation) {
+        OrganizationDomainModel existingDomain = organization.getDomains()
+                .filter(d -> d.getName().equalsIgnoreCase(name))
+                .findFirst()
+                .orElse(null);
+        
+        if (existingDomain == null) {
+            return Response.status(Status.NOT_FOUND).build();
+        }
+
+        // We only allow to update the idp id
+        String idpId = representation.getIdpId() != null 
+                ? representation.getIdpId() 
+                : existingDomain.getIdpId();
+        
+        OrganizationDomainModel updatedDomain = new OrganizationDomainModel(
+                existingDomain.getName(),
+                existingDomain.isVerified(),
+                idpId
+        );
+        
+        // Update the domain in the organization's domains set
+        java.util.Set<OrganizationDomainModel> domains = organization.getDomains().collect(java.util.stream.Collectors.toSet());
+        domains.remove(existingDomain);
+        domains.add(updatedDomain);
+        organization.setDomains(domains);
+
+        OrganizationDomainRepresentation updatedRep = ModelToRepresentation.toRepresentation(updatedDomain);
+        adminEvent.operation(OperationType.UPDATE)
+                .resourcePath(session.getContext().getUri())
+                .representation(updatedRep).success();
+
+        return Response.ok(updatedRep).build();
+    }
+}

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationIdentityProvidersResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationIdentityProvidersResource.java
@@ -42,6 +42,7 @@ import org.keycloak.models.utils.StripSecretsUtils;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
@@ -99,11 +100,8 @@ public class OrganizationIdentityProvidersResource {
                 throw ErrorResponse.error("Identity provider not found with the given alias", Status.BAD_REQUEST);
             }
 
-            if (organizationProvider.addIdentityProvider(organization, identityProvider)) {
-                return Response.noContent().build();
-            }
-
-            throw ErrorResponse.error("Identity provider already associated to the organization", Status.CONFLICT);
+            organizationProvider.addIdentityProvider(organization, identityProvider);
+            return Response.noContent().build();
         } catch (ModelException me) {
             throw ErrorResponse.error(me.getMessage(), Status.BAD_REQUEST);
         }
@@ -186,6 +184,37 @@ public class OrganizationIdentityProvidersResource {
 
         OrganizationGroupsResource groupsResource = new OrganizationGroupsResource(session, organization, adminEvent);
         return groupsResource.getGroups(search, searchQuery, exact, first, max, briefRepresentation, false, subGroupsCount);
+    }
+
+    @Path("{alias}/domains")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Returns organization domains for the identity provider",
+        description = "Returns the domains associated with the organization linked to the identity provider. " +
+                "Only returns domains if the identity provider is associated with the organization.")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "", content = @Content(schema = @Schema(implementation = OrganizationDomainRepresentation.class, type = SchemaType.ARRAY))),
+        @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public Stream<OrganizationDomainRepresentation> getDomains(
+            @Parameter(description = "The alias of the identity provider") @PathParam("alias") String alias) {
+        IdentityProviderModel identityProviderModel = organization.getIdentityProviders()
+                .filter(identityProvider -> alias.equals(identityProvider.getAlias()))
+                .findFirst()
+                .orElseThrow(() -> ErrorResponse.error("Identity provider not found with the given alias", Status.NOT_FOUND));
+
+        boolean matchWithAnyDomain = "ANY".equalsIgnoreCase(identityProviderModel.getConfig().get("kc.org.domain"));
+
+        if (matchWithAnyDomain) {
+            return organization.getDomains()
+                    .map(ModelToRepresentation::toRepresentation);
+        }
+
+        return organization.getDomains()
+                .filter(organizationDomainModel -> identityProviderModel.getInternalId().equals(organizationDomainModel.getIdpId()))
+                .map(ModelToRepresentation::toRepresentation);
     }
 
     @Path("{alias}")

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
@@ -142,4 +142,9 @@ public class OrganizationResource {
     public OrganizationGroupsResource groups() {
         return new OrganizationGroupsResource(session, organization, adminEvent);
     }
+
+    @Path("domains")
+    public OrganizationDomainResource domains() {
+        return new OrganizationDomainResource(session, organization, adminEvent);
+    }
 }

--- a/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
+++ b/services/src/main/java/org/keycloak/organization/authentication/authenticators/browser/OrganizationAuthenticator.java
@@ -279,13 +279,9 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
             return false;
         }
 
-        // first look for an IDP that matches exactly the specified domain (case-insensitive)
-        IdentityProviderModel idp = organization.getIdentityProviders()
-                .filter(broker -> IdentityProviderRedirectMode.EMAIL_MATCH.isSet(broker) &&
-                    domain.equalsIgnoreCase(broker.getConfig().get(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE))).findFirst().orElse(null);
+        IdentityProviderModel idp = resolveIdpByDomain(organization, domain);
 
         if (idp != null) {
-            // redirect the user using the broker that matches the specified domain
             redirect(context, idp.getAlias(), username);
             return true;
         }
@@ -302,6 +298,32 @@ public class OrganizationAuthenticator extends IdentityProviderAuthenticator {
         }
 
         return false;
+    }
+
+    private IdentityProviderModel resolveIdpByDomain(OrganizationModel organization, String domain) {
+        if (domain == null) {
+            return null;
+        }
+
+        // Find the domain in the organization
+        Optional<OrganizationDomainModel> domainModel = organization.getDomains()
+                .filter(d -> domain.equalsIgnoreCase(d.getName()))
+                .findFirst();
+
+        if (domainModel.isEmpty()) {
+            return null;
+        }
+
+        String idpId = domainModel.get().getIdpId();
+        if (idpId == null) {
+            return null;
+        }
+
+        // Find the IDP in the organization's identity providers
+        return organization.getIdentityProviders()
+                .filter(idp -> idpId.equals(idp.getInternalId()))
+                .findFirst()
+                .orElse(null);
     }
 
     private UserModel resolveUser(AuthenticationFlowContext context, String username) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/event/AdminEventTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/event/AdminEventTest.java
@@ -437,6 +437,32 @@ public class AdminEventTest {
         Assertions.assertNull(eventUserRep.getCredentials());
     }
 
+    @Test
+    public void testDomainUpdateAdminEvent() {
+        managedRealm.updateWithCleanup(r -> r.organizationsEnabled(true));
+
+        OrganizationRepresentation org = new OrganizationRepresentation();
+        org.setName("domainUpdateOrd");
+        org.setAlias("domainUpdateOrd");
+        org.addDomain(new OrganizationDomainRepresentation("example.com"));
+        String orgId = ApiUtil.getCreatedId(managedRealm.admin().organizations().create(org));
+        managedRealm.cleanup().add(r -> r.organizations().get(orgId).delete());
+
+        managedRealm.admin().clearAdminEvents();
+
+        OrganizationDomainRepresentation domainUpdate = new OrganizationDomainRepresentation();
+        domainUpdate.setIdpId("test-idp-id");
+        managedRealm.admin().organizations().get(orgId).domains().updateDomain("example.com", domainUpdate);
+
+        List<AdminEventRepresentation> events = events();
+        Assertions.assertEquals(1, events.size());
+        AdminEventRepresentation event = events.get(0);
+        AdminEventAssertion.assertSuccess(event)
+                .operationType(OperationType.UPDATE)
+                .resourcePath("organizations/" + orgId + "/domains/example.com");
+        Assertions.assertEquals(managedRealm.getId(), event.getRealmId());
+    }
+
     private static class AdminEventRealmConfig implements RealmConfig {
 
         @Override

--- a/tests/base/src/test/java/org/keycloak/tests/admin/organization/OrganizationDomainTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/organization/OrganizationDomainTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.organization;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.suites.DatabaseTest;
+import org.keycloak.testsuite.util.IdentityProviderBuilder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for organization domain management and identity provider linking.
+ */
+@KeycloakIntegrationTest
+@DatabaseTest
+public class OrganizationDomainTest {
+
+    @InjectRealm(config = OrgRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @BeforeEach
+    public void enableOrganizations() {
+        realm.updateWithCleanup(r -> r.organizationsEnabled(true));
+    }
+
+    private String createOrganization(String name, String... domainNames) {
+        OrganizationRepresentation org = new OrganizationRepresentation();
+        org.setName(name);
+        org.setAlias(name);
+        for (String domainName : domainNames) {
+            org.addDomain(new OrganizationDomainRepresentation(domainName));
+        }
+        String orgId = ApiUtil.getCreatedId(realm.admin().organizations().create(org));
+        realm.cleanup().add(realmResource -> realmResource.organizations().get(orgId).delete());
+        return orgId;
+    }
+
+    private IdentityProviderRepresentation createIdentityProvider(String alias) {
+        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
+                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+                .alias(alias)
+                .build();
+        try (Response response = realm.admin().identityProviders().create(idp)) {
+            Assertions.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        realm.cleanup().add(resource -> resource.identityProviders().get(alias).remove());
+        return realm.admin().identityProviders().get(alias).toRepresentation();
+    }
+
+
+    @Test
+    public void shouldListOrganizationDomain() {
+        String orgId = createOrganization("organization1", "domain1.com", "domain2.com");
+        OrganizationResource orgResource = realm.admin().organizations().get(orgId);
+
+        // Fetch domains from the organization
+        List<OrganizationDomainRepresentation> domains = orgResource.domains().getDomains();
+
+        // Validate there are exactly two domains
+        Assertions.assertEquals(2, domains.size(), "Organization should have exactly 2 domains");
+
+        // Verify domain names
+        Set<String> domainNames = domains.stream()
+                .map(OrganizationDomainRepresentation::getName)
+                .collect(Collectors.toSet());
+        Assertions.assertTrue(domainNames.contains("domain1.com"), "Should contain domain1.com");
+        Assertions.assertTrue(domainNames.contains("domain2.com"), "Should contain domain2.com");
+    }
+    @Test
+    public void shouldUpdateDomainWithIdpLink() {
+        // Create organization with three domains
+        String orgId = createOrganization("organization2", "domain3.com", "domain4.com", "domain5.com");
+        OrganizationResource orgResource = realm.admin().organizations().get(orgId);
+
+        // Create identity provider
+        String idpAlias = "testIdp";
+        IdentityProviderRepresentation idp = createIdentityProvider(idpAlias);
+        String idpId = idp.getInternalId();
+
+        // Link the IDP to the organization
+        try (Response response = orgResource.identityProviders().addIdentityProvider(idpAlias)) {
+            Assertions.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        }
+
+        // Link only domain1 and domain2 to the IDP
+        OrganizationDomainRepresentation domainUpdate = new OrganizationDomainRepresentation();
+        domainUpdate.setIdpId(idpId);
+        orgResource.domains().updateDomain("domain3.com", domainUpdate).close();
+        orgResource.domains().updateDomain("domain4.com", domainUpdate).close();
+
+        // Get domains by IDP
+        List<OrganizationDomainRepresentation> linkedDomains = 
+                orgResource.identityProviders().get(idpAlias).getDomains();
+
+        // Verify only the two linked domains are returned
+        Assertions.assertEquals(2, linkedDomains.size());
+        List<String> domainNames = linkedDomains.stream()
+                .map(OrganizationDomainRepresentation::getName)
+                .toList();
+        Assertions.assertTrue(domainNames.contains("domain3.com"));
+        Assertions.assertTrue(domainNames.contains("domain4.com"));
+        Assertions.assertFalse(domainNames.contains("domain5.com"));
+    }
+
+    public static class OrgRealmConfig implements RealmConfig {
+        @Override
+        public RealmConfigBuilder configure(RealmConfigBuilder realm) {
+            return realm.organizationsEnabled(false); // Will be enabled in @BeforeEach
+        }
+    }
+}


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Fixes #47554

Allow to link multiple domains to one organisation IDP

## Changes
- Adding one colomn in domain table to link an IDP. So relationship allow many domain to one IDP. Handle migration of IDP domain config attribute (KC_DOMAIN_NAME)
- New admin rest API :
- API to list the domains linked to a given IDP
- PATCH a domain is possible to link to an IDP
- Modify IdentityProviders.tsx to display all the linked domains for 
- Modify IDP link/edit modal
- Modified organisation authenticator so that we start by resolving the domain first, checking if an IDP is associated. It's still possible de configured an IDP for ANY domains, I didn't change that part for conveniency 

## Demo
https://github.com/user-attachments/assets/ee5f7b60-f87c-442e-8c19-7686b3d4f863

## Testing
Manual tests :
Adding some domains
Adding a couple of Identity Providers
Adding one IDP to several domains, list of domains is displayed 
When unlinking one IDP all domains get unlinked
Edition screen is working and it's possible to change IDP settings
Adding one domain do not affect othr domains

Some UT and UI tests have been added