### PR TITLE
Account UI throws error when accessing applications tab without permissions

### DIFF
--- a/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/index.ftl
+++ b/js/apps/account-ui/maven-resources/theme/keycloak.v3/account/index.ftl
@@ -160,6 +160,7 @@
           "deleteAccountAllowed": ${deleteAccountAllowed?c},
           "updateEmailFeatureEnabled": ${updateEmailFeatureEnabled?c},
           "updateEmailActionEnabled": ${updateEmailActionEnabled?c},
+          "isViewApplicationsEnabled": ${isViewApplicationsEnabled?c},
           "isViewGroupsEnabled": ${isViewGroupsEnabled?c},
           "isOid4VciEnabled": ${isOid4VciEnabled?c}
         },

--- a/js/apps/account-ui/public/content.json
+++ b/js/apps/account-ui/public/content.json
@@ -12,7 +12,11 @@
       }
     ]
   },
-  { "label": "applications", "path": "applications" },
+  {
+    "label": "applications",
+    "path": "applications",
+    "isVisible": "isViewApplicationsEnabled"
+  },
   {
     "label": "groups",
     "path": "groups",

--- a/js/apps/account-ui/src/index.ts
+++ b/js/apps/account-ui/src/index.ts
@@ -77,6 +77,7 @@ export type Feature = {
   deleteAccountAllowed: boolean;
   updateEmailFeatureEnabled: boolean;
   updateEmailActionEnabled: boolean;
+  isViewApplicationsEnabled: boolean;
   isViewGroupsEnabled: boolean;
   isViewOrganizationsEnabled: boolean;
   isOid4VciEnabled: boolean;

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountConsole.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,6 +38,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.services.Urls;
 import org.keycloak.services.managers.AppAuthManager;
@@ -181,15 +183,18 @@ public class AccountConsole implements AccountResourceProvider {
 
         boolean deleteAccountAllowed = false;
         boolean isViewGroupsEnabled = false;
+        boolean isViewApplicationsEnabled = false;
         if (user != null) {
-            RoleModel deleteAccountRole = realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).getRole(AccountRoles.DELETE_ACCOUNT);
-            deleteAccountAllowed = deleteAccountRole != null && user.hasRole(deleteAccountRole) && realm.getRequiredActionProviderByAlias(DeleteAccount.PROVIDER_ID).isEnabled();
-            RoleModel viewGrouRole = realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID).getRole(AccountRoles.VIEW_GROUPS);
-            isViewGroupsEnabled = viewGrouRole != null && user.hasRole(viewGrouRole);
+            AccountRoleChecker roleChecker = new AccountRoleChecker(session, realm, user);
+            // the 'manage-account' role works on the API level (for the 'account' client) as some kind of composite role
+            deleteAccountAllowed = roleChecker.hasOneOfRole(AccountRoles.MANAGE_ACCOUNT, AccountRoles.DELETE_ACCOUNT) && realm.getRequiredActionProviderByAlias(DeleteAccount.PROVIDER_ID).isEnabled();
+            isViewGroupsEnabled = roleChecker.hasOneOfRole(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_GROUPS);
+            isViewApplicationsEnabled = roleChecker.hasOneOfRole(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_APPLICATIONS);
         }
 
         map.put("deleteAccountAllowed", deleteAccountAllowed);
 
+        map.put("isViewApplicationsEnabled", isViewApplicationsEnabled);
         map.put("isViewGroupsEnabled", isViewGroupsEnabled);
         map.put("isViewOrganizationsEnabled", realm.isOrganizationsEnabled());
         map.put("isOid4VciEnabled", realm.isVerifiableCredentialsEnabled());
@@ -324,5 +329,34 @@ public class AccountConsole implements AccountResourceProvider {
                 .map(identityProviders::getByAlias);
 
         return Stream.concat(realmBrokers, linkedBrokers).findAny().isPresent();
+    }
+
+    /**
+     * Checks whether a user has account roles that will be present in the access token issued for the {@code account-console} client.
+     */
+    static class AccountRoleChecker {
+
+        private final ClientModel accountClient;
+        private final Set<RoleModel> scopeResolvedRoles;
+
+        AccountRoleChecker(KeycloakSession session, RealmModel realm, UserModel user) {
+            this.accountClient = realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
+            ClientModel accountConsoleClient = realm.getClientByClientId(Constants.ACCOUNT_CONSOLE_CLIENT_ID);
+            this.scopeResolvedRoles = TokenManager.getAccess(user, accountConsoleClient, TokenManager.getRequestedClientScopes(session, null, accountConsoleClient, user));
+        }
+
+        boolean hasRole(String roleName) {
+            RoleModel role = accountClient.getRole(roleName);
+            return role != null && scopeResolvedRoles.contains(role);
+        }
+
+        boolean hasOneOfRole(String... roleNames) {
+            for (String roleName : roleNames) {
+                if (hasRole(roleName)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -445,7 +445,7 @@ public class AccountRestService {
     @Produces(MediaType.APPLICATION_JSON)
     //TODO GROUPS this isn't paginated
     public Stream<GroupRepresentation> groupMemberships(@QueryParam("briefRepresentation") @DefaultValue("true") boolean briefRepresentation) {
-        auth.require(AccountRoles.VIEW_GROUPS);
+        auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_GROUPS);
         return user.getGroupsStream().map(g -> ModelToRepresentation.toRepresentation(g, !briefRepresentation));
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceRolesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceRolesTest.java
@@ -1,0 +1,242 @@
+package org.keycloak.tests.account;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.models.AccountRoles;
+import org.keycloak.models.Constants;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
+import org.keycloak.tests.utils.admin.AdminApiUtil;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.PkceGenerator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest
+public class AccountRestServiceRolesTest {
+
+    private static final String PASSWORD = "password";
+
+    @InjectRealm(config = AccountRolesRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectHttpClient
+    CloseableHttpClient httpClient;
+
+    @Test
+    public void applicationsEndpointAccess() throws IOException {
+        assertEndpointStatus("manage-account-user", "applications", 200);
+        assertEndpointStatus("view-applications-user", "applications", 200);
+        assertEndpointStatus("no-access-user", "applications", 403);
+    }
+
+    @Test
+    public void groupsEndpointAccess() throws IOException {
+        assertEndpointStatus("manage-account-user", "groups", 200);
+        assertEndpointStatus("view-groups-user", "groups", 200);
+        assertEndpointStatus("no-access-user", "groups", 403);
+    }
+
+    @Test
+    public void accountConsoleFeaturesForManageAccountUser() throws IOException {
+        assertAccountConsoleFeatures("manage-account-user", true, true);
+    }
+
+    @Test
+    public void accountConsoleFeaturesForViewApplicationsUser() throws IOException {
+        // view-applications is not in the account-console default scope (only manage-account and view-groups are)
+        addAccountConsoleScopeMapping(AccountRoles.VIEW_APPLICATIONS);
+        assertAccountConsoleFeatures("view-applications-user", true, false);
+    }
+
+    @Test
+    public void accountConsoleFeaturesForViewGroupsUser() throws IOException {
+        assertAccountConsoleFeatures("view-groups-user", false, true);
+    }
+
+    @Test
+    public void accountConsoleFeaturesForNoAccessUser() throws IOException {
+        assertAccountConsoleFeatures("no-access-user", false, false);
+    }
+
+    private void addAccountConsoleScopeMapping(String roleName) {
+        ClientResource accountConsole = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ACCOUNT_CONSOLE_CLIENT_ID);
+        ClientResource accountManagementClient = AdminApiUtil.findClientByClientId(realm.admin(), Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
+        assertNotNull(accountConsole);
+        assertNotNull(accountManagementClient);
+
+        String accountClientUuid = accountManagementClient.toRepresentation().getId();
+
+        RoleRepresentation role = accountManagementClient.roles().get(roleName).toRepresentation();
+        accountConsole.getScopeMappings().clientLevel(accountClientUuid).add(List.of(role));
+    }
+
+    private void assertAccountConsoleFeatures(String username, boolean expectApps, boolean expectGroups) throws IOException {
+        JsonNode features = getAccountConsoleFeatures(username);
+        assertEquals(expectApps, features.get("isViewApplicationsEnabled").asBoolean(),
+                "isViewApplicationsEnabled mismatch for " + username + ", features: " + features);
+        assertEquals(expectGroups, features.get("isViewGroupsEnabled").asBoolean(),
+                "isViewGroupsEnabled mismatch for " + username + ", features: " + features);
+    }
+
+    private JsonNode getAccountConsoleFeatures(String username) throws IOException {
+        // Disable redirect handling and manage cookies manually via headers,
+        // same approach as ConcurrentLoginTest — Apache HttpClient's cookie store
+        // does not reliably propagate cookies through redirect chains.
+        try (CloseableHttpClient client = HttpClientBuilder.create()
+                .disableRedirectHandling()
+                .build()) {
+
+            // Build authorization URL for account-console to trigger login flow
+            // PKCE is required for the account-console public client
+            PkceGenerator pkce = PkceGenerator.s256();
+            String authUrl = realm.getBaseUrl() + "/protocol/openid-connect/auth"
+                    + "?client_id=" + Constants.ACCOUNT_CONSOLE_CLIENT_ID
+                    + "&redirect_uri=" + URLEncoder.encode(realm.getBaseUrl() + "/account/", StandardCharsets.UTF_8)
+                    + "&response_type=code"
+                    + "&scope=openid"
+                    + "&" + OAuth2Constants.CODE_CHALLENGE + "=" + pkce.getCodeChallenge()
+                    + "&" + OAuth2Constants.CODE_CHALLENGE_METHOD + "=" + pkce.getCodeChallengeMethod();
+
+            // Step 1: GET login page, capture cookies from response
+            HttpResponse formResponse = client.execute(new HttpGet(authUrl));
+            String cookies = parseCookies(formResponse.getAllHeaders());
+            String loginPageHtml = EntityUtils.toString(formResponse.getEntity());
+
+            // Step 2: Extract action URL and POST credentials with cookies
+            Matcher actionMatcher = Pattern.compile("action=\"([^\"]*)\"").matcher(loginPageHtml);
+            assertTrue(actionMatcher.find(), "Login form action URL not found in HTML");
+            String actionUrl = actionMatcher.group(1).replace("&amp;", "&");
+
+            HttpPost loginRequest = new HttpPost(actionUrl);
+            loginRequest.setHeader("Cookie", cookies);
+            List<NameValuePair> params = new ArrayList<>();
+            params.add(new BasicNameValuePair("username", username));
+            params.add(new BasicNameValuePair("password", PASSWORD));
+            loginRequest.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+
+            HttpResponse loginResponse = client.execute(loginRequest);
+            assertEquals(302, loginResponse.getStatusLine().getStatusCode(),
+                    "Expected redirect after login, got " + loginResponse.getStatusLine().getStatusCode());
+
+            // Merge cookies from login response (includes KEYCLOAK_IDENTITY)
+            String allCookies = mergeCookies(cookies, parseCookies(loginResponse.getAllHeaders()));
+            EntityUtils.consume(loginResponse.getEntity());
+
+            // Step 3: Fetch account console HTML with session cookies
+            HttpGet accountRequest = new HttpGet(realm.getBaseUrl() + "/account/");
+            accountRequest.setHeader("Cookie", allCookies);
+
+            String accountHtml;
+            try (CloseableHttpResponse response = client.execute(accountRequest)) {
+                assertEquals(200, response.getStatusLine().getStatusCode());
+                accountHtml = EntityUtils.toString(response.getEntity());
+            }
+
+            // Parse features from <script id="environment"> JSON block
+            Matcher envMatcher = Pattern.compile(
+                    "<script id=\"environment\"[^>]*>\\s*(\\{.*?})\\s*</script>", Pattern.DOTALL
+            ).matcher(accountHtml);
+            assertTrue(envMatcher.find(), "Environment script block not found in account console HTML");
+
+            JsonNode environment = new ObjectMapper().readTree(envMatcher.group(1));
+            return environment.get("features");
+        }
+    }
+
+    private String parseCookies(Header[] headers) {
+        return Arrays.stream(headers)
+                .filter(h -> h.getName().equals("Set-Cookie"))
+                .map(h -> h.getValue().split(";")[0])
+                .collect(Collectors.joining("; "));
+    }
+
+    private String mergeCookies(String existing, String additional) {
+        if (existing.isEmpty()) return additional;
+        if (additional.isEmpty()) return existing;
+        return existing + "; " + additional;
+    }
+
+    private void assertEndpointStatus(String username, String endpoint, int expectedStatus) throws IOException {
+        AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest(username, PASSWORD);
+        assertTrue(tokenResponse.isSuccess(), "Token request failed for " + username + ": " + tokenResponse.getErrorDescription());
+
+        HttpGet request = new HttpGet(realm.getBaseUrl() + "/account/" + endpoint);
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.getAccessToken());
+        request.addHeader(HttpHeaders.ACCEPT, "application/json");
+
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            assertEquals(expectedStatus, response.getStatusLine().getStatusCode(),
+                    "Unexpected status for /" + endpoint + " with user " + username);
+        }
+    }
+
+    public static class AccountRolesRealmConfig implements RealmConfig {
+        @Override
+        public RealmConfigBuilder configure(RealmConfigBuilder realm) {
+            realm.addUser("manage-account-user")
+                    .name("Manage", "Account")
+                    .email("manage-account@localhost")
+                    .password(PASSWORD)
+                    .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);
+
+            realm.addUser("view-applications-user")
+                    .name("View", "Applications")
+                    .email("view-applications@localhost")
+                    .password(PASSWORD)
+                    .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.VIEW_APPLICATIONS, AccountRoles.VIEW_PROFILE);
+
+            realm.addUser("view-groups-user")
+                    .name("View", "Groups")
+                    .email("view-groups@localhost")
+                    .password(PASSWORD)
+                    .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.VIEW_GROUPS, AccountRoles.VIEW_PROFILE);
+
+            realm.addUser("no-access-user")
+                    .name("No", "Access")
+                    .email("no-access@localhost")
+                    .password(PASSWORD)
+                    .clientRoles(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID, AccountRoles.VIEW_PROFILE);
+
+            return realm;
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/suites/Base2TestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/Base2TestSuite.java
@@ -5,6 +5,7 @@ import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectPackages({
+        "org.keycloak.tests.account",
         "org.keycloak.tests.authz",
         "org.keycloak.tests.broker",
         "org.keycloak.tests.client",


### PR DESCRIPTION
- Closes: #40603
- The main issue is in the `AccountConsole` server logic, as the environment conditions passed to the render HTML do not take into account the client scopes of the `account-console` client - it should not just check if the user has appropriate roles to access the Account API, but also scopes for the public UI client token
- It means that after the cookie authn (before the `keycloak-js` init and before obtaining the token), the user sees data/tabs in the UI that their access token (issued for the 'account-console' client - handling also these client scopes) would never grant access to. 
- So, the init of the account console (SPA) just simulates the same condition that the user will have after initializing the 'keycloak-js' client and authz code flow execution and following obtaining bearer token

### Other considerations
#### Pseudo composite role `manage-account`
- On the Account API level, the `manage-account` role behaves the same as a composite role of all account roles (view-profile, view-applications, delete-account), but it's not really a composite role of those - and why not?
- IMHO, the `manage-account` role should be a composite role of those, as on the API level, it's treated as some kind of super-role
 
```java
auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);
// or
auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_CONSENT, AccountRoles.MANAGE_CONSENT);
```
cc: @mposolda @rmartinc 

#### Inconsistent handling of the `view-groups` role
- Why the `view-groups` behave differently from the other account roles?
- There's no check for the `manage-account` role on the API level, and for consistency, IMHO, it should
- Can you elaborate why it's even treated differently for the default dedicated client scopes for the 'account-console' client?
- The default dedicated client scopes are `manage-account`, and the `view-groups` for the `account-console` client
- IMO, the `view-groups` should not be part of the dedicated client scopes for the client
- Assess consistency here https://github.com/keycloak/keycloak/compare/main...mabartos:keycloak:KC-40603?expand=1#diff-fc123a23478ff3437efb058e4ab8b41bbcc9839a8404f74bc65e44d3fb8ac9aaR448
- btw. we can potentially hide the Groups tab if user is not part of any group

cc: @pedroigor @vramik @sguilhen 

### See it in action

https://github.com/user-attachments/assets/cdd664fc-183c-4529-a84c-1cd98637898c

