### PR TITLE
Build QOSDK from source in quarkus-next workflow

### DIFF
--- a/.github/actions/integration-test-setup/action.yml
+++ b/.github/actions/integration-test-setup/action.yml
@@ -29,6 +29,11 @@ runs:
       name: Maven cache
       uses: ./.github/actions/maven-cache
 
+    - id: restore-quarkus-snapshot
+      name: Restore Quarkus snapshot cache
+      if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+      uses: ./.github/actions/quarkus-snapshot-cache
+
     - id: pnpm-store-cache
       name: PNPM store cache
       uses: ./.github/actions/pnpm-store-cache

--- a/.github/actions/quarkus-snapshot-cache/action.yml
+++ b/.github/actions/quarkus-snapshot-cache/action.yml
@@ -1,5 +1,5 @@
 name: Quarkus Snapshot Cache
-description: Restores Quarkus snapshot artifacts built from quarkusio/quarkus main branch.
+description: Restores Quarkus and QOSDK snapshot artifacts built from source.
 
 runs:
   using: composite
@@ -10,6 +10,17 @@ runs:
       with:
         path: |
           ~/.m2/repository/io/quarkus
+          ~/.m2/repository/io/quarkiverse/operatorsdk
         key: quarkus-snapshot-
         restore-keys: |
           quarkus-snapshot-
+        enableCrossOsArchive: true
+
+    - name: Copy restored Quarkus cache to home folder on Windows
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        if [ -d ../../../.m2/repository ]; then
+          cp -r ../../../.m2/repository ~/.m2
+          rm -r ../../../.m2/repository
+        fi

--- a/.github/scripts/prepare-quarkus-next.sh
+++ b/.github/scripts/prepare-quarkus-next.sh
@@ -6,6 +6,14 @@ git checkout -b new-quarkus-next origin/main
 # Use io.quarkus:quarkus-bom built from source
 sed -i 's|<groupId>io.quarkus.platform</groupId>|<groupId>io.quarkus</groupId>|g' pom.xml
 
+# Use io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom built from source (QOSDK_VERSION dynamically parsed by the workflow)
+if [ -n "${QOSDK_VERSION:-}" ]; then
+  sed -i '/<groupId>io.quarkus.platform<\/groupId>/,/<\/dependency>/{
+    s|<groupId>io.quarkus.platform</groupId>|<groupId>io.quarkiverse.operatorsdk</groupId>|
+    s|<version>${quarkus.version}</version>|<version>'"${QOSDK_VERSION}"'</version>|
+  }' operator/pom.xml
+fi
+
 ./quarkus/set-quarkus-version.sh
 git commit -am "Set quarkus version to 999-SNAPSHOT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,6 +476,10 @@ jobs:
         name: Node cache
         uses: ./.github/actions/node-cache
 
+      - name: Restore Quarkus snapshot cache
+        if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+        uses: ./.github/actions/quarkus-snapshot-cache
+
       - id: aurora-init
         name: Initialize Aurora environment
         run: |
@@ -673,6 +677,10 @@ jobs:
       - id: node-cache
         name: Node cache
         uses: ./.github/actions/node-cache
+
+      - name: Restore Quarkus snapshot cache
+        if: github.ref == 'refs/heads/quarkus-next' || github.base_ref == 'quarkus-next'
+        uses: ./.github/actions/quarkus-snapshot-cache
 
       - id: azure-init
         name: Initialize Azure environment

--- a/.github/workflows/quarkus-next.yml
+++ b/.github/workflows/quarkus-next.yml
@@ -22,13 +22,22 @@ jobs:
     name: Build Quarkus snapshot
     if: github.event_name != 'schedule' || github.repository == 'keycloak/keycloak'
     runs-on: ubuntu-latest
+    outputs:
+      qosdk-version: ${{ steps.qosdk-version.outputs.version }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: quarkusio/quarkus
           ref: main
+          path: quarkus
 
-      # JDK 17 to match how Quarkus builds and publishes its own snapshots
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: quarkiverse/quarkus-operator-sdk
+          ref: main
+          path: quarkus-operator-sdk
+
+      # JDK 17 to match how Quarkus and QOSDK build and publish their own snapshots
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -45,14 +54,31 @@ jobs:
         with:
           path: |
             ~/.m2/repository/io/quarkus
+            ~/.m2/repository/io/quarkiverse/operatorsdk
           key: quarkus-snapshot-${{ steps.cache-key.outputs.date }}
+          enableCrossOsArchive: true
 
       - name: Build Quarkus snapshot
         if: steps.quarkus-cache.outputs.cache-hit != 'true'
         run: |
+          cd quarkus
           ./mvnw -B -e --no-transfer-progress \
             -Dquickly -Dno-test-modules -Prelocations \
             clean install
+
+      - name: Build Quarkus Operator SDK snapshot
+        if: steps.quarkus-cache.outputs.cache-hit != 'true'
+        run: |
+          cd quarkus-operator-sdk
+          ./mvnw -B -e --no-transfer-progress \
+            clean install -DskipTests -DskipITs -DskipDocs \
+            -Dquarkus.version=999-SNAPSHOT
+
+      - name: Extract QOSDK version
+        id: qosdk-version
+        run: |
+          version=$(ls ~/.m2/repository/io/quarkiverse/operatorsdk/quarkus-operator-sdk-bom/ | grep -E '.*-SNAPSHOT$' | head -1)
+          echo "version=$version" >> $GITHUB_OUTPUT
 
   update-quarkus-next-branch:
     name: Update quarkus-next branch
@@ -69,12 +95,17 @@ jobs:
       - name: Setup Java
         uses: ./.github/actions/java-setup
 
+      - name: Restore Quarkus snapshot cache
+        uses: ./.github/actions/quarkus-snapshot-cache
+
       - name: Configure Git
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
 
       - name: Cherry-pick additional commits in quarkus-next
+        env:
+          QOSDK_VERSION: ${{ needs.build-quarkus-snapshot.outputs.qosdk-version }}
         run: |
           ${GITHUB_WORKSPACE}/.github/scripts/prepare-quarkus-next.sh
 


### PR DESCRIPTION
Closes: #48129

@vmuzikar the build phase didn't fail previously because `quarkus.build.version` wasn't correctly changed to the SNAPSHOT. I fixed that by adding `Restore Quarkus snapshot cache` to make it available and thus fully resolvable. Since `set-quarkus-version.sh` silently swallows the errors (afaik by design), I haven't realized/noticed it. Sorry for that.

With that fixed, I got:
```
Non-resolvable import POM: io.quarkus.platform:quarkus-operator-sdk-bom:pom:999-SNAPSHOT (absent)
'dependencies.dependency.version' for io.quarkiverse.operatorsdk:quarkus-operator-sdk:jar is missing
'dependencies.dependency.version' for io.quarkiverse.operatorsdk:quarkus-operator-sdk-bundle-generator:jar is missing
```
which is exactly what we discussed yesterday, even without evidence.

From what I see only 2 direct dependencies rely on `quarkus-operator-sdk-bom` BOM -
`io.quarkiverse.operatorsdk:quarkus-operator-sdk` and `io.quarkiverse.operatorsdk:quarkus-operator-sdk-bundle-generator` + transitive JOSDK dependencies (`operator-framework-core`, `micrometer-support`).

So as I mentioned yesterday, I wanted to try to build QOSDK instead of the full platform build. I did some digging - I compared `io.quarkus.platform:quarkus-operator-sdk-bom:3.33.1` vs. `io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom:7.7.3`:
- all 9 shared dependencies have identical versions at the point of release (JOSDK 5.3.2, QOSDK 7.7.3),
- the platform BOM adds only 2 metadata artifacts (`*-quarkus-platform-descriptor`and `*-quarkus-platform-properties` - I assume this is not essential for our use case at all, most likely used by some Quarkus tooling, DEV UI maybe?) cc: @michalvavrik 
- no dependency version overrides in either direction as it was already suggested yesterday.

This makes me believe that we could use it instead of full platform build. The PR builds QOSDK from its `main` branch with `-Dquarkus.version=999-SNAPSHOT`. It produces `io.quarkiverse.operatorsdk:quarkus-operator-sdk-bom`  with the current QOSDK snapshot version (the version is dynamically parsed from the QOSDK pom.xml in order to inject it to `operator/pom.xml`). Uses released JOSDK, which is handy, because we don't need to build JOSDK from source as we were afraid. And most importantly it takes ~20 seconds.

The only difference I can see now is that `quarkus-next` builds QOSDK from main, so the actual versions tested will be newer than production, which probably isn't that big of a deal (!?). Alternatively we can try to build it from a release tag, but I haven't try that so far. The fact that the JOSDK version on QOSDK main is always equal to or newer than the JOSDK version in the platform BOM is probably more important, right?

Anyway, this is the best I could come up with so far, so please give it a thorough look. 😊 
Here are some preliminary results from my fork testing:
* Quarkus Next workflow (first time Quarkus and QOSDK build - took 26 mins): https://github.com/Pepo48/keycloak/actions/runs/24508151400
* subsequent Quarkus Next workflow (just to demonstrate that job hit the cache and skip both the Quarkus and QOSDK builds - took 7 mins): https://github.com/Pepo48/keycloak/actions/runs/24538154601
* Keycloak CI: https://github.com/Pepo48/keycloak/actions/runs/24538389242
* Operator CI: https://github.com/Pepo48/keycloak/actions/runs/24538390892

PRs that needs to be applied to get such results are:
* https://github.com/keycloak/keycloak/pull/47896
* https://github.com/keycloak/keycloak/pull/48175
(this actually proves that both are ready to be merged, without them in place the Keycloak build and Azure stage would fail pretty early)