### PR TITLE
Fix NumberFormatException for empty/invalid OIDC attribute values

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -182,8 +182,7 @@ public class OIDCAttributeMapperHelper {
         }
 
         String type = mappingModel.getConfig().get(JSON_TYPE);
-        Object converted = convertToType(type, attributeValue);
-        return converted != null ? converted : attributeValue;
+        return convertToType(type, attributeValue);
     }
 
     private static <X, T> List<T> transform(List<X> attributeValue, Function<X, T> mapper) {
@@ -202,7 +201,7 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getBoolean);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "String":
                 if (attributeValue instanceof String) return attributeValue;
                 if (attributeValue instanceof List) {
@@ -215,23 +214,23 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getLong);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "int":
                 Integer intObject = getInteger(attributeValue);
                 if (intObject != null) return intObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getInteger);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "JSON":
                 JsonNode jsonNodeObject = getJsonNode(attributeValue);
                 if (jsonNodeObject != null) return jsonNodeObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getJsonNode);
                 }
-                throw new RuntimeException("cannot map type for token claim");
-            default:
                 return null;
+            default:
+                return attributeValue;
         }
     }
 
@@ -242,13 +241,25 @@ public class OIDCAttributeMapperHelper {
 
     private static Long getLong(Object attributeValue) {
         if (attributeValue instanceof Long) return (Long) attributeValue;
-        if (attributeValue instanceof String) return Long.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            try {
+                return Long.valueOf((String) attributeValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 
     private static Integer getInteger(Object attributeValue) {
         if (attributeValue instanceof Integer) return (Integer) attributeValue;
-        if (attributeValue instanceof String) return Integer.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            try {
+                return Integer.valueOf((String) attributeValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
@@ -16,16 +16,16 @@
  */
 package org.keycloak.protocol.oidc.mappers;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.utils.JsonUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
@@ -16,18 +16,116 @@
  */
 package org.keycloak.protocol.oidc.mappers;
 
+import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.utils.JsonUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  *
  * @author hmlnarik
  */
 public class OIDCAttributeMapperHelperTest {
+
+    private ProtocolMapperModel createMappingModel(String jsonType) {
+        ProtocolMapperModel mappingModel = new ProtocolMapperModel();
+        Map<String, String> config = new HashMap<>();
+        config.put(OIDCAttributeMapperHelper.JSON_TYPE, jsonType);
+        mappingModel.setConfig(config);
+        return mappingModel;
+    }
+
+    @Test
+    public void testMapAttributeValue_longType_validValue() {
+        ProtocolMapperModel model = createMappingModel("long");
+        assertEquals(123L, OIDCAttributeMapperHelper.mapAttributeValue(model, "123"));
+    }
+
+    @Test
+    public void testMapAttributeValue_longType_emptyString() {
+        ProtocolMapperModel model = createMappingModel("long");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, ""));
+    }
+
+    @Test
+    public void testMapAttributeValue_longType_invalidString() {
+        ProtocolMapperModel model = createMappingModel("long");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, "not_a_number"));
+    }
+
+    @Test
+    public void testMapAttributeValue_longType_nullValue() {
+        ProtocolMapperModel model = createMappingModel("long");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, null));
+    }
+
+    @Test
+    public void testMapAttributeValue_intType_validValue() {
+        ProtocolMapperModel model = createMappingModel("int");
+        assertEquals(42, OIDCAttributeMapperHelper.mapAttributeValue(model, "42"));
+    }
+
+    @Test
+    public void testMapAttributeValue_intType_emptyString() {
+        ProtocolMapperModel model = createMappingModel("int");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, ""));
+    }
+
+    @Test
+    public void testMapAttributeValue_intType_invalidString() {
+        ProtocolMapperModel model = createMappingModel("int");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, "abc"));
+    }
+
+    @Test
+    public void testMapAttributeValue_booleanType_validValue() {
+        ProtocolMapperModel model = createMappingModel("boolean");
+        assertEquals(true, OIDCAttributeMapperHelper.mapAttributeValue(model, "true"));
+        assertEquals(false, OIDCAttributeMapperHelper.mapAttributeValue(model, "false"));
+    }
+
+    @Test
+    public void testMapAttributeValue_booleanType_nonBooleanObject() {
+        ProtocolMapperModel model = createMappingModel("boolean");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, 123));
+    }
+
+    @Test
+    public void testMapAttributeValue_stringType_value() {
+        ProtocolMapperModel model = createMappingModel("String");
+        assertEquals("hello", OIDCAttributeMapperHelper.mapAttributeValue(model, "hello"));
+    }
+
+    @Test
+    public void testMapAttributeValue_longType_listSingleValue() {
+        ProtocolMapperModel model = createMappingModel("long");
+        // non-multivalued model takes the first element
+        assertEquals(123L, OIDCAttributeMapperHelper.mapAttributeValue(model, Arrays.asList("123", "456")));
+    }
+
+    @Test
+    public void testMapAttributeValue_longType_listMultivalued() {
+        ProtocolMapperModel model = createMappingModel("long");
+        model.getConfig().put("multivalued", "true");
+        List<Object> result = (List<Object>) OIDCAttributeMapperHelper.mapAttributeValue(model, Arrays.asList("123", "456"));
+        assertEquals(Arrays.asList(123L, 456L), result);
+    }
+
+    @Test
+    public void testMapAttributeValue_jsonType_invalidString() {
+        ProtocolMapperModel model = createMappingModel("JSON");
+        assertNull(OIDCAttributeMapperHelper.mapAttributeValue(model, "not json"));
+    }
 
     @Test
     public void testSplitClaimPath() {


### PR DESCRIPTION
## Summary

Fixes #46132

The OIDC attribute mapper throws `NumberFormatException` when converting empty or invalid string values to numeric types (e.g., `updatedAt` attribute mapped as `long` in the `profile` scope).

### Changes

- **`getLong()` / `getInteger()`**: Catch `NumberFormatException` and return `null` instead of propagating the exception for empty/invalid strings
- **`convertToType()`**: Replace `throw new RuntimeException("cannot map type for token claim")` with `return null` for all types (`boolean`, `long`, `int`, `JSON`) to ensure consistent, resilient behavior
- **`mapAttributeValue()`**: Simplify to directly return `convertToType()` result; `default` case now returns `attributeValue` to preserve unknown types

This approach follows the direction outlined by @rmartinc in [this commit](https://github.com/keycloak/keycloak/commit/fea883456efd7e27951bb8dd3a1cb14606f0c2f8) and applies the fix consistently across all type conversions.

### Tests added

- `testMapAttributeValue_longType_validValue` — valid long conversion
- `testMapAttributeValue_longType_emptyString` — empty string returns null (the reported bug)
- `testMapAttributeValue_longType_invalidString` — non-numeric string returns null
- `testMapAttributeValue_longType_nullValue` — null input returns null
- `testMapAttributeValue_intType_validValue` — valid int conversion
- `testMapAttributeValue_intType_emptyString` — empty string returns null
- `testMapAttributeValue_intType_invalidString` — non-numeric string returns null
- `testMapAttributeValue_booleanType_validValue` — valid boolean conversion
- `testMapAttributeValue_booleanType_nonBooleanObject` — unconvertible type returns null
- `testMapAttributeValue_stringType_value` — string passthrough
- `testMapAttributeValue_longType_listSingleValue` — list with single-value model
- `testMapAttributeValue_longType_listMultivalued` — list with multivalued model
- `testMapAttributeValue_jsonType_invalidString` — invalid JSON returns null