### PR TITLE
AuthZEN lookup subject.type=user based upon username not UUID

### DIFF
--- a/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZenResource.java
+++ b/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZenResource.java
@@ -143,7 +143,7 @@ public class AuthZenResource {
         AuthZen.Subject subject = request.subject();
         Identity identity = switch (subject.type()) {
             case USER -> {
-                UserModel user = session.users().getUserById(realm, subject.id());
+                UserModel user = session.users().getUserByUsername(realm, subject.id());
                 yield user != null ? new UserModelIdentity(realm, user) : null;
             }
             case CLIENT -> {

--- a/authzen/tests/authzen-client/src/main/java/org/keycloak/testframework/authzen/client/AuthZenClient.java
+++ b/authzen/tests/authzen-client/src/main/java/org/keycloak/testframework/authzen/client/AuthZenClient.java
@@ -28,6 +28,7 @@ import org.keycloak.http.simple.SimpleHttp;
 import org.keycloak.http.simple.SimpleHttpRequest;
 import org.keycloak.http.simple.SimpleHttpResponse;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -46,9 +47,17 @@ public class AuthZenClient {
     }
 
     public EvaluationResult evaluate(AuthZen.EvaluationRequest request) throws IOException {
+        return evaluate((Object) request);
+    }
+
+    public EvaluationResult evaluate(JsonNode request) throws IOException {
+        return evaluate((Object) request);
+    }
+
+    private EvaluationResult evaluate(Object req) throws IOException {
         String url = realmUrl + "/authzen/access/v1/evaluation";
 
-        try (SimpleHttpResponse response = req(simpleHttp.doPost(url).json(request))) {
+        try (SimpleHttpResponse response = req(simpleHttp.doPost(url).json(req))) {
             int status = response.getStatus();
             AuthZen.EvaluationResponse body = response.asJson(AuthZen.EvaluationResponse.class);
             return new EvaluationResult(status, body);

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationInteropTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationInteropTest.java
@@ -21,9 +21,8 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-import org.keycloak.authorization.authzen.AuthZen;
-import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.authzen.client.AuthZenClient;
@@ -31,11 +30,11 @@ import org.keycloak.testframework.authzen.client.AuthZenClient.EvaluationResult;
 import org.keycloak.testframework.authzen.client.annotations.InjectAuthZenClient;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
-import org.keycloak.testframework.realm.ManagedClient;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
@@ -51,35 +50,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @KeycloakIntegrationTest(config = AuthZenServerConfig.class)
 public class AuthZenEvaluationInteropTest {
 
-    // Interop project subject IDs (base64-encoded, too long for Keycloak's VARCHAR(36) ID column)
-    private static final String INTEROP_RICK_ID = "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs";
-    private static final String INTEROP_MORTY_ID = "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs";
-    private static final String INTEROP_SUMMER_ID = "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs";
-    private static final String INTEROP_BETH_ID = "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs";
-    private static final String INTEROP_JERRY_ID = "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs";
-
-    // Keycloak-compatible UUIDs for each user
-    private static final String RICK_ID = "fd0614d3-c39a-4781-b7bd-8b96f5a5100d";
-    private static final String MORTY_ID = "fd1614d3-c39a-4781-b7bd-8b96f5a5100d";
-    private static final String SUMMER_ID = "fd2614d3-c39a-4781-b7bd-8b96f5a5100d";
-    private static final String BETH_ID = "fd3614d3-c39a-4781-b7bd-8b96f5a5100d";
-    private static final String JERRY_ID = "fd4614d3-c39a-4781-b7bd-8b96f5a5100d";
-
-    // Maps interop subject IDs to Keycloak UUIDs
-    private static final Map<String, String> INTEROP_TO_KC_ID = Map.of(
-          INTEROP_RICK_ID, RICK_ID,
-          INTEROP_MORTY_ID, MORTY_ID,
-          INTEROP_SUMMER_ID, SUMMER_ID,
-          INTEROP_BETH_ID, BETH_ID,
-          INTEROP_JERRY_ID, JERRY_ID
-    );
-
+    // Maps interop subject IDs (base64-encoded, used as usernames) to display names for test output
     private static final Map<String, String> USER_NAMES = Map.of(
-          RICK_ID, "rick",
-          MORTY_ID, "morty",
-          SUMMER_ID, "summer",
-          BETH_ID, "beth",
-          JERRY_ID, "jerry"
+          "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "rick",
+          "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "morty",
+          "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "summer",
+          "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "beth",
+          "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "jerry"
     );
 
     private static final String PDP_CLIENT_ID = "authzen-pdp";
@@ -87,9 +64,6 @@ public class AuthZenEvaluationInteropTest {
 
     @InjectRealm(fromJson = "authzen-interop-realm.json")
     ManagedRealm realm;
-
-    @InjectClient(attachTo = PDP_CLIENT_ID)
-    ManagedClient pdpClient;
 
     @InjectOAuthClient
     OAuthClient oauth;
@@ -117,11 +91,12 @@ public class AuthZenEvaluationInteropTest {
     }
 
     private static String buildTestName(InteropDecision decision) {
-        AuthZen.EvaluationRequest req = decision.request();
-        String userName = USER_NAMES.getOrDefault(req.subject().id(), req.subject().id());
-        String action = req.action().name();
-        String resourceType = req.resource().type();
-        String resourceId = req.resource().id();
+        JsonNode req = decision.request();
+        String subjectId = req.path("subject").path("id").asText();
+        String userName = USER_NAMES.getOrDefault(subjectId, subjectId);
+        String action = req.path("action").path("name").asText();
+        String resourceType = req.path("resource").path("type").asText();
+        String resourceId = req.path("resource").path("id").asText();
         String expected = decision.expected() ? "ALLOW" : "DENY";
         return String.format("%s | %s %s:%s => %s", userName, action, resourceType, resourceId, expected);
     }
@@ -129,29 +104,13 @@ public class AuthZenEvaluationInteropTest {
     private static List<InteropDecision> loadDecisions() throws IOException {
         try (InputStream is = AuthZenEvaluationInteropTest.class.getResourceAsStream(
               "decisions-authorization-api-1_0-01.json")) {
-            com.fasterxml.jackson.databind.ObjectMapper mapper = JsonSerialization.mapper;
-            mapper = mapper.copy().configure(
-                  com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            InteropDecisions decisions = mapper.readValue(is, InteropDecisions.class);
-            return decisions.evaluation().stream()
-                  .map(AuthZenEvaluationInteropTest::remapSubjectId)
+            JsonNode root = JsonSerialization.mapper.readTree(is);
+            return StreamSupport.stream(root.path("evaluation").spliterator(), false)
+                  .map(node -> new InteropDecision(node.get("request"), node.get("expected").asBoolean()))
                   .toList();
         }
     }
 
-    private static InteropDecision remapSubjectId(InteropDecision decision) {
-        AuthZen.EvaluationRequest req = decision.request();
-        String kcId = INTEROP_TO_KC_ID.get(req.subject().id());
-        if (kcId == null) {
-            return decision;
-        }
-        AuthZen.Subject remapped = new AuthZen.Subject(req.subject().type(), kcId, req.subject().properties());
-        return new InteropDecision(new AuthZen.EvaluationRequest(remapped, req.resource(), req.action(), req.context()), decision.expected());
-    }
-
-    public record InteropDecisions(List<InteropDecision> evaluation) {
-    }
-
-    public record InteropDecision(AuthZen.EvaluationRequest request, boolean expected) {
+    public record InteropDecision(JsonNode request, boolean expected) {
     }
 }

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationTest.java
@@ -67,8 +67,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @KeycloakIntegrationTest(config = AuthZenServerConfig.class)
 public class AuthZenEvaluationTest {
 
-    private static final String ADMIN_USER_ID = "a0000000-0000-0000-0000-000000000001";
-    private static final String REGULAR_USER_ID = "a0000000-0000-0000-0000-000000000002";
+    private static final String ADMIN_USER = "admin-user";
+    private static final String REGULAR_USER = "regular-user";
 
     @InjectRealm(config = TestRealmConfig.class)
     ManagedRealm realm;
@@ -107,7 +107,7 @@ public class AuthZenEvaluationTest {
     public void testAdminUserAccessAdminResource() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .resourceProperty("ignored", "property")
@@ -121,7 +121,7 @@ public class AuthZenEvaluationTest {
     public void testRegularUserDeniedAdminResource() throws IOException {
         EvaluationResult result = authzenClient("regular-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, REGULAR_USER_ID)
+                    .subject(USER, REGULAR_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -134,7 +134,7 @@ public class AuthZenEvaluationTest {
     public void testAdminUserAccessUsersResource() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/users")
                     .build());
@@ -147,7 +147,7 @@ public class AuthZenEvaluationTest {
     public void testRegularUserAccessUsersResource() throws IOException {
         EvaluationResult result = authzenClient("regular-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, REGULAR_USER_ID)
+                    .subject(USER, REGULAR_USER)
                     .action("read")
                     .resource("endpoint", "/users")
                     .build());
@@ -160,7 +160,7 @@ public class AuthZenEvaluationTest {
     public void testContextPassedToClaims() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/context-protected")
                     .contextProperty("environment", "production")
@@ -174,7 +174,7 @@ public class AuthZenEvaluationTest {
     public void testContextMismatchDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/context-protected")
                     .contextProperty("environment", "staging")
@@ -188,7 +188,7 @@ public class AuthZenEvaluationTest {
     public void testMissingContextDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/context-protected")
                     .build());
@@ -201,7 +201,7 @@ public class AuthZenEvaluationTest {
     public void testNestedContextPassedToClaims() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/nested-context")
                     .contextProperty("request", Map.of("ip", "10.0.0.1"))
@@ -215,7 +215,7 @@ public class AuthZenEvaluationTest {
     public void testNestedContextMismatchDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/nested-context")
                     .contextProperty("request", Map.of("ip", "192.168.1.1"))
@@ -229,7 +229,7 @@ public class AuthZenEvaluationTest {
     public void testUnknownResourceReturnsDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/nonexistent")
                     .build());
@@ -243,7 +243,7 @@ public class AuthZenEvaluationTest {
     public void testResourceTypeMismatchReturnsDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("wrong-type", "/admin")
                     .build());
@@ -257,7 +257,7 @@ public class AuthZenEvaluationTest {
     public void testEmptyTypeResourceMatchesEmptyType() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("", "/empty-type")
                     .build());
@@ -272,7 +272,7 @@ public class AuthZenEvaluationTest {
     public void testActionWithoutPermissionDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("write")
                     .resource("endpoint", "/scope-limited")
                     .build());
@@ -287,7 +287,7 @@ public class AuthZenEvaluationTest {
     public void testClientEvaluatesUserSubjectAuthorized() throws IOException {
         EvaluationResult result = authzenClient("regular-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -302,7 +302,7 @@ public class AuthZenEvaluationTest {
     public void testClientEvaluatesUserSubjectDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, REGULAR_USER_ID)
+                    .subject(USER, REGULAR_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -368,7 +368,7 @@ public class AuthZenEvaluationTest {
     public void testSubjectPropertiesPassedToIdentityAttributes() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .subjectProperty("department", "engineering")
                     .action("read")
                     .resource("endpoint", "/subject-protected")
@@ -382,7 +382,7 @@ public class AuthZenEvaluationTest {
     public void testSubjectPropertiesMismatchDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .subjectProperty("department", "marketing")
                     .action("read")
                     .resource("endpoint", "/subject-protected")
@@ -396,7 +396,7 @@ public class AuthZenEvaluationTest {
     public void testMissingSubjectPropertiesDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/subject-protected")
                     .build());
@@ -408,7 +408,7 @@ public class AuthZenEvaluationTest {
     @Test
     public void testUnauthenticatedUserReturnsUnauthorized() throws IOException {
         EvaluationResult result = authZenClient.evaluate(AuthZenClient.evaluationRequest()
-              .subject(USER, ADMIN_USER_ID)
+              .subject(USER, ADMIN_USER)
               .action("read")
               .resource("endpoint", "/admin")
               .build());
@@ -431,7 +431,7 @@ public class AuthZenEvaluationTest {
     public void testMissingSubjectTypeReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(null, ADMIN_USER_ID)
+                    .subject(null, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -487,7 +487,7 @@ public class AuthZenEvaluationTest {
         String json = """
               {"subject":{"type":"invalid-type","id":"%s"},\
               "resource":{"type":"endpoint","id":"/admin"},\
-              "action":{"name":"read"}}""".formatted(ADMIN_USER_ID);
+              "action":{"name":"read"}}""".formatted(ADMIN_USER);
 
         try (SimpleHttpResponse response = simpleHttp.doPost(url)
               .auth(tokenResponse.getAccessToken())
@@ -502,7 +502,7 @@ public class AuthZenEvaluationTest {
     public void testMissingResourceReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .build());
 
@@ -513,7 +513,7 @@ public class AuthZenEvaluationTest {
     public void testMissingResourceTypeReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource(null, "/admin")
                     .build());
@@ -525,7 +525,7 @@ public class AuthZenEvaluationTest {
     public void testMissingResourceIdReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", null)
                     .build());
@@ -537,7 +537,7 @@ public class AuthZenEvaluationTest {
     public void testMissingActionReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .resource("endpoint", "/admin")
                     .build());
 
@@ -548,7 +548,7 @@ public class AuthZenEvaluationTest {
     public void testUndefinedActionReturnsDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("undefined-action")
                     .resource("endpoint", "/admin")
                     .build());
@@ -565,7 +565,7 @@ public class AuthZenEvaluationTest {
 
         EvaluationResult result = authZenClient.withAccessToken(tokenResponse.getAccessToken())
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -753,14 +753,14 @@ public class AuthZenEvaluationTest {
             realm.realmRoles("admin");
 
             realm.users(UserBuilder.create("admin-user")
-                  .id(ADMIN_USER_ID)
+                  .username(ADMIN_USER)
                   .name("Admin", "User")
                   .email("admin@localhost")
                   .password("password")
                   .realmRoles("admin"));
 
             realm.users(UserBuilder.create("regular-user")
-                  .id(REGULAR_USER_ID)
+                  .username(REGULAR_USER)
                   .name("Regular", "User")
                   .email("regular@localhost")
                   .password("password"));

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationTest.java
@@ -66,8 +66,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @KeycloakIntegrationTest(config = AuthZenServerConfig.class)
 public class AuthZenEvaluationTest {
 
-    private static final String ADMIN_USER_ID = "a0000000-0000-0000-0000-000000000001";
-    private static final String REGULAR_USER_ID = "a0000000-0000-0000-0000-000000000002";
+    private static final String ADMIN_USER = "admin-user";
+    private static final String REGULAR_USER = "regular-user";
 
     @InjectRealm(config = TestRealmConfig.class)
     ManagedRealm realm;
@@ -106,7 +106,7 @@ public class AuthZenEvaluationTest {
     public void testAdminUserAccessAdminResource() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .resourceProperty("ignored", "property")
@@ -120,7 +120,7 @@ public class AuthZenEvaluationTest {
     public void testRegularUserDeniedAdminResource() throws IOException {
         EvaluationResult result = authzenClient("regular-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, REGULAR_USER_ID)
+                    .subject(USER, REGULAR_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -133,7 +133,7 @@ public class AuthZenEvaluationTest {
     public void testAdminUserAccessUsersResource() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/users")
                     .build());
@@ -146,7 +146,7 @@ public class AuthZenEvaluationTest {
     public void testRegularUserAccessUsersResource() throws IOException {
         EvaluationResult result = authzenClient("regular-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, REGULAR_USER_ID)
+                    .subject(USER, REGULAR_USER)
                     .action("read")
                     .resource("endpoint", "/users")
                     .build());
@@ -159,7 +159,7 @@ public class AuthZenEvaluationTest {
     public void testContextPassedToClaims() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/context-protected")
                     .contextProperty("environment", "production")
@@ -173,7 +173,7 @@ public class AuthZenEvaluationTest {
     public void testContextMismatchDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/context-protected")
                     .contextProperty("environment", "staging")
@@ -187,7 +187,7 @@ public class AuthZenEvaluationTest {
     public void testMissingContextDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/context-protected")
                     .build());
@@ -200,7 +200,7 @@ public class AuthZenEvaluationTest {
     public void testNestedContextPassedToClaims() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/nested-context")
                     .contextProperty("request", Map.of("ip", "10.0.0.1"))
@@ -214,7 +214,7 @@ public class AuthZenEvaluationTest {
     public void testNestedContextMismatchDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/nested-context")
                     .contextProperty("request", Map.of("ip", "192.168.1.1"))
@@ -228,7 +228,7 @@ public class AuthZenEvaluationTest {
     public void testUnknownResourceReturnsDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/nonexistent")
                     .build());
@@ -242,7 +242,7 @@ public class AuthZenEvaluationTest {
     public void testResourceTypeMismatchReturnsDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("wrong-type", "/admin")
                     .build());
@@ -256,7 +256,7 @@ public class AuthZenEvaluationTest {
     public void testEmptyTypeResourceMatchesEmptyType() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("", "/empty-type")
                     .build());
@@ -271,7 +271,7 @@ public class AuthZenEvaluationTest {
     public void testActionWithoutPermissionDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("write")
                     .resource("endpoint", "/scope-limited")
                     .build());
@@ -286,7 +286,7 @@ public class AuthZenEvaluationTest {
     public void testClientEvaluatesUserSubjectAuthorized() throws IOException {
         EvaluationResult result = authzenClient("regular-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -301,7 +301,7 @@ public class AuthZenEvaluationTest {
     public void testClientEvaluatesUserSubjectDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, REGULAR_USER_ID)
+                    .subject(USER, REGULAR_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -367,7 +367,7 @@ public class AuthZenEvaluationTest {
     public void testSubjectPropertiesPassedToIdentityAttributes() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .subjectProperty("department", "engineering")
                     .action("read")
                     .resource("endpoint", "/subject-protected")
@@ -381,7 +381,7 @@ public class AuthZenEvaluationTest {
     public void testSubjectPropertiesMismatchDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .subjectProperty("department", "marketing")
                     .action("read")
                     .resource("endpoint", "/subject-protected")
@@ -395,7 +395,7 @@ public class AuthZenEvaluationTest {
     public void testMissingSubjectPropertiesDeniesAccess() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/subject-protected")
                     .build());
@@ -407,7 +407,7 @@ public class AuthZenEvaluationTest {
     @Test
     public void testUnauthenticatedUserReturnsUnauthorized() throws IOException {
         EvaluationResult result = authZenClient.evaluate(AuthZenClient.evaluationRequest()
-              .subject(USER, ADMIN_USER_ID)
+              .subject(USER, ADMIN_USER)
               .action("read")
               .resource("endpoint", "/admin")
               .build());
@@ -430,7 +430,7 @@ public class AuthZenEvaluationTest {
     public void testMissingSubjectTypeReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(null, ADMIN_USER_ID)
+                    .subject(null, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -486,7 +486,7 @@ public class AuthZenEvaluationTest {
         String json = """
               {"subject":{"type":"invalid-type","id":"%s"},\
               "resource":{"type":"endpoint","id":"/admin"},\
-              "action":{"name":"read"}}""".formatted(ADMIN_USER_ID);
+              "action":{"name":"read"}}""".formatted(ADMIN_USER);
 
         try (SimpleHttpResponse response = simpleHttp.doPost(url)
               .auth(tokenResponse.getAccessToken())
@@ -501,7 +501,7 @@ public class AuthZenEvaluationTest {
     public void testMissingResourceReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .build());
 
@@ -512,7 +512,7 @@ public class AuthZenEvaluationTest {
     public void testMissingResourceTypeReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource(null, "/admin")
                     .build());
@@ -524,7 +524,7 @@ public class AuthZenEvaluationTest {
     public void testMissingResourceIdReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", null)
                     .build());
@@ -536,7 +536,7 @@ public class AuthZenEvaluationTest {
     public void testMissingActionReturnsBadRequest() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .resource("endpoint", "/admin")
                     .build());
 
@@ -547,7 +547,7 @@ public class AuthZenEvaluationTest {
     public void testUndefinedActionReturnsDenied() throws IOException {
         EvaluationResult result = authzenClient("admin-user", "password")
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("undefined-action")
                     .resource("endpoint", "/admin")
                     .build());
@@ -564,7 +564,7 @@ public class AuthZenEvaluationTest {
 
         EvaluationResult result = authZenClient.withAccessToken(tokenResponse.getAccessToken())
               .evaluate(AuthZenClient.evaluationRequest()
-                    .subject(USER, ADMIN_USER_ID)
+                    .subject(USER, ADMIN_USER)
                     .action("read")
                     .resource("endpoint", "/admin")
                     .build());
@@ -752,14 +752,12 @@ public class AuthZenEvaluationTest {
             realm.addRole("admin");
 
             realm.addUser("admin-user")
-                  .id(ADMIN_USER_ID)
                   .name("Admin", "User")
                   .email("admin@localhost")
                   .password("password")
                   .roles("admin");
 
             realm.addUser("regular-user")
-                  .id(REGULAR_USER_ID)
                   .name("Regular", "User")
                   .email("regular@localhost")
                   .password("password");

--- a/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/authzen-interop-realm.json
+++ b/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/authzen-interop-realm.json
@@ -9,8 +9,7 @@
     },
     "users": [
         {
-            "id": "fd0614d3-c39a-4781-b7bd-8b96f5a5100d",
-            "username": "rick",
+            "username": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
             "enabled": true,
             "firstName": "Rick",
             "lastName": "Sanchez",
@@ -21,8 +20,7 @@
             "realmRoles": ["admin"]
         },
         {
-            "id": "fd1614d3-c39a-4781-b7bd-8b96f5a5100d",
-            "username": "morty",
+            "username": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
             "enabled": true,
             "firstName": "Morty",
             "lastName": "Smith",
@@ -33,8 +31,7 @@
             "realmRoles": ["editor"]
         },
         {
-            "id": "fd2614d3-c39a-4781-b7bd-8b96f5a5100d",
-            "username": "summer",
+            "username": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
             "enabled": true,
             "firstName": "Summer",
             "lastName": "Smith",
@@ -45,8 +42,7 @@
             "realmRoles": ["editor"]
         },
         {
-            "id": "fd3614d3-c39a-4781-b7bd-8b96f5a5100d",
-            "username": "beth",
+            "username": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
             "enabled": true,
             "firstName": "Beth",
             "lastName": "Smith",
@@ -57,8 +53,7 @@
             "realmRoles": ["viewer"]
         },
         {
-            "id": "fd4614d3-c39a-4781-b7bd-8b96f5a5100d",
-            "username": "jerry",
+            "username": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
             "enabled": true,
             "firstName": "Jerry",
             "lastName": "Smith",

--- a/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/decisions-authorization-api-1_0-01.json
+++ b/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/decisions-authorization-api-1_0-01.json
@@ -228,7 +228,6 @@
       "request": {
         "subject": {
           "type": "user",
-          "_note" : "ID for Morty",
           "id":"CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
         },
         "action": {


### PR DESCRIPTION

- Remove interop Base64 mapping as now redundant
- Ensure that interop JSON requests are sent exactly as defined to the
  server
- Remove "_note" element from interop scenario as that is removed in the
  next interop scenarios, to be added in a future commit. Keeping this
  element prevents strict request checking on the server-side.

Closes #48287