### PR TITLE
fix(oidc): tolerate unparseable attribute values in claim type conversion

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -183,7 +183,8 @@ public class OIDCAttributeMapperHelper {
 
         String type = mappingModel.getConfig().get(JSON_TYPE);
         Object converted = convertToType(type, attributeValue);
-        return converted != null ? converted : attributeValue;
+        if (converted != null) return converted;
+        return type == null ? attributeValue : null;
     }
 
     private static <X, T> List<T> transform(List<X> attributeValue, Function<X, T> mapper) {
@@ -202,7 +203,7 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getBoolean);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "String":
                 if (attributeValue instanceof String) return attributeValue;
                 if (attributeValue instanceof List) {
@@ -215,21 +216,21 @@ public class OIDCAttributeMapperHelper {
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getLong);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "int":
                 Integer intObject = getInteger(attributeValue);
                 if (intObject != null) return intObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getInteger);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             case "JSON":
                 JsonNode jsonNodeObject = getJsonNode(attributeValue);
                 if (jsonNodeObject != null) return jsonNodeObject;
                 if (attributeValue instanceof List) {
                     return transform((List<?>) attributeValue, OIDCAttributeMapperHelper::getJsonNode);
                 }
-                throw new RuntimeException("cannot map type for token claim");
+                return null;
             default:
                 return null;
         }
@@ -242,19 +243,41 @@ public class OIDCAttributeMapperHelper {
 
     private static Long getLong(Object attributeValue) {
         if (attributeValue instanceof Long) return (Long) attributeValue;
-        if (attributeValue instanceof String) return Long.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            String str = ((String) attributeValue).trim();
+            if (str.isEmpty()) return null;
+            try {
+                return Long.valueOf(str);
+            } catch (NumberFormatException e) {
+                logger.warnf("Invalid numeric value '%s' for long claim mapping; omitting claim", str);
+                return null;
+            }
+        }
         return null;
     }
 
     private static Integer getInteger(Object attributeValue) {
         if (attributeValue instanceof Integer) return (Integer) attributeValue;
-        if (attributeValue instanceof String) return Integer.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            String str = ((String) attributeValue).trim();
+            if (str.isEmpty()) return null;
+            try {
+                return Integer.valueOf(str);
+            } catch (NumberFormatException e) {
+                logger.warnf("Invalid numeric value '%s' for int claim mapping; omitting claim", str);
+                return null;
+            }
+        }
         return null;
     }
 
     private static Boolean getBoolean(Object attributeValue) {
         if (attributeValue instanceof Boolean) return (Boolean) attributeValue;
-        if (attributeValue instanceof String) return Boolean.valueOf((String) attributeValue);
+        if (attributeValue instanceof String) {
+            String str = ((String) attributeValue).trim();
+            if (str.isEmpty()) return null;
+            return Boolean.valueOf(str);
+        }
         return null;
     }
 

--- a/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelperTest.java
@@ -1,13 +1,13 @@
 /*
  * Copyright 2018 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,15 +16,23 @@
  */
 package org.keycloak.protocol.oidc.mappers;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.utils.JsonUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
- *
  * @author hmlnarik
  */
 public class OIDCAttributeMapperHelperTest {
@@ -43,5 +51,158 @@ public class OIDCAttributeMapperHelperTest {
         assertThat(JsonUtils.splitClaimPath("c.a\\\\\\.b"), Matchers.contains("c", "a\\.b"));
         assertThat(JsonUtils.splitClaimPath("c\\\\\\.b.a\\\\\\.b"), Matchers.contains("c\\.b", "a\\.b"));
         assertThat(JsonUtils.splitClaimPath("c\\h\\.b.a\\\\\\.b"), Matchers.contains("ch.b", "a\\.b"));
+    }
+
+    // --- mapAttributeValue: long type ---
+
+    @Test
+    public void mapAttributeValue_longType_validValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), Collections.singletonList("12345"));
+        assertEquals(12345L, result);
+    }
+
+    @Test
+    public void mapAttributeValue_longType_emptyString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), Collections.singletonList(""));
+        assertNull(result);
+    }
+
+    @Test
+    public void mapAttributeValue_longType_blankString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), Collections.singletonList("   "));
+        assertNull(result);
+    }
+
+    @Test
+    public void mapAttributeValue_longType_invalidString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), Collections.singletonList("not-a-number"));
+        assertNull(result);
+    }
+
+    @Test
+    public void mapAttributeValue_longType_negativeValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), Collections.singletonList("-99"));
+        assertEquals(-99L, result);
+    }
+
+    // --- mapAttributeValue: int type ---
+
+    @Test
+    public void mapAttributeValue_intType_validValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("int"), Collections.singletonList("42"));
+        assertEquals(42, result);
+    }
+
+    @Test
+    public void mapAttributeValue_intType_emptyString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("int"), Collections.singletonList(""));
+        assertNull(result);
+    }
+
+    @Test
+    public void mapAttributeValue_intType_invalidString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("int"), Collections.singletonList("abc"));
+        assertNull(result);
+    }
+
+    // --- mapAttributeValue: boolean type ---
+
+    @Test
+    public void mapAttributeValue_booleanType_trueValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("boolean"), Collections.singletonList("true"));
+        assertEquals(Boolean.TRUE, result);
+    }
+
+    @Test
+    public void mapAttributeValue_booleanType_falseValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("boolean"), Collections.singletonList("false"));
+        assertEquals(Boolean.FALSE, result);
+    }
+
+    @Test
+    public void mapAttributeValue_booleanType_emptyString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("boolean"), Collections.singletonList(""));
+        assertNull(result);
+    }
+
+    // --- mapAttributeValue: String type ---
+
+    @Test
+    public void mapAttributeValue_stringType_value() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("String"), Collections.singletonList("hello"));
+        assertEquals("hello", result);
+    }
+
+    @Test
+    public void mapAttributeValue_stringType_emptyString() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("String"), Collections.singletonList(""));
+        assertEquals("", result);
+    }
+
+    // --- mapAttributeValue: null and empty collection ---
+
+    @Test
+    public void mapAttributeValue_nullValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), null);
+        assertNull(result);
+    }
+
+    @Test
+    public void mapAttributeValue_emptyCollection() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("long"), Collections.emptyList());
+        assertNull(result);
+    }
+
+    // --- mapAttributeValue: no JSON type configured ---
+
+    @Test
+    public void mapAttributeValue_noType_returnsRawValue() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel(null), Collections.singletonList("raw-value"));
+        assertEquals("raw-value", result);
+    }
+
+    // --- mapAttributeValue: JSON type with invalid value ---
+
+    @Test
+    public void mapAttributeValue_jsonType_invalidJson() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("JSON"), Collections.singletonList("not-json"));
+        assertNull(result);
+    }
+
+    @Test
+    public void mapAttributeValue_jsonType_validJson() {
+        Object result = OIDCAttributeMapperHelper.mapAttributeValue(
+                createMappingModel("JSON"), Collections.singletonList("{\"key\":\"value\"}"));
+        assertTrue(result instanceof com.fasterxml.jackson.databind.JsonNode);
+    }
+
+    private static ProtocolMapperModel createMappingModel(String jsonType) {
+        ProtocolMapperModel model = new ProtocolMapperModel();
+        model.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        model.setName("test-mapper");
+        Map<String, String> config = new HashMap<>();
+        if (jsonType != null) {
+            config.put(OIDCAttributeMapperHelper.JSON_TYPE, jsonType);
+        }
+        config.put(OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME, "test.claim");
+        model.setConfig(config);
+        return model;
     }
 }


### PR DESCRIPTION
## Problem

User attributes mapped to typed OIDC claims (`long`, `int`, `boolean`, `JSON`) throw `NumberFormatException` or `RuntimeException` when the attribute value is empty, blank, or otherwise not convertible to the target type. This breaks login flows for federated users whose storage providers resolve attributes like `updated_at` to empty strings instead of `null`.

**Stack trace from issue:**
```
java.lang.NumberFormatException: For input string: ""
    at OIDCAttributeMapperHelper.getLong
    at OIDCAttributeMapperHelper.convertToType
    at OIDCAttributeMapperHelper.mapAttributeValue
    at OIDCAttributeMapperHelper.mapClaim
    at UserAttributeMapper.setClaim
```

## Root Cause

`getLong` and `getInteger` call `Long.valueOf`/`Integer.valueOf` directly on the string value without guarding against empty or non-numeric input. Additionally, `convertToType` throws `RuntimeException("cannot map type for token claim")` when scalar conversion fails for `boolean`, `long`, `int`, and `JSON` types, turning a data quality issue into a hard server error.

## Solution

1. **`getLong`/`getInteger`**: Trim the input string, return `null` for empty/blank values, and catch `NumberFormatException` for non-numeric strings (logging a warning instead of throwing).

2. **`getBoolean`**: Treat empty/blank strings as absent (return `null`) rather than coercing to `false` via `Boolean.valueOf("")`. This is consistent with the numeric types: an empty attribute means "no value", not "false".

3. **`convertToType`**: Replace all `throw new RuntimeException` with `return null` for every JSON type branch (`boolean`, `long`, `int`, `JSON`). Unconvertible values now consistently result in the claim being omitted.

4. **`mapAttributeValue`**: Adjust the fallback logic so that when a JSON type IS configured but conversion returns `null`, the method returns `null` (claim omitted) rather than falling back to the raw string value. The raw-value fallback is preserved only when no type is configured.

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| `long` claim with `""` value | `NumberFormatException` -> 500 | Claim omitted from token |
| `int` claim with `"abc"` | `NumberFormatException` -> 500 | Claim omitted, warning logged |
| `boolean` claim with `""` | Coerced to `false` | Claim omitted |
| `JSON` claim with invalid JSON | `RuntimeException` -> 500 | Claim omitted |
| Unconvertible value, no type set | Raw value in token | Raw value in token (unchanged) |

## Tests

Extended `OIDCAttributeMapperHelperTest` with 17 new test cases covering:
- Valid, empty, blank, and invalid values for `long`, `int`, `boolean`, `String`, and `JSON` types
- Null input and empty collection handling
- No-type-configured fallback behavior

Closes #46132
