### PR TITLE
Added new LDAPRequiredActionGroupStorageMapper

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/RequiredActionLDAPGroupStorageMapper.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/RequiredActionLDAPGroupStorageMapper.java
@@ -1,0 +1,86 @@
+package org.keycloak.storage.ldap.mappers;
+
+import org.jboss.logging.Logger;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.storage.ldap.idm.query.Condition;
+import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
+import org.keycloak.storage.ldap.idm.query.internal.LDAPQueryConditionsBuilder;
+
+import java.util.List;
+import java.util.Objects;
+
+public class RequiredActionLDAPGroupStorageMapper extends AbstractLDAPStorageMapper {
+
+    public static final String USER_ATTR_FOR_REMEMBERING_REQUIRED_ACTIONS_PREFIX = "required-actions-set-from-ldap-";
+    private static final Logger logger = Logger.getLogger(RequiredActionLDAPGroupStorageMapper.class);
+
+
+    public RequiredActionLDAPGroupStorageMapper(ComponentModel mapperModel, LDAPStorageProvider ldapProvider) {
+        super(mapperModel, ldapProvider);
+    }
+
+    /**
+     * When a user is imported from LDAP and is in the specified LDAP group, then the chosen required actions will be added to the user.
+     * This will only happen if the user did not already have or had the required actions assigned through this mapper.
+     */
+    @Override
+    public void onImportUserFromLDAP(LDAPObject ldapUser, UserModel user, RealmModel realm, boolean isCreate) {
+        String mapperUserAttr = USER_ATTR_FOR_REMEMBERING_REQUIRED_ACTIONS_PREFIX + mapperModel.getName();
+        String alreadySetRequiredActionFromLdap = user.getFirstAttribute(mapperUserAttr);
+        List<String> requiredActionList = mapperModel.getConfig().getList(RequiredActionLDAPGroupStorageMapperFactory.REQUIRED_ACTION);
+        String requiredActionListString = String.join(",", requiredActionList);
+
+        String groupName = mapperModel.getConfig().getFirst(RequiredActionLDAPGroupStorageMapperFactory.GROUP);
+        String groupsDn = mapperModel.getConfig().getFirst(RequiredActionLDAPGroupStorageMapperFactory.GROUPS_DN);
+        String membershipAttrName = mapperModel.getConfig().getFirst(RequiredActionLDAPGroupStorageMapperFactory.MEMBERSHIP_ATTR_NAME);
+
+
+        logger.debugf("Checking LDAP group membership: groupName=%s, groupsDn=%s", groupName, groupsDn);
+
+        try (LDAPQuery query = new LDAPQuery(ldapProvider)) {
+            query.setSearchScope(ldapProvider.getLdapIdentityStore().getConfig().getSearchScope());
+            query.setSearchDn(groupsDn);
+
+            Condition groupNameCondition = new LDAPQueryConditionsBuilder().equal("cn", groupName);
+            query.addWhereCondition(groupNameCondition);
+            query.addReturningLdapAttribute(membershipAttrName);
+
+            LDAPObject ldapGroup = query.getFirstResult();
+
+            if (ldapGroup == null) {
+                logger.warnf("LDAP group [%s] not found under DN [%s]", groupName, groupsDn);
+                return;
+            }
+
+            logger.debugf("Found LDAP group [%s] at DN [%s]", groupName, ldapGroup.getDn());
+
+            String userDn = ldapUser.getDn().toString();
+            boolean isMember = ldapGroup.getAttributeAsSet(membershipAttrName).contains(userDn);
+
+            if (isMember && !Objects.equals(alreadySetRequiredActionFromLdap, requiredActionListString)) {
+                requiredActionList.forEach(user::addRequiredAction);
+                user.setAttribute(mapperUserAttr, List.of(requiredActionListString));
+                logger.debugf("Added required actions [%s] to user [%s]", String.join(",", requiredActionList), user.getUsername());
+            }
+        }
+    }
+
+    @Override
+    public void onRegisterUserToLDAP(LDAPObject ldapUser, UserModel localUser, RealmModel realm) {
+        // Nothing to do when user is registered to LDAP
+    }
+
+    @Override
+    public UserModel proxy(LDAPObject ldapUser, UserModel delegate, RealmModel realm) {
+        return delegate;
+    }
+
+    @Override
+    public void beforeLDAPQuery(LDAPQuery query) {
+        // Nothing to do before LDAP query
+    }
+}

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/RequiredActionLDAPGroupStorageMapperFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/RequiredActionLDAPGroupStorageMapperFactory.java
@@ -1,0 +1,105 @@
+package org.keycloak.storage.ldap.mappers;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.component.ComponentValidationException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.utils.KeycloakSessionUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RequiredActionLDAPGroupStorageMapperFactory extends AbstractLDAPStorageMapperFactory {
+
+    public static final String PROVIDER_ID = "required-action-ldap-group-mapper";
+    public static final String REQUIRED_ACTION = "requiredAction";
+    public static final String GROUP = "requiredGroup";
+    public static final String GROUPS_DN = "groupsDn";
+    public static final String MEMBERSHIP_ATTR_NAME = "membershipAttrName";
+
+
+    @Override
+    protected AbstractLDAPStorageMapper createMapper(ComponentModel mapperModel, LDAPStorageProvider federationProvider) {
+        return new RequiredActionLDAPGroupStorageMapper(mapperModel, federationProvider);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "When a user is imported from LDAP and is in the specified LDAP group, then the chosen required actions will be added to the user. This will only happen if the user did not already have or had the required actions assigned through this mapper. If the configured required actions changes, the new required actions will be added to all users regardless of prior assignments.";
+    }
+
+    @Override
+    public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel config) throws ComponentValidationException {
+        if (config.getConfig().getFirst(GROUP) == null) {
+            throw new ComponentValidationException("Group can't be null");
+        }
+
+        if (config.getConfig().getFirst(GROUPS_DN) == null) {
+            throw new ComponentValidationException("Group DN can't be null");
+        }
+
+        if (config.getConfig().getList(REQUIRED_ACTION) == null || config.getConfig().getList(REQUIRED_ACTION).isEmpty()) {
+            throw new ComponentValidationException("Required Action can't be null");
+        }
+
+        if (config.getConfig().getFirst(MEMBERSHIP_ATTR_NAME) == null) {
+            throw new ComponentValidationException("Membership Attribute Name can't be null");
+        }
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+        var availableRequiredActionIdList = KeycloakSessionUtil
+                .getKeycloakSession()
+                .getContext()
+                .getRealm()
+                .getRequiredActionProvidersStream()
+                .map(RequiredActionProviderModel::getProviderId)
+                .toList();
+
+        configProperties.add(createConfigProperty(
+                REQUIRED_ACTION,
+                "Required Action",
+                "Required Action to add to the user.",
+                ProviderConfigProperty.MULTIVALUED_LIST_TYPE,
+                availableRequiredActionIdList,
+                true)
+        );
+        configProperties.add(createConfigProperty(
+                GROUP,
+                "Ldap group",
+                "cn name of the group to check if the user is in. For example 'mygroup'.",
+                ProviderConfigProperty.STRING_TYPE,
+                null,
+                true)
+        );
+        configProperties.add(createConfigProperty(
+                GROUPS_DN,
+                "Groups DN",
+                "DN of the LDAP tree where groups are located. For example 'ou=Groups,dc=example,dc=com'",
+                ProviderConfigProperty.STRING_TYPE,
+                null,
+                true)
+        );
+        configProperties.add(createConfigProperty(
+                MEMBERSHIP_ATTR_NAME,
+                "Membership Attribute Name",
+                "Name of the attribute in the LDAP group that contains the members. Default is 'member'. Some LDAP schemas use 'uniqueMember' or 'memberUid' instead.",
+                ProviderConfigProperty.STRING_TYPE,
+                null,
+                true)
+        );
+
+        return configProperties;
+    }
+}

--- a/federation/ldap/src/main/resources/META-INF/services/org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory
+++ b/federation/ldap/src/main/resources/META-INF/services/org.keycloak.storage.ldap.mappers.LDAPStorageMapperFactory
@@ -27,3 +27,5 @@ org.keycloak.storage.ldap.mappers.msad.MSADUserAccountControlStorageMapperFactor
 org.keycloak.storage.ldap.mappers.msadlds.MSADLDSUserAccountControlStorageMapperFactory
 org.keycloak.storage.ldap.mappers.UserAttributeLDAPStorageMapperFactory
 org.keycloak.storage.ldap.mappers.CertificateLDAPStorageMapperFactory
+org.keycloak.storage.ldap.mappers.RequiredActionLDAPGroupStorageMapperFactory
+

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPRequiredActionGroupStorageMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPRequiredActionGroupStorageMapperTest.java
@@ -1,0 +1,188 @@
+package org.keycloak.testsuite.federation.ldap;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.LDAPConstants;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.storage.ldap.LDAPStorageProvider;
+import org.keycloak.storage.ldap.LDAPUtils;
+import org.keycloak.storage.ldap.idm.model.LDAPObject;
+import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
+import org.keycloak.storage.ldap.mappers.RequiredActionLDAPGroupStorageMapper;
+import org.keycloak.storage.ldap.mappers.RequiredActionLDAPGroupStorageMapperFactory;
+import org.keycloak.storage.ldap.mappers.membership.MembershipType;
+import org.keycloak.testsuite.util.LDAPRule;
+import org.keycloak.testsuite.util.LDAPTestUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * Integration tests for {@link RequiredActionLDAPGroupStorageMapper}.
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class LDAPRequiredActionGroupStorageMapperTest extends AbstractLDAPTest {
+
+    private static final String GROUPS_DN = "ou=Groups,dc=keycloak,dc=org";
+    private static final String REQUIRED_ACTION_GROUP_NAME = "required-action-group";
+    private static final String MAPPER_NAME = "requiredActionGroupMapper";
+
+    @ClassRule
+    public static LDAPRule ldapRule = new LDAPRule();
+
+    @Override
+    protected LDAPRule getLDAPRule() {
+        return ldapRule;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test realm / LDAP setup
+    // -----------------------------------------------------------------------
+
+    @Override
+    protected void afterImportTestRealm() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            ComponentModel mapperModel = KeycloakModelUtils.createComponentModel(
+                    MAPPER_NAME,
+                    ctx.getLdapModel().getId(),
+                    RequiredActionLDAPGroupStorageMapperFactory.PROVIDER_ID,
+                    LDAPStorageMapper.class.getName(),
+                    RequiredActionLDAPGroupStorageMapperFactory.GROUP,              REQUIRED_ACTION_GROUP_NAME,
+                    RequiredActionLDAPGroupStorageMapperFactory.GROUPS_DN,          GROUPS_DN,
+                    RequiredActionLDAPGroupStorageMapperFactory.MEMBERSHIP_ATTR_NAME, LDAPConstants.MEMBER
+            );
+            mapperModel.getConfig().add(
+                    RequiredActionLDAPGroupStorageMapperFactory.REQUIRED_ACTION,
+                    UserModel.RequiredAction.VERIFY_EMAIL.name()
+            );
+            appRealm.addComponentModel(mapperModel);
+
+            // Provision LDAP users
+            LDAPStorageProvider ldapProvider = LDAPTestUtils.getLdapProvider(session, ctx.getLdapModel());
+            LDAPTestUtils.removeAllLDAPUsers(ldapProvider, appRealm);
+
+            // John will be placed in the group → should receive the required action.
+            LDAPObject john = LDAPTestUtils.addLDAPUser(
+                    ldapProvider, appRealm,
+                    "johnkeycloak", "John", "Doe", "john@email.org", null, "1234");
+            LDAPTestUtils.updateLDAPPassword(ldapProvider, john, "Password1");
+
+            // Mary will NOT be in the group → must NOT receive the required action.
+            LDAPObject mary = LDAPTestUtils.addLDAPUser(
+                    ldapProvider, appRealm,
+                    "marykeycloak", "Mary", "Kelly", "mary@email.org", null, "5678");
+            LDAPTestUtils.updateLDAPPassword(ldapProvider, mary, "Password1");
+
+            // Create LDAP group and add John
+            LDAPObject ldapGroup = LDAPUtils.createLDAPGroup(
+                    ldapProvider,
+                    REQUIRED_ACTION_GROUP_NAME,
+                    "cn",
+                    Collections.singletonList("groupOfNames"),
+                    GROUPS_DN,
+                    new HashMap<>(),
+                    LDAPConstants.MEMBER
+            );
+            LDAPUtils.addMember(ldapProvider, MembershipType.DN,
+                    LDAPConstants.MEMBER, "not-used", ldapGroup, john);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void test_01_userInGroupGetsRequiredAction() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            // Loading the user triggers a forced import from LDAP (onImportUserFromLDAP).
+            UserModel john = session.users().getUserByUsername(appRealm, "johnkeycloak");
+            Assert.assertNotNull("johnkeycloak must be importable from LDAP", john);
+
+            Assert.assertTrue(
+                    "John (member of the LDAP group) must have the VERIFY_EMAIL required action",
+                    john.getRequiredActionsStream()
+                            .anyMatch(a -> UserModel.RequiredAction.VERIFY_EMAIL.name().equals(a))
+            );
+
+            // The tracking attribute must be set so the mapper knows it already acted.
+            String trackerAttr = RequiredActionLDAPGroupStorageMapper
+                    .USER_ATTR_FOR_REMEMBERING_REQUIRED_ACTIONS_PREFIX + MAPPER_NAME;
+            Assert.assertEquals(
+                    "Tracker attribute must equal the joined required-action list",
+                    UserModel.RequiredAction.VERIFY_EMAIL.name(),
+                    john.getFirstAttribute(trackerAttr)
+            );
+        });
+    }
+
+
+    @Test
+    public void test_02_userNotInGroupDoesNotGetRequiredAction() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            UserModel mary = session.users().getUserByUsername(appRealm, "marykeycloak");
+            Assert.assertNotNull("marykeycloak must be importable from LDAP", mary);
+
+            Assert.assertFalse(
+                    "Mary (not a member of the LDAP group) must NOT have the VERIFY_EMAIL required action",
+                    mary.getRequiredActionsStream()
+                            .anyMatch(a -> UserModel.RequiredAction.VERIFY_EMAIL.name().equals(a))
+            );
+        });
+    }
+
+
+    @Test
+    public void test_03_requiredActionNotReAddedAfterCompletion() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            UserModel john = session.users().getUserByUsername(appRealm, "johnkeycloak");
+            Assert.assertNotNull(john);
+
+            // Simulate the user completing the required action.
+            john.removeRequiredAction(UserModel.RequiredAction.VERIFY_EMAIL.name());
+
+            // Sanity-check: the tracker attribute must still be present.
+            String trackerAttr = RequiredActionLDAPGroupStorageMapper
+                    .USER_ATTR_FOR_REMEMBERING_REQUIRED_ACTIONS_PREFIX + MAPPER_NAME;
+            Assert.assertNotNull(
+                    "Tracker attribute must still be present after the user completed the action",
+                    john.getFirstAttribute(trackerAttr)
+            );
+        });
+
+        //trigger another import and verify VERIFY_EMAIL is NOT re-added.
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            // getUserByUsername always triggers a forced import (ImportType.FORCED),
+            // which calls onImportUserFromLDAP on every registered mapper.
+            UserModel john = session.users().getUserByUsername(appRealm, "johnkeycloak");
+            Assert.assertNotNull(john);
+
+            Assert.assertFalse(
+                    "VERIFY_EMAIL must NOT be re-added once the user has already completed it",
+                    john.getRequiredActionsStream()
+                            .anyMatch(a -> UserModel.RequiredAction.VERIFY_EMAIL.name().equals(a))
+            );
+        });
+    }
+}


### PR DESCRIPTION
When a user is imported from LDAP and is in a specified LDAP group, then the chosen required actions will be added to the user. This will only happen if the user did not already have or had the required actions assigned through this mapper. If the configured required actions changes, the new required actions will be added to all users regardless of prior assignments.

Closes #47006

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
