### PR TITLE
enhancement: require typed confirmation for deleting realms via gui

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -3815,3 +3815,4 @@ role_offline-access=Offline access
 role_uma_authorization=Obtain permissions
 scimApiEnabled=SCIM API
 scimApiEnabledHelp=If enabled, exposes realm resources through an API based on the System for Cross-domain Identity Management (SCIM) specification, namely RFC7643 and RFC7644.
+typeToConfirm=Type "{{expected}}" to confirm.

--- a/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
+++ b/js/apps/admin-ui/src/realm-settings/RealmSettingsTabs.tsx
@@ -7,9 +7,12 @@ import {
   ButtonVariant,
   Divider,
   DropdownItem,
+  Form,
+  FormGroup,
   PageSection,
   Tab,
   TabTitleText,
+  TextInput,
   Tooltip,
 } from "@patternfly/react-core";
 import { useEffect, useState } from "react";
@@ -17,7 +20,10 @@ import { Controller, FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import {
+  ConfirmDialogModal,
+  useConfirmDialog,
+} from "../components/confirm-dialog/ConfirmDialog";
 import type { RealmLoAMappingType } from "../components/realm-loa-mapping/RealmLoAMapping";
 import {
   RoutableTabs,
@@ -79,6 +85,8 @@ const RealmSettingsHeader = ({
   const navigate = useNavigate();
   const [partialImportOpen, setPartialImportOpen] = useState(false);
   const [partialExportOpen, setPartialExportOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteConfirmationText, setDeleteConfirmationText] = useState("");
   const { hasAccess } = useAccess();
   const canManageRealm = hasAccess("manage-realm");
 
@@ -92,27 +100,50 @@ const RealmSettingsHeader = ({
     },
   });
 
-  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
-    titleKey: "deleteConfirmTitle",
-    messageKey: "deleteConfirmRealmSetting",
-    continueButtonLabel: "delete",
-    continueButtonVariant: ButtonVariant.danger,
-    onConfirm: async () => {
-      try {
-        await adminClient.realms.del({ realm: realmName });
-        addAlert(t("deletedSuccessRealmSetting"), AlertVariant.success);
-        navigate(toDashboard({ realm: environment.masterRealm }));
-        refresh();
-      } catch (error) {
-        addError("deleteErrorRealmSetting", error);
-      }
-    },
-  });
+  const toggleDeleteDialog = () => {
+    setDeleteDialogOpen((open) => !open);
+    setDeleteConfirmationText("");
+  };
 
   return (
     <>
       <DisableConfirm />
-      <DeleteConfirm />
+      <ConfirmDialogModal
+        titleKey="deleteConfirmTitle"
+        continueButtonLabel="delete"
+        continueButtonVariant={ButtonVariant.danger}
+        confirmButtonDisabled={deleteConfirmationText !== realmName}
+        onConfirm={async () => {
+          try {
+            await adminClient.realms.del({ realm: realmName });
+            addAlert(t("deletedSuccessRealmSetting"), AlertVariant.success);
+            navigate(toDashboard({ realm: environment.masterRealm }));
+            refresh();
+          } catch (error) {
+            addError("deleteErrorRealmSetting", error);
+          }
+        }}
+        open={deleteDialogOpen}
+        toggleDialog={toggleDeleteDialog}
+      >
+        <Form>
+          <FormGroup fieldId="realm-settings-delete-confirmation-input">
+            <div className="pf-v5-u-mb-sm">
+              {t("deleteConfirmRealmSetting")}
+            </div>
+            <div className="pf-v5-u-mb-md">
+              {t("typeToConfirm", { expected: realmName })}
+            </div>
+            <TextInput
+              id="realm-settings-delete-confirmation-input"
+              data-testid="delete-confirmation-input"
+              autoFocus
+              value={deleteConfirmationText}
+              onChange={(_, value) => setDeleteConfirmationText(value)}
+            />
+          </FormGroup>
+        </Form>
+      </ConfirmDialogModal>
       <PartialImportDialog
         open={partialImportOpen}
         toggleDialog={() => setPartialImportOpen(!partialImportOpen)}

--- a/js/apps/admin-ui/src/realm/RealmSection.tsx
+++ b/js/apps/admin-ui/src/realm/RealmSection.tsx
@@ -4,12 +4,16 @@ import {
   AlertVariant,
   Badge,
   Button,
+  ButtonVariant,
   Dropdown,
   DropdownItem,
   DropdownList,
+  Form,
+  FormGroup,
   MenuToggle,
   PageSection,
   Popover,
+  TextInput,
   ToolbarItem,
 } from "@patternfly/react-core";
 import { EllipsisVIcon } from "@patternfly/react-icons";
@@ -18,7 +22,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
-import { useConfirmDialog } from "../components/confirm-dialog/ConfirmDialog";
+import { ConfirmDialogModal } from "../components/confirm-dialog/ConfirmDialog";
 import { ViewHeader } from "../components/view-header/ViewHeader";
 import { fetchAdminUI } from "../context/auth/admin-ui-endpoint";
 import { useRealm } from "../context/realm-context/RealmContext";
@@ -125,6 +129,10 @@ export default function RealmSection() {
 
   const [selected, setSelected] = useState<RealmRow[]>([]);
   const [openNewRealm, setOpenNewRealm] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteConfirmationText, setDeleteConfirmationText] = useState("");
+  const expectedDeleteText =
+    selected.length > 1 ? "DELETE" : (selected[0]?.name ?? "");
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
 
@@ -145,40 +153,72 @@ export default function RealmSection() {
     }
   };
 
-  const [toggleDeleteDialog, DeleteConfirm] = useConfirmDialog({
-    titleKey: t("deleteConfirmRealm", {
-      count: selected.length,
-      name: selected[0]?.name,
-    }),
-    messageKey: "deleteConfirmRealmSetting",
-    continueButtonLabel: "delete",
-    onConfirm: async () => {
-      try {
-        if (selected.filter(({ name }) => name === "master").length > 0) {
-          addAlert(t("cantDeleteMasterRealm"), AlertVariant.warning);
-        }
-        const filtered = selected.filter(({ name }) => name !== "master");
-        if (filtered.length === 0) return;
-        await Promise.all(
-          filtered.map(({ name: realmName }) =>
-            adminClient.realms.del({ realm: realmName }),
-          ),
-        );
-        addAlert(t("deletedSuccessRealmSetting"));
-        if (selected.filter(({ name }) => name === realm).length > 0) {
-          navigate(toRealm({ realm: "master" }));
-        }
-        refresh();
-        setSelected([]);
-      } catch (error) {
-        addError("deleteError", error);
-      }
-    },
-  });
+  const toggleDeleteDialog = () => {
+    setDeleteDialogOpen((open) => !open);
+    setDeleteConfirmationText("");
+  };
 
   return (
     <>
-      <DeleteConfirm />
+      <ConfirmDialogModal
+        titleKey={t("deleteConfirmRealm", {
+          count: selected.length,
+          name: selected[0]?.name,
+        })}
+        continueButtonLabel="delete"
+        continueButtonVariant={ButtonVariant.danger}
+        confirmButtonDisabled={
+          selected.length === 0 || deleteConfirmationText !== expectedDeleteText
+        }
+        onConfirm={async () => {
+          const containsMaster = selected.some(({ name }) => name === "master");
+          const deletableRealms = selected.filter(
+            ({ name }) => name !== "master",
+          );
+
+          try {
+            if (containsMaster) {
+              addAlert(t("cantDeleteMasterRealm"), AlertVariant.warning);
+            }
+            if (deletableRealms.length === 0) return;
+            await Promise.all(
+              deletableRealms.map(({ name: realmName }) =>
+                adminClient.realms.del({ realm: realmName }),
+              ),
+            );
+            addAlert(t("deletedSuccessRealmSetting"));
+            if (selected.some(({ name }) => name === realm)) {
+              navigate(toRealm({ realm: "master" }));
+            }
+            refresh();
+            setSelected([]);
+          } catch (error) {
+            addError("deleteError", error);
+          }
+        }}
+        open={deleteDialogOpen}
+        toggleDialog={toggleDeleteDialog}
+      >
+        <Form>
+          <FormGroup fieldId="realm-delete-confirmation-input">
+            <div className="pf-v5-u-mb-sm">
+              {t("deleteConfirmRealmSetting")}
+            </div>
+            <div className="pf-v5-u-mb-md">
+              {t("typeToConfirm", {
+                expected: expectedDeleteText,
+              })}
+            </div>
+            <TextInput
+              id="realm-delete-confirmation-input"
+              data-testid="delete-confirmation-input"
+              autoFocus
+              value={deleteConfirmationText}
+              onChange={(_, value) => setDeleteConfirmationText(value)}
+            />
+          </FormGroup>
+        </Form>
+      </ConfirmDialogModal>
       {openNewRealm && (
         <NewRealmForm
           onClose={() => {

--- a/js/apps/admin-ui/test/masthead/realm.spec.ts
+++ b/js/apps/admin-ui/test/masthead/realm.spec.ts
@@ -8,7 +8,7 @@ import {
   assertNotificationMessage,
   selectActionToggleItem,
 } from "../utils/masthead.ts";
-import { confirmModal } from "../utils/modal.ts";
+import { confirmModal, typeDeleteConfirmation } from "../utils/modal.ts";
 import { goToClients, goToRealmSettings } from "../utils/sidebar.ts";
 import { assertRowExists } from "../utils/table.ts";
 import {
@@ -87,6 +87,7 @@ test.describe.serial("Realm tests", () => {
 
     await goToRealmSettings(page);
     await selectActionToggleItem(page, "Delete");
+    await typeDeleteConfirmation(page, testDisabledName);
     await confirmModal(page);
 
     await assertNotificationMessage(page, "The realm has been deleted");

--- a/js/apps/admin-ui/test/utils/modal.ts
+++ b/js/apps/admin-ui/test/utils/modal.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 export async function assertModalTitle(page: Page, title: string) {
   await expect(page.getByText(title, { exact: true })).toBeVisible();
@@ -10,6 +10,10 @@ export async function assertModalMessage(page: Page, message: string) {
 
 export async function confirmModal(page: Page) {
   await page.getByTestId("confirm").click();
+}
+
+export async function typeDeleteConfirmation(page: Page, value: string) {
+  await page.getByTestId("delete-confirmation-input").fill(value);
 }
 
 export async function cancelModal(page: Page) {


### PR DESCRIPTION
When deleting a singular realm, users must type the realm name:
<img width="360" height="189" alt="singular" src="https://github.com/user-attachments/assets/27ca5d94-0a4a-40e5-ae53-e4a0d05a1fcb" />
When deleting multiple realms, users must type 'DELETE':
<img width="360" height="189" alt="multiple" src="https://github.com/user-attachments/assets/61617d1c-f437-4ef7-8cec-0f87a5d9a77a" />

RealmSection.tsx and RealmSettingsTabs.tsx now both use ConfirmDialogModal. 
Updated realm.spec.ts and modal.ts for CRUD test of Disabled realm. 
Added new key to messages_en.properties for popup dialog.

Closes #48078
