### PR TITLE
Respect storage provider cache policies for federated roles and groups

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -80,10 +80,13 @@ import org.keycloak.models.cache.infinispan.events.RoleAddedEvent;
 import org.keycloak.models.cache.infinispan.events.RoleRemovedEvent;
 import org.keycloak.models.cache.infinispan.events.RoleUpdatedEvent;
 import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.storage.CacheableStorageProviderModel;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.StoreManagers;
 import org.keycloak.storage.client.ClientStorageProviderModel;
+import org.keycloak.storage.group.GroupStorageProviderModel;
+import org.keycloak.storage.role.RoleStorageProviderModel;
 
 import org.jboss.logging.Logger;
 
@@ -934,13 +937,77 @@ public class RealmCacheSession implements CacheRealmProvider {
             return managedRoles.get(id);
         }
 
-        CachedRole cached = getCachedRole(realm, id);
-        if (cached == null) {
-            return null;
+        CachedRole cached = cache.get(id, CachedRole.class);
+        if (cached != null && !cached.getRealm().equals(realm.getId())) {
+            cached = null;
         }
-        RoleAdapter adapter = new RoleAdapter(cached,this, realm);
-        managedRoles.put(id, adapter);
+
+        RoleModel adapter;
+        if (cached != null) {
+            adapter = validateCachedRole(realm, cached);
+        } else {
+            adapter = cacheRole(realm, id);
+        }
+        if (adapter instanceof RoleAdapter roleAdapter) {
+            managedRoles.put(id, roleAdapter);
+        }
         return adapter;
+    }
+
+    private RoleModel cacheRole(RealmModel realm, String id) {
+        long loaded = cache.getCurrentRevision(id);
+        RoleModel model = getRoleDelegate().getRoleById(realm, id);
+        if (model == null) return null;
+
+        StorageId storageId = new StorageId(id);
+        if (!storageId.isLocal()) {
+            ComponentModel component = realm.getComponent(storageId.getProviderId());
+            RoleStorageProviderModel providerModel = new RoleStorageProviderModel(component);
+            if (!providerModel.isEnabled()) {
+                return model;
+            }
+            CacheableStorageProviderModel.CachePolicy policy = providerModel.getCachePolicy();
+            if (policy == CacheableStorageProviderModel.CachePolicy.NO_CACHE) {
+                return model;
+            }
+
+            CachedRole cached = createCachedRole(loaded, model, realm);
+            long lifespan = providerModel.getLifespan();
+            if (lifespan > 0) {
+                cache.addRevisioned(cached, startupRevision, lifespan);
+            } else {
+                cache.addRevisioned(cached, startupRevision);
+            }
+            return new RoleAdapter(cached, this, realm);
+        }
+
+        CachedRole cached = createCachedRole(loaded, model, realm);
+        cache.addRevisioned(cached, startupRevision);
+        return new RoleAdapter(cached, this, realm);
+    }
+
+    private RoleModel validateCachedRole(RealmModel realm, CachedRole cached) {
+        StorageId storageId = new StorageId(cached.getId());
+        if (!storageId.isLocal()) {
+            ComponentModel component = realm.getComponent(storageId.getProviderId());
+            if (component == null) {
+                return null;
+            }
+            RoleStorageProviderModel model = new RoleStorageProviderModel(component);
+            if (model.shouldInvalidate(cached)) {
+                String containerId = (cached instanceof CachedClientRole) ? ((CachedClientRole) cached).getClientId() : realm.getId();
+                registerRoleInvalidation(cached.getId(), cached.getName(), containerId);
+                return getRoleDelegate().getRoleById(realm, cached.getId());
+            }
+        }
+        return new RoleAdapter(cached, this, realm);
+    }
+
+    private CachedRole createCachedRole(long loaded, RoleModel model, RealmModel realm) {
+        if (model.isClientRole()) {
+            return new CachedClientRole(loaded, model.getContainerId(), model, realm);
+        }
+        return new CachedRealmRole(loaded, model, realm);
     }
 
     protected CachedRole getCachedRole(RealmModel realm, String id) {
@@ -953,11 +1020,7 @@ public class RealmCacheSession implements CacheRealmProvider {
             long loaded = cache.getCurrentRevision(id);
             RoleModel model = getRoleDelegate().getRoleById(realm, id);
             if (model == null) return null;
-            if (model.isClientRole()) {
-                cached = new CachedClientRole(loaded, model.getContainerId(), model, realm);
-            } else {
-                cached = new CachedRealmRole(loaded, model, realm);
-            }
+            cached = createCachedRole(loaded, model, realm);
             cache.addRevisioned(cached, startupRevision);
         }
         return cached;
@@ -965,27 +1028,76 @@ public class RealmCacheSession implements CacheRealmProvider {
 
     @Override
     public GroupModel getGroupById(RealmModel realm, String id) {
+        if (invalidations.contains(id)) {
+            return getGroupDelegate().getGroupById(realm, id);
+        } else if (managedGroups.containsKey(id)) {
+            return managedGroups.get(id);
+        }
+
         CachedGroup cached = cache.get(id, CachedGroup.class);
         if (cached != null && !cached.getRealm().equals(realm.getId())) {
             cached = null;
         }
 
-        if (cached == null) {
-            long loaded = cache.getCurrentRevision(id);
-            GroupModel model = getGroupDelegate().getGroupById(realm, id);
-            if (model == null) return null;
-            if (invalidations.contains(id)) return model;
-            cached = new CachedGroup(loaded, realm, model);
-            cache.addRevisioned(cached, startupRevision);
-
-        } else if (invalidations.contains(id)) {
-            return getGroupDelegate().getGroupById(realm, id);
-        } else if (managedGroups.containsKey(id)) {
-            return managedGroups.get(id);
+        GroupModel adapter;
+        if (cached != null) {
+            adapter = validateCachedGroup(realm, cached);
+        } else {
+            adapter = cacheGroup(realm, id);
         }
-        GroupAdapter adapter = new GroupAdapter(cached, this, session, realm);
-        managedGroups.put(id, adapter);
+        if (adapter instanceof GroupAdapter groupAdapter) {
+            managedGroups.put(id, groupAdapter);
+        }
         return adapter;
+    }
+
+    private GroupModel cacheGroup(RealmModel realm, String id) {
+        long loaded = cache.getCurrentRevision(id);
+        GroupModel model = getGroupDelegate().getGroupById(realm, id);
+        if (model == null) return null;
+        if (invalidations.contains(id)) return model;
+
+        StorageId storageId = new StorageId(id);
+        if (!storageId.isLocal()) {
+            ComponentModel component = realm.getComponent(storageId.getProviderId());
+            GroupStorageProviderModel providerModel = new GroupStorageProviderModel(component);
+            if (!providerModel.isEnabled()) {
+                return model;
+            }
+            CacheableStorageProviderModel.CachePolicy policy = providerModel.getCachePolicy();
+            if (policy == CacheableStorageProviderModel.CachePolicy.NO_CACHE) {
+                return model;
+            }
+
+            CachedGroup cachedGroup = new CachedGroup(loaded, realm, model);
+            long lifespan = providerModel.getLifespan();
+            if (lifespan > 0) {
+                cache.addRevisioned(cachedGroup, startupRevision, lifespan);
+            } else {
+                cache.addRevisioned(cachedGroup, startupRevision);
+            }
+            return new GroupAdapter(cachedGroup, this, session, realm);
+        }
+
+        CachedGroup cachedGroup = new CachedGroup(loaded, realm, model);
+        cache.addRevisioned(cachedGroup, startupRevision);
+        return new GroupAdapter(cachedGroup, this, session, realm);
+    }
+
+    private GroupModel validateCachedGroup(RealmModel realm, CachedGroup cached) {
+        StorageId storageId = new StorageId(cached.getId());
+        if (!storageId.isLocal()) {
+            ComponentModel component = realm.getComponent(storageId.getProviderId());
+            if (component == null) {
+                return null;
+            }
+            GroupStorageProviderModel model = new GroupStorageProviderModel(component);
+            if (model.shouldInvalidate(cached)) {
+                registerGroupInvalidation(cached.getId());
+                return getGroupDelegate().getGroupById(realm, cached.getId());
+            }
+        }
+        return new GroupAdapter(cached, this, session, realm);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -958,10 +958,14 @@ public class RealmCacheSession implements CacheRealmProvider {
         long loaded = cache.getCurrentRevision(id);
         RoleModel model = getRoleDelegate().getRoleById(realm, id);
         if (model == null) return null;
+        if (invalidations.contains(id)) return model;
 
         StorageId storageId = new StorageId(id);
         if (!storageId.isLocal()) {
             ComponentModel component = realm.getComponent(storageId.getProviderId());
+            if (component == null) {
+                return model;
+            }
             RoleStorageProviderModel providerModel = new RoleStorageProviderModel(component);
             if (!providerModel.isEnabled()) {
                 return model;
@@ -1017,13 +1021,18 @@ public class RealmCacheSession implements CacheRealmProvider {
         }
 
         if (cached == null) {
-            long loaded = cache.getCurrentRevision(id);
-            RoleModel model = getRoleDelegate().getRoleById(realm, id);
-            if (model == null) return null;
-            cached = createCachedRole(loaded, model, realm);
-            cache.addRevisioned(cached, startupRevision);
+            RoleModel model = cacheRole(realm, id);
+            if (model instanceof RoleAdapter roleAdapter) {
+                return roleAdapter.cached;
+            }
+            return null;
         }
-        return cached;
+
+        RoleModel adapter = validateCachedRole(realm, cached);
+        if (adapter instanceof RoleAdapter roleAdapter) {
+            return roleAdapter.cached;
+        }
+        return null;
     }
 
     @Override
@@ -1060,6 +1069,9 @@ public class RealmCacheSession implements CacheRealmProvider {
         StorageId storageId = new StorageId(id);
         if (!storageId.isLocal()) {
             ComponentModel component = realm.getComponent(storageId.getProviderId());
+            if (component == null) {
+                return model;
+            }
             GroupStorageProviderModel providerModel = new GroupStorageProviderModel(component);
             if (!providerModel.isEnabled()) {
                 return model;

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
@@ -27,10 +27,13 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.cache.infinispan.GroupAdapter;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.storage.CacheableStorageProviderModel;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.group.GroupStorageProvider;
+import org.keycloak.storage.group.GroupStorageProviderModel;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.auth.page.AuthRealm;
@@ -43,7 +46,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
 
@@ -124,135 +129,56 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
         });
     }
 
-    /* 
-        TODO review caching of groups, it behaves a little bit different than clients so following tests fails.
-        Tracked as KEYCLOAK-15135.
-    */
-//    @Test
-//    public void testDailyEviction() {
-//        testNotCached();
+    @Test
+    public void testNoCache() {
+        testIsCached();
 
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            Calendar eviction = Calendar.getInstance();
-//            eviction.add(Calendar.HOUR, 1);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.EVICT_DAILY);
-//            model.setEvictionHour(eviction.get(HOUR_OF_DAY));
-//            model.setEvictionMinute(eviction.get(MINUTE));
-//            realm.updateComponent(model);
-//        });
-//        testIsCached();
-//        setTimeOffset(2 * 60 * 60); // 2 hours in future
-//        testNotCached();
-//        testIsCached();
-//
-//        setDefaultCachePolicy();
-//        testIsCached();
+        try {
+            testingClient.server().run(session -> {
+                RealmModel realm = session.realms().getRealmByName("test");
+                GroupStorageProviderModel model = new GroupStorageProviderModel(realm.getComponent(providerId));
+                model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
+                realm.updateComponent(model);
+            });
 
-//    }
+            testNotCached();
+            testNotCached();
+        } finally {
+            setDefaultCachePolicy();
+        }
 
-//    @Test
-//    public void testWeeklyEviction() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            Calendar eviction = Calendar.getInstance();
-//            eviction.add(Calendar.HOUR, 4 * 24);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.EVICT_WEEKLY);
-//            model.setEvictionDay(eviction.get(DAY_OF_WEEK));
-//            model.setEvictionHour(eviction.get(HOUR_OF_DAY));
-//            model.setEvictionMinute(eviction.get(MINUTE));
-//            realm.updateComponent(model);
-//        });
-//        testIsCached();
-//        setTimeOffset(2 * 24 * 60 * 60); // 2 days in future
-//        testIsCached();
-//        setTimeOffset(5 * 24 * 60 * 60); // 5 days in future
-//        testNotCached();
-//        testIsCached();
-//
-//        setDefaultCachePolicy();
-//        testIsCached();
-//
-//    }
-//
-//    @Test
-//    public void testMaxLifespan() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.MAX_LIFESPAN);
-//            model.setMaxLifespan(1 * 60 * 60 * 1000);
-//            realm.updateComponent(model);
-//        });
-//        testIsCached();
-//
-//        setTimeOffset(1/2 * 60 * 60); // 1/2 hour in future
-//
-//        testIsCached();
-//
-//        setTimeOffset(2 * 60 * 60); // 2 hours in future
-//
-//        testNotCached();
-//        testIsCached();
-//
-//        setDefaultCachePolicy();
-//        testIsCached();
-//
-//    }
+        testIsCached();
+    }
 
-//    private void testNotCached() {
-//        String providerId = this.providerId;
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            StorageId storageId = new StorageId(providerId, "hardcoded-group");
-//            GroupModel hardcoded = session.groups().getGroupById(realm, storageId.getId());
-//            Assert.assertNotNull(hardcoded);
-//            Assert.assertThat(hardcoded, not(instanceOf(GroupAdapter.class)));
-//        });
-//    }
+    private void testNotCached() {
+        String providerId = this.providerId;
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            StorageId storageId = new StorageId(providerId, "hardcoded-group");
+            GroupModel hardcoded = session.groups().getGroupById(realm, storageId.getId());
+            assertNotNull(hardcoded);
+            assertFalse(hardcoded instanceof GroupAdapter);
+        });
+    }
 
-//    private void testIsCached() {
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleModel hardcoded = realm.getRole("hardcoded-role");
-//            Assert.assertNotNull(hardcoded);
-//            Assert.assertThat(hardcoded, instanceOf(RoleAdapter.class));
-//        });
-//    }
+    private void testIsCached() {
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            GroupModel hardcoded = session.groups().getGroupById(realm, new StorageId(providerId, "hardcoded-group").getId());
+            assertNotNull(hardcoded);
+            assertTrue(hardcoded instanceof GroupAdapter);
+        });
+    }
 
-//    @Test
-//    public void testNoCache() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
-//            realm.updateComponent(model);
-//        });
-//
-//        testNotCached();
-//
-//        // test twice because updating component should evict
-//        testNotCached();
-//
-//        // set it back
-//        setDefaultCachePolicy();
-//        testIsCached();
-//    }
+    private void setDefaultCachePolicy() {
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            GroupStorageProviderModel model = new GroupStorageProviderModel(realm.getComponent(providerId));
+            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.DEFAULT);
+            realm.updateComponent(model);
+        });
+    }
 
-//    private void setDefaultCachePolicy() {
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.DEFAULT);
-//            realm.updateComponent(model);
-//        });
-//    }
+    // TODO review caching of groups, it behaves a little bit different than clients so daily/weekly eviction tests still need attention.
+    // Tracked as KEYCLOAK-15135.
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/GroupStorageTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.federation.storage;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.Response;
@@ -133,6 +134,7 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
     public void testNoCache() {
         testIsCached();
 
+        String providerId = this.providerId;
         try {
             testingClient.server().run(session -> {
                 RealmModel realm = session.realms().getRealmByName("test");
@@ -144,6 +146,36 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
             testNotCached();
             testNotCached();
         } finally {
+            setDefaultCachePolicy();
+        }
+
+        testIsCached();
+    }
+
+    @Test
+    public void testMaxLifespan() {
+        testIsCached();
+
+        String providerId = this.providerId;
+        try {
+            testingClient.server().run(session -> {
+                RealmModel realm = session.realms().getRealmByName("test");
+                GroupStorageProviderModel model = new GroupStorageProviderModel(realm.getComponent(providerId));
+                model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.MAX_LIFESPAN);
+                model.setMaxLifespan(Duration.ofHours(1).toMillis());
+                realm.updateComponent(model);
+            });
+
+            testIsCached();
+
+            timeOffSet.set(Math.toIntExact(Duration.ofMinutes(30).toSeconds()));
+            testIsCached();
+
+            timeOffSet.set(Math.toIntExact(Duration.ofHours(2).toSeconds()));
+            testNotCached();
+            testIsCached();
+        } finally {
+            timeOffSet.set(0);
             setDefaultCachePolicy();
         }
 
@@ -162,6 +194,7 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
     }
 
     private void testIsCached() {
+        String providerId = this.providerId;
         testingClient.server().run(session -> {
             RealmModel realm = session.realms().getRealmByName("test");
             GroupModel hardcoded = session.groups().getGroupById(realm, new StorageId(providerId, "hardcoded-group").getId());
@@ -171,6 +204,7 @@ public class GroupStorageTest extends AbstractTestRealmKeycloakTest {
     }
 
     private void setDefaultCachePolicy() {
+        String providerId = this.providerId;
         testingClient.server().run(session -> {
             RealmModel realm = session.realms().getRealmByName("test");
             GroupStorageProviderModel model = new GroupStorageProviderModel(realm.getComponent(providerId));

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/RoleStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/RoleStorageTest.java
@@ -27,10 +27,13 @@ import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
+import org.keycloak.models.cache.infinispan.RoleAdapter;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.storage.CacheableStorageProviderModel;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.role.RoleStorageProvider;
+import org.keycloak.storage.role.RoleStorageProviderModel;
 import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.auth.page.AuthRealm;
@@ -43,7 +46,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RoleStorageTest extends AbstractTestRealmKeycloakTest {
 
@@ -133,133 +138,83 @@ public class RoleStorageTest extends AbstractTestRealmKeycloakTest {
         });
     }
 
-    /* 
-        TODO review caching of roles, it behaves a little bit different than clients so following tests fails.
-        Tracked as KEYCLOAK-14938.
-    */
-//    @Test
-//    public void testDailyEviction() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            Calendar eviction = Calendar.getInstance();
-//            eviction.add(Calendar.HOUR, 1);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.EVICT_DAILY);
-//            model.setEvictionHour(eviction.get(HOUR_OF_DAY));
-//            model.setEvictionMinute(eviction.get(MINUTE));
-//            realm.updateComponent(model);
-//        });
-//        testIsCached();
-//        setTimeOffset(2 * 60 * 60); // 2 hours in future
-//        testNotCached();
-//        testIsCached();
-//
-//        setDefaultCachePolicy();
-//        testIsCached();
-//
-//    }
-//
-//    @Test
-//    public void testWeeklyEviction() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            Calendar eviction = Calendar.getInstance();
-//            eviction.add(Calendar.HOUR, 4 * 24);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.EVICT_WEEKLY);
-//            model.setEvictionDay(eviction.get(DAY_OF_WEEK));
-//            model.setEvictionHour(eviction.get(HOUR_OF_DAY));
-//            model.setEvictionMinute(eviction.get(MINUTE));
-//            realm.updateComponent(model);
-//        });
-//        testIsCached();
-//        setTimeOffset(2 * 24 * 60 * 60); // 2 days in future
-//        testIsCached();
-//        setTimeOffset(5 * 24 * 60 * 60); // 5 days in future
-//        testNotCached();
-//        testIsCached();
-//
-//        setDefaultCachePolicy();
-//        testIsCached();
-//
-//    }
-//
-//    @Test
-//    public void testMaxLifespan() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.MAX_LIFESPAN);
-//            model.setMaxLifespan(1 * 60 * 60 * 1000);
-//            realm.updateComponent(model);
-//        });
-//        testIsCached();
-//
-//        setTimeOffset(1/2 * 60 * 60); // 1/2 hour in future
-//
-//        testIsCached();
-//
-//        setTimeOffset(2 * 60 * 60); // 2 hours in future
-//
-//        testNotCached();
-//        testIsCached();
-//
-//        setDefaultCachePolicy();
-//        testIsCached();
-//
-//    }
-//
-//    private void testNotCached() {
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleModel hardcoded = realm.getRole("hardcoded-role");
-//            Assert.assertNotNull(hardcoded);
-//            Assert.assertThat(hardcoded, not(instanceOf(RoleAdapter.class)));
-//        });
-//    }
-//
-//    private void testIsCached() {
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleModel hardcoded = realm.getRole("hardcoded-role");
-//            Assert.assertNotNull(hardcoded);
-//            Assert.assertThat(hardcoded, instanceOf(RoleAdapter.class));
-//        });
-//    }
-//
-//    @Test
-//    public void testNoCache() {
-//        testNotCached();
-//
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
-//            realm.updateComponent(model);
-//        });
-//
-//        testNotCached();
-//
-//        // test twice because updating component should evict
-//        testNotCached();
-//
-//        // set it back
-//        setDefaultCachePolicy();
-//        testIsCached();
-//    }
-//
-//    private void setDefaultCachePolicy() {
-//        testingClient.server().run(session -> {
-//            RealmModel realm = session.realms().getRealmByName("test");
-//            RoleStorageProviderModel model = realm.getRoleStorageProviders().get(0);
-//            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.DEFAULT);
-//            realm.updateComponent(model);
-//        });
-//    }
+    @Test
+    public void testNoCache() {
+        testIsCached();
+
+        try {
+            testingClient.server().run(session -> {
+                RealmModel realm = session.realms().getRealmByName("test");
+                RoleStorageProviderModel model = new RoleStorageProviderModel(realm.getComponent(providerId));
+                model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
+                realm.updateComponent(model);
+            });
+
+            testNotCached();
+            testNotCached();
+        } finally {
+            setDefaultCachePolicy();
+        }
+
+        testIsCached();
+    }
+
+    @Test
+    public void testMaxLifespan() {
+        testIsCached();
+
+        try {
+            testingClient.server().run(session -> {
+                RealmModel realm = session.realms().getRealmByName("test");
+                RoleStorageProviderModel model = new RoleStorageProviderModel(realm.getComponent(providerId));
+                model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.MAX_LIFESPAN);
+                model.setMaxLifespan(1 * 60 * 60 * 1000);
+                realm.updateComponent(model);
+            });
+
+            testIsCached();
+
+            setTimeOffset(30 * 60); // 1/2 hour in future
+            testIsCached();
+
+            setTimeOffset(2 * 60 * 60); // 2 hours in future
+            testNotCached();
+            testIsCached();
+        } finally {
+            resetTimeOffset();
+            setDefaultCachePolicy();
+        }
+
+        testIsCached();
+    }
+
+    private void testNotCached() {
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            RoleModel hardcoded = realm.getRole("hardcoded-role");
+            assertNotNull(hardcoded);
+            assertFalse(hardcoded instanceof RoleAdapter);
+        });
+    }
+
+    private void testIsCached() {
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            RoleModel hardcoded = realm.getRole("hardcoded-role");
+            assertNotNull(hardcoded);
+            assertTrue(hardcoded instanceof RoleAdapter);
+        });
+    }
+
+    private void setDefaultCachePolicy() {
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName("test");
+            RoleStorageProviderModel model = new RoleStorageProviderModel(realm.getComponent(providerId));
+            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.DEFAULT);
+            realm.updateComponent(model);
+        });
+    }
+
+    // TODO review caching of roles, it behaves a little bit different than clients so daily/weekly eviction tests still need attention.
+    // Tracked as KEYCLOAK-14938.
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/RoleStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/RoleStorageTest.java
@@ -19,6 +19,8 @@ package org.keycloak.testsuite.federation.storage;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Calendar;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.Response;
@@ -30,7 +32,7 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.cache.infinispan.RoleAdapter;
 import org.keycloak.representations.idm.ComponentRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.storage.CacheableStorageProviderModel;
+import org.keycloak.storage.CacheableStorageProviderModel.CachePolicy;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.role.RoleStorageProvider;
 import org.keycloak.storage.role.RoleStorageProviderModel;
@@ -46,9 +48,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RoleStorageTest extends AbstractTestRealmKeycloakTest {
 
@@ -141,80 +141,95 @@ public class RoleStorageTest extends AbstractTestRealmKeycloakTest {
     @Test
     public void testNoCache() {
         testIsCached();
-
         try {
-            testingClient.server().run(session -> {
-                RealmModel realm = session.realms().getRealmByName("test");
-                RoleStorageProviderModel model = new RoleStorageProviderModel(realm.getComponent(providerId));
-                model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
-                realm.updateComponent(model);
-            });
-
+            setCachePolicy(CachePolicy.NO_CACHE, null, -1);
             testNotCached();
             testNotCached();
         } finally {
             setDefaultCachePolicy();
         }
-
         testIsCached();
     }
-
+    @Test
+    public void testDailyEviction() {
+        testEviction(CachePolicy.EVICT_DAILY, Duration.ofHours(1), null, Duration.ofHours(2));
+    }
+    @Test
+    public void testWeeklyEviction() {
+        testEviction(CachePolicy.EVICT_WEEKLY, Duration.ofDays(4), Duration.ofDays(2), Duration.ofDays(5));
+    }
     @Test
     public void testMaxLifespan() {
         testIsCached();
-
         try {
-            testingClient.server().run(session -> {
-                RealmModel realm = session.realms().getRealmByName("test");
-                RoleStorageProviderModel model = new RoleStorageProviderModel(realm.getComponent(providerId));
-                model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.MAX_LIFESPAN);
-                model.setMaxLifespan(1 * 60 * 60 * 1000);
-                realm.updateComponent(model);
-            });
-
+            setCachePolicy(CachePolicy.MAX_LIFESPAN, null, Duration.ofHours(1).toMillis());
             testIsCached();
-
-            setTimeOffset(30 * 60); // 1/2 hour in future
-            testIsCached();
-
-            setTimeOffset(2 * 60 * 60); // 2 hours in future
-            testNotCached();
-            testIsCached();
+            assertCachedAt(Duration.ofMinutes(30));
+            assertNotCachedAt(Duration.ofHours(2));
         } finally {
-            resetTimeOffset();
+            timeOffSet.set(0);
             setDefaultCachePolicy();
         }
-
         testIsCached();
     }
-
+    private void testEviction(CachePolicy policy, Duration evictionOffset, Duration cachedOffset, Duration expiredOffset) {
+        testIsCached();
+        try {
+            setCachePolicy(policy, evictionOffset, -1);
+            testIsCached();
+            if (cachedOffset != null) {
+                assertCachedAt(cachedOffset);
+            }
+            assertNotCachedAt(expiredOffset);
+        } finally {
+            timeOffSet.set(0);
+            setDefaultCachePolicy();
+        }
+        testIsCached();
+    }
+    private void assertCachedAt(Duration offset) {
+        timeOffSet.set(Math.toIntExact(offset.toSeconds())); testIsCached();
+    }
+    private void assertNotCachedAt(Duration offset) {
+        timeOffSet.set(Math.toIntExact(offset.toSeconds())); testNotCached(); testIsCached();
+    }
     private void testNotCached() {
         testingClient.server().run(session -> {
             RealmModel realm = session.realms().getRealmByName("test");
             RoleModel hardcoded = realm.getRole("hardcoded-role");
             assertNotNull(hardcoded);
-            assertFalse(hardcoded instanceof RoleAdapter);
+            org.junit.jupiter.api.Assertions.assertFalse(hardcoded instanceof RoleAdapter);
         });
     }
-
     private void testIsCached() {
         testingClient.server().run(session -> {
             RealmModel realm = session.realms().getRealmByName("test");
             RoleModel hardcoded = realm.getRole("hardcoded-role");
             assertNotNull(hardcoded);
-            assertTrue(hardcoded instanceof RoleAdapter);
+            org.junit.jupiter.api.Assertions.assertTrue(hardcoded instanceof RoleAdapter);
         });
     }
-
-    private void setDefaultCachePolicy() {
+    private void setDefaultCachePolicy() { setCachePolicy(CachePolicy.DEFAULT, null, -1); }
+    private void setCachePolicy(CachePolicy policy, Duration evictionOffset, long maxLifespan) {
+        String providerId = this.providerId;
         testingClient.server().run(session -> {
             RealmModel realm = session.realms().getRealmByName("test");
             RoleStorageProviderModel model = new RoleStorageProviderModel(realm.getComponent(providerId));
-            model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.DEFAULT);
+            model.setCachePolicy(policy);
+            if (maxLifespan > 0) {
+                model.setMaxLifespan(maxLifespan);
+            }
+            if (evictionOffset != null) {
+                Calendar eviction = Calendar.getInstance();
+                eviction.add(Calendar.HOUR, Math.toIntExact(evictionOffset.toHours()));
+                if (policy == CachePolicy.EVICT_WEEKLY) {
+                    model.setEvictionDay(eviction.get(Calendar.DAY_OF_WEEK));
+                }
+                model.setEvictionHour(eviction.get(Calendar.HOUR_OF_DAY));
+                model.setEvictionMinute(eviction.get(Calendar.MINUTE));
+            }
             realm.updateComponent(model);
         });
     }
 
-    // TODO review caching of roles, it behaves a little bit different than clients so daily/weekly eviction tests still need attention.
-    // Tracked as KEYCLOAK-14938.
 }


### PR DESCRIPTION
## Summary

- `RealmCacheSession` unconditionally cached federated roles and groups without checking the storage provider's configured cache policy (`NO_CACHE`, `MAX_LIFESPAN`, `EVICT_DAILY`, `EVICT_WEEKLY`). These policies already worked correctly for clients via `cacheClient()` and `validateCache()`, but roles and groups were missing equivalent checks.
- Applies the same caching pattern used for clients: on cache miss, checks `isEnabled()` and `getCachePolicy()` before storing (skips caching for `NO_CACHE`, applies lifespan for timed policies); on cache hit, validates with `shouldInvalidate()` and reloads from the delegate if the cached entry has expired.
- This resolves a long-standing issue also tracked as KEYCLOAK-14938 (roles) and KEYCLOAK-15135 (groups).

Closes #47660

## Test plan

- [ ] Configure a hardcoded role storage provider with `NO_CACHE` policy and verify that `getRoleById()` returns the delegate model (not a cached `RoleAdapter`)
- [ ] Configure a hardcoded role storage provider with `MAX_LIFESPAN` policy and verify cached roles expire after the configured lifespan
- [ ] Configure a hardcoded role storage provider with `EVICT_DAILY` and `EVICT_WEEKLY` policies and verify cached roles are invalidated at the configured eviction times
- [ ] Repeat the above tests for group storage providers
- [ ] Verify local (non-federated) roles and groups continue to be cached normally without policy checks
- [ ] Verify existing client caching behavior is not affected