### PR TITLE
Clarify in FIPS docs that it is still recommended to use Java 21

### DIFF
--- a/docs/guides/server/fips.adoc
+++ b/docs/guides/server/fips.adoc
@@ -9,6 +9,10 @@ includedOptions="">
 
 The Federal Information Processing Standard Publication 140-2, (FIPS 140-2), is a U.S. government computer security standard used to approve cryptographic modules. {project_name} supports running in FIPS 140-2 compliant mode. In this case, {project_name} will use only FIPS approved cryptography algorithms for its functionality.
 
+NOTE: {project_name} FIPS 140-2 integration is tested with OpenJDK 25, however the underlying BouncyCastle
+FIPS library is not officially validated with OpenJDK 25. Hence for FIPS 140-2 compliance, it is still recommended to use
+{project_name} on OpenJDK 21.
+
 To run in FIPS 140-2, {project_name} should run on a FIPS 140-2 enabled system. This requirement usually assumes RHEL or Fedora where FIPS was enabled during installation.
 See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/security_hardening/index#assembly_installing-the-system-in-fips-mode_security-hardening[RHEL documentation]
 for the details. When the system is in FIPS mode, it makes sure that the underlying OpenJDK is in FIPS mode as well and would use only


### PR DESCRIPTION
closes #47621

Should be merged as a follow-up of https://github.com/keycloak/keycloak/pull/47581 (ideally together with that).
