### PR TITLE
fix: using inputstream to represent patches

### DIFF
--- a/js/libs/keycloak-admin-client/openapi.yaml
+++ b/js/libs/keycloak-admin-client/openapi.yaml
@@ -255,7 +255,9 @@ paths:
       - Clients (v2)
       requestBody:
         content:
-          application/merge-patch+json: {}
+          application/merge-patch+json:
+            schema:
+              type: object
         required: true
       responses:
         "200":

--- a/js/libs/keycloak-admin-client/test/clientsV2.spec.ts
+++ b/js/libs/keycloak-admin-client/test/clientsV2.spec.ts
@@ -74,15 +74,10 @@ describe("Clients V2 API", () => {
   it("should patch a client", async () => {
     const patchedDisplayName = "Patched Display Name";
 
-    // Note: Kiota's patch expects an ArrayBuffer for merge-patch+json
-    const patchBody = JSON.stringify({ displayName: patchedDisplayName });
-    const encoder = new TextEncoder();
-    const patchBuffer = encoder.encode(patchBody).buffer;
-
     const patchedClient = await kcAdminClient.clients
       .v2()
       .byId(currentClientId)
-      .patch(patchBuffer);
+      .patch({ additionalData: { displayName: patchedDisplayName } });
 
     expect((patchedClient as OIDCClientRepresentation).displayName).to.equal(
       patchedDisplayName,

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/ClientService.java
@@ -1,5 +1,6 @@
 package org.keycloak.services.client;
 
+import java.io.InputStream;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -8,8 +9,6 @@ import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.services.PatchType;
 import org.keycloak.services.Service;
 import org.keycloak.services.ServiceException;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 public interface ClientService extends Service {
 
@@ -50,5 +49,5 @@ public interface ClientService extends Service {
 
     BaseClientRepresentation createClient(RealmModel realm, BaseClientRepresentation client) throws ServiceException;
 
-    BaseClientRepresentation patchClient(RealmModel realm, String clientId, PatchType patchType, JsonNode patch) throws ServiceException;
+    BaseClientRepresentation patchClient(RealmModel realm, String clientId, PatchType patchType, InputStream patch) throws ServiceException;
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -1,6 +1,7 @@
 package org.keycloak.services.client;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -49,9 +50,10 @@ import org.keycloak.validation.jakarta.HibernateValidatorProvider;
 import org.keycloak.validation.jakarta.JakartaValidatorProvider;
 import org.keycloak.validation.jakarta.ValidationContext;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.http.HttpEntity;
@@ -224,20 +226,23 @@ public class DefaultClientService implements ClientService {
     }
 
     @Override
-    public BaseClientRepresentation patchClient(RealmModel realm, String clientId, PatchType patchType, JsonNode patch) throws ServiceException {
+    public BaseClientRepresentation patchClient(RealmModel realm, String clientId, PatchType patchType, InputStream patch) throws ServiceException {
         Supplier<BaseClientRepresentation> getOriginalClient = () -> getClient(realm, clientId)
                 .orElseThrow(() -> new ServiceException("Cannot find the specified client", Response.Status.NOT_FOUND));
 
         BaseClientRepresentation updated;
         switch (patchType) {
             case JSON_MERGE -> {
-                try {
-                    if (patch == null) {
-                        // based on the RFC 7396 JSON Merge Patch should replace the whole entity if the patch is not an object - we can't do it
-                        throw new ServiceException("Cannot replace client resource with null", Response.Status.BAD_REQUEST);
-                    }
+                try (JsonParser parser = MAPPER.getFactory().createParser(patch)) {
                     final ObjectReader objectReader = MAPPER.readerForUpdating(getOriginalClient.get());
-                    updated = objectReader.readValue(patch);
+                    JsonToken nextToken = parser.nextToken();
+                    if (nextToken != JsonToken.START_OBJECT) {
+                        throw new ServiceException("Cannot replace client resource with non-object", Response.Status.BAD_REQUEST);
+                    }
+                    updated = objectReader.readValue(parser);
+                    if (parser.nextToken() != null) {
+                        throw new ServiceException("Patch contains additional content", Response.Status.BAD_REQUEST);
+                    }
                 } catch (JsonMappingException e) {
                     var invalidFields = e.getPath().stream().map(JsonMappingException.Reference::getFieldName).collect(Collectors.joining(", "));
                     throw new ServiceException("Invalid values for these fields: %s".formatted((invalidFields)));

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/ClientApi.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/ClientApi.java
@@ -1,5 +1,7 @@
 package org.keycloak.admin.api.client;
 
+import java.io.InputStream;
+
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -13,10 +15,11 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.services.PatchTypeNames;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 
@@ -49,7 +52,8 @@ public interface ClientApi {
         @APIResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = BaseClientRepresentation.class))),
         @APIResponse(responseCode = "404", description = "Not Found")
     })
-    BaseClientRepresentation patchClient(JsonNode patch);
+    @RequestBody(required = true, content = @Content(schema = @Schema(type = SchemaType.OBJECT)))
+    BaseClientRepresentation patchClient(InputStream patch);
 
     @DELETE
     @Operation(summary = "Delete a client", description = "Deletes a client from the realm")

--- a/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
+++ b/rest/admin-v2/rest/src/main/java/org/keycloak/admin/api/client/DefaultClientApi.java
@@ -1,5 +1,7 @@
 package org.keycloak.admin.api.client;
 
+import java.io.InputStream;
+
 import jakarta.annotation.Nonnull;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -20,7 +22,6 @@ import org.keycloak.services.client.ClientServiceHelper;
 import org.keycloak.services.resources.admin.RealmAdminResource;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 
-import com.fasterxml.jackson.databind.JsonNode;
 
 public class DefaultClientApi implements ClientApi {
     private final KeycloakSession session;
@@ -60,7 +61,7 @@ public class DefaultClientApi implements ClientApi {
 
     @PATCH
     @Override
-    public BaseClientRepresentation patchClient(JsonNode patch) {
+    public BaseClientRepresentation patchClient(InputStream patch) {
         String contentType = session.getContext().getHttpRequest().getHttpHeaders().getHeaderString(HttpHeaders.CONTENT_TYPE);
         PatchType patchType = PatchType.getByMediaType(contentType)
                 .orElseThrow(() -> new WebApplicationException("Unsupported media type", Response.Status.UNSUPPORTED_MEDIA_TYPE));

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.tests.admin.client.v2;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
@@ -119,10 +120,10 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
     }
 
     @Test
-    public void jsonMergePatchClient() {
+    public void jsonMergePatchClient() throws JsonProcessingException {
         OIDCClientRepresentation patch = new OIDCClientRepresentation();
         patch.setDescription("I'm also a description");
-        BaseClientRepresentation baseRep = clients(masterRealm.getName()).v2().client(testClient.getClientId()).patchClient(mapper.valueToTree(patch));
+        BaseClientRepresentation baseRep = clients(masterRealm.getName()).v2().client(testClient.getClientId()).patchClient(new ByteArrayInputStream(mapper.writeValueAsBytes(patch)));
         assertEquals("I'm also a description", baseRep.getDescription());
     }
 
@@ -131,6 +132,12 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         HttpPatch request = new HttpPatch(getClientApiUrl(testClient.getClientId()));
         setAuthHeader(request);
         request.setHeader(HttpHeaders.CONTENT_TYPE, PatchTypeNames.JSON_MERGE);
+
+        request.setEntity(null);
+        try (var response = client.execute(request)) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+            assertThat(EntityUtils.toString(response.getEntity()), Matchers.containsString("Cannot replace client resource with non-object"));
+        }
 
         request.setEntity(new StringEntity("patch client invalid"));
         try (var response = client.execute(request)) {
@@ -148,11 +155,24 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
             assertEquals(200, response.getStatusLine().getStatusCode());
         }
 
+        request.setEntity(new StringEntity("\"a\""));
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(),is(400));
+            assertThat(EntityUtils.toString(response.getEntity()), Matchers.containsString("Cannot replace client resource with non-object"));
+        }
+
         request.setEntity(new StringEntity(""));
         try (var response = client.execute(request)) {
             assertThat(response.getStatusLine().getStatusCode(),is(400));
-            assertThat(EntityUtils.toString(response.getEntity()), Matchers.containsString("Cannot replace client resource with null"));
+            assertThat(EntityUtils.toString(response.getEntity()), Matchers.containsString("Cannot replace client resource with non-object"));
         }
+
+        request.setEntity(new StringEntity("{} {}"));
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(),is(400));
+            assertThat(EntityUtils.toString(response.getEntity()), Matchers.containsString("Patch contains additional content"));
+        }
+
     }
 
     @Test
@@ -884,9 +904,9 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         }
     }
 
-    private OIDCClientRepresentation.Auth getResultingAuthConfigPatch(OIDCClientRepresentation.Auth auth, String clientId, String... additionalFields) throws IllegalArgumentException {
+    private OIDCClientRepresentation.Auth getResultingAuthConfigPatch(OIDCClientRepresentation.Auth auth, String clientId, String... additionalFields) throws IllegalArgumentException, JsonProcessingException {
         var rep = getResultingClientRep(auth, clientId, additionalFields);
-        OIDCClientRepresentation createdClient = (OIDCClientRepresentation) clients(testRealm.getName()).v2().client(clientId).patchClient(mapper.valueToTree(rep));
+        OIDCClientRepresentation createdClient = (OIDCClientRepresentation) clients(testRealm.getName()).v2().client(clientId).patchClient(new ByteArrayInputStream(mapper.writeValueAsBytes(rep)));
         return assertClientEnabledIdDescriptionAndAuth(rep, createdClient);
     }
 

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/PatchClientValidationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/PatchClientValidationTest.java
@@ -92,7 +92,7 @@ public class PatchClientValidationTest extends AbstractClientValidationTest {
             assertThat(response.getStatusLine().getStatusCode(), is(400));
 
             String responseBody = EntityUtils.toString(response.getEntity());
-            assertThat(responseBody, containsString("Cannot replace client resource with null"));
+            assertThat(responseBody, containsString("Cannot replace client resource with non-object"));
         }
     }
 


### PR DESCRIPTION
closes: #47913

There's a couple of changes here:
- updated the schema for a patch to an object
- expanded the checks for whether it's a valid patch. The alternative is add additional checks to the existing code or to switch from JsonNode to JsonObject.
- changed the patch type to InputStream. We no longer need a databind dependency (for the api, it will still be used by the java client), and there's an improvement in the memory handling

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
