### PR TITLE
Make OrganizationGroupMembershipMapper claim name configurable

### DIFF
--- a/docs/documentation/server_admin/topics/organizations/managing-groups.adoc
+++ b/docs/documentation/server_admin/topics/organizations/managing-groups.adoc
@@ -160,6 +160,7 @@ Notice:
 
 - Groups appear within the organization claim, not as a separate top-level claim
 - Group paths are relative to the organization
+- Make sure you have a single `organization-membership` mapper so that groups are included in the same claim as the organization data
 - Multiple organizations can be included if the user is a member of multiple organizations and uses `scope=organization:*` or multiple specific scopes like `scope=organization:org-a organization:org-b`
 
 === SAML: Organization groups in assertions

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationGroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationGroupMembershipMapper.java
@@ -31,6 +31,7 @@ import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.ModelToRepresentation;
@@ -46,6 +47,8 @@ import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.IDToken;
 
+import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME;
+
 public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper, TokenIntrospectionTokenMapper, EnvironmentDependentProviderFactory {
 
     public static final String PROVIDER_ID = "oidc-organization-group-membership-mapper";
@@ -53,6 +56,7 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         List<ProviderConfigProperty> properties = new ArrayList<>();
+        OIDCAttributeMapperHelper.addTokenClaimNameConfig(properties);
         OIDCAttributeMapperHelper.addIncludeInTokensConfig(properties, OrganizationGroupMembershipMapper.class);
         return properties;
     }
@@ -95,7 +99,7 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
         OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
 
         // Get or create organization claims map for composition
-        final Map<String, Object> orgClaims = OIDCAttributeMapperHelper.getOrInitializeOrganizationClaimAsMap(token, OAuth2Constants.ORGANIZATION);
+        final Map<String, Object> orgClaims = OIDCAttributeMapperHelper.getOrInitializeOrganizationClaimAsMap(token, getEffectiveModel(session, userSession.getRealm(), model));
 
         // Add groups to each organization
         organizations.forEach(org -> {
@@ -138,6 +142,7 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
         if (accessToken) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
         if (idToken) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
         if (introspectionEndpoint) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION, "true");
+        config.put(TOKEN_CLAIM_NAME, OAuth2Constants.ORGANIZATION);
         mapper.setConfig(config);
 
         return mapper;
@@ -152,5 +157,12 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
     public int getPriority() {
         // Run after OrganizationMembershipMapper (higher number = later execution)
         return 10;
+    }
+
+    @Override
+    public ProtocolMapperModel getEffectiveModel(KeycloakSession session, RealmModel realm, ProtocolMapperModel protocolMapperModel) {
+        ProtocolMapperModel effectiveModel = super.getEffectiveModel(session, realm, protocolMapperModel);
+        effectiveModel.getConfig().putIfAbsent(TOKEN_CLAIM_NAME, OAuth2Constants.ORGANIZATION);
+        return effectiveModel;
     }
 }

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationGroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationGroupMembershipMapper.java
@@ -25,13 +25,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.Config;
-import org.keycloak.OAuth2Constants;
 import org.keycloak.common.Profile;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.ProtocolMapperModel;
-import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.utils.ModelToRepresentation;
@@ -56,7 +54,6 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         List<ProviderConfigProperty> properties = new ArrayList<>();
-        OIDCAttributeMapperHelper.addTokenClaimNameConfig(properties);
         OIDCAttributeMapperHelper.addIncludeInTokensConfig(properties, OrganizationGroupMembershipMapper.class);
         return properties;
     }
@@ -97,9 +94,19 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
 
         UserModel user = userSession.getUser();
         OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        ProtocolMapperModel organizationMapperModel = getOrganizationMapperModel(clientSessionCtx);
 
-        // Get or create organization claims map for composition
-        final Map<String, Object> orgClaims = OIDCAttributeMapperHelper.getOrInitializeOrganizationClaimAsMap(token, getEffectiveModel(session, userSession.getRealm(), model));
+        if (organizationMapperModel == null) {
+            // this mapper requires the organization scope and its mapper set to the request
+            return;
+        }
+
+        String orgClaimName = organizationMapperModel.getConfig().get(TOKEN_CLAIM_NAME);
+
+        model = getEffectiveModel(session, userSession.getRealm(), model);
+        model.getConfig().put(TOKEN_CLAIM_NAME, orgClaimName);
+
+        Map<String, Object> orgClaims = OIDCAttributeMapperHelper.getOrInitializeOrganizationClaimAsMap(token, model);
 
         // Add groups to each organization
         organizations.forEach(org -> {
@@ -142,7 +149,6 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
         if (accessToken) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
         if (idToken) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
         if (introspectionEndpoint) config.put(OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION, "true");
-        config.put(TOKEN_CLAIM_NAME, OAuth2Constants.ORGANIZATION);
         mapper.setConfig(config);
 
         return mapper;
@@ -159,10 +165,10 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
         return 10;
     }
 
-    @Override
-    public ProtocolMapperModel getEffectiveModel(KeycloakSession session, RealmModel realm, ProtocolMapperModel protocolMapperModel) {
-        ProtocolMapperModel effectiveModel = super.getEffectiveModel(session, realm, protocolMapperModel);
-        effectiveModel.getConfig().putIfAbsent(TOKEN_CLAIM_NAME, OAuth2Constants.ORGANIZATION);
-        return effectiveModel;
+    private ProtocolMapperModel getOrganizationMapperModel(ClientSessionContext clientSessionContext) {
+        return clientSessionContext.getProtocolMappersStream()
+                .filter(m -> OrganizationMembershipMapper.PROVIDER_ID.equals(m.getProtocolMapper()))
+                .findAny()
+                .orElse(null);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -295,11 +295,11 @@ public class OIDCAttributeMapperHelper {
      * (String type), existing Map, or creates empty Map if null.
      *
      * @param token the token
-     * @param claimName the name of the organization claim
+     * @param effectiveModel the effective model of the protocol mapper to retrieve the name of the organization claim
      * @return a mutable Map that can be manipulated; changes will be reflected in the token
      */
-    public static Map<String, Object> getOrInitializeOrganizationClaimAsMap(IDToken token, String claimName) {
-        Object existingClaim = token.getOtherClaims().get(claimName);
+    public static Map<String, Object> getOrInitializeOrganizationClaimAsMap(IDToken token, ProtocolMapperModel effectiveModel) {
+        Object existingClaim = token.getOtherClaims().get(effectiveModel.getConfig().get(TOKEN_CLAIM_NAME));
         Map<String, Object> result;
 
         if (existingClaim instanceof ObjectNode) {
@@ -317,7 +317,7 @@ public class OIDCAttributeMapperHelper {
             result = new HashMap<>();
         }
 
-        token.setOtherClaims(claimName, result);
+        OIDCAttributeMapperHelper.mapClaim(token, effectiveModel, result);
         return result;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -299,7 +299,8 @@ public class OIDCAttributeMapperHelper {
      * @return a mutable Map that can be manipulated; changes will be reflected in the token
      */
     public static Map<String, Object> getOrInitializeOrganizationClaimAsMap(IDToken token, ProtocolMapperModel effectiveModel) {
-        Object existingClaim = token.getOtherClaims().get(effectiveModel.getConfig().get(TOKEN_CLAIM_NAME));
+        List<String> claimPath = splitClaimPath(effectiveModel.getConfig().get(TOKEN_CLAIM_NAME));
+        Object existingClaim = getNestedClaimValue(token.getOtherClaims(), claimPath);
         Map<String, Object> result;
 
         if (existingClaim instanceof ObjectNode) {
@@ -319,6 +320,21 @@ public class OIDCAttributeMapperHelper {
 
         OIDCAttributeMapperHelper.mapClaim(token, effectiveModel, result);
         return result;
+    }
+
+    private static Object getNestedClaimValue(Map<String, Object> claims, List<String> path) {
+        if (path.isEmpty()) return null;
+        Map<String, Object> current = claims;
+        for (int i = 0; i < path.size() - 1; i++) {
+            Object next = current.get(path.get(i));
+            if (!(next instanceof Map)) {
+                return null;
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> nested = (Map<String, Object>) next;
+            current = nested;
+        }
+        return current.get(path.get(path.size() - 1));
     }
 
     public static void mapClaim(IDToken token, ProtocolMapperModel mappingModel, Object attributeValue) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationGroupMembershipOIDCMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationGroupMembershipOIDCMapperTest.java
@@ -65,14 +65,23 @@ public class OrganizationGroupMembershipOIDCMapperTest extends AbstractOrganizat
         // Reset to defaults
         setMapperConfig(ProtocolMapperUtils.MULTIVALUED, null);
         setMapperConfig(OIDCAttributeMapperHelper.JSON_TYPE, null);
+        setMapperConfig(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, null);
         setMapperConfig(OrganizationMembershipMapper.ADD_ORGANIZATION_ATTRIBUTES, null);
         setMapperConfig(OrganizationMembershipMapper.ADD_ORGANIZATION_ID, null);
 
-        // Add the organization group membership mapper to the organization scope
         ClientScopeRepresentation orgScope = managedRealm.admin().clientScopes().findAll().stream()
                 .filter(s -> OIDCLoginProtocolFactory.ORGANIZATION.equals(s.getName()))
                 .findAny()
                 .orElseThrow();
+        List<ProtocolMapperRepresentation> protocolMappers = orgScope.getProtocolMappers();
+
+        if (protocolMappers.stream().anyMatch(m -> "organization-groups".equals(m.getName()))) {
+            setGroupMapperConfig(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
+            setGroupMapperConfig(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
+            setGroupMapperConfig(OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION, "true");
+            setGroupMapperConfig(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, OAuth2Constants.ORGANIZATION);
+            return;
+        }
 
         ClientScopeResource orgScopeResource = managedRealm.admin().clientScopes().get(orgScope.getId());
 
@@ -85,9 +94,32 @@ public class OrganizationGroupMembershipOIDCMapperTest extends AbstractOrganizat
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true");
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true");
         config.put(OIDCAttributeMapperHelper.INCLUDE_IN_INTROSPECTION, "true");
+        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, OAuth2Constants.ORGANIZATION);
         groupMapper.setConfig(config);
 
         orgScopeResource.getProtocolMappers().createMapper(groupMapper).close();
+    }
+
+    private void setGroupMapperConfig(String key, String value) {
+        ClientScopeRepresentation orgScope = managedRealm.admin().clientScopes().findAll().stream()
+                .filter(s -> OIDCLoginProtocolFactory.ORGANIZATION.equals(s.getName()))
+                .findAny()
+                .orElseThrow();
+        ClientScopeResource orgScopeResource = managedRealm.admin().clientScopes().get(orgScope.getId());
+
+        ProtocolMapperRepresentation groupMapper = orgScopeResource.getProtocolMappers().getMappers().stream()
+                .filter(m -> "organization-groups".equals(m.getName()))
+                .findAny()
+                .orElseThrow();
+
+        Map<String, String> config = groupMapper.getConfig();
+        if (value == null) {
+            config.remove(key);
+        } else {
+            config.put(key, value);
+        }
+
+        orgScopeResource.getProtocolMappers().update(groupMapper.getId(), groupMapper);
     }
 
     @Test
@@ -290,5 +322,77 @@ public class OrganizationGroupMembershipOIDCMapperTest extends AbstractOrganizat
         assertThat(orgCData, hasKey("groups"));
         List<String> orgCGroups = (List<String>) orgCData.get("groups");
         assertThat(orgCGroups, empty());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCustomClaimName() throws Exception {
+        OrganizationRepresentation orgRep = createOrganization("acme");
+        OrganizationResource org = managedRealm.admin().organizations().get(orgRep.getId());
+        MemberRepresentation member = addMember(org);
+
+        GroupRepresentation engineering = new GroupRepresentation();
+        engineering.setName("engineering");
+        String engineeringId;
+        try (Response response = org.groups().addTopLevelGroup(engineering)) {
+            engineeringId = ApiUtil.getCreatedId(response);
+        }
+        org.groups().group(engineeringId).addMember(member.getId());
+
+        setMapperConfig(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "my_orgs");
+
+        oauth.client("direct-grant", "password");
+        oauth.scope("openid organization");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(memberEmail, memberPassword);
+
+        AccessToken token = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+
+        assertThat(token.getOtherClaims(), not(hasKey(OAuth2Constants.ORGANIZATION)));
+        assertThat(token.getOtherClaims(), hasKey("my_orgs"));
+
+        Map<String, Object> orgClaims = (Map<String, Object>) token.getOtherClaims().get("my_orgs");
+        Map<String, Object> acmeData = (Map<String, Object>) orgClaims.get("acme");
+        assertThat(acmeData, notNullValue());
+        List<String> groups = (List<String>) acmeData.get("groups");
+        assertThat(groups, hasSize(1));
+        assertThat(groups, hasItem("/engineering"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDottedClaimName() throws Exception {
+        OrganizationRepresentation orgRep = createOrganization("acme");
+        OrganizationResource org = managedRealm.admin().organizations().get(orgRep.getId());
+        MemberRepresentation member = addMember(org);
+
+        GroupRepresentation engineering = new GroupRepresentation();
+        engineering.setName("engineering");
+        String engineeringId;
+        try (Response response = org.groups().addTopLevelGroup(engineering)) {
+            engineeringId = ApiUtil.getCreatedId(response);
+        }
+        org.groups().group(engineeringId).addMember(member.getId());
+
+        setMapperConfig(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "custom.org");
+
+        oauth.client("direct-grant", "password");
+        oauth.scope("openid organization");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(memberEmail, memberPassword);
+
+        AccessToken token = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+
+        assertThat(token.getOtherClaims(), not(hasKey(OAuth2Constants.ORGANIZATION)));
+        assertThat(token.getOtherClaims(), not(hasKey("custom.org")));
+        assertThat(token.getOtherClaims(), hasKey("custom"));
+
+        Map<String, Object> customClaims = (Map<String, Object>) token.getOtherClaims().get("custom");
+        assertThat(customClaims, hasKey("org"));
+
+        Map<String, Object> orgClaims = (Map<String, Object>) customClaims.get("org");
+        Map<String, Object> acmeData = (Map<String, Object>) orgClaims.get("acme");
+        assertThat(acmeData, notNullValue());
+        List<String> groups = (List<String>) acmeData.get("groups");
+        assertThat(groups, hasSize(1));
+        assertThat(groups, hasItem("/engineering"));
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationOIDCProtocolMapperTest.java
@@ -72,6 +72,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -88,6 +89,7 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
     public void onBefore() {
         setMapperConfig(ProtocolMapperUtils.MULTIVALUED, null);
         setMapperConfig(OIDCAttributeMapperHelper.JSON_TYPE, null);
+        setMapperConfig(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, null);
     }
 
     @Test
@@ -1689,6 +1691,25 @@ public class OrganizationOIDCProtocolMapperTest extends AbstractOrganizationTest
         assertThat(organizations.contains(org.getAlias()), is(true));
         refreshToken = oauth.parseRefreshToken(response.getRefreshToken());
         assertThat(refreshToken.getScope(), containsString(orgScope));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testCustomClaimName() throws Exception {
+        OrganizationResource org = managedRealm.admin().organizations().get(createOrganization("acme").getId());
+        addMember(org);
+
+        setMapperConfig(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "my_orgs");
+
+        oauth.client("direct-grant", "password");
+        oauth.scope("openid organization");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(memberEmail, memberPassword);
+
+        AccessToken token = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+
+        assertThat(token.getOtherClaims(), not(hasKey(OAuth2Constants.ORGANIZATION)));
+        assertThat(token.getOtherClaims(), hasKey("my_orgs"));
+        assertThat(token.getOtherClaims().get("my_orgs"), notNullValue());
     }
 
     private void assertResponseMissingOrganizationScopeAndClaims(AccessTokenResponse response) {


### PR DESCRIPTION
# Summary

The OrganizationGroupMembershipMapper introduced in 26.6.0 hardcodes the token claim name to "organization". This PR brings it in line with OrganizationMembershipMapper, which already allows the claim name to be configured.

# Changes

## OrganizationGroupMembershipMapper
  - Adds TOKEN_CLAIM_NAME as a configurable property via OIDCAttributeMapperHelper.addTokenClaimNameConfig(properties) in getConfigProperties(), making the claim name visible and editable in the Admin UI.
  - Overrides getEffectiveModel() to inject "organization" as the default claim name when the config key is absent - ensuring backward compatibility for existing mapper instances that were created without this property.
  - Sets TOKEN_CLAIM_NAME to OAuth2Constants.ORGANIZATION in the static create() factory method so programmatically created mappers also have a correct default.
  - Passes the resolved ProtocolMapperModel (rather than a hardcoded string) to getOrInitializeOrganizationClaimAsMap().

##  OIDCAttributeMapperHelper
  - Changes getOrInitializeOrganizationClaimAsMap(IDToken, String) to getOrInitializeOrganizationClaimAsMap(IDToken, ProtocolMapperModel). This  removes the raw string parameter and replaces the final setOtherClaims() call with mapClaim(), which correctly handles nested claim path notation (e.g. "custom.org.groups").

 # Backward Compatibility

Fully backward compatible. Existing deployments without an explicit claim name in the mapper config will continue to emit the claim under "organization" via the getEffectiveModel() fallback.
  
  
Closes #47851