### PR TITLE
Fix session type of access token in offline access refresh token flow

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -342,7 +342,7 @@ public class PolicyEvaluationService {
                     AuthenticationManager.setClientScopesInSession(keycloakSession, authSession);
                     ClientSessionContext clientSessionCtx = TokenManager.attachAuthenticationSession(keycloakSession, userSession, authSession);
 
-                    accessToken = new TokenManager().createClientAccessToken(keycloakSession, realm, clientModel, userModel, userSession, clientSessionCtx);
+                    accessToken = new TokenManager().createClientAccessToken(keycloakSession, realm, clientModel, userModel, userSession, clientSessionCtx, clientSessionCtx.isOfflineTokenRequested());
                 }
             }
         }

--- a/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
+++ b/services/src/main/java/org/keycloak/authorization/common/KeycloakIdentity.java
@@ -145,7 +145,7 @@ public class KeycloakIdentity implements Identity {
             AuthenticatedClientSessionModel clientSessionModel = userSession.getAuthenticatedClientSessionByClient(client.getId());
 
             ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionScopeParameter(clientSessionModel, keycloakSession);
-            this.accessToken = new TokenManager().createClientAccessToken(keycloakSession, realm, client, userSession.getUser(), userSession, clientSessionCtx);
+            this.accessToken = new TokenManager().createClientAccessToken(keycloakSession, realm, client, userSession.getUser(), userSession, clientSessionCtx, clientSessionCtx.isOfflineTokenRequested());
         }
 
         AccessToken.Access realmAccess = this.accessToken.getRealmAccess();

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -253,7 +253,7 @@ public class TokenManager {
         clientSessionCtx.setAttribute(Constants.GRANT_TYPE, OAuth2Constants.REFRESH_TOKEN);
 
         // recreate token.
-        AccessToken newToken = createClientAccessToken(session, realm, client, user, userSession, clientSessionCtx);
+        AccessToken newToken = createClientAccessToken(session, realm, client, user, userSession, clientSessionCtx, userSession.isOffline());
 
         return new TokenValidation(user, userSession, clientSessionCtx, newToken);
     }
@@ -557,8 +557,8 @@ public class TokenManager {
     }
 
     public AccessToken createClientAccessToken(KeycloakSession session, RealmModel realm, ClientModel client, UserModel user, UserSessionModel userSession,
-                                               ClientSessionContext clientSessionCtx) {
-        AccessToken token = initToken(session, realm, client, user, userSession, clientSessionCtx, session.getContext().getUri());
+                                               ClientSessionContext clientSessionCtx, boolean isOffline) {
+        AccessToken token = initToken(session, realm, client, user, userSession, clientSessionCtx, isOffline);
         token = transformAccessToken(session, token, userSession, clientSessionCtx);
         return token;
     }
@@ -1015,11 +1015,10 @@ public class TokenManager {
     }
 
     protected AccessToken initToken(KeycloakSession session, RealmModel realm, ClientModel client, UserModel user, UserSessionModel userSession,
-                                    ClientSessionContext clientSessionCtx, UriInfo uriInfo) {
+                                    ClientSessionContext clientSessionCtx, boolean isOffline) {
         AccessToken token = new AccessToken();
-
         TokenContextEncoderProvider encoder = session.getProvider(TokenContextEncoderProvider.class);
-        AccessTokenContext tokenCtx = encoder.getTokenContextFromClientSessionContext(clientSessionCtx, SecretGenerator.getInstance().generateSecureID());
+        AccessTokenContext tokenCtx = encoder.getTokenContextFromClientSessionContext(clientSessionCtx, SecretGenerator.getInstance().generateSecureID(), isOffline);
         token.id(encoder.encodeTokenId(tokenCtx));
 
         token.type(formatTokenType(client, token));
@@ -1174,7 +1173,7 @@ public class TokenManager {
 
         public AccessTokenResponseBuilder generateAccessToken() {
             UserModel user = userSession.getUser();
-            accessToken = createClientAccessToken(session, realm, client, user, userSession, clientSessionCtx);
+            accessToken = createClientAccessToken(session, realm, client, user, userSession, clientSessionCtx, clientSessionCtx.isOfflineTokenRequested());
             responseTokenType = formatTokenType(client, accessToken);
             return this;
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/encode/DefaultTokenContextEncoderProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/encode/DefaultTokenContextEncoderProvider.java
@@ -42,7 +42,7 @@ public class DefaultTokenContextEncoderProvider implements TokenContextEncoderPr
     }
 
     @Override
-    public AccessTokenContext getTokenContextFromClientSessionContext(ClientSessionContext clientSessionContext, String rawTokenId) {
+    public AccessTokenContext getTokenContextFromClientSessionContext(ClientSessionContext clientSessionContext, String rawTokenId, boolean isOffline) {
         AccessTokenContext.SessionType sessionType;
         UserSessionModel userSession = clientSessionContext.getClientSession().getUserSession();
         if (userSession.getPersistenceState() == UserSessionModel.SessionPersistenceState.TRANSIENT) {
@@ -53,7 +53,7 @@ public class DefaultTokenContextEncoderProvider implements TokenContextEncoderPr
                 sessionType = AccessTokenContext.SessionType.TRANSIENT;
             }
         } else {
-            sessionType = clientSessionContext.isOfflineTokenRequested() ? AccessTokenContext.SessionType.OFFLINE : AccessTokenContext.SessionType.ONLINE;
+            sessionType = isOffline ? AccessTokenContext.SessionType.OFFLINE : AccessTokenContext.SessionType.ONLINE;
         }
 
         boolean useLightweightToken = AbstractOIDCProtocolMapper.getShouldUseLightweightToken(session);

--- a/services/src/main/java/org/keycloak/protocol/oidc/encode/TokenContextEncoderProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/encode/TokenContextEncoderProvider.java
@@ -30,7 +30,7 @@ import org.keycloak.provider.Provider;
  */
 public interface TokenContextEncoderProvider extends Provider {
 
-    AccessTokenContext getTokenContextFromClientSessionContext(ClientSessionContext clientSessionContext, String rawTokenId);
+    AccessTokenContext getTokenContextFromClientSessionContext(ClientSessionContext clientSessionContext, String rawTokenId, boolean isOffline);
 
     AccessTokenContext getTokenContextFromTokenId(String encodedTokenId);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -111,7 +111,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
     protected Response createTokenResponse(UserModel user, UserSessionModel userSession, ClientSessionContext clientSessionCtx,
         String scopeParam, boolean code, Function<TokenManager.AccessTokenResponseBuilder, ClientPolicyContext> clientPolicyContextGenerator) {
         clientSessionCtx.setAttribute(Constants.GRANT_TYPE, context.getGrantType());
-        AccessToken token = tokenManager.createClientAccessToken(session, realm, client, user, userSession, clientSessionCtx);
+        AccessToken token = tokenManager.createClientAccessToken(session, realm, client, user, userSession, clientSessionCtx, clientSessionCtx.isOfflineTokenRequested());
 
         TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager
             .responseBuilder(realm, client, event, session, userSession, clientSessionCtx).accessToken(token);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -91,7 +91,8 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                 clientSession.getClient(),
                 clientSession.getUserSession().getUser(),
                 clientSession.getUserSession(),
-                sessionContext);
+                sessionContext,
+                sessionContext.isOfflineTokenRequested());
 
         TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.responseBuilder(
                 clientSession.getRealm(),

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OfflineTokenTest.java
@@ -48,6 +48,7 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.SessionTimeoutHelper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
+import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -75,6 +76,7 @@ import org.keycloak.testsuite.util.UserBuilder;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
 import org.keycloak.testsuite.util.oauth.LogoutResponse;
+import org.keycloak.testsuite.util.oauth.UserInfoResponse;
 import org.keycloak.testsuite.utils.tls.TLSUtils;
 import org.keycloak.util.TokenUtil;
 
@@ -1648,6 +1650,37 @@ public class OfflineTokenTest extends AbstractKeycloakTest {
                     .detail(Details.REFRESH_TOKEN_ID, offlineToken.getId())
                     .detail(Details.REASON, "Offline session invalid because offline access not granted anymore")
                     .assertEvent();
+        }
+    }
+
+    @Test
+    public void userInfoWithRefreshedAccessTokenFromOfflineRefreshToken() {
+        oauth.scope("openid " + OAuth2Constants.OFFLINE_ACCESS);
+        oauth.client("offline-client", "secret1");
+
+        AccessTokenResponse initialTokenResponse = oauth.doPasswordGrantRequest("test-user@localhost", "password");
+        assertEquals(200, initialTokenResponse.getStatusCode());
+
+        String initialAccessToken = initialTokenResponse.getAccessToken();
+        String offlineRefreshToken = initialTokenResponse.getRefreshToken();
+        setTimeOffset(20);
+
+        try {
+            UserInfoResponse expiredResponse = oauth.doUserInfoRequest(initialAccessToken);
+            assertEquals(401, expiredResponse.getStatusCode());
+
+            oauth.scope("openid email profile basic");
+            AccessTokenResponse refreshedTokenResponse = oauth.doRefreshTokenRequest(offlineRefreshToken);
+            assertEquals(200, refreshedTokenResponse.getStatusCode());
+
+            AccessToken refreshedAccessToken = oauth.verifyToken(refreshedTokenResponse.getAccessToken());
+            AccessTokenContext refreshedCtx = testingClient.testing("test").getTokenContext(refreshedAccessToken.getId());
+            assertEquals(AccessTokenContext.SessionType.OFFLINE, refreshedCtx.getSessionType());
+
+            UserInfoResponse refreshedUserInfoResponse = oauth.doUserInfoRequest(refreshedTokenResponse.getAccessToken());
+            assertEquals(200, refreshedUserInfoResponse.getStatusCode());
+        } finally {
+            setTimeOffset(0);
         }
     }
 }


### PR DESCRIPTION
Closes #47776


(cherry picked from commit 52c4d90caa24454cf135dc7e22f645ae34f9e452)

Backport needed to add the new test method into class `OfflineTokenTest` in the old testsuite (Original commit used different test class in the new testsuite as `OfflineTokenTest` was already migrated in Keycloak main and removed from the old testsuite)