### PR TITLE
when the realm session limit is exceeded and behavior is set to Termi…

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -194,7 +194,11 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
      */
     private List<UserSessionModel> logoutOldestSessions(List<UserSessionModel> userSessions, long limit, EventBuilder eventBuilder) {
         long numberOfSessionsThatNeedToBeLoggedOut = getNumberOfSessionsThatNeedToBeLoggedOut(userSessions.size(), limit);
-        if (numberOfSessionsThatNeedToBeLoggedOut == 1) {
+
+        if (numberOfSessionsThatNeedToBeLoggedOut == 0) {
+            logger.debug("No additional sessions that need to be logged out");
+            return Collections.emptyList();
+        } else if (numberOfSessionsThatNeedToBeLoggedOut == 1) {
             logger.info("Logging out oldest session");
         } else {
             logger.infof("Logging out oldest %s sessions", numberOfSessionsThatNeedToBeLoggedOut);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/sessionlimits/UserSessionLimitsAuthenticator.java
@@ -116,7 +116,7 @@ public class UserSessionLimitsAuthenticator implements Authenticator {
     }
 
     private long getNumberOfSessionsThatNeedToBeLoggedOut(long count, long limit) {
-        return count - (limit - 1);
+        return Math.max(0, count - (limit - 1));
     }
 
     private int getIntConfigProperty(String key, Map<String, String> config) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/sessionlimits/UserSessionLimitsTest.java
@@ -265,6 +265,40 @@ public class UserSessionLimitsTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
+    public void testRealmSessionLimitExceededButClientLimitNotExceededShouldNotThrow() throws Exception {
+        // Reproduces: realm limit exceeded on client-a, then login to client-b whose client
+        // session count is below the client limit. Without the fix, logoutOldestSessions()
+        // receives a negative count and Stream.limit() throws IllegalArgumentException.
+        try {
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "2");
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "3");
+
+            AccessTokenResponse response = oauth.client("direct-grant-1", "password")
+                    .doPasswordGrantRequest("test-user@localhost", "password");
+            assertEquals(200, response.getStatusCode());
+
+            response = oauth.client("direct-grant-1", "password")
+                    .doPasswordGrantRequest("test-user@localhost", "password");
+            assertEquals(200, response.getStatusCode());
+
+            // realm limit reached (2 sessions on direct-grant-1); direct-grant-2 has 0 sessions,
+            // below the client limit of 3. login must succeed and must not throw a 500.
+            response = oauth.client("direct-grant-2", "password")
+                    .doPasswordGrantRequest("test-user@localhost", "password");
+            assertEquals(200, response.getStatusCode());
+
+            testingClient.server(realmName).run(assertSessionCount(realmName, username, 2));
+            testingClient.server(realmName).run(assertClientSessionCount(realmName, username, "direct-grant-1", 1));
+            testingClient.server(realmName).run(assertClientSessionCount(realmName, username, "direct-grant-2", 1));
+        } finally {
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.DENY_NEW_SESSION);
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_REALM_LIMIT, "0");
+            setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.USER_CLIENT_LIMIT, "1");
+        }
+    }
+
+    @Test
     public void testRealmSessionCountAndClientSessionCountExceededAndOldestClientSessionShouldBePrioritized() throws Exception {
         try {
             setAuthenticatorConfigItem(DefaultAuthenticationFlows.DIRECT_GRANT_FLOW, UserSessionLimitsAuthenticatorFactory.BEHAVIOR, UserSessionLimitsAuthenticatorFactory.TERMINATE_OLDEST_SESSION);


### PR DESCRIPTION
when the realm session limit is exceeded and behavior is set to Terminate oldest session, the authenticator calls
handleLimitExceeded(userSessionsForClient, userClientLimit) first.


if the user has fewer existing sessions for the current client than userClientLimit - 1, getNumberOfSessionsThatNeedToBeLoggedOut() returns a negative value and Stream.limit(negative) throws IllegalArgumentException, producing a 500 on every login to that client.

This change ensures that getNumberOfSessionsThatNeedToBeLoggedOut returns 0 if the calculated value is negative. The dependent execution steps remain unchanged.
A result of 0 sessions to be purged from the current client triggers the removal of the oldest sessions across all clients.

also added a regression test in UserSessionLimitsTest that reproduces the scenario: realm limit=2, client limit=3, two logins on client-a to saturate the realm, then login on client-b (0 existing client sessions).

Fixes #48040

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
