### PR TITLE
Avoid running CI on copilot branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - copilot/**
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - copilot/**
       - quarkus-next
   pull_request:
      branches: [main]

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - copilot/**
       - quarkus-next
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/guides.yml
+++ b/.github/workflows/guides.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - copilot/**
       - quarkus-next
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - copilot/**
       - quarkus-next
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - main
       - dependabot/**
+      - copilot/**
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
This avoids running CI on copilot branches, those are short-lived, and will be removed shortly after (usually before the cleanup of the Aurora databases finishes). 

The CI will still run on pull requests created by copilot. 

Closes #47435

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
