### PR TITLE
[OID4VCI] Revisit invalid authorization requests handling

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -550,12 +550,30 @@ public class OID4VCBasicWallet {
             return this;
         }
 
-        public void openLoginForm() {
+        public boolean openLoginForm() {
             loginForm.open();
+            String currUrl = oauth.getDriver().getCurrentUrl();
+            return currUrl != null && !currUrl.contains("error=") && !currUrl.contains("error_description=");
+        }
+
+        public AuthorizationEndpointRequest fillLoginForm(String username, String password) {
+            oauth.fillLoginForm(username, password);
+            return this;
+        }
+
+        public AuthorizationEndpointResponse parseLoginResponse() {
+            return oauth.parseLoginResponse();
         }
 
         public AuthorizationEndpointResponse send(String username, String password) {
-            return loginForm.doLogin(username, password);
+            openLoginForm();
+            fillLoginForm(username, password);
+            return parseLoginResponse();
+        }
+
+        public AuthorizationEndpointResponse send() {
+            openLoginForm();
+            return parseLoginResponse();
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPublicClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPublicClientTest.java
@@ -27,6 +27,7 @@ import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.tests.oid4vc.OID4VCBasicWallet.AuthorizationEndpointRequest;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestServerConfig;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -124,8 +126,12 @@ public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
 
         // Send AuthorizationRequest without required PKCE
         //
-        oauth.loginForm().scope(ctx.getScope()).open();
-        AuthorizationEndpointResponse authResponse = oauth.parseLoginResponse();
+        AuthorizationEndpointRequest authRequest = wallet
+                .authorizationRequest()
+                .scope(ctx.getScope());
+
+        assertFalse(authRequest.openLoginForm(), "Error expected");
+        AuthorizationEndpointResponse authResponse = authRequest.parseLoginResponse();
 
         assertNull(authResponse.getCode(), "Expected no auth code");
         assertEquals("invalid_request", authResponse.getError());

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
@@ -192,12 +192,10 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
 
         try {
             AuthorizationEndpointRequest authRequest = authRequestSupplier.get();
-            authRequest.openLoginForm();
-            String currUrl = oauth.getDriver().getCurrentUrl();
-            if (currUrl != null && !currUrl.contains("error=") && !currUrl.contains("error_description=")) {
-                oauth.fillLoginForm(ctx.getHolder(), TEST_PASSWORD);
+            if (authRequest.openLoginForm()) {
+                authRequest.fillLoginForm(ctx.getHolder(), TEST_PASSWORD);
             }
-            AuthorizationEndpointResponse authResponse = oauth.parseLoginResponse();
+            AuthorizationEndpointResponse authResponse = authRequest.parseLoginResponse();
             if (authResponse.getError() != null)
                 throw new IllegalStateException(authResponse.getErrorDescription());
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
@@ -130,6 +130,29 @@ public class LoginUrlBuilder extends AbstractUrlBuilder {
         }
     }
 
+    /**
+     * Composite login method for the Authorization Code Flow
+     *
+     * <ol>
+     *  <li>It builds and opens the authorization request url</li>
+     *  <li>Fills the login form with user credentials (i.e. username, password)</li>
+     *  <li>Parses the authorization response</li>
+     * </ol>
+     *
+     * This method is intended to be used only for the purpose of the basic login flow when the server is expected to open a login form.
+     *
+     * For more complex scenarios like:
+     * <ul>
+     *     <li>SSO login (user being automatically authenticated without the need to provide a username/password</li>
+     *     <li>Automatic redirect to the client with the error as result of an invalid authorization request</li>
+     *     <li>The call not being redirected back to the client either due to an incorrect username/password or some other screen being displayed</li>
+     * </ul>
+     *
+     * calls to level API will be needed.
+     *
+     * In short, the caller should always know whether they expect a login-form to be shown or not.
+     * For details, there is <a href="https://github.com/keycloak/keycloak/discussions/48308">this discussion</a>.
+     */
     public AuthorizationEndpointResponse doLogin(String username, String password) {
         open();
         client.fillLoginForm(username, password);


### PR DESCRIPTION
closes #47649

This PR is about these three lines of code in `LoginUrlBuilder` ...

```
    public AuthorizationEndpointResponse doLogin(String username, String password) {
        open();
        client.fillLoginForm(username, password);
        return client.parseLoginResponse();
    }
```

It fixes the incorrect assumption that a login form can always be filled regardless of the http response resulting from sending an authorization request. 

The second step is now conditioned on success of the first step.

```
    /**
     * Composite login method for the Authorization Code Flow
     *
     * <ol>
     *  <li>It builds and opens the authorization request url</li>
     *  <li>Fills the login form with user credentials (i.e. username, password)</li>
     *  <li>Parses the authorization response</li>
     * </ol>
     *
     * Step two is conditioned on successful processing of step one (i.e. the login page is displayed).
     * In case of error, step two is skipped and the authorization response is parsed directly. It then
     * contains the root cause of the authorization request error.
     *
     * @return An AuthorizationEndpointResponse
     */
    public AuthorizationEndpointResponse doLogin(String username, String password) {
        open();
        String currUrl = client.driver.getCurrentUrl();
        if (currUrl != null && !currUrl.contains("error=") && !currUrl.contains("error_description=")) {
            client.fillLoginForm(username, password);
        }
        return client.parseLoginResponse();
    }
```

A related discussion is here: #48308

Depends on

1. #48312

