### PR TITLE
Migrate Organization Partial Export test into new testsuite

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/organization/exportimport/OrganizationExportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/exportimport/OrganizationExportTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.organization.exportimport;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.keycloak.representations.idm.PartialImportRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.tests.organization.admin.AbstractOrganizationTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest
+public class OrganizationExportTest extends AbstractOrganizationTest {
+
+    @Test
+    public void testPartialExport() {
+        createOrganization();
+        assertPartialExportImport(false, false);
+        assertPartialExportImport(true, false);
+        assertPartialExportImport(true, true);
+        assertPartialExportImport(false, true);
+    }
+
+    private void assertPartialExportImport(boolean exportGroupsAndRoles, boolean exportClients) {
+        RealmRepresentation export = realm.admin().partialExport(exportGroupsAndRoles, exportClients);
+        assertTrue(Optional.ofNullable(export.getOrganizations()).orElse(List.of()).isEmpty());
+        assertTrue(Optional.ofNullable(export.getIdentityProviders()).orElse(List.of()).stream().noneMatch(idp -> Objects.nonNull(idp.getOrganizationId())));
+        PartialImportRepresentation rep = new PartialImportRepresentation();
+        rep.setUsers(export.getUsers());
+        rep.setClients(export.getClients());
+        rep.setRoles(export.getRoles());
+        rep.setIdentityProviders(export.getIdentityProviders());
+        rep.setGroups(export.getGroups());
+        realm.admin().partialImport(rep).close();
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/exportimport/OrganizationExportTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/exportimport/OrganizationExportTest.java
@@ -22,8 +22,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 
 import jakarta.ws.rs.core.Response;
 
@@ -42,7 +40,6 @@ import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
-import org.keycloak.representations.idm.PartialImportRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testsuite.admin.ApiUtil;
@@ -326,28 +323,6 @@ public class OrganizationExportTest extends AbstractOrganizationTest {
         });
 
         return testRealm().toRepresentation();
-    }
-
-    @Test
-    public void testPartialExport() {
-        createOrganization();
-        assertPartialExportImport(false, false);
-        assertPartialExportImport(true, false);
-        assertPartialExportImport(true, true);
-        assertPartialExportImport(false, true);
-    }
-
-    private void assertPartialExportImport(boolean exportGroupsAndRoles, boolean exportClients) {
-        RealmRepresentation export = testRealm().partialExport(exportGroupsAndRoles, exportClients);
-        assertTrue(Optional.ofNullable(export.getOrganizations()).orElse(List.of()).isEmpty());
-        assertTrue(Optional.ofNullable(export.getIdentityProviders()).orElse(List.of()).stream().noneMatch(idp -> Objects.nonNull(idp.getOrganizationId())));
-        PartialImportRepresentation rep = new PartialImportRepresentation();
-        rep.setUsers(export.getUsers());
-        rep.setClients(export.getClients());
-        rep.setRoles(export.getRoles());
-        rep.setIdentityProviders(export.getIdentityProviders());
-        rep.setGroups(export.getGroups());
-        testRealm().partialImport(rep).close();
     }
 
     private String createTopLevelGroup(OrganizationResource organization, String name) {


### PR DESCRIPTION
Parent tracking issue: keycloak/keycloak#47926

Part of #48181

Migrates `testPartialExport` from the legacy `OrganizationExportTest` (`testsuite/integration-arquillian/.../organization/exportimport/`) to the new framework under `tests/base/.../organization/exportimport/`.

Only `testPartialExport` is ported in this PR because it is the one test method in the legacy file that relies solely on the organization admin API (`realm.partialExport(...)` / `realm.partialImport(...)`). The remaining two tests in the legacy file are **not** migrated here:

- `testExport` — exercises broker-driven federated user flows (`bc.setUpIdentityProvider()`, `loginPage`, etc.). Requires a new-framework equivalent of `BrokerConfiguration`, which does not yet exist.
- `testExportImportEmptyOrg` — uses `TestingExportImportResource` plus `testRealm().remove()` followed by re-import. The new framework's `ManagedRealm` owns the realm lifecycle, so removing the realm beneath it breaks the fixture. This test needs a testframework-level design decision (export/import support) before it can be migrated.

No logic changes — just the usual annotation / import swap:

- Extends the new-framework `AbstractOrganizationTest`.
- `@KeycloakIntegrationTest` added at class level.
- `testRealm().partialExport(...)` → `realm.admin().partialExport(...)`.
- JUnit 4 `@Test` / `assertTrue` → JUnit 5 equivalents.

Legacy file still contains the two unported tests so coverage is not lost.