### PR TITLE
avoid SRCFG01008 warning for log-console-output=default in Quarkus dev mode

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -55,6 +55,10 @@ public final class Environment {
         return Boolean.getBoolean("quarkus.launch.rebuild");
     }
 
+    public static boolean isAugmentation() {
+        return isRebuild() || Boolean.getBoolean(KC_TEST_REBUILD) || LaunchMode.current() == LaunchMode.DEVELOPMENT;
+    }
+
     public static Optional<String> getHomeDir() {
         return Optional.ofNullable(System.getProperty(KC_HOME_DIR));
     }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -35,7 +35,6 @@ import io.smallrye.config.ConfigValue;
 import io.smallrye.config.Expressions;
 import org.jboss.logging.Logger;
 
-import static org.keycloak.quarkus.runtime.Environment.isRebuild;
 import static org.keycloak.quarkus.runtime.Environment.isRebuildCheck;
 import static org.keycloak.quarkus.runtime.configuration.KeycloakConfigSourceProvider.isKeyStoreConfigSource;
 
@@ -82,7 +81,7 @@ public final class PropertyMappers {
         // and we need to resolve them. That should be fine as they are generally not considered security sensitive.
         // If however expressions are not enabled that means quarkus is specifically looking for runtime defaults, and we should not provide a value
         // See https://github.com/quarkusio/quarkus/pull/42157
-        if ((isRebuild() || Boolean.getBoolean(Environment.KC_TEST_REBUILD)) && isKeycloakRuntime(name, mapper)
+        if (Environment.isAugmentation() && isKeycloakRuntime(name, mapper)
                 && (NestedPropertyMappingInterceptor.getResolvingRoot().or(() -> Optional.of(name))
                         .filter(n -> n.startsWith("quarkus.log.") || n.startsWith("quarkus.console.")).isEmpty()
                         || !Expressions.isEnabled())) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/LoggingConfigurationTest.java
@@ -26,7 +26,9 @@ import org.keycloak.config.LoggingOptions;
 import org.keycloak.quarkus.runtime.Environment;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 
+import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.logging.LogRuntimeConfig;
+import io.smallrye.config.Expressions;
 import io.smallrye.config.SmallRyeConfig;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
@@ -394,6 +396,19 @@ public class LoggingConfigurationTest extends AbstractConfigurationTest {
         Environment.setRebuildCheck(true); // will be reset by the system properties logic
         ConfigArgsConfigSource.setCliArgs("");
         assertEquals("true", createConfig().getConfigValue("quarkus.log.console.enable").getValue());
+    }
+
+    @Test
+    public void testDefaultLogOutputIsHiddenDuringDevModeAugmentation() {
+        LaunchMode previousLaunchMode = LaunchMode.current();
+        LaunchMode.set(LaunchMode.DEVELOPMENT);
+
+        try {
+            SmallRyeConfig config = createConfig();
+            assertNull(Expressions.withoutExpansion(() -> config.getConfigValue("quarkus.log.console.json.enabled")).getValue());
+        } finally {
+            LaunchMode.set(previousLaunchMode);
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #47659 

The existing logic that suppresses runtime values during augmentation relied on system properties that are not set in Quarkus dev mode.

This change introduces a centralized augmentation detection method and extends it to include Quarkus dev mode via LaunchMode.DEVELOPMENT, so dev mode follows the same behavior as other augmentation paths.

As a result, runtime configuration values are no longer incorrectly passed through boolean conversion during dev-mode startup, preventing the SRCFG01008 warning.

Behavior validated via test coverage.

Note: AI tools were used to assist with code exploration and drafting. All changes were reviewed and verified manually.