### PR TITLE
More robust handling of the algorithm:none in TokenManager. Tests for…

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/TokenManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/TokenManager.java
@@ -57,18 +57,25 @@ public interface TokenManager {
     /**
      *
      *
-     * @param token
-     * @param client
-     * @param clazz
-     * @param <T>
-     * @return
+     * @param token JWT token, which might be signed or encrypted by the keys of specified client. It cannot use "alg: none" in the header
+     * @param client client, whose keys/secret might be used to decrypt the token or verify it's signatures
+     * @param clazz class, which the provided token would be cast to
+     * @return decoded java object from the provided token. If it returns null, then signature validation failed or provided token was not valid
      */
     default <T> T decodeClientJWT(String token, ClientModel client, Class<T> clazz) {
-        return decodeClientJWT(token, client, DEFAULT_VALIDATOR, clazz);
+        return decodeClientJWT(token, client, DEFAULT_VALIDATOR, clazz, false);
     }
 
+    /**
+     * @param token JWT token, which might be signed or encrypted by the keys of specified client. It can use "alg: none" in the header just if parameter "allowAlgorithmNone" is true
+     * @param client client, whose keys/secret might be used to decrypt the token or verify it's signatures
+     * @param jwtValidator Additional validator
+     * @param clazz class, which the provided token would be cast to
+     * @param allowAlgorithmNone Whether the token using "alg: none" is allowed or not. If this parameter is false and "alg: none" is used, the {@link IllegalArgumentException} will be thrown
+     * @return decoded java object from the provided token. If it returns null, then signature validation failed or provided token was not valid
+     */
     <T> T decodeClientJWT(String token, ClientModel client, BiConsumer<JOSE, ClientModel> jwtValidator,
-            Class<T> clazz);
+            Class<T> clazz, boolean allowAlgorithmNone);
 
     String encodeAndEncrypt(Token token);
     String cekManagementAlgorithm(TokenCategory category);

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientAuthenticator.java
@@ -117,7 +117,7 @@ public class JWTClientAuthenticator extends AbstractClientAuthenticator {
                 if (!signatureProvider.isAsymmetricAlgorithm()) {
                     throw new RuntimeException("Algorithm is not asymmetric");
                 }
-            }, JsonWebToken.class);
+            }, JsonWebToken.class, false);
             signatureValid = jwt != null;
         } catch (RuntimeException e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/JWTClientSecretAuthenticator.java
@@ -114,7 +114,7 @@ public class JWTClientSecretAuthenticator extends AbstractClientAuthenticator {
                 if (signatureProvider.isAsymmetricAlgorithm()) {
                     throw new RuntimeException("Algorithm is not symmetric");
                 }
-            }, JsonWebToken.class);
+            }, JsonWebToken.class, false);
             signatureValid = jwt != null;
             //try authenticate with client rotated secret
             if (!signatureValid && wrapper.hasRotatedSecret() && !wrapper.isClientRotatedSecretExpired()) {

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -120,7 +120,7 @@ public class DefaultTokenManager implements TokenManager {
     }
 
     @Override
-    public <T> T decodeClientJWT(String jwt, ClientModel client, BiConsumer<JOSE, ClientModel> jwtValidator, Class<T> clazz) {
+    public <T> T decodeClientJWT(String jwt, ClientModel client, BiConsumer<JOSE, ClientModel> jwtValidator, Class<T> clazz, boolean allowNoneAlgorithm) {
         if (jwt == null) {
             return null;
         }
@@ -157,7 +157,7 @@ public class DefaultTokenManager implements TokenManager {
 
                     if (jws instanceof JWSInput) {
                         jwtValidator.accept(jws, client);
-                        return verifyJWS(client, clazz, (JWSInput) jws);
+                        return verifyJWS(client, clazz, (JWSInput) jws, allowNoneAlgorithm);
                     }
                 } catch (Exception ignore) {
                     // try to decrypt content as is
@@ -171,16 +171,16 @@ public class DefaultTokenManager implements TokenManager {
             }
         }
 
-        return verifyJWS(client, clazz, (JWSInput) joseToken);
+        return verifyJWS(client, clazz, (JWSInput) joseToken, allowNoneAlgorithm);
     }
 
-    private <T> T verifyJWS(ClientModel client, Class<T> clazz, JWSInput jws) {
+    private <T> T verifyJWS(ClientModel client, Class<T> clazz, JWSInput jws, boolean allowNoneAlgorithm) {
         try {
             String signatureAlgorithm = jws.getHeader().getAlgorithm().name();
             ClientSignatureVerifierProvider signatureProvider = session.getProvider(ClientSignatureVerifierProvider.class, signatureAlgorithm);
 
             if (signatureProvider == null) {
-                if (jws.getHeader().getAlgorithm().equals(org.keycloak.jose.jws.Algorithm.none)) {
+                if (allowNoneAlgorithm && jws.getHeader().getAlgorithm().equals(org.keycloak.jose.jws.Algorithm.none)) {
                     return jws.readJsonContent(clazz);
                 }
                 return null;

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestObjectParser.java
@@ -43,7 +43,7 @@ public class AuthzEndpointRequestObjectParser extends AuthzEndpointRequestParser
 
     public AuthzEndpointRequestObjectParser(KeycloakSession session, String requestObject, ClientModel client) {
         super(session);
-        this.requestParams = session.tokens().decodeClientJWT(requestObject, client, createRequestObjectValidator(session), JsonNode.class);
+        this.requestParams = session.tokens().decodeClientJWT(requestObject, client, createRequestObjectValidator(session), JsonNode.class, true);
 
         if (this.requestParams == null) {
             throw new RuntimeException("Failed to verify signature on 'request' object");

--- a/tests/base/src/test/java/org/keycloak/tests/client/authentication/external/AbstractBaseClientAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/authentication/external/AbstractBaseClientAuthTest.java
@@ -1,6 +1,7 @@
 package org.keycloak.tests.client.authentication.external;
 
 import org.keycloak.common.util.Time;
+import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.testframework.oauth.OAuthIdentityProvider;
@@ -9,6 +10,8 @@ import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public abstract class AbstractBaseClientAuthTest extends AbstractClientAuthTest {
 
@@ -146,6 +149,23 @@ public abstract class AbstractBaseClientAuthTest extends AbstractClientAuthTest 
         jwt.exp((long) (Time.currentTime() + 30));
         assertSuccess(internalClientId, doClientGrant(jwt));
         assertSuccess(internalClientId, jwt.getId(), expectedTokenIssuer, externalClientId, events.poll());
+    }
+
+    @Test
+    public void testTokenWithNoneAlgorithm() throws Exception {
+        JsonWebToken token = createDefaultToken();
+
+        // Create token with "alg: none" header
+        String noneRequest = new JWSBuilder().jsonContent(token).none();
+        AccessTokenResponse response = oAuthClient.clientCredentialsGrantRequest().clientJwt(noneRequest).send();
+        assertFalse(response.isSuccess());
+
+        // Create token with "alg: none" header, but with valid "kid" preserved in the JWS header
+        OAuthIdentityProvider.OAuthIdentityProviderKeys keys = getIdentityProvider().getKeys();
+        String noneRequestWithKid = new JWSBuilder().kid(keys.getKeyWrapper().getKid()).jsonContent(token).none();
+
+        response = oAuthClient.clientCredentialsGrantRequest().clientJwt(noneRequestWithKid).send();
+        assertFalse(response.isSuccess());
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/AbstractJWTAuthorizationGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/AbstractJWTAuthorizationGrantTest.java
@@ -10,6 +10,7 @@ import org.keycloak.common.util.PemUtils;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.Details;
+import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
@@ -218,6 +219,22 @@ public abstract class AbstractJWTAuthorizationGrantTest extends BaseAbstractJWTA
         newKeys.getKeyWrapper().setKid(keys.getKeyWrapper().getKid());
         String jwt = getIdentityProvider().encodeToken(token, newKeys);
         AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(jwt).send();
+        assertFailure("Invalid signature", response, events.poll());
+    }
+
+
+    @Test
+    public void testSignatureWithNoneAlgorithm() {
+        JsonWebToken token = createDefaultAuthorizationGrantToken();
+
+        String noneRequest = new JWSBuilder().jsonContent(token).none();
+        AccessTokenResponse response = oAuthClient.jwtAuthorizationGrantRequest(noneRequest).send();
+        assertFailure("Invalid signature", response, events.poll());
+
+        token = createDefaultAuthorizationGrantToken();
+        OAuthIdentityProvider.OAuthIdentityProviderKeys keys = getIdentityProvider().getKeys();
+        String noneRequestWithKid = new JWSBuilder().kid(keys.getKeyWrapper().getKid()).jsonContent(token).none();
+        response = oAuthClient.jwtAuthorizationGrantRequest(noneRequestWithKid).send();
         assertFailure("Invalid signature", response, events.poll());
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
@@ -41,6 +41,8 @@ import org.keycloak.common.util.UriUtils;
 import org.keycloak.constants.ServiceUrlConstants;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.Details;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.ClientSecretConstants;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
@@ -319,6 +321,27 @@ public class ClientAuthSecretSignedJWTTest extends AbstractKeycloakTest {
 
         String code = oauth.parseLoginResponse().getCode();
         AccessTokenResponse response = doAccessTokenRequest(code, getClientSignedJWT("ppassswordd", 20));
+
+        // https://tools.ietf.org/html/rfc6749#section-5.2
+        assertEquals(400, response.getStatusCode());
+        assertEquals("unauthorized_client", response.getError());
+    }
+
+    @Test
+    public void testAssertionWithNoneAlgorithm() throws Exception {
+        oauth.clientId("test-app");
+        oauth.doLogin("test-user@localhost", "password");
+        EventRepresentation loginEvent = events.expectLogin()
+                .client("test-app")
+                .assertEvent();
+
+        String code = oauth.parseLoginResponse().getCode();
+
+        String client1Jwt = getClientSignedJWT("ppassswordd", 20);
+        JsonWebToken client1JsonWebToken = new JWSInput(client1Jwt).readJsonContent(JsonWebToken.class);
+        String request = new JWSBuilder().jsonContent(client1JsonWebToken).none();
+
+        AccessTokenResponse response = doAccessTokenRequest(code, request);
 
         // https://tools.ietf.org/html/rfc6749#section-5.2
         assertEquals(400, response.getStatusCode());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSignedJWTTest.java
@@ -604,6 +604,17 @@ public class ClientAuthSignedJWTTest extends AbstractClientAuthSignedJWTTest {
         assertError(response, "client1", OAuthErrorException.INVALID_CLIENT, AuthenticationFlowError.CLIENT_CREDENTIALS_SETUP_REQUIRED.toString().toLowerCase());
     }
 
+    @Test
+    public void testAssertionWithNoneAlgorithm() throws Exception {
+        String client1Jwt = getClient1SignedJWT();
+
+        JsonWebToken client1JsonWebToken = new JWSInput(client1Jwt).readJsonContent(JsonWebToken.class);
+        String request = new JWSBuilder().jsonContent(client1JsonWebToken).none();
+        AccessTokenResponse response = doClientCredentialsGrantRequest(request);
+
+        assertError(response, "client1", OAuthErrorException.INVALID_CLIENT, AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS.toString().toLowerCase());
+    }
+
 
     @Test
     public void testAssertionExpired() throws Exception {


### PR DESCRIPTION
… tokens using 'alg: none' would fail client authentication

closes #48169

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
