### PR TITLE
Add saml-full-name-mapper

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/saml/mappers/FullNameMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/saml/mappers/FullNameMapper.java
@@ -1,0 +1,74 @@
+package org.keycloak.protocol.saml.mappers;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
+import org.keycloak.models.AuthenticatedClientSessionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * Mappings User's full name to an AttributeStatement.
+ */
+public class FullNameMapper extends AbstractSAMLProtocolMapper implements SAMLAttributeStatementMapper {
+
+    public static final String PROVIDER_ID = "saml-full-name-mapper";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
+
+    static {
+        AttributeStatementHelper.setConfigProperties(configProperties);
+    }
+
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "User's full name";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return AttributeStatementHelper.ATTRIBUTE_STATEMENT_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Maps the user's first and last name to the SAML Assertion. Format is <first> + ' ' + <last>";
+    }
+
+    @Override
+    public void transformAttributeStatement(AttributeStatementType attributeStatement, ProtocolMapperModel mappingModel, KeycloakSession session, UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+        UserModel user = userSession.getUser();
+        List<String> parts = new LinkedList<>();
+
+        Optional.ofNullable(user.getFirstName()).filter(s -> !s.isEmpty()).ifPresent(parts::add);
+        Optional.ofNullable(user.getLastName()).filter(s -> !s.isEmpty()).ifPresent(parts::add);
+
+        if (!parts.isEmpty()) {
+            AttributeStatementHelper.addAttribute(attributeStatement, mappingModel, String.join(" ", parts));
+        }
+    }
+
+    public static ProtocolMapperModel create(String name,
+                                             String samlAttributeName, String nameFormat, String friendlyName, String value) {
+        String mapperId = PROVIDER_ID;
+
+        return AttributeStatementHelper.createAttributeMapper(name, null, samlAttributeName, nameFormat, friendlyName,
+                mapperId);
+    }
+
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -62,3 +62,4 @@ org.keycloak.protocol.oidc.mappers.SubMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationGroupMembershipMapper
 org.keycloak.protocol.saml.mappers.AuthnContextClassRefMapper
+org.keycloak.protocol.saml.mappers.FullNameMapper

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/FullNameMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/saml/FullNameMapperTest.java
@@ -1,0 +1,84 @@
+package org.keycloak.testsuite.saml;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.keycloak.dom.saml.v2.assertion.AssertionType;
+import org.keycloak.dom.saml.v2.assertion.AttributeType;
+import org.keycloak.protocol.saml.mappers.AttributeStatementHelper;
+import org.keycloak.protocol.saml.mappers.FullNameMapper;
+import org.keycloak.saml.common.constants.JBossSAMLURIConstants;
+import org.keycloak.saml.processing.core.saml.v2.common.SAMLDocumentHolder;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
+import org.keycloak.testsuite.updaters.ProtocolMappersUpdater;
+import org.keycloak.testsuite.util.Matchers;
+import org.keycloak.testsuite.util.SamlClient;
+import org.keycloak.testsuite.util.SamlClientBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.keycloak.testsuite.saml.RoleMapperTest.createSamlProtocolMapper;
+import static org.keycloak.testsuite.util.SamlStreams.assertionsUnencrypted;
+import static org.keycloak.testsuite.util.SamlStreams.attributeStatements;
+import static org.keycloak.testsuite.util.SamlStreams.attributesUnecrypted;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+public class FullNameMapperTest extends AbstractSamlTest {
+
+    public static final String FULL_NAME_ATTRIBUTE_NAME = "fullname";
+
+    private ClientAttributeUpdater cau;
+    private ProtocolMappersUpdater pmu;
+
+    @Before
+    public void cleanMappersAndScopes() {
+        this.cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, SAML_CLIENT_ID_EMPLOYEE_2)
+                .setDefaultClientScopes(Collections.EMPTY_LIST)
+                .update();
+        this.pmu = cau.protocolMappers()
+                .clear()
+                .update();
+
+        getCleanup(REALM_NAME)
+                .addCleanup(this.cau)
+                .addCleanup(this.pmu);
+    }
+
+    @Test
+    public void fullnameMapperTest() throws Exception {
+        String fullName = bburkeUser.getFirstName() + " " + bburkeUser.getLastName();
+
+        pmu.add(
+            createSamlProtocolMapper(FullNameMapper.PROVIDER_ID,
+                AttributeStatementHelper.SAML_ATTRIBUTE_NAME, FULL_NAME_ATTRIBUTE_NAME,
+                AttributeStatementHelper.SAML_ATTRIBUTE_NAMEFORMAT, AttributeStatementHelper.BASIC,
+                FullNameMapper.ATTRIBUTE_VALUE
+            )
+        ).update();
+
+        SAMLDocumentHolder samlResponse = new SamlClientBuilder()
+            .authnRequest(getAuthServerSamlEndpoint(REALM_NAME), SAML_CLIENT_ID_EMPLOYEE_2, SAML_ASSERTION_CONSUMER_URL_EMPLOYEE_2, SamlClient.Binding.POST)
+            .build()
+            .login().user(bburkeUser).build()
+            .getSamlResponse(SamlClient.Binding.POST);
+
+        assertThat(samlResponse.getSamlObject(), Matchers.isSamlResponse(JBossSAMLURIConstants.STATUS_SUCCESS));
+
+        Stream<AssertionType> assertions = assertionsUnencrypted(samlResponse.getSamlObject());
+        Stream<AttributeType> attributes = attributesUnecrypted(attributeStatements(assertions));
+        Set<String> attributeValues = attributes
+                .filter(a -> a.getName().equals(FULL_NAME_ATTRIBUTE_NAME))
+                .flatMap(a -> a.getAttributeValue().stream())
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+
+        assertThat(attributeValues, hasSize(1));
+        assertThat(attributeValues.iterator().next(), fullName);
+    }
+}


### PR DESCRIPTION
This PR adds a SAML full-name mapper. This is the SAML equivalent of the OIDC full-name mapper (https://github.com/keycloak/keycloak/blob/main/services/src/main/java/org/keycloak/protocol/oidc/mappers/FullNameMapper.java).

Closes #21198

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
