### PR TITLE
Validate .conf extension for --config-file option

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -107,13 +107,13 @@ public final class Main {
             description = "Set the path to a configuration file. By default, configuration properties are read from the \"keycloak.conf\" file in the \"conf\" directory.",
             paramLabel = "file")
     public void setConfigFile(String path) {
-        if (Files.notExists(Path.of(path))) {
-            throw new CommandLine.ParameterException(spec.commandLine(),
-                    String.format("File specified via '%s' or '%s' option does not exist.", CONFIG_FILE_LONG_NAME, CONFIG_FILE_SHORT_NAME));
-        }
         if (!path.endsWith(".conf")) {
             throw new CommandLine.ParameterException(spec.commandLine(),
                     String.format("Configuration file specified via '%s' or '%s' must have the '.conf' extension.", CONFIG_FILE_LONG_NAME, CONFIG_FILE_SHORT_NAME));
+        }
+        if (Files.notExists(Path.of(path))) {
+            throw new CommandLine.ParameterException(spec.commandLine(),
+                    String.format("File specified via '%s' or '%s' option does not exist.", CONFIG_FILE_LONG_NAME, CONFIG_FILE_SHORT_NAME));
         }
         System.setProperty(KeycloakPropertiesConfigSource.KEYCLOAK_CONFIG_FILE_PROP, path);
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Main.java
@@ -111,6 +111,10 @@ public final class Main {
             throw new CommandLine.ParameterException(spec.commandLine(),
                     String.format("File specified via '%s' or '%s' option does not exist.", CONFIG_FILE_LONG_NAME, CONFIG_FILE_SHORT_NAME));
         }
+        if (!path.endsWith(".conf")) {
+            throw new CommandLine.ParameterException(spec.commandLine(),
+                    String.format("Configuration file specified via '%s' or '%s' must have the '.conf' extension.", CONFIG_FILE_LONG_NAME, CONFIG_FILE_SHORT_NAME));
+        }
         System.setProperty(KeycloakPropertiesConfigSource.KEYCLOAK_CONFIG_FILE_PROP, path);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
@@ -99,6 +99,11 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
                 return null;
             }
 
+            if (!filePath.endsWith(".conf")) {
+                throw new RuntimeException(
+                        String.format("Configuration file '%s' must have the '.conf' extension.", filePath));
+            }
+
             return Paths.get(filePath);
         }
     }

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -250,6 +250,13 @@ public class StartCommandDistTest {
         cliResult.assertError(String.format("Try '%s --help' for more information on the available options.", KeycloakDistribution.SCRIPT_CMD));
     }
 
+    @DryRun
+    @Test
+    @Launch({CONFIG_FILE_LONG_NAME + "=src/test/resources/keycloak.properties", "start", "--db=dev-file"})
+    void testConfigFileWithWrongExtension(CLIResult cliResult) {
+        cliResult.assertError("Configuration file specified via '--config-file' or '-cf' must have the '.conf' extension.");
+    }
+
     @RawDistOnly(reason = "Containers are immutable")
     @Test
     void testRuntimeValuesAreNotCaptured(KeycloakDistribution dist) {

--- a/quarkus/tests/integration/src/test/resources/keycloak.properties
+++ b/quarkus/tests/integration/src/test/resources/keycloak.properties
@@ -1,0 +1,1 @@
+# test config with wrong extension


### PR DESCRIPTION
Adds explicit validation to reject configuration files that do not end with the `.conf` extension.

Previously, using `--config-file` or `KC_CONFIG_FILE` with a non-`.conf` file would silently ignore the file contents because the underlying SmallRye config source loader filters by extension and returns an empty list for unrecognized extensions. There was no indication to the user that their configuration was not being applied.

The validation is added in two places:
- The CLI option setter in `Main.setConfigFile()`, which catches the case at parse time
- The config source file resolution in `KeycloakPropertiesConfigSource.InFileSystem.getConfigurationFile()`, which catches the case when the path is set via the `KC_CONFIG_FILE` environment variable

Closes #46978