### PR TITLE
fix: reviewed hidden options for what can be removed

### DIFF
--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -149,10 +149,6 @@ public class DatabaseOptions {
             .description("The type of the truststore file. Common values include 'JKS' (Java KeyStore) and 'PKCS12'. If not specified, it uses the driver's default.")
             .build();
 
-    public static final Option<String> DB_ORACLE_TLS_TRANSPORT = new OptionBuilder<>("db-oracle-protocol", String.class)
-            .hidden()
-            .build();
-
     public static final class Datasources {
         /**
          * Options that have their sibling for a named datasource
@@ -179,8 +175,7 @@ public class DatabaseOptions {
                 DB_TLS_MODE,
                 DB_TLS_TRUST_STORE_FILE,
                 DB_TLS_TRUST_STORE_PASSWORD,
-                DB_TLS_TRUST_STORE_TYPE,
-                DB_ORACLE_TLS_TRANSPORT
+                DB_TLS_TRUST_STORE_TYPE
         ).map(Option::getKey).toList();
 
         /**

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -118,12 +118,6 @@ public class DatabaseOptions {
             .description("If the named datasource <datasource> should be enabled at runtime.")
             .build();
 
-    public static final Option<String> DB_POSTGRESQL_TARGET_SERVER_TYPE = new OptionBuilder<>("db-postgres-target-server-type", String.class)
-            .category(OptionCategory.DATABASE)
-            .defaultValue("primary") // cause the propertymapping logic to always advertise this property
-            .hidden()
-            .build();
-
     public static final Option<String> DB_CONNECT_TIMEOUT = new OptionBuilder<>("db-connect-timeout", String.class)
             .category(OptionCategory.DATABASE)
             .description("Sets the JDBC driver connection timeout and login timeout. " + DURATION_DESCRIPTION)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/LoggingOptions.java
@@ -151,7 +151,7 @@ public class LoggingOptions {
 
     public static final Option<Boolean> LOG_CONSOLE_ENABLED = new OptionBuilder<>("log-console-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
-            .hidden()
+            .synthetic()
             .build();
 
     // Console Async
@@ -170,7 +170,7 @@ public class LoggingOptions {
     // File
     public static final Option<Boolean> LOG_FILE_ENABLED = new OptionBuilder<>("log-file-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
-            .hidden()
+            .synthetic()
             .build();
 
     public static final Option<File> LOG_FILE = new OptionBuilder<>("log-file", File.class)
@@ -266,7 +266,7 @@ public class LoggingOptions {
     // Syslog
     public static final Option<Boolean> LOG_SYSLOG_ENABLED = new OptionBuilder<>("log-syslog-enabled", Boolean.class)
             .category(OptionCategory.LOGGING)
-            .hidden()
+            .synthetic()
             .build();
 
     public static final Option<String> LOG_SYSLOG_ENDPOINT = new OptionBuilder<>("log-syslog-endpoint", String.class)

--- a/quarkus/config-api/src/main/java/org/keycloak/config/ProxyOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/ProxyOptions.java
@@ -20,32 +20,6 @@ public class ProxyOptions {
             .defaultValue(Boolean.FALSE)
             .build();
 
-    public static final Option<Boolean> PROXY_FORWARDED_HOST = new OptionBuilder<>("proxy-forwarded-host", Boolean.class)
-            .category(OptionCategory.PROXY)
-            .defaultValue(Boolean.FALSE)
-            .build();
-
-    public static final Option<Boolean> PROXY_FORWARDED_HEADER_ENABLED = new OptionBuilder<>("proxy-allow-forwarded-header", Boolean.class)
-            .category(OptionCategory.PROXY)
-            .defaultValue(Boolean.FALSE)
-            .build();
-
-    public static final Option<Boolean> PROXY_X_FORWARDED_HEADER_ENABLED = new OptionBuilder<>("proxy-allow-x-forwarded-header", Boolean.class)
-            .category(OptionCategory.PROXY)
-            .defaultValue(Boolean.FALSE)
-            .build();
-
-    public static final Option<Boolean> PROXY_X_FORWARDED_PREFIX_HEADER_ENABLED = new OptionBuilder<>("proxy-allow-x-forwarded-prefix-header", Boolean.class)
-            .category(OptionCategory.PROXY)
-            .defaultValue(Boolean.FALSE)
-            .build();
-
-    public static final Option<Boolean> PROXY_TRUSTED_HEADER_ENABLED = new OptionBuilder<>("proxy-trusted-header-enabled", Boolean.class)
-            .category(OptionCategory.PROXY)
-            .defaultValue(Boolean.FALSE)
-            .hidden()
-            .build();
-
     public static final Option<List<String>> PROXY_TRUSTED_ADDRESSES = OptionBuilder.listOptionBuilder("proxy-trusted-addresses", String.class)
             .category(OptionCategory.PROXY)
             .description("A comma separated list of trusted proxy addresses. If set, then proxy headers from other addresses will be ignored. By default all addresses are trusted. A trusted proxy address is specified as an IP address (IPv4 or IPv6) or Classless Inter-Domain Routing (CIDR) notation.")

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
@@ -4,12 +4,6 @@ import java.util.List;
 
 public class TelemetryOptions {
 
-    public static final Option<Boolean> TELEMETRY_ENABLED = new OptionBuilder<>("telemetry-enabled", Boolean.class)
-            .category(OptionCategory.TELEMETRY)
-            .buildTime(true)
-            .hidden()
-            .build();
-
     public static final Option<String> TELEMETRY_ENDPOINT = new OptionBuilder<>("telemetry-endpoint", String.class)
             .category(OptionCategory.TELEMETRY)
             .description("OpenTelemetry endpoint to connect to.")

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
@@ -67,7 +67,6 @@ public class TelemetryOptions {
     public static final Option<List<String>> TELEMETRY_LOGS_HEADERS = OptionBuilder.listOptionBuilder("telemetry-logs-headers", String.class)
             .category(OptionCategory.TELEMETRY)
             .synthetic()
-            .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'telemetry-logs-header-<header>' options.")
             .build();
 
     // Telemetry Metrics
@@ -103,6 +102,5 @@ public class TelemetryOptions {
     public static final Option<List<String>> TELEMETRY_METRICS_HEADERS = OptionBuilder.listOptionBuilder("telemetry-metrics-headers", String.class)
             .category(OptionCategory.TELEMETRY)
             .synthetic()
-            .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'telemetry-metrics-header-<header>' options.")
             .build();
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TelemetryOptions.java
@@ -66,7 +66,7 @@ public class TelemetryOptions {
 
     public static final Option<List<String>> TELEMETRY_LOGS_HEADERS = OptionBuilder.listOptionBuilder("telemetry-logs-headers", String.class)
             .category(OptionCategory.TELEMETRY)
-            .hidden()
+            .synthetic()
             .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'telemetry-logs-header-<header>' options.")
             .build();
 
@@ -102,7 +102,7 @@ public class TelemetryOptions {
 
     public static final Option<List<String>> TELEMETRY_METRICS_HEADERS = OptionBuilder.listOptionBuilder("telemetry-metrics-headers", String.class)
             .category(OptionCategory.TELEMETRY)
-            .hidden()
+            .synthetic()
             .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'telemetry-metrics-header-<header>' options.")
             .build();
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TracingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TracingOptions.java
@@ -113,7 +113,6 @@ public class TracingOptions {
     public static final Option<List<String>> TRACING_HEADERS = OptionBuilder.listOptionBuilder("tracing-headers", String.class)
             .category(OptionCategory.TRACING)
             .synthetic()
-            .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'tracing-header-<header>' options.")
             .build();
 
 }

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TracingOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TracingOptions.java
@@ -112,7 +112,7 @@ public class TracingOptions {
 
     public static final Option<List<String>> TRACING_HEADERS = OptionBuilder.listOptionBuilder("tracing-headers", String.class)
             .category(OptionCategory.TRACING)
-            .hidden()
+            .synthetic()
             .description("Hidden option for OpenTelemetry headers that will be part of the exporter request. Values in format 'key1=val1,key2=val2'. Overrides the 'tracing-header-<header>' options.")
             .build();
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/TransactionOptions.java
@@ -35,13 +35,6 @@ public class TransactionOptions {
             .defaultValue(MIGRATION_TRANSACTION_TIMEOUT)
             .build();
 
-    public static final Option<String> DB_LOCK_TIMEOUT = new OptionBuilder<>("transaction-db-lock-timeout", String.class)
-            .category(OptionCategory.TRANSACTION)
-            .description("Hidden option to map transaction-setup-timeout to db lock timeout.")
-            .buildTime(false)
-            .hidden()
-            .build();
-
     public static String getNamedTxXADatasource(String namedProperty) {
         if ("<default>".equals(namedProperty)) {
             return TRANSACTION_XA_ENABLED.getKey();

--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -37,7 +37,7 @@ import static java.util.Arrays.asList;
 
 public final class Database {
     
-    public static String ORACLE_URL_PREFIX = "jdbc:oracle:thin:@";
+    public final static String ORACLE_URL_PREFIX = "jdbc:oracle:thin:@";
 
     private static final Map<String, Vendor> DATABASES = new HashMap<>();
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/database/Database.java
@@ -36,6 +36,8 @@ import io.quarkus.runtime.util.StringUtil;
 import static java.util.Arrays.asList;
 
 public final class Database {
+    
+    public static String ORACLE_URL_PREFIX = "jdbc:oracle:thin:@";
 
     private static final Map<String, Vendor> DATABASES = new HashMap<>();
 
@@ -210,8 +212,7 @@ public final class Database {
                 "oracle.jdbc.driver.OracleDriver",
                 "org.hibernate.dialect.OracleDialect",
                 // default URL looks like this: "jdbc:oracle:thin:@//${kc.db-url-host:localhost}:${kc.db-url-port:1521}/${kc.db-url-database:keycloak}"
-                (namedProperty, alias) -> "jdbc:oracle:thin:%s//%s:%s/%s".formatted(
-                        getProperty(DatabaseOptions.DB_ORACLE_TLS_TRANSPORT, namedProperty, "@"),
+                (namedProperty, alias) -> ORACLE_URL_PREFIX + "//%s:%s/%s".formatted(
                         getProperty(DatabaseOptions.DB_URL_HOST, namedProperty, "localhost"),
                         getProperty(DatabaseOptions.DB_URL_PORT, namedProperty, "1521"),
                         getProperty(DatabaseOptions.DB_URL_DATABASE, namedProperty, "keycloak")),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/ShortErrorMessageHandler.java
@@ -40,7 +40,7 @@ public class ShortErrorMessageHandler implements IParameterExceptionHandler {
 
             final BooleanSupplier isUnknownOption = () -> mapper == null || !(cmd.getCommand() instanceof AbstractCommand);
 
-            if (mapper == null && disabled.isPresent()) {
+            if (mapper == null && disabled.filter(m -> !m.getOption().isHidden()).isPresent()) {
                 var enabledWhen = disabled
                         .flatMap(PropertyMapper::getEnabledWhen)
                         .map(desc -> format(". %s", desc))

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -220,7 +220,7 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
         // finally add mappers that aren't intended to work with other datasources
         // - also this usage of isEnabled won't work correctly with wildcard mappers
         result.addAll(List.of(
-                fromOption(DatabaseOptions.DB_POSTGRESQL_TARGET_SERVER_TYPE)
+                fromOption(SYNTHETIC_RUNTIME_DB_OPTION).mapFrom(DB, (name, value, context) -> "primary")
                         .to(PG_TARGET_SERVER_TYPE)
                         .isEnabled(DatabasePropertyMappers::isPostgresqlTargetServerTypeEnabled)
                         .build(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -32,7 +32,6 @@ import io.smallrye.config.ConfigValue;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.config.DatabaseOptions.DB;
-import static org.keycloak.config.DatabaseOptions.DB_ORACLE_TLS_TRANSPORT;
 import static org.keycloak.config.DatabaseOptions.DB_POOL_INITIAL_SIZE;
 import static org.keycloak.config.DatabaseOptions.DB_POOL_MAX_SIZE;
 import static org.keycloak.config.DatabaseOptions.DB_TLS_MODE;
@@ -163,8 +162,6 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 // Database TLS configuration
                 fromOption(DB_TLS_MODE)
                         .paramLabel("mode")
-                        .transformer(DatabasePropertyMappers::transformOracleProtocol)
-                        .to(NS_KEYCLOAK_PREFIX + DB_ORACLE_TLS_TRANSPORT.getKey())
                         .build(),
                 fromOption(DB_TLS_TRUST_STORE_FILE)
                         .paramLabel("path")
@@ -381,6 +378,11 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                 url += urlProps;
             }
             url = amendH2(url);
+        } else if (Database.getVendor(value).filter(Vendor.ORACLE::equals).isPresent()) {
+            var tlsMode = getDatabaseTlsMode(name);
+            if (tlsMode != DatabaseOptions.DatabaseTlsMode.DISABLED) {
+                url = Database.ORACLE_URL_PREFIX + "tcps:" + url.substring(Database.ORACLE_URL_PREFIX.length());
+            }
         }
         return url;
     }
@@ -494,11 +496,6 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
             }
             return to;
         }
-    }
-
-    private static String transformOracleProtocol(String datasource, String value, ConfigSourceInterceptorContext configSourceInterceptorContext) {
-        var tlsMode = DatabaseOptions.DatabaseTlsMode.fromCliValue(value);
-        return tlsMode != DatabaseOptions.DatabaseTlsMode.DISABLED ? "@tcps:" : "@";
     }
 
     private static PropertyMapper<?> setTlsJdbcProperty(String jdbcPropertyKey, Map<Database.Vendor, String> vendorValues) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ExportPropertyMappers.java
@@ -104,7 +104,7 @@ public final class ExportPropertyMappers implements PropertyMapperGrouping {
             .category(OptionCategory.EXPORT)
             .description("Placeholder for determining export mode")
             .buildTime(false)
-            .hidden()
+            .synthetic()
             .build();
 
     private static boolean isSingleFileProvider() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ImportPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ImportPropertyMappers.java
@@ -82,7 +82,7 @@ public final class ImportPropertyMappers implements PropertyMapperGrouping {
             .category(OptionCategory.IMPORT)
             .description("Placeholder for determining import mode")
             .buildTime(false)
-            .hidden()
+            .synthetic()
             .build();
 
     private static boolean isSingleFileProvider() {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -256,7 +256,7 @@ public class PropertyMapper<T> {
     }
 
     public boolean isHidden() {
-        return this.option.isHidden() || this.getDescription() == null;
+        return this.option.isHidden();
     }
 
     public boolean isBuildTime() {
@@ -589,6 +589,9 @@ public class PropertyMapper<T> {
             Option<T> opt = option;
             if (Objects.equals(option.getKey(), mapFrom)) {
                 opt = option.toBuilder().synthetic().build();
+            }
+            if (this.description == null && !opt.isHidden()) {
+                throw new AssertionError("Non-hidden options require a description");
             }
             if (option.getKey().contains(WildcardOptionsUtil.WILDCARD_START)) {
                 return new WildcardPropertyMapper<>(opt, to, enabled, enabledWhen, mapper, mapFrom, parentMapper, paramLabel, isMasked, validator, description, isRequired, requiredWhen, wildcardKeysTransformer, wildcardMapFrom);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -323,10 +323,31 @@ public final class PropertyMappers {
 
             sanitizeMappers(buildTimeMappers, disabledBuildTimeMappers, command);
             sanitizeMappers(runtimeTimeMappers, disabledRuntimeMappers, command);
-
-            entrySet().stream().filter(e -> e.getValue().size() > 1).findFirst().ifPresent(e -> {
-                throw new PropertyException(String.format("Duplicated mapper for key '%s'.", e.getKey()));
+            
+            // enforce single mappings - by dropping multiple mapping synthetics
+            entrySet().stream().forEach(e -> {
+                if (e.getValue().size() <= 1) {
+                    return;
+                }
+                if (e.getKey().startsWith(MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX)) {
+                    PropertyMapper<?> canonicalMapper = null;
+                    for (PropertyMapper<?> mapper : e.getValue()) {
+                        if (canonicalMapper != null) {
+                            if (mapper.option.isSynthetic()) {
+                                continue;
+                            }
+                            if (!canonicalMapper.option.isSynthetic()) {
+                                throw new PropertyException(String.format("Duplicated mapper for key '%s'.", e.getKey()));                    
+                            }
+                        }
+                        canonicalMapper = mapper;
+                    }
+                    e.setValue(List.of(canonicalMapper));
+                } else {
+                    throw new PropertyException(String.format("Duplicated mapper for key '%s'.", e.getKey()));
+                }
             });
+
         }
 
         public Map<OptionCategory, List<PropertyMapper<?>>> getRuntimeMappers() {
@@ -359,10 +380,7 @@ public final class PropertyMappers {
         }
 
         private static void handleMapper(PropertyMapper<?> mapper, BiConsumer<String, PropertyMapper<?>> operation) {
-            // skip accounting for the from if it is a synthetic option
-            if (!mapper.getOption().isSynthetic()) {
-                operation.accept(mapper.getFrom(), mapper);
-            }
+            operation.accept(mapper.getFrom(), mapper);
             if (!mapper.getFrom().equals(mapper.getTo())) {
                 String to = mapper.getTo();
                 operation.accept(to, mapper);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/ProxyPropertyMappers.java
@@ -2,6 +2,7 @@ package org.keycloak.quarkus.runtime.configuration.mappers;
 
 import java.util.List;
 
+import org.keycloak.config.Option;
 import org.keycloak.config.ProxyOptions;
 import org.keycloak.quarkus.runtime.cli.PropertyException;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
@@ -15,6 +16,7 @@ final class ProxyPropertyMappers implements PropertyMapperGrouping{
 
     @Override
     public List<PropertyMapper<?>> getPropertyMappers() {
+        Option<?> syntheticOption = ProxyOptions.PROXY_HEADERS.toBuilder().synthetic().build();
         return List.of(
                 fromOption(ProxyOptions.PROXY_HEADERS)
                         .to("quarkus.http.proxy.proxy-address-forwarding")
@@ -29,23 +31,23 @@ final class ProxyPropertyMappers implements PropertyMapperGrouping{
                             }
                         })
                         .build(),
-                fromOption(ProxyOptions.PROXY_FORWARDED_HOST)
+                fromOption(syntheticOption)
                         .to("quarkus.http.proxy.enable-forwarded-host")
                         .mapFrom(ProxyOptions.PROXY_HEADERS, (v, c) -> proxyEnabled(null, v, c))
                         .build(),
-                fromOption(ProxyOptions.PROXY_FORWARDED_HEADER_ENABLED)
+                fromOption(syntheticOption)
                         .to("quarkus.http.proxy.allow-forwarded")
                         .mapFrom(ProxyOptions.PROXY_HEADERS, (v, c) -> proxyEnabled(ProxyOptions.Headers.forwarded, v, c))
                         .build(),
-                fromOption(ProxyOptions.PROXY_X_FORWARDED_HEADER_ENABLED)
+                fromOption(syntheticOption)
                         .to("quarkus.http.proxy.allow-x-forwarded")
                         .mapFrom(ProxyOptions.PROXY_HEADERS, (v, c) -> proxyEnabled(ProxyOptions.Headers.xforwarded, v, c))
                         .build(),
-                fromOption(ProxyOptions.PROXY_X_FORWARDED_PREFIX_HEADER_ENABLED)
+                fromOption(syntheticOption)
                         .to("quarkus.http.proxy.enable-forwarded-prefix")
                         .mapFrom(ProxyOptions.PROXY_HEADERS, (v, c) -> proxyEnabled(ProxyOptions.Headers.xforwarded, v, c))
                         .build(),
-                fromOption(ProxyOptions.PROXY_TRUSTED_HEADER_ENABLED)
+                fromOption(syntheticOption)
                         .to("quarkus.http.proxy.enable-trusted-proxy-header")
                         .mapFrom(ProxyOptions.PROXY_HEADERS, (v, c) -> proxyEnabled(null, v, c))
                         .build(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TelemetryPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TelemetryPropertyMappers.java
@@ -22,7 +22,6 @@ import io.quarkus.runtime.configuration.DurationConverter;
 import io.smallrye.config.ConfigSourceInterceptorContext;
 import org.jboss.logging.Logger;
 
-import static org.keycloak.config.TelemetryOptions.TELEMETRY_ENABLED;
 import static org.keycloak.config.TelemetryOptions.TELEMETRY_ENDPOINT;
 import static org.keycloak.config.TelemetryOptions.TELEMETRY_HEADER;
 import static org.keycloak.config.TelemetryOptions.TELEMETRY_LOGS_ENABLED;
@@ -44,12 +43,12 @@ import static org.keycloak.config.TracingOptions.TRACING_HEADER;
 import static org.keycloak.config.WildcardOptionsUtil.getWildcardPrefix;
 import static org.keycloak.config.WildcardOptionsUtil.getWildcardValue;
 import static org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider.NS_KEYCLOAK_PREFIX;
+import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromFeature;
 import static org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper.fromOption;
 
 public class TelemetryPropertyMappers implements PropertyMapperGrouping{
     private static final Logger log = Logger.getLogger(TelemetryPropertyMappers.class);
 
-    private static final String OTEL_FEATURE_ENABLED_MSG = "'opentelemetry' feature is enabled";
     private static final String OTEL_COLLECTOR_ENABLED_MSG = "any of available OpenTelemetry components (Logs, Metrics, Traces) is turned on";
     private static final String OTEL_LOGS_FEATURE_ENABLED_MSG = "feature '%s' is enabled".formatted(Profile.Feature.OPENTELEMETRY_LOGS.getVersionedKey());
     private static final String OTEL_LOGS_ENABLED_MSG = "Telemetry Logs functionality ('%s') is enabled".formatted(TELEMETRY_LOGS_ENABLED.getKey());
@@ -60,8 +59,7 @@ public class TelemetryPropertyMappers implements PropertyMapperGrouping{
     public List<? extends PropertyMapper<?>> getPropertyMappers() {
         TELEMETRY_HEADERS_CACHE = null;
         return List.of(
-                fromOption(TELEMETRY_ENABLED)
-                        .isEnabled(TelemetryPropertyMappers::isOtelFeatureEnabled, OTEL_FEATURE_ENABLED_MSG)
+                fromFeature(Profile.Feature.OPENTELEMETRY)
                         .transformer(TelemetryPropertyMappers::checkIfDependantsAreEnabled)
                         .to("quarkus.otel.enabled")
                         .build(),

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TransactionPropertyMappers.java
@@ -36,7 +36,7 @@ public class TransactionPropertyMappers implements PropertyMapperGrouping {
                         .validator(value -> validateDuration(TransactionOptions.TRANSACTION_SETUP_TIMEOUT, value))
                         .paramLabel("timeout")
                         .build(),
-                fromOption(TransactionOptions.DB_LOCK_TIMEOUT)
+                fromOption(TransactionOptions.TRANSACTION_SETUP_TIMEOUT)
                         .mapFrom(TransactionOptions.TRANSACTION_SETUP_TIMEOUT)
                         .to("kc.spi-dblock--jpa--lock-wait-timeout")
                         .paramLabel("timeout")

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -1230,12 +1230,6 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertNoError(nonRunningPicocli);
         // the last is accepted
         assertExternalConfig("quarkus.otel.exporter.otlp.logs.headers", "Content-Language=de-DE");
-        onAfter();
-
-        // Hidden 'telemetry-logs-headers' takes precedence
-        nonRunningPicocli = pseudoLaunch("start-dev", "--features=opentelemetry-logs", "--telemetry-logs-enabled=true", "--telemetry-logs-headers=Overridden-by-me=yes", "--telemetry-logs-header-Authorization=Bearer asdlkfjadsflkj", "--telemetry-logs-header-Host=localhost:8080");
-        assertNoError(nonRunningPicocli);
-        assertExternalConfig("quarkus.otel.exporter.otlp.logs.headers", "Overridden-by-me=yes");
     }
 
     @Test
@@ -1268,29 +1262,18 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertNoError(nonRunningPicocli);
         // the last is accepted
         assertExternalConfig("quarkus.otel.exporter.otlp.metrics.headers", "Content-Language=de-DE");
-        onAfter();
-
-        // Hidden 'telemetry-metrics-headers' takes precedence
-        nonRunningPicocli = pseudoLaunch("start-dev", "--features=opentelemetry-metrics", "--telemetry-metrics-enabled=true", "--metrics-enabled=true", "--telemetry-metrics-headers=Overridden-by-me=yes", "--telemetry-metrics-header-Authorization=Bearer asdlkfjadsflkj", "--telemetry-metrics-header-Host=localhost:8080");
-        assertNoError(nonRunningPicocli);
-        assertExternalConfig("quarkus.otel.exporter.otlp.metrics.headers", "Overridden-by-me=yes");
     }
 
     @Test
-    public void tracingHiddenParentHeaders() {
+    public void tracingSyntheticParentHeaders() {
         var nonRunningPicocli = pseudoLaunch("start-dev", "--tracing-headers=Authorization=Bearer asdlkfjadsflkj");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
-        assertThat(nonRunningPicocli.getErrString(), containsString("Disabled option: '--tracing-headers'. Available only when Tracing is enabled"));
+        assertThat(nonRunningPicocli.getErrString(), containsString("Unknown option: '--tracing-headers'"));
         onAfter();
 
         nonRunningPicocli = pseudoLaunch("start-dev", "--tracing-enabled=true", "--tracing-headers=Authorization=Bearer asdlkfjadsflkj");
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertExternalConfig("quarkus.otel.exporter.otlp.traces.headers", "Authorization=Bearer asdlkfjadsflkj");
-        onAfter();
-
-        nonRunningPicocli = pseudoLaunch("start-dev", "--tracing-enabled=true", "--tracing-headers=Authorization=Bearer asdlkfjadsflkj,Host=localhost:8080");
-        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertExternalConfig("quarkus.otel.exporter.otlp.traces.headers", "Authorization=Bearer asdlkfjadsflkj,Host=localhost:8080");
+        assertExternalConfig("quarkus.otel.exporter.otlp.traces.headers", "");
     }
 
     @Test
@@ -1323,12 +1306,6 @@ public class PicocliTest extends AbstractConfigurationTest {
         assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
         // the last is accepted
         assertExternalConfig("quarkus.otel.exporter.otlp.traces.headers", "Content-Language=de-DE");
-        onAfter();
-
-        // Hidden 'tracing-headers' takes precedence
-        nonRunningPicocli = pseudoLaunch("start-dev", "--tracing-enabled=true", "--tracing-headers=Overridden-by-me=yes", "--tracing-header-Authorization=Bearer asdlkfjadsflkj", "--tracing-header-Host=localhost:8080");
-        assertEquals(CommandLine.ExitCode.OK, nonRunningPicocli.exitCode);
-        assertExternalConfig("quarkus.otel.exporter.otlp.traces.headers", "Overridden-by-me=yes");
     }
 
     @Test

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/ConfigurationTest.java
@@ -209,11 +209,11 @@ public class ConfigurationTest extends AbstractConfigurationTest {
     @Test
     public void testResolveTransformedValue() {
         ConfigArgsConfigSource.setCliArgs("");
-        assertEquals("false", createConfig().getConfigValue("kc.proxy-allow-forwarded-header").getValue());
+        assertNull(createConfig().getConfigValue("quarkus.http.proxy.allow-forwarded").getValue());
         ConfigArgsConfigSource.setCliArgs("--proxy-headers=xforwarded");
-        assertEquals("false", createConfig().getConfigValue("kc.proxy-allow-forwarded-header").getValue());
+        assertEquals("false", createConfig().getConfigValue("quarkus.http.proxy.allow-forwarded").getValue());
         ConfigArgsConfigSource.setCliArgs("--proxy-headers=forwarded");
-        assertEquals("true", createConfig().getConfigValue("kc.proxy-allow-forwarded-header").getValue());
+        assertEquals("true", createConfig().getConfigValue("quarkus.http.proxy.allow-forwarded").getValue());
     }
 
     @Test
@@ -402,44 +402,44 @@ public class ConfigurationTest extends AbstractConfigurationTest {
         assertEquals("test-schema", config.getConfigValue("kc.db-schema").getValue());
 
         config = createConfigFromCliArguments("--db=postgres");
-        assertTrue(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
         assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).anyMatch(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE::equals));
         assertEquals("primary", config.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
 
         config = createConfigFromCliArguments("--db=postgres", "--db-url-properties=?targetServerType=any");
-        assertFalse(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
+        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false).noneMatch(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE::equals));
+        assertNull(config.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
 
         config = createConfigFromCliArguments("--db=postgres", "--db-driver=software.amazon.jdbc.Driver");
-        assertFalse(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
+        assertNull(config.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
 
         config = createConfigFromCliArguments("--db=postgres", "--db-url=jdbc:postgresql://localhost:5432/keycloak?targetServerType=any");
-        assertFalse(DatabasePropertyMappers.isPostgresqlTargetServerTypeEnabled());
+        assertNull(config.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
 
         // MSSQL: sendStringParametersAsUnicode should be set to false by default
         config = createConfigFromCliArguments("--db=mssql");
-        assertTrue(DatabasePropertyMappers.isMssqlSendStringParametersAsUnicode());
         assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false)
                 .anyMatch(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE::equals));
         assertEquals("false", config.getConfigValue(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE).getValue());
 
         // sendStringParametersAsUnicode already present in db-url-properties -> disabled
         config = createConfigFromCliArguments("--db=mssql", "--db-url-properties=;sendStringParametersAsUnicode=true");
-        assertFalse(DatabasePropertyMappers.isMssqlSendStringParametersAsUnicode());
+        assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false)
+                .noneMatch(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE::equals));
+        assertNull(config.getConfigValue(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE).getValue());
 
         // custom JDBC driver -> disabled
         config = createConfigFromCliArguments("--db=mssql", "--db-driver=com.custom.CustomSQLServerDriver");
-        assertFalse(DatabasePropertyMappers.isMssqlSendStringParametersAsUnicode());
+        assertNull(config.getConfigValue(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE).getValue());
 
         // sendStringParametersAsUnicode already present in db-url -> disabled
         config = createConfigFromCliArguments("--db=mssql", "--db-url=jdbc:sqlserver://localhost:1433;databaseName=keycloak;sendStringParametersAsUnicode=false");
-        assertFalse(DatabasePropertyMappers.isMssqlSendStringParametersAsUnicode());
         assertTrue(StreamSupport.stream(config.getPropertyNames().spliterator(), false)
                 .noneMatch(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE::equals));
         assertNull(config.getConfigValue(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE).getValue());
 
         // other db vendor -> disabled (already covered implicitly but good to be explicit)
         config = createConfigFromCliArguments("--db=postgres");
-        assertFalse(DatabasePropertyMappers.isMssqlSendStringParametersAsUnicode());
+        assertNull(config.getConfigValue(DatabasePropertyMappers.MSSQL_SEND_STRING_PARAMETER_AS_UNICODE).getValue());
     }
 
     // KEYCLOAK-15632

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TelemetryConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TelemetryConfigurationTest.java
@@ -10,7 +10,6 @@ public class TelemetryConfigurationTest extends AbstractConfigurationTest {
     public void rootDefaults() {
         initConfig();
         assertConfig(Map.of(
-                "telemetry-enabled", "false",
                 "telemetry-endpoint", "http://localhost:4317",
                 "telemetry-service-name", "keycloak",
                 "telemetry-protocol", "grpc"

--- a/tests/base/src/test/java/org/keycloak/tests/db/DbTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/db/DbTest.java
@@ -2,6 +2,7 @@ package org.keycloak.tests.db;
 
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
+import org.keycloak.quarkus.runtime.configuration.mappers.DatabasePropertyMappers;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
@@ -22,9 +23,9 @@ public class DbTest {
         runOnServer.run(session -> {
             if (Configuration.getConfigValue(DatabaseOptions.DB).getValue().equals("postgres") &&
                 Configuration.getConfigValue(DatabaseOptions.DB_DRIVER).getValue().equals("org.postgresql.Driver")) {
-                Assertions.assertEquals("primary", Configuration.getConfigValue(DatabaseOptions.DB_POSTGRESQL_TARGET_SERVER_TYPE).getValue());
+                Assertions.assertEquals("primary", Configuration.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
             } else {
-                Assertions.assertNull(Configuration.getConfigValue(DatabaseOptions.DB_POSTGRESQL_TARGET_SERVER_TYPE).getValue());
+                Assertions.assertNull(Configuration.getConfigValue(DatabasePropertyMappers.PG_TARGET_SERVER_TYPE).getValue());
             }
         });
     }


### PR DESCRIPTION
~also converted db-connect-timeout to an option for all datasources~

~and exposed more management options~

closes: #48003

The only remaining hidden options once this and the related prs are merged will be those that we either explicitly rely on as an intermediate value, or possible need (db-dialect, several header options).

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
