### PR TITLE
fix typo extraneous $ template in doc

### DIFF
--- a/docs/documentation/server_admin/topics/identity-broker/kubernetes.adoc
+++ b/docs/documentation/server_admin/topics/identity-broker/kubernetes.adoc
@@ -19,7 +19,7 @@ this value by decoding a service account token to retrieve the value of the `iss
 
 Keycloak must be able to invoke the endpoint `<ISSUER>/.well-known/openid-configuration` and additionally the
 JWKS endpoint returned in the well-known configuration. By default, these endpoints require authentication with a
-service account token. ${project_name} will automatically use the token from `/var/run/secrets/kubernetes.io/serviceaccount/token`
+service account token. {project_name} will automatically use the token from `/var/run/secrets/kubernetes.io/serviceaccount/token`
 if available and the token issuer matches the configured issuer.
 
 Each identity provider must have a unique issuer. Each client must also have a unique subject identifier for each


### PR DESCRIPTION
Closes #47867

`${project_name}` is rendered as `$Keycloak`, cf https://www.keycloak.org/docs/26.6.0/server_admin/#_identity_broker_kubernetes
expected: `Keycloak`