### PR TITLE
Fix CORS origin validation for Admin and Account REST Apis

### DIFF
--- a/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/DefaultAdminRootV2.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/DefaultAdminRootV2.java
@@ -26,7 +26,7 @@ public class DefaultAdminRootV2 implements AdminRootV2 {
   @Override
   public Response preFlight() {
     checkApiEnabled();
-    return new AdminCorsPreflightService().preflight();
+    return new AdminCorsPreflightService(AdminCorsPreflightService.resolveAdminConsoleClient(session)).preflight();
   }
 
   private void checkApiEnabled() {

--- a/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java
@@ -77,6 +77,8 @@ public interface Cors extends Provider {
 
     Cors allowedOrigins(AccessToken token);
 
+    Cors allowedOrigins(AccessToken token, KeycloakSession session, ClientModel fallbackClient);
+
     Cors allowedOrigins(String... allowedOrigins);
 
     Cors allowedOrigins(List<String> allowedOrigins);

--- a/services/src/main/java/org/keycloak/services/cors/DefaultCors.java
+++ b/services/src/main/java/org/keycloak/services/cors/DefaultCors.java
@@ -111,6 +111,15 @@ public class DefaultCors implements Cors {
     }
 
     @Override
+    public Cors allowedOrigins(AccessToken token, KeycloakSession session, ClientModel fallbackClient) {
+        allowedOrigins(token);
+        if (allowedOrigins == null || allowedOrigins.isEmpty()) {
+            allowedOrigins(session, fallbackClient);
+        }
+        return this;
+    }
+
+    @Override
     public Cors allowedOrigins(String... allowedOrigins) {
         if (allowedOrigins != null && allowedOrigins.length > 0) {
             this.allowedOrigins = new HashSet<>(Arrays.asList(allowedOrigins));
@@ -169,7 +178,7 @@ public class DefaultCors implements Cors {
             return;
         }
 
-        if (!preflight && (allowedOrigins == null || (!allowedOrigins.contains(origin) && !allowedOrigins.contains(ACCESS_CONTROL_ALLOW_ORIGIN_WILDCARD)))) {
+        if (allowedOrigins == null ? !preflight : (!allowedOrigins.contains(origin) && !allowedOrigins.contains(ACCESS_CONTROL_ALLOW_ORIGIN_WILDCARD))) {
             String requestOrigin = UriUtils.getOrigin(session.getContext().getUri().getRequestUri());
             if (!origin.equals(requestOrigin) && logger.isDebugEnabled()) {
                 logger.debugv("Invalid CORS request: origin {0} not in allowed origins {1}", origin, allowedOrigins);

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -136,7 +136,8 @@ public class AccountLoader {
 
         Auth auth = new Auth(session.getContext().getRealm(), accessToken, authResult.user(), client, authResult.session(), false);
 
-        Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
+        Cors.builder().allowedOrigins(auth.getToken(), session, session.getContext().getRealm().getClientByClientId(Constants.ACCOUNT_CONSOLE_CLIENT_ID))
+                .allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
 
         if (authResult.user().getServiceAccountClientLink() != null) {
             throw new NotAuthorizedException("Service accounts are not allowed to access this service");

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -185,7 +185,7 @@ public class AdminConsole {
     @Path("whoami")
     @OPTIONS
     public Response whoAmIPreFlight() {
-        return new AdminCorsPreflightService().preflight();
+        return new AdminCorsPreflightService(realm.getClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID)).preflight();
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminCorsPreflightService.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminCorsPreflightService.java
@@ -1,15 +1,29 @@
 package org.keycloak.services.resources.admin;
 
+import java.util.List;
+
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.services.cors.Cors;
+import org.keycloak.utils.KeycloakSessionUtil;
 
 /**
  * Created by st on 21/03/17.
  */
 public class AdminCorsPreflightService {
+
+    private final ClientModel adminConsole;
+
+    public AdminCorsPreflightService(ClientModel adminConsole) {
+        this.adminConsole = adminConsole;
+    }
 
     /**
      * CORS preflight
@@ -19,7 +33,32 @@ public class AdminCorsPreflightService {
     @Path("{any:.*}")
     @OPTIONS
     public Response preflight() {
-        return Cors.builder().preflight().allowedMethods("GET", "PUT", "POST", "DELETE").auth().add(Response.ok());
+        KeycloakSession session = KeycloakSessionUtil.getKeycloakSession();
+        return Cors.builder().preflight().allowedMethods("GET", "PUT", "POST", "DELETE").auth()
+                .allowedOrigins(session, adminConsole).add(Response.ok());
+    }
+
+    public static ClientModel resolveAdminConsoleClient(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        if (realm == null) {
+            String realmName = extractRealmName(session.getContext().getUri().getPathSegments());
+            if (realmName != null) {
+                realm = session.realms().getRealmByName(realmName);
+            }
+        }
+        return realm == null ? null : realm.getClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID);
+    }
+
+    private static String extractRealmName(List<PathSegment> segments) {
+        if (segments.size() < 3) {
+            return null;
+        }
+        // /admin/realms/{realm}/... (v1) or /admin/api/{realm}/... (v2)
+        String resourceType = segments.get(1).getPath();
+        if ("realms".equals(resourceType) || "api".equals(resourceType)) {
+            return segments.get(2).getPath();
+        }
+        return null;
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -40,6 +40,8 @@ import org.keycloak.common.util.Encode;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakUriInfo;
 import org.keycloak.models.RealmModel;
@@ -238,7 +240,7 @@ public class AdminRoot {
         }
 
         if (request.getHttpMethod().equals(HttpMethod.OPTIONS)) {
-            return new RealmsAdminResourcePreflight(session, null, tokenManager, request);
+            return new RealmsAdminResourcePreflight(session, null, tokenManager, request, resolveAdminConsoleClient());
         }
 
         AdminAuth auth = authenticateRealmAdminRequest(session);
@@ -248,7 +250,8 @@ public class AdminRoot {
             }
         }
 
-        Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").exposedHeaders("Location").auth().add();
+        Cors.builder().allowedOrigins(auth.getToken(), session, auth.getRealm().getClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID))
+                .allowedMethods("GET", "PUT", "POST", "DELETE").exposedHeaders("Location").auth().failOnInvalidOrigin().add();
 
         return new RealmsAdminResource(session, auth, tokenManager);
     }
@@ -261,7 +264,7 @@ public class AdminRoot {
             throw new NotFoundException();
         }
 
-        return new AdminCorsPreflightService();
+        return new AdminCorsPreflightService(resolveAdminConsoleClient());
     }
 
     /**
@@ -280,7 +283,7 @@ public class AdminRoot {
         HttpRequest request = getHttpRequest();
 
         if (request.getHttpMethod().equals(HttpMethod.OPTIONS)) {
-            return new AdminCorsPreflightService();
+            return new AdminCorsPreflightService(resolveAdminConsoleClient());
         }
 
         AdminAuth auth = authenticateRealmAdminRequest(session);
@@ -292,13 +295,18 @@ public class AdminRoot {
             logger.debugf("authenticated admin access for: %s", auth.getUser().getUsername());
         }
 
-        Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
+        Cors.builder().allowedOrigins(auth.getToken(), session, auth.getRealm().getClientByClientId(Constants.ADMIN_CONSOLE_CLIENT_ID))
+                .allowedMethods("GET", "PUT", "POST", "DELETE").auth().failOnInvalidOrigin().add();
 
         return new ServerInfoAdminResource(session, auth);
     }
 
     private HttpRequest getHttpRequest() {
         return session.getContext().getHttpRequest();
+    }
+
+    private ClientModel resolveAdminConsoleClient() {
+        return AdminCorsPreflightService.resolveAdminConsoleClient(session);
     }
 
     public static Theme getTheme(KeycloakSession session, RealmModel realm) throws IOException {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResourcePreflight.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RealmsAdminResourcePreflight.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.http.HttpRequest;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.services.cors.Cors;
@@ -29,20 +30,20 @@ import org.keycloak.services.cors.Cors;
 public class RealmsAdminResourcePreflight extends RealmsAdminResource {
 
     private HttpRequest request;
+    private final ClientModel adminConsole;
 
-    public RealmsAdminResourcePreflight(KeycloakSession session, AdminAuth auth, TokenManager tokenManager) {
-        super(session, auth, tokenManager);
-    }
-
-    public RealmsAdminResourcePreflight(KeycloakSession session, AdminAuth auth, TokenManager tokenManager, HttpRequest request) {
+    public RealmsAdminResourcePreflight(KeycloakSession session, AdminAuth auth, TokenManager tokenManager,
+                                        HttpRequest request, ClientModel adminConsole) {
         super(session, auth, tokenManager);
         this.request = request;
+        this.adminConsole = adminConsole;
     }
 
     @Path("{any:.*}")
     @OPTIONS
     public Response preFlight() {
-        return Cors.builder().preflight().allowedMethods("GET", "PUT", "POST", "DELETE").auth().add(Response.ok());
+        return Cors.builder().preflight().allowedMethods("GET", "PUT", "POST", "DELETE").auth()
+                .allowedOrigins(session, adminConsole).add(Response.ok());
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/AdminPreflightTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/AdminPreflightTest.java
@@ -14,6 +14,7 @@ import org.apache.http.client.methods.HttpOptions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest
@@ -35,15 +36,27 @@ public class AdminPreflightTest {
         testPreflightForAdminPath("/serverinfo");
     }
 
+    @Test
+    public void testPreflightInvalidOrigin() throws IOException {
+        HttpOptions options = new HttpOptions(keycloakUrls.getAdminBuilder().path("/realms/master/users").build());
+        options.setHeader("Origin", "http://invalid.example.com");
+
+        HttpResponse response = client.execute(options);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertNull(response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
     private void testPreflightForAdminPath(String path) throws IOException {
+        String validOrigin = keycloakUrls.getBase().toString();
+
         HttpOptions options = new HttpOptions(keycloakUrls.getAdminBuilder().path(path).build());
-        options.setHeader("Origin", "http://test");
+        options.setHeader("Origin", validOrigin);
 
         HttpResponse response = client.execute(options);
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertEquals("true", response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_CREDENTIALS).getValue());
         assertEquals("DELETE, POST, GET, PUT", response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_METHODS).getValue());
-        assertEquals("http://test", response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN).getValue());
+        assertEquals(validOrigin, response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN).getValue());
         assertEquals("3600", response.getFirstHeader(Cors.ACCESS_CONTROL_MAX_AGE).getValue());
         assertTrue(response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_HEADERS).getValue().contains("Authorization"));
         assertTrue(response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_HEADERS).getValue().contains("Content-Type"));

--- a/tests/base/src/test/java/org/keycloak/tests/cors/AdminCorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/cors/AdminCorsTest.java
@@ -1,0 +1,88 @@
+package org.keycloak.tests.cors;
+
+import java.io.IOException;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.services.cors.Cors;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakUrls;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest
+public class AdminCorsTest {
+
+    private static final String VALID_ORIGIN = "https://valid-origin.example.com";
+    private static final String INVALID_ORIGIN = "https://evil.example.com";
+
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    private String token;
+    private String usersUrl;
+
+    @BeforeEach
+    public void setup() {
+        adminClient.realm("master").clients().findByClientId("security-admin-console").forEach(client -> {
+            if (!client.getWebOrigins().contains(VALID_ORIGIN)) {
+                client.getWebOrigins().add(VALID_ORIGIN);
+                adminClient.realm("master").clients().get(client.getId()).update(client);
+            }
+        });
+
+        token = adminClient.tokenManager().getAccessTokenString();
+        usersUrl = keycloakUrls.getAdminBuilder().path("/realms/master/users").build().toString();
+    }
+
+    @Test
+    public void validOriginReturnsHeaders() throws IOException {
+        try (SimpleHttpResponse response = simpleHttp.doGet(usersUrl + "?max=1")
+                .auth(token).header("Origin", VALID_ORIGIN).asResponse()) {
+            assertEquals(200, response.getStatus());
+            assertEquals(VALID_ORIGIN, response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
+            assertEquals("true", response.getFirstHeader(Cors.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        }
+    }
+
+    @Test
+    public void invalidOriginIsRejected() throws IOException {
+        try (SimpleHttpResponse response = simpleHttp.doGet(usersUrl + "?max=1")
+                .auth(token).header("Origin", INVALID_ORIGIN).asResponse()) {
+            assertEquals(403, response.getStatus());
+            assertNull(response.getHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+    }
+
+    @Test
+    public void noOriginHeaderIsUnaffected() throws IOException {
+        try (SimpleHttpResponse response = simpleHttp.doGet(usersUrl + "?max=1")
+                .auth(token).asResponse()) {
+            assertEquals(200, response.getStatus());
+            assertNull(response.getHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+    }
+
+    @Test
+    public void preflightRejectsInvalidOrigin() throws IOException {
+        try (SimpleHttpResponse response = simpleHttp.doOptions(usersUrl)
+                .header("Origin", INVALID_ORIGIN).asResponse()) {
+            assertEquals(200, response.getStatus());
+            assertNull(response.getHeader(Cors.ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+    }
+}


### PR DESCRIPTION
This PR will close #45957. 

The changes under this PR make admin preflight now only allows origins that are configured in the security-admin-console client's Web Origins. 

Requests to the admin API from disallowed origins are rejected with 403 before they execute, so even with a valid token a cross-origin attacker cannot create or delete users. Responses now include Access-Control-Allow-Origin only for allowed origins, so the browser will block any cross-origin script from reading admin data.

The account API gets the same origin validation on responses, but it will be without the 403 rejection since the account-console client has no Web Origins configured by default ("+") and adding failOnInvalidOrigin would break the built-in account UI.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
