### PR TITLE
Fix multiselect options not highlighted as selected in user profile

### DIFF
--- a/js/libs/ui-shared/src/user-profile/SelectComponent.tsx
+++ b/js/libs/ui-shared/src/user-profile/SelectComponent.tsx
@@ -47,14 +47,18 @@ export const SelectComponent = (props: UserProfileFieldProps) => {
   const fetchLabel = (option: string) =>
     label(props.t, optionLabel[option], option, prefix);
 
-  const convertOptions = (selected: string) =>
+  const convertOptions = (selected: string | string[]) =>
     options
       .filter((o) =>
         fetchLabel(o)!.toLowerCase().includes(filter.toLowerCase()),
       )
       .map((option) => (
         <SelectOption
-          selected={selected === option}
+          selected={
+            Array.isArray(selected)
+              ? selected.includes(option)
+              : selected === option
+          }
           key={option}
           value={option}
         >


### PR DESCRIPTION
## Description

The `convertOptions` function in `SelectComponent.tsx` accepted `selected` as `string`, but for multiselect fields `field.value` is a `string[]`. The comparison `selected === option` always evaluated to `false` for arrays, so no options appeared as selected in the dropdown.

The fix changes the parameter type to `string | string[]` and uses `Array.isArray` to handle both cases. This is the same pattern already used in `OptionsComponent.tsx` (`field.value?.includes(option)`).


https://github.com/user-attachments/assets/dd2fc8c7-d34b-491e-b7a3-f73111534a30


Closes #47929