### PR TITLE
Fall back to theme.properties for custom theme descriptions

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -267,12 +267,15 @@ public class ServerInfoAdminResource {
         Locale locale = session.getContext().resolveLocale(null);
 
         Properties enhancedMessages = theme.getEnhancedMessages(session.getContext().getRealm(), locale);
-        if (enhancedMessages == null) {
-            return null;
+        if (enhancedMessages != null) {
+            String descriptionKey = "theme." + theme.getName() + "." + theme.getType().name().toLowerCase(Locale.ROOT) + ".description";
+            String description = enhancedMessages.getProperty(descriptionKey);
+            if (description != null) {
+                return description;
+            }
         }
 
-        String descriptionKey = "theme." + theme.getName() + "." + theme.getType().name().toLowerCase(Locale.ROOT) + ".description";
-        return enhancedMessages.getProperty(descriptionKey);
+        return theme.getProperties().getProperty("description");
     }
 
     private LinkedList<String> filterThemes(Theme.Type type, LinkedList<String> themeNames) {


### PR DESCRIPTION
## Summary

When a custom theme extends a built-in theme (e.g., `keycloak.v2`) and defines its own `description` in `theme.properties`, the description is never rendered in the admin UI. This is because `getThemeDescription()` only looks up theme-name-specific message bundle keys (e.g., `theme.quick-theme.login.description`), which custom themes typically do not define.

This PR adds a fallback: if the message bundle key is not found, the method reads the `description` property from `theme.properties`. This allows custom theme authors to simply add `description=My theme description` to their `theme.properties` file.

The change also handles the case where `getEnhancedMessages()` returns null by falling back to `theme.getProperties()` instead of returning null immediately.

Closes #47703

## Test plan

- [ ] Deploy a custom theme that extends `keycloak.v2` with `description=Custom description` in `theme.properties`
- [ ] Verify the custom description is shown in the admin console theme selector
- [ ] Verify built-in themes (keycloak, keycloak.v2) still show their descriptions via message bundle keys
- [ ] Verify themes with no description property show no description (null)