### PR TITLE
Allow customization of SAML service provider metadata

### DIFF
--- a/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/saml/SAMLIdentityProvider.java
@@ -384,116 +384,122 @@ public class SAMLIdentityProvider extends AbstractIdentityProvider<SAMLIdentityP
         return binding;
     }
 
+    protected EntityDescriptorType getEntityDescriptor(UriInfo uriInfo, RealmModel realm, String format) {
+        URI endpoint = uriInfo.getBaseUriBuilder()
+                .path("realms").path(realm.getName())
+                .path("broker")
+                .path(getConfig().getAlias())
+                .path("endpoint")
+                .build();
+
+        List<EndpointType> assertionConsumerServices = getConfig().isPostBindingAuthnRequest()
+                ? List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint),
+                        new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint),
+                        new EndpointType(JBossSAMLURIConstants.SAML_HTTP_ARTIFACT_BINDING.getUri(), endpoint))
+                : List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint),
+                        new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint),
+                        new EndpointType(JBossSAMLURIConstants.SAML_HTTP_ARTIFACT_BINDING.getUri(), endpoint));
+
+        List<EndpointType> singleLogoutServices = getConfig().isPostBindingLogout()
+                ? List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint),
+                        new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint))
+                : List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint),
+                        new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint));
+
+        boolean wantAuthnRequestsSigned = getConfig().isWantAuthnRequestsSigned();
+        boolean wantAssertionsSigned = getConfig().isWantAssertionsSigned();
+        boolean wantAssertionsEncrypted = getConfig().isWantAssertionsEncrypted();
+        String entityId = getEntityId(uriInfo, realm);
+        String nameIDPolicyFormat = getConfig().getNameIDPolicyFormat();
+
+        // We export all keys for algorithm RS256, both active and passive so IDP is able to verify signature even
+        //  if a key rotation happens in the meantime
+        List<KeyDescriptorType> signingKeys = session.keys().getKeysStream(realm, KeyUse.SIG, Algorithm.RS256)
+                .filter(key -> key.getCertificate() != null)
+                .sorted(SamlService::compareKeys)
+                .map(key -> {
+                    try {
+                        return SPMetadataDescriptor.buildKeyInfoElement(key.getKid(), PemUtils.encodeCertificate(key.getCertificate()));
+                    } catch (ParserConfigurationException e) {
+                        logger.warn("Failed to export SAML SP Metadata!", e);
+                        throw new RuntimeException(e);
+                    }
+                })
+                .map(key -> SPMetadataDescriptor.buildKeyDescriptorType(key, KeyTypes.SIGNING, null))
+                .collect(Collectors.toList());
+
+        // We export only active ENC keys so IDP uses different key as soon as possible if a key rotation happens
+        String encAlg = getConfig().getEncryptionAlgorithm();
+        List<KeyDescriptorType> encryptionKeys = session.keys().getKeysStream(realm)
+                .filter(key -> key.getStatus().isActive() && KeyUse.ENC.equals(key.getUse())
+                        && (encAlg == null || Objects.equals(encAlg, key.getAlgorithmOrDefault()))
+                        && SAMLEncryptionAlgorithms.forKeycloakIdentifier(key.getAlgorithm()) != null
+                        && key.getCertificate() != null)
+                .sorted(SamlService::compareKeys)
+                .map(key -> {
+                    Element keyInfo;
+                    try {
+                        keyInfo = SPMetadataDescriptor.buildKeyInfoElement(key.getKid(), PemUtils.encodeCertificate(key.getCertificate()));
+                    } catch (ParserConfigurationException e) {
+                        logger.warn("Failed to export SAML SP Metadata!", e);
+                        throw new RuntimeException(e);
+                    }
+
+                    return SPMetadataDescriptor.buildKeyDescriptorType(keyInfo, KeyTypes.ENCRYPTION, SAMLEncryptionAlgorithms.forKeycloakIdentifier(key.getAlgorithm()).getXmlEncIdentifiers());
+                })
+                .collect(Collectors.toList());
+
+        EntityDescriptorType entityDescriptor = SPMetadataDescriptor.buildSPDescriptor(
+            assertionConsumerServices, singleLogoutServices,
+            wantAuthnRequestsSigned, wantAssertionsSigned, wantAssertionsEncrypted,
+            entityId, nameIDPolicyFormat, signingKeys, encryptionKeys, getConfig().getDescriptorCacheSeconds());
+
+        // Create the AttributeConsumingService if at least one attribute importer mapper exists
+        List<Entry<IdentityProviderMapperModel, SamlMetadataDescriptorUpdater>> metadataAttrProviders = new ArrayList<>();
+        session.identityProviders().getMappersByAliasStream(getConfig().getAlias())
+            .forEach(mapper -> {
+                IdentityProviderMapper target = (IdentityProviderMapper) session.getKeycloakSessionFactory().getProviderFactory(IdentityProviderMapper.class, mapper.getIdentityProviderMapper());
+                if (target instanceof SamlMetadataDescriptorUpdater samlMetadataDescriptorUpdater)
+                    metadataAttrProviders.add(new java.util.AbstractMap.SimpleEntry<>(mapper, samlMetadataDescriptorUpdater));
+            });
+
+        if (!metadataAttrProviders.isEmpty()) {
+            int attributeConsumingServiceIndex = getConfig().getAttributeConsumingServiceIndex() != null ? getConfig().getAttributeConsumingServiceIndex() : 1;
+            String attributeConsumingServiceName = getConfig().getAttributeConsumingServiceName();
+            //default value for attributeConsumingServiceName
+            if (attributeConsumingServiceName == null)
+                attributeConsumingServiceName = realm.getDisplayName() != null ? realm.getDisplayName() : realm.getName() ;
+            AttributeConsumingServiceType attributeConsumingService = new AttributeConsumingServiceType(attributeConsumingServiceIndex);
+            attributeConsumingService.setIsDefault(true);
+
+            String currentLocale = realm.getDefaultLocale() == null ? "en" : realm.getDefaultLocale();
+            LocalizedNameType attributeConsumingServiceNameElement = new LocalizedNameType(currentLocale);
+            attributeConsumingServiceNameElement.setValue(attributeConsumingServiceName);
+            attributeConsumingService.addServiceName(attributeConsumingServiceNameElement);
+
+            // Look for the SP descriptor and add the attribute consuming service
+            for (EntityDescriptorType.EDTChoiceType choiceType : entityDescriptor.getChoiceType()) {
+                List<EntityDescriptorType.EDTDescriptorChoiceType> descriptors = choiceType.getDescriptors();
+                for (EntityDescriptorType.EDTDescriptorChoiceType descriptor : descriptors) {
+                    descriptor.getSpDescriptor().addAttributeConsumerService(attributeConsumingService);
+                }
+            }
+
+            // Add the attribute mappers
+            metadataAttrProviders.forEach(mapper -> {
+                SamlMetadataDescriptorUpdater metadataAttrProvider = mapper.getValue();
+                metadataAttrProvider.updateMetadata(mapper.getKey(), entityDescriptor);
+            });
+        }
+
+        return entityDescriptor;
+    }
+
     @Override
     public Response export(UriInfo uriInfo, RealmModel realm, String format) {
         try
         {
-            URI endpoint = uriInfo.getBaseUriBuilder()
-                    .path("realms").path(realm.getName())
-                    .path("broker")
-                    .path(getConfig().getAlias())
-                    .path("endpoint")
-                    .build();
-
-            List<EndpointType> assertionConsumerServices = getConfig().isPostBindingAuthnRequest()
-                    ? List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint),
-                            new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint),
-                            new EndpointType(JBossSAMLURIConstants.SAML_HTTP_ARTIFACT_BINDING.getUri(), endpoint))
-                    : List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint),
-                            new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint),
-                            new EndpointType(JBossSAMLURIConstants.SAML_HTTP_ARTIFACT_BINDING.getUri(), endpoint));
-
-            List<EndpointType> singleLogoutServices = getConfig().isPostBindingLogout()
-                    ? List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint),
-                            new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint))
-                    : List.of(new EndpointType(JBossSAMLURIConstants.SAML_HTTP_REDIRECT_BINDING.getUri(), endpoint),
-                            new EndpointType(JBossSAMLURIConstants.SAML_HTTP_POST_BINDING.getUri(), endpoint));
-
-            boolean wantAuthnRequestsSigned = getConfig().isWantAuthnRequestsSigned();
-            boolean wantAssertionsSigned = getConfig().isWantAssertionsSigned();
-            boolean wantAssertionsEncrypted = getConfig().isWantAssertionsEncrypted();
-            String entityId = getEntityId(uriInfo, realm);
-            String nameIDPolicyFormat = getConfig().getNameIDPolicyFormat();
-
-            // We export all keys for algorithm RS256, both active and passive so IDP is able to verify signature even
-            //  if a key rotation happens in the meantime
-            List<KeyDescriptorType> signingKeys = session.keys().getKeysStream(realm, KeyUse.SIG, Algorithm.RS256)
-                    .filter(key -> key.getCertificate() != null)
-                    .sorted(SamlService::compareKeys)
-                    .map(key -> {
-                        try {
-                            return SPMetadataDescriptor.buildKeyInfoElement(key.getKid(), PemUtils.encodeCertificate(key.getCertificate()));
-                        } catch (ParserConfigurationException e) {
-                            logger.warn("Failed to export SAML SP Metadata!", e);
-                            throw new RuntimeException(e);
-                        }
-                    })
-                    .map(key -> SPMetadataDescriptor.buildKeyDescriptorType(key, KeyTypes.SIGNING, null))
-                    .collect(Collectors.toList());
-
-            // We export only active ENC keys so IDP uses different key as soon as possible if a key rotation happens
-            String encAlg = getConfig().getEncryptionAlgorithm();
-            List<KeyDescriptorType> encryptionKeys = session.keys().getKeysStream(realm)
-                    .filter(key -> key.getStatus().isActive() && KeyUse.ENC.equals(key.getUse())
-                            && (encAlg == null || Objects.equals(encAlg, key.getAlgorithmOrDefault()))
-                            && SAMLEncryptionAlgorithms.forKeycloakIdentifier(key.getAlgorithm()) != null
-                            && key.getCertificate() != null)
-                    .sorted(SamlService::compareKeys)
-                    .map(key -> {
-                        Element keyInfo;
-                        try {
-                            keyInfo = SPMetadataDescriptor.buildKeyInfoElement(key.getKid(), PemUtils.encodeCertificate(key.getCertificate()));
-                        } catch (ParserConfigurationException e) {
-                            logger.warn("Failed to export SAML SP Metadata!", e);
-                            throw new RuntimeException(e);
-                        }
-
-                        return SPMetadataDescriptor.buildKeyDescriptorType(keyInfo, KeyTypes.ENCRYPTION, SAMLEncryptionAlgorithms.forKeycloakIdentifier(key.getAlgorithm()).getXmlEncIdentifiers());
-                    })
-                    .collect(Collectors.toList());
-
-            EntityDescriptorType entityDescriptor = SPMetadataDescriptor.buildSPDescriptor(
-                assertionConsumerServices, singleLogoutServices,
-                wantAuthnRequestsSigned, wantAssertionsSigned, wantAssertionsEncrypted,
-                entityId, nameIDPolicyFormat, signingKeys, encryptionKeys, getConfig().getDescriptorCacheSeconds());
-
-            // Create the AttributeConsumingService if at least one attribute importer mapper exists
-            List<Entry<IdentityProviderMapperModel, SamlMetadataDescriptorUpdater>> metadataAttrProviders = new ArrayList<>();
-            session.identityProviders().getMappersByAliasStream(getConfig().getAlias())
-                .forEach(mapper -> {
-                    IdentityProviderMapper target = (IdentityProviderMapper) session.getKeycloakSessionFactory().getProviderFactory(IdentityProviderMapper.class, mapper.getIdentityProviderMapper());
-                    if (target instanceof SamlMetadataDescriptorUpdater samlMetadataDescriptorUpdater)
-                        metadataAttrProviders.add(new java.util.AbstractMap.SimpleEntry<>(mapper, samlMetadataDescriptorUpdater));
-                });
-
-            if (!metadataAttrProviders.isEmpty()) {
-                int attributeConsumingServiceIndex = getConfig().getAttributeConsumingServiceIndex() != null ? getConfig().getAttributeConsumingServiceIndex() : 1;
-                String attributeConsumingServiceName = getConfig().getAttributeConsumingServiceName();
-                //default value for attributeConsumingServiceName
-                if (attributeConsumingServiceName == null)
-                    attributeConsumingServiceName = realm.getDisplayName() != null ? realm.getDisplayName() : realm.getName() ;
-                AttributeConsumingServiceType attributeConsumingService = new AttributeConsumingServiceType(attributeConsumingServiceIndex);
-                attributeConsumingService.setIsDefault(true);
-
-                String currentLocale = realm.getDefaultLocale() == null ? "en" : realm.getDefaultLocale();
-                LocalizedNameType attributeConsumingServiceNameElement = new LocalizedNameType(currentLocale);
-                attributeConsumingServiceNameElement.setValue(attributeConsumingServiceName);
-                attributeConsumingService.addServiceName(attributeConsumingServiceNameElement);
-
-                // Look for the SP descriptor and add the attribute consuming service
-                for (EntityDescriptorType.EDTChoiceType choiceType : entityDescriptor.getChoiceType()) {
-                    List<EntityDescriptorType.EDTDescriptorChoiceType> descriptors = choiceType.getDescriptors();
-                    for (EntityDescriptorType.EDTDescriptorChoiceType descriptor : descriptors) {
-                        descriptor.getSpDescriptor().addAttributeConsumerService(attributeConsumingService);
-                    }
-                }
-
-                // Add the attribute mappers
-                metadataAttrProviders.forEach(mapper -> {
-                    SamlMetadataDescriptorUpdater metadataAttrProvider = mapper.getValue();
-                    metadataAttrProvider.updateMetadata(mapper.getKey(), entityDescriptor);
-                });
-            }
+            EntityDescriptorType entityDescriptor = getEntityDescriptor(uriInfo, realm, format);
 
             String descriptor;
 


### PR DESCRIPTION
Allow customization of SAML service provider metadata in SAMLIdentityProvider descendant.

No tests added since it's just a minor refactor inside SAMLIdentityProvider: "export" method now calls protected "getEntityDescriptor" before signing the response.

Closes #45866