### PR TITLE
fix(session-limits): guard against negative stream limit when realm limit exceeded but client is not

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -194,6 +194,9 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
      */
     private List<UserSessionModel> logoutOldestSessions(List<UserSessionModel> userSessions, long limit, EventBuilder eventBuilder) {
         long numberOfSessionsThatNeedToBeLoggedOut = getNumberOfSessionsThatNeedToBeLoggedOut(userSessions.size(), limit);
+        if (numberOfSessionsThatNeedToBeLoggedOut <= 0) {
+            return Collections.emptyList();
+        }
         if (numberOfSessionsThatNeedToBeLoggedOut == 1) {
             logger.info("Logging out oldest session");
         } else {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -265,6 +265,40 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void testRealmSessionLimitExceededButClientLimitNotExceededShouldNotThrow() throws Exception {
+        // Reproduces: realm limit exceeded on client-a, then login to client-b whose client
+        // session count is below the client limit. Without the fix, logoutOldestSessions()
+        // receives a negative count and Stream.limit() throws IllegalArgumentException.
+        try {
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "2");
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "3");
+
+            AccessTokenResponse response = oauth.client("direct-grant-1", "password")
+                    .doPasswordGrantRequest("test-user@localhost", "password");
+            assertEquals(200, response.getStatusCode());
+
+            response = oauth.client("direct-grant-1", "password")
+                    .doPasswordGrantRequest("test-user@localhost", "password");
+            assertEquals(200, response.getStatusCode());
+
+            // realm limit reached (2 sessions on direct-grant-1); direct-grant-2 has 0 sessions,
+            // below the client limit of 3. login must succeed and must not throw a 500.
+            response = oauth.client("direct-grant-2", "password")
+                    .doPasswordGrantRequest("test-user@localhost", "password");
+            assertEquals(200, response.getStatusCode());
+
+            testingClient.server(realmName).run(assertSessionCount(realmName, username, 2));
+            testingClient.server(realmName).run(assertClientSessionCount(realmName, username, "direct-grant-1", 1));
+            testingClient.server(realmName).run(assertClientSessionCount(realmName, username, "direct-grant-2", 1));
+        } finally {
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.DENY_NEW_SESSION);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "0");
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "1");
+        }
+    }
+
+    @Test
     public void testRealmSessionCountAndClientSessionCountExceededAndOldestClientSessionShouldBePrioritized() throws Exception {
         try {
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION);


### PR DESCRIPTION
when the realm session limit is exceeded and `behavior` is set to `Terminate oldest session`, the authenticator calls
`handleLimitExceeded(userSessionsForClient, userClientLimit)` first.

if the user has fewer existing sessions for the current client than `userClientLimit - 1`, `getNumberOfSessionsThatNeedToBeLoggedOut()` returns a negative value and `Stream.limit(negative)` throws
`IllegalArgumentException`, producing a 500 on every login to that client.

added an early return in `logoutOldestSessions()` for the case where `numberOfSessionsThatNeedToBeLoggedOut <= 0`. the existing second check (`exceedsLimit(realmCount - removed.size(), realmLimit)`) then picks up
and removes a session using the realm-scoped list and realm limit, which always produces a non-negative count.

also added a regression test in `UserSessionLimitsTest` that reproduces the scenario: realm limit=2, client limit=3, two logins on client-a to saturate the realm, then login on client-b (0 existing client sessions).

Fixes #48040