### PR TITLE
Override hasDirectRole in GroupAdapter to use targeted query

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/GroupAdapter.java
@@ -342,6 +342,17 @@ public class GroupAdapter implements GroupModel , JpaModel<GroupEntity> {
         return parent != null && parent.hasRole(role);
     }
 
+    @Override
+    public boolean hasDirectRole(RoleModel role) {
+        TypedQuery<GroupRoleMappingEntity> query = getGroupRoleMappingEntityTypedQuery(role);
+        GroupRoleMappingEntity membership = query.getSingleResultOrNull();
+        // Avoid keeping it in the persistence context, as the group might be detached for example in a bulk delete
+        if (membership != null) {
+            em.detach(membership);
+        }
+        return membership != null;
+    }
+
     protected TypedQuery<GroupRoleMappingEntity> getGroupRoleMappingEntityTypedQuery(RoleModel role) {
         TypedQuery<GroupRoleMappingEntity> query = em.createNamedQuery("groupHasRole", GroupRoleMappingEntity.class);
         query.setParameter("group", getEntity());


### PR DESCRIPTION
`GroupAdapter.hasDirectRole()` falls back to the default `RoleMapperModel` implementation, which calls `getRoleMappingsStream()` — loading all role mappings from the database just to check if a single mapping exists. This is called from `grantRole()` as a guard check.

This overrides `hasDirectRole()` to use the existing `groupHasRole` named query directly, matching the optimization already done in `UserAdapter`. 

Closes #48088


