### PR TITLE
[OID4VCI] credential_offer_uri can only be consumed once

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -606,6 +606,7 @@ public class OID4VCIssuerEndpoint {
         checkIsOid4vciEnabled(eventBuilder);
 
         // Retrieve the associated credential offer state
+        // The credential offer state remains in storage until it expires or the associated credential is fetched
         CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
         CredentialOfferState offerState = offerStorage.getOfferStateByNonce(nonce);
         if (offerState == null) {
@@ -617,7 +618,7 @@ public class OID4VCIssuerEndpoint {
         // We treat the credential offer URI as an unprotected capability URL and rely solely on the later authorization step
         // i.e. an authenticated client/user session is not required nor checked against the offer state
         CredentialsOffer credOffer = offerState.getCredentialsOffer();
-        LOGGER.debugf("Found credential offer state: [ids=%s, cid=%s, uid=%s, nonce=%s]",
+        LOGGER.debugf("Found credential offer: [ids=%s, cid=%s, uid=%s, nonce=%s]",
                 credOffer.getCredentialConfigurationIds(), offerState.getTargetClientId(), offerState.getTargetUserId(), offerState.getNonce());
 
         if (offerState.isExpired()) {
@@ -625,18 +626,6 @@ public class OID4VCIssuerEndpoint {
             eventBuilder.detail(Details.REASON, errorMessage).error(Errors.EXPIRED_CODE);
             throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST, errorMessage));
         }
-
-        // Remove the nonce entry atomically for replay protection
-        // This prevents the same offer URL from being accessed multiple times
-        // while keeping offerId entries available
-        Map<String, String> removed = session.singleUseObjects().remove(nonce);
-        if (removed == null) {
-            var errorMessage = "Credential offer not found or already consumed";
-            LOGGER.debugf("Credential offer with nonce %s not found or already consumed", nonce);
-            eventBuilder.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_REQUEST.getValue());
-            throw new BadRequestException(getErrorResponse(ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST, errorMessage));
-        }
-        LOGGER.debugf("Removed credential offer nonce %s for replay protection", nonce);
 
         // Add event details
         if (offerState.getTargetClientId() != null) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialsOffer.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialsOffer.java
@@ -124,6 +124,11 @@ public class CredentialsOffer {
                 .orElse(null);
     }
 
+    @JsonIgnore
+    public boolean hasPreAuthorizedGrant() {
+        return grants.get(PRE_AUTH_GRANT_TYPE) != null;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -17,7 +17,6 @@ import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
-import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
@@ -29,6 +28,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -261,14 +261,52 @@ public class OID4VCBasicWallet {
             public Oid4vcCredentialResponse send() {
                 Oid4vcCredentialResponse response = super.send();
                 ctx.putAttachment(CREDENTIALS_RESPONSE_ATTACHMENT_KEY, response);
-                if (response.isSuccess()) {
-                    CredentialResponse credentialResponse = response.getCredentialResponse();
-                }
                 return response;
             }
         };
         request.bearerToken(accessToken);
         return request;
+    }
+
+    public Oid4vcCredentialResponse fetchCredentialByOffer(OID4VCTestContext ctx, CredentialsOffer offer) {
+        AccessTokenResponse tokenResponse;
+        if (offer.hasPreAuthorizedGrant()) {
+            tokenResponse = accessTokenRequestPreAuth(ctx, offer.getPreAuthorizedCode()).send();
+        } else {
+            String scope = ctx.getScope();
+            String issuerState = offer.getIssuerState();
+            String credConfigId = offer.getCredentialConfigurationIds().get(0);
+            if (!ctx.getCredentialConfigurationId().equals(credConfigId)) {
+                SupportedCredentialConfiguration credConfig = getIssuerMetadata(ctx).getCredentialsSupported().get(credConfigId);
+                scope = credConfig.getScope();
+            }
+            String authCode = authorizationRequest()
+                    .scope(scope)
+                    .issuerState(issuerState)
+                    .send(ctx.getHolder(), TEST_PASSWORD)
+                    .getCode();
+            tokenResponse = accessTokenRequest(ctx, authCode).send();
+        }
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        Oid4vcCredentialResponse credResponse = credentialRequest(ctx, tokenResponse.getAccessToken())
+                .credentialIdentifier(credentialIdentifier)
+                .proofs(generateJwtProof(ctx))
+                .send();
+        return credResponse;
+    }
+
+    public Oid4vcCredentialResponse fetchCredentialByScope(OID4VCTestContext ctx, String scope) {
+        String authCode = authorizationRequest()
+                .scope(scope)
+                .send(ctx.getHolder(), TEST_PASSWORD)
+                .getCode();
+        AccessTokenResponse tokenResponse = accessTokenRequest(ctx, authCode).send();
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        Oid4vcCredentialResponse credResponse = credentialRequest(ctx, tokenResponse.getAccessToken())
+                .credentialIdentifier(credentialIdentifier)
+                .proofs(generateJwtProof(ctx))
+                .send();
+        return credResponse;
     }
 
     /**
@@ -298,14 +336,9 @@ public class OID4VCBasicWallet {
 
     // State Validation ------------------------------------------------------------------------------------------------
 
-    public void verifyCredentialsSignature(CredentialResponse credResponse, String algorithm) throws Exception {
+    public void verifyCredentialsSignature(CredentialResponse credResponse) {
         for (Credential credEntry : credResponse.getCredentials()) {
-
             String encodedCredential = credEntry.getCredential().toString();
-            JWSInput jwsInput = new JWSInput(encodedCredential);
-            JWSHeader header = jwsInput.getHeader();
-
-            assertEquals(algorithm, header.getRawAlgorithm());
             oauth.verifyToken(encodedCredential, JsonWebToken.class);
         }
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -1212,49 +1212,6 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
     }
 
     @Test
-    public void testCredentialOfferReplayProtection() {
-        String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
-        final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
-                .get(CredentialScopeModel.VC_CONFIGURATION_ID);
-
-        // 1. Retrieving the create-credential-offer
-        CredentialOfferURI credentialOfferURI = oauth.oid4vc()
-                .credentialOfferUriRequest(credentialConfigurationId)
-                .preAuthorized(false)
-                .targetUser("john")
-                .bearerToken(token)
-                .send()
-                .getCredentialOfferURI();
-
-        assertNotNull(credentialOfferURI, "Credential offer URI should not be null");
-
-        String nonce = credentialOfferURI.getNonce();
-        assertNotNull(nonce, "Nonce should not be null");
-
-        // 2. First access to the credential offer URL - should succeed
-        CredentialsOffer credentialsOffer = oauth.oid4vc()
-                .credentialOfferRequest(nonce)
-                .bearerToken(token)
-                .send()
-                .getCredentialsOffer();
-
-        assertNotNull(credentialsOffer, "Credential offer should not be null");
-
-        String issuerState = credentialsOffer.getIssuerState();
-        assertNotNull(issuerState, "Issuer state should not be null");
-
-        // 3. Second access to the same credential offer URL - should fail with replay protection error
-        CredentialOfferResponse response = oauth.oid4vc()
-                .credentialOfferRequest(nonce)
-                .bearerToken(token)
-                .send();
-
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatusCode(), "Second access to credential offer should fail with 400 Bad Request");
-        assertEquals(ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST.getValue(), response.getError(), "Error type should be INVALID_CREDENTIAL_OFFER_REQUEST");
-        assertTrue(response.getErrorDescription().contains("not found") || response.getErrorDescription().contains("already consumed"), "Error description should mention that offer is not found or already consumed");
-    }
-
-    @Test
     public void testCredentialOfferDifferentNoncesIndependent() {
         String token = getBearerToken(oauth, client, jwtTypeCredentialScope.getName());
         final String credentialConfigurationId = jwtTypeCredentialScope.getAttributes()
@@ -1302,24 +1259,6 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                 .send()
                 .getCredentialsOffer();
         assertNotNull(credentialsOffer2, "Second credential offer should not be null");
-
-        // 5. Verify that accessing first offer again fails (replay protection per-nonce)
-        CredentialOfferResponse response1 = oauth.oid4vc()
-                .credentialOfferRequest(nonce1)
-                .bearerToken(token)
-                .send();
-
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatusCode(), "First offer should fail on second access (replay protection)");
-        assertEquals(ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST.getValue(), response1.getError(), "Error type should be INVALID_CREDENTIAL_OFFER_REQUEST");
-
-        // 6. Verify that accessing second offer again also fails (replay protection per-nonce)
-        CredentialOfferResponse response2 = oauth.oid4vc()
-                .credentialOfferRequest(nonce2)
-                .bearerToken(token)
-                .send();
-
-        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response2.getStatusCode(), "Second offer should fail on second access (replay protection)");
-        assertEquals(ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST.getValue(), response2.getError(), "Error type should be INVALID_CREDENTIAL_OFFER_REQUEST");
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPublicClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCPublicClientTest.java
@@ -36,7 +36,6 @@ import org.keycloak.util.JsonSerialization;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
-import org.opentest4j.AssertionFailedError;
 
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
 
@@ -142,29 +141,6 @@ public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
         // assertEquals("Missing parameter: code_challenge_method", authResponse.getErrorDescription());
     }
 
-    @Test
-    public void testAuthorizationRequestWrongPassword() throws Exception {
-
-        var ctx = new OID4VCTestContext(pubClient, jwtTypeCredentialScope);
-
-        // Send AuthorizationRequest with incorrect credentials
-        //
-        AssertionFailedError ex = assertThrows(AssertionFailedError.class, () -> wallet
-                .authorizationRequest()
-                .scope(ctx.getScope())
-                .codeChallenge(PkceGenerator.s256())
-                .send(ctx.getHolder(), "wrong_password"));
-
-        assertTrue(ex.getMessage().contains("Expected OAuth callback, but URL was"), ex.getMessage());
-        assertTrue(ex.getMessage().contains("after timeout"), ex.getMessage());
-
-        // [TODO #47649] OAuthClient cannot handle invalid authorization requests
-        // https://github.com/keycloak/keycloak/issues/47649
-        // assertEquals("unauthorized", authResponse.getError());
-        // assertNull(authResponse.getErrorDescription(), "Null error description");
-
-    }
-
     // Private ---------------------------------------------------------------------------------------------------------
 
     private void verifyCredentialResponse(OID4VCTestContext ctx, String expUser, CredentialResponse credResponse) throws Exception {
@@ -172,6 +148,8 @@ public class OID4VCPublicClientTest extends OID4VCIssuerTestBase {
         String scope = ctx.getScope();
         CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
         assertNotNull(credentialObj, "The first credential in the array should not be null");
+
+        wallet.verifyCredentialsSignature(credResponse);
 
         JsonWebToken jsonWebToken = TokenVerifier.create((String) credentialObj.getCredential(), JsonWebToken.class).getToken();
         assertEquals("did:web:test.org", jsonWebToken.getIssuer());

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
@@ -116,37 +116,43 @@ public class OID4VCTestContext {
                 .orElse(null);
     }
 
-    public Optional<AccessTokenResponse> getAccessTokenResponse() {
+    public AccessTokenResponse getAccessTokenResponse() {
         var tokenResponse = getAttachment(ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY);
-        return Optional.ofNullable(tokenResponse);
+        return tokenResponse;
     }
 
-    public Optional<CredentialOfferUriResponse> getCredentialsOfferUriResponse() {
+    public CredentialOfferUriResponse getCredentialsOfferUriResponse() {
         var credOfferUriResponse = getAttachment(CREDENTIALS_OFFER_URI_RESPONSE_ATTACHMENT_KEY);
-        return Optional.ofNullable(credOfferUriResponse);
+        return credOfferUriResponse;
     }
 
-    public Optional<CredentialOfferURI> getCredentialsOfferUri() {
-        return getCredentialsOfferUriResponse().map(CredentialOfferUriResponse::getCredentialOfferURI);
+    public CredentialOfferURI getCredentialsOfferUri() {
+        return Optional.ofNullable(getCredentialsOfferUriResponse())
+                .map(CredentialOfferUriResponse::getCredentialOfferURI)
+                .orElse(null);
     }
 
-    public Optional<CredentialOfferResponse> getCredentialsOfferResponse() {
+    public CredentialOfferResponse getCredentialsOfferResponse() {
         var credOfferResponse = getAttachment(CREDENTIALS_OFFER_RESPONSE_ATTACHMENT_KEY);
-        return Optional.ofNullable(credOfferResponse);
+        return credOfferResponse;
     }
 
-    public Optional<CredentialsOffer> getCredentialsOffer() {
-        return getCredentialsOfferResponse().map(CredentialOfferResponse::getCredentialsOffer);
+    public CredentialsOffer getCredentialsOffer() {
+        return Optional.ofNullable(getCredentialsOfferResponse())
+                .map(CredentialOfferResponse::getCredentialsOffer)
+                .orElse(null);
     }
 
-    public Optional<Oid4vcCredentialResponse> getOid4vcCredentialResponse() {
+    public Oid4vcCredentialResponse getOid4vcCredentialResponse() {
         var credResponse = getAttachment(CREDENTIALS_RESPONSE_ATTACHMENT_KEY);
-        return Optional.ofNullable(credResponse);
+        return credResponse;
     }
 
-    public Optional<CredentialResponse> getCredentialResponse() {
+    public CredentialResponse getCredentialResponse() {
         var credResponse = getOid4vcCredentialResponse();
-        return credResponse.map(Oid4vcCredentialResponse::getCredentialResponse);
+        return Optional.ofNullable(credResponse)
+                .map(Oid4vcCredentialResponse::getCredentialResponse)
+                .orElse(null);
     }
 
     public String getCredentialConfigurationId() {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialByScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialByScopeTest.java
@@ -30,30 +30,8 @@ public class OID4VCredentialByScopeTest extends OID4VCIssuerTestBase {
 
         var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
 
-        // Send AuthorizationRequest
-        //
-        AuthorizationEndpointResponse authResponse = wallet
-                .authorizationRequest()
-                .scope(ctx.getScope())
-                .send(ctx.getHolder(), "password");
-        String authCode = authResponse.getCode();
-        assertNotNull(authCode, "No authCode");
-
-        // Build and send AccessTokenRequest
-        //
-        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode).send();
-        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
-        assertNotNull(accessToken, "No accessToken");
-
-        String authorizedIdentifier = ctx.getAuthorizedCredentialIdentifier();
-        assertNotNull(authorizedIdentifier, "No authorized credential identifier");
-
-        // Send the CredentialRequest
-        //
-        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
-                .credentialIdentifier(authorizedIdentifier)
-                .proofs(wallet.generateJwtProof(ctx))
-                .send().getCredentialResponse();
+        CredentialResponse credResponse = wallet.fetchCredentialByScope(ctx, ctx.getScope())
+                .getCredentialResponse();
 
         verifyCredentialResponse(ctx, ctx.getHolder(), credResponse);
     }
@@ -76,7 +54,7 @@ public class OID4VCredentialByScopeTest extends OID4VCIssuerTestBase {
                 .authorizationRequest()
                 .scope(ctx.getScope())
                 .authorizationDetails(authDetail)
-                .send(ctx.getHolder(), "password");
+                .send(ctx.getHolder(), TEST_PASSWORD);
         String authCode = authResponse.getCode();
         assertNotNull(authCode, "No authCode");
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
@@ -16,6 +16,7 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestServerConfig;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriResponse;
 import org.keycloak.util.JsonSerialization;
 
@@ -62,13 +63,22 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
         String issuerState = credOffer.getIssuerState();
         assertNotNull(issuerState, "No IssuerState");
 
+        CredentialOfferURI offerURI = ctx.getCredentialsOfferUri();
+        assertNotNull(offerURI, "No CredentialOfferURI");
+
+        // Fetch credential offer again
+        // https://github.com/keycloak/keycloak/issues/48014
+        credOffer = wallet.credentialsOfferRequest(ctx, offerURI).send().getCredentialsOffer();
+        issuerState = credOffer.getIssuerState();
+        assertNotNull(issuerState, "No IssuerState");
+
         // Send AuthorizationRequest
         //
         AuthorizationEndpointResponse authResponse = wallet
                 .authorizationRequest()
                 .scope(ctx.getScope())
                 .issuerState(issuerState)
-                .send(ctx.getHolder(), "password");
+                .send(ctx.getHolder(), TEST_PASSWORD);
         String authCode = authResponse.getCode();
         assertNotNull(authCode, "No authCode");
 
@@ -89,6 +99,12 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
                 .send().getCredentialResponse();
 
         verifyCredentialResponse(ctx, ctx.getHolder(), credResponse);
+
+        // Attempt to fetch the credential offer again after it has been consumed
+
+        CredentialOfferResponse res = wallet.credentialsOfferRequest(ctx, offerURI).send();
+        assertEquals("invalid_credential_offer_request", res.getError());
+        assertEquals("Credential offer not found or already consumed", res.getErrorDescription());
     }
 
     @Test
@@ -111,7 +127,7 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
                 .authorizationRequest()
                 .scope(ctx1.getScope())
                 .issuerState(issuerState)
-                .send(ctx1.getHolder(), "password");
+                .send(ctx1.getHolder(), TEST_PASSWORD);
         String authCode = authResponse1.getCode();
         assertNotNull(authCode, "No authCode");
 
@@ -146,7 +162,7 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
                 .authorizationRequest()
                 .scope(ctx2.getScope())
                 .issuerState(issuerState)
-                .send(ctx2.getHolder(), "password");
+                .send(ctx2.getHolder(), TEST_PASSWORD);
         authCode = authResponse2.getCode();
         assertNotNull(authCode, "No authCode");
 
@@ -202,7 +218,7 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
                 .authorizationRequest()
                 .scope(ctx.getScope())
                 .issuerState(issuerState)
-                .send(ctx.getHolder(), "password");
+                .send(ctx.getHolder(), TEST_PASSWORD);
         String authCode = authResponse.getCode();
         assertNotNull(authCode, "No authCode");
 
@@ -248,7 +264,7 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
                 .authorizationRequest()
                 .scope(ctx.getScope())
                 .issuerState(issuerState)
-                .send(ctx.getHolder(), "password");
+                .send(ctx.getHolder(), TEST_PASSWORD);
         String authCode = authResponse.getCode();
         assertNotNull(authCode, "No authCode");
 
@@ -283,7 +299,7 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
         String issuerState = credOffer.getIssuerState();
         assertNotNull(issuerState, "No IssuerState");
 
-        CredentialOfferURI credOfferURI = ctx.getCredentialsOfferUriResponse().get().getCredentialOfferURI();
+        CredentialOfferURI credOfferURI = ctx.getCredentialsOfferUriResponse().getCredentialOfferURI();
         assertNotNull(credOfferURI, "No CredentialOfferURI");
         assertNotNull(credOfferURI.getQrCode(), "No QR Code");
     }
@@ -297,7 +313,7 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
             req.responseType(OfferResponseType.URI_QR);
             req.width(1000).height(1000);
         }));
-        CredentialOfferUriResponse res = ctx.getCredentialsOfferUriResponse().orElseThrow();
+        CredentialOfferUriResponse res = ctx.getCredentialsOfferUriResponse();
 
         String error = res.getError();
         assertNotNull(error, "No Error");

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
@@ -14,6 +15,7 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
 import org.keycloak.util.JsonSerialization;
 
 import org.junit.jupiter.api.Test;
@@ -110,6 +112,16 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
         });
 
         String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "preAuthCode");
+
+        CredentialOfferURI offerURI = ctx.getCredentialsOfferUri();
+        assertNotNull(offerURI, "No CredentialOfferURI");
+
+        // Fetch credential offer again
+        // https://github.com/keycloak/keycloak/issues/48014
+        credOffer = wallet.credentialsOfferRequest(ctx, offerURI).send().getCredentialsOffer();
+        preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "preAuthCode");
 
         // Redeem Pre-Authorized Code for AccessToken
         //
@@ -130,6 +142,11 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
                 .send().getCredentialResponse();
 
         verifyCredentialResponse(ctx, ctx.getHolder(), credResponse);
+
+        // Attempt to fetch the credential offer again after it has been consumed
+        CredentialOfferResponse res = wallet.credentialsOfferRequest(ctx, offerURI).send();
+        assertEquals("invalid_credential_offer_request", res.getError());
+        assertEquals("Credential offer not found or already consumed", res.getErrorDescription());
     }
 
     // Private ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
closes #48014

Removes the replay protected for credential offer uri. It cannot be assumed that all use cases will only fetch the credential offer once.

The credential offer uri would now be considered valid until the offer state expires or the respective credential is consumed. 