### PR TITLE
Fixing teams ownership for core authn

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -10,15 +10,14 @@ team/continuous-delivery:
   - area/testsuite
 
 team/core-clients:
+
+team/core-protocols:
   - area/adapter/fuse
   - area/adapter/java-cli
   - area/adapter/jee
   - area/adapter/jee-saml
   - area/adapter/spring
   - area/adapter/javascript
-  - area/authentication
-  - area/authentication/webauthn
-  - area/login/ui
   - area/oidc
   - area/oid4vc
   - area/saml
@@ -35,14 +34,9 @@ team/core-iam:
   - area/workflows
 
 team/core-authn:
-  - area/account/ui
-  - area/admin/ui
   - area/authentication
-  - area/core
-  - area/identity-brokering
-  - area/saml
-  - area/test-framework
-  - area/token-exchange/subject-impersonation
+  - area/authentication/webauthn
+  - area/login/ui
 
 team/core-shared:
   - area/account/api


### PR DESCRIPTION
We need to have a chat to discuss how we break things up in more detail, but the changes that where recently merged to this file contained quite a few inaccurate things.