### PR TITLE
[OID4VCI-FAPI2] Pass fapi2-security-profile-final-access-token-type-header-case-sensitivity

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -150,7 +150,7 @@ public class UserInfoEndpoint {
                 MultivaluedMap<String, String> formParams = request.getDecodedFormParameters();
                 checkAccessTokenDuplicated(formParams);
                 String accessToken = formParams.getFirst(OAuth2Constants.ACCESS_TOKEN);
-                authHeader = accessToken == null ? null : new AppAuthManager.AuthHeader(AppAuthManager.BEARER, accessToken);
+                authHeader = accessToken == null ? null : new AppAuthManager.AuthHeader(TokenUtil.TOKEN_TYPE_BEARER, accessToken);
                 authorization(authHeader);
             }
         } catch (IllegalArgumentException e) {

--- a/services/src/main/java/org/keycloak/services/managers/AppAuthManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AppAuthManager.java
@@ -30,17 +30,17 @@ import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.services.util.DPoPUtil;
-import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
+
+import static org.keycloak.util.TokenUtil.TOKEN_TYPE_BEARER;
+import static org.keycloak.util.TokenUtil.TOKEN_TYPE_DPOP;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class AppAuthManager extends AuthenticationManager {
-
-    public static final String BEARER = "Bearer";
 
     @Override
     public AuthResult authenticateIdentityCookie(KeycloakSession session, RealmModel realm) {
@@ -72,14 +72,15 @@ public class AppAuthManager extends AuthenticationManager {
         String typeString = authHeader.substring(0, indexOfSpace);
         String tokenString = authHeader.substring(indexOfSpace + 1);
 
-        boolean isBearerHeader = typeString.equalsIgnoreCase(BEARER);
+        // Auth schemes are case insensitive per RFC9110-11.1
+        // Checked by fapi2-security-profile-final-access-token-type-header-case-sensitivity
+        boolean isBearerHeader = typeString.equalsIgnoreCase(TOKEN_TYPE_BEARER);
         if (!Profile.isFeatureEnabled(Profile.Feature.DPOP)) {
             if (!isBearerHeader) {
                 return null;
             }
         } else {
-            // "Bearer" is case-insensitive for historical reasons. "DPoP" is case-sensitive to follow the spec.
-            if (!isBearerHeader && !typeString.equals(TokenUtil.TOKEN_TYPE_DPOP)) {
+            if (!isBearerHeader && !typeString.equalsIgnoreCase(TOKEN_TYPE_DPOP)) {
                 return null;
             }
         }
@@ -104,7 +105,7 @@ public class AppAuthManager extends AuthenticationManager {
             return null;
         }
         if (authHeaders.size() != 1) {
-            throw new NotAuthorizedException(BEARER);
+            throw new NotAuthorizedException(TOKEN_TYPE_BEARER);
         }
         String authHeader = headers.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION);
         return extractTokenStringFromAuthHeader(authHeader);
@@ -124,7 +125,7 @@ public class AppAuthManager extends AuthenticationManager {
         }
         AuthHeader parsedHeader = extractTokenStringFromAuthHeader(authHeader);
         if (parsedHeader == null ){
-            throw new NotAuthorizedException(BEARER);
+            throw new NotAuthorizedException(TOKEN_TYPE_BEARER);
         }
         return parsedHeader.getToken();
     }

--- a/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
@@ -242,13 +242,13 @@ public class DPoPUtil {
                         boolean isSchemeDPoP = false;
                         if (StringUtil.isNotBlank(validator.authHeader)) {
                             String[] split = WHITESPACES.split(validator.authHeader);
-                            isSchemeDPoP = TokenUtil.TOKEN_TYPE_DPOP.equals(split[0]);
+                            isSchemeDPoP = TokenUtil.TOKEN_TYPE_DPOP.equalsIgnoreCase(split[0]);
                         }
 
-                        if (!isSchemeDPoP && DPoPUtil.DPOP_TOKEN_TYPE.equals(token.getType())) {
+                        if (!isSchemeDPoP && DPoPUtil.DPOP_TOKEN_TYPE.equalsIgnoreCase(token.getType())) {
                             throw new VerificationException("The access token type is DPoP but Authorization Header is not DPoP");
                         }
-                        if (isSchemeDPoP && !DPoPUtil.DPOP_TOKEN_TYPE.equals(token.getType())) {
+                        if (isSchemeDPoP && !DPoPUtil.DPOP_TOKEN_TYPE.equalsIgnoreCase(token.getType())) {
                             throw new VerificationException("The access token type is not DPoP but Authorization Header is DPoP");
                         }
                         ClientModel clientModel = realm.getClientByClientId(token.getIssuedFor());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
@@ -195,7 +195,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
 
         get = new HttpGet(oauth.getEndpoints().getUserInfo());
         get.addHeader("Accept", MediaType.APPLICATION_JSON);
-        String authorization = "DPoP" + " " + response.getAccessToken();
+        String authorization = TokenUtil.TOKEN_TYPE_DPOP + " " + response.getAccessToken();
         get.addHeader(HttpHeaders.AUTHORIZATION, authorization);
         get.addHeader(HttpHeaders.AUTHORIZATION, authorization);
 
@@ -214,7 +214,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
 
         get = new HttpGet(oauth.getEndpoints().getUserInfo());
         get.addHeader("Accept", MediaType.APPLICATION_JSON);
-        String authorization = "Bearer" + " " + response.getAccessToken();
+        String authorization = TokenUtil.TOKEN_TYPE_BEARER + " " + response.getAccessToken();
         get.addHeader(HttpHeaders.AUTHORIZATION, authorization);
 
         UserInfoResponse userInfoResponse = new UserInfoResponse(oauth.httpClient().get().execute(get));
@@ -223,6 +223,21 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
         oauth.doLogout(response.getRefreshToken());
     }
 
+    @Test
+    public void testDPoPAccessTokenBearerAuthorizationCaseSensitivity() throws Exception {
+        KeyPair rsaKeyPair = KeyUtils.generateRsaKeyPair(2048);
+        AccessTokenResponse response = getDPoPBindAccessToken(rsaKeyPair);
+
+        get = new HttpGet(oauth.getEndpoints().getUserInfo());
+        get.addHeader("Accept", MediaType.APPLICATION_JSON);
+        String authorization = "BeArEr" + " " + response.getAccessToken();
+        get.addHeader(HttpHeaders.AUTHORIZATION, authorization);
+
+        UserInfoResponse userInfoResponse = new UserInfoResponse(oauth.httpClient().get().execute(get));
+        assertEquals(401, userInfoResponse.getStatusCode());
+
+        oauth.doLogout(response.getRefreshToken());
+    }
 
     @Test
     public void testDPoPByPublicClientWithDpopJkt() throws Exception {


### PR DESCRIPTION
closes #48045

Proposes to change DPoP authorization scheme checks to case insensitive as per RFC9110-11.1