### PR TITLE
Fix: link existing local users to LDAP federation instead of failing sync

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPConfig.java
@@ -37,6 +37,14 @@ public class LDAPConfig {
 
     public static final String DEFAULT_CONNECTION_TIMEOUT = "5000";
 
+    public static final String EXISTING_USER_HANDLING = "existingUserHandling";
+
+    public enum ExistingUserHandling {
+        LINK,   // Link existing local user to the LDAP user — preserves OTP, credentials, roles
+        SKIP,   // Log a warning and skip — local user is left unlinked
+        FAIL    // Throw an exception — admin must resolve the conflict manually
+    }
+
     private final MultivaluedHashMap<String, String> config;
     private final Set<String> binaryAttributeNames = new HashSet<>();
 
@@ -250,6 +258,18 @@ public class LDAPConfig {
             return UserStorageProvider.EditMode.READ_ONLY;
         } else {
             return UserStorageProvider.EditMode.valueOf(editModeString);
+        }
+    }
+
+    public ExistingUserHandling getExistingUserHandling() {
+        String value = config.getFirst(EXISTING_USER_HANDLING);
+        if (value == null) {
+            return ExistingUserHandling.LINK;
+        }
+        try {
+            return ExistingUserHandling.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ExistingUserHandling.LINK;
         }
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -728,7 +728,31 @@ public class LDAPStorageProvider implements UserStorageProvider,
                         UserStorageUtil.userCache(session).evict(realm, existingLocalUser);
                     }
                 } else {
-                    imported = userProvider.addUser(realm, ldapUsername);
+                    // Check if a local user with the same username exists but has no federation link yet.
+                    // This happens when users were created in Keycloak before LDAP federation was added.
+                    UserModel localUserByUsername = userProvider.getUserByUsername(realm, ldapUsername);
+                    if (localUserByUsername != null && localUserByUsername.getFederationLink() == null) {
+                        LDAPConfig.ExistingUserHandling handling = ldapIdentityStore.getConfig().getExistingUserHandling();
+                        if (handling == LDAPConfig.ExistingUserHandling.LINK) {
+                            logger.debugf("Linking existing local user '%s' to LDAP federation provider '%s'",
+                                    ldapUsername, model.getName());
+                            imported = localUserByUsername;
+                            if (UserStorageUtil.userCache(session) != null) {
+                                UserStorageUtil.userCache(session).evict(realm, localUserByUsername);
+                            }
+                        } else if (handling == LDAPConfig.ExistingUserHandling.SKIP) {
+                            logger.warnf("Skipping LDAP import for user '%s': a local user exists without a federation link. " +
+                                    "Set 'Existing Local User Handling' to LINK to enable automatic linking.", ldapUsername);
+                            return null;
+                        } else {
+                            // FAIL — preserve previous exception-based behaviour but with a clear message
+                            throw new ModelDuplicateException("Cannot import LDAP user '" + ldapUsername +
+                                    "': a local user with the same username exists without a federation link. " +
+                                    "Set 'Existing Local User Handling' to LINK or SKIP to resolve.");
+                        }
+                    } else {
+                        imported = userProvider.addUser(realm, ldapUsername);
+                    }
                 }
             } else {
                 InMemoryUserAdapter adapter = new InMemoryUserAdapter(session, realm, new StorageId(model.getId(), ldapUsername).getId());

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -52,6 +52,7 @@ import org.keycloak.storage.UserStorageProvider;
 import org.keycloak.storage.UserStorageProviderFactory;
 import org.keycloak.storage.UserStorageProviderModel;
 import org.keycloak.storage.UserStorageUtil;
+import org.keycloak.storage.ldap.LDAPConfig;
 import org.keycloak.storage.ldap.idm.model.LDAPObject;
 import org.keycloak.storage.ldap.idm.query.Condition;
 import org.keycloak.storage.ldap.idm.query.internal.LDAPQuery;
@@ -113,6 +114,13 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                 .property().name(UserStorageProviderModel.IMPORT_ENABLED)
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
                 .defaultValue("true")
+                .add()
+                .property().name(LDAPConfig.EXISTING_USER_HANDLING)
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .defaultValue(LDAPConfig.ExistingUserHandling.LINK.name())
+                .options(LDAPConfig.ExistingUserHandling.LINK.name(),
+                        LDAPConfig.ExistingUserHandling.SKIP.name(),
+                        LDAPConfig.ExistingUserHandling.FAIL.name())
                 .add()
                 .property().name(LDAPConstants.SYNC_REGISTRATIONS)
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)
@@ -698,6 +706,24 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                                 }
                                 logger.debugf("Updated user from LDAP: %s", currentUser.getUsername());
                                 syncResult.increaseUpdated();
+                            } else if (currentUser.getFederationLink() == null) {
+                                // Local user exists without any federation link — apply configured handling
+                                LDAPConfig.ExistingUserHandling handling = ldapFedProvider.getLdapIdentityStore().getConfig().getExistingUserHandling();
+                                if (handling == LDAPConfig.ExistingUserHandling.LINK) {
+                                    // Delegate to importUserFromLDAP which will link the existing user
+                                    exists.value = false;
+                                    ldapFedProvider.importUserFromLDAP(session, currentRealm, ldapUser);
+                                    syncResult.increaseAdded();
+                                } else if (handling == LDAPConfig.ExistingUserHandling.SKIP) {
+                                    logger.warnf("Skipping sync for user '%s': a local user exists without a federation link. " +
+                                            "Set 'Existing Local User Handling' to LINK to enable automatic linking.", username);
+                                    syncResult.increaseFailed();
+                                } else {
+                                    // FAIL — original strict behaviour
+                                    logger.warnf("User '%s' is not updated during sync as a local user exists without a federation link to provider '%s'. " +
+                                            "Set 'Existing Local User Handling' to LINK or SKIP to resolve.", username, fedModel.getName());
+                                    syncResult.increaseFailed();
+                                }
                             } else {
                                 logger.warnf("User with ID '%s' is not updated during sync as he already exists in Keycloak database but is not linked to federation provider '%s'", ldapUser.getUuid(), fedModel.getName());
                                 syncResult.increaseFailed();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPSyncTest.java
@@ -730,4 +730,89 @@ public class LDAPSyncTest extends AbstractLDAPTest {
             ctx.getRealm().updateComponent(mapperModel);
         });
     }
+
+    /**
+     * Reproduces https://github.com/keycloak/keycloak/issues/23835
+     *
+     * When a local Keycloak user exists without a federation link and the same username exists in LDAP,
+     * a full sync currently fails to import that user (counts as "failed") instead of linking the
+     * existing local user to its LDAP counterpart.
+     *
+     * This test demonstrates the current broken behavior: sync fails for the conflicting user,
+     * the local user is left without a federation link, and any credentials or role assignments
+     * on the local user are preserved only by accident (the user was never touched).
+     *
+     * Expected behavior after fix: sync succeeds, the local user is linked to LDAP (federationLink set),
+     * and existing credentials/role assignments are preserved.
+     */
+    @Test
+    public void testSyncFailsWhenLocalUserExistsWithSameUsername() {
+        // Step 1: create a local user that pre-dates LDAP federation being added.
+        // Assign a realm role to simulate real-world state that must be preserved.
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            UserModel localUser = LDAPTestUtils.addLocalUser(session, appRealm, "preexisting", "preexisting@local.org", "localpassword");
+
+            // Assign a role so we can verify it survives (or is lost) after sync
+            appRealm.addRole("preexisting-role");
+            localUser.grantRole(appRealm.getRole("preexisting-role"));
+
+            Assert.assertNull("Local user should have no federation link before sync",
+                    localUser.getFederationLink());
+        });
+
+        // Step 2: the same username also exists in LDAP (e.g. added via AD before federation was configured)
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), ctx.getRealm(),
+                    "preexisting", "Pre", "Existing", "preexisting@ldap.org", null, "999");
+        });
+
+        // Step 3: run a full sync — the fix should link the existing local user instead of failing.
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+
+            SynchronizationResult result = UserStoragePrivateUtil.runFullSync(
+                    session.getKeycloakSessionFactory(), ctx.getLdapModel());
+
+            Assert.assertEquals("Sync should report 0 failed users after fix", 0, result.getFailed());
+        });
+
+        // Step 4: verify the local user is now linked to LDAP and all existing data is preserved.
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            UserModel localUser = UserStoragePrivateUtil.userLocalStorage(session)
+                    .getUserByUsername(appRealm, "preexisting");
+
+            Assert.assertNotNull("Local user should still exist after sync", localUser);
+            Assert.assertNotNull("Local user should now have a federation link",
+                    localUser.getFederationLink());
+            Assert.assertEquals("Federation link should point to the LDAP provider",
+                    ctx.getLdapModel().getId(), localUser.getFederationLink());
+            Assert.assertTrue("Role assignment on local user should be preserved",
+                    localUser.hasRole(appRealm.getRole("preexisting-role")));
+        });
+
+        // Cleanup
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            UserModel localUser = UserStoragePrivateUtil.userLocalStorage(session)
+                    .getUserByUsername(appRealm, "preexisting");
+            if (localUser != null) {
+                UserStoragePrivateUtil.userLocalStorage(session).removeUser(appRealm, localUser);
+            }
+            LDAPTestUtils.removeLDAPUserByUsername(ctx.getLdapProvider(), appRealm,
+                    ctx.getLdapProvider().getLdapIdentityStore().getConfig(), "preexisting");
+
+            if (appRealm.getRole("preexisting-role") != null) {
+                appRealm.removeRole(appRealm.getRole("preexisting-role"));
+            }
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #23835

When a local Keycloak user exists without a federation link and the same username is found in LDAP during a full sync, the sync currently counts that user as **failed** and leaves them unlinked. This affects any deployment that adds LDAP/AD federation after users already exist locally — a common migration scenario in multi-tenant SaaS and enterprise environments.

### Root cause

`LDAPStorageProviderFactory.importLdapUsers()` checks for existing local users before calling `importUserFromLDAP()`. When a local user is found whose `federationLink` doesn't match the current provider, it immediately calls `syncResult.increaseFailed()` with no opportunity to link.

### Fix

- Adds a new `existingUserHandling` configuration property on the LDAP federation provider (dropdown in admin console)
- Three options:
  - **LINK** (default): link the existing local user to the LDAP identity — preserves OTP credentials, role assignments, and group memberships
  - **SKIP**: log a warning and skip the user, leaving them unlinked
  - **FAIL**: preserve the previous strict behaviour (counts as sync failure)
- Primary fix in `LDAPStorageProviderFactory.importLdapUsers()`
- Defensive fallback also added in `LDAPStorageProvider.importUserFromLDAP()` for direct callers

### Test

Added `testSyncLinksExistingLocalUserToLDAP` to `LDAPSyncTest`:
1. Creates a local user with a role assignment (simulates pre-federation state)
2. Adds the same username to LDAP
3. Runs full sync
4. Asserts 0 failures, federation link set, role preserved

## Test plan

- [ ] `LDAPSyncTest#testSyncLinksExistingLocalUserToLDAP` passes with default LINK behaviour
- [ ] Existing `LDAPSyncTest` suite passes (no regression)
- [ ] Manually verify dropdown appears in admin console under LDAP federation provider settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)