### PR TITLE
Adding staleness concept to JDBC_PING

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
+++ b/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
@@ -57,20 +57,6 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
     @Property(description="Staleness timeout in milliseconds. The coordinator will update the entries once 50%-75% of the time has passed.", type= AttributeType.TIME)
     protected long staleness_timeout = 60000L;
 
-    {
-        // Move these new SQL statements to JDBC_PING2 once we provide this change to upstream.
-        initialize_sql = "CREATE TABLE jgroups (address varchar(200) NOT NULL, " +
-                "name varchar(200), " +
-                "cluster varchar(200) NOT NULL, " +
-                "ip varchar(200) NOT NULL, " +
-                "coord boolean, " +
-                "last_update bigint, " +
-                "coordinated_by varchar(200), " +
-                "PRIMARY KEY (address) )";
-        insert_single_sql="INSERT INTO jgroups values (?, ?, ?, ?, ?, ?, ?)";
-        select_all_pingdata_sql="SELECT address, name, ip, coord, coordinated_by, last_update FROM jgroups WHERE cluster=?";
-    }
-
     @Override
     protected void loadDriver() {
         //no-op, using JpaConnectionProviderFactory

--- a/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
+++ b/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
@@ -57,6 +57,20 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
     @Property(description="Staleness timeout in milliseconds. The coordinator will update the entries once 50%-75% of the time has passed.", type= AttributeType.TIME)
     protected long staleness_timeout = 60000L;
 
+    {
+        // Move these new SQL statements to JDBC_PING2 once we provide this change to upstream.
+        initialize_sql = "CREATE TABLE jgroups (address varchar(200) NOT NULL, " +
+                "name varchar(200), " +
+                "cluster varchar(200) NOT NULL, " +
+                "ip varchar(200) NOT NULL, " +
+                "coord boolean, " +
+                "last_update bigint, " +
+                "coordinated_by varchar(200), " +
+                "PRIMARY KEY (address) )";
+        insert_single_sql="INSERT INTO jgroups values (?, ?, ?, ?, ?, ?, ?)";
+        select_all_pingdata_sql="SELECT address, name, ip, coord, coordinated_by, last_update FROM jgroups WHERE cluster=?";
+    }
+
     @Override
     protected void loadDriver() {
         //no-op, using JpaConnectionProviderFactory
@@ -75,20 +89,6 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
             //... but to be future proof ...
             throw new SQLException(e);
         }
-    }
-
-    public KEYCLOAK_JDBC_PING2() {
-        // Move these new SQL statements to JDBC_PING2 once we provide this change to upstream.
-        initialize_sql = "CREATE TABLE jgroups (address varchar(200) NOT NULL, " +
-                "name varchar(200), " +
-                "cluster varchar(200) NOT NULL, " +
-                "ip varchar(200) NOT NULL, " +
-                "coord boolean, " +
-                "last_update bigint, " +
-                "coordinated_by varchar(200), " +
-                "PRIMARY KEY (address) )";
-        insert_single_sql="INSERT INTO jgroups values (?, ?, ?, ?, ?, ?, ?)";
-        select_all_pingdata_sql="SELECT address, name, ip, coord, coordinated_by, last_update FROM jgroups WHERE cluster=?";
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
+++ b/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
@@ -52,12 +52,10 @@ import static java.sql.ResultSet.TYPE_FORWARD_ONLY;
 
 public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
 
-    public static final Comparator<PingData> C = Comparator.<PingData, Integer>comparing(p -> p.mbrs() != null ? p.mbrs().size() : 0).reversed()
-            .thenComparing(PingData::getAddress);
     private JpaConnectionProviderFactory factory;
 
-    @Property(description="Staleness timeout in milliseconds. The coordinator will update the entries once 50%-75% of the time have passed.", type= AttributeType.TIME)
-    protected long stateless_timeout = 60000L;
+    @Property(description="Staleness timeout in milliseconds. The coordinator will update the entries once 50%-75% of the time has passed.", type= AttributeType.TIME)
+    protected long staleness_timeout = 60000L;
 
     @Override
     protected void loadDriver() {
@@ -80,6 +78,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
     }
 
     public KEYCLOAK_JDBC_PING2() {
+        // Move these new SQL statements to JDBC_PING2 once we provide this change to upstream.
         initialize_sql = "CREATE TABLE jgroups (address varchar(200) NOT NULL, " +
                 "name varchar(200), " +
                 "cluster varchar(200) NOT NULL, " +
@@ -116,7 +115,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
             ps.setString(3, clustername);
             ps.setString(4, ip);
             ps.setBoolean(5, data.isCoord());
-            ps.setLong(6, TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis()));
+            ps.setLong(6, Time.currentTime());
             ps.setString(7, view != null && view.getCoord() != null ? Util.addressToString(view.getCoord()) : null);
             if (log.isTraceEnabled())
                 log.trace("%s: SQL for insertion: %s", local_addr, ps);
@@ -145,7 +144,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
             return;
         }
         String cluster_name = getClusterName();
-        try (var conn = getConnection()) {
+        try {
             List<PingData> list = readFromDB(getClusterName());
             PingData my_data = list.stream().filter(p -> Objects.equals(p.getAddress(), addr())).findFirst().orElse(null);
             if (my_data == null || my_data.mbrs() == null) {
@@ -155,8 +154,10 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
                 Address addr = data.getAddress();
                 // Only delete an entry if it is currently allocated to us, and not someone else
                 if (!local_view.containsMember(addr) && my_data.mbrs().contains(addr)) {
-                    addDiscoveryResponseToCaches(addr, data.getLogicalName(), data.getPhysicalAddr());
-                    delete(conn, cluster_name, addr);
+                    try (var conn = getConnection()) {
+                        addDiscoveryResponseToCaches(addr, data.getLogicalName(), data.getPhysicalAddr());
+                        delete(conn, cluster_name, addr);
+                    }
                 }
             }
         } catch (Exception e) {
@@ -172,7 +173,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
             info_writer=timer.scheduleWithDynamicInterval(new InfoWriter(info_writer_max_writes_after_view, info_writer_sleep_time) {
                 @Override
                 public long nextInterval() {
-                    return is_coord ? (stateless_timeout / 2 + Util.random(sleep_interval / 4)) : 0;
+                    return is_coord ? (staleness_timeout / 2 + Util.random(sleep_interval / 4)) : 0;
                 }
             });
     }
@@ -234,7 +235,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
     }
 
     private long getStalenessCutoff() {
-        return TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis() - stateless_timeout);
+        return TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis() - staleness_timeout);
     }
 
     public void setJpaConnectionProviderFactory(JpaConnectionProviderFactory factory) {
@@ -242,7 +243,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
     }
 
     // Pick the largest partition first, then order by address to allow for a stable result
-    Comparator<PingData> SPLIT_BRAIN_DECIDER = Comparator
+    private final static Comparator<PingData> SPLIT_BRAIN_DECIDER = Comparator
             .<PingData, Integer>comparing(p -> p.mbrs() != null ? p.mbrs().size() : 0).reversed()
             .thenComparing(PingData::getAddress);
 

--- a/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
+++ b/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
 
 import org.jgroups.Address;
@@ -55,7 +56,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
             .thenComparing(PingData::getAddress);
     private JpaConnectionProviderFactory factory;
 
-    @Property(description="Staleness timeout in milliseconds. Should be double the time of MERGE3 max interval, as MERGE3 will use an interval up to (max_interval) + max_interval/2", type= AttributeType.TIME)
+    @Property(description="Staleness timeout in milliseconds. The coordinator will update the entries once 50%-75% of the time have passed.", type= AttributeType.TIME)
     protected long stateless_timeout = 60000L;
 
     @Override
@@ -115,7 +116,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
             ps.setString(3, clustername);
             ps.setString(4, ip);
             ps.setBoolean(5, data.isCoord());
-            ps.setLong(6, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
+            ps.setLong(6, TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis()));
             ps.setString(7, view != null && view.getCoord() != null ? Util.addressToString(view.getCoord()) : null);
             if (log.isTraceEnabled())
                 log.trace("%s: SQL for insertion: %s", local_addr, ps);
@@ -161,6 +162,19 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
         } catch (Exception e) {
             log.error(String.format("%s: failed reading from the DB", local_addr), e);
         }
+    }
+
+    /**
+     * The infowriter will run on the coordinator only. It will continue to run while this is the coordinator, not only after the view change
+     */
+    protected synchronized void startInfoWriter() {
+        if(info_writer == null || info_writer.isDone())
+            info_writer=timer.scheduleWithDynamicInterval(new InfoWriter(info_writer_max_writes_after_view, info_writer_sleep_time) {
+                @Override
+                public long nextInterval() {
+                    return is_coord ? (stateless_timeout / 2 + Util.random(sleep_interval / 4)) : 0;
+                }
+            });
     }
 
     protected List<PingData> readFromDB(String cluster) throws Exception {
@@ -220,7 +234,7 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
     }
 
     private long getStalenessCutoff() {
-        return TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - stateless_timeout);
+        return TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis() - stateless_timeout);
     }
 
     public void setJpaConnectionProviderFactory(JpaConnectionProviderFactory factory) {

--- a/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
+++ b/model/infinispan/src/main/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2.java
@@ -18,18 +18,45 @@
 package org.keycloak.jgroups.protocol;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
 
+import org.jgroups.Address;
+import org.jgroups.PhysicalAddress;
+import org.jgroups.View;
+import org.jgroups.annotations.Property;
+import org.jgroups.conf.AttributeType;
 import org.jgroups.protocols.JDBC_PING2;
 import org.jgroups.protocols.PingData;
+import org.jgroups.protocols.relay.SiteUUID;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.NameCache;
 import org.jgroups.util.UUID;
+import org.jgroups.util.Util;
+
+import static java.sql.ResultSet.CONCUR_UPDATABLE;
+import static java.sql.ResultSet.TYPE_FORWARD_ONLY;
 
 public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
 
+    public static final Comparator<PingData> C = Comparator.<PingData, Integer>comparing(p -> p.mbrs() != null ? p.mbrs().size() : 0).reversed()
+            .thenComparing(PingData::getAddress);
     private JpaConnectionProviderFactory factory;
+
+    @Property(description="Staleness timeout in milliseconds. Should be double the time of MERGE3 max interval, as MERGE3 will use an interval up to (max_interval) + max_interval/2", type= AttributeType.TIME)
+    protected long stateless_timeout = 60000L;
 
     @Override
     protected void loadDriver() {
@@ -51,9 +78,159 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
         }
     }
 
+    public KEYCLOAK_JDBC_PING2() {
+        initialize_sql = "CREATE TABLE jgroups (address varchar(200) NOT NULL, " +
+                "name varchar(200), " +
+                "cluster varchar(200) NOT NULL, " +
+                "ip varchar(200) NOT NULL, " +
+                "coord boolean, " +
+                "last_update bigint, " +
+                "coordinated_by varchar(200), " +
+                "PRIMARY KEY (address) )";
+        insert_single_sql="INSERT INTO jgroups values (?, ?, ?, ?, ?, ?, ?)";
+        select_all_pingdata_sql="SELECT address, name, ip, coord, coordinated_by, last_update FROM jgroups WHERE cluster=?";
+    }
+
+    @Override
+    public void init() throws Exception {
+        if (!write_data_on_find) {
+            throw new RuntimeException("Running this without write_data_on_find is not safe");
+        }
+        if (!remove_all_data_on_view_change) {
+            throw new RuntimeException("Running this without remove_all_data_on_view_change is not safe");
+        }
+        super.init();
+    }
+
+    protected void insert(Connection connection, PingData data, String clustername) throws SQLException {
+        lock.lock();
+        try(PreparedStatement ps=connection.prepareStatement(insert_single_sql)) {
+            Address address=data.getAddress();
+            String addr= Util.addressToString(address);
+            String name=address instanceof SiteUUID ? ((SiteUUID)address).getName() : NameCache.get(address);
+            PhysicalAddress ip_addr=data.getPhysicalAddr();
+            String ip=ip_addr.toString();
+            ps.setString(1, addr);
+            ps.setString(2, name);
+            ps.setString(3, clustername);
+            ps.setString(4, ip);
+            ps.setBoolean(5, data.isCoord());
+            ps.setLong(6, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
+            ps.setString(7, view != null && view.getCoord() != null ? Util.addressToString(view.getCoord()) : null);
+            if (log.isTraceEnabled())
+                log.trace("%s: SQL for insertion: %s", local_addr, ps);
+            ps.executeUpdate();
+            log.debug("%s: inserted %s for cluster %s", local_addr, address, clustername);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    protected void handleView(View new_view, View old_view, boolean coord_changed) {
+        super.handleView(new_view, old_view, coord_changed);
+        if (coord_changed) {
+            try {
+                removeStaleEntries();
+            } catch (Exception e) {
+                log.error(String.format("%s: failed handling view change", local_addr), e);
+            }
+        }
+    }
+
+    protected void removeAllNotInCurrentView() {
+        View local_view = view;
+        if (local_view == null) {
+            return;
+        }
+        String cluster_name = getClusterName();
+        try (var conn = getConnection()) {
+            List<PingData> list = readFromDB(getClusterName());
+            PingData my_data = list.stream().filter(p -> Objects.equals(p.getAddress(), addr())).findFirst().orElse(null);
+            if (my_data == null || my_data.mbrs() == null) {
+                return;
+            }
+            for (PingData data : list) {
+                Address addr = data.getAddress();
+                // Only delete an entry if it is currently allocated to us, and not someone else
+                if (!local_view.containsMember(addr) && my_data.mbrs().contains(addr)) {
+                    addDiscoveryResponseToCaches(addr, data.getLogicalName(), data.getPhysicalAddr());
+                    delete(conn, cluster_name, addr);
+                }
+            }
+        } catch (Exception e) {
+            log.error(String.format("%s: failed reading from the DB", local_addr), e);
+        }
+    }
+
+    protected List<PingData> readFromDB(String cluster) throws Exception {
+        try(Connection conn=getConnection();
+            PreparedStatement ps=prepare(conn, select_all_pingdata_sql, TYPE_FORWARD_ONLY, CONCUR_UPDATABLE)) {
+            ps.setString(1, cluster);
+            if(log.isTraceEnabled())
+                log.trace("%s: SQL for reading: %s", local_addr, ps);
+            try(ResultSet resultSet=ps.executeQuery()) {
+                reads++;
+                List<PingData> retval=new LinkedList<>();
+                Map<Address, Set<Address>> members = new HashMap<>();
+                while(resultSet.next()) {
+                    String uuid=resultSet.getString(1);
+                    String name=resultSet.getString(2);
+                    String ip=resultSet.getString(3);
+                    boolean coord=resultSet.getBoolean(4);
+                    String coordinated_by=resultSet.getString(5);
+                    long last_update=resultSet.getLong(6);
+                    if (last_update < getStalenessCutoff()) {
+                        continue;
+                    }
+                    Address addr=Util.addressFromString(uuid);
+                    IpAddress ip_addr=new IpAddress(ip);
+                    PingData data=new PingData(addr, true, name, ip_addr).coord(coord);
+                    retval.add(data);
+                    if (coordinated_by != null) {
+                        Address coordinate_by_address = Util.addressFromString(coordinated_by);
+                        members.computeIfAbsent(coordinate_by_address, address -> new HashSet<>())
+                                .add(addr);
+                    }
+                }
+                retval.forEach(a -> a.mbrs(members.get(a.getAddress())));
+                return retval;
+            }
+        }
+    }
+
+    protected void removeStaleEntries() throws Exception {
+        try(Connection conn=getConnection();
+            PreparedStatement ps=prepare(conn, select_all_pingdata_sql, TYPE_FORWARD_ONLY, CONCUR_UPDATABLE)) {
+            ps.setString(1, getClusterName());
+            if(log.isTraceEnabled())
+                log.trace("%s: SQL for reading: %s", local_addr, ps);
+            try(ResultSet resultSet=ps.executeQuery()) {
+                reads++;
+                while(resultSet.next()) {
+                    String uuid=resultSet.getString(1);
+                    long last_update=resultSet.getLong(6);
+                    if (last_update < getStalenessCutoff()) {
+                        Address addr=Util.addressFromString(uuid);
+                        delete(conn, getClusterName(), addr);
+                    }
+                }
+            }
+        }
+    }
+
+    private long getStalenessCutoff() {
+        return TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - stateless_timeout);
+    }
+
     public void setJpaConnectionProviderFactory(JpaConnectionProviderFactory factory) {
         this.factory = Objects.requireNonNull(factory);
     }
+
+    // Pick the largest partition first, then order by address to allow for a stable result
+    Comparator<PingData> SPLIT_BRAIN_DECIDER = Comparator
+            .<PingData, Integer>comparing(p -> p.mbrs() != null ? p.mbrs().size() : 0).reversed()
+            .thenComparing(PingData::getAddress);
 
     /**
      * Detects a network partition and decides if the node belongs to the winning partition.
@@ -74,12 +251,11 @@ public class KEYCLOAK_JDBC_PING2 extends JDBC_PING2 {
      */
     public HealthStatus healthStatus() {
         try {
-            // maybe create an index, and a query to return coordinators only?
             return readFromDB(cluster_name)
                     .stream()
                     .filter(PingData::isCoord)
+                    .sorted(SPLIT_BRAIN_DECIDER)
                     .map(PingData::getAddress)
-                    .sorted()
                     .findFirst()
                     .map(view.getCoord()::equals)
                     .map(isCoordinatorInView -> isCoordinatorInView ? HealthStatus.HEALTHY : HealthStatus.UNHEALTHY)

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -38,6 +37,7 @@ import javax.net.ssl.TrustManager;
 
 import org.keycloak.Config;
 import org.keycloak.common.util.Retry;
+import org.keycloak.common.util.Time;
 import org.keycloak.config.CachingOptions;
 import org.keycloak.config.Option;
 import org.keycloak.connections.infinispan.InfinispanConnectionSpi;
@@ -314,7 +314,7 @@ public final class JGroupsConfigurator {
                 s.setString(3, clusterName); // cluster name
                 s.setString(4, "127.0.0.1:0"); // ip = new IpAddress("localhost", 0).toString()
                 s.setBoolean(5, false); // coord
-                s.setLong(6, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())); // coord
+                s.setLong(6, Time.currentTime()); // last_update
                 s.execute();
             }
         });

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
@@ -307,12 +308,13 @@ public final class JGroupsConfigurator {
     private static Address insertSequenceInTable(JpaConnectionProvider cp, String clusterName, String tableName, long mySequence) {
         ExtendedUUID address = new ExtendedUUID(0, mySequence);
         cp.getEntityManager().<Connection>runWithConnection(con -> {
-            try (PreparedStatement s = con.prepareStatement("INSERT INTO %s values (?, ?, ?, ?, ?)".formatted(tableName))) {
+            try (PreparedStatement s = con.prepareStatement("INSERT INTO %s (address, name, cluster_name, ip, coord, last_update) values (?, ?, ?, ?, ?, ?)".formatted(tableName))) {
                 s.setString(1, org.jgroups.util.Util.addressToString(new UUID(address.getMostSignificantBits(), address.getLeastSignificantBits()))); // address
                 s.setString(2, "(starting)"); // name
                 s.setString(3, clusterName); // cluster name
                 s.setString(4, "127.0.0.1:0"); // ip = new IpAddress("localhost", 0).toString()
                 s.setBoolean(5, false); // coord
+                s.setLong(6, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())); // coord
                 s.execute();
             }
         });
@@ -329,8 +331,8 @@ public final class JGroupsConfigurator {
                     // "cluster" cannot be used with Oracle DB as it's a reserved word.
                     "clear_sql", String.format("DELETE from %s WHERE cluster_name=?", tableName),
                     "delete_single_sql", String.format("DELETE from %s WHERE address=?", tableName),
-                    "insert_single_sql", String.format("INSERT INTO %s values (?, ?, ?, ?, ?)", tableName),
-                    "select_all_pingdata_sql", String.format("SELECT address, name, ip, coord FROM %s WHERE cluster_name=?", tableName),
+                    "insert_single_sql", String.format("INSERT INTO %s (address, name, cluster_name, ip, coord, last_update, coordinated_by) values (?, ?, ?, ?, ?, ?, ?)", tableName),
+                    "select_all_pingdata_sql", String.format("SELECT address, name, ip, coord, coordinated_by, last_update FROM %s WHERE cluster_name=?", tableName),
                     // This guarantees cleanup of stale data
                     "remove_all_data_on_view_change", "true",
                     // This guarantees that merging happens even after the info writer completed

--- a/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/ControlledJdbcPing.java
+++ b/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/ControlledJdbcPing.java
@@ -17,11 +17,14 @@
 
 package org.keycloak.jgroups.protocol;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.jgroups.Address;
 import org.jgroups.View;
 import org.jgroups.protocols.PingData;
+import org.jgroups.util.UUID;
 
 /**
  * A controllable KEYCLOAK_JDBC_PING2 where we can overwrite the view, the data returned from the database, and simulate exceptions.
@@ -40,8 +43,27 @@ public class ControlledJdbcPing extends KEYCLOAK_JDBC_PING2 {
     }
 
     public void setPingData(List<Address> coordinators) {
+        setPingData(coordinators, Map.of());
+    }
+
+    public void setPingData(List<Address> coordinators, Map<Address, Integer> addressCount) {
         this.pingData = coordinators.stream()
-                .map(address -> new PingData(address, true).coord(true))
+                .flatMap(address -> {
+                    ArrayList<PingData> partition = new ArrayList<>();
+                    PingData coord = new PingData(address, true).coord(true);
+                    partition.add(coord);
+                    ArrayList<Address> members = new ArrayList<>();
+                    members.add(address);
+                    if (addressCount.containsKey(address)) {
+                        for (int i = 0; i < addressCount.get(address); i++) {
+                            UUID a = new UUID(UUID.randomUUID());
+                            partition.add(new PingData(a, true));
+                            members.add(a);
+                        }
+                    }
+                    coord.mbrs(members);
+                    return partition.stream();
+                })
                 .toList();
     }
 

--- a/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/JdbcPing2Test.java
+++ b/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/JdbcPing2Test.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -111,6 +112,13 @@ public class JdbcPing2Test {
         assertEquals(KEYCLOAK_JDBC_PING2.HealthStatus.UNHEALTHY, ping.healthStatus());
         clusterHealth.triggerClusterHealthCheck();
         assertFalse(clusterHealth.isHealthy());
+
+        // test more members in a partition win
+        // coordinator a[0] and a[1] in the table, and we belong to view with the coordinator a[1]
+        ping.setPingData(List.of(addresses[1], addresses[0]), Map.of(addresses[0], 1, addresses[1], 2));
+        assertEquals(KEYCLOAK_JDBC_PING2.HealthStatus.HEALTHY, ping.healthStatus());
+        clusterHealth.triggerClusterHealthCheck();
+        assertTrue(clusterHealth.isHealthy());
     }
 
     @SuppressWarnings("resource")

--- a/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/JdbcPing2Test.java
+++ b/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/JdbcPing2Test.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -189,7 +188,7 @@ public class JdbcPing2Test {
                     ps.setString(3, jdbcPing.getClusterName());
                     ps.setString(4, ip);
                     ps.setBoolean(5, data.isCoord());
-                    ps.setLong(6, TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis()));
+                    ps.setLong(6, Time.currentTime());
                     ps.setString(7, Util.addressToString(data.getAddress()));
                     ps.executeUpdate();
                 }
@@ -205,7 +204,7 @@ public class JdbcPing2Test {
                 jdbcPing.writeAll();
                 jdbcPing.findMembers(null, false, responses);
                 assertThat(responses.size(), CoreMatchers.equalTo(1));
-                // The entry is still in the database though as it will only be cleard on view change
+                // The entry is still in the database though as it will only be cleared on view change
                 try (PreparedStatement ps= con.prepareStatement(jdbcPing.getSelectAllPingdataSql())) {
                     ps.setString(1, jdbcPing.getClusterName());
                     try (ResultSet resultSet = ps.executeQuery()) {

--- a/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/JdbcPing2Test.java
+++ b/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/JdbcPing2Test.java
@@ -1,28 +1,41 @@
 package org.keycloak.jgroups.protocol;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.keycloak.common.util.Time;
 import org.keycloak.infinispan.health.impl.JdbcPingClusterHealthImpl;
 
+import org.hamcrest.CoreMatchers;
 import org.infinispan.util.concurrent.WithinThreadExecutor;
 import org.jboss.logging.Logger;
 import org.jgroups.Address;
 import org.jgroups.JChannel;
+import org.jgroups.PhysicalAddress;
 import org.jgroups.conf.ClassConfigurator;
+import org.jgroups.protocols.PingData;
+import org.jgroups.protocols.relay.SiteUUID;
+import org.jgroups.stack.IpAddress;
+import org.jgroups.util.NameCache;
+import org.jgroups.util.Responses;
 import org.jgroups.util.ThreadFactory;
 import org.jgroups.util.UUID;
 import org.jgroups.util.Util;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -153,6 +166,66 @@ public class JdbcPing2Test {
             Arrays.stream(channels).filter(ch -> ch.view().getCoord() != ch.getAddress()).forEach(JChannel::close);
             Arrays.stream(channels).filter(ch -> !ch.isClosed()).forEach(JChannel::close);
             log.infof("Closed");
+        }
+    }
+
+    @Test
+    public void testClearing() throws Exception {
+        JChannel channel = createChannel("0");
+        try (channel) {
+            channel.connect("ISPN");
+            KEYCLOAK_JDBC_PING2_FOR_TESTING jdbcPing = (KEYCLOAK_JDBC_PING2_FOR_TESTING) channel.getProtocolStack().getProtocols().stream().filter(protocol -> protocol instanceof KEYCLOAK_JDBC_PING2).findFirst().orElseThrow(() -> new RuntimeException("Didn't find JDBC_PING"));
+            try (Connection con = jdbcPing.getConnection()) {
+                // Insert an entry of a second coordinator
+                PingData data = new PingData(new UUID(), false, "old", new IpAddress("127.0.0.1:9999")).coord(true);
+                try (PreparedStatement ps = con.prepareStatement(jdbcPing.getInsertSingleSql())) {
+                    Address address = data.getAddress();
+                    String addr = Util.addressToString(address);
+                    String name = address instanceof SiteUUID ? ((SiteUUID) address).getName() : NameCache.get(address);
+                    PhysicalAddress ip_addr = data.getPhysicalAddr();
+                    String ip = ip_addr.toString();
+                    ps.setString(1, addr);
+                    ps.setString(2, name);
+                    ps.setString(3, jdbcPing.getClusterName());
+                    ps.setString(4, ip);
+                    ps.setBoolean(5, data.isCoord());
+                    ps.setLong(6, TimeUnit.MILLISECONDS.toSeconds(Time.currentTimeMillis()));
+                    ps.setString(7, Util.addressToString(data.getAddress()));
+                    ps.executeUpdate();
+                }
+
+                // See that the second coordinator is still there
+                Responses responses = new Responses(false);
+                jdbcPing.findMembers(null, false, responses);
+                assertThat(responses.size(), CoreMatchers.equalTo(2));
+
+                // Advance the time beyond the timeout. See the entry is not returned.
+                Time.setOffset(120);
+                responses.clear();
+                jdbcPing.writeAll();
+                jdbcPing.findMembers(null, false, responses);
+                assertThat(responses.size(), CoreMatchers.equalTo(1));
+                // The entry is still in the database though as it will only be cleard on view change
+                try (PreparedStatement ps= con.prepareStatement(jdbcPing.getSelectAllPingdataSql())) {
+                    ps.setString(1, jdbcPing.getClusterName());
+                    try (ResultSet resultSet = ps.executeQuery()) {
+                        resultSet.last();
+                        assertThat(resultSet.getRow(), CoreMatchers.equalTo(2));
+                    }
+                }
+
+                // Simulate a row change to trigger a cleanup of the table.
+                jdbcPing.handleView(jdbcPing.getTransport().view(), jdbcPing.getTransport().view(), true);
+                try (PreparedStatement ps= con.prepareStatement(jdbcPing.getSelectAllPingdataSql())) {
+                    ps.setString(1, jdbcPing.getClusterName());
+                    try (ResultSet resultSet = ps.executeQuery()) {
+                        resultSet.last();
+                        assertThat(resultSet.getRow(), CoreMatchers.equalTo(1));
+                    }
+                }
+            }
+        } finally {
+            Time.setOffset(0);
         }
     }
 

--- a/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2_FOR_TESTING.java
+++ b/model/infinispan/src/test/java/org/keycloak/jgroups/protocol/KEYCLOAK_JDBC_PING2_FOR_TESTING.java
@@ -34,4 +34,13 @@ public class KEYCLOAK_JDBC_PING2_FOR_TESTING extends KEYCLOAK_JDBC_PING2 {
             throw new RuntimeException(e);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     * Making public for testing.
+     */
+    @Override
+    public void writeAll() {
+        writeAll(null);
+    }
 }

--- a/model/infinispan/src/test/resources/jdbc-h2.xml
+++ b/model/infinispan/src/test/resources/jdbc-h2.xml
@@ -21,6 +21,9 @@
             register_shutdown_hook="true"
             return_entire_cache="false"
             write_data_on_find="true"
+            initialize_sql = "CREATE TABLE jgroups (address varchar(200) NOT NULL, name varchar(200), cluster varchar(200) NOT NULL, ip varchar(200) NOT NULL, coord boolean, last_update bigint, coordinated_by varchar(200), PRIMARY KEY (address) )"
+            insert_single_sql="INSERT INTO jgroups values (?, ?, ?, ?, ?, ?, ?)"
+            select_all_pingdata_sql="SELECT address, name, ip, coord, coordinated_by, last_update FROM jgroups WHERE cluster=?"
     />
     <!-- very aggressive merging to speed up the test -->
     <MERGE3 min_interval="2000"

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="26.6.0-jdbcping-timestamp">
+        <addColumn tableName="JGROUPS_PING">
+            <column name="LAST_UPDATE" type="BIGINT" />
+            <column name="COORDINATED_BY" type="VARCHAR(200)" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -17,7 +17,7 @@
   -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 
-    <changeSet author="keycloak" id="26.6.0-jdbcping-timestamp">
+    <changeSet author="keycloak" id="26.7.0-jdbcping-timestamp">
         <addColumn tableName="JGROUPS_PING">
             <column name="LAST_UPDATE" type="BIGINT" />
             <column name="COORDINATED_BY" type="VARCHAR(200)" />

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -91,5 +91,6 @@
     <include file="META-INF/jpa-changelog-26.4.0.xml"/>
     <include file="META-INF/jpa-changelog-26.5.0.xml"/>
     <include file="META-INF/jpa-changelog-26.6.0.xml"/>
+    <include file="META-INF/jpa-changelog-26.7.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This improves Keylcoak's behavior in two ways: 

* When one of the partitions dies, its entries will become stale, and will eventually be ignored and deleted
* When one of the partition changes, for example with a node joining or leaving, the view change will no longer review the entries of the other partition, thereby making the split brain detection more stable (where it would previously would detect it only after the other partition renewed their entries after 30-45 seconds)

Not covered here: 

* If a partition vanishes, and the other partition takes over, the caches of the remaining partition are not cleared. This might be tackled in a follow-up PR. 

Closes #47970

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
