### PR TITLE
Client API v2 CLI client: enable users to update clients using editors

### DIFF
--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2Cmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2Cmd.java
@@ -94,6 +94,7 @@ public class KcAdmV2Cmd extends BaseGlobalOptionsCmd {
         configCmd.getCommandSpec().removeSubcommand("credentials");
         configCmd.addSubcommand("credentials", new CommandLine(new KcAdmV2ConfigCredentialsCmd(cacheDir)));
         configCmd.addSubcommand("openapi", new CommandLine(new KcAdmV2ConfigOpenApiCmd(cacheDir)));
+        configCmd.addSubcommand("editor", new CommandLine(new KcAdmV2ConfigEditorCmd()));
         cli.addSubcommand(configCmd);
         KcAdmV2CommandDescriptor descriptor = loadDescriptor();
         KcAdmV2CommandBuilder.addCommands(cli, descriptor);

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandBuilder.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2CommandBuilder.java
@@ -22,7 +22,8 @@ class KcAdmV2CommandBuilder {
     private static final String OPT_HELP = "--help";
     static final String OPT_FILE = "-f";
     static final String OPT_COMPRESSED = "--compressed";
-
+    private static final String CONNECTION_OPTIONS_HEADING = "%nConnection options:%n";
+    private static final String CMD_EDIT = "edit";
 
     static void addCommands(CommandLine cli, KcAdmV2CommandDescriptor descriptor) {
         for (ResourceDescriptor resource : descriptor.getResources()) {
@@ -35,8 +36,20 @@ class KcAdmV2CommandBuilder {
             CommandLine groupCli = new CommandLine(groupSpec);
             groupCommand.setSpec(groupSpec);
 
+            CommandDescriptor getDescriptor = null;
+            CommandDescriptor putDescriptor = null;
+
             for (CommandDescriptor cmd : resource.getCommands()) {
                 groupCli.addSubcommand(cmd.getName(), buildSubcommand(cmd));
+                if (KcAdmV2DescriptorBuilder.CMD_NAME_GET.equals(cmd.getName())) {
+                    getDescriptor = cmd;
+                } else if (KcAdmV2DescriptorBuilder.CMD_NAME_APPLY.equals(cmd.getName())) {
+                    putDescriptor = cmd;
+                }
+            }
+
+            if (getDescriptor != null && putDescriptor != null) {
+                groupCli.addSubcommand(CMD_EDIT, buildEditCommand(getDescriptor, putDescriptor));
             }
 
             cli.addSubcommand(resource.getName(), groupCli);
@@ -70,7 +83,7 @@ class KcAdmV2CommandBuilder {
         CommandSpec spec = CommandSpec.forAnnotatedObject(executor);
         spec.name(variant != null ? variant.getName() : cmd.getName());
         spec.usageMessage().description(cmd.getDescription());
-        spec.usageMessage().optionListHeading("%nConnection options:%n");
+        spec.usageMessage().optionListHeading(CONNECTION_OPTIONS_HEADING);
 
         // Replace inherited --help with usageHelp=true so PicoCLI skips
         // required parameter validation when --help is present
@@ -82,13 +95,7 @@ class KcAdmV2CommandBuilder {
         }
 
         if (!isVariantParent && cmd.isRequiresId()) {
-            spec.addPositional(PositionalParamSpec.builder()
-                    .index("0")
-                    .paramLabel("<id>")
-                    .description("Resource identifier")
-                    .required(true)
-                    .type(String.class)
-                    .build());
+            addIdPositional(spec, cmd.getResourceName());
         }
 
         boolean hasFieldOptions = options != null && !options.isEmpty();
@@ -145,6 +152,33 @@ class KcAdmV2CommandBuilder {
                 .paramLabel("<file>")
                 .description(description)
                 .build();
+    }
+
+    private static CommandLine buildEditCommand(CommandDescriptor getCmd, CommandDescriptor putCmd) {
+        String resourceName = getCmd.getResourceName();
+
+        KcAdmV2EditCmd executor = new KcAdmV2EditCmd(getCmd, putCmd);
+        CommandSpec spec = CommandSpec.forAnnotatedObject(executor);
+        spec.name(CMD_EDIT);
+        spec.usageMessage().description(KcAdmV2EditCmd.createDescription(resourceName));
+        spec.usageMessage().optionListHeading(CONNECTION_OPTIONS_HEADING);
+
+        spec.remove(spec.findOption(OPT_HELP));
+        addHelpOption(spec);
+        addOutputGroup(spec);
+        addIdPositional(spec, resourceName);
+
+        return new CommandLine(spec);
+    }
+
+    private static void addIdPositional(CommandSpec spec, String resourceName) {
+        spec.addPositional(PositionalParamSpec.builder()
+                .index("0")
+                .paramLabel("<id>")
+                .description(capitalize(resourceName) + " identifier")
+                .required(true)
+                .type(String.class)
+                .build());
     }
 
     private static void addOutputGroup(CommandSpec spec) {

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2ConfigEditorCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2ConfigEditorCmd.java
@@ -1,0 +1,43 @@
+package org.keycloak.client.admin.cli.v2;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.cli.common.BaseAuthOptionsCmd;
+import org.keycloak.client.cli.config.FileConfigHandler;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+
+@Command(name = "editor", description = "Configure the text editor for the edit command")
+class KcAdmV2ConfigEditorCmd implements Runnable {
+
+    @Parameters(index = "0", paramLabel = "<editor>",
+            description = "Editor command (e.g., vi, nano, 'code --wait')")
+    String editorValue;
+
+    @Option(names = "--config", description = "Path to the config file (${sys:" + BaseAuthOptionsCmd.DEFAULT_CONFIG_PATH_STRING_KEY + "} by default)")
+    String config;
+
+    @Option(names = {"-h", "--help"}, usageHelp = true, hidden = true)
+    boolean help;
+
+    @Spec
+    CommandSpec spec;
+
+    @Override
+    public void run() {
+        FileConfigHandler.setConfigFile(config != null ? config : KcAdmMain.DEFAULT_CONFIG_FILE_PATH);
+        try {
+            new FileConfigHandler().saveMergeConfig(c -> c.setEditor(editorValue));
+        } finally {
+            // TODO: this must be dropped when we move away from the static config file pattern
+            FileConfigHandler.setConfigFile(null);
+        }
+
+        spec.commandLine().getErr().println("Editor configured: " + editorValue);
+    }
+
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2DescriptorBuilder.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2DescriptorBuilder.java
@@ -37,12 +37,15 @@ public class KcAdmV2DescriptorBuilder {
     static final String ID_PATH_PARAM = "{id}";
 
 
+    static final String CMD_NAME_GET = "get";
+    static final String CMD_NAME_APPLY = "apply";
+
     private static final Map<PathItem.HttpMethod, String> HTTP_METHOD_TO_COMMAND = Map.of(
-            PathItem.HttpMethod.GET, "get",
+            PathItem.HttpMethod.GET, CMD_NAME_GET,
             PathItem.HttpMethod.POST, "create",
             PathItem.HttpMethod.PATCH, "patch",
             PathItem.HttpMethod.DELETE, "delete",
-            PathItem.HttpMethod.PUT, "apply"
+            PathItem.HttpMethod.PUT, CMD_NAME_APPLY
     );
 
     public static KcAdmV2CommandDescriptor convert(OpenAPI openApi) {

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2EditCmd.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2EditCmd.java
@@ -1,0 +1,158 @@
+package org.keycloak.client.admin.cli.v2;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.keycloak.client.admin.cli.KcAdmMain;
+import org.keycloak.client.admin.cli.v2.KcAdmV2CommandDescriptor.CommandDescriptor;
+import org.keycloak.client.cli.common.Globals;
+import org.keycloak.client.cli.config.ConfigData;
+import org.keycloak.client.cli.util.OutputUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import static org.keycloak.client.admin.cli.KcAdmMain.CMD;
+import static org.keycloak.client.admin.cli.KcAdmMain.V2_FLAG;
+import static org.keycloak.client.cli.util.ConfigUtil.credentialsAvailable;
+import static org.keycloak.client.cli.util.HttpUtil.APPLICATION_JSON;
+import static org.keycloak.client.cli.util.IoUtil.readFully;
+import static org.keycloak.client.cli.util.OsUtil.OS_ARCH;
+
+@Command
+final class KcAdmV2EditCmd extends KcAdmV2RequestExecutor {
+
+    private static final String ENV_KC_CLI_EDITOR = "KC_CLI_EDITOR";
+    private static final String ENV_VISUAL = "VISUAL";
+    private static final String ENV_EDITOR = "EDITOR";
+    private static final String DEFAULT_EDITOR_UNIX = "vi";
+    private static final String DEFAULT_EDITOR_WINDOWS = "notepad";
+    private static final int EXIT_CODE_COMMAND_NOT_FOUND = 127;
+
+    private final String resourceName;
+    private final String getMethod;
+    private final String putMethod;
+
+    KcAdmV2EditCmd(CommandDescriptor getDescriptor, CommandDescriptor putDescriptor) {
+        super(getDescriptor, null);
+        this.resourceName = getDescriptor.getResourceName();
+        this.getMethod = getDescriptor.getHttpMethod().toLowerCase();
+        this.putMethod = putDescriptor.getHttpMethod().toLowerCase();
+    }
+
+    @Override
+    public void run() {
+        if (Globals.help) {
+            spec.commandLine().usage(spec.commandLine().getOut());
+            return;
+        }
+
+        PrintWriter out = spec.commandLine().getOut();
+        PrintWriter err = spec.commandLine().getErr();
+
+        try {
+            RequestContext ctx = prepareRequest();
+            String url = buildUrl(ctx.configData(), null);
+
+            String originalJson = readFully(executeRequest(getMethod, url, ctx.token(), null, null).getBody());
+            JsonNode originalNode = OutputUtil.MAPPER.readTree(originalJson);
+
+            String editor = resolveEditor(ctx.configData());
+            String prettyOriginal = OutputUtil.MAPPER.writeValueAsString(originalNode);
+            String modifiedContent = openInEditor(editor, prettyOriginal);
+
+            final JsonNode modifiedNode;
+            try {
+                modifiedNode = OutputUtil.MAPPER.readTree(modifiedContent);
+            } catch (Exception e) {
+                throw new RuntimeException("Modified content is not valid JSON: " + e.getMessage());
+            }
+
+            if (originalNode.equals(modifiedNode)) {
+                err.println("Edit cancelled, no changes made.");
+                return;
+            }
+
+            String id = spec.commandLine().getParseResult().matchedPositional(0).getValue();
+            err.println("Updating " + resourceName + " '" + id + "' ...");
+            err.println();
+
+            String freshToken = credentialsAvailable(ctx.configData()) ? ensureToken(ctx.configData()) : ctx.token();
+            String responseBody = readFully(
+                    executeRequest(putMethod, url, freshToken, modifiedContent, APPLICATION_JSON).getBody());
+            out.println(formatOutput(responseBody));
+        } catch (CommandLine.ExecutionException e) {
+            throw e;
+        } catch (Exception e) {
+            String message = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            throw new CommandLine.ExecutionException(spec.commandLine(), message, e);
+        }
+    }
+
+    private String resolveEditor(ConfigData configData) {
+        String editor = configData.getEditor();
+        if (editor != null && !editor.isBlank()) {
+            return editor;
+        }
+
+        editor = System.getenv(ENV_KC_CLI_EDITOR);
+        if (editor != null && !editor.isBlank()) {
+            return editor;
+        }
+
+        editor = System.getenv(ENV_VISUAL);
+        if (editor != null && !editor.isBlank()) {
+            return editor;
+        }
+
+        editor = System.getenv(ENV_EDITOR);
+        if (editor != null && !editor.isBlank()) {
+            return editor;
+        }
+
+        return OS_ARCH.isWindows() ? DEFAULT_EDITOR_WINDOWS : DEFAULT_EDITOR_UNIX;
+    }
+
+    private String openInEditor(String editor, String content) throws IOException, InterruptedException {
+        Path tempFile = Files.createTempFile("kcadm-edit-", ".json");
+        try {
+            Files.writeString(tempFile, content);
+
+            ProcessBuilder pb;
+            if (OS_ARCH.isWindows()) {
+                pb = new ProcessBuilder("cmd", "/c", editor + " \"" + tempFile + "\"");
+            } else {
+                pb = new ProcessBuilder("/bin/sh", "-c", editor + " \"" + tempFile + "\"");
+            }
+            pb.inheritIO();
+
+            int exitCode = pb.start().waitFor();
+            if (exitCode == EXIT_CODE_COMMAND_NOT_FOUND) {
+                throw new RuntimeException("Editor '" + editor + "' not found. "
+                        + "Configure your editor with: " + KcAdmMain.CMD + " " + KcAdmMain.V2_FLAG
+                        + " config editor <editor> or set the " + ENV_KC_CLI_EDITOR + " environment variable.");
+            }
+            if (exitCode != 0) {
+                throw new RuntimeException("Editor exited with error (exit code " + exitCode + "). "
+                        + "Verify your editor works correctly or reconfigure with: "
+                        + KcAdmMain.CMD + " " + KcAdmMain.V2_FLAG + " config editor <editor>");
+            }
+
+            return Files.readString(tempFile);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    static String[] createDescription(String resourceName) {
+        return new String[] {
+                "Edit a " + resourceName + " by opening it in a text editor and applying the modifications.",
+                "Editor is resolved from (in order): '" + CMD + " " + V2_FLAG + " config editor' setting,",
+                ENV_KC_CLI_EDITOR + ", " + ENV_VISUAL + ", " + ENV_EDITOR + " environment variables, or "
+                        + DEFAULT_EDITOR_UNIX + " (" + DEFAULT_EDITOR_WINDOWS + " on Windows)."
+        };
+    }
+}

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2RequestExecutor.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/admin/cli/v2/KcAdmV2RequestExecutor.java
@@ -90,6 +90,67 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
         }
     }
 
+    protected record RequestContext(ConfigData configData, String token) {}
+
+    protected final RequestContext prepareRequest() {
+        processOptions();
+
+        ConfigData configData = loadConfig();
+
+        // Apply CLI overrides onto config
+        if (server != null) {
+            configData.setServerUrl(server);
+        }
+        if (realm != null) {
+            configData.setRealm(realm);
+        }
+        if (externalToken != null) {
+            configData.setExternalToken(externalToken);
+        }
+
+        // Default realm to master if not set anywhere
+        if (configData.getRealm() == null) {
+            configData.setRealm(DEFAULT_REALM);
+        }
+
+        String v2Cmd = KcAdmMain.CMD + " " + KcAdmMain.V2_FLAG;
+
+        if (configData.getServerUrl() == null) {
+            throw new RuntimeException(
+                    "No server URL configured. Use --server or '" + v2Cmd + " config credentials' first.");
+        }
+        if (!configData.getServerUrl().startsWith("http://") && !configData.getServerUrl().startsWith("https://")) {
+            throw new RuntimeException(
+                    "Invalid server URL: " + configData.getServerUrl() + ". URL must start with http:// or https://");
+        }
+
+        setupTruststore(configData);
+
+        // Set fields so ensureAuthInfo/BaseConfigCredentialsCmd can use them
+        if (server == null) {
+            server = configData.getServerUrl();
+        }
+        if (realm == null) {
+            realm = configData.getRealm();
+        }
+
+        configData = ensureAuthInfo(configData);
+        configData = copyWithServerInfo(configData);
+
+        String token = null;
+        if (credentialsAvailable(configData)) {
+            token = ensureToken(configData);
+        }
+
+        String requestRealm = getTargetRealm(configData);
+        if (requestRealm == null) {
+            requestRealm = DEFAULT_REALM;
+        }
+        configData.setRealm(requestRealm);
+
+        return new RequestContext(configData, token);
+    }
+
     @Override
     public void run() {
         if (Globals.help) {
@@ -100,89 +161,22 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
         PrintWriter out = spec.commandLine().getOut();
 
         try {
-            processOptions();
-
-            ConfigData configData = loadConfig();
-
-            // Apply CLI overrides onto config
-            if (server != null) {
-                configData.setServerUrl(server);
-            }
-            if (realm != null) {
-                configData.setRealm(realm);
-            }
-            if (externalToken != null) {
-                configData.setExternalToken(externalToken);
-            }
-
-            // Default realm to master if not set anywhere
-            if (configData.getRealm() == null) {
-                configData.setRealm(DEFAULT_REALM);
-            }
-
-            String v2Cmd = KcAdmMain.CMD + " " + KcAdmMain.V2_FLAG;
-
-            if (configData.getServerUrl() == null) {
-                throw new RuntimeException(
-                        "No server URL configured. Use --server or '" + v2Cmd + " config credentials' first.");
-            }
-            if (!configData.getServerUrl().startsWith("http://") && !configData.getServerUrl().startsWith("https://")) {
-                throw new RuntimeException(
-                        "Invalid server URL: " + configData.getServerUrl() + ". URL must start with http:// or https://");
-            }
-
-            setupTruststore(configData);
-
-            // Set fields so ensureAuthInfo/BaseConfigCredentialsCmd can use them
-            if (server == null) {
-                server = configData.getServerUrl();
-            }
-            if (realm == null) {
-                realm = configData.getRealm();
-            }
-
-            configData = ensureAuthInfo(configData);
-            configData = copyWithServerInfo(configData);
-
-            String token = null;
-            if (credentialsAvailable(configData)) {
-                token = ensureToken(configData);
-            }
-
-            String requestRealm = getTargetRealm(configData);
-            if (requestRealm == null) {
-                requestRealm = DEFAULT_REALM;
-            }
-            configData.setRealm(requestRealm);
+            RequestContext ctx = prepareRequest();
 
             String body = buildRequestBody();
             if (body == null && isVariantParent()) {
                 throw new RuntimeException(
                         "No file specified. Use -f/--file to provide a request body.");
             }
-            String url = buildUrl(configData, body);
+            String url = buildUrl(ctx.configData(), body);
 
-            Headers headers = new Headers();
-            if (token != null) {
-                headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
-            }
-            headers.add(HttpHeaders.ACCEPT, APPLICATION_JSON);
+            String contentType = body != null
+                    ? ("PATCH".equals(descriptor.getHttpMethod()) ? MERGE_PATCH_JSON : APPLICATION_JSON)
+                    : null;
 
-            InputStream bodyStream = null;
-            if (body != null) {
-                String contentType = "PATCH".equals(descriptor.getHttpMethod())
-                        ? MERGE_PATCH_JSON : APPLICATION_JSON;
-                headers.add(HttpHeaders.CONTENT_TYPE, contentType);
-                bodyStream = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
-            }
+            HeadersBodyStatus response = executeRequest(descriptor.getHttpMethod().toLowerCase(), url, ctx.token(), body,
+                    contentType);
 
-            HeadersBodyStatus response = HttpUtil.doRequest(
-                    descriptor.getHttpMethod().toLowerCase(),
-                    url,
-                    new HeadersBody(headers, bodyStream),
-                    true);
-
-            response.checkSuccess();
             String responseBody = response.getBody() != null ? readFully(response.getBody()) : "";
 
             if (!responseBody.isBlank()) {
@@ -198,7 +192,26 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
         }
     }
 
-    private String buildUrl(ConfigData configData, String body) {
+    protected final HeadersBodyStatus executeRequest(String method, String url, String token,
+                                               String body, String contentType) throws IOException {
+        Headers headers = new Headers();
+        if (token != null) {
+            headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+        headers.add(HttpHeaders.ACCEPT, APPLICATION_JSON);
+
+        InputStream bodyStream = null;
+        if (body != null) {
+            headers.add(HttpHeaders.CONTENT_TYPE, contentType);
+            bodyStream = new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+        }
+
+        HeadersBodyStatus response = HttpUtil.doRequest(method, url, new HeadersBody(headers, bodyStream), true);
+        response.checkSuccess();
+        return response;
+    }
+
+    protected final String buildUrl(ConfigData configData, String body) {
         String path = descriptor.getPath()
                 .replace("{realmName}", HttpUtil.urlencode(configData.getRealm()))
                 .replace("{version}", API_VERSION);
@@ -323,7 +336,7 @@ class KcAdmV2RequestExecutor extends AbstractTargetAuthOptionsCmd {
         return file != null ? file : parentFile;
     }
 
-    private String formatOutput(String json) {
+    protected final String formatOutput(String json) {
         try {
             var parseResult = spec.commandLine().getParseResult();
             boolean compressed = parseResult.matchedOptionValue(KcAdmV2CommandBuilder.OPT_COMPRESSED, false);

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/config/ConfigData.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/config/ConfigData.java
@@ -40,6 +40,8 @@ public class ConfigData {
 
     private String trustpass;
 
+    private String editor;
+
     private Map<String, Map<String, RealmConfigData>> endpoints = new HashMap<>();
 
 
@@ -83,6 +85,14 @@ public class ConfigData {
 
     public void setTrustpass(String trustpass) {
         this.trustpass = trustpass;
+    }
+
+    public String getEditor() {
+        return editor;
+    }
+
+    public void setEditor(String editor) {
+        this.editor = editor;
     }
 
     public Map<String, Map<String, RealmConfigData>> getEndpoints() {
@@ -143,6 +153,7 @@ public class ConfigData {
         realm = source.realm;
         truststore = source.truststore;
         trustpass = source.trustpass;
+        editor = source.editor;
 
         RealmConfigData current = getRealmConfigData(serverUrl, realm);
         RealmConfigData sourceRealm = source.getRealmConfigData(serverUrl, realm);
@@ -160,6 +171,7 @@ public class ConfigData {
         data.realm = realm;
         data.truststore = truststore;
         data.trustpass = trustpass;
+        data.editor = editor;
         data.endpoints = new HashMap<>();
 
         for (Map.Entry<String, Map<String, RealmConfigData>> item: endpoints.entrySet()) {

--- a/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/HeadersBodyStatus.java
+++ b/integration/client-cli/admin-cli/src/main/java/org/keycloak/client/cli/util/HeadersBodyStatus.java
@@ -75,7 +75,7 @@ public class HeadersBodyStatus extends HeadersBody {
                 }
 
                 if (message == null) {
-                    message = msg != null ? msg : err != null ? (description + " [" + error.get("error") + "]") : null;
+                    message = msg != null ? msg : err != null ? (description != null ? description + " [" + err + "]" : err) : null;
                 }
             }
             throw new HttpResponseException(getStatusCodeAndReason(), message, new RuntimeException(content));

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2CompleterTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2CompleterTest.java
@@ -40,6 +40,7 @@ public class KcAdmV2CompleterTest {
         assertTrue("Should suggest 'patch'", candidates.contains("patch"));
         assertTrue("Should suggest 'apply'", candidates.contains("apply"));
         assertTrue("Should suggest 'delete'", candidates.contains("delete"));
+        assertTrue("Should suggest 'edit'", candidates.contains("edit"));
     }
 
     @Test
@@ -156,10 +157,27 @@ public class KcAdmV2CompleterTest {
     }
 
     @Test
+    public void testEditOptionsInAutocomplete() {
+        List<String> candidates = complete("client", "edit", "--");
+        assertTrue("Should suggest '--config'", candidates.contains("--config"));
+        assertTrue("Should suggest '--compressed'", candidates.contains("--compressed"));
+        assertFalse("Should not suggest '--file'", candidates.contains("--file"));
+        assertFalse("Should not suggest '--client-id'", candidates.contains("--client-id"));
+    }
+
+    @Test
     public void testConfigShowsSubcommands() {
         List<String> candidates = complete("config", "");
         assertTrue("Should suggest 'credentials'", candidates.contains("credentials"));
         assertTrue("Should suggest 'openapi'", candidates.contains("openapi"));
+        assertTrue("Should suggest 'editor'", candidates.contains("editor"));
+    }
+
+    @Test
+    public void testConfigEditorOptionsInAutocomplete() {
+        List<String> candidates = complete("config", "editor", "--");
+        assertTrue("Should suggest '--config': " + candidates, candidates.contains("--config"));
+        assertTrue("Should suggest '--help': " + candidates, candidates.contains("--help"));
     }
 
     @Test

--- a/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2HelpTest.java
+++ b/integration/client-cli/admin-cli/src/test/java/org/keycloak/client/admin/cli/commands/v2/KcAdmV2HelpTest.java
@@ -62,7 +62,7 @@ public class KcAdmV2HelpTest {
         CommandLine clientCli = cli.getSubcommands().get("client");
 
         String help = clientCli.getUsageMessage();
-        for (String cmd : List.of("list", "create", "get", "patch", "apply", "delete")) {
+        for (String cmd : List.of("list", "create", "get", "patch", "apply", "delete", "edit")) {
             assertTrue("Client help should list '" + cmd + "'", help.contains(cmd));
         }
     }
@@ -387,6 +387,44 @@ public class KcAdmV2HelpTest {
         int exitCode = cli.execute("client", "patch", "oidc", "--help");
         assertEquals("--help on variant leaf with required ID should exit with 0, err: " + err, 0, exitCode);
         assertTrue("should show help with --client-id option", out.toString().contains("--client-id"));
+    }
+
+    @Test
+    public void testEditHelpMentionsEditorConfiguration() {
+        String help = getSubcommandHelp("client", "edit");
+        assertTrue("edit help should mention KC_CLI_EDITOR env var", help.contains("KC_CLI_EDITOR"));
+        assertTrue("edit help should mention config editor command", help.contains("config editor"));
+        assertTrue("edit help should show <id> parameter", help.contains("<id>"));
+    }
+
+    @Test
+    public void testEditHasNoFileOrFieldOptions() {
+        String help = getSubcommandHelp("client", "edit");
+        assertFalse("edit should not have --file option", help.contains("--file"));
+        assertFalse("edit should not have -f option", help.contains("-f"));
+        assertFalse("edit should not have --client-id option", help.contains("--client-id"));
+    }
+
+    @Test
+    public void testEditHasConnectionAndOutputOptions() {
+        String help = getSubcommandHelp("client", "edit");
+        assertTrue("edit should have --config", help.contains("--config"));
+        assertTrue("edit should have --realm", help.contains("--realm"));
+        assertTrue("edit should have Output options", help.contains("Output options:"));
+    }
+
+    @Test
+    public void testConfigEditorHelpShowsUsage() {
+        CommandLine cli = createCli();
+        StringWriter out = new StringWriter();
+        cli.setOut(new PrintWriter(out));
+        cli.setErr(new PrintWriter(new StringWriter()));
+
+        int exitCode = cli.execute("config", "editor", "--help");
+        assertEquals("--help on config editor should exit with 0", 0, exitCode);
+        String help = out.toString();
+        assertTrue("should show editor parameter: " + help, help.contains("<editor>"));
+        assertTrue("should show --config option: " + help, help.contains("--config"));
     }
 
     @Test

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2EditCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2EditCLITest.java
@@ -1,0 +1,212 @@
+package org.keycloak.tests.admin.cli.v2;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.keycloak.client.cli.util.HttpUtil;
+import org.keycloak.common.Profile;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.config.Config;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@KeycloakIntegrationTest(config = KcAdmV2EditCLITest.V2ApiServerConfig.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Test scripts require POSIX shell and Unix utilities")
+public class KcAdmV2EditCLITest extends AbstractKcAdmV2CLITest {
+
+    @InjectRealm
+    ManagedRealm realm;
+
+    @TempDir
+    static File tempDir;
+
+    private static String configFilePath;
+
+    @TestSetup
+    public void login() {
+        configFilePath = new File(tempDir, "kcadm.config").getAbsolutePath();
+        HttpUtil.clearHttpClient();
+
+        CommandResult result = kcAdmV2Cmd(
+                "config", "credentials",
+                "--server", keycloakUrls.getBase(),
+                "--realm", "master",
+                "--client", Config.getAdminClientId(),
+                "--secret", Config.getAdminClientSecret());
+
+        assertThat("login should succeed: " + result.err(), result.exitCode(), is(0));
+    }
+
+    @Test
+    void testEditNoChanges() {
+        createClient("edit-no-changes");
+        setEditor("/usr/bin/true");
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "edit-no-changes");
+
+        assertThat("edit with no changes should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat("should report no changes", result.err(), containsString("no changes"));
+        assertThat("should not print any resource to stdout", result.out().trim(), is(""));
+    }
+
+    @Test
+    void testEditAppliesUpdate() throws Exception {
+        CommandResult createResult = createClient("edit-applies-update", "--enabled", "true");
+        assertThat("client should be created as enabled",
+                createResult.out(), containsString("\"enabled\" : true"));
+        setEditor(createEnabledFlipEditor());
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "edit-applies-update");
+
+        assertThat("edit should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat("updated resource should reflect the change",
+                result.out(), containsString("\"enabled\" : false"));
+        assertThat("updated resource should contain the clientId",
+                result.out(), containsString("\"clientId\" : \"edit-applies-update\""));
+
+        CommandResult getResult = kcAdmV2Cmd("client", "get", "edit-applies-update");
+        assertThat("get after edit should succeed", getResult.exitCode(), is(0));
+        assertThat("change should be persisted", getResult.out(), containsString("\"enabled\" : false"));
+    }
+
+    @Test
+    void testEditNonExistentResource() {
+        setEditor("/usr/bin/true");
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "non-existent-id");
+
+        assertThat("edit non-existent should fail", result.exitCode(), is(not(0)));
+        assertThat(result.err().trim(), is("Could not find client"));
+    }
+
+    @Test
+    void testEditEditorExitsNonZero() {
+        createClient("edit-non-zero");
+        setEditor("/usr/bin/false");
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "edit-non-zero");
+
+        assertThat("edit should fail when editor exits non-zero", result.exitCode(), is(not(0)));
+        assertThat("should explain the editor failed",
+                result.err(), containsString("exited with error"));
+        assertThat("should tell user how to reconfigure the editor",
+                result.err(), containsString("config editor"));
+    }
+
+    @Test
+    void testEditEditorNotFound() {
+        createClient("edit-not-found");
+        setEditor(tempDir.toPath().resolve("nonexistent-editor").toString());
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "edit-not-found");
+
+        assertThat("edit should fail when editor not found", result.exitCode(), is(not(0)));
+        assertThat("should tell user how to configure via command",
+                result.err(), containsString("config editor"));
+        assertThat("should tell user about the env var alternative",
+                result.err(), containsString("KC_CLI_EDITOR"));
+    }
+
+    @Test
+    void testEditWithRealmOverride() throws Exception {
+        assertThat("managed realm should not be master", realm.getName(), is(not("master")));
+
+        CommandResult createResult = kcAdmV2Cmd("client", "create", "oidc",
+                "-r", realm.getName(),
+                "--client-id", "edit-realm-override",
+                "--enabled", "true");
+        assertThat("setup: create should succeed: " + createResult.err(), createResult.exitCode(), is(0));
+        assertThat("client should be created as enabled",
+                createResult.out(), containsString("\"enabled\" : true"));
+
+        setEditor(createEnabledFlipEditor());
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "edit-realm-override", "-r", realm.getName());
+
+        assertThat("edit in other realm should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat(result.out(), containsString("\"enabled\" : false"));
+    }
+
+    @Test
+    void testEditInvalidJsonAfterEdit() throws Exception {
+        createClient("edit-invalid-json");
+        setEditor(createTestEditor("""
+                #!/bin/sh
+                echo "this is not json" > "$1"
+                """));
+
+        CommandResult result = kcAdmV2Cmd("client", "edit", "edit-invalid-json");
+
+        assertThat("edit with invalid JSON should fail", result.exitCode(), is(not(0)));
+        assertThat("should report JSON error", result.err(), containsString("not valid JSON"));
+    }
+
+    private CommandResult createClient(String clientId, String... extraArgs) {
+        final String[] baseArgs = {"client", "create", "oidc", "--client-id", clientId};
+        final String[] args;
+        if (extraArgs.length == 0) {
+            args = baseArgs;
+        } else {
+            args = new String[baseArgs.length + extraArgs.length];
+            System.arraycopy(baseArgs, 0, args, 0, baseArgs.length);
+            System.arraycopy(extraArgs, 0, args, baseArgs.length, extraArgs.length);
+        }
+
+        CommandResult result = kcAdmV2Cmd(args);
+        assertThat("setup: create should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat("create should return the resource",
+                result.out(), containsString("\"clientId\" : \"" + clientId + "\""));
+        return result;
+    }
+
+    private void setEditor(String editor) {
+        CommandResult result = kcAdmV2Cmd("config", "editor", editor);
+        assertThat("config editor should succeed: " + result.err(), result.exitCode(), is(0));
+        assertThat("should confirm editor configuration: " + result.err(), result.err(), containsString(editor));
+        try {
+            assertThat("editor should be persisted in config", Files.readString(Path.of(configFilePath)), containsString(editor));
+        } catch (Exception e) {
+            fail("Could not read config file: " + configFilePath, e);
+        }
+    }
+
+    private String createEnabledFlipEditor() throws Exception {
+        return createTestEditor("""
+                #!/bin/sh
+                sed 's/"enabled" : true/"enabled" : false/' "$1" > "$1.tmp" && mv "$1.tmp" "$1"
+                """);
+    }
+
+    private String createTestEditor(String script) throws Exception {
+        Path editorScript = Files.createTempFile(tempDir.toPath(), "test-editor-", ".sh");
+        Files.writeString(editorScript, script);
+        assertThat("editor script should be made executable", editorScript.toFile().setExecutable(true), is(true));
+        return editorScript.toString();
+    }
+
+    private CommandResult kcAdmV2Cmd(String... args) {
+        return kcAdmV2Cmd(null, configFilePath, args);
+    }
+
+    public static class V2ApiServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.CLIENT_ADMIN_API_V2);
+        }
+    }
+}


### PR DESCRIPTION
Make users lives easier when they need to update existing client they don't have stored locally.
Instead of doing "get", then modifying the client somewhere and then doing "apply", now users can use "edit" command.

How it works (just happy path, read the commit for all the scenarios):

1. `kcadm.sh --v2 client edit test-client`
2. editor is opened (you can configure which one by env vars or using a config command. Interesting: My Fedora Linux seems to have by default set environment variable `EDITOR` to `nano`, so unless I configure the editor explicitly, the `nano` editor is used.
3. use PUT method to apply the user changes
4. print out to user the resulting resource (updated resource)

Simple example:

```bash
mvavrik@fedora:~/sources/keycloak$ kcadm.sh --v2 client edit test
Updating client 'test' ...

{
  "uuid" : "3b60ac14-a83b-459f-95fd-4786f8906ade",
  "clientId" : "test",
  "enabled" : true,
  "protocol" : "openid-connect"
}
```

* Closes: https://github.com/keycloak/keycloak/issues/47498
