### PR TITLE
Fix corrupted pnpm-lock.yaml with duplicate entries

### DIFF
--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -4204,10 +4204,6 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
-  serialize-javascript@7.0.5:
-    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
-    engines: {node: '>=20.0.0'}
-
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -8934,8 +8930,6 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
-
-  serialize-javascript@7.0.5: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
The pnpm-lock.yaml file contained duplicate entries for serialize-javascript@7.0.5 at lines 4213 and 4217, which was causing CI failures. This occurred because the lockfile wasn't properly regenerated after the override was added to package.json.

Regenerated the lockfile by removing it and running pnpm install to ensure proper synchronization with the overrides defined in package.json.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
