### PR TITLE
Fix release nightly doc build by excluding Admin API v2 for now

### DIFF
--- a/distribution/api-docs-dist/pom.xml
+++ b/distribution/api-docs-dist/pom.xml
@@ -103,7 +103,8 @@
                         <dependencySourceInclude>org.keycloak:*</dependencySourceInclude>
                     </dependencySourceIncludes>
                     <dependencySourceExcludes>
-                        <dependencySourceInclude>org.keycloak:keycloak-operator</dependencySourceInclude>
+                        <dependencySourceExclude>org.keycloak:keycloak-operator</dependencySourceExclude>
+                        <dependencySourceExclude>org.keycloak:keycloak-admin-v2-rest</dependencySourceExclude>
                     </dependencySourceExcludes>
                 </configuration>
                 <executions>


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/47720
* Fixes typo introduced by https://github.com/keycloak/keycloak/pull/29985
