### PR TITLE
Disable configuration override forcing access token to be of JWT type

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/KeycloakOIDCIdentityProvider.java
@@ -52,7 +52,6 @@ public class KeycloakOIDCIdentityProvider extends OIDCIdentityProvider {
 
     public KeycloakOIDCIdentityProvider(KeycloakSession session, OIDCIdentityProviderConfig config) {
         super(session, config);
-        config.setAccessTokenJwt(true); // force access token JWT
     }
 
     @Override


### PR DESCRIPTION
Closes #44222

It looks that the line this commit removes is a development artifact, as override was introduced in the same commit as config parameters it overrides (https://github.com/keycloak/keycloak/commit/a8bca522c1a378eee8de0c82ce2f7d13c3622265)
