### PR TITLE
Disable automatic redirect handling in te HTTP provider

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_1.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_1.adoc
@@ -1,0 +1,17 @@
+== Breaking changes
+
+Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
+In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
+
+=== Outgoing HTTP connections do not follow redirects
+
+Since this release, the HTTP connections originated from the {project_name} server do not follow redirects by default. The HTTP result will be the redirect status (`3xx`) code, and the `Location` header will not be automatically fetched. With this change, the server avoids retrieving unwanted redirects that can bypass allowed URLs defined by client policies or other future configurations.
+
+The new option `allow-redirects` (SPI `connections-http-client`, provider `default`) is available to revert to the previous behavior. This option is deprecated and will be removed in a future version.
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --spi-connections-http-client--default--allow-redirects true
+----
+
+See link:{server_guide_base_link}/outgoinghttp[Outgoing HTTP requests documentation] for more information.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -1,6 +1,10 @@
 [[migration-changes]]
 == Migration Changes
 
+=== Migrating to 26.6.1
+
+include::changes-26_6_1.adoc[leveloffset=2]
+
 === Migrating to 26.6.0
 
 include::changes-26_6_0.adoc[leveloffset=2]

--- a/docs/guides/server/outgoinghttp.adoc
+++ b/docs/guides/server/outgoinghttp.adoc
@@ -48,6 +48,7 @@ Enable or disable caching of cookies. Default: true.
 *allow-redirects*::
 Whether to allow following HTTP redirects. Default: false.
 This option is deprecated, only provided for backwards compatibility, and will be removed in a future release.
+It is recommended to be `false` to avoid redirects that could lead for example to server-side request forgery (SSRF).
 
 *client-keystore*::
 File path to a Java keystore file. This keystore contains client certificates for mTLS.

--- a/docs/guides/server/outgoinghttp.adoc
+++ b/docs/guides/server/outgoinghttp.adoc
@@ -45,6 +45,10 @@ Maximum time an idle connection stays in the connection pool, in milliseconds. I
 *disable-cookies*::
 Enable or disable caching of cookies. Default: true.
 
+*allow-redirects*::
+Whether to allow following HTTP redirects. Default: false.
+This option is deprecated, only provided for backwards compatibility, and will be removed in a future release.
+
 *client-keystore*::
 File path to a Java keystore file. This keystore contains client certificates for mTLS.
 

--- a/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/DefaultHttpClientFactory.java
@@ -66,6 +66,7 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
     private static final String HTTP_PROXY = "http_proxy";
     private static final String NO_PROXY = "no_proxy";
     public static final String MAX_CONSUMED_RESPONSE_SIZE = "max-consumed-response-size";
+    public static final String ALLOW_REDIRECTS = "allow-redirects";
 
     private volatile CloseableHttpClient httpClient;
     private Config.Scope config;
@@ -238,6 +239,10 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                     	builder.disableTrustManager();
                     }
 
+                    if (!config.getBoolean(ALLOW_REDIRECTS, false)) {
+                        builder.disableRedirectHandling();
+                    }
+
                     if (clientKeystore != null) {
                         clientKeystore = EnvUtil.replace(clientKeystore);
                         try {
@@ -408,6 +413,12 @@ public class DefaultHttpClientFactory implements HttpClientFactory {
                 .type("long")
                 .helpText("Maximum size of a response consumed by the client (to prevent denial of service)")
                 .defaultValue(HttpClientProvider.DEFAULT_MAX_CONSUMED_RESPONSE_SIZE)
+                .add()
+                .property()
+                .name(ALLOW_REDIRECTS)
+                .type("boolean")
+                .helpText("Whether to allow following HTTP redirects. Default: false. This option is deprecated, only provided for backwards compatibility, and will be removed in a future release.")
+                .defaultValue(false)
                 .add()
                 .property()
                 .name("max-retries")

--- a/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
+++ b/services/src/main/java/org/keycloak/connections/httpclient/HttpClientBuilder.java
@@ -188,6 +188,15 @@ public class HttpClientBuilder {
     }
 
     /**
+     * Disables automatic redirect handling.
+     * @return
+     */
+    public HttpClientBuilder disableRedirectHandling() {
+        apacheBuilder.disableRedirectHandling();
+        return this;
+    }
+
+    /**
      * Disable cookie management.
      */
     public HttpClientBuilder disableCookies(boolean disable) {

--- a/services/src/test/java/org/keycloak/connections/httpclient/DefaultHttpClientFactoryTest.java
+++ b/services/src/test/java/org/keycloak/connections/httpclient/DefaultHttpClientFactoryTest.java
@@ -18,8 +18,11 @@
 package org.keycloak.connections.httpclient;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -30,11 +33,18 @@ import org.keycloak.services.resteasy.ResteasyKeycloakSession;
 import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
 import org.keycloak.utils.ScopeUtil;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -44,9 +54,50 @@ public class DefaultHttpClientFactoryTest {
 	private static final String TEST_DOMAIN = "keycloak.org";
 	private static final String MAX_RETRIES_PROPERTY = "max-retries";
 
+        // HTTP server for tests
+        private static HttpServer server;
+
 	// Common objects for tests
 	private DefaultHttpClientFactory factory;
 	private KeycloakSession session;
+
+        private static class RedirectHandler implements HttpHandler {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                try (exchange) {
+                    exchange.getResponseHeaders().add("Location", "http://localhost:8280/hello");
+                    exchange.sendResponseHeaders(302, 0);
+                }
+            }
+        }
+
+        private static class HelloWorldHandler implements HttpHandler {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                try (exchange) {
+                    byte[] res = "Hello world!".getBytes(StandardCharsets.UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "text/plain;charset=utf-8");
+                    exchange.sendResponseHeaders(200, res.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(res);
+                    }
+                }
+            }
+        }
+
+        @BeforeClass
+        public static void startHttpServer() throws IOException {
+            server = HttpServer.create(new InetSocketAddress(8280), 0);
+            server.createContext("/redirect", new RedirectHandler());
+            server.createContext("/hello", new HelloWorldHandler());
+            server.setExecutor(null); // creates a default executor
+            server.start();
+        }
+
+        @AfterClass
+        public static void stopHttpServer() {
+            server.stop(0);
+        }
 
 	/**
 	 * Helper method to create and initialize factory with default settings
@@ -122,8 +173,37 @@ public class DefaultHttpClientFactoryTest {
 		CloseableHttpClient client = provider.getHttpClient();
 
 		// Verify client is not null
-		org.junit.Assert.assertNotNull("HTTP client should not be null", client);
+		Assert.assertNotNull("HTTP client should not be null", client);
 	}
+
+        @Test
+        public void testRedirectDefault() throws IOException {
+            HttpClientProvider provider = createDefaultProvider();
+
+            try (CloseableHttpClient httpClient = provider.getHttpClient()) {
+                try (CloseableHttpResponse res1 = httpClient.execute(new HttpGet("http://localhost:8280/redirect"))) {
+                    Assert.assertEquals(302, res1.getStatusLine().getStatusCode());
+                    Assert.assertEquals("http://localhost:8280/hello", res1.getHeaders("Location")[0].getValue());
+                    try (CloseableHttpResponse res2 = httpClient.execute(new HttpGet(res1.getHeaders("Location")[0].getValue()))) {
+                        Assert.assertEquals(200, res2.getStatusLine().getStatusCode());
+                        Assert.assertEquals("Hello world!", EntityUtils.toString(res2.getEntity(), StandardCharsets.UTF_8));
+                    }
+                }
+            }
+        }
+
+        @Test
+        public void testRedirectEnabled() throws IOException {
+            HttpClientProvider provider = createProviderWithProperties(
+                    Map.of(DefaultHttpClientFactory.ALLOW_REDIRECTS, Boolean.TRUE.toString()));
+
+            try (CloseableHttpClient httpClient = provider.getHttpClient()) {
+                try (CloseableHttpResponse res2 = httpClient.execute(new HttpGet("http://localhost:8280/redirect"))) {
+                    Assert.assertEquals(200, res2.getStatusLine().getStatusCode());
+                    Assert.assertEquals("Hello world!", EntityUtils.toString(res2.getEntity(), StandardCharsets.UTF_8));
+                }
+            }
+        }
 
 	private Optional<String> getTestURL() {
 		try {


### PR DESCRIPTION
Closes #47276

Adding an option to disable the redirects in the HTTP provider. The option defaults to true (disabled) as discussed. The PR adds the provider option and uses the apache client method `disableRedirectHandling` to control the behavior. We can do more complicated configurations if needed. But, for the moment, it's just what we discussed. No problems in tests and a breaking change note added in the upgrading guide.

@mposolda @ahus1 Take a look when you have time. Check if you think this is enough or you prefer a more complicated configuration.
