### PR TITLE
Skip no-op reorder in authentication flow drag-and-drop

### DIFF
--- a/js/apps/admin-ui/src/authentication/FlowDetails.tsx
+++ b/js/apps/admin-ui/src/authentication/FlowDetails.tsx
@@ -425,6 +425,10 @@ export default function FlowDetails() {
                 }}
                 onDrop={(source, dest) => {
                   if (dest) {
+                    if (source.index === dest.index) {
+                      return false;
+                    }
+
                     const dragged = executionList.findExecution(source.index)!;
                     const order = executionList.order().map((ex) => ex.id!);
                     setLiveText(


### PR DESCRIPTION
## Problem

When a user drags an authentication flow execution step and drops it back in its **original position** (no-op), the Admin UI still shows a "Flow successfully updated" success notification and triggers an unnecessary `refresh()` call. This is misleading because no change actually occurred.

## Root Cause

The `onDrop` handler in `FlowDetails.tsx` unconditionally calls `executeChange()` when a destination exists, even when `source.index === dest.index`. While `executeChange()` correctly runs 0 API calls in this case (the reorder loop runs `Math.abs(0)` times), it still executes `refresh()` and `addAlert(t("updateFlowSuccess"))` at the end.

## Fix

Added an early return in the `onDrop` handler: when `source.index === dest.index`, we return `false` immediately, skipping `executeChange()` entirely. This prevents both the unnecessary refresh and the false success notification.


Closes #47710
