### PR TITLE
testsuite: fix 'occured' -> 'occurred' in AbstractCommand error log

### DIFF
--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/AbstractCommand.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/AbstractCommand.java
@@ -54,7 +54,7 @@ public abstract class AbstractCommand {
         } catch (HandledException handled) {
             // Fine to ignore. Was handled already
         } catch (RuntimeException e) {
-            log.error("Error occured during command. ", e);
+            log.error("Error occurred during command. ", e);
         }
     }
 


### PR DESCRIPTION
Log message in `testsuite/utils/src/main/java/org/keycloak/testsuite/util/cli/AbstractCommand.java` line 57 reads `Error occured during command`. Fixed to `occurred`. String-literal-only change.