### PR TITLE
Add a title atttribute for the freemarker templates

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -337,9 +337,11 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
                 break;
             case FRONTCHANNEL_LOGOUT:
                 attributes.put("logout", new FrontChannelLogoutBean(session));
+                attributes.put("title", getMessage("frontchannel-logout.title"));
                 break;
             case LOGOUT_CONFIRM:
                 attributes.put("logoutConfirm", new LogoutConfirmBean(accessCode, authenticationSession));
+                attributes.put("title", getMessage("logoutConfirmTitle"));
                 break;
         }
 
@@ -499,7 +501,9 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
         }
 
         if (realm != null) {
-            attributes.put("realm", new RealmBean(realm));
+            RealmBean realmBean = new RealmBean(realm);
+            attributes.put("realm", realmBean);
+            attributes.put("title", getMessage("loginTitle", realmBean.getDisplayName()));
 
             IdentityProviderBean idpBean = new IdentityProviderBean(session, realm, baseUriWithCodeAndClientId, context);
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/AbstractBaseBrokerTest.java
@@ -395,6 +395,7 @@ public abstract class AbstractBaseBrokerTest extends AbstractKeycloakTest {
     // Check whether the logout confirmation is present; if yes, confirm the logout and verify the current page
     private void checkLogoutConfirmation(String realm, String idTokenHint, String clientId) {
         if (logoutConfirmPage.isCurrent()) {
+            Assertions.assertEquals("Logging out", driver.getTitle());
             confirmLogout();
             if (idTokenHint != null || clientId != null) {
                 assertLoginPage(realm);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcBrokerLogoutTest.java
@@ -271,6 +271,7 @@ public class KcOidcBrokerLogoutTest extends AbstractKcOidcBrokerLogoutTest {
 
             WaitUtils.waitForPageToLoad();
             logoutConfirmPage.isCurrent();
+            Assertions.assertEquals("Logging out", driver.getTitle());
             Assertions.assertTrue(driver.getPageSource().contains("You are logging out from following apps"));
             Assertions.assertTrue(driver.getPageSource().contains("broker-app"));
 

--- a/themes/src/main/resources/theme/base/login/frontchannel-logout.ftl
+++ b/themes/src/main/resources/theme/base/login/frontchannel-logout.ftl
@@ -1,9 +1,6 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout; section>
     <#if section = "header">
-        <script>
-            document.title =  "${msg("frontchannel-logout.title")}";
-        </script>
         ${msg("frontchannel-logout.title")}
     <#elseif section = "form">
         <p>${msg("frontchannel-logout.message")}</p>

--- a/themes/src/main/resources/theme/base/login/template.ftl
+++ b/themes/src/main/resources/theme/base/login/template.ftl
@@ -12,7 +12,7 @@
             <meta name="${meta?split('==')[0]}" content="${meta?split('==')[1]}"/>
         </#list>
     </#if>
-    <title>${msg("loginTitle",(realm.displayName!''))}</title>
+    <title>${title!}</title>
     <link rel="icon" href="${url.resourcesPath}/img/favicon.ico" />
     <#if properties.stylesCommon?has_content>
         <#list properties.stylesCommon?split(' ') as style>

--- a/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/template.ftl
@@ -37,7 +37,7 @@
             <meta name="${meta?split('==')[0]}" content="${meta?split('==')[1]}"/>
         </#list>
     </#if>
-    <title>${msg("loginTitle",(realm.displayName!''))}</title>
+    <title>${title!}</title>
     <link rel="icon" href="${url.resourcesPath}/img/favicon.ico" />
     <#if properties.stylesCommon?has_content>
         <#list properties.stylesCommon?split(' ') as style>


### PR DESCRIPTION
Closes #48241

Adding a `title` attribute that is always added with the realm display name. The attribute can be overloaded for the different pages, in this case the two logout pages (logout and logout-confirm). I decided to also change the logout confirm that previously was showing the `Login to <realm>`. If you think that another name or a constant should be used just let me know (I'm just following what is done in the rest of attributes).

@ahus1 WDYT? Did you have something else in mind?
