### PR TITLE
Build Quarkus from source in quarkus-next workflow

### DIFF
--- a/.github/actions/build-keycloak/action.yml
+++ b/.github/actions/build-keycloak/action.yml
@@ -24,6 +24,11 @@ runs:
       with:
         create-cache-if-it-doesnt-exist: true
 
+    - id: restore-quarkus-snapshot
+      name: Restore Quarkus snapshot cache
+      if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+      uses: ./.github/actions/quarkus-snapshot-cache
+
     - id: pnpm-store-cache
       name: PNPM store cache
       uses: ./.github/actions/pnpm-store-cache

--- a/.github/actions/quarkus-snapshot-cache/action.yml
+++ b/.github/actions/quarkus-snapshot-cache/action.yml
@@ -1,0 +1,15 @@
+name: Quarkus Snapshot Cache
+description: Restores Quarkus snapshot artifacts built from quarkusio/quarkus main branch.
+
+runs:
+  using: composite
+  steps:
+    - id: restore-quarkus-snapshot
+      name: Restore Quarkus snapshot cache
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: |
+          ~/.m2/repository/io/quarkus
+        key: quarkus-snapshot-
+        restore-keys: |
+          quarkus-snapshot-

--- a/.github/scripts/prepare-quarkus-next.sh
+++ b/.github/scripts/prepare-quarkus-next.sh
@@ -1,57 +1,18 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-add_repository() {
-  local file=$1
-  local element=$2
-
-  local id="sonatype-snapshots"
-  local name="Sonatype Snapshots"
-  local url="https://central.sonatype.com/repository/maven-snapshots/"
-
-  # Decide the tag based on the element
-  local tag
-  if [ "$element" = "repository" ]; then
-    tag="repositories"
-  elif [ "$element" = "pluginRepository" ]; then
-    tag="pluginRepositories"
-  fi
-
-  # Repository to be inserted
-  local repository="<$element> \
-            <id>$id</id> \
-            <name>$name</name> \
-            <url>$url</url> \
-            <snapshots> \
-                <enabled>true</enabled> \
-                <updatePolicy>daily</updatePolicy> \
-            </snapshots> \
-            <releases> \
-                <enabled>false</enabled> \
-            </releases> \
-            </$element>"
-
-  # Check if the tag exists in the file
-  if grep -q "<$tag>" "$file"; then
-    # Insert the element before the closing tag
-    sed -i "/<\/$tag>/i $repository" "$file"
-  else
-    # If the tag doesn't exist, create it and insert the element
-    sed -i "/<\/project>/i \
-            <$tag> \
-            $repository \
-            </$tag>" "$file"
-  fi
-}
-
 git checkout -b new-quarkus-next origin/main
 
-add_repository "pom.xml" "repository"
-add_repository "quarkus/pom.xml" "pluginRepository"
-add_repository "operator/pom.xml" "pluginRepository"
+# Use io.quarkus:quarkus-bom built from source
+sed -i 's|<groupId>io.quarkus.platform</groupId>|<groupId>io.quarkus</groupId>|g' pom.xml
 
 ./quarkus/set-quarkus-version.sh
 git commit -am "Set quarkus version to 999-SNAPSHOT"
+
+if ! git rev-parse origin/quarkus-next &>/dev/null; then
+  echo "No existing quarkus-next branch, skipping cherry-pick."
+  exit 0
+fi
 
 snapshot_version_hash=$(git log origin/quarkus-next --grep="Set quarkus version to 999-SNAPSHOT" --format="%H" -n 1)
 commits_to_cherry_pick=$(git rev-list --right-only --no-merges --reverse new-quarkus-next...origin/quarkus-next | grep -vE "$snapshot_version_hash" || echo "")

--- a/.github/workflows/operator-ci.yml
+++ b/.github/workflows/operator-ci.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Setup Java
         uses: ./.github/actions/java-setup
 
+      - name: Restore Quarkus snapshot cache
+        if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+        uses: ./.github/actions/quarkus-snapshot-cache
+
       - name: Test operator running locally
         run: |
           ./mvnw install -Poperator -pl :keycloak-operator -am
@@ -89,6 +93,10 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Quarkus snapshot cache
+        if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+        uses: ./.github/actions/quarkus-snapshot-cache
 
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d # v2.16.1
@@ -137,6 +145,10 @@ jobs:
 
       - name: Setup Java
         uses: ./.github/actions/java-setup
+
+      - name: Restore Quarkus snapshot cache
+        if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+        uses: ./.github/actions/quarkus-snapshot-cache
 
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d # v2.16.1

--- a/.github/workflows/quarkus-next.yml
+++ b/.github/workflows/quarkus-next.yml
@@ -16,12 +16,48 @@ concurrency:
 
 permissions:
   contents: read
-  
+
 jobs:
-  update-quarkus-next-branch:
-    name: Update quarkus-next branch
+  build-quarkus-snapshot:
+    name: Build Quarkus snapshot
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak'
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: quarkusio/quarkus
+          ref: main
+
+      # JDK 17 to match how Quarkus builds and publishes its own snapshots
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Key for daily rotation of cache
+        id: cache-key
+        run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Quarkus snapshot cache
+        id: quarkus-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.m2/repository/io/quarkus
+          key: quarkus-snapshot-${{ steps.cache-key.outputs.date }}
+
+      - name: Build Quarkus snapshot
+        if: steps.quarkus-cache.outputs.cache-hit != 'true'
+        run: |
+          ./mvnw -B -e --no-transfer-progress \
+            -Dquickly -Dno-test-modules -Prelocations \
+            clean install
+
+  update-quarkus-next-branch:
+    name: Update quarkus-next branch
+    runs-on: ubuntu-latest
+    needs: build-quarkus-snapshot
     permissions:
       contents: write # Required to push changes to the repository
     steps:
@@ -29,6 +65,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
+      - name: Setup Java
+        uses: ./.github/actions/java-setup
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Closes: #47500
Surpasses: https://github.com/keycloak/keycloak/pull/47501

This PR is following a recommendation from the Quarkus team - build the snapshot artiffacts on your own.
So for the needs of the `quarkus-next branch` the artifacts (~160 MB) are built directly from source and shared via cache. I introduced a prefix-based cache so that `ci.yml` and `operator-ci.yml` can pick up the `999-SNAPSHOT` artifacts when they run on the quarkus-next branch. Without an external repository like Sonatype before, we needed some way to pass them to the downstream jobs that quarkus-next triggers. 

Then I added a second, date-based cache in the build job itself after I realized a fresh Quarkus build takes about 30 minutes (based on the tests performed in my own fork). That's fine for the nightly scheduled run, but gets obnoxious fast when you're need to test something repeatedly on your own fork. With the date-based key, Quarkus is only rebuilt once per day and subsequent manual triggers just reuse the cache. If you need a fresh build sooner, you can force it by deleting the cache manually, e.g. `gh cache delete --repo Pepo48/keycloak quarkus-snapshot-2026-04-09`.

