### PR TITLE
Declarative UI: Copy params map to avoid silent failure to add path params

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/ui/extend/UiTabProviderFactory.java
@@ -16,7 +16,7 @@ public interface UiTabProviderFactory<T> extends ComponentFactory<T, UiTabProvid
     default Map<String, Object> getTypeMetadata() {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("path", getPath());
-        metadata.put("params", getParams());
+        metadata.put("params", new HashMap<>(getParams()));
         return metadata;
     }
 


### PR DESCRIPTION
Declarative UI: Copy params map to avoid silent failure when adding additional path params to type metadata.

See #24805
Closes #47914