### PR TITLE
Fix typo: boostrap to bootstrap in documentation files and strings

### DIFF
--- a/docs/guides/observability/health.adoc
+++ b/docs/guides/observability/health.adoc
@@ -67,7 +67,7 @@ It is possible to enable the health checks using the build time option `health-e
 
 <@kc.build parameters="--health-enabled=true"/>
 
-When the health endpoints are enabled, async server bootstrap is also enabled by default, resulting in the HTTP ports being open while bootstrapping is in progress. See <@links.server id="configuration-production" anchor="server-boostrap-behavior" /> for more details.
+When the health endpoints are enabled, async server bootstrap is also enabled by default, resulting in the HTTP ports being open while bootstrapping is in progress. See <@links.server id="configuration-production" anchor="server-bootstrap-behavior" /> for more details.
 
 == Using the health checks
 

--- a/docs/guides/operator/advanced-configuration.adoc
+++ b/docs/guides/operator/advanced-configuration.adoc
@@ -402,7 +402,7 @@ This option cannot be `false` if you plan to use an external Infinispan cluster,
 
 When you create a new instance the Keycloak CR spec.bootstrapAdmin stanza may be used to configure the bootstrap user and/or service account. If you do not specify anything for the spec.bootstrapAdmin, the operator will create a Secret named "metadata.name"-initial-admin with a username temp-admin and a generated password. If you specify a Secret name for the bootstrap admin user, then the Secret will need to contain `username` and `password` key value pairs. If you specify a Secret name for bootstrap admin service account, then the Secret will need to contain `client-id` and `client-secret` key value pairs.
 
-If a master realm has already been created for your cluster, then the spec.boostrapAdmin is effectively ignored. If you need to create a recovery admin account, then you'll need to run the CLI command against a Pod directly.
+If a master realm has already been created for your cluster, then the spec.bootstrapAdmin is effectively ignored. If you need to create a recovery admin account, then you'll need to run the CLI command against a Pod directly.
 
 For more information on how to bootstrap a temporary admin user or service account and recover lost admin access, refer to the <@links.server id="bootstrap-admin-recovery"/> guide.
 

--- a/docs/guides/server/configuration-production.adoc
+++ b/docs/guides/server/configuration-production.adoc
@@ -52,7 +52,7 @@ By default, there is no limit set.
 Set the option `http-max-queued-requests` to limit the number of queued requests to a given threshold matching your environment.
 Any request that exceeds this limit would return with an immediate `503 Server not Available` response.
 
-[[server-boostrap-behavior]]
+[[server-bootstrap-behavior]]
 == Server bootstrap behavior
 
 Server initialization, such as database migrations, may take a significant amount of time to complete.

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -98,7 +98,7 @@ import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakHandlerChainCustomizer;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakTracingCustomizer;
 import org.keycloak.quarkus.runtime.logging.ClearMappedDiagnosticContextFilter;
-import org.keycloak.quarkus.runtime.services.health.BoostrapReadyHealthCheck;
+import org.keycloak.quarkus.runtime.services.health.BootstrapReadyHealthCheck;
 import org.keycloak.quarkus.runtime.services.health.KeycloakClusterReadyHealthCheck;
 import org.keycloak.quarkus.runtime.services.health.KeycloakReadyHealthCheck;
 import org.keycloak.quarkus.runtime.storage.database.jpa.NamedJpaConnectionProviderFactory;
@@ -849,7 +849,7 @@ class KeycloakProcessor {
     }
 
     private static void disableBootstrapReadyHealthCheck(BuildProducer<BuildTimeConditionBuildItem> removeBeans, CombinedIndexBuildItem index) {
-        ClassInfo disabledBean = index.getIndex().getClassByName(DotName.createSimple(BoostrapReadyHealthCheck.class.getName()));
+        ClassInfo disabledBean = index.getIndex().getClassByName(DotName.createSimple(BootstrapReadyHealthCheck.class.getName()));
         removeBeans.produce(new BuildTimeConditionBuildItem(disabledBean.asClass(), false));
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/BootstrapFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/BootstrapFilter.java
@@ -57,7 +57,7 @@ public class BootstrapFilter {
         return Response
                 .status(Response.Status.SERVICE_UNAVAILABLE)
                 .type(MediaType.TEXT_PLAIN)
-                .entity("Boostrap in progress. Retry in " + retry + " seconds.")
+                .entity("Bootstrap in progress. Retry in " + retry + " seconds.")
                 .header(HttpHeaders.RETRY_AFTER, retry)
                 .header("Refresh", retry)
                 .build();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/BootstrapReadyHealthCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/BootstrapReadyHealthCheck.java
@@ -33,7 +33,7 @@ import org.eclipse.microprofile.health.Readiness;
  */
 @Readiness
 @ApplicationScoped
-public class BoostrapReadyHealthCheck implements AsyncHealthCheck {
+public class BootstrapReadyHealthCheck implements AsyncHealthCheck {
 
     private static final HealthCheckResponse UP = builder().up().build();
     private boolean bootstrapCompleted;

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
@@ -104,7 +104,7 @@ public class HealthDistTest {
                 .body("checks.size()", equalTo(3))
                 .body(containsString("\"Keycloak Initialized\""));
         assertTrue(result.getOutput().indexOf(LISTENING_ON_HTTP) < result.getOutput().indexOf(BOOTSTRAP_COMPLETED),
-                () -> "Should first listen, then boostrap");
+                () -> "Should first listen, then bootstrap");
     }
 
     @Test


### PR DESCRIPTION
Rename file / class: BoostrapReadyHealthCheck.java to BootstrapReadyHealthCheck.java

Closes #48032

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
