### PR TITLE
fix: Keycloak ships source maps for Admin UI and Account UI

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/ThemeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/ThemeResource.java
@@ -46,6 +46,7 @@ import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.Provider;
 
 import org.keycloak.common.Version;
+import org.keycloak.common.util.Environment;
 import org.keycloak.common.util.MimeTypeUtil;
 import org.keycloak.encoding.ResourceEncodingHelper;
 import org.keycloak.encoding.ResourceEncodingProvider;
@@ -92,6 +93,10 @@ public class ThemeResource {
         final Optional<Theme.Type> type = getThemeType(themeType);
 
         if (type.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+
+        if (path.endsWith(".js.map") && !Environment.isDevMode()) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
 


### PR DESCRIPTION
## Summary

This change prevents `.js.map` source map files from being served through the theme resource endpoint in production mode.

## Problem

Keycloak was serving `.js.map` source map files for the Admin UI and Account UI when requested by appending `.map` to a JS file URL. While Keycloak is open source, customized deployments may include proprietary code that should not be exposed via source maps.

## Fix

Added a server-side check in `ThemeResource.getResource()` that returns 404 for any path ending in `.js.map` when Keycloak is not running in dev mode (`start-dev`). This is minimal, safe, and consistent with the project pattern of using `Environment.isDevMode()` for dev-only behavior.

When running in `start-dev` mode, source maps continue to work normally for development purposes.

## Files Changed

- `services/src/main/java/org/keycloak/services/resources/ThemeResource.java`

## Testing

- The change is logically simple: an early return of 404 before any resource lookup for `.js.map` paths in non-dev mode.
- Full CI tests (integration/unit) should validate no regressions in theme resource serving.
- Manual testing: request a `.js.map` URL in production mode should return 404; in `start-dev` mode should return the map file as before.

Closes keycloak/keycloak#47545