### PR TITLE
fix: remove extra dependencies from the operator

### DIFF
--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/BaseOperatorTest.java
@@ -117,6 +117,7 @@ public class BaseOperatorTest implements QuarkusTestAfterEachCallback {
   public static final String OPERATOR_KUBERNETES_IP = "test.operator.kubernetes.ip";
   public static final String OPERATOR_CUSTOM_IMAGE = "test.operator.custom.image";
   public static final String POSTGRESQL_NAME = "postgresql-db";
+  public static final String KEYCLOAK_OPERATOR = "keycloak-operator";
 
   public static final String TEST_RESULTS_DIR = "target/operator-test-results/";
   public static final String POD_LOGS_DIR = TEST_RESULTS_DIR + "pod-logs/";
@@ -401,7 +402,7 @@ public enum OperatorDeployment {local_apiserver,local,remote}
           logKeycloaks();
           logKeycloakRealmImports();
           if (operatorDeployment == OperatorDeployment.remote) {
-              log(k8sclient.apps().deployments().withName("keycloak-operator"), Deployment::getStatus, false);
+              log(k8sclient.apps().deployments().withName(KEYCLOAK_OPERATOR), Deployment::getStatus, false);
           }
           if (operatorDeployment != OperatorDeployment.local_apiserver) {
               logFailed(k8sclient.apps().statefulSets().withName(POSTGRESQL_NAME), StatefulSet::getStatus);

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakDeploymentTest.java
@@ -79,6 +79,7 @@ import static org.keycloak.operator.testsuite.utils.K8sUtils.waitForKeycloakToBe
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisabledIfApiServerTest
@@ -114,6 +115,14 @@ public class KeycloakDeploymentTest extends BaseOperatorTest {
         k8sclient.resource(kc).delete();
         Awaitility.await()
                 .untilAsserted(() -> assertThat(k8sclient.apps().statefulSets().inNamespace(namespace).withName(deploymentName).get()).isNull());
+
+        // check that the operator is not attempting to use telemetry
+        if (operatorDeployment == OperatorDeployment.remote) {
+            String log = k8sclient.apps().deployments().withName(BaseOperatorTest.KEYCLOAK_OPERATOR).getLog();
+            if (log != null) {
+                assertFalse(log.contains("opentelemetry"), "Should not mention opentelemetry " + log);
+            }
+        }
     }
 
     /**

--- a/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakNewServiceClientTest.java
+++ b/operator/src/test/java/org/keycloak/operator/testsuite/integration/KeycloakNewServiceClientTest.java
@@ -2,7 +2,6 @@ package org.keycloak.operator.testsuite.integration;
 
 import org.keycloak.operator.crds.v2beta1.deployment.Keycloak;
 import org.keycloak.operator.crds.v2beta1.deployment.ValueOrSecret;
-import org.keycloak.utils.StringUtil;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Tag;
@@ -26,7 +25,7 @@ public class KeycloakNewServiceClientTest extends KeycloakClientTest {
 
         if (existingJavaOptsAppend != null) {
             String existingValue = existingJavaOptsAppend.getValue();
-            if (StringUtil.isNotBlank(existingValue)) {
+            if (existingValue != null && !existingValue.isBlank()) {
                 existingJavaOptsAppend.setValue(existingValue + " " + newClientServiceProperty);
             } else {
                 existingJavaOptsAppend.setValue(newClientServiceProperty);

--- a/rest/admin-v2/api/pom.xml
+++ b/rest/admin-v2/api/pom.xml
@@ -28,10 +28,12 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/rest/admin-v2/rest/pom.xml
+++ b/rest/admin-v2/rest/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
+             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
@@ -41,6 +42,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
+             <scope>provided</scope>
         </dependency>
         <!-- used by OAS Filter during OpenAPI spec generation -->
         <dependency>


### PR DESCRIPTION
closes: #47872

An alternative for main is https://github.com/keycloak/keycloak/pull/47874

But we can always proceed with this fix there as well first, then refine further.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
