### PR TITLE
fix: hide runtime defaults during Quarkus dev mode augmentation

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -30,6 +30,7 @@ import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.NestedPropertyMappingInterceptor;
 import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
+import io.quarkus.runtime.LaunchMode;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Expressions;
@@ -86,6 +87,11 @@ public final class PropertyMappers {
                 && (NestedPropertyMappingInterceptor.getResolvingRoot().or(() -> Optional.of(name))
                         .filter(n -> n.startsWith("quarkus.log.") || n.startsWith("quarkus.console.")).isEmpty()
                         || !Expressions.isEnabled())) {
+            return ConfigValue.builder().withName(name).build();
+        }
+
+        // In Quarkus dev mode, also hide runtime defaults during augmentation probing (fixes #47659)
+        if (LaunchMode.current() == LaunchMode.DEVELOPMENT && !Expressions.isEnabled() && isKeycloakRuntime(name, mapper)) {
             return ConfigValue.builder().withName(name).build();
         }
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -39,6 +39,7 @@ import org.keycloak.quarkus.runtime.vault.FilesPlainTextVaultProviderFactory;
 import org.keycloak.spi.infinispan.CacheEmbeddedConfigProviderSpi;
 import org.keycloak.spi.infinispan.impl.embedded.DefaultCacheEmbeddedConfigProviderFactory;
 
+import io.quarkus.runtime.LaunchMode;
 import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Expressions;
 import io.smallrye.config.PropertiesConfigSource;
@@ -106,6 +107,21 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertEquals("debug", createConfig().getRawValue("kc.log-level"));
         Environment.setRebuild();
         assertNull(Expressions.withoutExpansion(() -> Configuration.getConfigValue("kc.log-level")).getValue());
+    }
+
+    @Test
+    public void testDevModeAugmentationHidesRuntimeDefaults() {
+        ConfigArgsConfigSource.setCliArgs("--log-console-output=default");
+        createConfig();
+        LaunchMode.set(LaunchMode.DEVELOPMENT);
+        try {
+            // runtime values should be hidden when Quarkus probes for defaults during dev-mode augmentation
+            assertNull(Expressions.withoutExpansion(() -> Configuration.getConfigValue("kc.log-console-output")).getValue());
+            // but visible during normal dev-mode runtime (expressions enabled)
+            assertNotNull(Configuration.getConfigValue("kc.log-console-output").getValue());
+        } finally {
+            LaunchMode.set(LaunchMode.NORMAL);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Fixes SRCFG01008 boolean conversion warning when running Keycloak from source via `mvn quarkus:dev` with `kc.log-console-output=default`
- The existing augmentation detection (`isRebuild()` / `KC_TEST_REBUILD`) doesn't cover Quarkus dev mode, which manages augmentation internally without setting these flags
- Detects dev-mode augmentation by combining `LaunchMode.DEVELOPMENT` with disabled expressions — this precisely identifies when Quarkus probes for runtime defaults during augmentation, without matching dev-mode runtime or plain JUnit tests

## Changes
- `PropertyMappers.getValue()`: Added a second condition after the existing augmentation check that hides runtime property values when `LaunchMode` is `DEVELOPMENT` and expressions are disabled
- `ConfigurationTest`: Added test verifying runtime values are hidden during dev-mode augmentation probing and visible during normal dev-mode runtime

Closes #47659