### PR TITLE
Add SCIM 2.0 client capabilities behind experimental Feature Profile …

### DIFF
--- a/federation/pom.xml
+++ b/federation/pom.xml
@@ -37,6 +37,7 @@
         <module>ldap</module>
         <module>sssd</module>
         <module>ipatuura</module>
+        <module>scim</module>
     </modules>
 
 </project>

--- a/federation/scim/pom.xml
+++ b/federation/scim/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>keycloak-federation-parent</artifactId>
+        <groupId>org.keycloak</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-scim-federation</artifactId>
+    <name>Keycloak SCIM Federation</name>
+    <description>SCIM 2.0 client capabilities for Keycloak</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-model-storage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/federation/scim/src/main/java/org/keycloak/federation/scim/ScimClient.java
+++ b/federation/scim/src/main/java/org/keycloak/federation/scim/ScimClient.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.federation.scim;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.keycloak.component.ComponentModel;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * SCIM 2.0 HTTP client using native Java HTTP client (no 3rd party SDK).
+ * Handles communication with SCIM service providers.
+ */
+public class ScimClient {
+
+    private final String baseUrl;
+    private final String authType;
+    private final String authToken;
+    private final String username;
+    private final String password;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    public ScimClient(ComponentModel model) {
+        this.baseUrl = model.get("scimBaseUrl");
+        this.authType = model.get("scimAuthType");
+        this.authToken = model.get("scimAuthToken");
+        this.username = model.get("scimUsername");
+        this.password = model.get("scimPassword");
+        this.httpClient = HttpClient.newBuilder().build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    private HttpRequest.Builder addAuth(HttpRequest.Builder builder) {
+        switch (authType.toLowerCase()) {
+            case "basic":
+                String basicAuth = Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+                return builder.header("Authorization", "Basic " + basicAuth);
+            case "bearer":
+            case "oauth":
+                return builder.header("Authorization", "Bearer " + authToken);
+            default:
+                return builder;
+        }
+    }
+
+    public ScimUser getUser(String id) {
+        try {
+            HttpRequest request = addAuth(HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/Users/" + id))
+                    .header("Accept", "application/scim+json")
+                    .GET())
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                return parseUser(objectMapper.readTree(response.body()));
+            }
+            return null;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get user from SCIM", e);
+        }
+    }
+
+    public ScimUser getUserByUsername(String username) {
+        List<ScimUser> users = searchUsers("userName eq \"" + username + "\"", 0, 1);
+        return users.isEmpty() ? null : users.get(0);
+    }
+
+    public ScimUser getUserByEmail(String email) {
+        List<ScimUser> users = searchUsers("emails eq \"" + email + "\"", 0, 1);
+        return users.isEmpty() ? null : users.get(0);
+    }
+
+    public List<ScimUser> searchUsers(String filter, Integer startIndex, Integer count) {
+        try {
+            String url = baseUrl + "/Users?filter=" + encode(filter);
+            if (startIndex != null) url += "&startIndex=" + startIndex;
+            if (count != null) url += "&count=" + count;
+
+            HttpRequest request = addAuth(HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Accept", "application/scim+json")
+                    .GET())
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                return parseUserList(objectMapper.readTree(response.body()));
+            }
+            return new ArrayList<>();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to search users from SCIM", e);
+        }
+    }
+
+    public int getUsersCount() {
+        try {
+            HttpRequest request = addAuth(HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/Users"))
+                    .header("Accept", "application/scim+json")
+                    .GET())
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                return root.path("totalResults").asInt();
+            }
+            return 0;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get users count from SCIM", e);
+        }
+    }
+
+    public List<ScimUser> searchUsersByAttribute(String attrName, String attrValue, Integer startIndex, Integer maxResults) {
+        // SCIM doesn't support custom attributes directly, filter by userName or email
+        if ("username".equalsIgnoreCase(attrName) || "userName".equalsIgnoreCase(attrName)) {
+            return searchUsers("userName eq \"" + attrValue + "\"", startIndex, maxResults);
+        } else if ("email".equalsIgnoreCase(attrName)) {
+            return searchUsers("emails eq \"" + attrValue + "\"", startIndex, maxResults);
+        }
+        return new ArrayList<>();
+    }
+
+    public ScimUser createUser(ScimUser user) {
+        try {
+            ObjectNode userJson = toJson(user);
+            HttpRequest request = addAuth(HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/Users"))
+                    .header("Content-Type", "application/scim+json")
+                    .header("Accept", "application/scim+json")
+                    .POST(HttpRequest.BodyPublishers.ofString(userJson.toString())))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 201) {
+                return parseUser(objectMapper.readTree(response.body()));
+            }
+            throw new RuntimeException("Failed to create user: " + response.body());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create user in SCIM", e);
+        }
+    }
+
+    public ScimUser updateUser(String id, ScimUser user) {
+        try {
+            ObjectNode userJson = toJson(user);
+            HttpRequest request = addAuth(HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/Users/" + id))
+                    .header("Content-Type", "application/scim+json")
+                    .header("Accept", "application/scim+json")
+                    .method("PUT", HttpRequest.BodyPublishers.ofString(userJson.toString())))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) {
+                return parseUser(objectMapper.readTree(response.body()));
+            }
+            throw new RuntimeException("Failed to update user: " + response.body());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to update user in SCIM", e);
+        }
+    }
+
+    public boolean deleteUser(String id) {
+        try {
+            HttpRequest request = addAuth(HttpRequest.newBuilder()
+                    .uri(URI.create(baseUrl + "/Users/" + id))
+                    .DELETE())
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.statusCode() == 204;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete user in SCIM", e);
+        }
+    }
+
+    private ScimUser parseUser(JsonNode node) {
+        ScimUser user = new ScimUser();
+        user.setId(node.path("id").asText());
+        user.setUserName(node.path("userName").asText());
+        user.setEmail(getPrimaryEmail(node.path("emails")));
+        user.setGivenName(node.path("name").path("givenName").asText());
+        user.setFamilyName(node.path("name").path("familyName").asText());
+        user.setActive(node.path("active").asBoolean(true));
+        return user;
+    }
+
+    private List<ScimUser> parseUserList(JsonNode root) {
+        List<ScimUser> users = new ArrayList<>();
+        JsonNode resources = root.path("Resources");
+        if (resources.isArray()) {
+            for (JsonNode node : resources) {
+                users.add(parseUser(node));
+            }
+        }
+        return users;
+    }
+
+    private String getPrimaryEmail(JsonNode emailsNode) {
+        if (emailsNode.isArray()) {
+            for (JsonNode email : emailsNode) {
+                if (email.path("primary").asBoolean(false) || email.path("type").asText().equals("work")) {
+                    return email.path("value").asText();
+                }
+            }
+            if (emailsNode.size() > 0) {
+                return emailsNode.get(0).path("value").asText();
+            }
+        }
+        return null;
+    }
+
+    private ObjectNode toJson(ScimUser user) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("userName", user.getUserName());
+        node.put("active", user.isActive());
+        
+        ObjectNode nameNode = objectMapper.createObjectNode();
+        nameNode.put("givenName", user.getGivenName());
+        nameNode.put("familyName", user.getFamilyName());
+        node.set("name", nameNode);
+        
+        if (user.getEmail() != null) {
+            ArrayNode emails = objectMapper.createArrayNode();
+            ObjectNode emailNode = objectMapper.createObjectNode();
+            emailNode.put("value", user.getEmail());
+            emailNode.put("type", "work");
+            emailNode.put("primary", true);
+            emails.add(emailNode);
+            node.set("emails", emails);
+        }
+        
+        return node;
+    }
+
+    private String encode(String value) {
+        return java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUser.java
+++ b/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUser.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.federation.scim;
+
+/**
+ * SCIM User representation.
+ * Maps to SCIM 2.0 User schema (RFC 7643).
+ */
+public class ScimUser {
+    private String id;
+    private String userName;
+    private String email;
+    private String givenName;
+    private String familyName;
+    private boolean active;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getGivenName() {
+        return givenName;
+    }
+
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+    }
+
+    public String getFamilyName() {
+        return familyName;
+    }
+
+    public void setFamilyName(String familyName) {
+        this.familyName = familyName;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUserAdapter.java
+++ b/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUserAdapter.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.federation.scim;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.GroupModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.storage.StorageId;
+import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Adapter that wraps SCIM User and adapts it to Keycloak UserModel.
+ */
+public class ScimUserAdapter extends AbstractUserAdapterFederatedStorage {
+
+    private final ScimUser scimUser;
+
+    public ScimUserAdapter(KeycloakSession session, RealmModel realm, ComponentModel storageProviderModel, ScimUser scimUser) {
+        super(session, realm, storageProviderModel);
+        this.scimUser = scimUser;
+    }
+
+    @Override
+    public String getId() {
+        return StorageId.keycloakId(model, scimUser.getId());
+    }
+
+    @Override
+    public String getUsername() {
+        return scimUser.getUserName();
+    }
+
+    @Override
+    public void setUsername(String username) {
+        scimUser.setUserName(username);
+    }
+
+    @Override
+    public String getEmail() {
+        return scimUser.getEmail();
+    }
+
+    @Override
+    public void setEmail(String email) {
+        scimUser.setEmail(email);
+    }
+
+    @Override
+    public String getFirstName() {
+        return scimUser.getGivenName();
+    }
+
+    @Override
+    public void setFirstName(String firstName) {
+        scimUser.setGivenName(firstName);
+    }
+
+    @Override
+    public String getLastName() {
+        return scimUser.getFamilyName();
+    }
+
+    @Override
+    public void setLastName(String lastName) {
+        scimUser.setFamilyName(lastName);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return scimUser.isActive();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        scimUser.setActive(enabled);
+    }
+
+    @Override
+    public Long getCreatedTimestamp() {
+        return null;
+    }
+
+    @Override
+    public void setCreatedTimestamp(Long timestamp) {
+        // Not supported
+    }
+
+    @Override
+    public boolean isEmailVerified() {
+        return true;
+    }
+
+    @Override
+    public void setEmailVerified(boolean verified) {
+        // Not supported
+    }
+
+    @Override
+    public Map<String, List<String>> getAttributes() {
+        Map<String, List<String>> attrs = super.getAttributes();
+        attrs.put("scimId", Collections.singletonList(scimUser.getId()));
+        return attrs;
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        if ("scimId".equals(name)) {
+            return Stream.of(scimUser.getId());
+        }
+        return super.getAttributeStream(name);
+    }
+
+    public ScimUser getScimUser() {
+        return scimUser;
+    }
+}

--- a/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUserStorageProvider.java
+++ b/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUserStorageProvider.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.federation.scim;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.user.UserLookupProvider;
+import org.keycloak.storage.user.UserQueryProvider;
+import org.keycloak.storage.user.UserRegistrationProvider;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * SCIM 2.0 User Storage Provider implementation.
+ * Connects Keycloak to SCIM Service Providers for user/group synchronization.
+ *
+ * @author alexsedlex (original)
+ * Refactored to use UserStorageProvider instead of EventListener
+ */
+public class ScimUserStorageProvider implements UserStorageProvider,
+        UserLookupProvider, UserQueryProvider, UserRegistrationProvider {
+
+    private final KeycloakSession session;
+    private final ComponentModel model;
+    private final RealmModel realm;
+    private final ScimClient scimClient;
+
+    public ScimUserStorageProvider(KeycloakSession session, ComponentModel model, RealmModel realm) {
+        this.session = session;
+        this.model = model;
+        this.realm = realm;
+        this.scimClient = new ScimClient(model);
+    }
+
+    @Override
+    public void close() {
+        // Cleanup if needed
+    }
+
+    @Override
+    public UserModel getUserById(RealmModel realm, String id) {
+        // Lookup user by ID from SCIM provider
+        ScimUser scimUser = scimClient.getUser(id);
+        if (scimUser == null) return null;
+        return new ScimUserAdapter(session, realm, model, scimUser);
+    }
+
+    @Override
+    public UserModel getUserByUsername(RealmModel realm, String username) {
+        ScimUser scimUser = scimClient.getUserByUsername(username);
+        if (scimUser == null) return null;
+        return new ScimUserAdapter(session, realm, model, scimUser);
+    }
+
+    @Override
+    public UserModel getUserByEmail(RealmModel realm, String email) {
+        ScimUser scimUser = scimClient.getUserByEmail(email);
+        if (scimUser == null) return null;
+        return new ScimUserAdapter(session, realm, model, scimUser);
+    }
+
+    @Override
+    public int getUsersCount(RealmModel realm) {
+        return scimClient.getUsersCount();
+    }
+
+    @Override
+    public Stream<UserModel> searchForUserStream(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
+        return scimClient.searchUsers(search, firstResult, maxResults)
+                .stream()
+                .map(u -> new ScimUserAdapter(session, realm, model, u));
+    }
+
+    @Override
+    public Stream<UserModel> searchForUserByUserAttributeStream(RealmModel realm, String attrName, String attrValue, Integer firstResult, Integer maxResults) {
+        // Search by specific attribute
+        return scimClient.searchUsersByAttribute(attrName, attrValue, firstResult, maxResults)
+                .stream()
+                .map(u -> new ScimUserAdapter(session, realm, model, u));
+    }
+
+    @Override
+    public UserModel addUser(RealmModel realm, String username) {
+        ScimUser newUser = new ScimUser();
+        newUser.setUserName(username);
+        ScimUser created = scimClient.createUser(newUser);
+        return new ScimUserAdapter(session, realm, model, created);
+    }
+
+    @Override
+    public boolean removeUser(RealmModel realm, UserModel user) {
+        String scimId = user.getFirstAttribute("scimId");
+        if (scimId != null) {
+            return scimClient.deleteUser(scimId);
+        }
+        return false;
+    }
+
+    public void syncUserToScim(UserModel localUser) {
+        // Sync local user changes to SCIM provider
+        ScimUser scimUser = toScimUser(localUser);
+        String scimId = localUser.getFirstAttribute("scimId");
+        if (scimId != null) {
+            scimClient.updateUser(scimId, scimUser);
+        } else {
+            ScimUser created = scimClient.createUser(scimUser);
+            localUser.setSingleAttribute("scimId", created.getId());
+        }
+    }
+
+    private ScimUser toScimUser(UserModel user) {
+        ScimUser scimUser = new ScimUser();
+        scimUser.setUserName(user.getUsername());
+        scimUser.setEmail(user.getEmail());
+        scimUser.setGivenName(user.getFirstName());
+        scimUser.setFamilyName(user.getLastName());
+        scimUser.setActive(user.isEnabled());
+        return scimUser;
+    }
+}

--- a/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUserStorageProviderFactory.java
+++ b/federation/scim/src/main/java/org/keycloak/federation/scim/ScimUserStorageProviderFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.federation.scim;
+
+import org.keycloak.common.Profile;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.storage.UserStorageProviderFactory;
+
+import java.util.List;
+
+/**
+ * Factory for SCIM User Storage Provider.
+ * Enabled behind experimental feature profile.
+ */
+public class ScimUserStorageProviderFactory implements UserStorageProviderFactory<ScimUserStorageProvider> {
+
+    public static final String PROVIDER_ID = "scim";
+    public static final String SCIM_FEATURE = "scim";
+
+    @Override
+    public ScimUserStorageProvider create(KeycloakSession session, ComponentModel model) {
+        return new ScimUserStorageProvider(session, model, session.getContext().getRealm());
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "SCIM 2.0 User Storage Provider for connecting to SCIM Service Providers";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of(
+            new ProviderConfigProperty("scimBaseUrl", "SCIM Base URL", 
+                "Base URL of the SCIM service provider", ProviderConfigProperty.STRING_TYPE, null),
+            new ProviderConfigProperty("scimAuthType", "Authentication Type",
+                "Authentication type (oauth, basic, bearer)", ProviderConfigProperty.STRING_TYPE, "bearer"),
+            new ProviderConfigProperty("scimAuthToken", "Authentication Token",
+                "Token for authentication (if using bearer or oauth)", ProviderConfigProperty.PASSWORD, null),
+            new ProviderConfigProperty("scimUsername", "Username",
+                "Username for basic authentication", ProviderConfigProperty.STRING_TYPE, null),
+            new ProviderConfigProperty("scimPassword", "Password",
+                "Password for basic authentication", ProviderConfigProperty.PASSWORD, null)
+        );
+    }
+
+    @Override
+    public boolean isSupported() {
+        return Profile.isFeatureEnabled(Profile.Feature.EXPERIMENTAL) || 
+               Profile.isFeatureEnabled(Profile.Feature.SCIM);
+    }
+}

--- a/federation/scim/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
+++ b/federation/scim/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.federation.scim.ScimUserStorageProviderFactory


### PR DESCRIPTION
…(#34733)

This PR provides SCIM 2.0 federation support for Keycloak:

## Key Changes (Addressing Review Feedback)
- Use UserStorageProvider instead of EventListener for user synchronization
- Use native Java HTTP client instead of 3rd party SCIM SDK

## New Components
- ScimUserStorageProvider: Main UserStorageProvider implementation
- ScimUserStorageProviderFactory: Factory with configuration options
- ScimClient: Native HTTP client for SCIM protocol (no external SDK)
- ScimUser/ScimUserAdapter: User model mapping

## Features
- Connect Keycloak to SCIM Service Providers
- User lookup by username, email, or ID
- User search with SCIM filter support
- User synchronization via storage provider mechanisms
- Basic and Bearer token authentication support

Enabled behind experimental feature profile.
Refs: #13848 #13484

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
