### PR TITLE
Stabilize EmbeddedInfinispanSplitBrainTest

### DIFF
--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/EmbeddedInfinispanSplitBrainTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/EmbeddedInfinispanSplitBrainTest.java
@@ -1,6 +1,5 @@
 package org.keycloak.testsuite.model.infinispan;
 
-import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -20,8 +19,6 @@ import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.WORK_CACHE_NAME;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -64,7 +61,7 @@ public class EmbeddedInfinispanSplitBrainTest extends KeycloakModelTest {
    @Test
    public void testLocalCacheClearedOnMergeEvent() throws InterruptedException {
       var numFactories = 2;
-      var partitionManager = new PartitionManager(numFactories, Set.of(WORK_CACHE_NAME));
+      var partitionManager = new PartitionManager(numFactories);
       var factoryIndex = new AtomicInteger(0);
       var barrier = new CyclicBarrier(numFactories);
       closeKeycloakSessionFactory();

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/PartitionManager.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/infinispan/PartitionManager.java
@@ -3,12 +3,9 @@ package org.keycloak.testsuite.model.infinispan;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.infinispan.Cache;
 import org.infinispan.configuration.global.TransportConfiguration;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.test.TestingUtil;
@@ -22,243 +19,238 @@ import org.jgroups.protocols.Discovery;
 import org.jgroups.protocols.TP;
 import org.jgroups.protocols.pbcast.GMS;
 import org.jgroups.protocols.pbcast.STABLE;
-import org.jgroups.stack.Protocol;
 import org.jgroups.stack.ProtocolStack;
 import org.jgroups.util.MutableDigest;
+import org.junit.Assert;
+
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.ACTION_TOKEN_CACHE;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHENTICATION_SESSIONS_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOGIN_FAILURE_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.WORK_CACHE_NAME;
 
 import static org.infinispan.test.TestingUtil.blockUntilViewsReceived;
 import static org.infinispan.test.TestingUtil.waitForNoRebalance;
 
 public class PartitionManager {
 
-   private static final Logger log = Logger.getLogger(PartitionManager.class);
+    private static final Logger log = Logger.getLogger(PartitionManager.class);
 
-   final int numberOfCacheManagers;
-   final Set<String> cacheNames;
-   final EmbeddedCacheManager[] cacheManagers;
-   final AtomicInteger viewId;
-   volatile Partition[] partitions;
+    final EmbeddedCacheManager[] cacheManagers;
+    final AtomicInteger viewId;
+    volatile Partition[] partitions;
 
-   public PartitionManager(int numberOfCacheManagers, Set<String> cacheNames) {
-      this.numberOfCacheManagers = numberOfCacheManagers;
-      this.cacheNames = cacheNames;
-      this.cacheManagers = new EmbeddedCacheManager[2];
-      this.viewId = new AtomicInteger(5);
-   }
+    public PartitionManager(int numberOfCacheManagers) {
+        this.cacheManagers = new EmbeddedCacheManager[numberOfCacheManagers];
+        this.viewId = new AtomicInteger(5);
+    }
 
-   public void addManager(int index, EmbeddedCacheManager cacheManager) {
-      this.cacheManagers[index] = cacheManager;
-   }
+    public void addManager(int index, EmbeddedCacheManager cacheManager) {
+        this.cacheManagers[index] = cacheManager;
+    }
 
-   public void splitCluster(int[]... parts) {
-      List<Address> allMembers = channel(0).getView().getMembers();
-      partitions = new Partition[parts.length];
-      for (int i = 0; i < parts.length; i++) {
-         Partition p = new Partition(viewId, allMembers, getCaches());
-         for (int j : parts[i]) {
-            p.addNode(channel(j));
-         }
-         partitions[i] = p;
-         p.discardOtherMembers();
-      }
-      // Only install the new views after installing DISCARD
-      // Otherwise broadcasts from the first partition would be visible in the other partitions
-      for (Partition p : partitions) {
-         p.partition();
-      }
-   }
-
-   public void merge(int p1, int p2) {
-      var partition = partitions[p1];
-      partition.merge(partitions[p2]);
-      List<Partition> tmp = new ArrayList<>(Arrays.asList(this.partitions));
-      if (!tmp.remove(partition)) throw new AssertionError();
-      this.partitions = tmp.toArray(new Partition[0]);
-   }
-
-   private List<Cache<?, ?>> getCaches() {
-      return cacheNames.stream()
-            .flatMap(
-                  name -> Arrays.stream(cacheManagers).map(m -> m.getCache(name))
-            )
-            .collect(Collectors.toList());
-   }
-
-   private JChannel channel(int index) {
-      return TestingUtil.extractJChannel(cacheManagers[index]);
-   }
-
-   private static class Partition {
-      final AtomicInteger viewId;
-      final List<Address> allMembers;
-      final List<Cache<?, ?>> caches;
-      final List<JChannel> channels = new ArrayList<>();
-
-      public Partition(AtomicInteger viewId, List<Address> allMembers, List<Cache<?, ?>> caches) {
-         this.viewId = viewId;
-         this.allMembers = allMembers;
-         this.caches = caches;
-      }
-
-      public void addNode(JChannel c) {
-         channels.add(c);
-      }
-
-      public void partition() {
-         log.info("Partition forming");
-         disableDiscovery();
-         installNewView();
-         assertPartitionFormed();
-         log.info("New views installed");
-      }
-
-      private void disableDiscovery() {
-         channels.forEach(c ->
-               ((Discovery) c.getProtocolStack().findProtocol(Discovery.class)).setClusterName(c.getAddressAsString())
-         );
-      }
-
-      private void assertPartitionFormed() {
-         final List<Address> viewMembers = new ArrayList<>();
-         for (JChannel ac : channels) viewMembers.add(ac.getAddress());
-         for (JChannel c : channels) {
-            List<Address> members = c.getView().getMembers();
-            if (!members.equals(viewMembers)) throw new AssertionError();
-         }
-      }
-
-      private List<Address> installNewView() {
-         final List<Address> viewMembers = new ArrayList<>();
-         for (JChannel c : channels) viewMembers.add(c.getAddress());
-         View view = View.create(channels.get(0).getAddress(), viewId.incrementAndGet(),
-               viewMembers.toArray(new Address[0]));
-
-         log.trace("Before installing new view...");
-         for (JChannel c : channels) {
-            getGms(c).installView(view);
-         }
-         return viewMembers;
-      }
-
-      private List<Address> installMergeView(ArrayList<JChannel> view1, ArrayList<JChannel> view2) {
-         List<Address> allAddresses =
-               Stream.concat(view1.stream(), view2.stream()).map(JChannel::getAddress).distinct()
-                     .collect(Collectors.toList());
-
-         View v1 = toView(view1);
-         View v2 = toView(view2);
-         List<View> allViews = new ArrayList<>();
-         allViews.add(v1);
-         allViews.add(v2);
-
-         // Remove all sent NAKACK2 messages to reproduce ISPN-9291
-         for (JChannel c : channels) {
-            STABLE stable = c.getProtocolStack().findProtocol(STABLE.class);
-            stable.gc();
-         }
-         try {
-            Thread.sleep(10);
-         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("Interrupted.");
-            return allMembers;
-         }
-
-         MergeView mv = new MergeView(view1.get(0).getAddress(), viewId.incrementAndGet(), allAddresses, allViews);
-         // Compute the merge digest, without it nodes would request the retransmission of all messages
-         // Including those that were removed by STABLE earlier
-         MutableDigest digest = new MutableDigest(allAddresses.toArray(new Address[0]));
-         for (JChannel c : channels) {
-            digest.merge(getGms(c).getDigest());
-         }
-
-         for (JChannel c : channels) {
-            getGms(c).installView(mv, digest);
-         }
-         return allMembers;
-      }
-
-      private View toView(ArrayList<JChannel> channels) {
-         final List<Address> viewMembers = new ArrayList<>();
-         for (JChannel c : channels) viewMembers.add(c.getAddress());
-         return View.create(channels.get(0).getAddress(), viewId.incrementAndGet(),
-               viewMembers.toArray(new Address[0]));
-      }
-
-      private void discardOtherMembers() {
-         List<Address> outsideMembers = new ArrayList<>();
-         for (Address a : allMembers) {
-            boolean inThisPartition = false;
-            for (JChannel c : channels) {
-               if (c.getAddress().equals(a)) inThisPartition = true;
+    public void splitCluster(int[]... parts) {
+        partitions = new Partition[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            Partition p = new Partition();
+            for (int j : parts[i]) {
+                p.addNode(cacheManagers[j]);
             }
-            if (!inThisPartition) outsideMembers.add(a);
-         }
-         for (JChannel c : channels) {
-            DISCARD discard = new DISCARD();
-            log.tracef("%s discarding messages from %s", c.getAddress(), outsideMembers);
-            for (Address a : outsideMembers) discard.addIgnoreMember(a);
+            partitions[i] = p;
+            p.discardOtherMembers();
+        }
+        // Only install the new views after installing DISCARD
+        // Otherwise broadcasts from the first partition would be visible in the other partitions
+        for (Partition p : partitions) {
+            p.partition();
+        }
+        for (var p : partitions) {
+            waitForNoRebalanceInClusteredCaches(p.cacheManagerList);
+        }
+    }
+
+    public void merge(int p1, int p2) {
+        var partition = partitions[p1];
+        partition.merge(partitions[p2]);
+        List<Partition> tmp = new ArrayList<>(Arrays.asList(this.partitions));
+        if (!tmp.remove(partition)) throw new AssertionError();
+        this.partitions = tmp.toArray(new Partition[0]);
+    }
+
+    private static Address addressOf(EmbeddedCacheManager cm) {
+        return TestingUtil.extractJChannel(cm).getAddress();
+    }
+
+    private static GMS gmsProtocolOf(EmbeddedCacheManager cm) {
+        return TestingUtil.extractJChannel(cm).getProtocolStack().findProtocol(GMS.class);
+    }
+
+    private static STABLE stableProtocolOf(EmbeddedCacheManager cm) {
+        return TestingUtil.extractJChannel(cm).getProtocolStack().findProtocol(STABLE.class);
+    }
+
+    private static void waitForNoRebalanceInClusteredCaches(List<EmbeddedCacheManager> cacheManagers) {
+        for (var cacheName : List.of(WORK_CACHE_NAME, AUTHENTICATION_SESSIONS_CACHE_NAME, ACTION_TOKEN_CACHE, LOGIN_FAILURE_CACHE_NAME)) {
+            var caches = cacheManagers.stream()
+                    .map(cm -> cm.getCache(cacheName))
+                    .toList();
+            blockUntilViewsReceived(10000, caches);
+            waitForNoRebalance(caches);
+        }
+    }
+
+    private class Partition {
+        final List<EmbeddedCacheManager> cacheManagerList = new ArrayList<>();
+
+        public void addNode(EmbeddedCacheManager c) {
+            cacheManagerList.add(c);
+        }
+
+        public void partition() {
+            log.info("Partition forming");
+            disableDiscovery();
+            installNewView();
+            assertPartitionFormed();
+            log.info("New views installed");
+        }
+
+        private void disableDiscovery() {
+            getPartitionChannels().forEach(c ->
+                    c.getProtocolStack().<Discovery>findProtocol(Discovery.class).setClusterName(c.getAddressAsString())
+            );
+        }
+
+        private void assertPartitionFormed() {
+            var viewMembers = getPartitionAddresses();
+            getPartitionChannels().forEach(c -> {
+                var members = c.getView().getMembers();
+                Assert.assertEquals(members, viewMembers);
+            });
+        }
+
+        private void installNewView() {
+            var viewMembers = getPartitionAddresses();
+            var view = View.create(addressOf(cacheManagerList.get(0)), viewId.incrementAndGet(),
+                    viewMembers.toArray(new Address[0]));
+
+            log.info("Before installing new view...");
+            cacheManagerList.stream()
+                    .map(PartitionManager::gmsProtocolOf)
+                    .forEach(p -> p.installView(view));
+        }
+
+        private void installMergeView(List<JChannel> view1, List<JChannel> view2) {
+            var allAddresses = Stream.concat(view1.stream(), view2.stream())
+                    .map(JChannel::getAddress)
+                    .distinct()
+                    .toList();
+
+            View v1 = toView(view1);
+            View v2 = toView(view2);
+            List<View> allViews = new ArrayList<>();
+            allViews.add(v1);
+            allViews.add(v2);
+
+            // Remove all sent NAKACK2 messages to reproduce ISPN-9291
+            cacheManagerList.stream()
+                    .map(PartitionManager::stableProtocolOf)
+                    .forEach(STABLE::gc);
             try {
-               c.getProtocolStack().insertProtocol(discard, ProtocolStack.Position.ABOVE, TP.class);
-            } catch (Exception e) {
-               throw new RuntimeException(e);
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Interrupted.");
+                return;
             }
-         }
-      }
 
-      private GMS getGms(JChannel c) {
-         return c.getProtocolStack().findProtocol(GMS.class);
-      }
+            MergeView mv = new MergeView(view1.get(0).getAddress(), viewId.incrementAndGet(), allAddresses, allViews);
+            // Compute the merge digest, without it nodes would request the retransmission of all messages
+            // Including those that were removed by STABLE earlier
+            MutableDigest digest = new MutableDigest(allAddresses.toArray(new Address[0]));
+            var gmsList = cacheManagerList.stream()
+                    .map(PartitionManager::gmsProtocolOf)
+                    .toList();
+            gmsList.stream()
+                    .map(GMS::getDigest)
+                    .forEach(digest::merge);
+            gmsList.forEach(gms -> gms.installView(mv, digest));
+        }
 
-      public void merge(Partition partition) {
-         log.infof("Merging partition. %s and %s", this, partition);
-         observeMembers(partition);
-         partition.observeMembers(this);
-         ArrayList<JChannel> view1 = new ArrayList<>(channels);
-         ArrayList<JChannel> view2 = new ArrayList<>(partition.channels);
-         partition.channels.stream().filter(c -> !channels.contains(c)).forEach(channels::add);
-         installMergeView(view1, view2);
-         enableDiscovery();
-         waitForPartitionToForm();
-      }
+        private View toView(List<JChannel> channels) {
+            final List<Address> viewMembers = new ArrayList<>();
+            for (JChannel c : channels) viewMembers.add(c.getAddress());
+            return View.create(channels.get(0).getAddress(), viewId.incrementAndGet(),
+                    viewMembers.toArray(new Address[0]));
+        }
 
-      private void waitForPartitionToForm() {
-         var caches = new ArrayList<>(this.caches);
-         caches.removeIf(c -> !channels.contains(TestingUtil.extractJChannel(c.getCacheManager())));
-         blockUntilViewsReceived(10000, caches);
-         waitForNoRebalance(caches);
-      }
-
-      public void enableDiscovery() {
-         channels.forEach(c -> {
-            try {
-               String defaultClusterName = TransportConfiguration.CLUSTER_NAME.getDefaultValue();
-               ((Discovery) c.getProtocolStack().findProtocol(Discovery.class)).setClusterName(defaultClusterName);
-            } catch (Exception e) {
-               throw new RuntimeException(e);
+        private void discardOtherMembers() {
+            List<Address> outsideMembers = new ArrayList<>();
+            for (var cm : cacheManagers) {
+                var a = addressOf(cm);
+                boolean inThisPartition = false;
+                for (var otherCm : cacheManagerList) {
+                    if (addressOf(otherCm).equals(a)) inThisPartition = true;
+                }
+                if (!inThisPartition) outsideMembers.add(a);
             }
-         });
-         log.info("Discovery started.");
-      }
-
-      private void observeMembers(Partition partition) {
-         for (JChannel c : channels) {
-            List<Protocol> protocols = c.getProtocolStack().getProtocols();
-            for (Protocol p : protocols) {
-               if (p instanceof DISCARD) {
-                  for (JChannel oc : partition.channels) {
-                     ((DISCARD) p).removeIgnoredMember(oc.getAddress());
-                  }
-               }
+            for (var c : getPartitionChannels()) {
+                DISCARD discard = new DISCARD();
+                log.infof("%s discarding messages from %s", c.getAddress(), outsideMembers);
+                for (Address a : outsideMembers) discard.addIgnoreMember(a);
+                try {
+                    c.getProtocolStack().insertProtocol(discard, ProtocolStack.Position.ABOVE, TP.class);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
             }
-         }
-      }
+        }
 
-      @Override
-      public String toString() {
-         StringBuilder addresses = new StringBuilder();
-         for (JChannel c : channels) addresses.append(c.getAddress()).append(" ");
-         return "Partition{" + addresses + '}';
-      }
-   }
+        public void merge(Partition partition) {
+            log.infof("Merging partition. %s and %s", this, partition);
+            observeMembers(partition);
+            partition.observeMembers(this);
+            var view1 = getPartitionChannels();
+            var view2 = partition.getPartitionChannels();
+            partition.cacheManagerList.stream().filter(c -> !cacheManagerList.contains(c)).forEach(cacheManagerList::add);
+            installMergeView(view1, view2);
+            enableDiscovery();
+            waitForNoRebalanceInClusteredCaches(cacheManagerList);
+        }
+
+        public void enableDiscovery() {
+            getPartitionChannels().forEach(c -> {
+                try {
+                    String defaultClusterName = TransportConfiguration.CLUSTER_NAME.getDefaultValue();
+                    ((Discovery) c.getProtocolStack().findProtocol(Discovery.class)).setClusterName(defaultClusterName);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            log.info("Discovery started.");
+        }
+
+        private void observeMembers(Partition partition) {
+            for (JChannel c : getPartitionChannels()) {
+                var discard = c.getProtocolStack().<DISCARD>findProtocol(DISCARD.class);
+                partition.getPartitionAddresses().forEach(discard::removeIgnoredMember);
+            }
+        }
+
+        private List<Address> getPartitionAddresses() {
+            return getPartitionChannels().stream()
+                    .map(JChannel::getAddress)
+                    .toList();
+        }
+
+        private List<JChannel> getPartitionChannels() {
+            return cacheManagerList.stream()
+                    .map(TestingUtil::extractJChannel)
+                    .toList();
+        }
+
+
+        @Override
+        public String toString() {
+            return "Partition{" + getPartitionAddresses() +'}';
+        }
+    }
 }


### PR DESCRIPTION
Closes #46883

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

The partition and merge events happen at the same time, causing inconsistencies. I changed the `PartitionManager` to wait until the caches are stable after the split event before merging the partitions. Example in the logs
```
2026-03-28T11:47:05.2725995Z 11:47:05,207 INFO  pool-4-thread-2 [org.keycloak.testsuite.model.infinispan.PartitionManager] Partition forming
2026-03-28T11:47:05.2751634Z 11:47:05,210 INFO  pool-4-thread-2 [org.keycloak.testsuite.model.infinispan.PartitionManager] New views installed
2026-03-28T11:47:05.2765759Z 11:47:05,210 INFO  pool-4-thread-2 [org.keycloak.testsuite.model.infinispan.PartitionManager] Partition forming
2026-03-28T11:47:05.2771116Z 11:47:05,210 INFO  pool-4-thread-2 [org.keycloak.testsuite.model.infinispan.PartitionManager] New views installed
2026-03-28T11:47:05.2775363Z 11:47:05,213 WARN  non-blocking-thread-node-2-3-4 [org.infinispan.CLUSTER] [Context=authenticationSessions] ISPN000314: Lost at least half of the stable members, possible split brain causing data inconsistency. Current members are [node-2], lost members are [node-3], stable members are [node-2, node-3]
MERGING happening here! >>>>>> 2026-03-28T11:47:05.2787882Z 11:47:05,216 INFO  pool-4-thread-2 [org.keycloak.testsuite.model.infinispan.PartitionManager] Merging partition. Partition{node-3(v=16.0.8) } and Partition{node-2(v=16.0.8) } <<<<<<< MERGING happening here!
2026-03-28T11:47:05.2791673Z 11:47:05,219 FATAL non-blocking-thread-node-2-3-4 [org.infinispan.CLUSTER] [Context=sessions] ISPN000313: Lost data because of abrupt leavers [node-3]
2026-03-28T11:47:05.2797397Z 11:47:05,220 WARN  jgroups-123,ISPN,node-3(v=16.0.8) [org.jgroups.protocols.pbcast.NAKACK2] JGRP000011: node-3(v=16.0.8): dropped message from non-member node-2(v=16.0.8) (view=[node-3(v=16.0.8)|6] (1) [node-3(v=16.0.8)])
2026-03-28T11:47:05.2801126Z 11:47:05,220 WARN  jgroups-99,ISPN,node-2(v=16.0.8) [org.jgroups.protocols.pbcast.NAKACK2] JGRP000011: node-2(v=16.0.8): dropped message from non-member node-3(v=16.0.8) (view=[node-2(v=16.0.8)|7] (1) [node-2(v=16.0.8)])
2026-03-28T11:47:05.2805905Z 11:47:05,224 WARN  non-blocking-thread-node-2-3-4 [org.infinispan.CLUSTER] [Context=___protobuf_metadata] ISPN000314: Lost at least half of the stable members, possible split brain causing data inconsistency. Current members are [node-2], lost members are [node-3], stable members are [node-2, node-3]
2026-03-28T11:47:05.2847831Z 11:47:05,226 FATAL non-blocking-thread-node-2-3-4 [org.infinispan.CLUSTER] [Context=clientSessions] ISPN000313: Lost data because of abrupt leavers [node-3]
2026-03-28T11:47:05.2852382Z 11:47:05,229 WARN  non-blocking-thread-node-2-3-4 [org.infinispan.CLUSTER] [Context=work] ISPN000314: Lost at least half of the stable members, possible split brain causing data inconsistency. Current members are [node-2], lost members are [node-3], stable members are [node-2, node-3]
```