### PR TITLE
Pin Azure CLI to 2.82.0 to fix JSON parsing error

### DIFF
--- a/.github/scripts/ansible/azure_vm_manager.sh
+++ b/.github/scripts/ansible/azure_vm_manager.sh
@@ -17,6 +17,9 @@ VM_SIZE="Standard_D2s_v5"
 IMAGE="Ubuntu2404"
 
 if [[ "$ACTION" == "create" ]]; then
+  # Pin Azure CLI to 2.82.0 (azure-core 1.38.0+ causes JSON parsing errors with az vm create)
+  sudo apt-get install -y -q --allow-downgrades azure-cli=2.82.0-1~noble
+
   # 1. Resource group (created via idempotent command)
   az group create --name "$CLUSTER" --location "$REGION"
 


### PR DESCRIPTION
Closes: #47827

The full version string is deliberate (otherwise apt does not find the package).

Test run: https://github.com/Pepo48/keycloak/actions/runs/24098525925/job/70303546307