### PR TITLE
added optional storage type for the declarative ui

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -152,7 +152,7 @@ public class Profile {
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),
         OPENTELEMETRY_METRICS("Micrometer to OpenTelemetry bridge support for metrics", Type.EXPERIMENTAL, OPENTELEMETRY),
 
-        DECLARATIVE_UI("declarative ui spi", Type.EXPERIMENTAL),
+        DECLARATIVE_UI("declarative ui spi", Type.PREVIEW),
 
         ORGANIZATION("Organization support within realms", Type.DEFAULT),
 

--- a/docs/guides/ui-customization/declarative-ui.adoc
+++ b/docs/guides/ui-customization/declarative-ui.adoc
@@ -1,0 +1,104 @@
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
+
+<@tmpl.guide
+title="Extending the Admin Console declaratively"
+priority=25
+summary="Add pages and tabs to the Admin Console with Java SPIs and automatic form rendering.">
+
+The declarative UI SPI lets extension authors add Admin Console pages and tabs without writing React code.
+Implement `UiPageProviderFactory` for new top-level pages or `UiTabProviderFactory` for tabs on existing routes.
+The Admin Console renders forms from `ProviderConfigProperty` definitions returned by the provider factory.
+
+== Enable the feature
+
+The SPI is available as a preview feature:
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --features=declarative-ui
+----
+
+See link:{adminguide_link}#features[Enabling and disabling features] for other ways to enable preview features.
+
+== Implement a page or tab
+
+. Create a JAR with a `META-INF/services/org.keycloak.services.ui.extend.UiPageProviderFactory` or
+  `META-INF/services/org.keycloak.services.ui.extend.UiTabProviderFactory` service file.
+. Implement the factory and return configuration properties from `getConfigProperties()`.
+. Deploy the provider JAR to the `providers` directory and restart {project_name}.
+
+An example extension is available in the
+https://github.com/keycloak/keycloak-quickstarts/tree/latest/extension/extend-admin-console-spi[keycloak-quickstarts repository].
+
+== Storage types for tabs
+
+Tabs can store form data in different backends by overriding `getStorageType()`:
+
+[cols="1,2", options="header"]
+|===
+| Storage type | Description
+
+| `COMPONENT`
+| Default. Data is stored as a realm component through the components REST API.
+
+| `CLIENT`
+| Reads and writes `client.attributes` for the `clientId` in the current route.
+
+| `USER`
+| Reads and writes `user.attributes` for the `id` route parameter.
+
+| `IDENTITY_PROVIDER`
+| Reads and writes `identityProvider.config` for the `alias` route parameter.
+
+| `CUSTOM`
+| Uses a custom admin REST endpoint declared with `getEndpoint()`.
+|===
+
+For `CUSTOM` storage, implement GET and PUT handlers relative to `/admin/realms/{realm}/`:
+
+* `GET` returns JSON with a `config` object whose keys match property names.
+* `PUT` receives submitted form data plus resolved route parameters as top-level fields.
+
+== Runtime configuration
+
+Static properties from server startup are still exposed through server info.
+For context-aware fields (for example dropdowns populated from realm data), override:
+
+[source,java]
+----
+List<ProviderConfigProperty> getConfigProperties(KeycloakSession session, Map<String, String> contextParams)
+----
+
+The Admin Console loads these properties at runtime from:
+
+* `/admin/realms/{realm}/ui-extensions/tabs/{providerId}/config`
+* `/admin/realms/{realm}/ui-extensions/pages/{providerId}/config`
+
+Pass route parameters such as `clientId`, `id`, or `alias` as query parameters when opening a tab.
+
+== Permissions and navigation
+
+Override these methods to control access and placement:
+
+* `getRequiredViewRoles()` and `getRequiredManageRoles()` — defaults to `view-realm` / `manage-realm`
+* `getNavSection()` for pages — `manage`, `configure`, or `extensions`
+* `getTabLabel()` for tabs — localized label key used instead of the provider id
+
+Entity-backed tabs (`CLIENT`, `USER`, `IDENTITY_PROVIDER`) use the existing admin-client APIs, so fine-grained permissions for those resources apply automatically.
+
+Component-backed pages and tabs can declare narrower roles in metadata.
+When a factory also implements `ComponentStorageFactory`, component CRUD is delegated to the custom storage backend.
+
+== Page detail tabs
+
+Pages can expose additional declarative tabs on their detail view by overriding:
+
+[source,java]
+----
+boolean supportsDetailTabs()
+----
+
+Child `UiTabProvider` entries whose path matches the page detail route are rendered automatically.
+
+</@tmpl.guide>

--- a/docs/guides/ui-customization/declarative-ui.adoc
+++ b/docs/guides/ui-customization/declarative-ui.adoc
@@ -60,6 +60,12 @@ For `CUSTOM` storage, implement GET and PUT handlers relative to `/admin/realms/
 * `GET` returns JSON with a `config` object whose keys match property names.
 * `PUT` receives submitted form data plus resolved route parameters as top-level fields.
 
+Custom endpoints are served by a separate `AdminRealmResourceProvider` and are not protected by
+`getRequiredViewRoles()` / `getRequiredManageRoles()`. Each handler must enforce admin permissions
+explicitly, for example by using `AdminPermissionEvaluator` in the resource implementation.
+The UI role metadata only controls Admin Console visibility; it is not a security boundary for
+direct REST access.
+
 == Runtime configuration
 
 Static properties from server startup are still exposed through server info.

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -547,6 +547,7 @@ searchProfile=Search profile
 eventTypes.UPDATE_EMAIL_ERROR.name=Update email error
 removeConfirm_other=Are you sure you want to remove these groups?
 configure=Configure
+extensions=Extensions
 searchScopeHelp=For one level, the search applies only for users in the DNs specified by User DNs. For subtree, the search applies to the whole subtree. See LDAP documentation for more details.
 jumpToSection=Jump to section
 noUsersEmptyStateDescription=Only the users with this role directly assigned will appear under this tab. If you need to find users assigned to this role, go to

--- a/js/apps/admin-ui/src/PageNav.tsx
+++ b/js/apps/admin-ui/src/PageNav.tsx
@@ -140,6 +140,12 @@ export const PageNav = () => {
     isFeatureEnabled(Feature.Workflows);
 
   const showManageRealm = environment.masterRealm === environment.realm;
+  const showManageSection =
+    showManage ||
+    (isFeatureEnabled(Feature.DeclarativeUI) && managePages.length > 0);
+  const showConfigureSection =
+    showConfigure ||
+    (isFeatureEnabled(Feature.DeclarativeUI) && configurePages.length > 0);
 
   return (
     <PageSidebar className="keycloak__page_nav__nav">
@@ -159,7 +165,7 @@ export const PageNav = () => {
               <LeftNav title={t("manageRealms")} path="/realms" />
             </NavGroup>
           )}
-          {showManage && (
+          {showManageSection && (
             <NavGroup aria-label={t("manage")} title={t("manage")}>
               {isFeatureEnabled(Feature.Organizations) &&
                 realmRepresentation.organizationsEnabled && (
@@ -183,7 +189,7 @@ export const PageNav = () => {
             </NavGroup>
           )}
 
-          {showConfigure && (
+          {showConfigureSection && (
             <NavGroup aria-label={t("configure")} title={t("configure")}>
               <LeftNav title="realmSettings" path="/realm-settings" />
               <LeftNav title="authentication" path="/authentication" />

--- a/js/apps/admin-ui/src/PageNav.tsx
+++ b/js/apps/admin-ui/src/PageNav.tsx
@@ -15,6 +15,8 @@ import { useServerInfo } from "./context/server-info/ServerInfoProvider";
 import type { Environment } from "./environment-types";
 import { toPage } from "./page/routes";
 import { normalizeNavRoutePath } from "./page-nav-utils";
+import { PAGE_PROVIDER } from "./page/constants";
+import { canViewUiExtension, getNavSection } from "./page/uiExtensionAccess";
 import { routes } from "./routes";
 import { resolveDisplayName } from "./util";
 import useIsFeatureEnabled, { Feature } from "./utils/useIsFeatureEnabled";
@@ -25,6 +27,28 @@ type LeftNavProps = {
   title: string;
   path: string;
   id?: string;
+};
+
+const ExtensionNav = ({ title, path }: { title: string; path: string }) => {
+  const { t } = useTranslation();
+  const { realm } = useRealm();
+  const encodedRealm = encodeURIComponent(realm);
+  const name = "nav-item" + path.replace("/", "-");
+
+  return (
+    <li>
+      <NavLink
+        id={name}
+        data-testid={name}
+        to={`/${encodedRealm}${path}`}
+        className={({ isActive }) =>
+          `pf-v5-c-nav__link${isActive ? " pf-m-current" : ""}`
+        }
+      >
+        {t(title)}
+      </NavLink>
+    </li>
+  );
 };
 
 const LeftNav = ({ title, path, id }: LeftNavProps) => {
@@ -67,11 +91,20 @@ const LeftNav = ({ title, path, id }: LeftNavProps) => {
 export const PageNav = () => {
   const { t } = useTranslation();
   const { environment } = useEnvironment<Environment>();
-  const { hasSomeAccess } = useAccess();
+  const { hasSomeAccess, hasAccess } = useAccess();
   const { componentTypes } = useServerInfo();
   const isFeatureEnabled = useIsFeatureEnabled();
   const pages =
-    componentTypes?.["org.keycloak.services.ui.extend.UiPageProvider"];
+    componentTypes?.[PAGE_PROVIDER]?.filter((page) =>
+      canViewUiExtension(page, { hasAccess, hasSomeAccess }),
+    ) ?? [];
+  const extensionPages = pages.filter(
+    (page) => getNavSection(page) === "extensions",
+  );
+  const configurePages = pages.filter(
+    (page) => getNavSection(page) === "configure",
+  );
+  const managePages = pages.filter((page) => getNavSection(page) === "manage");
   const navigate = useNavigate();
   const { realm, realmRepresentation } = useRealm();
 
@@ -139,6 +172,14 @@ export const PageNav = () => {
               <LeftNav title="groups" path="/groups" />
               <LeftNav title="sessions" path="/sessions" />
               <LeftNav title="events" path="/events" />
+              {isFeatureEnabled(Feature.DeclarativeUI) &&
+                managePages.map((p) => (
+                  <ExtensionNav
+                    key={p.id}
+                    title={p.id!}
+                    path={toPage({ providerId: p.id }).pathname!}
+                  />
+                ))}
             </NavGroup>
           )}
 
@@ -154,16 +195,27 @@ export const PageNav = () => {
               <LeftNav title="userFederation" path="/user-federation" />
               {showWorkflows && <LeftNav title="workflows" path="/workflows" />}
               {isFeatureEnabled(Feature.DeclarativeUI) &&
-                pages?.map((p) => (
-                  <LeftNav
+                configurePages.map((p) => (
+                  <ExtensionNav
                     key={p.id}
-                    title={p.id}
+                    title={p.id!}
                     path={toPage({ providerId: p.id }).pathname!}
-                    id="/page-section"
                   />
                 ))}
             </NavGroup>
           )}
+          {isFeatureEnabled(Feature.DeclarativeUI) &&
+            extensionPages.length > 0 && (
+              <NavGroup aria-label={t("extensions")} title={t("extensions")}>
+                {extensionPages.map((p) => (
+                  <ExtensionNav
+                    key={p.id}
+                    title={p.id!}
+                    path={toPage({ providerId: p.id }).pathname!}
+                  />
+                ))}
+              </NavGroup>
+            )}
         </Nav>
       </PageSidebarBody>
     </PageSidebar>

--- a/js/apps/admin-ui/src/components/routable-tabs/RoutableTabs.tsx
+++ b/js/apps/admin-ui/src/components/routable-tabs/RoutableTabs.tsx
@@ -21,8 +21,10 @@ import {
   useParams,
 } from "react-router-dom";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
+import { useAccess } from "../../context/access/Access";
 import { PageHandler } from "../../page/PageHandler";
 import { TAB_PROVIDER } from "../../page/constants";
+import { canViewUiExtension, getTabTitle } from "../../page/uiExtensionAccess";
 import useIsFeatureEnabled, { Feature } from "../../utils/useIsFeatureEnabled";
 import { useTranslation } from "react-i18next";
 
@@ -48,7 +50,10 @@ export const RoutableTabs = ({
   const { pathname } = useLocation();
   const params = useParams();
   const { componentTypes } = useServerInfo();
-  const tabs = componentTypes?.[TAB_PROVIDER] || [];
+  const access = useAccess();
+  const tabs = (componentTypes?.[TAB_PROVIDER] || []).filter((tab) =>
+    canViewUiExtension(tab, access),
+  );
   const isFeatureEnabled = useIsFeatureEnabled();
   const { t } = useTranslation();
 
@@ -100,7 +105,11 @@ export const RoutableTabs = ({
       {children as any}
       {isFeatureEnabled(Feature.DeclarativeUI) &&
         matchedTabs.map<any>((tab) => (
-          <DynamicTab key={tab.id} eventKey={tab.pathname} title={t(tab.id)}>
+          <DynamicTab
+            key={tab.id}
+            eventKey={tab.pathname}
+            title={getTabTitle(tab, t)}
+          >
             <PageHandler page={tab} providerType={TAB_PROVIDER} />
           </DynamicTab>
         ))}

--- a/js/apps/admin-ui/src/page/Page.tsx
+++ b/js/apps/admin-ui/src/page/Page.tsx
@@ -44,6 +44,7 @@ export default function Page() {
   const [pageData, setPageData] = useState<ComponentRepresentation>();
 
   const page = pages?.find((p) => p.id === providerId);
+  const canView = page ? canViewUiExtension(page, access) : false;
   const detailTabPath = page?.metadata.detailTabPath as string | undefined;
   const supportsDetailTabs = Boolean(page?.metadata.supportsDetailTabs);
   const settingsTab = useRoutableTab(
@@ -58,9 +59,14 @@ export default function Page() {
   );
 
   useFetch(
-    async () => (id ? adminClient.components.findOne({ id }) : undefined),
+    async () => {
+      if (!canView || !id) {
+        return undefined;
+      }
+      return adminClient.components.findOne({ id });
+    },
     setPageData,
-    [id],
+    [id, canView],
   );
 
   const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({

--- a/js/apps/admin-ui/src/page/Page.tsx
+++ b/js/apps/admin-ui/src/page/Page.tsx
@@ -1,6 +1,11 @@
 import ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import { useAlerts, useFetch } from "@keycloak/keycloak-ui-shared";
-import { ButtonVariant, DropdownItem } from "@patternfly/react-core";
+import {
+  ButtonVariant,
+  DropdownItem,
+  Tab,
+  TabTitleText,
+} from "@patternfly/react-core";
 import { get } from "lodash-es";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -8,11 +13,15 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../components/view-header/ViewHeader";
+import {
+  RoutableTabs,
+  useRoutableTab,
+} from "../components/routable-tabs/RoutableTabs";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { PageHandler } from "./PageHandler";
 import { PAGE_PROVIDER } from "./constants";
-import { PageParams, toPage } from "./routes";
+import { PageParams, toDetailPage, toPage } from "./routes";
 
 export default function Page() {
   const { adminClient } = useAdminClient();
@@ -30,6 +39,13 @@ export default function Page() {
   if (!page) {
     throw new Error(t("notFound"));
   }
+
+  const supportsDetailTabs = Boolean(page.metadata.supportsDetailTabs);
+  const settingsTab = useRoutableTab(
+    id && providerId
+      ? toDetailPage({ realm, providerId, id })
+      : { pathname: "" },
+  );
 
   useFetch(
     async () => adminClient.components.findOne({ id: id! }),
@@ -78,7 +94,18 @@ export default function Page() {
             : undefined
         }
       />
-      <PageHandler providerType={PAGE_PROVIDER} id={id} page={page} />
+      {supportsDetailTabs && id && providerId ? (
+        <RoutableTabs defaultLocation={toDetailPage({ realm, providerId, id })}>
+          <Tab
+            {...settingsTab}
+            title={<TabTitleText>{t("settings")}</TabTitleText>}
+          >
+            <PageHandler providerType={PAGE_PROVIDER} id={id} page={page} />
+          </Tab>
+        </RoutableTabs>
+      ) : (
+        <PageHandler providerType={PAGE_PROVIDER} id={id} page={page} />
+      )}
     </>
   );
 }

--- a/js/apps/admin-ui/src/page/Page.tsx
+++ b/js/apps/admin-ui/src/page/Page.tsx
@@ -17,11 +17,14 @@ import {
   RoutableTabs,
   useRoutableTab,
 } from "../components/routable-tabs/RoutableTabs";
-import { useRealm } from "../context/realm-context/RealmContext";
+import { ForbiddenSection } from "../ForbiddenSection";
+import { useAccess } from "../context/access/Access";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { PageHandler } from "./PageHandler";
 import { PAGE_PROVIDER } from "./constants";
+import { useRealm } from "../context/realm-context/RealmContext";
 import { PageParams, toDetailPage, toPage } from "./routes";
+import { canViewUiExtension, getRequiredViewRoles } from "./uiExtensionAccess";
 
 export default function Page() {
   const { adminClient } = useAdminClient();
@@ -29,6 +32,7 @@ export default function Page() {
   const { t } = useTranslation();
   const { componentTypes } = useServerInfo();
   const { realm } = useRealm();
+  const access = useAccess();
   const pages = componentTypes?.[PAGE_PROVIDER];
   const navigate = useNavigate();
   const { id, providerId } = useParams<PageParams>();
@@ -36,19 +40,21 @@ export default function Page() {
   const [pageData, setPageData] = useState<ComponentRepresentation>();
 
   const page = pages?.find((p) => p.id === providerId);
-  if (!page) {
-    throw new Error(t("notFound"));
-  }
-
-  const supportsDetailTabs = Boolean(page.metadata.supportsDetailTabs);
+  const detailTabPath = page?.metadata.detailTabPath as string | undefined;
+  const supportsDetailTabs = Boolean(page?.metadata.supportsDetailTabs);
   const settingsTab = useRoutableTab(
     id && providerId
-      ? toDetailPage({ realm, providerId, id })
+      ? toDetailPage({
+          realm,
+          providerId,
+          id,
+          detailTabPath,
+        })
       : { pathname: "" },
   );
 
   useFetch(
-    async () => adminClient.components.findOne({ id: id! }),
+    async () => (id ? adminClient.components.findOne({ id }) : undefined),
     setPageData,
     [id],
   );
@@ -70,6 +76,15 @@ export default function Page() {
       }
     },
   });
+
+  if (!page) {
+    throw new Error(t("notFound"));
+  }
+
+  if (!canViewUiExtension(page, access)) {
+    return <ForbiddenSection permissionNeeded={getRequiredViewRoles(page)} />;
+  }
+
   return (
     <>
       <DeleteConfirm />
@@ -95,7 +110,14 @@ export default function Page() {
         }
       />
       {supportsDetailTabs && id && providerId ? (
-        <RoutableTabs defaultLocation={toDetailPage({ realm, providerId, id })}>
+        <RoutableTabs
+          defaultLocation={toDetailPage({
+            realm,
+            providerId,
+            id,
+            detailTabPath,
+          })}
+        >
           <Tab
             {...settingsTab}
             title={<TabTitleText>{t("settings")}</TabTitleText>}

--- a/js/apps/admin-ui/src/page/Page.tsx
+++ b/js/apps/admin-ui/src/page/Page.tsx
@@ -24,7 +24,11 @@ import { PageHandler } from "./PageHandler";
 import { PAGE_PROVIDER } from "./constants";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { PageParams, toDetailPage, toPage } from "./routes";
-import { canViewUiExtension, getRequiredViewRoles } from "./uiExtensionAccess";
+import {
+  canManageUiExtension,
+  canViewUiExtension,
+  getRequiredViewRoles,
+} from "./uiExtensionAccess";
 
 export default function Page() {
   const { adminClient } = useAdminClient();
@@ -85,6 +89,8 @@ export default function Page() {
     return <ForbiddenSection permissionNeeded={getRequiredViewRoles(page)} />;
   }
 
+  const canManage = canManageUiExtension(page, access);
+
   return (
     <>
       <DeleteConfirm />
@@ -96,7 +102,7 @@ export default function Page() {
           )?.[0] || t("createItem")
         }
         dropdownItems={
-          id
+          id && canManage
             ? [
                 <DropdownItem
                   data-testid="delete-item"

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -10,7 +10,7 @@ import { ActionGroup, Button, Form, PageSection } from "@patternfly/react-core";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
 import { useRealm } from "../context/realm-context/RealmContext";
@@ -18,15 +18,15 @@ import { getAuthorizationHeaders } from "../utils/getAuthorizationHeaders";
 import { joinPath } from "../utils/joinPath";
 import { useParams } from "../utils/useParams";
 import { PAGE_PROVIDER, TAB_PROVIDER } from "./constants";
+import {
+  getEntityId,
+  interpolateEndpoint,
+  isEntityStorageType,
+  normalizeConfig,
+  resolveTabParams,
+  type StorageType,
+} from "./pageHandlerStorage";
 import { toPage } from "./routes";
-
-type StorageType =
-  | "COMPONENT"
-  | "CLIENT"
-  | "USER"
-  | "GROUP"
-  | "IDENTITY_PROVIDER"
-  | "CUSTOM";
 
 type PageHandlerProps = {
   id?: string;
@@ -46,7 +46,13 @@ export const PageHandler = ({
   const { realm: realmName, realmRepresentation: realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const [id, setId] = useState(idAttribute);
-  const params = useParams();
+  const routeParams = useParams();
+  const { pathname } = useLocation();
+  const tabParams = resolveTabParams(
+    pathname,
+    page.metadata.path as string | undefined,
+    routeParams,
+  );
 
   const [isLoading, setIsLoading] = useState(true);
 
@@ -55,40 +61,68 @@ export const PageHandler = ({
 
   useFetch(
     async () => {
+      const entityId = getEntityId(storageType, tabParams, pathname);
+
       switch (storageType) {
         case "CLIENT":
-          if (params.clientId) {
+          if (entityId) {
+            const attributes = (
+              await adminClient.clients.findOne({ id: entityId })
+            )?.attributes;
             return {
-              config: (
-                await adminClient.clients.findOne({ id: params.clientId })
-              )?.attributes,
+              config: normalizeConfig(
+                attributes as Record<string, unknown>,
+                page.properties,
+                "load",
+                "string-map",
+              ),
             };
           }
           return undefined;
         case "USER":
-          if (params.userId) {
+          if (entityId) {
+            const attributes = (
+              await adminClient.users.findOne({ id: entityId })
+            )?.attributes;
             return {
-              config: (await adminClient.users.findOne({ id: params.userId }))
-                ?.attributes,
+              config: normalizeConfig(
+                attributes as Record<string, unknown>,
+                page.properties,
+                "load",
+                "list-map",
+              ),
             };
           }
           return undefined;
         case "GROUP":
-          if (params.groupId) {
+          if (entityId) {
+            const attributes = (
+              await adminClient.groups.findOne({ id: entityId })
+            )?.attributes;
             return {
-              config: (await adminClient.groups.findOne({ id: params.groupId }))
-                ?.attributes,
+              config: normalizeConfig(
+                attributes as Record<string, unknown>,
+                page.properties,
+                "load",
+                "list-map",
+              ),
             };
           }
           return undefined;
         case "IDENTITY_PROVIDER":
-          if (params.providerId) {
+          if (entityId) {
+            const config = (
+              await adminClient.identityProviders.findOne({
+                alias: entityId,
+              })
+            )?.config;
             return {
-              config: (
-                await adminClient.identityProviders.findOne({
-                  alias: params.providerId,
-                })
-              )?.config,
+              config: normalizeConfig(
+                config as Record<string, unknown>,
+                page.properties,
+                "load",
+                "string-map",
+              ),
             };
           }
           return undefined;
@@ -96,7 +130,7 @@ export const PageHandler = ({
           if (page.metadata.endpoint) {
             const endpoint = interpolateEndpoint(
               page.metadata.endpoint as string,
-              params,
+              tabParams,
             );
             const response = await fetchWithError(
               joinPath(
@@ -142,79 +176,99 @@ export const PageHandler = ({
 
   const onSubmit = async (formData: ComponentRepresentation) => {
     try {
+      const entityId = getEntityId(storageType, tabParams, pathname);
+
       if (
-        (storageType === "CLIENT" && !params.clientId) ||
-        (storageType === "USER" && !params.userId) ||
-        (storageType === "GROUP" && !params.groupId) ||
-        (storageType === "IDENTITY_PROVIDER" && !params.providerId) ||
+        (isEntityStorageType(storageType) && !entityId) ||
         (storageType === "CUSTOM" && !page.metadata.endpoint)
       ) {
         throw new Error(
           `Missing required parameters for storageType: ${storageType}`,
         );
       }
+
       switch (storageType) {
         case "CLIENT":
-          if (params.clientId) {
+          if (entityId) {
             const client = await adminClient.clients.findOne({
-              id: params.clientId,
+              id: entityId,
             });
             await adminClient.clients.update(
-              { id: params.clientId },
+              { id: entityId },
               {
                 ...client,
                 attributes: {
                   ...client?.attributes,
-                  ...formData.config,
+                  ...normalizeConfig(
+                    formData.config as Record<string, unknown>,
+                    page.properties,
+                    "save",
+                    "string-map",
+                  ),
                 },
               },
             );
           }
           break;
         case "USER":
-          if (params.userId) {
-            const user = await adminClient.users.findOne({ id: params.userId });
+          if (entityId) {
+            const user = await adminClient.users.findOne({ id: entityId });
             await adminClient.users.update(
-              { id: params.userId },
+              { id: entityId },
               {
                 ...user,
                 attributes: {
                   ...user?.attributes,
-                  ...formData.config,
+                  ...normalizeConfig(
+                    formData.config as Record<string, unknown>,
+                    page.properties,
+                    "save",
+                    "list-map",
+                  ),
                 },
               },
             );
           }
           break;
         case "GROUP":
-          if (params.groupId) {
+          if (entityId) {
             const group = await adminClient.groups.findOne({
-              id: params.groupId,
+              id: entityId,
             });
             await adminClient.groups.update(
-              { id: params.groupId },
+              { id: entityId },
               {
                 ...group,
                 attributes: {
                   ...group?.attributes,
-                  ...formData.config,
+                  ...normalizeConfig(
+                    formData.config as Record<string, unknown>,
+                    page.properties,
+                    "save",
+                    "list-map",
+                  ),
                 },
               },
             );
           }
           break;
         case "IDENTITY_PROVIDER":
-          if (params.providerId) {
+          if (entityId) {
             const idp = await adminClient.identityProviders.findOne({
-              alias: params.providerId,
+              alias: entityId,
             });
             await adminClient.identityProviders.update(
-              { alias: params.providerId },
+              { alias: entityId },
               {
                 ...idp,
                 config: {
                   ...idp?.config,
-                  ...formData.config,
+                  ...normalizeConfig(
+                    formData.config as Record<string, unknown>,
+                    page.properties,
+                    "save",
+                    "string-map",
+                  ),
                 },
               },
             );
@@ -224,7 +278,7 @@ export const PageHandler = ({
           if (page.metadata.endpoint) {
             const endpoint = interpolateEndpoint(
               page.metadata.endpoint as string,
-              params,
+              tabParams,
             );
             await fetchWithError(
               joinPath(
@@ -241,7 +295,7 @@ export const PageHandler = ({
                   ),
                   "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ ...formData, ...params }),
+                body: JSON.stringify({ ...formData, ...tabParams }),
               },
             );
           }
@@ -250,7 +304,7 @@ export const PageHandler = ({
         case "COMPONENT":
         default: {
           const component = formData as ComponentRepresentation;
-          component.config = Object.assign(component.config || {}, params);
+          component.config = Object.assign(component.config || {}, tabParams);
           Object.entries(component.config).forEach(
             ([key, value]) =>
               (component.config![key] = Array.isArray(value) ? value : [value]),
@@ -324,10 +378,3 @@ export const PageHandler = ({
     </PageSection>
   );
 };
-
-function interpolateEndpoint(
-  endpoint: string,
-  params: Record<string, string>,
-): string {
-  return endpoint.replace(/\{(\w+)\}/g, (_, key) => params[key] || `{${key}}`);
-}

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -142,6 +142,17 @@ export const PageHandler = ({
 
   const onSubmit = async (formData: ComponentRepresentation) => {
     try {
+      if (
+        (storageType === "CLIENT" && !params.clientId) ||
+        (storageType === "USER" && !params.userId) ||
+        (storageType === "GROUP" && !params.groupId) ||
+        (storageType === "IDENTITY_PROVIDER" && !params.providerId) ||
+        (storageType === "CUSTOM" && !page.metadata.endpoint)
+      ) {
+        throw new Error(
+          `Missing required parameters for storageType: ${storageType}`,
+        );
+      }
       switch (storageType) {
         case "CLIENT":
           if (params.clientId) {

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -248,28 +248,6 @@ export const PageHandler = ({
             );
           }
           break;
-        case "GROUP":
-          if (entityId) {
-            const group = await adminClient.groups.findOne({
-              id: entityId,
-            });
-            await adminClient.groups.update(
-              { id: entityId },
-              {
-                ...group,
-                attributes: {
-                  ...group?.attributes,
-                  ...normalizeConfig(
-                    formData.config as Record<string, unknown>,
-                    page.properties,
-                    "save",
-                    "list-map",
-                  ),
-                },
-              },
-            );
-          }
-          break;
         case "IDENTITY_PROVIDER":
           if (entityId) {
             const idp = await adminClient.identityProviders.findOne({

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -1,3 +1,4 @@
+import { fetchWithError } from "@keycloak/keycloak-admin-client";
 import ComponentRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentRepresentation";
 import ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
 import {
@@ -13,9 +14,19 @@ import { Link } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
 import { useRealm } from "../context/realm-context/RealmContext";
+import { getAuthorizationHeaders } from "../utils/getAuthorizationHeaders";
+import { joinPath } from "../utils/joinPath";
 import { useParams } from "../utils/useParams";
 import { PAGE_PROVIDER, TAB_PROVIDER } from "./constants";
 import { toPage } from "./routes";
+
+type StorageType =
+  | "COMPONENT"
+  | "CLIENT"
+  | "USER"
+  | "GROUP"
+  | "IDENTITY_PROVIDER"
+  | "CUSTOM";
 
 type PageHandlerProps = {
   id?: string;
@@ -31,7 +42,7 @@ export const PageHandler = ({
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
-  const form = useForm<ComponentTypeRepresentation>();
+  const form = useForm<ComponentRepresentation>();
   const { realm: realmName, realmRepresentation: realm } = useRealm();
   const { addAlert, addError } = useAlerts();
   const [id, setId] = useState(idAttribute);
@@ -39,42 +50,217 @@ export const PageHandler = ({
 
   const [isLoading, setIsLoading] = useState(true);
 
+  const storageType: StorageType =
+    (page.metadata.storageType as StorageType | undefined) || "COMPONENT";
+
   useFetch(
-    async () =>
-      await Promise.all([
-        id ? adminClient.components.findOne({ id }) : Promise.resolve(),
-        providerType === TAB_PROVIDER
-          ? adminClient.components.find({ type: TAB_PROVIDER })
-          : Promise.resolve(),
-      ]),
-    ([data, tabs]) => {
-      const tab = (tabs || []).find((t) => t.providerId === providerId);
-      form.reset(data || tab || {});
-      if (tab) setId(tab.id);
+    async () => {
+      switch (storageType) {
+        case "CLIENT":
+          if (params.clientId) {
+            return {
+              config: (
+                await adminClient.clients.findOne({ id: params.clientId })
+              )?.attributes,
+            };
+          }
+          return undefined;
+        case "USER":
+          if (params.userId) {
+            return {
+              config: (await adminClient.users.findOne({ id: params.userId }))
+                ?.attributes,
+            };
+          }
+          return undefined;
+        case "GROUP":
+          if (params.groupId) {
+            return {
+              config: (await adminClient.groups.findOne({ id: params.groupId }))
+                ?.attributes,
+            };
+          }
+          return undefined;
+        case "IDENTITY_PROVIDER":
+          if (params.providerId) {
+            return {
+              config: (
+                await adminClient.identityProviders.findOne({
+                  alias: params.providerId,
+                })
+              )?.config,
+            };
+          }
+          return undefined;
+        case "CUSTOM": {
+          if (page.metadata.endpoint) {
+            const endpoint = interpolateEndpoint(
+              page.metadata.endpoint as string,
+              params,
+            );
+            const response = await fetchWithError(
+              joinPath(
+                adminClient.baseUrl,
+                "admin/realms",
+                realmName,
+                endpoint,
+              ),
+              {
+                method: "GET",
+                headers: {
+                  ...getAuthorizationHeaders(
+                    await adminClient.getAccessToken(),
+                  ),
+                  Accept: "application/json",
+                },
+              },
+            );
+            return response.json();
+          }
+          return undefined;
+        }
+        case "COMPONENT":
+        default: {
+          const [data, tabs] = await Promise.all([
+            id ? adminClient.components.findOne({ id }) : Promise.resolve(),
+            providerType === TAB_PROVIDER
+              ? adminClient.components.find({ type: TAB_PROVIDER })
+              : Promise.resolve(),
+          ]);
+          const tab = (tabs || []).find((t) => t.providerId === providerId);
+          return data || tab;
+        }
+      }
+    },
+    (data) => {
+      form.reset(data || {});
+      setId(data?.id);
       setIsLoading(false);
     },
     [],
   );
 
-  const onSubmit = async (component: ComponentRepresentation) => {
-    component.config = Object.assign(component.config || {}, params);
-    Object.entries(component.config).forEach(
-      ([key, value]) =>
-        (component.config![key] = Array.isArray(value) ? value : [value]),
-    );
+  const onSubmit = async (formData: ComponentRepresentation) => {
     try {
-      const updatedComponent = {
-        ...component,
-        providerId,
-        providerType,
-        parentId: realm.id,
-      };
-      if (id) {
-        await adminClient.components.update({ id }, updatedComponent);
-      } else {
-        const { id } = await adminClient.components.create(updatedComponent);
-        setId(id);
+      switch (storageType) {
+        case "CLIENT":
+          if (params.clientId) {
+            const client = await adminClient.clients.findOne({
+              id: params.clientId,
+            });
+            await adminClient.clients.update(
+              { id: params.clientId },
+              {
+                ...client,
+                attributes: {
+                  ...client?.attributes,
+                  ...formData.config,
+                },
+              },
+            );
+          }
+          break;
+        case "USER":
+          if (params.userId) {
+            const user = await adminClient.users.findOne({ id: params.userId });
+            await adminClient.users.update(
+              { id: params.userId },
+              {
+                ...user,
+                attributes: {
+                  ...user?.attributes,
+                  ...formData.config,
+                },
+              },
+            );
+          }
+          break;
+        case "GROUP":
+          if (params.groupId) {
+            const group = await adminClient.groups.findOne({
+              id: params.groupId,
+            });
+            await adminClient.groups.update(
+              { id: params.groupId },
+              {
+                ...group,
+                attributes: {
+                  ...group?.attributes,
+                  ...formData.config,
+                },
+              },
+            );
+          }
+          break;
+        case "IDENTITY_PROVIDER":
+          if (params.providerId) {
+            const idp = await adminClient.identityProviders.findOne({
+              alias: params.providerId,
+            });
+            await adminClient.identityProviders.update(
+              { alias: params.providerId },
+              {
+                ...idp,
+                config: {
+                  ...idp?.config,
+                  ...formData.config,
+                },
+              },
+            );
+          }
+          break;
+        case "CUSTOM": {
+          if (page.metadata.endpoint) {
+            const endpoint = interpolateEndpoint(
+              page.metadata.endpoint as string,
+              params,
+            );
+            await fetchWithError(
+              joinPath(
+                adminClient.baseUrl,
+                "admin/realms",
+                realmName,
+                endpoint,
+              ),
+              {
+                method: "PUT",
+                headers: {
+                  ...getAuthorizationHeaders(
+                    await adminClient.getAccessToken(),
+                  ),
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ ...formData, ...params }),
+              },
+            );
+          }
+          break;
+        }
+        case "COMPONENT":
+        default: {
+          const component = formData as ComponentRepresentation;
+          component.config = Object.assign(component.config || {}, params);
+          Object.entries(component.config).forEach(
+            ([key, value]) =>
+              (component.config![key] = Array.isArray(value) ? value : [value]),
+          );
+          const updatedComponent = {
+            ...component,
+            providerId,
+            providerType,
+            parentId: realm.id,
+          };
+          if (id) {
+            await adminClient.components.update({ id }, updatedComponent);
+          } else {
+            const { id: newId } =
+              await adminClient.components.create(updatedComponent);
+            setId(newId);
+          }
+          break;
+        }
       }
+
       addAlert(t("itemSaveSuccessful"));
     } catch (error) {
       addError("itemSaveError", error);
@@ -127,3 +313,10 @@ export const PageHandler = ({
     </PageSection>
   );
 };
+
+function interpolateEndpoint(
+  endpoint: string,
+  params: Record<string, string>,
+): string {
+  return endpoint.replace(/\{(\w+)\}/g, (_, key) => params[key] || `{${key}}`);
+}

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -61,7 +61,7 @@ export const PageHandler = ({
 
   useFetch(
     async () => {
-      const entityId = getEntityId(storageType, tabParams, pathname);
+      const entityId = getEntityId(storageType, tabParams);
 
       switch (storageType) {
         case "CLIENT":
@@ -83,21 +83,6 @@ export const PageHandler = ({
           if (entityId) {
             const attributes = (
               await adminClient.users.findOne({ id: entityId })
-            )?.attributes;
-            return {
-              config: normalizeConfig(
-                attributes as Record<string, unknown>,
-                page.properties,
-                "load",
-                "list-map",
-              ),
-            };
-          }
-          return undefined;
-        case "GROUP":
-          if (entityId) {
-            const attributes = (
-              await adminClient.groups.findOne({ id: entityId })
             )?.attributes;
             return {
               config: normalizeConfig(
@@ -176,7 +161,7 @@ export const PageHandler = ({
 
   const onSubmit = async (formData: ComponentRepresentation) => {
     try {
-      const entityId = getEntityId(storageType, tabParams, pathname);
+      const entityId = getEntityId(storageType, tabParams);
 
       if (
         (isEntityStorageType(storageType) && !entityId) ||

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -7,7 +7,7 @@ import {
   useFetch,
 } from "@keycloak/keycloak-ui-shared";
 import { ActionGroup, Button, Form, PageSection } from "@patternfly/react-core";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
@@ -58,16 +58,39 @@ export const PageHandler = ({
 
   const storageType: StorageType =
     (page.metadata.storageType as StorageType | undefined) || "COMPONENT";
+  const resolvedEntityId = getEntityId(storageType, tabParams);
+  const componentId = idAttribute ?? id;
+  const customEndpointTemplate = page.metadata.endpoint as string | undefined;
+  const customEndpointDependency =
+    storageType === "CUSTOM"
+      ? [
+          customEndpointTemplate || "",
+          ...Object.entries(tabParams)
+            .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+            .map(([key, value]) => `${key}=${value}`),
+        ].join("|")
+      : undefined;
+
+  const resolveCustomEndpoint = () => {
+    if (!customEndpointTemplate) {
+      return undefined;
+    }
+
+    return interpolateEndpoint(customEndpointTemplate, tabParams);
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    form.reset({});
+  }, [form, idAttribute, resolvedEntityId, customEndpointDependency]);
 
   useFetch(
     async () => {
-      const entityId = getEntityId(storageType, tabParams);
-
       switch (storageType) {
         case "CLIENT":
-          if (entityId) {
+          if (resolvedEntityId) {
             const attributes = (
-              await adminClient.clients.findOne({ id: entityId })
+              await adminClient.clients.findOne({ id: resolvedEntityId })
             )?.attributes;
             return {
               config: normalizeConfig(
@@ -80,9 +103,9 @@ export const PageHandler = ({
           }
           return undefined;
         case "USER":
-          if (entityId) {
+          if (resolvedEntityId) {
             const attributes = (
-              await adminClient.users.findOne({ id: entityId })
+              await adminClient.users.findOne({ id: resolvedEntityId })
             )?.attributes;
             return {
               config: normalizeConfig(
@@ -95,10 +118,10 @@ export const PageHandler = ({
           }
           return undefined;
         case "IDENTITY_PROVIDER":
-          if (entityId) {
+          if (resolvedEntityId) {
             const config = (
               await adminClient.identityProviders.findOne({
-                alias: entityId,
+                alias: resolvedEntityId,
               })
             )?.config;
             return {
@@ -112,11 +135,11 @@ export const PageHandler = ({
           }
           return undefined;
         case "CUSTOM": {
-          if (page.metadata.endpoint) {
-            const endpoint = interpolateEndpoint(
-              page.metadata.endpoint as string,
-              tabParams,
-            );
+          if (customEndpointTemplate) {
+            const endpoint = resolveCustomEndpoint();
+            if (!endpoint) {
+              return undefined;
+            }
             const response = await fetchWithError(
               joinPath(
                 adminClient.baseUrl,
@@ -141,7 +164,9 @@ export const PageHandler = ({
         case "COMPONENT":
         default: {
           const [data, tabs] = await Promise.all([
-            id ? adminClient.components.findOne({ id }) : Promise.resolve(),
+            componentId
+              ? adminClient.components.findOne({ id: componentId })
+              : Promise.resolve(),
             providerType === TAB_PROVIDER
               ? adminClient.components.find({ type: TAB_PROVIDER })
               : Promise.resolve(),
@@ -156,16 +181,24 @@ export const PageHandler = ({
       setId(data?.id);
       setIsLoading(false);
     },
-    [],
+    [
+      storageType,
+      idAttribute,
+      providerId,
+      providerType,
+      realmName,
+      resolvedEntityId,
+      customEndpointDependency,
+    ],
   );
 
   const onSubmit = async (formData: ComponentRepresentation) => {
     try {
-      const entityId = getEntityId(storageType, tabParams);
+      const entityId = resolvedEntityId;
 
       if (
         (isEntityStorageType(storageType) && !entityId) ||
-        (storageType === "CUSTOM" && !page.metadata.endpoint)
+        (storageType === "CUSTOM" && !customEndpointTemplate)
       ) {
         throw new Error(
           `Missing required parameters for storageType: ${storageType}`,
@@ -260,11 +293,11 @@ export const PageHandler = ({
           }
           break;
         case "CUSTOM": {
-          if (page.metadata.endpoint) {
-            const endpoint = interpolateEndpoint(
-              page.metadata.endpoint as string,
-              tabParams,
-            );
+          if (customEndpointTemplate) {
+            const endpoint = resolveCustomEndpoint();
+            if (!endpoint) {
+              break;
+            }
             await fetchWithError(
               joinPath(
                 adminClient.baseUrl,
@@ -300,8 +333,11 @@ export const PageHandler = ({
             providerType,
             parentId: realm.id,
           };
-          if (id) {
-            await adminClient.components.update({ id }, updatedComponent);
+          if (componentId) {
+            await adminClient.components.update(
+              { id: componentId },
+              updatedComponent,
+            );
           } else {
             const { id: newId } =
               await adminClient.components.create(updatedComponent);

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -212,12 +212,15 @@ export const PageHandler = ({
             const client = await adminClient.clients.findOne({
               id: entityId,
             });
+            if (!client) {
+              throw new Error(`Client not found: ${entityId}`);
+            }
             await adminClient.clients.update(
               { id: entityId },
               {
                 ...client,
                 attributes: mergeEntityConfig(
-                  client?.attributes as Record<string, unknown>,
+                  client.attributes as Record<string, unknown>,
                   formData.config as Record<string, unknown>,
                   page.properties,
                   "string-map",
@@ -229,12 +232,15 @@ export const PageHandler = ({
         case "USER":
           if (entityId) {
             const user = await adminClient.users.findOne({ id: entityId });
+            if (!user) {
+              throw new Error(`User not found: ${entityId}`);
+            }
             await adminClient.users.update(
               { id: entityId },
               {
                 ...user,
                 attributes: mergeEntityConfig(
-                  user?.attributes as Record<string, unknown>,
+                  user.attributes as Record<string, unknown>,
                   formData.config as Record<string, unknown>,
                   page.properties,
                   "list-map",
@@ -248,12 +254,15 @@ export const PageHandler = ({
             const idp = await adminClient.identityProviders.findOne({
               alias: entityId,
             });
+            if (!idp) {
+              throw new Error(`Identity provider not found: ${entityId}`);
+            }
             await adminClient.identityProviders.update(
               { alias: entityId },
               {
                 ...idp,
                 config: mergeEntityConfig(
-                  idp?.config as Record<string, unknown>,
+                  idp.config as Record<string, unknown>,
                   formData.config as Record<string, unknown>,
                   page.properties,
                   "string-map",

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -22,6 +22,7 @@ import {
   getEntityId,
   interpolateEndpoint,
   isEntityStorageType,
+  mergeEntityConfig,
   normalizeConfig,
   resolveTabParams,
   type StorageType,
@@ -215,15 +216,12 @@ export const PageHandler = ({
               { id: entityId },
               {
                 ...client,
-                attributes: {
-                  ...client?.attributes,
-                  ...normalizeConfig(
-                    formData.config as Record<string, unknown>,
-                    page.properties,
-                    "save",
-                    "string-map",
-                  ),
-                },
+                attributes: mergeEntityConfig(
+                  client?.attributes as Record<string, unknown>,
+                  formData.config as Record<string, unknown>,
+                  page.properties,
+                  "string-map",
+                ) as typeof client.attributes,
               },
             );
           }
@@ -235,15 +233,12 @@ export const PageHandler = ({
               { id: entityId },
               {
                 ...user,
-                attributes: {
-                  ...user?.attributes,
-                  ...normalizeConfig(
-                    formData.config as Record<string, unknown>,
-                    page.properties,
-                    "save",
-                    "list-map",
-                  ),
-                },
+                attributes: mergeEntityConfig(
+                  user?.attributes as Record<string, unknown>,
+                  formData.config as Record<string, unknown>,
+                  page.properties,
+                  "list-map",
+                ) as typeof user.attributes,
               },
             );
           }
@@ -257,15 +252,12 @@ export const PageHandler = ({
               { alias: entityId },
               {
                 ...idp,
-                config: {
-                  ...idp?.config,
-                  ...normalizeConfig(
-                    formData.config as Record<string, unknown>,
-                    page.properties,
-                    "save",
-                    "string-map",
-                  ),
-                },
+                config: mergeEntityConfig(
+                  idp?.config as Record<string, unknown>,
+                  formData.config as Record<string, unknown>,
+                  page.properties,
+                  "string-map",
+                ) as typeof idp.config,
               },
             );
           }

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
+import { useAccess } from "../context/access/Access";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { getAuthorizationHeaders } from "../utils/getAuthorizationHeaders";
 import { joinPath } from "../utils/joinPath";
@@ -28,6 +29,7 @@ import {
   type StorageType,
 } from "./pageHandlerStorage";
 import { toPage } from "./routes";
+import { canManageUiExtension, canViewUiExtension } from "./uiExtensionAccess";
 
 type PageHandlerProps = {
   id?: string;
@@ -38,14 +40,16 @@ type PageHandlerProps = {
 export const PageHandler = ({
   id: idAttribute,
   providerType,
-  page: { id: providerId, ...page },
+  page: pageType,
 }: PageHandlerProps) => {
+  const { id: providerId, ...page } = pageType;
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
   const form = useForm<ComponentRepresentation>();
   const { realm: realmName, realmRepresentation: realm } = useRealm();
   const { addAlert, addError } = useAlerts();
+  const access = useAccess();
   const [id, setId] = useState(idAttribute);
   const routeParams = useParams();
   const { pathname } = useLocation();
@@ -56,6 +60,9 @@ export const PageHandler = ({
   );
 
   const [isLoading, setIsLoading] = useState(true);
+  const [properties, setProperties] = useState(page.properties);
+  const canView = canViewUiExtension(pageType, access);
+  const canManage = canManageUiExtension(pageType, access);
 
   const storageType: StorageType =
     (page.metadata.storageType as StorageType | undefined) || "COMPONENT";
@@ -81,6 +88,60 @@ export const PageHandler = ({
   };
 
   useEffect(() => {
+    setProperties(page.properties);
+  }, [page.properties]);
+
+  useFetch(
+    async () => {
+      const params = new URLSearchParams();
+      if (providerType === TAB_PROVIDER) {
+        Object.entries(tabParams).forEach(([key, value]) => {
+          if (value) {
+            params.set(key, value);
+          }
+        });
+      } else if (componentId) {
+        params.set("componentId", componentId);
+      }
+
+      const query = params.toString();
+      const resource =
+        providerType === TAB_PROVIDER
+          ? `ui-extensions/tabs/${providerId}/config`
+          : `ui-extensions/pages/${providerId}/config`;
+      const response = await fetchWithError(
+        joinPath(
+          adminClient.baseUrl,
+          "admin/realms",
+          realmName,
+          `${resource}${query ? `?${query}` : ""}`,
+        ),
+        {
+          method: "GET",
+          headers: {
+            ...getAuthorizationHeaders(await adminClient.getAccessToken()),
+            Accept: "application/json",
+          },
+        },
+      );
+      return response.json();
+    },
+    (runtimeProperties) => {
+      if (Array.isArray(runtimeProperties) && runtimeProperties.length > 0) {
+        setProperties(runtimeProperties);
+      }
+    },
+    [
+      providerId,
+      providerType,
+      realmName,
+      resolvedEntityId,
+      componentId,
+      customEndpointDependency,
+    ],
+  );
+
+  useEffect(() => {
     setIsLoading(true);
     form.reset({});
   }, [form, idAttribute, resolvedEntityId, customEndpointDependency]);
@@ -96,7 +157,7 @@ export const PageHandler = ({
             return {
               config: normalizeConfig(
                 attributes as Record<string, unknown>,
-                page.properties,
+                properties,
                 "load",
                 "string-map",
               ),
@@ -111,7 +172,7 @@ export const PageHandler = ({
             return {
               config: normalizeConfig(
                 attributes as Record<string, unknown>,
-                page.properties,
+                properties,
                 "load",
                 "list-map",
               ),
@@ -128,7 +189,7 @@ export const PageHandler = ({
             return {
               config: normalizeConfig(
                 config as Record<string, unknown>,
-                page.properties,
+                properties,
                 "load",
                 "string-map",
               ),
@@ -222,7 +283,7 @@ export const PageHandler = ({
                 attributes: mergeEntityConfig(
                   client.attributes as Record<string, unknown>,
                   formData.config as Record<string, unknown>,
-                  page.properties,
+                  properties,
                   "string-map",
                 ) as typeof client.attributes,
               },
@@ -242,7 +303,7 @@ export const PageHandler = ({
                 attributes: mergeEntityConfig(
                   user.attributes as Record<string, unknown>,
                   formData.config as Record<string, unknown>,
-                  page.properties,
+                  properties,
                   "list-map",
                 ) as typeof user.attributes,
               },
@@ -264,7 +325,7 @@ export const PageHandler = ({
                 config: mergeEntityConfig(
                   idp.config as Record<string, unknown>,
                   formData.config as Record<string, unknown>,
-                  page.properties,
+                  properties,
                   "string-map",
                 ) as typeof idp.config,
               },
@@ -332,6 +393,10 @@ export const PageHandler = ({
     }
   };
 
+  if (!canView) {
+    return null;
+  }
+
   if (isLoading) {
     return <KeycloakSpinner />;
   }
@@ -344,13 +409,15 @@ export const PageHandler = ({
         className="keycloak__form"
       >
         <FormProvider {...form}>
-          <DynamicComponents properties={page.properties} />
+          <DynamicComponents properties={properties} />
         </FormProvider>
 
         <ActionGroup>
-          <Button data-testid="save" type="submit">
-            {t("save")}
-          </Button>
+          {canManage && (
+            <Button data-testid="save" type="submit">
+              {t("save")}
+            </Button>
+          )}
           {providerType === PAGE_PROVIDER ? (
             <Button
               data-testid="cancel"

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -280,6 +280,10 @@ export const PageHandler = ({
   );
 
   const onSubmit = async (formData: ComponentRepresentation) => {
+    if (!canManage) {
+      return;
+    }
+
     try {
       const entityId = resolvedEntityId;
       const converted = convertFormValuesToObject(formData);
@@ -431,7 +435,11 @@ export const PageHandler = ({
     <PageSection variant="light">
       <Form
         isHorizontal
-        onSubmit={form.handleSubmit(onSubmit)}
+        onSubmit={
+          canManage
+            ? form.handleSubmit(onSubmit)
+            : (event) => event.preventDefault()
+        }
         className="keycloak__form"
       >
         <FormProvider {...form}>

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -18,6 +18,7 @@ import { useRealm } from "../context/realm-context/RealmContext";
 import { getAuthorizationHeaders } from "../utils/getAuthorizationHeaders";
 import { joinPath } from "../utils/joinPath";
 import { useParams } from "../utils/useParams";
+import { convertFormValuesToObject, convertToFormValues } from "../util";
 import { PAGE_PROVIDER, TAB_PROVIDER } from "./constants";
 import {
   getEntityId,
@@ -78,6 +79,14 @@ export const PageHandler = ({
             .map(([key, value]) => `${key}=${value}`),
         ].join("|")
       : undefined;
+  const tabParamsDependency = Object.entries(tabParams)
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("|");
+  const propertySignature = properties
+    .map((property) => `${property.name}:${property.type}`)
+    .join("|");
+  const encodedRealmName = encodeURIComponent(realmName);
 
   const resolveCustomEndpoint = () => {
     if (!customEndpointTemplate) {
@@ -113,7 +122,7 @@ export const PageHandler = ({
         joinPath(
           adminClient.baseUrl,
           "admin/realms",
-          realmName,
+          encodedRealmName,
           `${resource}${query ? `?${query}` : ""}`,
         ),
         {
@@ -127,24 +136,31 @@ export const PageHandler = ({
       return response.json();
     },
     (runtimeProperties) => {
-      if (Array.isArray(runtimeProperties) && runtimeProperties.length > 0) {
+      if (Array.isArray(runtimeProperties)) {
         setProperties(runtimeProperties);
       }
     },
     [
       providerId,
       providerType,
-      realmName,
+      encodedRealmName,
       resolvedEntityId,
       componentId,
       customEndpointDependency,
+      tabParamsDependency,
     ],
   );
 
   useEffect(() => {
     setIsLoading(true);
     form.reset({});
-  }, [form, idAttribute, resolvedEntityId, customEndpointDependency]);
+  }, [
+    form,
+    idAttribute,
+    resolvedEntityId,
+    customEndpointDependency,
+    propertySignature,
+  ]);
 
   useFetch(
     async () => {
@@ -206,7 +222,7 @@ export const PageHandler = ({
               joinPath(
                 adminClient.baseUrl,
                 "admin/realms",
-                realmName,
+                encodedRealmName,
                 endpoint,
               ),
               {
@@ -230,7 +246,11 @@ export const PageHandler = ({
               ? adminClient.components.findOne({ id: componentId })
               : Promise.resolve(),
             providerType === TAB_PROVIDER
-              ? adminClient.components.find({ type: TAB_PROVIDER })
+              ? adminClient.components.find({
+                  type: TAB_PROVIDER,
+                  providerId,
+                  parent: realm.id,
+                })
               : Promise.resolve(),
           ]);
           const tab = (tabs || []).find((t) => t.providerId === providerId);
@@ -239,7 +259,10 @@ export const PageHandler = ({
       }
     },
     (data) => {
-      form.reset(data || {});
+      form.reset({});
+      if (data) {
+        convertToFormValues(data, form.setValue);
+      }
       setId(data?.id);
       setIsLoading(false);
     },
@@ -248,15 +271,18 @@ export const PageHandler = ({
       idAttribute,
       providerId,
       providerType,
-      realmName,
+      encodedRealmName,
       resolvedEntityId,
       customEndpointDependency,
+      propertySignature,
+      tabParamsDependency,
     ],
   );
 
   const onSubmit = async (formData: ComponentRepresentation) => {
     try {
       const entityId = resolvedEntityId;
+      const converted = convertFormValuesToObject(formData);
 
       if (
         (isEntityStorageType(storageType) && !entityId) ||
@@ -282,7 +308,7 @@ export const PageHandler = ({
                 ...client,
                 attributes: mergeEntityConfig(
                   client.attributes as Record<string, unknown>,
-                  formData.config as Record<string, unknown>,
+                  converted.config as Record<string, unknown>,
                   properties,
                   "string-map",
                 ) as typeof client.attributes,
@@ -302,7 +328,7 @@ export const PageHandler = ({
                 ...user,
                 attributes: mergeEntityConfig(
                   user.attributes as Record<string, unknown>,
-                  formData.config as Record<string, unknown>,
+                  converted.config as Record<string, unknown>,
                   properties,
                   "list-map",
                 ) as typeof user.attributes,
@@ -324,7 +350,7 @@ export const PageHandler = ({
                 ...idp,
                 config: mergeEntityConfig(
                   idp.config as Record<string, unknown>,
-                  formData.config as Record<string, unknown>,
+                  converted.config as Record<string, unknown>,
                   properties,
                   "string-map",
                 ) as typeof idp.config,
@@ -342,7 +368,7 @@ export const PageHandler = ({
               joinPath(
                 adminClient.baseUrl,
                 "admin/realms",
-                realmName,
+                encodedRealmName,
                 endpoint,
               ),
               {
@@ -353,7 +379,7 @@ export const PageHandler = ({
                   ),
                   "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ ...formData, ...tabParams }),
+                body: JSON.stringify({ ...converted, ...tabParams }),
               },
             );
           }
@@ -361,7 +387,7 @@ export const PageHandler = ({
         }
         case "COMPONENT":
         default: {
-          const component = formData as ComponentRepresentation;
+          const component = converted as ComponentRepresentation;
           component.config = Object.assign(component.config || {}, tabParams);
           Object.entries(component.config).forEach(
             ([key, value]) =>

--- a/js/apps/admin-ui/src/page/PageList.tsx
+++ b/js/apps/admin-ui/src/page/PageList.tsx
@@ -34,15 +34,21 @@ import {
 type DetailLinkProps = {
   obj: ComponentRepresentation;
   field: string;
+  detailTabPath?: string;
 };
 
-const DetailLink = ({ obj, field }: DetailLinkProps) => {
+const DetailLink = ({ obj, field, detailTabPath }: DetailLinkProps) => {
   const { realm } = useRealm();
   const value = get(obj, field);
   return (
     <Link
       key={value}
-      to={toDetailPage({ realm, providerId: obj.providerId!, id: obj.id! })}
+      to={toDetailPage({
+        realm,
+        providerId: obj.providerId!,
+        id: obj.id!,
+        detailTabPath,
+      })}
     >
       {value}
     </Link>
@@ -105,6 +111,7 @@ export default function PageList() {
   }
 
   const canManage = canManageUiExtension(page, access);
+  const detailTabPath = page.metadata.detailTabPath as string | undefined;
 
   return (
     <PageSection variant="light" className="pf-v5-u-p-0">
@@ -156,7 +163,11 @@ export default function PageList() {
             cellRenderer:
               index === 0
                 ? (obj: ComponentRepresentation) => (
-                    <DetailLink obj={obj} field={`config.${name}`} />
+                    <DetailLink
+                      obj={obj}
+                      field={`config.${name}`}
+                      detailTabPath={detailTabPath}
+                    />
                   )
                 : undefined,
           })),

--- a/js/apps/admin-ui/src/page/PageList.tsx
+++ b/js/apps/admin-ui/src/page/PageList.tsx
@@ -25,7 +25,11 @@ import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { PAGE_PROVIDER } from "./constants";
 import { addDetailPage, PageListParams, toDetailPage } from "./routes";
-import { canViewUiExtension, getRequiredViewRoles } from "./uiExtensionAccess";
+import {
+  canManageUiExtension,
+  canViewUiExtension,
+  getRequiredViewRoles,
+} from "./uiExtensionAccess";
 
 type DetailLinkProps = {
   obj: ComponentRepresentation;
@@ -100,6 +104,8 @@ export default function PageList() {
     return <ForbiddenSection permissionNeeded={getRequiredViewRoles(page)} />;
   }
 
+  const canManage = canManageUiExtension(page, access);
+
   return (
     <PageSection variant="light" className="pf-v5-u-p-0">
       <DeleteConfirm />
@@ -107,28 +113,37 @@ export default function PageList() {
       <KeycloakDataTable
         key={key}
         toolbarItem={
-          <ToolbarItem>
-            <Button
-              component={(props) => (
-                <Link
-                  {...props}
-                  to={addDetailPage({ realm: realmName, providerId: page.id })}
-                />
-              )}
-            >
-              {t("createItem")}
-            </Button>
-          </ToolbarItem>
+          canManage ? (
+            <ToolbarItem>
+              <Button
+                component={(props) => (
+                  <Link
+                    {...props}
+                    to={addDetailPage({
+                      realm: realmName,
+                      providerId: page.id,
+                    })}
+                  />
+                )}
+              >
+                {t("createItem")}
+              </Button>
+            </ToolbarItem>
+          ) : undefined
         }
-        actionResolver={(item: IRowData) => [
-          {
-            title: t("delete"),
-            onClick() {
-              setSelectedItem(item.data);
-              toggleDeleteDialog();
-            },
-          },
-        ]}
+        actionResolver={
+          canManage
+            ? (item: IRowData) => [
+                {
+                  title: t("delete"),
+                  onClick() {
+                    setSelectedItem(item.data);
+                    toggleDeleteDialog();
+                  },
+                },
+              ]
+            : undefined
+        }
         searchPlaceholderKey="searchItem"
         loader={loader}
         columns={[
@@ -152,11 +167,14 @@ export default function PageList() {
             hasIcon
             message={t("noItems")}
             instructions={t("noItemsInstructions")}
-            primaryActionText={t("createItem")}
-            onPrimaryAction={() =>
-              void navigate(
-                addDetailPage({ realm: realmName, providerId: page.id }),
-              )
+            primaryActionText={canManage ? t("createItem") : undefined}
+            onPrimaryAction={
+              canManage
+                ? () =>
+                    void navigate(
+                      addDetailPage({ realm: realmName, providerId: page.id }),
+                    )
+                : undefined
             }
           />
         }

--- a/js/apps/admin-ui/src/page/PageList.tsx
+++ b/js/apps/admin-ui/src/page/PageList.tsx
@@ -19,10 +19,13 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
 import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../components/view-header/ViewHeader";
+import { ForbiddenSection } from "../ForbiddenSection";
+import { useAccess } from "../context/access/Access";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
 import { PAGE_PROVIDER } from "./constants";
 import { addDetailPage, PageListParams, toDetailPage } from "./routes";
+import { canViewUiExtension, getRequiredViewRoles } from "./uiExtensionAccess";
 
 type DetailLinkProps = {
   obj: ComponentRepresentation;
@@ -54,9 +57,10 @@ export default function PageList() {
   const { realm: realmName, realmRepresentation: realm } = useRealm();
   const [selectedItem, setSelectedItem] = useState<ComponentRepresentation>();
   const { componentTypes } = useServerInfo();
+  const access = useAccess();
   const pages = componentTypes?.[PAGE_PROVIDER];
 
-  const page = pages?.find((p) => p.id === providerId)!;
+  const page = pages?.find((p) => p.id === providerId);
 
   const loader = {
     signal: { providerId },
@@ -87,6 +91,14 @@ export default function PageList() {
       }
     },
   });
+
+  if (!page) {
+    throw new Error(t("notFound"));
+  }
+
+  if (!canViewUiExtension(page, access)) {
+    return <ForbiddenSection permissionNeeded={getRequiredViewRoles(page)} />;
+  }
 
   return (
     <PageSection variant="light" className="pf-v5-u-p-0">

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.test.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getEntityId,
   interpolateEndpoint,
+  mergeEntityConfig,
   normalizeConfig,
   resolveTabParams,
 } from "./pageHandlerStorage";
@@ -162,6 +163,52 @@ describe("normalizeConfig", () => {
 
     expect(saved).toEqual({
       redirectUris: ["https://a.example", "https://b.example"],
+    });
+  });
+
+  it("round-trips IdentityProviderMultiList values for string-map targets", () => {
+    const property: ConfigPropertyRepresentation = {
+      name: "linkedIdps",
+      type: "IdentityProviderMultiList",
+    };
+    const loaded = normalizeConfig(
+      { linkedIdps: "google##github" },
+      [property],
+      "load",
+      "string-map",
+    );
+
+    expect(loaded).toEqual({ linkedIdps: ["google", "github"] });
+
+    const saved = normalizeConfig(loaded, [property], "save", "string-map");
+
+    expect(saved).toEqual({ linkedIdps: "google##github" });
+  });
+});
+
+describe("mergeEntityConfig", () => {
+  it("removes cleared declared properties from existing values", () => {
+    const result = mergeEntityConfig(
+      { host: "old.example.com", keep: "value" },
+      { host: undefined },
+      [scalarProperty],
+      "string-map",
+    );
+
+    expect(result).toEqual({ keep: "value" });
+  });
+
+  it("updates declared properties and leaves unrelated values intact", () => {
+    const result = mergeEntityConfig(
+      { host: "old.example.com", keep: "value" },
+      { host: ["new.example.com"] },
+      [scalarProperty],
+      "string-map",
+    );
+
+    expect(result).toEqual({
+      host: "new.example.com",
+      keep: "value",
     });
   });
 });

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.test.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.test.ts
@@ -1,0 +1,183 @@
+import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
+import { describe, expect, it } from "vitest";
+import {
+  getEntityId,
+  interpolateEndpoint,
+  normalizeConfig,
+  resolveTabParams,
+} from "./pageHandlerStorage";
+
+const scalarProperty: ConfigPropertyRepresentation = {
+  name: "host",
+  type: "String",
+};
+
+const multivaluedProperty: ConfigPropertyRepresentation = {
+  name: "redirectUris",
+  type: "MultivaluedString",
+};
+
+describe("resolveTabParams", () => {
+  it("merges route params with params from the metadata path", () => {
+    const params = resolveTabParams(
+      "/master/clients/abc-123/settings",
+      "/:realm/clients/:clientId/:tab?",
+      { realm: "master" },
+    );
+
+    expect(params).toEqual({
+      realm: "master",
+      clientId: "abc-123",
+      tab: "settings",
+    });
+  });
+
+  it("returns route params when metadata path does not match", () => {
+    const params = resolveTabParams(
+      "/master/users/user-1",
+      "/:realm/clients/:clientId/:tab?",
+      { realm: "master", id: "user-1" },
+    );
+
+    expect(params).toEqual({ realm: "master", id: "user-1" });
+  });
+});
+
+describe("getEntityId", () => {
+  it("resolves entity ids from route params", () => {
+    expect(
+      getEntityId("CLIENT", { clientId: "client-1", realm: "master" }),
+    ).toBe("client-1");
+    expect(getEntityId("USER", { id: "user-1", realm: "master" })).toBe(
+      "user-1",
+    );
+    expect(
+      getEntityId("IDENTITY_PROVIDER", {
+        alias: "google",
+        providerId: "oidc",
+      }),
+    ).toBe("google");
+    expect(getEntityId("COMPONENT", { clientId: "client-1" })).toBeUndefined();
+  });
+});
+
+describe("normalizeConfig", () => {
+  it("loads only declared scalar properties for string-map targets", () => {
+    const result = normalizeConfig(
+      {
+        host: "smtp.example.com",
+        unrelated: "ignored",
+      },
+      [scalarProperty],
+      "load",
+      "string-map",
+    );
+
+    expect(result).toEqual({ host: ["smtp.example.com"] });
+  });
+
+  it("saves only declared scalar properties for string-map targets", () => {
+    const result = normalizeConfig(
+      {
+        host: ["smtp.example.com"],
+        unrelated: ["ignored"],
+      },
+      [scalarProperty],
+      "save",
+      "string-map",
+    );
+
+    expect(result).toEqual({ host: "smtp.example.com" });
+  });
+
+  it("round-trips multivalued string-map values with delimiter", () => {
+    const properties = [multivaluedProperty];
+    const loaded = normalizeConfig(
+      { redirectUris: "https://a.example##https://b.example" },
+      properties,
+      "load",
+      "string-map",
+    );
+
+    expect(loaded).toEqual({
+      redirectUris: ["https://a.example", "https://b.example"],
+    });
+
+    const saved = normalizeConfig(loaded, properties, "save", "string-map");
+
+    expect(saved).toEqual({
+      redirectUris: "https://a.example##https://b.example",
+    });
+  });
+
+  it("keeps multivalued string-map values intact when delimiter is absent", () => {
+    const result = normalizeConfig(
+      { redirectUris: "https://single.example" },
+      [multivaluedProperty],
+      "load",
+      "string-map",
+    );
+
+    expect(result).toEqual({ redirectUris: ["https://single.example"] });
+  });
+
+  it("round-trips scalar list-map values", () => {
+    const departmentProperty: ConfigPropertyRepresentation = {
+      name: "department",
+      type: "String",
+    };
+    const loaded = normalizeConfig(
+      { department: "engineering" },
+      [departmentProperty],
+      "load",
+      "list-map",
+    );
+
+    expect(loaded).toEqual({ department: ["engineering"] });
+
+    const saved = normalizeConfig(
+      loaded,
+      [departmentProperty],
+      "save",
+      "list-map",
+    );
+
+    expect(saved).toEqual({ department: ["engineering"] });
+  });
+
+  it("round-trips multivalued list-map values", () => {
+    const properties = [multivaluedProperty];
+    const loaded = normalizeConfig(
+      { redirectUris: ["https://a.example", "https://b.example"] },
+      properties,
+      "load",
+      "list-map",
+    );
+
+    expect(loaded).toEqual({
+      redirectUris: ["https://a.example", "https://b.example"],
+    });
+
+    const saved = normalizeConfig(loaded, properties, "save", "list-map");
+
+    expect(saved).toEqual({
+      redirectUris: ["https://a.example", "https://b.example"],
+    });
+  });
+});
+
+describe("interpolateEndpoint", () => {
+  it("replaces placeholders with encoded values", () => {
+    expect(
+      interpolateEndpoint("extensions/clients/{clientId}/settings", {
+        clientId: "abc/123",
+      }),
+    ).toBe("extensions/clients/abc%2F123/settings");
+  });
+
+  it("throws when a placeholder is missing", () => {
+    expect(() =>
+      interpolateEndpoint("extensions/clients/{clientId}/settings", {}),
+    ).toThrow("Missing endpoint parameter(s): clientId");
+  });
+});

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.test.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.test.ts
@@ -211,6 +211,21 @@ describe("mergeEntityConfig", () => {
       keep: "value",
     });
   });
+
+  it("removes cleared multiline values represented as an empty string array", () => {
+    const multilineProperty: ConfigPropertyRepresentation = {
+      name: "notes",
+      type: "MultivaluedString",
+    };
+    const result = mergeEntityConfig(
+      { notes: "existing" },
+      { notes: [""] },
+      [multilineProperty],
+      "string-map",
+    );
+
+    expect(result).toEqual({});
+  });
 });
 
 describe("interpolateEndpoint", () => {

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.ts
@@ -1,0 +1,137 @@
+import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
+import { matchPath } from "react-router-dom";
+import { getLastId } from "../groups/groupIdUtils";
+
+const MULTIVALUED_DELIMITER = "##";
+
+const MULTIVALUED_TYPES = new Set(["MultivaluedString", "MultivaluedList"]);
+
+export type StorageType =
+  | "COMPONENT"
+  | "CLIENT"
+  | "USER"
+  | "GROUP"
+  | "IDENTITY_PROVIDER"
+  | "CUSTOM";
+
+export type ConfigMapTarget = "string-map" | "list-map";
+
+export function resolveTabParams(
+  pathname: string,
+  metadataPath: string | undefined,
+  routeParams: Record<string, string | undefined>,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(routeParams)) {
+    if (value !== undefined) {
+      resolved[key] = value;
+    }
+  }
+
+  if (metadataPath) {
+    const match = matchPath({ path: metadataPath, end: false }, pathname);
+    if (match?.params) {
+      for (const [key, value] of Object.entries(match.params)) {
+        if (value !== undefined) {
+          resolved[key] = value;
+        }
+      }
+    }
+  }
+
+  return resolved;
+}
+
+export function getEntityId(
+  storageType: StorageType,
+  params: Record<string, string | undefined>,
+  pathname: string,
+): string | undefined {
+  switch (storageType) {
+    case "CLIENT":
+      return params.clientId!;
+    case "USER":
+      return params.id!;
+    case "GROUP":
+      return params.id ?? getLastId(pathname);
+    case "IDENTITY_PROVIDER":
+      return params.alias!;
+    default:
+      return undefined;
+  }
+}
+
+export function isEntityStorageType(
+  storageType: StorageType,
+): storageType is "CLIENT" | "USER" | "GROUP" | "IDENTITY_PROVIDER" {
+  return (
+    storageType === "CLIENT" ||
+    storageType === "USER" ||
+    storageType === "GROUP" ||
+    storageType === "IDENTITY_PROVIDER"
+  );
+}
+
+function isMultivaluedProperty(
+  property: ConfigPropertyRepresentation,
+): boolean {
+  return !!property.type && MULTIVALUED_TYPES.has(property.type);
+}
+
+export function normalizeConfig(
+  config: Record<string, unknown> | undefined,
+  properties: ConfigPropertyRepresentation[],
+  direction: "load" | "save",
+  target: ConfigMapTarget,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const multivaluedNames = new Set(
+    properties.filter(isMultivaluedProperty).map((property) => property.name!),
+  );
+
+  for (const [key, value] of Object.entries(config || {})) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (direction === "load") {
+      if (
+        target === "string-map" &&
+        multivaluedNames.has(key) &&
+        typeof value === "string"
+      ) {
+        result[key] = value.split(MULTIVALUED_DELIMITER);
+      } else {
+        result[key] = Array.isArray(value) ? value : [value];
+      }
+    } else if (target === "string-map") {
+      result[key] = Array.isArray(value)
+        ? value.join(MULTIVALUED_DELIMITER)
+        : String(value);
+    } else {
+      result[key] = Array.isArray(value) ? value : [value];
+    }
+  }
+
+  return result;
+}
+
+export function interpolateEndpoint(
+  endpoint: string,
+  params: Record<string, string | undefined>,
+): string {
+  const missing: string[] = [];
+  const result = endpoint.replace(/\{(\w+)\}/g, (_, key) => {
+    const value = params[key];
+    if (value == null || value === "") {
+      missing.push(key);
+      return `{${key}}`;
+    }
+    return encodeURIComponent(value);
+  });
+  if (missing.length > 0) {
+    throw new Error(`Missing endpoint parameter(s): ${missing.join(", ")}`);
+  }
+  return result;
+}

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.ts
@@ -1,6 +1,5 @@
 import type { ConfigPropertyRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation";
 import { matchPath } from "react-router-dom";
-import { getLastId } from "../groups/groupIdUtils";
 
 const MULTIVALUED_DELIMITER = "##";
 
@@ -10,7 +9,6 @@ export type StorageType =
   | "COMPONENT"
   | "CLIENT"
   | "USER"
-  | "GROUP"
   | "IDENTITY_PROVIDER"
   | "CUSTOM";
 
@@ -46,15 +44,12 @@ export function resolveTabParams(
 export function getEntityId(
   storageType: StorageType,
   params: Record<string, string | undefined>,
-  pathname: string,
 ): string | undefined {
   switch (storageType) {
     case "CLIENT":
       return params.clientId!;
     case "USER":
       return params.id!;
-    case "GROUP":
-      return params.id ?? getLastId(pathname);
     case "IDENTITY_PROVIDER":
       return params.alias!;
     default:
@@ -64,11 +59,10 @@ export function getEntityId(
 
 export function isEntityStorageType(
   storageType: StorageType,
-): storageType is "CLIENT" | "USER" | "GROUP" | "IDENTITY_PROVIDER" {
+): storageType is "CLIENT" | "USER" | "IDENTITY_PROVIDER" {
   return (
     storageType === "CLIENT" ||
     storageType === "USER" ||
-    storageType === "GROUP" ||
     storageType === "IDENTITY_PROVIDER"
   );
 }

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.ts
@@ -84,7 +84,9 @@ export function normalizeConfig(
     properties.filter(isMultivaluedProperty).map((property) => property.name!),
   );
 
-  for (const [key, value] of Object.entries(config || {})) {
+  for (const property of properties) {
+    const key = property.name!;
+    const value = config?.[key];
     if (value === undefined || value === null) {
       continue;
     }
@@ -93,7 +95,8 @@ export function normalizeConfig(
       if (
         target === "string-map" &&
         multivaluedNames.has(key) &&
-        typeof value === "string"
+        typeof value === "string" &&
+        value.includes(MULTIVALUED_DELIMITER)
       ) {
         result[key] = value.split(MULTIVALUED_DELIMITER);
       } else {

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.ts
@@ -3,7 +3,11 @@ import { matchPath } from "react-router-dom";
 
 const MULTIVALUED_DELIMITER = "##";
 
-const MULTIVALUED_TYPES = new Set(["MultivaluedString", "MultivaluedList"]);
+const MULTIVALUED_TYPES = new Set([
+  "MultivaluedString",
+  "MultivaluedList",
+  "IdentityProviderMultiList",
+]);
 
 export type StorageType =
   | "COMPONENT"
@@ -71,6 +75,46 @@ function isMultivaluedProperty(
   property: ConfigPropertyRepresentation,
 ): boolean {
   return !!property.type && MULTIVALUED_TYPES.has(property.type);
+}
+
+function isClearedValue(value: unknown): boolean {
+  if (value === undefined || value === null || value === "") {
+    return true;
+  }
+
+  return Array.isArray(value) && value.length === 0;
+}
+
+export function mergeEntityConfig(
+  existing: Record<string, unknown> | undefined,
+  config: Record<string, unknown> | undefined,
+  properties: ConfigPropertyRepresentation[],
+  target: ConfigMapTarget,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...(existing || {}) };
+
+  for (const property of properties) {
+    const key = property.name!;
+    const value = config?.[key];
+
+    if (isClearedValue(value)) {
+      delete result[key];
+      continue;
+    }
+
+    const normalized = normalizeConfig(
+      { [key]: value },
+      [property],
+      "save",
+      target,
+    );
+
+    if (key in normalized) {
+      result[key] = normalized[key];
+    }
+  }
+
+  return result;
 }
 
 export function normalizeConfig(

--- a/js/apps/admin-ui/src/page/pageHandlerStorage.ts
+++ b/js/apps/admin-ui/src/page/pageHandlerStorage.ts
@@ -82,7 +82,11 @@ function isClearedValue(value: unknown): boolean {
     return true;
   }
 
-  return Array.isArray(value) && value.length === 0;
+  if (Array.isArray(value)) {
+    return value.length === 0 || value.every((item) => isClearedValue(item));
+  }
+
+  return false;
 }
 
 export function mergeEntityConfig(

--- a/js/apps/admin-ui/src/page/routes.tsx
+++ b/js/apps/admin-ui/src/page/routes.tsx
@@ -12,7 +12,7 @@ const PageListRoute: AppRouteObject = {
   path: "/:realm?/page-section/:providerId",
   element: <PageList />,
   handle: {
-    access: "view-realm",
+    access: "anyone",
     breadcrumb: (t) => t("page"),
   },
 };
@@ -21,7 +21,7 @@ const PageDetailRoute: AppRouteObject = {
   path: "/:realm/page-section/:providerId/:id/:tab?",
   element: <Page />,
   handle: {
-    access: "view-realm",
+    access: "anyone",
     breadcrumb: (t) => t("details"),
   },
 };
@@ -30,7 +30,7 @@ const PageDetailLegacyRoute: AppRouteObject = {
   path: "/:realm/page-section/:providerId/:id",
   element: <Page />,
   handle: {
-    access: "view-realm",
+    access: "anyone",
     breadcrumb: (t) => t("details"),
   },
 };
@@ -39,7 +39,7 @@ const AddPageDetailRoute: AppRouteObject = {
   path: "/:realm/page-section/:providerId/add",
   element: <Page />,
   handle: {
-    access: "view-realm",
+    access: "anyone",
     breadcrumb: (t) => t("add"),
   },
 };
@@ -55,8 +55,10 @@ export const toPage = (params: PageListParams): Partial<Path> => ({
   pathname: generatePath(PageListRoute.path, params),
 });
 
-export const toDetailPage = (params: PageParams): Partial<Path> => ({
-  pathname: generatePath(PageDetailRoute.path, params),
+export const toDetailPage = (
+  params: PageParams & { detailTabPath?: string },
+): Partial<Path> => ({
+  pathname: generatePath(params.detailTabPath ?? PageDetailRoute.path, params),
 });
 
 export const addDetailPage = (params: Partial<PageParams>): Partial<Path> => ({

--- a/js/apps/admin-ui/src/page/routes.tsx
+++ b/js/apps/admin-ui/src/page/routes.tsx
@@ -18,6 +18,15 @@ const PageListRoute: AppRouteObject = {
 };
 
 const PageDetailRoute: AppRouteObject = {
+  path: "/:realm/page-section/:providerId/:id/:tab?",
+  element: <Page />,
+  handle: {
+    access: "view-realm",
+    breadcrumb: (t) => t("details"),
+  },
+};
+
+const PageDetailLegacyRoute: AppRouteObject = {
   path: "/:realm/page-section/:providerId/:id",
   element: <Page />,
   handle: {
@@ -37,6 +46,7 @@ const AddPageDetailRoute: AppRouteObject = {
 
 const routes: AppRouteObject[] = [
   PageDetailRoute,
+  PageDetailLegacyRoute,
   AddPageDetailRoute,
   PageListRoute,
 ];

--- a/js/apps/admin-ui/src/page/uiExtensionAccess.test.ts
+++ b/js/apps/admin-ui/src/page/uiExtensionAccess.test.ts
@@ -40,7 +40,7 @@ describe("uiExtensionAccess", () => {
     expect(getRequiredManageRoles(extension)).toEqual(["manage-clients"]);
   });
 
-  it("gates view and manage access", () => {
+  it("gates manage access with any declared role", () => {
     const extension = page({
       requiredViewRoles: ["view-clients"],
       requiredManageRoles: ["manage-clients"],

--- a/js/apps/admin-ui/src/page/uiExtensionAccess.test.ts
+++ b/js/apps/admin-ui/src/page/uiExtensionAccess.test.ts
@@ -1,0 +1,73 @@
+import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
+import { describe, expect, it } from "vitest";
+import {
+  canManageUiExtension,
+  canViewUiExtension,
+  getNavSection,
+  getRequiredManageRoles,
+  getRequiredViewRoles,
+  getTabTitle,
+} from "./uiExtensionAccess";
+
+const page = (
+  metadata: Record<string, unknown> = {},
+): ComponentTypeRepresentation =>
+  ({
+    id: "my-extension",
+    metadata,
+  }) as ComponentTypeRepresentation;
+
+const access = (roles: string[]) => ({
+  hasAccess: (...types: string[]) =>
+    types.every((type) => roles.includes(type)),
+  hasSomeAccess: (...types: string[]) =>
+    types.some((type) => roles.includes(type)),
+});
+
+describe("uiExtensionAccess", () => {
+  it("uses realm roles by default", () => {
+    expect(getRequiredViewRoles(page())).toEqual(["view-realm"]);
+    expect(getRequiredManageRoles(page())).toEqual(["manage-realm"]);
+  });
+
+  it("reads declared roles from metadata", () => {
+    const extension = page({
+      requiredViewRoles: ["view-clients"],
+      requiredManageRoles: ["manage-clients"],
+    });
+
+    expect(getRequiredViewRoles(extension)).toEqual(["view-clients"]);
+    expect(getRequiredManageRoles(extension)).toEqual(["manage-clients"]);
+  });
+
+  it("gates view and manage access", () => {
+    const extension = page({
+      requiredViewRoles: ["view-clients"],
+      requiredManageRoles: ["manage-clients"],
+    });
+
+    expect(canViewUiExtension(extension, access(["view-clients"]))).toBe(true);
+    expect(canViewUiExtension(extension, access(["view-realm"]))).toBe(false);
+    expect(canManageUiExtension(extension, access(["manage-clients"]))).toBe(
+      true,
+    );
+    expect(canManageUiExtension(extension, access(["manage-realm"]))).toBe(
+      false,
+    );
+  });
+
+  it("resolves navigation sections", () => {
+    expect(getNavSection(page())).toBe("configure");
+    expect(getNavSection(page({ navSection: "manage" }))).toBe("manage");
+    expect(getNavSection(page({ navSection: "extensions" }))).toBe(
+      "extensions",
+    );
+  });
+
+  it("resolves tab titles from metadata", () => {
+    expect(getTabTitle(page(), (key) => `t:${key}`)).toBe("t:my-extension");
+    expect(
+      getTabTitle(page({ tabLabel: "customTab" }), (key) => `t:${key}`),
+    ).toBe("t:customTab");
+  });
+});

--- a/js/apps/admin-ui/src/page/uiExtensionAccess.ts
+++ b/js/apps/admin-ui/src/page/uiExtensionAccess.ts
@@ -34,9 +34,9 @@ export function canViewUiExtension(
 
 export function canManageUiExtension(
   page: ComponentTypeRepresentation,
-  { hasAccess }: AccessChecker,
+  { hasSomeAccess }: AccessChecker,
 ): boolean {
-  return hasAccess(...getRequiredManageRoles(page));
+  return hasSomeAccess(...getRequiredManageRoles(page));
 }
 
 export function getNavSection(page: ComponentTypeRepresentation): NavSection {

--- a/js/apps/admin-ui/src/page/uiExtensionAccess.ts
+++ b/js/apps/admin-ui/src/page/uiExtensionAccess.ts
@@ -1,0 +1,56 @@
+import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
+import type ComponentTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation";
+
+type AccessChecker = {
+  hasAccess: (...types: AccessType[]) => boolean;
+  hasSomeAccess: (...types: AccessType[]) => boolean;
+};
+
+const DEFAULT_VIEW_ROLES: AccessType[] = ["view-realm"];
+const DEFAULT_MANAGE_ROLES: AccessType[] = ["manage-realm"];
+
+export type NavSection = "manage" | "configure" | "extensions";
+
+export function getRequiredViewRoles(
+  page: ComponentTypeRepresentation,
+): AccessType[] {
+  const roles = page.metadata.requiredViewRoles as string[] | undefined;
+  return roles?.length ? (roles as AccessType[]) : DEFAULT_VIEW_ROLES;
+}
+
+export function getRequiredManageRoles(
+  page: ComponentTypeRepresentation,
+): AccessType[] {
+  const roles = page.metadata.requiredManageRoles as string[] | undefined;
+  return roles?.length ? (roles as AccessType[]) : DEFAULT_MANAGE_ROLES;
+}
+
+export function canViewUiExtension(
+  page: ComponentTypeRepresentation,
+  { hasSomeAccess }: AccessChecker,
+): boolean {
+  return hasSomeAccess(...getRequiredViewRoles(page));
+}
+
+export function canManageUiExtension(
+  page: ComponentTypeRepresentation,
+  { hasAccess }: AccessChecker,
+): boolean {
+  return hasAccess(...getRequiredManageRoles(page));
+}
+
+export function getNavSection(page: ComponentTypeRepresentation): NavSection {
+  const section = page.metadata.navSection as NavSection | undefined;
+  if (section === "manage" || section === "extensions") {
+    return section;
+  }
+  return "configure";
+}
+
+export function getTabTitle(
+  page: ComponentTypeRepresentation,
+  t: (key: string) => string,
+): string {
+  const tabLabel = page.metadata.tabLabel as string | undefined;
+  return tabLabel ? t(tabLabel) : t(page.id!);
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/ComponentStorageFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/ComponentStorageFactory.java
@@ -1,0 +1,23 @@
+package org.keycloak.services.ui.extend;
+
+import java.util.stream.Stream;
+
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+/**
+ * Optional storage backend for declarative UI extensions that should not use the default component table.
+ */
+public interface ComponentStorageFactory {
+
+    Stream<ComponentModel> listComponents(KeycloakSession session, RealmModel realm, String parentId, String providerId);
+
+    ComponentModel getComponent(KeycloakSession session, RealmModel realm, String id);
+
+    ComponentModel createComponent(KeycloakSession session, RealmModel realm, ComponentModel model);
+
+    ComponentModel updateComponent(KeycloakSession session, RealmModel realm, ComponentModel oldModel, ComponentModel newModel);
+
+    void removeComponent(KeycloakSession session, RealmModel realm, ComponentModel model);
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
@@ -1,0 +1,49 @@
+package org.keycloak.services.ui.extend;
+
+/**
+ * Defines the storage backend for UI tab data.
+ * <p>
+ * When implementing a {@link UiTabProvider}, you can specify how the form data
+ * should be stored. The default is {@link #COMPONENT}, which stores data as a
+ * Keycloak component. Other options allow storing data directly on existing
+ * Keycloak entities like clients, users, groups, or identity providers.
+ */
+public enum StorageType {
+
+    /**
+     * Store data as a Keycloak component (default behavior).
+     * Data is saved using the components API.
+     */
+    COMPONENT,
+
+    /**
+     * Store data on a client's attributes.
+     * Requires 'clientId' parameter in the URL.
+     */
+    CLIENT,
+
+    /**
+     * Store data on a user's attributes.
+     * Requires 'userId' parameter in the URL.
+     */
+    USER,
+
+    /**
+     * Store data on a group's attributes.
+     * Requires 'groupId' parameter in the URL.
+     */
+    GROUP,
+
+    /**
+     * Store data on an identity provider's config.
+     * Requires 'providerId' parameter in the URL.
+     */
+    IDENTITY_PROVIDER,
+
+    /**
+     * Use a custom endpoint for storage.
+     * Requires implementing an {@link org.keycloak.services.resources.admin.ext.AdminRealmResourceProvider}
+     * and specifying the endpoint path via {@link UiTabProviderFactory#getEndpoint()}.
+     */
+    CUSTOM
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
@@ -24,19 +24,19 @@ public enum StorageType {
 
     /**
      * Store data on a user's attributes.
-     * Requires 'userId' parameter in the URL.
+     * Requires 'id' parameter in the URL (user route).
      */
     USER,
 
     /**
      * Store data on a group's attributes.
-     * Requires 'groupId' parameter in the URL.
+     * Requires 'id' parameter in the URL (group route).
      */
     GROUP,
 
     /**
      * Store data on an identity provider's config.
-     * Requires 'providerId' parameter in the URL.
+     * Requires 'alias' parameter in the URL (identity provider route).
      */
     IDENTITY_PROVIDER,
 

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
@@ -29,12 +29,6 @@ public enum StorageType {
     USER,
 
     /**
-     * Store data on a group's attributes.
-     * Requires 'id' parameter in the URL (group route).
-     */
-    GROUP,
-
-    /**
      * Store data on an identity provider's config.
      * Requires 'alias' parameter in the URL (identity provider route).
      */

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/StorageType.java
@@ -6,7 +6,7 @@ package org.keycloak.services.ui.extend;
  * When implementing a {@link UiTabProvider}, you can specify how the form data
  * should be stored. The default is {@link #COMPONENT}, which stores data as a
  * Keycloak component. Other options allow storing data directly on existing
- * Keycloak entities like clients, users, groups, or identity providers.
+ * Keycloak entities like clients, users, or identity providers.
  */
 public enum StorageType {
 

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiExtensionSupport.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiExtensionSupport.java
@@ -1,0 +1,55 @@
+package org.keycloak.services.ui.extend;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ConfiguredProvider;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public interface UiExtensionSupport {
+
+    default List<String> getRequiredViewRoles() {
+        return List.of(AdminRoles.VIEW_REALM);
+    }
+
+    default List<String> getRequiredManageRoles() {
+        return List.of(AdminRoles.MANAGE_REALM);
+    }
+
+    /**
+     * Navigation section for {@link UiPageProvider} entries: {@code manage}, {@code configure}, or {@code extensions}.
+     */
+    default String getNavSection() {
+        return "configure";
+    }
+
+    /**
+     * Optional localized label key for tabs. When {@code null}, the provider id is used.
+     */
+    default String getTabLabel() {
+        return null;
+    }
+
+    /**
+     * Returns form properties for the current context. Override to populate fields from realm, client, or other models.
+     */
+    default List<ProviderConfigProperty> getConfigProperties(KeycloakSession session, Map<String, String> contextParams) {
+        if (this instanceof ConfiguredProvider configuredProvider) {
+            return configuredProvider.getConfigProperties();
+        }
+        return Collections.emptyList();
+    }
+
+    default void putExtensionMetadata(Map<String, Object> metadata) {
+        metadata.put("requiredViewRoles", getRequiredViewRoles());
+        metadata.put("requiredManageRoles", getRequiredManageRoles());
+        metadata.put("navSection", getNavSection());
+        String tabLabel = getTabLabel();
+        if (tabLabel != null) {
+            metadata.put("tabLabel", tabLabel);
+        }
+    }
+}

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiPageProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiPageProviderFactory.java
@@ -1,11 +1,51 @@
 package org.keycloak.services.ui.extend;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.keycloak.component.ComponentFactory;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 
-public interface UiPageProviderFactory<T> extends ComponentFactory<T, UiPageProvider> {
+public interface UiPageProviderFactory<T> extends ComponentFactory<T, UiPageProvider>, UiExtensionSupport {
     default T create(KeycloakSession session, ComponentModel model) {
         return null;
+    }
+
+    /**
+     * Fields shown in the page list. Defaults to the first configured property.
+     */
+    default List<String> getDisplayFields() {
+        return List.of();
+    }
+
+    /**
+     * When {@code true}, the page detail view renders declarative tabs using {@link #getDetailTabPath()}.
+     */
+    default boolean supportsDetailTabs() {
+        return false;
+    }
+
+    /**
+     * Route pattern for detail tabs, for example {@code /:realm/page-section/:providerId/:id/:tab?}.
+     */
+    default String getDetailTabPath() {
+        return "/:realm/page-section/:providerId/:id/:tab?";
+    }
+
+    @Override
+    default Map<String, Object> getTypeMetadata() {
+        Map<String, Object> metadata = new HashMap<>();
+        List<String> displayFields = getDisplayFields();
+        if (!displayFields.isEmpty()) {
+            metadata.put("displayFields", displayFields);
+        }
+        if (supportsDetailTabs()) {
+            metadata.put("supportsDetailTabs", true);
+            metadata.put("detailTabPath", getDetailTabPath());
+        }
+        putExtensionMetadata(metadata);
+        return metadata;
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiPageProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiPageProviderFactory.java
@@ -29,7 +29,9 @@ public interface UiPageProviderFactory<T> extends ComponentFactory<T, UiPageProv
     }
 
     /**
-     * Route pattern for detail tabs, for example {@code /:realm/page-section/:providerId/:id/:tab?}.
+     * Route pattern for detail tabs. Must match the Admin Console page detail route
+     * ({@code /:realm/page-section/:providerId/:id/:tab?}); only the optional tab
+     * segment should be customized.
      */
     default String getDetailTabPath() {
         return "/:realm/page-section/:providerId/:id/:tab?";

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiPageProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiPageProviderFactory.java
@@ -14,7 +14,8 @@ public interface UiPageProviderFactory<T> extends ComponentFactory<T, UiPageProv
     }
 
     /**
-     * Fields shown in the page list. Defaults to the first configured property.
+     * Fields shown in the page list. When empty, the Admin Console falls back to
+     * the first three configured properties.
      */
     default List<String> getDisplayFields() {
         return List.of();

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -48,7 +48,6 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
      *   <li>{@link StorageType#COMPONENT} - Store as a Keycloak component (default)</li>
      *   <li>{@link StorageType#CLIENT} - Store on client attributes (requires clientId param)</li>
      *   <li>{@link StorageType#USER} - Store on user attributes (requires id param)</li>
-     *   <li>{@link StorageType#GROUP} - Store on group attributes (requires id param)</li>
      *   <li>{@link StorageType#IDENTITY_PROVIDER} - Store on IdP config (requires alias param)</li>
      *   <li>{@link StorageType#CUSTOM} - Use custom endpoint (requires {@link #getEndpoint()})</li>
      * </ul>

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -17,10 +17,61 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("path", getPath());
         metadata.put("params", new HashMap<>(getParams()));
+        metadata.put("storageType", getStorageType().name());
+        String endpoint = getEndpoint();
+        if (endpoint != null) {
+            metadata.put("endpoint", endpoint);
+        }
         return metadata;
     }
 
+    /**
+     * Returns the path pattern for this tab.
+     * The path can contain parameters like {@code :clientId} or {@code :userId}.
+     *
+     * @return the path pattern
+     */
     String getPath();
 
+    /**
+     * Returns the parameter names used in the path.
+     *
+     * @return map of parameter names
+     */
     Map<String, String> getParams();
+
+    /**
+     * Returns the storage type for this tab's data.
+     * <p>
+     * Override this method to change how form data is stored:
+     * <ul>
+     *   <li>{@link StorageType#COMPONENT} - Store as a Keycloak component (default)</li>
+     *   <li>{@link StorageType#CLIENT} - Store on client attributes (requires clientId param)</li>
+     *   <li>{@link StorageType#USER} - Store on user attributes (requires userId param)</li>
+     *   <li>{@link StorageType#GROUP} - Store on group attributes (requires groupId param)</li>
+     *   <li>{@link StorageType#IDENTITY_PROVIDER} - Store on IdP config (requires providerId param)</li>
+     *   <li>{@link StorageType#REALM} - Store on realm attributes</li>
+     *   <li>{@link StorageType#CUSTOM} - Use custom endpoint (requires {@link #getEndpoint()})</li>
+     * </ul>
+     *
+     * @return the storage type
+     */
+    default StorageType getStorageType() {
+        return StorageType.COMPONENT;
+    }
+
+    /**
+     * Returns the custom endpoint path for {@link StorageType#CUSTOM} storage.
+     * <p>
+     * The endpoint should be implemented via
+     * {@link org.keycloak.services.resources.admin.ext.AdminRealmResourceProvider}.
+     * The path is relative to {@code /admin/realms/{realm}/}.
+     * <p>
+     * Example: {@code "my-extension/clients/{clientId}/settings"}
+     *
+     * @return the endpoint path, or null if not using custom storage
+     */
+    default String getEndpoint() {
+        return null;
+    }
 }

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -27,7 +27,7 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
 
     /**
      * Returns the path pattern for this tab.
-     * The path can contain parameters like {@code :clientId} or {@code :userId}.
+     * The path can contain parameters like {@code :clientId} or {@code :id}.
      *
      * @return the path pattern
      */
@@ -47,9 +47,9 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
      * <ul>
      *   <li>{@link StorageType#COMPONENT} - Store as a Keycloak component (default)</li>
      *   <li>{@link StorageType#CLIENT} - Store on client attributes (requires clientId param)</li>
-     *   <li>{@link StorageType#USER} - Store on user attributes (requires userId param)</li>
-     *   <li>{@link StorageType#GROUP} - Store on group attributes (requires groupId param)</li>
-     *   <li>{@link StorageType#IDENTITY_PROVIDER} - Store on IdP config (requires providerId param)</li>
+     *   <li>{@link StorageType#USER} - Store on user attributes (requires id param)</li>
+     *   <li>{@link StorageType#GROUP} - Store on group attributes (requires id param)</li>
+     *   <li>{@link StorageType#IDENTITY_PROVIDER} - Store on IdP config (requires alias param)</li>
      *   <li>{@link StorageType#CUSTOM} - Use custom endpoint (requires {@link #getEndpoint()})</li>
      * </ul>
      *

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -50,7 +50,6 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
      *   <li>{@link StorageType#USER} - Store on user attributes (requires userId param)</li>
      *   <li>{@link StorageType#GROUP} - Store on group attributes (requires groupId param)</li>
      *   <li>{@link StorageType#IDENTITY_PROVIDER} - Store on IdP config (requires providerId param)</li>
-     *   <li>{@link StorageType#REALM} - Store on realm attributes</li>
      *   <li>{@link StorageType#CUSTOM} - Use custom endpoint (requires {@link #getEndpoint()})</li>
      * </ul>
      *

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -63,9 +63,23 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
      * <p>
      * The endpoint should be implemented via
      * {@link org.keycloak.services.resources.admin.ext.AdminRealmResourceProvider}.
-     * The path is relative to {@code /admin/realms/{realm}/}.
+     * The path is relative to {@code /admin/realms/{realm}/} and may contain
+     * placeholders such as {@code {clientId}} that are replaced with values from
+     * the current route.
      * <p>
      * Example: {@code "my-extension/clients/{clientId}/settings"}
+     * <p>
+     * The Admin Console uses the following protocol for custom endpoints:
+     * <ul>
+     *   <li>{@code GET} — returns JSON used to populate the form. The response must
+     *       include a {@code config} object whose keys match the property names
+     *       declared by {@link #getConfigProperties()}.</li>
+     *   <li>{@code PUT} — receives JSON with the submitted form data plus the
+     *       resolved route parameters as top-level fields. The extension is
+     *       responsible for persisting the values and should return a successful
+     *       response (for example {@code 204 No Content}).</li>
+     * </ul>
+     * Non-successful responses are surfaced to the user as save errors.
      *
      * @return the endpoint path, or null if not using custom storage
      */

--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -7,7 +7,7 @@ import org.keycloak.component.ComponentFactory;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.KeycloakSession;
 
-public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvider> {
+public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvider>, UiExtensionSupport {
     default T create(KeycloakSession session, ComponentModel model) {
         return null;
     }
@@ -22,6 +22,7 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
         if (endpoint != null) {
             metadata.put("endpoint", endpoint);
         }
+        putExtensionMetadata(metadata);
         return metadata;
     }
 

--- a/server-spi-private/src/test/java/org/keycloak/services/ui/extend/UiExtensionSupportTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/services/ui/extend/UiExtensionSupportTest.java
@@ -1,0 +1,56 @@
+package org.keycloak.services.ui.extend;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.keycloak.models.AdminRoles;
+
+import static org.junit.Assert.assertEquals;
+
+public class UiExtensionSupportTest {
+
+    private final UiExtensionSupport support = new UiExtensionSupport() {
+    };
+
+    @Test
+    public void defaultRolesAndNavSection() {
+        assertEquals(List.of(AdminRoles.VIEW_REALM), support.getRequiredViewRoles());
+        assertEquals(List.of(AdminRoles.MANAGE_REALM), support.getRequiredManageRoles());
+        assertEquals("configure", support.getNavSection());
+    }
+
+    @Test
+    public void putExtensionMetadataIncludesDeclaredValues() {
+        UiExtensionSupport customSupport = new UiExtensionSupport() {
+            @Override
+            public List<String> getRequiredViewRoles() {
+                return List.of(AdminRoles.VIEW_CLIENTS);
+            }
+
+            @Override
+            public List<String> getRequiredManageRoles() {
+                return List.of(AdminRoles.MANAGE_CLIENTS);
+            }
+
+            @Override
+            public String getNavSection() {
+                return "extensions";
+            }
+
+            @Override
+            public String getTabLabel() {
+                return "customTab";
+            }
+        };
+
+        Map<String, Object> metadata = new HashMap<>();
+        customSupport.putExtensionMetadata(metadata);
+
+        assertEquals(List.of(AdminRoles.VIEW_CLIENTS), metadata.get("requiredViewRoles"));
+        assertEquals(List.of(AdminRoles.MANAGE_CLIENTS), metadata.get("requiredManageRoles"));
+        assertEquals("extensions", metadata.get("navSection"));
+        assertEquals("customTab", metadata.get("tabLabel"));
+    }
+}

--- a/server-spi-private/src/test/java/org/keycloak/services/ui/extend/UiExtensionSupportTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/services/ui/extend/UiExtensionSupportTest.java
@@ -4,8 +4,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
 import org.keycloak.models.AdminRoles;
+
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -177,7 +177,8 @@ public class ComponentResource {
     @Operation()
     public ComponentRepresentation getComponent(@PathParam("id") String id) {
         ComponentModel model = resolveComponentModel(id);
-        if (model == null) {
+        if (model == null || isInternalComponent(model.getProviderType(), model.getProviderId())) {
+            requireViewForProviderType(null, null);
             throw new NotFoundException("Could not find component");
         }
         requireViewForProviderType(model.getProviderType(), model.getProviderId());
@@ -198,6 +199,7 @@ public class ComponentResource {
         try {
             ComponentModel model = resolveComponentModel(id);
             if (model == null) {
+                requireManageForProviderType(null, null);
                 throw new NotFoundException("Could not find component");
             }
             rejectInternalComponent(model.getProviderType(), model.getProviderId());
@@ -205,20 +207,22 @@ public class ComponentResource {
             ComponentModel oldModel = new ComponentModel(model);
             String oldProviderType = model.getProviderType();
             String oldProviderId = model.getProviderId();
-            RepresentationToModel.updateComponent(session, rep, model, false);
-            rejectInternalComponent(model.getProviderType(), model.getProviderId());
-            requireManageForProviderType(model.getProviderType(), model.getProviderId());
-            if (!Objects.equals(oldProviderType, model.getProviderType())
-                    || !Objects.equals(oldProviderId, model.getProviderId())) {
+            String newProviderType = rep.getProviderType() != null ? rep.getProviderType() : oldProviderType;
+            String newProviderId = rep.getProviderId() != null ? rep.getProviderId() : oldProviderId;
+            if (!Objects.equals(oldProviderType, newProviderType)
+                    || !Objects.equals(oldProviderId, newProviderId)) {
                 boolean oldCustom = UiExtensionComponentStorage.usesCustomStorage(
                         oldProviderType, oldProviderId, session);
                 boolean newCustom = UiExtensionComponentStorage.usesCustomStorage(
-                        model.getProviderType(), model.getProviderId(), session);
+                        newProviderType, newProviderId, session);
                 if (oldCustom || newCustom) {
                     throw new BadRequestException(
                             "Cannot change provider type or ID for components with custom storage");
                 }
             }
+            RepresentationToModel.updateComponent(session, rep, model, false);
+            rejectInternalComponent(model.getProviderType(), model.getProviderId());
+            requireManageForProviderType(model.getProviderType(), model.getProviderId());
             ComponentModel customModel = UiExtensionComponentStorage.updateComponent(session, realm, oldModel, model);
             if (customModel != null) {
                 model = customModel;
@@ -240,6 +244,7 @@ public class ComponentResource {
     public void removeComponent(@PathParam("id") String id) {
         ComponentModel model = resolveComponentModel(id);
         if (model == null) {
+            requireManageForProviderType(null, null);
             throw new NotFoundException("Could not find component");
         }
         rejectInternalComponent(model.getProviderType(), model.getProviderId());
@@ -324,7 +329,7 @@ public class ComponentResource {
 
     private ComponentModel resolveComponentModel(String id) {
         ComponentModel model = realm.getComponent(id);
-        if (model != null && !isInternalComponent(model.getProviderType(), model.getProviderId())) {
+        if (model != null) {
             return model;
         }
         return UiExtensionComponentStorage.getComponentById(session, realm, id);

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -109,18 +109,23 @@ public class ComponentResource {
                                                        @QueryParam("providerId") String providerId) {
         requireViewForProviderType(type, providerId);
         Stream<ComponentModel> customComponents = UiExtensionComponentStorage.listComponents(session, realm, parent, type, providerId);
-        Stream<ComponentModel> components;
-        if (customComponents != null) {
-            components = customComponents;
-        } else if (parent == null && type == null) {
-            components = realm.getComponentsStream();
-
+        Stream<ComponentModel> realmComponents;
+        if (parent == null && type == null) {
+            realmComponents = realm.getComponentsStream();
         } else if (type == null) {
-            components = realm.getComponentsStream(parent);
+            realmComponents = realm.getComponentsStream(parent);
         } else if (parent == null) {
-            components = realm.getComponentsStream(realm.getId(), type);
+            realmComponents = realm.getComponentsStream(realm.getId(), type);
         } else {
-            components = realm.getComponentsStream(parent, type);
+            realmComponents = realm.getComponentsStream(parent, type);
+        }
+        Stream<ComponentModel> components;
+        if (providerId != null && customComponents != null) {
+            components = customComponents;
+        } else if (customComponents != null) {
+            components = Stream.concat(realmComponents, customComponents);
+        } else {
+            components = realmComponents;
         }
 
         return components
@@ -198,9 +203,22 @@ public class ComponentResource {
             rejectInternalComponent(model.getProviderType(), model.getProviderId());
             requireManageForProviderType(model.getProviderType(), model.getProviderId());
             ComponentModel oldModel = new ComponentModel(model);
+            String oldProviderType = model.getProviderType();
+            String oldProviderId = model.getProviderId();
             RepresentationToModel.updateComponent(session, rep, model, false);
             rejectInternalComponent(model.getProviderType(), model.getProviderId());
             requireManageForProviderType(model.getProviderType(), model.getProviderId());
+            if (!Objects.equals(oldProviderType, model.getProviderType())
+                    || !Objects.equals(oldProviderId, model.getProviderId())) {
+                boolean oldCustom = UiExtensionComponentStorage.usesCustomStorage(
+                        oldProviderType, oldProviderId, session);
+                boolean newCustom = UiExtensionComponentStorage.usesCustomStorage(
+                        model.getProviderType(), model.getProviderId(), session);
+                if (oldCustom || newCustom) {
+                    throw new BadRequestException(
+                            "Cannot change provider type or ID for components with custom storage");
+                }
+            }
             ComponentModel customModel = UiExtensionComponentStorage.updateComponent(session, realm, oldModel, model);
             if (customModel != null) {
                 model = customModel;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -59,6 +59,7 @@ import org.keycloak.representations.idm.ComponentTypeRepresentation;
 import org.keycloak.representations.idm.ConfigPropertyRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.ui.extend.UiExtensionSupport;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -106,9 +107,12 @@ public class ComponentResource {
                                                        @QueryParam("type") String type,
                                                        @QueryParam("name") String name,
                                                        @QueryParam("providerId") String providerId) {
-        auth.realm().requireViewRealm();
+        requireViewForProviderType(type, providerId);
+        Stream<ComponentModel> customComponents = UiExtensionComponentStorage.listComponents(session, realm, parent, type, providerId);
         Stream<ComponentModel> components;
-        if (parent == null && type == null) {
+        if (customComponents != null) {
+            components = customComponents;
+        } else if (parent == null && type == null) {
             components = realm.getComponentsStream();
 
         } else if (type == null) {
@@ -138,13 +142,18 @@ public class ComponentResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation()
     public Response create(ComponentRepresentation rep) {
-        auth.realm().requireManageRealm();
+        requireManageForProviderType(rep.getProviderType(), rep.getProviderId());
         try {
             rejectInternalComponent(rep.getProviderType(), rep.getProviderId());
             ComponentModel model = RepresentationToModel.toModel(session, rep);
             if (model.getParentId() == null) model.setParentId(realm.getId());
 
-            model = realm.addComponentModel(model);
+            ComponentModel customModel = UiExtensionComponentStorage.createComponent(session, realm, model);
+            if (customModel != null) {
+                model = customModel;
+            } else {
+                model = realm.addComponentModel(model);
+            }
 
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri(), model.getId()).representation(rep).success();
             return Response.created(session.getContext().getUri().getAbsolutePathBuilder().path(model.getId()).build()).build();
@@ -162,10 +171,14 @@ public class ComponentResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation()
     public ComponentRepresentation getComponent(@PathParam("id") String id) {
-        auth.realm().requireViewRealm();
         ComponentModel model = realm.getComponent(id);
         if (model == null || isInternalComponent(model.getProviderType(), model.getProviderId())) {
             throw new NotFoundException("Could not find component");
+        }
+        requireViewForProviderType(model.getProviderType(), model.getProviderId());
+        ComponentModel customModel = UiExtensionComponentStorage.getComponent(session, realm, model);
+        if (customModel != null) {
+            model = customModel;
         }
         ComponentRepresentation rep = ModelToRepresentation.toRepresentation(session, model, false);
         return rep;
@@ -177,16 +190,22 @@ public class ComponentResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation()
     public Response updateComponent(@PathParam("id") String id, ComponentRepresentation rep) {
-        auth.realm().requireManageRealm();
         try {
             ComponentModel model = realm.getComponent(id);
             if (model == null) {
                 throw new NotFoundException("Could not find component");
             }
             rejectInternalComponent(model.getProviderType(), model.getProviderId());
+            requireManageForProviderType(model.getProviderType(), model.getProviderId());
+            ComponentModel oldModel = model;
             RepresentationToModel.updateComponent(session, rep, model, false);
+            ComponentModel customModel = UiExtensionComponentStorage.updateComponent(session, realm, oldModel, model);
+            if (customModel != null) {
+                model = customModel;
+            } else {
+                realm.updateComponent(model);
+            }
             adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
-            realm.updateComponent(model);
             return Response.noContent().build();
         } catch (ComponentValidationException e) {
             return localizedErrorResponse(e);
@@ -199,14 +218,18 @@ public class ComponentResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation()
     public void removeComponent(@PathParam("id") String id) {
-        auth.realm().requireManageRealm();
         ComponentModel model = realm.getComponent(id);
         if (model == null) {
             throw new NotFoundException("Could not find component");
         }
         rejectInternalComponent(model.getProviderType(), model.getProviderId());
+        requireManageForProviderType(model.getProviderType(), model.getProviderId());
         adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
-        realm.removeComponent(model);
+        if (UiExtensionComponentStorage.usesCustomStorage(model.getProviderType(), model.getProviderId(), session)) {
+            UiExtensionComponentStorage.removeComponent(session, realm, model);
+        } else {
+            realm.removeComponent(model);
+        }
     }
 
     private Response localizedErrorResponse(ComponentValidationException cve) {
@@ -277,6 +300,24 @@ public class ComponentResource {
         if (isInternalComponent(providerType, providerId)) {
             throw new ForbiddenException("Components managed through internal APIs cannot be managed through the component endpoint");
         }
+    }
+
+    private void requireViewForProviderType(String providerType, String providerId) {
+        UiExtensionSupport extension = UiExtensionComponentStorage.getExtensionFactory(session, providerType, providerId);
+        if (extension != null) {
+            UiExtensionPermissions.requireView(auth, extension);
+            return;
+        }
+        auth.realm().requireViewRealm();
+    }
+
+    private void requireManageForProviderType(String providerType, String providerId) {
+        UiExtensionSupport extension = UiExtensionComponentStorage.getExtensionFactory(session, providerType, providerId);
+        if (extension != null) {
+            UiExtensionPermissions.requireManage(auth, extension);
+            return;
+        }
+        auth.realm().requireManageRealm();
     }
 
     private ComponentTypeRepresentation toComponentTypeRepresentation(ProviderFactory factory, ComponentModel parent) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -199,6 +199,8 @@ public class ComponentResource {
             requireManageForProviderType(model.getProviderType(), model.getProviderId());
             ComponentModel oldModel = new ComponentModel(model);
             RepresentationToModel.updateComponent(session, rep, model, false);
+            rejectInternalComponent(model.getProviderType(), model.getProviderId());
+            requireManageForProviderType(model.getProviderType(), model.getProviderId());
             ComponentModel customModel = UiExtensionComponentStorage.updateComponent(session, realm, oldModel, model);
             if (customModel != null) {
                 model = customModel;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -59,8 +59,8 @@ import org.keycloak.representations.idm.ComponentTypeRepresentation;
 import org.keycloak.representations.idm.ConfigPropertyRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.KeycloakOpenAPI;
-import org.keycloak.services.ui.extend.UiExtensionSupport;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+import org.keycloak.services.ui.extend.UiExtensionSupport;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;

--- a/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ComponentResource.java
@@ -171,8 +171,8 @@ public class ComponentResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation()
     public ComponentRepresentation getComponent(@PathParam("id") String id) {
-        ComponentModel model = realm.getComponent(id);
-        if (model == null || isInternalComponent(model.getProviderType(), model.getProviderId())) {
+        ComponentModel model = resolveComponentModel(id);
+        if (model == null) {
             throw new NotFoundException("Could not find component");
         }
         requireViewForProviderType(model.getProviderType(), model.getProviderId());
@@ -191,13 +191,13 @@ public class ComponentResource {
     @Operation()
     public Response updateComponent(@PathParam("id") String id, ComponentRepresentation rep) {
         try {
-            ComponentModel model = realm.getComponent(id);
+            ComponentModel model = resolveComponentModel(id);
             if (model == null) {
                 throw new NotFoundException("Could not find component");
             }
             rejectInternalComponent(model.getProviderType(), model.getProviderId());
             requireManageForProviderType(model.getProviderType(), model.getProviderId());
-            ComponentModel oldModel = model;
+            ComponentModel oldModel = new ComponentModel(model);
             RepresentationToModel.updateComponent(session, rep, model, false);
             ComponentModel customModel = UiExtensionComponentStorage.updateComponent(session, realm, oldModel, model);
             if (customModel != null) {
@@ -218,7 +218,7 @@ public class ComponentResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation()
     public void removeComponent(@PathParam("id") String id) {
-        ComponentModel model = realm.getComponent(id);
+        ComponentModel model = resolveComponentModel(id);
         if (model == null) {
             throw new NotFoundException("Could not find component");
         }
@@ -300,6 +300,14 @@ public class ComponentResource {
         if (isInternalComponent(providerType, providerId)) {
             throw new ForbiddenException("Components managed through internal APIs cannot be managed through the component endpoint");
         }
+    }
+
+    private ComponentModel resolveComponentModel(String id) {
+        ComponentModel model = realm.getComponent(id);
+        if (model != null && !isInternalComponent(model.getProviderType(), model.getProviderId())) {
+            return model;
+        }
+        return UiExtensionComponentStorage.getComponentById(session, realm, id);
     }
 
     private void requireViewForProviderType(String providerType, String providerId) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java
@@ -400,6 +400,11 @@ public class RealmAdminResource {
         return new ComponentResource(session, auth, adminEvent);
     }
 
+    @Path("ui-extensions")
+    public UiExtensionsResource getUiExtensions() {
+        return new UiExtensionsResource(session, realm, auth);
+    }
+
     /**
      * base path for managing realm-level roles of this realm
      *

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
@@ -1,5 +1,6 @@
 package org.keycloak.services.resources.admin;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.keycloak.component.ComponentFactory;
@@ -53,6 +54,18 @@ final class UiExtensionComponentStorage {
             return null;
         }
         return storageFactory.getComponent(session, realm, model.getId());
+    }
+
+    static ComponentModel getComponentById(KeycloakSession session, RealmModel realm, String id) {
+        return Stream.concat(
+                session.getKeycloakSessionFactory().getProviderFactoriesStream(UiPageProvider.class),
+                session.getKeycloakSessionFactory().getProviderFactoriesStream(UiTabProvider.class))
+                .filter(factory -> factory instanceof ComponentStorageFactory)
+                .map(ComponentStorageFactory.class::cast)
+                .map(storage -> storage.getComponent(session, realm, id))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
     }
 
     static ComponentModel createComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
@@ -61,6 +61,8 @@ final class UiExtensionComponentStorage {
                 session.getKeycloakSessionFactory().getProviderFactoriesStream(UiPageProvider.class),
                 session.getKeycloakSessionFactory().getProviderFactoriesStream(UiTabProvider.class))
                 .filter(factory -> factory instanceof ComponentStorageFactory)
+                .filter(factory -> !(factory instanceof ComponentFactory<?, ?> componentFactory
+                        && componentFactory.isInternal()))
                 .map(ComponentStorageFactory.class::cast)
                 .map(storage -> storage.getComponent(session, realm, id))
                 .filter(Objects::nonNull)

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
@@ -41,11 +41,29 @@ final class UiExtensionComponentStorage {
             String parent,
             String type,
             String providerId) {
-        ComponentStorageFactory storageFactory = getStorageFactory(session, type, providerId);
-        if (storageFactory == null) {
+        if (providerId != null) {
+            ComponentStorageFactory storageFactory = getStorageFactory(session, type, providerId);
+            if (storageFactory == null) {
+                return null;
+            }
+            return storageFactory.listComponents(session, realm, parent, providerId);
+        }
+        if (type == null) {
             return null;
         }
-        return storageFactory.listComponents(session, realm, parent, providerId);
+        try {
+            Class<? extends Provider> providerClass =
+                    (Class<? extends Provider>) session.getProviderClass(type);
+            return session.getKeycloakSessionFactory()
+                    .getProviderFactoriesStream(providerClass)
+                    .filter(factory -> factory instanceof ComponentStorageFactory)
+                    .filter(factory -> !(factory instanceof ComponentFactory<?, ?> componentFactory
+                            && componentFactory.isInternal()))
+                    .flatMap(factory -> ((ComponentStorageFactory) factory)
+                            .listComponents(session, realm, parent, factory.getId()));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     static ComponentModel getComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
@@ -1,0 +1,104 @@
+package org.keycloak.services.resources.admin;
+
+import java.util.stream.Stream;
+
+import org.keycloak.component.ComponentFactory;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.services.ui.extend.ComponentStorageFactory;
+import org.keycloak.services.ui.extend.UiExtensionSupport;
+import org.keycloak.services.ui.extend.UiPageProvider;
+import org.keycloak.services.ui.extend.UiTabProvider;
+
+final class UiExtensionComponentStorage {
+
+    private UiExtensionComponentStorage() {
+    }
+
+    static ComponentStorageFactory getStorageFactory(KeycloakSession session, String providerType, String providerId) {
+        ProviderFactory<?> factory = getProviderFactory(session, providerType, providerId);
+        if (factory instanceof ComponentStorageFactory storageFactory) {
+            return storageFactory;
+        }
+        return null;
+    }
+
+    static UiExtensionSupport getExtensionFactory(KeycloakSession session, String providerType, String providerId) {
+        ProviderFactory<?> factory = getProviderFactory(session, providerType, providerId);
+        if (factory instanceof UiExtensionSupport extensionSupport) {
+            return extensionSupport;
+        }
+        return null;
+    }
+
+    static Stream<ComponentModel> listComponents(
+            KeycloakSession session,
+            RealmModel realm,
+            String parent,
+            String type,
+            String providerId) {
+        ComponentStorageFactory storageFactory = getStorageFactory(session, type, providerId);
+        if (storageFactory == null) {
+            return null;
+        }
+        return storageFactory.listComponents(session, realm, parent, providerId);
+    }
+
+    static ComponentModel getComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        ComponentStorageFactory storageFactory = getStorageFactory(session, model.getProviderType(), model.getProviderId());
+        if (storageFactory == null) {
+            return null;
+        }
+        return storageFactory.getComponent(session, realm, model.getId());
+    }
+
+    static ComponentModel createComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        ComponentStorageFactory storageFactory = getStorageFactory(session, model.getProviderType(), model.getProviderId());
+        if (storageFactory == null) {
+            return null;
+        }
+        return storageFactory.createComponent(session, realm, model);
+    }
+
+    static ComponentModel updateComponent(
+            KeycloakSession session,
+            RealmModel realm,
+            ComponentModel oldModel,
+            ComponentModel newModel) {
+        ComponentStorageFactory storageFactory = getStorageFactory(session, oldModel.getProviderType(), oldModel.getProviderId());
+        if (storageFactory == null) {
+            return null;
+        }
+        return storageFactory.updateComponent(session, realm, oldModel, newModel);
+    }
+
+    static void removeComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        ComponentStorageFactory storageFactory = getStorageFactory(session, model.getProviderType(), model.getProviderId());
+        if (storageFactory != null) {
+            storageFactory.removeComponent(session, realm, model);
+        }
+    }
+
+    static boolean usesCustomStorage(String providerType, String providerId, KeycloakSession session) {
+        return getStorageFactory(session, providerType, providerId) != null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ProviderFactory<?> getProviderFactory(KeycloakSession session, String providerType, String providerId) {
+        try {
+            Class<? extends Provider> providerClass =
+                    (Class<? extends Provider>) session.getProviderClass(providerType);
+            ProviderFactory<?> factory =
+                    session.getKeycloakSessionFactory().getProviderFactory(providerClass, providerId);
+            if (factory instanceof ComponentFactory<?, ?> componentFactory && componentFactory.isInternal()) {
+                return null;
+            }
+            return factory;
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionComponentStorage.java
@@ -44,9 +44,13 @@ final class UiExtensionComponentStorage {
         if (providerId != null) {
             ComponentStorageFactory storageFactory = getStorageFactory(session, type, providerId);
             if (storageFactory == null) {
+                storageFactory = findStorageFactoryByProviderId(session, providerId);
+            }
+            if (storageFactory == null) {
                 return null;
             }
-            return storageFactory.listComponents(session, realm, parent, providerId);
+            String resolvedParent = parent != null ? parent : realm.getId();
+            return storageFactory.listComponents(session, realm, resolvedParent, providerId);
         }
         if (type == null) {
             return null;
@@ -117,6 +121,20 @@ final class UiExtensionComponentStorage {
 
     static boolean usesCustomStorage(String providerType, String providerId, KeycloakSession session) {
         return getStorageFactory(session, providerType, providerId) != null;
+    }
+
+    private static ComponentStorageFactory findStorageFactoryByProviderId(
+            KeycloakSession session, String providerId) {
+        return Stream.concat(
+                session.getKeycloakSessionFactory().getProviderFactoriesStream(UiPageProvider.class),
+                session.getKeycloakSessionFactory().getProviderFactoriesStream(UiTabProvider.class))
+                .filter(factory -> factory instanceof ComponentStorageFactory)
+                .filter(factory -> !(factory instanceof ComponentFactory<?, ?> componentFactory
+                        && componentFactory.isInternal()))
+                .filter(factory -> providerId.equals(factory.getId()))
+                .map(ComponentStorageFactory.class::cast)
+                .findFirst()
+                .orElse(null);
     }
 
     @SuppressWarnings("unchecked")

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionPermissions.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionPermissions.java
@@ -1,0 +1,39 @@
+package org.keycloak.services.resources.admin;
+
+import java.util.List;
+
+import jakarta.ws.rs.ForbiddenException;
+
+import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+import org.keycloak.services.ui.extend.UiExtensionSupport;
+
+final class UiExtensionPermissions {
+
+    private UiExtensionPermissions() {
+    }
+
+    static void requireView(AdminPermissionEvaluator auth, UiExtensionSupport extension) {
+        requireAnyRole(auth, extension.getRequiredViewRoles(), false);
+    }
+
+    static void requireManage(AdminPermissionEvaluator auth, UiExtensionSupport extension) {
+        requireAnyRole(auth, extension.getRequiredManageRoles(), true);
+    }
+
+    private static void requireAnyRole(AdminPermissionEvaluator auth, List<String> roles, boolean manage) {
+        if (roles == null || roles.isEmpty()) {
+            if (manage) {
+                auth.realm().requireManageRealm();
+            } else {
+                auth.realm().requireViewRealm();
+            }
+            return;
+        }
+
+        if (roles.stream().anyMatch(role -> auth.hasOneAdminRole(role))) {
+            return;
+        }
+
+        throw new ForbiddenException();
+    }
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionsResource.java
@@ -1,0 +1,109 @@
+package org.keycloak.services.resources.admin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.component.ComponentFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.representations.idm.ConfigPropertyRepresentation;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+import org.keycloak.services.ui.extend.UiExtensionSupport;
+import org.keycloak.services.ui.extend.UiPageProvider;
+import org.keycloak.services.ui.extend.UiTabProvider;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.NoCache;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+public class UiExtensionsResource {
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+    private final AdminPermissionEvaluator auth;
+
+    public UiExtensionsResource(KeycloakSession session, RealmModel realm, AdminPermissionEvaluator auth) {
+        this.session = session;
+        this.realm = realm;
+        this.auth = auth;
+    }
+
+    @GET
+    @Path("tabs/{providerId}/config")
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
+    @Operation(summary = "Returns runtime configuration properties for a declarative UI tab")
+    public List<ConfigPropertyRepresentation> getTabConfig(
+            @PathParam("providerId") String providerId,
+            @QueryParam("clientId") String clientId,
+            @QueryParam("id") String id,
+            @QueryParam("alias") String alias) {
+        UiExtensionSupport factory = getFactory(UiTabProvider.class, providerId);
+        UiExtensionPermissions.requireView(auth, factory);
+        return toRepresentation(factory.getConfigProperties(session, contextParams(clientId, id, alias)));
+    }
+
+    @GET
+    @Path("pages/{providerId}/config")
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
+    @Operation(summary = "Returns runtime configuration properties for a declarative UI page")
+    public List<ConfigPropertyRepresentation> getPageConfig(
+            @PathParam("providerId") String providerId,
+            @QueryParam("componentId") String componentId) {
+        UiExtensionSupport factory = getFactory(UiPageProvider.class, providerId);
+        UiExtensionPermissions.requireView(auth, factory);
+        Map<String, String> params = new HashMap<>();
+        if (componentId != null) {
+            params.put("componentId", componentId);
+        }
+        return toRepresentation(factory.getConfigProperties(session, params));
+    }
+
+    private <T extends Provider> UiExtensionSupport getFactory(Class<T> providerClass, String providerId) {
+        ProviderFactory<T> factory = session.getKeycloakSessionFactory().getProviderFactory(providerClass, providerId);
+        if (!(factory instanceof UiExtensionSupport extensionSupport)) {
+            throw new NotFoundException("Could not find UI extension provider");
+        }
+        if (factory instanceof ComponentFactory<?, ?> componentFactory && componentFactory.isInternal()) {
+            throw new NotFoundException("Could not find UI extension provider");
+        }
+        return extensionSupport;
+    }
+
+    private Map<String, String> contextParams(String clientId, String id, String alias) {
+        Map<String, String> params = new HashMap<>();
+        if (clientId != null) {
+            params.put("clientId", clientId);
+        }
+        if (id != null) {
+            params.put("id", id);
+        }
+        if (alias != null) {
+            params.put("alias", alias);
+        }
+        return params;
+    }
+
+    private List<ConfigPropertyRepresentation> toRepresentation(List<ProviderConfigProperty> properties) {
+        return ModelToRepresentation.toRepresentation(properties);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UiExtensionsResource.java
@@ -9,8 +9,8 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.keycloak.component.ComponentFactory;
 import org.keycloak.models.KeycloakSession;
@@ -51,13 +51,10 @@ public class UiExtensionsResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation(summary = "Returns runtime configuration properties for a declarative UI tab")
     public List<ConfigPropertyRepresentation> getTabConfig(
-            @PathParam("providerId") String providerId,
-            @QueryParam("clientId") String clientId,
-            @QueryParam("id") String id,
-            @QueryParam("alias") String alias) {
+            @PathParam("providerId") String providerId) {
         UiExtensionSupport factory = getFactory(UiTabProvider.class, providerId);
         UiExtensionPermissions.requireView(auth, factory);
-        return toRepresentation(factory.getConfigProperties(session, contextParams(clientId, id, alias)));
+        return toRepresentation(factory.getConfigProperties(session, queryParams()));
     }
 
     @GET
@@ -67,15 +64,10 @@ public class UiExtensionsResource {
     @Tag(name = KeycloakOpenAPI.Admin.Tags.COMPONENT)
     @Operation(summary = "Returns runtime configuration properties for a declarative UI page")
     public List<ConfigPropertyRepresentation> getPageConfig(
-            @PathParam("providerId") String providerId,
-            @QueryParam("componentId") String componentId) {
+            @PathParam("providerId") String providerId) {
         UiExtensionSupport factory = getFactory(UiPageProvider.class, providerId);
         UiExtensionPermissions.requireView(auth, factory);
-        Map<String, String> params = new HashMap<>();
-        if (componentId != null) {
-            params.put("componentId", componentId);
-        }
-        return toRepresentation(factory.getConfigProperties(session, params));
+        return toRepresentation(factory.getConfigProperties(session, queryParams()));
     }
 
     private <T extends Provider> UiExtensionSupport getFactory(Class<T> providerClass, String providerId) {
@@ -89,16 +81,13 @@ public class UiExtensionsResource {
         return extensionSupport;
     }
 
-    private Map<String, String> contextParams(String clientId, String id, String alias) {
+    private Map<String, String> queryParams() {
+        MultivaluedMap<String, String> query = session.getContext().getUri().getQueryParameters();
         Map<String, String> params = new HashMap<>();
-        if (clientId != null) {
-            params.put("clientId", clientId);
-        }
-        if (id != null) {
-            params.put("id", id);
-        }
-        if (alias != null) {
-            params.put("alias", alias);
+        for (Map.Entry<String, List<String>> entry : query.entrySet()) {
+            if (!entry.getValue().isEmpty() && entry.getValue().get(0) != null) {
+                params.put(entry.getKey(), entry.getValue().get(0));
+            }
         }
         return params;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/UiExtensionComponentStorageTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/UiExtensionComponentStorageTest.java
@@ -1,5 +1,6 @@
 package org.keycloak.tests.admin;
 
+import java.io.Serializable;
 import java.util.List;
 
 import jakarta.ws.rs.BadRequestException;
@@ -123,7 +124,8 @@ public class UiExtensionComponentStorageTest {
         }
     }
 
-    private record RealmComponentExists(String componentId) implements FetchOnServerWrapper<Boolean> {
+    private record RealmComponentExists(String componentId)
+            implements FetchOnServerWrapper<Boolean>, Serializable {
 
         @Override
         public FetchOnServer getRunOnServer() {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/UiExtensionComponentStorageTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/UiExtensionComponentStorageTest.java
@@ -1,0 +1,129 @@
+package org.keycloak.tests.admin;
+
+import java.util.List;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.resource.ComponentsResource;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.models.RealmModel;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.services.ui.extend.UiPageProvider;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.providers.runonserver.FetchOnServer;
+import org.keycloak.testframework.remote.providers.runonserver.FetchOnServerWrapper;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.providers.ui.TestCustomStorageUiPageProviderFactory;
+import org.keycloak.tests.suites.DatabaseTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KeycloakIntegrationTest(config = UiExtensionComponentStorageTest.ServerConfig.class)
+@DatabaseTest
+public class UiExtensionComponentStorageTest {
+
+    @InjectRealm(lifecycle = LifeCycle.METHOD)
+    ManagedRealm managedRealm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    private ComponentsResource components;
+
+    @BeforeEach
+    public void before() {
+        components = managedRealm.admin().components();
+    }
+
+    @Test
+    public void testCustomStorageCrud() {
+        ComponentRepresentation created = createComponentRepresentation("custom-storage-item");
+        created.getConfig().addFirst("value", "initial");
+
+        String id = createComponent(created);
+
+        assertFalse(isStoredInRealmComponentTable(id));
+
+        List<ComponentRepresentation> listed = components.query(
+                managedRealm.getId(),
+                UiPageProvider.class.getName());
+        assertThat(listed, hasSize(1));
+        assertEquals(id, listed.get(0).getId());
+        assertEquals("initial", listed.get(0).getConfig().getFirst("value"));
+
+        ComponentRepresentation fetched = components.component(id).toRepresentation();
+        assertEquals("custom-storage-item", fetched.getName());
+        assertEquals("initial", fetched.getConfig().getFirst("value"));
+
+        fetched.getConfig().putSingle("value", "updated");
+        components.component(id).update(fetched);
+
+        ComponentRepresentation updated = components.component(id).toRepresentation();
+        assertEquals("updated", updated.getConfig().getFirst("value"));
+
+        components.component(id).remove();
+
+        assertThrows(NotFoundException.class, () -> components.component(id).toRepresentation());
+        assertThat(components.query(managedRealm.getId(), UiPageProvider.class.getName()), hasSize(0));
+    }
+
+    private String createComponent(ComponentRepresentation rep) {
+        try (Response response = components.add(rep)) {
+            return ApiUtil.getCreatedId(response);
+        }
+    }
+
+    private ComponentRepresentation createComponentRepresentation(String name) {
+        ComponentRepresentation rep = new ComponentRepresentation();
+        rep.setName(name);
+        rep.setParentId(managedRealm.getId());
+        rep.setProviderId(TestCustomStorageUiPageProviderFactory.PROVIDER_ID);
+        rep.setProviderType(UiPageProvider.class.getName());
+        rep.setConfig(new MultivaluedHashMap<>());
+        return rep;
+    }
+
+    private boolean isStoredInRealmComponentTable(String componentId) {
+        return runOnServer.fetch(new RealmComponentExists(componentId));
+    }
+
+    public static class ServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.dependency("org.keycloak.tests", "keycloak-tests-custom-providers")
+                    .features(org.keycloak.common.Profile.Feature.DECLARATIVE_UI);
+        }
+    }
+
+    private record RealmComponentExists(String componentId) implements FetchOnServerWrapper<Boolean> {
+
+        @Override
+        public FetchOnServer getRunOnServer() {
+            return session -> {
+                RealmModel realm = session.getContext().getRealm();
+                return realm.getComponent(componentId) != null;
+            };
+        }
+
+        @Override
+        public Class<Boolean> getResultClass() {
+            return Boolean.class;
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/UiExtensionComponentStorageTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/UiExtensionComponentStorageTest.java
@@ -2,6 +2,7 @@ package org.keycloak.tests.admin;
 
 import java.util.List;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
@@ -80,6 +81,17 @@ public class UiExtensionComponentStorageTest {
 
         assertThrows(NotFoundException.class, () -> components.component(id).toRepresentation());
         assertThat(components.query(managedRealm.getId(), UiPageProvider.class.getName()), hasSize(0));
+    }
+
+    @Test
+    public void testRejectProviderChangeForCustomStorage() {
+        ComponentRepresentation created = createComponentRepresentation("custom-storage-item");
+        String id = createComponent(created);
+
+        ComponentRepresentation fetched = components.component(id).toRepresentation();
+        fetched.setProviderId("another-provider");
+
+        assertThrows(BadRequestException.class, () -> components.component(id).update(fetched));
     }
 
     private String createComponent(ComponentRepresentation rep) {

--- a/tests/custom-providers/src/main/java/org/keycloak/tests/providers/ui/TestCustomStorageUiPageProviderFactory.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/tests/providers/ui/TestCustomStorageUiPageProviderFactory.java
@@ -1,0 +1,111 @@
+package org.keycloak.tests.providers.ui;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.keycloak.Config;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.services.ui.extend.ComponentStorageFactory;
+import org.keycloak.services.ui.extend.UiPageProvider;
+import org.keycloak.services.ui.extend.UiPageProviderFactory;
+
+import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
+
+public class TestCustomStorageUiPageProviderFactory
+        implements UiPageProviderFactory<UiPageProvider>, ComponentStorageFactory {
+
+    public static final String PROVIDER_ID = "test-custom-storage-ui-page";
+
+    private static final Map<String, Map<String, ComponentModel>> STORAGE = new ConcurrentHashMap<>();
+
+    private final List<ProviderConfigProperty> config = ProviderConfigurationBuilder.create()
+            .property("value", "Value", "Stored configuration value", STRING_TYPE, null, null, false)
+            .build();
+
+    @Override
+    public UiPageProvider create(KeycloakSession session, ComponentModel model) {
+        return null;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Test UiPage provider with custom component storage";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return config;
+    }
+
+    @Override
+    public Stream<ComponentModel> listComponents(
+            KeycloakSession session,
+            RealmModel realm,
+            String parentId,
+            String providerId) {
+        return realmStorage(realm).values().stream()
+                .filter(model -> parentId.equals(model.getParentId()))
+                .filter(model -> providerId.equals(model.getProviderId()));
+    }
+
+    @Override
+    public ComponentModel getComponent(KeycloakSession session, RealmModel realm, String id) {
+        ComponentModel model = realmStorage(realm).get(id);
+        return model == null ? null : new ComponentModel(model);
+    }
+
+    @Override
+    public ComponentModel createComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        if (model.getId() == null) {
+            model.setId(KeycloakModelUtils.generateId());
+        }
+        ComponentModel stored = new ComponentModel(model);
+        realmStorage(realm).put(stored.getId(), stored);
+        return new ComponentModel(stored);
+    }
+
+    @Override
+    public ComponentModel updateComponent(
+            KeycloakSession session,
+            RealmModel realm,
+            ComponentModel oldModel,
+            ComponentModel newModel) {
+        ComponentModel stored = new ComponentModel(newModel);
+        realmStorage(realm).put(stored.getId(), stored);
+        return new ComponentModel(stored);
+    }
+
+    @Override
+    public void removeComponent(KeycloakSession session, RealmModel realm, ComponentModel model) {
+        realmStorage(realm).remove(model.getId());
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    private Map<String, ComponentModel> realmStorage(RealmModel realm) {
+        return STORAGE.computeIfAbsent(realm.getId(), id -> new ConcurrentHashMap<>());
+    }
+}

--- a/tests/custom-providers/src/main/java/org/keycloak/tests/providers/ui/TestCustomStorageUiPageProviderFactory.java
+++ b/tests/custom-providers/src/main/java/org/keycloak/tests/providers/ui/TestCustomStorageUiPageProviderFactory.java
@@ -2,6 +2,7 @@ package org.keycloak.tests.providers.ui;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -52,7 +53,7 @@ public class TestCustomStorageUiPageProviderFactory
             String parentId,
             String providerId) {
         return realmStorage(realm).values().stream()
-                .filter(model -> parentId.equals(model.getParentId()))
+                .filter(model -> Objects.equals(parentId, model.getParentId()))
                 .filter(model -> providerId.equals(model.getProviderId()));
     }
 

--- a/tests/custom-providers/src/main/resources/META-INF/services/org.keycloak.services.ui.extend.UiPageProviderFactory
+++ b/tests/custom-providers/src/main/resources/META-INF/services/org.keycloak.services.ui.extend.UiPageProviderFactory
@@ -1,0 +1,18 @@
+#
+# Copyright 2026 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.keycloak.tests.providers.ui.TestCustomStorageUiPageProviderFactory


### PR DESCRIPTION
By adding a storage type to your UI it can save the config onto other
models and bypass the update and create logic from your provider

fixes: #47858

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
