### PR TITLE
Add account-console to defaultClients to prevent deletion of built-in…

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -40,7 +40,7 @@ public final class Constants {
     public static final String AUTH_BASE_URL_PROP = "${authBaseUrl}";
     public static final String AUTH_ADMIN_URL_PROP = "${authAdminUrl}";
 
-    public static final Collection<String> defaultClients = Arrays.asList(ACCOUNT_MANAGEMENT_CLIENT_ID, ADMIN_CLI_CLIENT_ID, BROKER_SERVICE_CLIENT_ID, REALM_MANAGEMENT_CLIENT_ID, ADMIN_CONSOLE_CLIENT_ID);
+    public static final Collection<String> defaultClients = Arrays.asList(ACCOUNT_MANAGEMENT_CLIENT_ID, ACCOUNT_CONSOLE_CLIENT_ID, ADMIN_CLI_CLIENT_ID, BROKER_SERVICE_CLIENT_ID, REALM_MANAGEMENT_CLIENT_ID, ADMIN_CONSOLE_CLIENT_ID);
 
     public static final String INSTALLED_APP_URN = "urn:ietf:wg:oauth:2.0:oob";
 


### PR DESCRIPTION
## Summary
The `account-console` client is a built-in internal client created during realm setup, but it was missing from the `defaultClients` collection. This meant it could be deleted via the Admin REST API, unlike the other 5 built-in clients (`account`, `admin-cli`, `broker`, `realm-management`, `security-admin-console`).

Closes #47923

## Changes

Added `ACCOUNT_CONSOLE_CLIENT_ID` to the `defaultClients` collection in `Constants.java`. This gives `account-console` the same protections as the other built-in clients:
- Cannot be deleted via the Admin REST API
- Filtered during partial realm imports

No test changes are needed - the existing `removeInternalClientExpectingBadRequestException` test iterates over `defaultClients` directly, so it automatically covers the new entry.

## Demo

[account-console-protected.webm](https://github.com/user-attachments/assets/95b21dbf-11f4-4343-985e-531bcfa0c38b)
