### PR TITLE
Allow organization IdPs for members linked to another broker

### DIFF
--- a/docs/documentation/server_admin/topics/organizations/managing-identity-providers.adoc
+++ b/docs/documentation/server_admin/topics/organizations/managing-identity-providers.adoc
@@ -45,6 +45,9 @@ If this identity provider should be hidden in login pages when the user is authe
 Hide on login page when organization not resolved::
 If enabled, the identity provider will be hidden on the login page when the organization cannot be resolved based on the user's email domain. Otherwise, the identity provider will be shown on the login page regardless of whether the organization is resolved or not. If 'Hide on login page' is also enabled, the identity provider will always be hidden on the login page.
 
+Show on login page for unlinked members::
+If enabled, organization members can see this identity provider on the login page even when they are already linked to another identity provider.
+
 Redirect when email domain matches::
 If members should be automatically redirected to the identity provider when their email domain matches the domain set to the identity provider. If the domain is set to `Any`, members whose email domain matches *any* of the organization domains will be redirected to the identity provider.
 

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3774,6 +3774,8 @@ eventTypes.USER_SESSION_DELETED_ERROR.name=User session deleted error
 eventTypes.USER_SESSION_DELETED_ERROR.description=User session deleted error
 hideOnLoginWhenOrgNotResolved=Hide on login page when organization not resolved
 hideOnLoginWhenOrgNotResolvedHelp=If enabled, the identity provider will be hidden on the login page when the organization cannot be resolved based on the user's email domain. Otherwise, the identity provider will be shown on the login page regardless of whether the organization is resolved or not. If 'Hide on login page' is also enabled, the identity provider will always be hidden on the login page.
+showOnLoginForUnlinkedMembers=Show on login page for unlinked members
+showOnLoginForUnlinkedMembersHelp=If enabled, this identity provider is shown to organization members even when they are already linked to another identity provider.
 theme.keycloak.v2.admin.description=Cleaner and more modern, v2 supports automatic light/dark mode switching. (Default for Admin)
 
 # Roles

--- a/js/apps/admin-ui/src/organizations/LinkIdentityProviderModal.tsx
+++ b/js/apps/admin-ui/src/organizations/LinkIdentityProviderModal.tsx
@@ -163,6 +163,14 @@ export const LinkIdentityProviderModal = ({
           />
           <DefaultSwitchControl
             name={convertAttributeNameToForm(
+              "config.kc.org.broker.login.show-when-linked-elsewhere",
+            )}
+            label={t("showOnLoginForUnlinkedMembers")}
+            labelIcon={t("showOnLoginForUnlinkedMembersHelp")}
+            stringify
+          />
+          <DefaultSwitchControl
+            name={convertAttributeNameToForm(
               "config.kc.org.broker.redirect.mode.email-matches",
             )}
             label={t("redirectWhenEmailMatches")}

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -4046,6 +4046,10 @@ packages:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -8622,6 +8626,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.2: {}
+
+  serialize-javascript@7.0.5: {}
 
   serialize-javascript@7.0.5: {}
 

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -4046,10 +4046,6 @@ packages:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
     engines: {node: '>=20.0.0'}
 
-  serialize-javascript@7.0.5:
-    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
-    engines: {node: '>=20.0.0'}
-
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -8626,8 +8622,6 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.7.2: {}
-
-  serialize-javascript@7.0.5: {}
 
   serialize-javascript@7.0.5: {}
 

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -31,6 +31,7 @@ public interface OrganizationModel {
     String ORGANIZATION_DOMAIN_ATTRIBUTE = "kc.org.domain";
     String ALIAS = "alias";
     String HIDE_IDP_ON_LOGIN_WHEN_ORGANIZATION_UNKNOWN = "kc.org.broker.login.hide-when-org-unknown";
+    String SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE = "kc.org.broker.login.show-when-linked-elsewhere";
 
     enum IdentityProviderRedirectMode {
         EMAIL_MATCH("kc.org.broker.redirect.mode.email-matches");

--- a/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
@@ -71,7 +71,7 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
 
         Set<String> allBrokerAliases = new HashSet<>(linkedBrokerAliases);
 
-        allBrokerAliases.addAll(getOrganizationBrokersAvailableToUnlinkedMembers(context.getUser()));
+        allBrokerAliases.addAll(getOrgBrokersShownWhenLinkedElsewhere(context.getUser()));
 
         return allBrokerAliases;
     }
@@ -143,7 +143,7 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
         return Booleans.isFalse(idp.isHideOnLogin());
     }
 
-    private Set<String> getOrganizationBrokersAvailableToUnlinkedMembers(UserModel user) {
+    private Set<String> getOrgBrokersShownWhenLinkedElsewhere(UserModel user) {
         OrganizationProvider provider = Organizations.getProvider(session);
 
         if (!Organizations.isEnabledAndOrganizationsPresent(provider)) {
@@ -153,12 +153,12 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
         return provider.getByMember(user)
                 .filter(OrganizationModel::isEnabled)
                 .flatMap(OrganizationModel::getIdentityProviders)
-                .filter(this::isAvailableToUnlinkedMembers)
+                .filter(this::isShownWhenLinkedElsewhere)
                 .map(IdentityProviderModel::getAlias)
                 .collect(Collectors.toSet());
     }
 
-    private boolean isAvailableToUnlinkedMembers(IdentityProviderModel idp) {
+    private boolean isShownWhenLinkedElsewhere(IdentityProviderModel idp) {
         if (idp.getOrganizationId() == null) {
             return false;
         }

--- a/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
@@ -17,14 +17,22 @@
 
 package org.keycloak.organization.forms.login.freemarker.model;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
+import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.forms.login.freemarker.model.IdentityProviderBean;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.util.Booleans;
 
@@ -51,6 +59,21 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
         this.organization = Organizations.resolveOrganization(super.session);
         this.onlyRealmBrokers = onlyRealmBrokers;
         this.onlyOrganizationBrokers = onlyOrganizationBrokers;
+    }
+
+    @Override
+    protected Set<String> getLinkedBrokerAliases(KeycloakSession session, RealmModel realm, AuthenticationFlowContext context) {
+        Set<String> linkedBrokerAliases = super.getLinkedBrokerAliases(session, realm, context);
+
+        if (linkedBrokerAliases == null || linkedBrokerAliases.isEmpty() || context == null || context.getUser() == null || onlyRealmBrokers) {
+            return linkedBrokerAliases;
+        }
+
+        Set<String> allBrokerAliases = new HashSet<>(linkedBrokerAliases);
+
+        allBrokerAliases.addAll(getOrganizationBrokersAvailableToUnlinkedMembers(context.getUser()));
+
+        return allBrokerAliases;
     }
 
     @Override
@@ -118,5 +141,40 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
             return false;
         }
         return Booleans.isFalse(idp.isHideOnLogin());
+    }
+
+    private Set<String> getOrganizationBrokersAvailableToUnlinkedMembers(UserModel user) {
+        OrganizationProvider provider = Organizations.getProvider(session);
+
+        if (!Organizations.isEnabledAndOrganizationsPresent(provider)) {
+            return Set.of();
+        }
+
+        return provider.getByMember(user)
+                .filter(OrganizationModel::isEnabled)
+                .flatMap(OrganizationModel::getIdentityProviders)
+                .filter(this::isAvailableToUnlinkedMembers)
+                .map(IdentityProviderModel::getAlias)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isAvailableToUnlinkedMembers(IdentityProviderModel idp) {
+        if (idp.getOrganizationId() == null) {
+            return false;
+        }
+
+        if (!Boolean.parseBoolean(idp.getConfig().get(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE))) {
+            return false;
+        }
+
+        if (organization != null && !Objects.equals(organization.getId(), idp.getOrganizationId())) {
+            return false;
+        }
+
+        if (organization == null && Boolean.parseBoolean(idp.getConfig().get(OrganizationModel.HIDE_IDP_ON_LOGIN_WHEN_ORGANIZATION_UNKNOWN))) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -509,6 +509,15 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
 
     @Test
     public void testShowOnlyBrokersLinkedUserInPasswordPage() {
+        assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(false);
+    }
+
+    @Test
+    public void testShowOrganizationBrokerLinkedElsewhereInPasswordPage() {
+        assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(true);
+    }
+
+    private void assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(boolean showWhenLinkedElsewhere) {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
         IdentityProviderRepresentation brokerRep = broker.toRepresentation();
@@ -520,6 +529,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         secondIdp.setInternalId(null);
         secondIdp.setHideOnLogin(false);
         secondIdp.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
+        secondIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.toString(showWhenLinkedElsewhere));
         testRealm().identityProviders().create(secondIdp).close();
         getCleanup().addCleanup(testRealm().identityProviders().get("second-idp")::remove);
         organization.identityProviders().addIdentityProvider(secondIdp.getAlias()).close();
@@ -553,8 +563,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         Assert.assertFalse(loginPage.isUsernameInputPresent());
         Assert.assertTrue(loginPage.isPasswordInputPresent());
         Assert.assertTrue(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
-        // second-idp not shown because user is linked to another broker
-        Assert.assertFalse(loginPage.isSocialButtonPresent(secondIdp.getAlias()));
+        Assert.assertEquals(showWhenLinkedElsewhere, loginPage.isSocialButtonPresent(secondIdp.getAlias()));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -517,61 +517,6 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(true);
     }
 
-    @Test
-    public void testShowFlaggedBrokersFromAllMemberOrganizationsWhenOrganizationNotResolved() {
-        OrganizationResource orgA = testRealm().organizations().get(createOrganization("org-a").getId());
-        OrganizationResource orgB = testRealm().organizations().get(createOrganization("org-b").getId());
-
-        IdentityProviderRepresentation orgABroker = orgA.identityProviders().getIdentityProviders().get(0);
-        orgABroker.setHideOnLogin(false);
-        orgABroker.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
-        orgABroker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
-        testRealm().identityProviders().get(orgABroker.getAlias()).update(orgABroker);
-
-        IdentityProviderRepresentation orgBBroker = orgB.identityProviders().getIdentityProviders().get(0);
-        orgBBroker.setHideOnLogin(false);
-        orgBBroker.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
-        orgBBroker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
-        testRealm().identityProviders().get(orgBBroker.getAlias()).update(orgBBroker);
-
-        String username = "user-" + KeycloakModelUtils.generateId();
-        String email = username + "@user.org";
-        UserRepresentation account = UserBuilder.create()
-                .username(username)
-                .email(email)
-                .password("updated-password")
-                .enabled(true)
-                .build();
-        try (Response response = testRealm().users().create(account)) {
-            account.setId(ApiUtil.getCreatedId(response));
-        }
-        UserRepresentation finalAccount = account;
-        getCleanup().addCleanup(() -> testRealm().users().get(finalAccount.getId()).remove());
-
-        FederatedIdentityRepresentation identity = new FederatedIdentityRepresentation();
-        identity.setIdentityProvider(orgABroker.getAlias());
-        identity.setUserId(KeycloakModelUtils.generateId());
-        identity.setUserName(username);
-        try (Response response = testRealm().users().get(account.getId()).addFederatedIdentity(orgABroker.getAlias(), identity)) {
-            assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
-        }
-
-        orgA.members().addMember(account.getId()).close();
-        orgB.members().addMember(account.getId()).close();
-
-        // logout to force the user to authenticate again
-        realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
-        realmsResouce().realm(bc.providerRealmName()).logoutAll();
-
-        oauth.clientId("broker-app");
-        loginPage.open(bc.consumerRealmName());
-        loginPage.loginUsername(username);
-        Assert.assertFalse(loginPage.isUsernameInputPresent());
-        Assert.assertTrue(loginPage.isPasswordInputPresent());
-        Assert.assertTrue(loginPage.isSocialButtonPresent(orgABroker.getAlias()));
-        Assert.assertTrue(loginPage.isSocialButtonPresent(orgBBroker.getAlias()));
-    }
-
     private void assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(boolean showWhenLinkedElsewhere) {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
@@ -622,84 +567,59 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
     }
 
     @Test
-    public void testHideWhenOrgNotResolvedTakesPrecedenceOverShowWhenLinkedElsewhere() {
-        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
-        OrganizationResource secondOrganization = testRealm().organizations().get(createOrganization("org-2").getId());
-        OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
-        IdentityProviderRepresentation brokerRep = broker.toRepresentation();
-        brokerRep.setHideOnLogin(false);
-        brokerRep.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
-        testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
-
-        IdentityProviderRepresentation secondOrgBrokerRep = secondOrganization.identityProviders().getIdentityProviders().get(0);
-        secondOrgBrokerRep.setHideOnLogin(false);
-        secondOrgBrokerRep.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
-        testRealm().identityProviders().get(secondOrgBrokerRep.getAlias()).update(secondOrgBrokerRep);
-
-        String secondAlias = "second-idp-" + KeycloakModelUtils.generateId();
-        IdentityProviderRepresentation secondIdp = bc.setUpIdentityProvider();
-        secondIdp.setAlias(secondAlias);
-        secondIdp.setInternalId(null);
-        secondIdp.setHideOnLogin(false);
-        secondIdp.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
-        secondIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
-        secondIdp.getConfig().put(OrganizationModel.HIDE_IDP_ON_LOGIN_WHEN_ORGANIZATION_UNKNOWN, Boolean.TRUE.toString());
-        testRealm().identityProviders().create(secondIdp).close();
-        getCleanup().addCleanup(testRealm().identityProviders().get(secondAlias)::remove);
-        organization.identityProviders().addIdentityProvider(secondAlias).close();
-
+    public void testShowWhenLinkedElsewhereEdgeCases() {
+        OrganizationResource orgA = testRealm().organizations().get(createOrganization("org-a").getId());
+        OrganizationResource orgB = testRealm().organizations().get(createOrganization("org-b").getId());
+        IdentityProviderRepresentation orgABroker = orgA.identityProviders().getIdentityProviders().get(0);
+        orgABroker.setHideOnLogin(false);
+        orgABroker.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        orgABroker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(orgABroker.getAlias()).update(orgABroker);
+        IdentityProviderRepresentation orgBBroker = orgB.identityProviders().getIdentityProviders().get(0);
+        orgBBroker.setHideOnLogin(false);
+        orgBBroker.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        orgBBroker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(orgBBroker.getAlias()).update(orgBBroker);
+        String hideUnknownAlias = "hide-unknown-idp-" + KeycloakModelUtils.generateId();
+        IdentityProviderRepresentation hideUnknownIdp = bc.setUpIdentityProvider();
+        hideUnknownIdp.setAlias(hideUnknownAlias);
+        hideUnknownIdp.setInternalId(null);
+        hideUnknownIdp.setHideOnLogin(false);
+        hideUnknownIdp.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
+        hideUnknownIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        hideUnknownIdp.getConfig().put(OrganizationModel.HIDE_IDP_ON_LOGIN_WHEN_ORGANIZATION_UNKNOWN, Boolean.TRUE.toString());
+        testRealm().identityProviders().create(hideUnknownIdp).close();
+        getCleanup().addCleanup(testRealm().identityProviders().get(hideUnknownAlias)::remove);
+        orgA.identityProviders().addIdentityProvider(hideUnknownAlias).close();
         String username = "user-" + KeycloakModelUtils.generateId();
-        String email = username + "@user.org";
-        UserRepresentation account = UserBuilder.create()
-                .username(username)
-                .email(email)
-                .password("updated-password")
-                .enabled(true)
-                .build();
+        String unresolvedEmail = username + "@user.org";
+        UserRepresentation account = UserBuilder.create().username(username).email(unresolvedEmail).password("updated-password").enabled(true).build();
         try (Response response = testRealm().users().create(account)) {
             account.setId(ApiUtil.getCreatedId(response));
         }
         UserRepresentation finalAccount = account;
         getCleanup().addCleanup(() -> testRealm().users().get(finalAccount.getId()).remove());
-
         FederatedIdentityRepresentation identity = new FederatedIdentityRepresentation();
-        identity.setIdentityProvider(brokerRep.getAlias());
+        identity.setIdentityProvider(orgABroker.getAlias());
         identity.setUserId(KeycloakModelUtils.generateId());
         identity.setUserName(username);
-        try (Response response = testRealm().users().get(account.getId()).addFederatedIdentity(brokerRep.getAlias(), identity)) {
+        try (Response response = testRealm().users().get(account.getId()).addFederatedIdentity(orgABroker.getAlias(), identity)) {
             assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
         }
-
-        organization.members().addMember(account.getId()).close();
-        secondOrganization.members().addMember(account.getId()).close();
-
-        // logout to force the user to authenticate again
+        orgA.members().addMember(account.getId()).close();
+        orgB.members().addMember(account.getId()).close();
         realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
         realmsResouce().realm(bc.providerRealmName()).logoutAll();
-
         oauth.clientId("broker-app");
         loginPage.open(bc.consumerRealmName());
         loginPage.loginUsername(username);
-        Assert.assertFalse(loginPage.isSocialButtonPresent(secondAlias));
-
-        String orgResolvedEmail = username + "@neworg.org";
+        Assert.assertTrue(loginPage.isSocialButtonPresent(orgABroker.getAlias()));
+        Assert.assertTrue(loginPage.isSocialButtonPresent(orgBBroker.getAlias()));
+        Assert.assertFalse(loginPage.isSocialButtonPresent(hideUnknownAlias));
+        String resolvedEmail = username + "@org-a.org";
         UserRepresentation updatedAccount = testRealm().users().get(account.getId()).toRepresentation();
-        updatedAccount.setEmail(orgResolvedEmail);
+        updatedAccount.setEmail(resolvedEmail);
         testRealm().users().get(account.getId()).update(updatedAccount);
-
-        loginPage.open(bc.consumerRealmName());
-        loginPage.loginUsername(orgResolvedEmail);
-        Assert.assertTrue(loginPage.isSocialButtonPresent(secondAlias));
-    }
-
-    @Test
-    public void testDoNotShowDisabledOrLinkOnlyBrokersWhenShowWhenLinkedElsewhereEnabled() {
-        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
-        OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
-        IdentityProviderRepresentation brokerRep = broker.toRepresentation();
-        brokerRep.setHideOnLogin(false);
-        testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
-
         String disabledAlias = "disabled-idp-" + KeycloakModelUtils.generateId();
         IdentityProviderRepresentation disabledIdp = bc.setUpIdentityProvider();
         disabledIdp.setAlias(disabledAlias);
@@ -710,8 +630,7 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         disabledIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
         testRealm().identityProviders().create(disabledIdp).close();
         getCleanup().addCleanup(testRealm().identityProviders().get(disabledAlias)::remove);
-        organization.identityProviders().addIdentityProvider(disabledAlias).close();
-
+        orgA.identityProviders().addIdentityProvider(disabledAlias).close();
         String linkOnlyAlias = "link-only-idp-" + KeycloakModelUtils.generateId();
         IdentityProviderRepresentation linkOnlyIdp = bc.setUpIdentityProvider();
         linkOnlyIdp.setAlias(linkOnlyAlias);
@@ -722,22 +641,10 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         linkOnlyIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
         testRealm().identityProviders().create(linkOnlyIdp).close();
         getCleanup().addCleanup(testRealm().identityProviders().get(linkOnlyAlias)::remove);
-        organization.identityProviders().addIdentityProvider(linkOnlyAlias).close();
-
-        assertBrokerRegistration(organization, bc.getUserLogin(), bc.getUserEmail());
-        UserRepresentation account = getUserRepresentation(bc.getUserEmail());
-        ApiUtil.resetUserPassword(realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()), "updated-password", false);
-        brokerRep.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
-        testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
-
-        // logout to force the user to authenticate again
-        realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
-        realmsResouce().realm(bc.providerRealmName()).logoutAll();
-
-        oauth.clientId("broker-app");
+        orgA.identityProviders().addIdentityProvider(linkOnlyAlias).close();
         loginPage.open(bc.consumerRealmName());
-        loginPage.loginUsername(bc.getUserEmail());
-        Assert.assertTrue(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
+        loginPage.loginUsername(resolvedEmail);
+        Assert.assertTrue(loginPage.isSocialButtonPresent(hideUnknownAlias));
         Assert.assertFalse(loginPage.isSocialButtonPresent(disabledAlias));
         Assert.assertFalse(loginPage.isSocialButtonPresent(linkOnlyAlias));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/broker/AbstractBrokerSelfRegistrationTest.java
@@ -517,6 +517,61 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(true);
     }
 
+    @Test
+    public void testShowFlaggedBrokersFromAllMemberOrganizationsWhenOrganizationNotResolved() {
+        OrganizationResource orgA = testRealm().organizations().get(createOrganization("org-a").getId());
+        OrganizationResource orgB = testRealm().organizations().get(createOrganization("org-b").getId());
+
+        IdentityProviderRepresentation orgABroker = orgA.identityProviders().getIdentityProviders().get(0);
+        orgABroker.setHideOnLogin(false);
+        orgABroker.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        orgABroker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(orgABroker.getAlias()).update(orgABroker);
+
+        IdentityProviderRepresentation orgBBroker = orgB.identityProviders().getIdentityProviders().get(0);
+        orgBBroker.setHideOnLogin(false);
+        orgBBroker.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        orgBBroker.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(orgBBroker.getAlias()).update(orgBBroker);
+
+        String username = "user-" + KeycloakModelUtils.generateId();
+        String email = username + "@user.org";
+        UserRepresentation account = UserBuilder.create()
+                .username(username)
+                .email(email)
+                .password("updated-password")
+                .enabled(true)
+                .build();
+        try (Response response = testRealm().users().create(account)) {
+            account.setId(ApiUtil.getCreatedId(response));
+        }
+        UserRepresentation finalAccount = account;
+        getCleanup().addCleanup(() -> testRealm().users().get(finalAccount.getId()).remove());
+
+        FederatedIdentityRepresentation identity = new FederatedIdentityRepresentation();
+        identity.setIdentityProvider(orgABroker.getAlias());
+        identity.setUserId(KeycloakModelUtils.generateId());
+        identity.setUserName(username);
+        try (Response response = testRealm().users().get(account.getId()).addFederatedIdentity(orgABroker.getAlias(), identity)) {
+            assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        }
+
+        orgA.members().addMember(account.getId()).close();
+        orgB.members().addMember(account.getId()).close();
+
+        // logout to force the user to authenticate again
+        realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
+        realmsResouce().realm(bc.providerRealmName()).logoutAll();
+
+        oauth.clientId("broker-app");
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(username);
+        Assert.assertFalse(loginPage.isUsernameInputPresent());
+        Assert.assertTrue(loginPage.isPasswordInputPresent());
+        Assert.assertTrue(loginPage.isSocialButtonPresent(orgABroker.getAlias()));
+        Assert.assertTrue(loginPage.isSocialButtonPresent(orgBBroker.getAlias()));
+    }
+
     private void assertOrganizationBrokerVisibilityWhenUserIsLinkedElsewhere(boolean showWhenLinkedElsewhere) {
         OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
         OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
@@ -564,6 +619,127 @@ public abstract class AbstractBrokerSelfRegistrationTest extends AbstractOrganiz
         Assert.assertTrue(loginPage.isPasswordInputPresent());
         Assert.assertTrue(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
         Assert.assertEquals(showWhenLinkedElsewhere, loginPage.isSocialButtonPresent(secondIdp.getAlias()));
+    }
+
+    @Test
+    public void testHideWhenOrgNotResolvedTakesPrecedenceOverShowWhenLinkedElsewhere() {
+        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        OrganizationResource secondOrganization = testRealm().organizations().get(createOrganization("org-2").getId());
+        OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
+        IdentityProviderRepresentation brokerRep = broker.toRepresentation();
+        brokerRep.setHideOnLogin(false);
+        brokerRep.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
+
+        IdentityProviderRepresentation secondOrgBrokerRep = secondOrganization.identityProviders().getIdentityProviders().get(0);
+        secondOrgBrokerRep.setHideOnLogin(false);
+        secondOrgBrokerRep.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(secondOrgBrokerRep.getAlias()).update(secondOrgBrokerRep);
+
+        String secondAlias = "second-idp-" + KeycloakModelUtils.generateId();
+        IdentityProviderRepresentation secondIdp = bc.setUpIdentityProvider();
+        secondIdp.setAlias(secondAlias);
+        secondIdp.setInternalId(null);
+        secondIdp.setHideOnLogin(false);
+        secondIdp.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
+        secondIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        secondIdp.getConfig().put(OrganizationModel.HIDE_IDP_ON_LOGIN_WHEN_ORGANIZATION_UNKNOWN, Boolean.TRUE.toString());
+        testRealm().identityProviders().create(secondIdp).close();
+        getCleanup().addCleanup(testRealm().identityProviders().get(secondAlias)::remove);
+        organization.identityProviders().addIdentityProvider(secondAlias).close();
+
+        String username = "user-" + KeycloakModelUtils.generateId();
+        String email = username + "@user.org";
+        UserRepresentation account = UserBuilder.create()
+                .username(username)
+                .email(email)
+                .password("updated-password")
+                .enabled(true)
+                .build();
+        try (Response response = testRealm().users().create(account)) {
+            account.setId(ApiUtil.getCreatedId(response));
+        }
+        UserRepresentation finalAccount = account;
+        getCleanup().addCleanup(() -> testRealm().users().get(finalAccount.getId()).remove());
+
+        FederatedIdentityRepresentation identity = new FederatedIdentityRepresentation();
+        identity.setIdentityProvider(brokerRep.getAlias());
+        identity.setUserId(KeycloakModelUtils.generateId());
+        identity.setUserName(username);
+        try (Response response = testRealm().users().get(account.getId()).addFederatedIdentity(brokerRep.getAlias(), identity)) {
+            assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        }
+
+        organization.members().addMember(account.getId()).close();
+        secondOrganization.members().addMember(account.getId()).close();
+
+        // logout to force the user to authenticate again
+        realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
+        realmsResouce().realm(bc.providerRealmName()).logoutAll();
+
+        oauth.clientId("broker-app");
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(username);
+        Assert.assertFalse(loginPage.isSocialButtonPresent(secondAlias));
+
+        String orgResolvedEmail = username + "@neworg.org";
+        UserRepresentation updatedAccount = testRealm().users().get(account.getId()).toRepresentation();
+        updatedAccount.setEmail(orgResolvedEmail);
+        testRealm().users().get(account.getId()).update(updatedAccount);
+
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(orgResolvedEmail);
+        Assert.assertTrue(loginPage.isSocialButtonPresent(secondAlias));
+    }
+
+    @Test
+    public void testDoNotShowDisabledOrLinkOnlyBrokersWhenShowWhenLinkedElsewhereEnabled() {
+        OrganizationResource organization = testRealm().organizations().get(createOrganization().getId());
+        OrganizationIdentityProviderResource broker = organization.identityProviders().get(bc.getIDPAlias());
+        IdentityProviderRepresentation brokerRep = broker.toRepresentation();
+        brokerRep.setHideOnLogin(false);
+        testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
+
+        String disabledAlias = "disabled-idp-" + KeycloakModelUtils.generateId();
+        IdentityProviderRepresentation disabledIdp = bc.setUpIdentityProvider();
+        disabledIdp.setAlias(disabledAlias);
+        disabledIdp.setInternalId(null);
+        disabledIdp.setEnabled(false);
+        disabledIdp.setHideOnLogin(false);
+        disabledIdp.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
+        disabledIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        testRealm().identityProviders().create(disabledIdp).close();
+        getCleanup().addCleanup(testRealm().identityProviders().get(disabledAlias)::remove);
+        organization.identityProviders().addIdentityProvider(disabledAlias).close();
+
+        String linkOnlyAlias = "link-only-idp-" + KeycloakModelUtils.generateId();
+        IdentityProviderRepresentation linkOnlyIdp = bc.setUpIdentityProvider();
+        linkOnlyIdp.setAlias(linkOnlyAlias);
+        linkOnlyIdp.setInternalId(null);
+        linkOnlyIdp.setLinkOnly(true);
+        linkOnlyIdp.setHideOnLogin(false);
+        linkOnlyIdp.getConfig().remove(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE);
+        linkOnlyIdp.getConfig().put(OrganizationModel.SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE, Boolean.TRUE.toString());
+        testRealm().identityProviders().create(linkOnlyIdp).close();
+        getCleanup().addCleanup(testRealm().identityProviders().get(linkOnlyAlias)::remove);
+        organization.identityProviders().addIdentityProvider(linkOnlyAlias).close();
+
+        assertBrokerRegistration(organization, bc.getUserLogin(), bc.getUserEmail());
+        UserRepresentation account = getUserRepresentation(bc.getUserEmail());
+        ApiUtil.resetUserPassword(realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()), "updated-password", false);
+        brokerRep.getConfig().put(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.FALSE.toString());
+        testRealm().identityProviders().get(brokerRep.getAlias()).update(brokerRep);
+
+        // logout to force the user to authenticate again
+        realmsResouce().realm(bc.consumerRealmName()).users().get(account.getId()).logout();
+        realmsResouce().realm(bc.providerRealmName()).logoutAll();
+
+        oauth.clientId("broker-app");
+        loginPage.open(bc.consumerRealmName());
+        loginPage.loginUsername(bc.getUserEmail());
+        Assert.assertTrue(loginPage.isSocialButtonPresent(bc.getIDPAlias()));
+        Assert.assertFalse(loginPage.isSocialButtonPresent(disabledAlias));
+        Assert.assertFalse(loginPage.isSocialButtonPresent(linkOnlyAlias));
     }
 
     @Test


### PR DESCRIPTION
Resolves #47431

## Summary
- add a new organization broker config flag `kc.org.broker.login.show-when-linked-elsewhere`
- when enabled, organization members can see that organization IdP on the login page even if they are already linked to a different IdP
- keep current default behavior unchanged when the new flag is not enabled
- expose the flag in the Admin UI and document it in the server admin guide

## Test Added
A focused integration test (`OrganizationOIDCBrokerSelfRegistrationTest#testShowOrganizationBrokerLinkedElsewhereInPasswordPage`) was added to verify the organization IdP is shown for members linked to a different broker when the new switch is enabled.
