### PR TITLE
Fix low-severity npm transitive dependency vulnerabilities via pnpm overrides

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -60,7 +60,9 @@
       "minimatch@~3": "^3.1.4",
       "minimatch@~9": "^9.0.7",
       "@isaacs/brace-expansion@^5": "^5.0.1",
-      "serialize-javascript": "^7.0.3"
+      "serialize-javascript": "^7.0.3",
+      "diff@^4": "^4.0.4",
+      "diff@^7": "^8.0.3"
     }
   }
 }

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -11,6 +11,8 @@ overrides:
   minimatch@~9: ^9.0.7
   '@isaacs/brace-expansion@^5': ^5.0.1
   serialize-javascript: ^7.0.3
+  diff@^4: ^4.0.4
+  diff@^7: ^8.0.3
 
 importers:
 
@@ -2557,12 +2559,12 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
-  diff@7.0.0:
-    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
@@ -6943,9 +6945,9 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
-  diff@7.0.0: {}
+  diff@8.0.4: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -8107,7 +8109,7 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 8.0.4
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 10.5.0
@@ -9014,7 +9016,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
@@ -9034,7 +9036,7 @@ snapshots:
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1


### PR DESCRIPTION
The `diff` package has a Denial of Service vulnerability in `parsePatch` and `applyPatch` (Dependabot alerts #265, #270). It is pulled in as a transitive dependency by `ts-node` (diff@4.0.2) and `mocha` (diff@7.0.0),
neither of which have upstream releases with the fix available.

Overrides applied:
- diff@^4 → ^4.0.4 (patched version for ts-node's range)
- diff@^7 → ^8.0.3 (no 7.x patch exists; 8.0.3 is the first fixed release)

Note: These changes were created with the assistance of AI and reviewed before
submission.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
