### PR TITLE
Display Javascript policy description and code in admin UI

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/js/DeployedScriptPolicyFactory.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/js/DeployedScriptPolicyFactory.java
@@ -22,6 +22,7 @@ import org.keycloak.authorization.model.Policy;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.ScriptModel;
 import org.keycloak.representations.idm.authorization.JSPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.provider.ScriptProviderMetadata;
 import org.keycloak.scripting.ScriptingProvider;
 
@@ -56,6 +57,16 @@ public final class DeployedScriptPolicyFactory extends JSPolicyProviderFactory {
     }
 
     @Override
+    public String getDescription() {
+        return metadata.getDescription();
+    }
+
+    @Override
+    public String getCode() {
+        return metadata.getCode();
+    }
+
+    @Override
     public boolean isInternal() {
         return false;
     }
@@ -87,7 +98,18 @@ public final class DeployedScriptPolicyFactory extends JSPolicyProviderFactory {
             representation.setDescription(metadata.getDescription());
             policy.setDescription(metadata.getDescription());
         }
+        if (representation.getCode() == null) {
+            representation.setCode(metadata.getCode());
+        }
         super.onCreate(policy, representation, authorization);
+    }
+
+    @Override
+    public void onImport(Policy policy, PolicyRepresentation representation, AuthorizationProvider authorization) {
+        if (policy.getDescription() == null) {
+            policy.setDescription(metadata.getDescription());
+        }
+        super.onImport(policy, representation, authorization);
     }
 
     public ScriptProviderMetadata getMetadata() {

--- a/core/src/main/java/org/keycloak/representations/idm/authorization/PolicyProviderRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/authorization/PolicyProviderRepresentation.java
@@ -24,6 +24,8 @@ public class PolicyProviderRepresentation {
     private String type;
     private String name;
     private String group;
+    private String description;
+    private String code;
 
     public String getType() {
         return this.type;
@@ -47,5 +49,21 @@ public class PolicyProviderRepresentation {
 
     public void setGroup( String group) {
         this.group = group;
+    }
+
+    public String getDescription() {
+        return this.description;
+    }
+
+    public void setDescription( String description) {
+        this.description = description;
+    }
+
+    public String getCode() {
+        return this.code;
+    }
+
+    public void setCode( String code) {
+        this.code = code;
     }
 }

--- a/js/apps/admin-ui/src/clients/authorization/NewPolicyDialog.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/NewPolicyDialog.tsx
@@ -63,8 +63,9 @@ export const NewPolicyDialog = ({
             >
               <Td>{provider.name}</Td>
               <Td style={{ textWrap: "wrap" }}>
-                {isValidComponentType(provider.type!) &&
-                  t(`policyProvider.${provider.type}`)}
+                {isValidComponentType(provider.type!)
+                  ? t(`policyProvider.${provider.type}`)
+                  : provider.description}
               </Td>
             </Tr>
           ))}

--- a/js/apps/admin-ui/src/clients/authorization/policy/PolicyDetails.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/policy/PolicyDetails.tsx
@@ -101,6 +101,20 @@ export default function PolicyDetails() {
           policies: result[1].map((p) => p.id),
         };
       }
+      if (!isValidComponentType(policyType!)) {
+        const providers = await adminClient.clients.listPolicyProviders({
+          id: permissionClientId ?? id,
+        });
+        const provider = providers.find((p) => p.type === policyType);
+        if (provider) {
+          return {
+            policy: {
+              code: provider.code,
+              description: provider.description,
+            } as PolicyRepresentation,
+          };
+        }
+      }
       return {};
     },
     ({ policy, policies }) => {

--- a/js/libs/keycloak-admin-client/src/defs/policyProviderRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/policyProviderRepresentation.ts
@@ -2,4 +2,6 @@ export default interface PolicyProviderRepresentation {
   type?: string;
   name?: string;
   group?: string;
+  description?: string;
+  code?: string;
 }

--- a/server-spi-private/src/main/java/org/keycloak/authorization/policy/provider/PolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/authorization/policy/provider/PolicyProviderFactory.java
@@ -34,6 +34,14 @@ public interface PolicyProviderFactory<R extends AbstractPolicyRepresentation> e
 
     String getGroup();
 
+    default String getDescription() {
+        return null;
+    }
+
+    default String getCode() {
+        return null;
+    }
+
     default boolean isInternal() {
         return false;
     }

--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyService.java
@@ -54,6 +54,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.representations.idm.authorization.AbstractPolicyRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyProviderRepresentation;
 import org.keycloak.representations.idm.authorization.PolicyRepresentation;
@@ -158,7 +159,9 @@ public class PolicyService {
             throw new ErrorResponseException("Policy with name [" + representation.getName() + "] already exists", "Conflicting policy", Status.CONFLICT);
         }
 
-        return policyStore.create(resourceServer, representation);
+        Policy policy = policyStore.create(resourceServer, representation);
+        RepresentationToModel.toModel(representation, authorization, policy);
+        return policy;
     }
 
     @Path("/search")
@@ -331,6 +334,8 @@ public class PolicyService {
                             representation.setName(factory.getName());
                             representation.setGroup(factory.getGroup());
                             representation.setType(factory.getId());
+                            representation.setDescription(factory.getDescription());
+                            representation.setCode(factory.getCode());
 
                             return representation;
                         })

--- a/tests/base/src/test/java/org/keycloak/tests/authz/services/DeployedScriptPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/authz/services/DeployedScriptPolicyTest.java
@@ -1,0 +1,54 @@
+package org.keycloak.tests.authz.services;
+
+import java.util.List;
+
+import org.keycloak.representations.idm.authorization.PolicyProviderRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.tests.authz.services.config.DefaultResourceServerConfig;
+import org.keycloak.tests.authz.services.config.DeployedScriptPolicyServerConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest(config = DeployedScriptPolicyServerConfig.class)
+public class DeployedScriptPolicyTest {
+
+    private static final String DEPLOYED_SCRIPT_TYPE = "script-scripts/default-policy.js";
+    private static final String EXPECTED_DESCRIPTION = "A policy that grants access only for users within this realm";
+
+    @InjectClient(config = DefaultResourceServerConfig.class)
+    ManagedClient client;
+
+    @Test
+    public void testDescriptionInPolicyProviders() {
+        List<PolicyProviderRepresentation> providers = client.admin().authorization().policies().policyProviders();
+
+        PolicyProviderRepresentation scriptProvider = providers.stream()
+                .filter(p -> DEPLOYED_SCRIPT_TYPE.equals(p.getType()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(scriptProvider, "Deployed script policy provider should be listed");
+        assertEquals(EXPECTED_DESCRIPTION, scriptProvider.getDescription());
+    }
+
+    @Test
+    public void testDescriptionOnCreatedPolicy() {
+        PolicyRepresentation policy = new PolicyRepresentation();
+        policy.setName("Test Default Policy");
+        policy.setType(DEPLOYED_SCRIPT_TYPE);
+
+        client.admin().authorization().policies().create(policy).close();
+
+        PolicyRepresentation created = client.admin().authorization().policies()
+                .findByName("Test Default Policy");
+
+        assertNotNull(created, "Created policy should be found by name");
+        assertEquals(EXPECTED_DESCRIPTION, created.getDescription());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/authz/services/config/DeployedScriptPolicyServerConfig.java
+++ b/tests/base/src/test/java/org/keycloak/tests/authz/services/config/DeployedScriptPolicyServerConfig.java
@@ -1,0 +1,15 @@
+package org.keycloak.tests.authz.services.config;
+
+import org.keycloak.common.Profile;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+public class DeployedScriptPolicyServerConfig implements KeycloakServerConfig {
+
+    @Override
+    public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+        return config
+                .features(Profile.Feature.SCRIPTS)
+                .dependency("org.keycloak.tests", "keycloak-tests-custom-scripts");
+    }
+}


### PR DESCRIPTION

Closes #47452

The script code was previously not displayed in the browser before the "save" button, which I have also fixed. See screenshots below.

<img width="1411" height="421" alt="image" src="https://github.com/user-attachments/assets/0f3f403f-62aa-4c0f-b689-99f249c4b4ab" />

<img width="828" height="632" alt="image" src="https://github.com/user-attachments/assets/d09e5efe-d6d5-4897-bc66-26bbb316b73b" />


<img width="1065" height="1054" alt="image" src="https://github.com/user-attachments/assets/e25fa9c2-0141-40ec-a198-332a3bb86072" />
