### PR TITLE
fix: return null for unparseable OIDC attribute values instead of throwing

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -182,8 +182,7 @@ public class OIDCAttributeMapperHelper {
         }
 
         String type = mappingModel.getConfig().get(JSON_TYPE);
-        Object converted = convertToType(type, attributeValue);
-        return converted != null ? converted : attributeValue;
+        return convertToType(type, attributeValue);
     }
 
     private static <X, T> List<T> transform(List<X> attributeValue, Function<X, T> mapper) {
@@ -202,7 +201,7 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getBoolean);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "String":
                 if (attributeValue instanceof String) return attributeValue;
                 if (attributeValue instanceof List) {
@@ -215,23 +214,23 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getLong);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "int":
                 Integer intObject = getInteger(attributeValue);
                 if (intObject != null) return intObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getInteger);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "JSON":
                 JsonNode jsonNodeObject = getJsonNode(attributeValue);
                 if (jsonNodeObject != null) return jsonNodeObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getJsonNode);
                 }
-                throw new RuntimeException("cannot map type for token claim");
-            default:
                 return null;
+            default:
+                return attributeValue;
         }
     }
 
@@ -242,13 +241,25 @@ public class OIDCAttributeMapperHelper {
 
     private static Long getLong(Object attributeValue) {
         if (attributeValue instanceof Long) return (Long) attributeValue;
-        if (attributeValue instanceof String) return Long.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            try {
+                return Long.valueOf((String) attributeValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 
     private static Integer getInteger(Object attributeValue) {
         if (attributeValue instanceof Integer) return (Integer) attributeValue;
-        if (attributeValue instanceof String) return Integer.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            try {
+                return Integer.valueOf((String) attributeValue);
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
## Fix

Make `convertToType()` return `null` instead of throwing `RuntimeException` for all claim types (boolean, long, int, JSON). Also make `getLong()` and `getInteger()` catch `NumberFormatException` for empty/invalid strings instead of propagating it.

This prevents login failures when custom federation providers return empty/missing numeric attributes like `updated_at`.

## Context

Picks up from #46764/#46841 (which were closed due to the original author being banned). Incorporates the approach from @rmartinc's [reference commit](https://github.com/keycloak/keycloak/commit/fea883456efd7e27951bb8dd3a1cb14606f0c2f8):
- All `throw new RuntimeException` replaced with `return null`
- `default` case returns `attributeValue`
- `mapAttributeValue` simplified
- Added try-catch in `getLong()` and `getInteger()` for NFE on empty/invalid strings (the direct crash path reported in the issue)

Happy to add unit tests for the edge cases if needed.

Closes #46132
