### PR TITLE
Remove console.log from admin UI workflow test

### DIFF
--- a/js/apps/admin-ui/test/workflows/main.spec.ts
+++ b/js/apps/admin-ui/test/workflows/main.spec.ts
@@ -145,7 +145,6 @@ test.describe.serial("Workflow CRUD", () => {
   });
 
   test("should delete workflow from list", async ({ page }) => {
-    console.log("Deleting workflow:", complexWorkflowNameCopy);
     await assertRowExists(page, complexWorkflowNameCopy);
     await clickRowKebabItem(page, complexWorkflowNameCopy, "Delete");
     await confirmModal(page);


### PR DESCRIPTION
## Summary
- Removes a stray `console.log()` statement from the admin UI workflow Playwright test (`main.spec.ts`), which was logging workflow names to the console during test execution.

## Details
The `console.log("Deleting workflow:", complexWorkflowNameCopy)` on line 148 of `js/apps/admin-ui/test/workflows/main.spec.ts` was left from debugging and should not be present in test code. This was the only `console.log` in the entire admin UI test directory.

Closes #47958
