### PR TITLE
Client API v2 CLI client: make discriminator subcommand optional

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandBuilder.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandBuilder.java
@@ -44,8 +44,7 @@ class KcAdmV2CommandBuilder {
     }
 
     private static CommandLine buildSubcommand(CommandDescriptor cmd) {
-        List<VariantDescriptor> variants = cmd.getVariants();
-        if (variants != null && !variants.isEmpty()) {
+        if (cmd.hasVariants()) {
             return buildVariantParentCommand(cmd);
         }
 
@@ -53,14 +52,7 @@ class KcAdmV2CommandBuilder {
     }
 
     private static CommandLine buildVariantParentCommand(CommandDescriptor cmd) {
-        GroupCommand groupCommand = new GroupCommand(cmd.getName());
-        CommandSpec parentSpec = CommandSpec.wrapWithoutInspection(groupCommand);
-        parentSpec.name(cmd.getName());
-        parentSpec.usageMessage().description(cmd.getDescription());
-        addHelpOption(parentSpec);
-
-        CommandLine parentCli = new CommandLine(parentSpec);
-        groupCommand.setSpec(parentSpec);
+        CommandLine parentCli = buildLeafCommand(cmd, null, null);
 
         for (VariantDescriptor variant : cmd.getVariants()) {
             parentCli.addSubcommand(variant.getName(),
@@ -72,6 +64,8 @@ class KcAdmV2CommandBuilder {
 
     private static CommandLine buildLeafCommand(CommandDescriptor cmd,
             List<OptionDescriptor> options, VariantDescriptor variant) {
+        boolean isVariantParent = variant == null && cmd.hasVariants();
+
         KcAdmV2RequestExecutor executor = new KcAdmV2RequestExecutor(cmd, variant);
         CommandSpec spec = CommandSpec.forAnnotatedObject(executor);
         spec.name(variant != null ? variant.getName() : cmd.getName());
@@ -87,7 +81,7 @@ class KcAdmV2CommandBuilder {
             addOutputGroup(spec);
         }
 
-        if (cmd.isRequiresId()) {
+        if (!isVariantParent && cmd.isRequiresId()) {
             spec.addPositional(PositionalParamSpec.builder()
                     .index("0")
                     .paramLabel("<id>")
@@ -97,21 +91,20 @@ class KcAdmV2CommandBuilder {
                     .build());
         }
 
-        if (options != null && !options.isEmpty()) {
+        boolean hasFieldOptions = options != null && !options.isEmpty();
+        if (hasFieldOptions || isVariantParent) {
             ArgGroupSpec.Builder fieldGroup = ArgGroupSpec.builder()
                     .heading("%nOptions:%n")
                     .exclusive(false)
                     .validate(false)
                     .order(1);
 
-            fieldGroup.addArg(OptionSpec.builder(OPT_FILE, "--file")
-                    .type(String.class)
-                    .paramLabel("<file>")
-                    .description("JSON file with request body (mutually exclusive with field options)")
-                    .build());
+            fieldGroup.addArg(buildFileOption(hasFieldOptions));
 
-            for (OptionDescriptor opt : options) {
-                fieldGroup.addArg(buildOption(opt));
+            if (hasFieldOptions) {
+                for (OptionDescriptor opt : options) {
+                    fieldGroup.addArg(buildOption(opt));
+                }
             }
 
             spec.addArgGroup(fieldGroup.build());
@@ -141,6 +134,17 @@ class KcAdmV2CommandBuilder {
         }
 
         return builder.build();
+    }
+
+    private static OptionSpec buildFileOption(boolean hasFieldOptions) {
+        String description = hasFieldOptions
+                ? "JSON file with request body (mutually exclusive with field options)"
+                : "JSON file with request body";
+        return OptionSpec.builder(OPT_FILE, "--file")
+                .type(String.class)
+                .paramLabel("<file>")
+                .description(description)
+                .build();
     }
 
     private static void addOutputGroup(CommandSpec spec) {

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandDescriptor.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandDescriptor.java
@@ -128,6 +128,10 @@ public class KcAdmV2CommandDescriptor {
             return variants;
         }
 
+        public boolean hasVariants() {
+            return variants != null && !variants.isEmpty();
+        }
+
         public void setVariants(List<VariantDescriptor> variants) {
             this.variants = variants;
         }

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2RequestExecutor.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2RequestExecutor.java
@@ -49,6 +49,12 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
     static final String API_VERSION = "v2";
     static final String DEFAULT_REALM = "master";
 
+    // Maps resource name to the JSON field that holds its ID, used to extract
+    // the path parameter from --file content when no positional <id> is given
+    private static final Map<String, String> RESOURCE_ID_FIELDS = Map.of(
+            "client", "clientId"
+    );
+
     @Spec CommandSpec spec;
     private final CommandDescriptor descriptor;
     private final VariantDescriptor variant;
@@ -57,6 +63,10 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
         super();
         this.descriptor = descriptor;
         this.variant = variant;
+    }
+
+    private boolean isVariantParent() {
+        return variant == null && descriptor.hasVariants();
     }
 
     @Override
@@ -145,8 +155,12 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
             }
             configData.setRealm(requestRealm);
 
-            String url = buildUrl(configData);
             String body = buildRequestBody();
+            if (body == null && isVariantParent()) {
+                throw new RuntimeException(
+                        "No file specified. Use -f/--file to provide a request body.");
+            }
+            String url = buildUrl(configData, body);
 
             Headers headers = new Headers();
             if (token != null) {
@@ -184,25 +198,45 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
         }
     }
 
-    private String buildUrl(ConfigData configData) {
+    private String buildUrl(ConfigData configData, String body) {
         String path = descriptor.getPath()
                 .replace("{realmName}", HttpUtil.urlencode(configData.getRealm()))
                 .replace("{version}", API_VERSION);
 
         if (descriptor.isRequiresId()) {
             var positional = spec.commandLine().getParseResult().matchedPositional(0);
-            if (positional == null) {
-                throw new RuntimeException("Missing required ID argument");
+            final String id;
+            if (positional != null) {
+                id = positional.getValue();
+            } else {
+                id = extractIdFromBody(body);
             }
-            path = path.replace(KcAdmV2DescriptorBuilder.ID_PATH_PARAM, HttpUtil.urlencode(positional.getValue()));
+            path = path.replace(KcAdmV2DescriptorBuilder.ID_PATH_PARAM, HttpUtil.urlencode(id));
         }
 
         return configData.getServerUrl() + path;
     }
 
+    private String extractIdFromBody(String body) {
+        String idField = RESOURCE_ID_FIELDS.get(descriptor.getResourceName());
+        if (idField == null) {
+            throw new RuntimeException("Cannot extract '" + descriptor.getResourceName()
+                    + "' resource ID from file. Use a subcommand that accepts <id> instead.");
+        }
+        try {
+            JsonNode node = JsonSerialization.readValue(body, JsonNode.class);
+            JsonNode idNode = node.get(idField);
+            if (idNode == null || idNode.isNull() || idNode.asText().isBlank()) {
+                throw new RuntimeException("File does not contain required '" + idField + "' field");
+            }
+            return idNode.asText();
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot parse JSON to extract ID: " + e.getMessage(), e);
+        }
+    }
+
     private String buildRequestBody() throws IOException {
-        String file = spec.commandLine().getParseResult()
-                .matchedOptionValue(KcAdmV2CommandBuilder.OPT_FILE, null);
+        String file = resolveFileOption();
 
         List<OptionDescriptor> options = variant != null
                 ? variant.getOptions() : descriptor.getOptions();
@@ -273,6 +307,20 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
             }
         }
         return false;
+    }
+
+    private String resolveFileOption() {
+        String file = spec.commandLine().getParseResult().matchedOptionValue(KcAdmV2CommandBuilder.OPT_FILE, null);
+        CommandLine parent = spec.commandLine().getParent();
+        String parentFile = parent != null
+                ? parent.getParseResult().matchedOptionValue(KcAdmV2CommandBuilder.OPT_FILE, null)
+                : null;
+
+        if (file != null && parentFile != null) {
+            throw new RuntimeException(
+                    "Option -f/--file specified twice. Use it either before or after the subcommand, not both.");
+        }
+        return file != null ? file : parentFile;
     }
 
     private String formatOutput(String json) {

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2CompleterTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2CompleterTest.java
@@ -113,6 +113,19 @@ public class KcAdmV2CompleterTest {
     }
 
     @Test
+    public void testFileOptionInAutocompleteForCreateParent() {
+        List<String> candidates = complete("client", "create", "-");
+        assertTrue("Should suggest '-f' at parent level", candidates.contains("-f"));
+    }
+
+    @Test
+    public void testFieldOptionsNotInAutocompleteForCreateParent() {
+        List<String> candidates = complete("client", "create", "--");
+        assertFalse("Should not suggest '--client-id' at parent level", candidates.contains("--client-id"));
+        assertFalse("Should not suggest '--login-flows' at parent level", candidates.contains("--login-flows"));
+    }
+
+    @Test
     public void testFileOptionNotInAutocompleteForList() {
         List<String> candidates = complete("client", "list", "-");
         assertFalse("list should not suggest '-f'", candidates.contains("-f"));

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2HelpTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2HelpTest.java
@@ -321,6 +321,44 @@ public class KcAdmV2HelpTest {
     }
 
     @Test
+    public void testVariantParentShowsFileOptionForCreate() {
+        String help = getVariantParentHelp("create");
+        assertTrue("create parent should show -f option: " + help, help.contains("-f"));
+        assertTrue("create parent should show --file option: " + help, help.contains("--file"));
+    }
+
+    @Test
+    public void testVariantParentShowsFileOptionForUpdate() {
+        String help = getVariantParentHelp("update");
+        assertTrue("update parent should show -f option: " + help, help.contains("-f"));
+        assertTrue("update parent should show --file option: " + help, help.contains("--file"));
+        assertFalse("update parent should not show <id>: " + help, help.contains("<id>"));
+    }
+
+    @Test
+    public void testVariantParentShowsFileOptionForPatch() {
+        String help = getVariantParentHelp("patch");
+        assertTrue("patch parent should show -f option: " + help, help.contains("-f"));
+        assertTrue("patch parent should show --file option: " + help, help.contains("--file"));
+        assertFalse("patch parent should not show <id>: " + help, help.contains("<id>"));
+    }
+
+    @Test
+    public void testVariantParentDoesNotShowFieldOptions() {
+        String help = getVariantParentHelp("create");
+        assertFalse("create parent should not show --client-id: " + help, help.contains("--client-id"));
+        assertFalse("create parent should not show --login-flows: " + help, help.contains("--login-flows"));
+        assertFalse("create parent should not show --sign-documents: " + help, help.contains("--sign-documents"));
+    }
+
+    @Test
+    public void testVariantParentShowsConnectionOptions() {
+        String help = getVariantParentHelp("create");
+        assertTrue("create parent should show --config: " + help, help.contains("--config"));
+        assertTrue("create parent should show --server: " + help, help.contains("--server"));
+    }
+
+    @Test
     public void testHelpFlagOnVariantParent() {
         CommandLine cli = createCli();
         StringWriter out = new StringWriter();
@@ -413,6 +451,16 @@ public class KcAdmV2HelpTest {
                 .getSubcommands().get("credentials").getCommand()).help();
         assertTrue("should show --openapi-url option: " + help, help.contains("--openapi-url"));
         assertTrue("should show --v2 in command: " + help, help.contains("--v2"));
+    }
+
+    private String getVariantParentHelp(String command) {
+        CommandLine cli = createCli();
+        StringWriter out = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(new StringWriter()));
+        int exitCode = cli.execute("client", command, "--help");
+        assertEquals("--help should exit with 0", 0, exitCode);
+        return out.toString();
     }
 
     private String getVariantHelp(String command, String variant) {

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2ClientCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2ClientCLITest.java
@@ -602,6 +602,189 @@ public class KcAdmV2ClientCLITest extends AbstractKcAdmV2CLITest {
                 result.err(), containsString("config openapi"));
     }
 
+    @Test
+    void testClientCreateOidcFromFile() throws Exception {
+        Path jsonFile = new File(tempDir, "create-from-file-oidc.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "file-no-disc", "protocol": "openid-connect", "enabled": true}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "create", "--file", jsonFile.toString());
+        assertThat("'client create --file' should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("file-no-disc"));
+
+        String id = extractId(result);
+        CommandResult getResult = kcAdmV2Cmd("client", "get", id);
+        assertThat("get should succeed", getResult.exitCode(), is(0));
+        assertThat(getResult.out(), containsString("file-no-disc"));
+    }
+
+    @Test
+    void testClientCreateSamlFromFile() throws Exception {
+        Path jsonFile = new File(tempDir, "create-from-file-saml.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "saml-no-disc", "protocol": "saml", "enabled": true}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "create", "-f", jsonFile.toString());
+        assertThat("'client create -f' for SAML should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("saml-no-disc"));
+
+        String id = extractId(result);
+        CommandResult getResult = kcAdmV2Cmd("client", "get", id);
+        assertThat("get should succeed", getResult.exitCode(), is(0));
+        assertThat(getResult.out(), containsString("saml-no-disc"));
+    }
+
+    @Test
+    void testClientUpdateFromFile() throws Exception {
+        CommandResult createResult = kcAdmV2Cmd("client", "create", "oidc",
+                "--client-id", "update-no-disc", "--enabled", "true");
+        assertThat("setup: create should succeed", createResult.exitCode(), is(0));
+
+        Path jsonFile = new File(tempDir, "update-from-file.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "update-no-disc", "protocol": "openid-connect", "enabled": false}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "update", "-f", jsonFile.toString());
+        assertThat("'client update -f' should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("\"enabled\" : false"));
+    }
+
+    @Test
+    void testClientPatchFromFile() throws Exception {
+        CommandResult createResult = kcAdmV2Cmd("client", "create", "oidc",
+                "--client-id", "patch-no-disc", "--enabled", "true");
+        assertThat("setup: create should succeed", createResult.exitCode(), is(0));
+        String id = extractId(createResult);
+
+        Path jsonFile = new File(tempDir, "patch-from-file.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "%s", "enabled": false}
+                """.formatted(id));
+
+        CommandResult result = kcAdmV2Cmd("client", "patch", "-f", jsonFile.toString());
+        assertThat("'client patch -f' should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("\"enabled\" : false"));
+    }
+
+    @Test
+    void testClientCreateWithoutFileOrSubcommandFails() {
+        CommandResult result = kcAdmV2Cmd("client", "create");
+        assertThat("'client create' without file or subcommand should fail", result.exitCode(), is(not(0)));
+        assertThat("should tell user to provide a file: " + result.err(), result.err(), containsString("-f/--file"));
+    }
+
+    @Test
+    void testClientCreateFileNotFound() {
+        CommandResult result = kcAdmV2Cmd("client", "create", "-f", "/nonexistent/file.json");
+        assertThat("should fail for non-existent file", result.exitCode(), is(not(0)));
+        assertThat(result.err(), containsString("not found"));
+    }
+
+    @Test
+    void testClientPatchFromFileMissingClientId() throws Exception {
+        Path jsonFile = new File(tempDir, "patch-no-id.json").toPath();
+        Files.writeString(jsonFile, """
+                {"enabled": false}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "patch", "-f", jsonFile.toString());
+        assertThat("'client patch -f' without clientId in file should fail", result.exitCode(), is(not(0)));
+        assertThat("should report the missing field", result.err(), containsString("does not contain required"));
+        assertThat("should name the expected field", result.err(), containsString("clientId"));
+    }
+
+    @Test
+    void testClientPatchFromFileBlankClientId() throws Exception {
+        Path jsonFile = new File(tempDir, "patch-blank-id.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "", "enabled": false}
+                """);
+
+        CommandResult result = kcAdmV2Cmd("client", "patch", "-f", jsonFile.toString());
+        assertThat("'client patch -f' with blank clientId should fail, err: " + result.err(), result.exitCode(), is(not(0)));
+        assertThat("should report the missing field, err: " + result.err(), result.err(),
+                containsString("does not contain required"));
+        assertThat("should name the expected field, err: " + result.err(), result.err(), containsString("clientId"));
+    }
+
+    @Test
+    void testClientPatchFromFileMalformedJson() throws Exception {
+        Path jsonFile = new File(tempDir, "patch-bad.json").toPath();
+        Files.writeString(jsonFile, "{ not valid json }");
+
+        CommandResult result = kcAdmV2Cmd("client", "patch", "-f", jsonFile.toString());
+        assertThat("'client patch -f' with malformed JSON should fail, err: " + result.err(),
+                result.exitCode(), is(not(0)));
+        assertThat("should report local JSON parsing failure from ID extraction, err: " + result.err(),
+                result.err(), containsString("Cannot parse JSON to extract ID"));
+    }
+
+    @Test
+    void testClientCreateFromFileBeforeSubcommand() throws Exception {
+        Path jsonFile = new File(tempDir, "create-before-sub.json").toPath();
+        Files.writeString(jsonFile, """
+                {"clientId": "create-before-sub", "protocol": "openid-connect", "enabled": true}
+                """);
+
+        // -f before the variant subcommand: parent consumes -f, leaf must pick it up
+        CommandResult result = kcAdmV2Cmd("client", "create", "-f", jsonFile.toString(), "oidc");
+        assertThat("-f before subcommand should not be silently ignored, err: " + result.err()
+                        + ", out: " + result.out(),
+                result.exitCode(), is(0));
+        assertThat("file content should be used as request body, out: " + result.out(),
+                result.out(), containsString("create-before-sub"));
+    }
+
+    @Test
+    void testClientPatchFromFileBeforeSubcommand() throws Exception {
+        CommandResult createResult = kcAdmV2Cmd("client", "create", "saml",
+                "--client-id", "patch-before-sub", "--enabled", "true");
+        assertThat("setup: create should succeed", createResult.exitCode(), is(0));
+        String id = extractId(createResult);
+
+        Path jsonFile = new File(tempDir, "patch-before-sub.json").toPath();
+        Files.writeString(jsonFile, """
+                {"enabled": false}
+                """);
+
+        // -f before the variant subcommand: parent consumes -f, leaf must pick it up
+        CommandResult result = kcAdmV2Cmd("client", "patch", "-f", jsonFile.toString(),
+                "saml", id);
+        assertThat("-f before subcommand should not be silently ignored, err: " + result.err()
+                        + ", out: " + result.out(),
+                result.exitCode(), is(0));
+        assertThat("file content should be applied as patch body, out: " + result.out(),
+                result.out(), containsString("\"enabled\" : false"));
+    }
+
+    @Test
+    void testFileBeforeSubcommandAndFieldOptionsMutuallyExclusive() {
+        // -f on parent + field options on leaf should still be rejected as mutually exclusive
+        // no real file needed — mutual exclusivity check fires before file access
+        CommandResult result = kcAdmV2Cmd("client", "update", "-f", "/any/path.json",
+                "oidc", "exclusive-test", "--client-id", "exclusive-test");
+        assertThat("-f before subcommand with field options should fail, err: " + result.err()
+                        + ", out: " + result.out(),
+                result.exitCode(), is(not(0)));
+        assertThat("should report mutual exclusivity, err: " + result.err(),
+                result.err(), containsString("mutually exclusive"));
+    }
+
+    @Test
+    void testFileSpecifiedOnBothParentAndSubcommandFails() {
+        // no real files needed — duplicate check fires before file access
+        CommandResult result = kcAdmV2Cmd("client", "create",
+                "-f", "/first.json", "oidc", "-f", "/second.json");
+        assertThat("-f on both parent and subcommand should fail, err: " + result.err()
+                        + ", out: " + result.out(),
+                result.exitCode(), is(not(0)));
+        assertThat("should report duplicate -f, err: " + result.err(),
+                result.err(), containsString("-f/--file"));
+    }
+
     private String createClientWithAllParams(String clientId) {
         CommandResult result = kcAdmV2Cmd("client", "create", "oidc",
                 "--client-id", clientId,


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/47463

Before this PR, when creating / updating / patching clients you had to specify protocol discriminator to distinguish between `openid-connect` and `saml` client protocols. However that is not aligned with what we do for `list` or `get` commands where you could omit the discriminator sub-command like this:

```bash
kcadm.sh client list
```

For that reason, we now allow to omit the discriminator when you create / update / patch the client from a file like this:

```bash
kcadm.sh client patch -f my-patch.json
kcadm.sh client update -f my-update.json
kcadm.sh client create -f my-create.json
```

However, I did not allow to do this without file (e.g. `kcadm.sh client create --client-id test-client`) because we would hit potential name conflicts specific for OIDC / SAML and we would also allow users to mix combinations that are not allowed (like options only specific to OIDC and options only specific to SAML). It would be confusing, if users will require it, we can follow-up in the future.