### PR TITLE
Update Openshift version referenced in the HA guide from `4.18` to `4.21`

### DIFF
--- a/docs/guides/high-availability/multi-cluster/concepts-memory-and-cpu-sizing.adoc
+++ b/docs/guides/high-availability/multi-cluster/concepts-memory-and-cpu-sizing.adoc
@@ -48,7 +48,7 @@ The benefit of this setup is that the number of Pods does not need to scale duri
 
 The following setup was used to retrieve the settings above to run tests of about 10 minutes for different scenarios:
 
-* OpenShift 4.18.x deployed on AWS via ROSA.
+* OpenShift 4.21.x deployed on AWS via ROSA.
 * Machine pool with `c7g.2xlarge` instances.^*^
 * {project_name} deployed with the Operator and 3 pods in a high-availability setup with two sites in active/active mode.
 * OpenShift's reverse proxy runs in the passthrough mode where the TLS connection of the client is terminated at the Pod.

--- a/docs/guides/high-availability/multi-cluster/introduction.adoc
+++ b/docs/guides/high-availability/multi-cluster/introduction.adoc
@@ -38,7 +38,7 @@ We regularly test {project_name} with the following configuration:
 using ROSA HCP.
 
 ** All worker nodes reside in a single Availability Zone.
-** OpenShift version 4.18.
+** OpenShift version 4.21.
 
 * Amazon Aurora PostgreSQL database
 ** High availability with a primary DB instance in one availability zone, and a synchronously replicated reader in the second availability zone
@@ -60,7 +60,7 @@ either ROSA HCP or ROSA classic.
 ** Each {kubernetes} cluster has all its workers in a single Availability Zone.
 <@profile.ifProduct>
 ** OpenShift version
-4.18 (or later).
+4.21 (or later).
 </@profile.ifProduct>
 <@profile.ifCommunity>
 ** Kubernetes version 1.30

--- a/docs/guides/high-availability/single-cluster/introduction.adoc
+++ b/docs/guides/high-availability/single-cluster/introduction.adoc
@@ -34,7 +34,7 @@ We regularly test {project_name} with the following configuration:
 using ROSA HCP.
 
 ** At least one worker node for each availability-zone
-** OpenShift version 4.18.
+** OpenShift version 4.21.
 
 * Amazon Aurora PostgreSQL database
 ** High availability with a primary DB instance in one availability zone, and synchronously replicated readers in the other availability zones


### PR DESCRIPTION
Closes #47963.