### PR TITLE
docs(admin): unify realm placeholder to {realm-name}

### DIFF
--- a/docs/documentation/server_admin/topics/organizations/managing-members.adoc
+++ b/docs/documentation/server_admin/topics/organizations/managing-members.adoc
@@ -157,10 +157,10 @@ NOTE: When a user successfully accepts an invitation, the invitation is automati
 
 Organization invitations can also be managed programmatically through the Admin REST API:
 
-* `GET /admin/realms/{realm}/orgs/{orgId}/invitations` - List all invitations
-* `GET /admin/realms/{realm}/orgs/{orgId}/invitations/{invitationId}` - Get specific invitation
-* `POST /admin/realms/{realm}/orgs/{orgId}/invitations/{invitationId}/resend` - Resend invitation
-* `DELETE /admin/realms/{realm}/orgs/{orgId}/invitations/{invitationId}` - Delete invitation
+* `GET /admin/realms/{realm-name}/orgs/{orgId}/invitations` - List all invitations
+* `GET /admin/realms/{realm-name}/orgs/{orgId}/invitations/{invitationId}` - Get specific invitation
+* `POST /admin/realms/{realm-name}/orgs/{orgId}/invitations/{invitationId}/resend` - Resend invitation
+* `DELETE /admin/realms/{realm-name}/orgs/{orgId}/invitations/{invitationId}` - Delete invitation
 
 For detailed API documentation, refer to the {project_name} Admin REST API documentation.
 


### PR DESCRIPTION
## Summary

Small placeholder-alignment step for #33018. Switches the 4 `{realm}` occurrences in `managing-members.adoc` to `{realm-name}`, matching the convention already used across the rest of the admin / SSO-protocol / authz-services docs.

```diff
-* `GET /admin/realms/{realm}/orgs/{orgId}/invitations` - List all invitations
+* `GET /admin/realms/{realm-name}/orgs/{orgId}/invitations` - List all invitations
...
```

## Scope

A quick grep over `docs/documentation/` shows:

```
 96 {realm-name}
 18 {realm}
```

Nearly all the remaining `{realm}` residue is in `upgrading/` and `release_notes/` files that document historical behaviour and should not be edited. `managing-members.adoc` is the only current-docs file with `{realm}` outside those snapshots, so the whole cleanup for current docs is these 4 lines.

## Follow-ups left out

- SAML docs use `{url-name}` (in `idp-initiated-login.adoc`) vs `{client-url-name}` (in `proc-creating-saml-client.adoc`) for the same **IDP-Initiated SSO URL Name** concept. That's a legitimate second pass but feels orthogonal; happy to fold it in here or send a follow-up if preferred.

Part of #33018