### PR TITLE
Fix Maven wrapper failing when path contains spaces on Windows

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -40,7 +40,7 @@
 @SET __MVNW_ARG0_NAME__=
 @SET MVNW_USERNAME=
 @SET MVNW_PASSWORD=
-@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
 @echo Cannot start maven from wrapper >&2 && exit /b 1
 @GOTO :EOF
 : end batch / begin powershell #>


### PR DESCRIPTION
## Summary

- Quotes `%__MVNW_CMD__%` in `mvnw.cmd` line 43 so that paths containing spaces (e.g., `C:\Users\John Doe\.m2\...`) are handled correctly by Windows `cmd.exe`.
- Without quotes, the command path is split at the first space, resulting in `"'C:\Users\John' is not recognized as an internal or external command"`.
- This is the same one-character fix merged upstream in apache/maven-wrapper 3.3.3 (apache/maven-wrapper#152, MWRAPPER-151).

Closes #47499

## Test plan

- [ ] Build Keycloak from source on Windows with a username containing spaces (e.g., `C:\Users\John Doe\`)
- [ ] Verify `mvnw.cmd` launches Maven correctly without "is not recognized" errors
- [ ] Verify `mvnw.cmd` continues to work on paths without spaces