### PR TITLE
User search parameter for service account inclusion/exclusion

### DIFF
--- a/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -160,6 +160,13 @@ public interface UsersResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> searchByLastName(@QueryParam("lastName") String email, @QueryParam("exact") Boolean exact);
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByUserAccounts(@QueryParam("search") String search,
+                                                  @QueryParam("enabled") Boolean enabled,
+                                                  @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
+
+
     /**
      * Search for users based on the given filters.
      *
@@ -345,6 +352,21 @@ public interface UsersResource {
     Integer count(@QueryParam("search") String search);
 
     /**
+     * Returns the users that can be viewed and match the given filters.
+     *
+     * @param search criteria to search for
+     * @param enabled Boolean representing if user is enabled or not
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts
+     * @return number of users matching the search criteria
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("search") String search,
+                  @QueryParam("enabled") Boolean enabled,
+                  @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
+
+    /**
      * Returns the number of users that can be viewed and match the given filters.
      * If none of the filters is specified this is equivalent to {{@link #count()}}.
      *
@@ -485,6 +507,7 @@ public interface UsersResource {
      * @param searchQuery   A query to search for custom attributes
      * @param createdAfter  only count users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
      * @param createdBefore only count users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts
      * @return number of users matching the given filters
      */
     @Path("count")
@@ -502,7 +525,8 @@ public interface UsersResource {
                   @QueryParam("exact") Boolean exact,
                   @QueryParam("q") String searchQuery,
                   @QueryParam("createdAfter") String createdAfter,
-                  @QueryParam("createdBefore") String createdBefore);
+                  @QueryParam("createdBefore") String createdBefore,
+                  @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
 
     /**
      * Returns the number of users with the given status for emailVerified.

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UsersResource.java
@@ -160,6 +160,13 @@ public interface UsersResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<UserRepresentation> searchByLastName(@QueryParam("lastName") String email, @QueryParam("exact") Boolean exact);
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> searchByUserAccounts(@QueryParam("search") String search,
+                                                  @QueryParam("enabled") Boolean enabled,
+                                                  @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
+
+
     /**
      * Search for users based on the given filters.
      *
@@ -344,6 +351,21 @@ public interface UsersResource {
     Integer count(@QueryParam("search") String search);
 
     /**
+     * Returns the users that can be viewed and match the given filters.
+     *
+     * @param search criteria to search for
+     * @param enabled Boolean representing if user is enabled or not
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts
+     * @return number of users matching the search criteria
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@QueryParam("search") String search,
+                  @QueryParam("enabled") Boolean enabled,
+                  @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
+
+    /**
      * Returns the number of users that can be viewed and match the given filters.
      * If none of the filters is specified this is equivalent to {{@link #count()}}.
      *
@@ -484,6 +506,7 @@ public interface UsersResource {
      * @param searchQuery   A query to search for custom attributes
      * @param createdAfter  only count users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
      * @param createdBefore only count users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts
      * @return number of users matching the given filters
      */
     @Path("count")
@@ -501,7 +524,8 @@ public interface UsersResource {
                   @QueryParam("exact") Boolean exact,
                   @QueryParam("q") String searchQuery,
                   @QueryParam("createdAfter") String createdAfter,
-                  @QueryParam("createdBefore") String createdBefore);
+                  @QueryParam("createdBefore") String createdBefore,
+                  @QueryParam("includeServiceAccounts") Boolean includeServiceAccounts);
 
     /**
      * Returns the number of users with the given status for emailVerified.

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -263,6 +263,7 @@ public class UsersResource {
      * @param briefRepresentation Boolean which defines whether brief representations are returned (default: false)
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts. When "true" then always included, "false" then never, null will fall back to known legacy behavior
      * @return a non-null {@code Stream} of users
      */
     @GET
@@ -291,7 +292,8 @@ public class UsersResource {
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
             @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
-            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore,
+            @Parameter(description = "Boolean, which defines whether result list should include service accounts. When \"true\" then always included, \"false\" then never, null will fall back to known legacy behavior") @QueryParam("includeServiceAccounts") Optional<Boolean> includeServiceAccounts) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
 
         userPermissionEvaluator.requireQuery();
@@ -325,7 +327,7 @@ public class UsersResource {
                 addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
 
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                        maxResults, false);
+                        maxResults, includeServiceAccounts.orElse(false));
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
                 || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
@@ -363,10 +365,10 @@ public class UsersResource {
                     attributes.putAll(searchAttributes);
 
                     return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                            maxResults, true);
+                            maxResults, includeServiceAccounts.orElse(true));
                 } else {
                     return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
-                            firstResult, maxResults, false);
+                            firstResult, maxResults, includeServiceAccounts.orElse(false));
                 }
 
         return toRepresentation(realm, userPermissionEvaluator, briefRepresentation, userModels);
@@ -398,6 +400,7 @@ public class UsersResource {
      * @param enabled Boolean representing if user is enabled or not
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts. When "true" then always included, "false" then never, null will fall back to known legacy behavior
      * @return the number of users that match the given criteria
      */
     @Path("count")
@@ -428,7 +431,8 @@ public class UsersResource {
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
             @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
-            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore,
+            @Parameter(description = "Boolean, which defines whether result list should include service accounts. When \"true\" then always included, \"false\" then never, null will fall back to known legacy behavior") @QueryParam("includeServiceAccounts") Optional<Boolean> includeServiceAccounts) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
         userPermissionEvaluator.requireQuery();
 
@@ -456,7 +460,7 @@ public class UsersResource {
             }
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             // search /users equivalent to this doesn't include service-accounts so counting shouldn't as well
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.orElse(false).toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {
@@ -500,7 +504,7 @@ public class UsersResource {
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             parameters.putAll(searchAttributes);
             // search /users equivalent to this does include service-accounts so we should be explicit
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "true");
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.orElse(true).toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {
@@ -513,7 +517,7 @@ public class UsersResource {
         } else {
             Map<String, String> parameters = new HashMap<>();
             // list /users equivalent to this doesn't include service-accounts so counting shouldn't as well
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.orElse(false).toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -264,6 +264,7 @@ public class UsersResource {
      * @param briefRepresentation Boolean which defines whether brief representations are returned (default: false)
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts. When "true" then always included, "false" then never, null will fall back to known legacy behavior
      * @return a non-null {@code Stream} of users
      */
     @GET
@@ -292,7 +293,8 @@ public class UsersResource {
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
             @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
-            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore,
+            @Parameter(description = "Boolean, which defines whether result list should include service accounts. When \"true\" then always included, \"false\" then never, null will fall back to known legacy behavior") @QueryParam("includeServiceAccounts") Optional<Boolean> includeServiceAccounts) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
 
         userPermissionEvaluator.requireQuery();
@@ -324,7 +326,7 @@ public class UsersResource {
                 addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
 
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                        maxResults, false);
+                        maxResults, includeServiceAccounts.orElse(false));
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
                 || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
@@ -362,10 +364,10 @@ public class UsersResource {
                     attributes.putAll(searchAttributes);
 
                     return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                            maxResults, true);
+                            maxResults, includeServiceAccounts.orElse(true));
                 } else {
                     return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
-                            firstResult, maxResults, false);
+                            firstResult, maxResults, includeServiceAccounts.orElse(false));
                 }
 
         return toRepresentation(realm, userPermissionEvaluator, briefRepresentation, userModels);
@@ -397,6 +399,7 @@ public class UsersResource {
      * @param enabled Boolean representing if user is enabled or not
      * @param exact Boolean which defines whether the params "last", "first", "email" and "username" must match exactly
      * @param searchQuery A query to search for custom attributes, in the format 'key1:value2 key2:value2'
+     * @param includeServiceAccounts Boolean, which defines whether result list should include service accounts. When "true" then always included, "false" then never, null will fall back to known legacy behavior
      * @return the number of users that match the given criteria
      */
     @Path("count")
@@ -427,7 +430,8 @@ public class UsersResource {
             @Parameter(description = "Boolean which defines whether the params \"last\", \"first\", \"email\" and \"username\" must match exactly") @QueryParam("exact") Boolean exact,
             @Parameter(description = "A query to search for custom attributes, in the format 'key1:value2 key2:value2'") @QueryParam("q") String searchQuery,
             @Parameter(description = "Only return users created after (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdAfter") String createdAfter,
-            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore) {
+            @Parameter(description = "Only return users created before (inclusive) the given date, in ISO-8601 format (yyyy-MM-dd) or epoch milliseconds") @QueryParam("createdBefore") String createdBefore,
+            @Parameter(description = "Boolean, which defines whether result list should include service accounts. When \"true\" then always included, \"false\" then never, null will fall back to known legacy behavior") @QueryParam("includeServiceAccounts") Optional<Boolean> includeServiceAccounts) {
         UserPermissionEvaluator userPermissionEvaluator = auth.users();
         userPermissionEvaluator.requireQuery();
 
@@ -451,7 +455,7 @@ public class UsersResource {
             }
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             // search /users equivalent to this doesn't include service-accounts so counting shouldn't as well
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.orElse(false).toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {
@@ -495,7 +499,7 @@ public class UsersResource {
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
             parameters.putAll(searchAttributes);
             // search /users equivalent to this does include service-accounts so we should be explicit
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "true");
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.orElse(true).toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {
@@ -508,7 +512,7 @@ public class UsersResource {
         } else {
             Map<String, String> parameters = new HashMap<>();
             // list /users equivalent to this doesn't include service-accounts so counting shouldn't as well
-            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
+            parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.orElse(false).toString());
             if (userPermissionEvaluator.canView()) {
                 return session.users().getUsersCount(realm, parameters);
             } else {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -846,7 +846,7 @@ public class UserSearchTest extends AbstractUserTest {
 
     @Test
     public void testCountAndSearchConsistencyWithMissingParameters() {
-        createUser("user1", "user1@example.com");
+        createUser("account", "user1@example.com");
 
         // Count users before creating service account (should be 1 regular user)
         Integer countBefore = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, true, null);
@@ -861,6 +861,7 @@ public class UserSearchTest extends AbstractUserTest {
         client.setRedirectUris(Arrays.asList("http://localhost"));
 
         String clientId = ApiUtil.getCreatedId(managedRealm.admin().clients().create(client));
+        managedRealm.cleanup().add(r -> r.clients().get(clientId).remove());
         
         // Count users after creating service account (should be 2: 1 regular + 1 service account)
         Integer countAfter = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, true, null);
@@ -870,6 +871,7 @@ public class UserSearchTest extends AbstractUserTest {
         Integer count = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, true, null);
         List<UserRepresentation> users = managedRealm.admin().users().search(null, null, null, null, 0, 10, null, null, true);
         assertEquals(count.intValue(), users.size(), "Count and search should return same number with exact=true");
+        assertEquals(2, count.intValue(), "Default handling of service accounts should include service accounts with exact=true");
 
         // idpAlias parameter with service account inclusion inconsistency
         Integer countWithIdp = managedRealm.admin().users().count(null, null, null, null, null, null, null, "nonexistent-idp", null, null);
@@ -880,8 +882,54 @@ public class UserSearchTest extends AbstractUserTest {
         Integer countWithIdpUserId = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, "nonexistent-user-id", null);
         List<UserRepresentation> usersWithIdpUserId = managedRealm.admin().users().search(null, null, null, null, null, null, "nonexistent-user-id", 0, 10, null, null);
         assertEquals(countWithIdpUserId.intValue(), usersWithIdpUserId.size(), "Count and search should return same number with idpUserId parameter");
-        
-        managedRealm.admin().clients().get(clientId).remove();
+
+        // search parameter ignores service accounts by default
+        Integer countWithSearch = managedRealm.admin().users().count("*account*", null, null, null, null, null, null, null, null, null);
+        List<UserRepresentation> usersWithSearch = managedRealm.admin().users().searchByUserAccounts("*account*", null, null);
+        assertEquals(countWithSearch.intValue(), usersWithSearch.size(), "Count and search should return same number with search parameter");
+        assertEquals(1, countWithSearch.intValue(), "Default handling of service accounts should exclude service accounts with search parameter");
+
+        // count and search without parameters excludes service account by default
+        Integer countAllAfter = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, null, null);
+        List<UserRepresentation> usersAllAfter = managedRealm.admin().users().searchByUserAccounts(null, null, null);
+        assertEquals(countAllAfter.intValue(), usersAllAfter.size(), "Count and search should return same number without any parameters");
+        assertEquals(1, countAllAfter.intValue(), "Should have 1 (regular) user after service account creation");
+
+        // include service accounts in result list and enabled=true
+        Integer countWithServiceAccounts = managedRealm.admin().users().count(null, true, true);
+        List<UserRepresentation> usersWithServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, true, true);
+        assertEquals(countWithServiceAccounts.intValue(), usersWithServiceAccounts.size(), "Count and search enabled users should return same number with includeUserAccounts=true");
+        assertEquals(2, countWithServiceAccounts.intValue(), "Should have 2 enabled users including service accounts (1 regular + 1 service account)");
+
+        // include service accounts in result list and search parameter
+        Integer countSearchWithServiceAccounts = managedRealm.admin().users().count("*account*", null, true);
+        List<UserRepresentation> usersSearchWithServiceAccounts = managedRealm.admin().users().searchByUserAccounts("*account*", null, true);
+        assertEquals(countSearchWithServiceAccounts.intValue(), usersSearchWithServiceAccounts.size(), "Count and search should return same number with includeUserAccounts=true");
+        assertEquals(2, countSearchWithServiceAccounts.intValue(), "Should have 2 'account' users including service accounts (1 regular + 1 service account)");
+
+        // include service accounts in result list for all users
+        Integer countAllWithServiceAccounts = managedRealm.admin().users().count(null, null, true);
+        List<UserRepresentation> usersAllWithServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, null, true);
+        assertEquals(countAllWithServiceAccounts.intValue(), usersAllWithServiceAccounts.size(), "Count and list all users should return same number with includeUserAccounts=true");
+        assertEquals(2, countAllWithServiceAccounts.intValue(), "Should have 2 users including service accounts (1 regular + 1 service account)");
+
+        // exclude service accounts in result list and enabled=true
+        Integer countWithoutServiceAccounts = managedRealm.admin().users().count(null, true, false);
+        List<UserRepresentation> usersWithoutServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, true, false);
+        assertEquals(countWithoutServiceAccounts.intValue(), usersWithoutServiceAccounts.size(), "Count and search enabled users should return same number with includeUserAccounts=true");
+        assertEquals(1, countWithoutServiceAccounts.intValue(), "Should have 1 enabled user and no service accounts");
+
+        // exclude service accounts in result list and search parameter
+        Integer countSearchWithoutServiceAccounts = managedRealm.admin().users().count("account", null, false);
+        List<UserRepresentation> usersSearchWithoutServiceAccounts = managedRealm.admin().users().searchByUserAccounts("account", null, false);
+        assertEquals(countSearchWithoutServiceAccounts.intValue(), usersSearchWithoutServiceAccounts.size(), "Count and search should return same number with includeUserAccounts=true");
+        assertEquals(1, countSearchWithoutServiceAccounts.intValue(), "Should have 1 'account' user and no service accounts");
+
+        // exclude service accounts in result list for all users
+        Integer countAllWithoutServiceAccounts = managedRealm.admin().users().count(null, null, false);
+        List<UserRepresentation> usersAllWithoutServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, null, false);
+        assertEquals(countAllWithoutServiceAccounts.intValue(), usersAllWithoutServiceAccounts.size(), "Count and list all users should return same number with includeUserAccounts=true");
+        assertEquals(1, countAllWithoutServiceAccounts.intValue(), "Should have 1 user and no service accounts");
     }
 
     @Test
@@ -975,20 +1023,20 @@ public class UserSearchTest extends AbstractUserTest {
 
         Integer count = managedRealm.admin().users().count(
                 null, null, null, null, null, null, null, null, null, null, null,
-                String.valueOf(beforeCreation), String.valueOf(afterCreation));
+                String.valueOf(beforeCreation), String.valueOf(afterCreation), null);
         assertEquals(2, count.intValue(), "Should count 2 users created in the time range");
 
         // Future range should count 0
         Integer zeroCount = managedRealm.admin().users().count(
                 null, null, null, null, null, null, null, null, null, null, null,
-                String.valueOf(afterCreation + 100_000), null);
+                String.valueOf(afterCreation + 100_000), null, null);
         assertEquals(0, zeroCount.intValue(), "Should count 0 users for future timestamp");
 
         // Count using ISO date (today) should include the users
         String today = LocalDate.now(ZoneOffset.UTC).toString();
         Integer isoCount = managedRealm.admin().users().count(
                 null, null, null, null, null, null, null, null, null, null, null,
-                today, today);
+                today, today, null);
         assertTrue(isoCount >= 2, "Should count at least 2 users created today using ISO date");
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -916,7 +916,7 @@ public class UserSearchTest extends AbstractUserTest {
 
     @Test
     public void testCountAndSearchConsistencyWithMissingParameters() {
-        createUser("user1", "user1@example.com");
+        createUser("account", "user1@example.com");
 
         // Count users before creating service account (should be 1 regular user)
         Integer countBefore = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, true, null);
@@ -931,6 +931,7 @@ public class UserSearchTest extends AbstractUserTest {
         client.setRedirectUris(Arrays.asList("http://localhost"));
 
         String clientId = ApiUtil.getCreatedId(managedRealm.admin().clients().create(client));
+        managedRealm.cleanup().add(r -> r.clients().get(clientId).remove());
         
         // Count users after creating service account (should be 2: 1 regular + 1 service account)
         Integer countAfter = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, true, null);
@@ -940,6 +941,7 @@ public class UserSearchTest extends AbstractUserTest {
         Integer count = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, true, null);
         List<UserRepresentation> users = managedRealm.admin().users().search(null, null, null, null, 0, 10, null, null, true);
         assertEquals(count.intValue(), users.size(), "Count and search should return same number with exact=true");
+        assertEquals(2, count.intValue(), "Default handling of service accounts should include service accounts with exact=true");
 
         // idpAlias parameter with service account inclusion inconsistency
         Integer countWithIdp = managedRealm.admin().users().count(null, null, null, null, null, null, null, "nonexistent-idp", null, null);
@@ -950,8 +952,54 @@ public class UserSearchTest extends AbstractUserTest {
         Integer countWithIdpUserId = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, "nonexistent-user-id", null);
         List<UserRepresentation> usersWithIdpUserId = managedRealm.admin().users().search(null, null, null, null, null, null, "nonexistent-user-id", 0, 10, null, null);
         assertEquals(countWithIdpUserId.intValue(), usersWithIdpUserId.size(), "Count and search should return same number with idpUserId parameter");
-        
-        managedRealm.admin().clients().get(clientId).remove();
+
+        // search parameter ignores service accounts by default
+        Integer countWithSearch = managedRealm.admin().users().count("*account*", null, null, null, null, null, null, null, null, null);
+        List<UserRepresentation> usersWithSearch = managedRealm.admin().users().searchByUserAccounts("*account*", null, null);
+        assertEquals(countWithSearch.intValue(), usersWithSearch.size(), "Count and search should return same number with search parameter");
+        assertEquals(1, countWithSearch.intValue(), "Default handling of service accounts should exclude service accounts with search parameter");
+
+        // count and search without parameters excludes service account by default
+        Integer countAllAfter = managedRealm.admin().users().count(null, null, null, null, null, null, null, null, null, null, null);
+        List<UserRepresentation> usersAllAfter = managedRealm.admin().users().searchByUserAccounts(null, null, null);
+        assertEquals(countAllAfter.intValue(), usersAllAfter.size(), "Count and search should return same number without any parameters");
+        assertEquals(1, countAllAfter.intValue(), "Should have 1 (regular) user after service account creation");
+
+        // include service accounts in result list and enabled=true
+        Integer countWithServiceAccounts = managedRealm.admin().users().count(null, true, true);
+        List<UserRepresentation> usersWithServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, true, true);
+        assertEquals(countWithServiceAccounts.intValue(), usersWithServiceAccounts.size(), "Count and search enabled users should return same number with includeUserAccounts=true");
+        assertEquals(2, countWithServiceAccounts.intValue(), "Should have 2 enabled users including service accounts (1 regular + 1 service account)");
+
+        // include service accounts in result list and search parameter
+        Integer countSearchWithServiceAccounts = managedRealm.admin().users().count("*account*", null, true);
+        List<UserRepresentation> usersSearchWithServiceAccounts = managedRealm.admin().users().searchByUserAccounts("*account*", null, true);
+        assertEquals(countSearchWithServiceAccounts.intValue(), usersSearchWithServiceAccounts.size(), "Count and search should return same number with includeUserAccounts=true");
+        assertEquals(2, countSearchWithServiceAccounts.intValue(), "Should have 2 'account' users including service accounts (1 regular + 1 service account)");
+
+        // include service accounts in result list for all users
+        Integer countAllWithServiceAccounts = managedRealm.admin().users().count(null, null, true);
+        List<UserRepresentation> usersAllWithServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, null, true);
+        assertEquals(countAllWithServiceAccounts.intValue(), usersAllWithServiceAccounts.size(), "Count and list all users should return same number with includeUserAccounts=true");
+        assertEquals(2, countAllWithServiceAccounts.intValue(), "Should have 2 users including service accounts (1 regular + 1 service account)");
+
+        // exclude service accounts in result list and enabled=true
+        Integer countWithoutServiceAccounts = managedRealm.admin().users().count(null, true, false);
+        List<UserRepresentation> usersWithoutServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, true, false);
+        assertEquals(countWithoutServiceAccounts.intValue(), usersWithoutServiceAccounts.size(), "Count and search enabled users should return same number with includeUserAccounts=true");
+        assertEquals(1, countWithoutServiceAccounts.intValue(), "Should have 1 enabled user and no service accounts");
+
+        // exclude service accounts in result list and search parameter
+        Integer countSearchWithoutServiceAccounts = managedRealm.admin().users().count("account", null, false);
+        List<UserRepresentation> usersSearchWithoutServiceAccounts = managedRealm.admin().users().searchByUserAccounts("account", null, false);
+        assertEquals(countSearchWithoutServiceAccounts.intValue(), usersSearchWithoutServiceAccounts.size(), "Count and search should return same number with includeUserAccounts=true");
+        assertEquals(1, countSearchWithoutServiceAccounts.intValue(), "Should have 1 'account' user and no service accounts");
+
+        // exclude service accounts in result list for all users
+        Integer countAllWithoutServiceAccounts = managedRealm.admin().users().count(null, null, false);
+        List<UserRepresentation> usersAllWithoutServiceAccounts = managedRealm.admin().users().searchByUserAccounts(null, null, false);
+        assertEquals(countAllWithoutServiceAccounts.intValue(), usersAllWithoutServiceAccounts.size(), "Count and list all users should return same number with includeUserAccounts=true");
+        assertEquals(1, countAllWithoutServiceAccounts.intValue(), "Should have 1 user and no service accounts");
     }
 
     @Test
@@ -1045,20 +1093,20 @@ public class UserSearchTest extends AbstractUserTest {
 
         Integer count = managedRealm.admin().users().count(
                 null, null, null, null, null, null, null, null, null, null, null,
-                String.valueOf(beforeCreation), String.valueOf(afterCreation));
+                String.valueOf(beforeCreation), String.valueOf(afterCreation), null);
         assertEquals(2, count.intValue(), "Should count 2 users created in the time range");
 
         // Future range should count 0
         Integer zeroCount = managedRealm.admin().users().count(
                 null, null, null, null, null, null, null, null, null, null, null,
-                String.valueOf(afterCreation + 100_000), null);
+                String.valueOf(afterCreation + 100_000), null, null);
         assertEquals(0, zeroCount.intValue(), "Should count 0 users for future timestamp");
 
         // Count using ISO date (today) should include the users
         String today = LocalDate.now(ZoneOffset.UTC).toString();
         Integer isoCount = managedRealm.admin().users().count(
                 null, null, null, null, null, null, null, null, null, null, null,
-                today, today);
+                today, today, null);
         assertTrue(isoCount >= 2, "Should count at least 2 users created today using ISO date");
     }
 


### PR DESCRIPTION
## Summary
This pull request introduces a new parameter for the user REST API (user search and count) to be able to include/exclude service accounts per request.

## Related tickets
Closes #48031