### PR TITLE
fix: extract 12 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/aurora-delete.yml
+++ b/.github/workflows/aurora-delete.yml
@@ -24,10 +24,13 @@ jobs:
 
       - name: Initialize AWS client
         run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
+          aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
           aws configure set region ${{ inputs.region }}
 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: delete
         shell: bash
         run: ./aurora_delete.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -701,7 +701,7 @@ jobs:
         id: parse-creds
         shell: bash
         run: |
-          SUBSCRIPTION=$(echo ''"${AZURE_CREDENTIALS}"'' | jq -r '.subscriptionId')
+          SUBSCRIPTION=$(echo "${AZURE_CREDENTIALS}" | jq -r '.subscriptionId')
           if [[ -z "$SUBSCRIPTION" || "$SUBSCRIPTION" == "null" ]]; then
             echo "ERROR: Failed to parse subscriptionId from AZURE_CREDENTIALS"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,29 +64,36 @@ jobs:
         id: auroradb-tests
         run: |
           RUN_AURORADB_TESTS=false
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && -n "${{ secrets.AWS_SECRET_ACCESS_KEY }}" ]]; then
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && -n "${AWS_SECRET_ACCESS_KEY}" ]]; then
             RUN_AURORADB_TESTS=true
           fi
           echo "run-aurora-tests=$RUN_AURORADB_TESTS" >> $GITHUB_OUTPUT
 
+        env:
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Azure conditional check
         id: azure-tests
         run: |
           RUN_AZURE_TESTS=false
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && -n "${{ secrets.AZURE_CREDENTIALS }}" ]]; then
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && -n "${AZURE_CREDENTIALS}" ]]; then
             RUN_AZURE_TESTS=true
           fi
           echo "run-azure-tests=$RUN_AZURE_TESTS" >> $GITHUB_OUTPUT
 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Additional DBs conditional check
         id: additional-dbs-tests
         run: |
           RUN_ADDITIONAL_DBS_TESTS=false
-          if [[ $GITHUB_EVENT_NAME != "pull_request" && -n "${{ secrets.PRIVATE_DBS_QUAY_USERNAME }}" && -n "${{ secrets.PRIVATE_DBS_QUAY_TOKEN }}" ]]; then
+          if [[ $GITHUB_EVENT_NAME != "pull_request" && -n "${PRIVATE_DBS_QUAY_USERNAME}" && -n "${PRIVATE_DBS_QUAY_TOKEN}" ]]; then
             RUN_ADDITIONAL_DBS_TESTS=true
           fi
           echo "run-additional-dbs-tests=$RUN_ADDITIONAL_DBS_TESTS" >> $GITHUB_OUTPUT
 
+        env:
+          PRIVATE_DBS_QUAY_USERNAME: ${{ secrets.PRIVATE_DBS_QUAY_USERNAME }}
+          PRIVATE_DBS_QUAY_TOKEN: ${{ secrets.PRIVATE_DBS_QUAY_TOKEN }}
   testsuite-deprecation-check:
     name: Testsuite Deprecation Check
     runs-on: ubuntu-latest
@@ -481,8 +488,8 @@ jobs:
           AWS_REGION=us-east-1
           echo "AWS Region: ${AWS_REGION}"
           
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set aws_access_key_id "${AWS_ACCESS_KEY_ID}"
+          aws configure set aws_secret_access_key "${AWS_SECRET_ACCESS_KEY}"
           aws configure set region ${AWS_REGION}
           
           AURORA_CLUSTER_NAME="gh-action-$(git rev-parse --short HEAD)-${{ github.run_id }}-${{ github.run_attempt }}"
@@ -497,6 +504,9 @@ jobs:
           JDBC_PARAMS='?ssl=true&sslmode=verify-ca&sslrootcert=/opt/keycloak/aws.pem'
           echo "jdbc_params=${JDBC_PARAMS}" >> $GITHUB_OUTPUT
 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - id: aurora-create
         name: Create Aurora DB
         uses: ./.github/actions/aurora-create-database
@@ -653,9 +663,10 @@ jobs:
             -f name=${{ steps.aurora-init.outputs.aurora-cluster-name }} \
             -f region=${{ steps.aurora-init.outputs.region }} \
             --repo ${{ github.repository }} \
-            --ref ${{ github.ref_name }}
+            --ref "${REF_NAME}"
         env:
           GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
 
   azure-integration-tests:
     name: AzureDB IT
@@ -690,7 +701,7 @@ jobs:
         id: parse-creds
         shell: bash
         run: |
-          SUBSCRIPTION=$(echo '${{ secrets.AZURE_CREDENTIALS }}' | jq -r '.subscriptionId')
+          SUBSCRIPTION=$(echo ''"${AZURE_CREDENTIALS}"'' | jq -r '.subscriptionId')
           if [[ -z "$SUBSCRIPTION" || "$SUBSCRIPTION" == "null" ]]; then
             echo "ERROR: Failed to parse subscriptionId from AZURE_CREDENTIALS"
             exit 1
@@ -699,6 +710,8 @@ jobs:
           echo "::add-mask::$SUBSCRIPTION"
           echo "subscription=$SUBSCRIPTION" >> $GITHUB_OUTPUT
 
+        env:
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Login to Azure
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:

--- a/.github/workflows/version-compatibility-matrix.yml
+++ b/.github/workflows/version-compatibility-matrix.yml
@@ -27,11 +27,12 @@ jobs:
         id: version-compatibility
         env:
           GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             BRANCH="${{ github.base_ref }}"
           else
-            BRANCH="${{ github.ref_name }}"
+            BRANCH="${REF_NAME}"
           fi
           MATRIX_JSON=$(./.github/scripts/version-compatibility.sh "${BRANCH}")
           echo "${MATRIX_JSON}"

--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -33,7 +33,10 @@ jobs:
     steps:
       # language=bash
       - run: |
-          if [ '${{ secrets.WEBLATE_TOKEN }}' != '' ]; then
-            curl --fail-with-body -d operation=pull -H "Authorization: Token ${{ secrets.WEBLATE_TOKEN }}" https://hosted.weblate.org/api/projects/keycloak/repository/
-            curl --fail-with-body -d operation=push -H "Authorization: Token ${{ secrets.WEBLATE_TOKEN }}" https://hosted.weblate.org/api/projects/keycloak/repository/
+          if [ ''"${WEBLATE_TOKEN}"'' != '' ]; then
+            curl --fail-with-body -d operation=pull -H "Authorization: Token ${WEBLATE_TOKEN}" https://hosted.weblate.org/api/projects/keycloak/repository/
+            curl --fail-with-body -d operation=push -H "Authorization: Token ${WEBLATE_TOKEN}" https://hosted.weblate.org/api/projects/keycloak/repository/
           fi
+
+        env:
+          WEBLATE_TOKEN: ${{ secrets.WEBLATE_TOKEN }}

--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # language=bash
       - run: |
-          if [ "${WEBLATE_TOKEN}" != '' ]; then
+          if [ "${WEBLATE_TOKEN}" != "" ]; then
             curl --fail-with-body -d operation=pull -H "Authorization: Token ${WEBLATE_TOKEN}" https://hosted.weblate.org/api/projects/keycloak/repository/
             curl --fail-with-body -d operation=push -H "Authorization: Token ${WEBLATE_TOKEN}" https://hosted.weblate.org/api/projects/keycloak/repository/
           fi

--- a/.github/workflows/weblate.yml
+++ b/.github/workflows/weblate.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # language=bash
       - run: |
-          if [ ''"${WEBLATE_TOKEN}"'' != '' ]; then
+          if [ "${WEBLATE_TOKEN}" != '' ]; then
             curl --fail-with-body -d operation=pull -H "Authorization: Token ${WEBLATE_TOKEN}" https://hosted.weblate.org/api/projects/keycloak/repository/
             curl --fail-with-body -d operation=push -H "Authorization: Token ${WEBLATE_TOKEN}" https://hosted.weblate.org/api/projects/keycloak/repository/
           fi


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning GitHub Actions to immutable commit SHAs and extracting unsafe expressions from `run:` blocks into `env:` mappings.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-008 | high | `aurora-delete.yml` | Extracted 2 expression(s) to env vars |
| RGS-008 | high | `ci.yml` | Extracted 8 expression(s) to env vars |
| RGS-008 | high | `version-compatibility-matrix.yml` | Extracted 1 expression(s) to env vars |
| RGS-008 | high | `weblate.yml` | Extracted 1 expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-012 | high | `ci.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-006 | high | `operator-ci.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-006 | high | `operator-ci.yml` | Curl-Pipe-Bash Remote Code Execution |
| RGS-012 | high | `weblate.yml` | Secret Exfiltration via Outbound HTTP Request |
| RGS-005 | medium | `label.yml` | Excessive Permissions on Untrusted Trigger |


## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` - original version preserved as comment
- **Expression extraction**: `${{ expr }}` in `run:` moves to `env:` block, referenced as `"${ENV_VAR}"` in the script
- No workflow logic, triggers, or permissions are modified

I've had 22 merges so far. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))