### PR TITLE
Make JDBC_PING in 26.6 compatible with 26.7 schema changes

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/JGroupsConfigurator.java
@@ -307,7 +307,7 @@ public final class JGroupsConfigurator {
     private static Address insertSequenceInTable(JpaConnectionProvider cp, String clusterName, String tableName, long mySequence) {
         ExtendedUUID address = new ExtendedUUID(0, mySequence);
         cp.getEntityManager().<Connection>runWithConnection(con -> {
-            try (PreparedStatement s = con.prepareStatement("INSERT INTO %s values (?, ?, ?, ?, ?)".formatted(tableName))) {
+            try (PreparedStatement s = con.prepareStatement("INSERT INTO %s (address, name, cluster_name, ip, coord) values (?, ?, ?, ?, ?)".formatted(tableName))) {
                 s.setString(1, org.jgroups.util.Util.addressToString(new UUID(address.getMostSignificantBits(), address.getLeastSignificantBits()))); // address
                 s.setString(2, "(starting)"); // name
                 s.setString(3, clusterName); // cluster name
@@ -329,7 +329,7 @@ public final class JGroupsConfigurator {
                     // "cluster" cannot be used with Oracle DB as it's a reserved word.
                     "clear_sql", String.format("DELETE from %s WHERE cluster_name=?", tableName),
                     "delete_single_sql", String.format("DELETE from %s WHERE address=?", tableName),
-                    "insert_single_sql", String.format("INSERT INTO %s values (?, ?, ?, ?, ?)", tableName),
+                    "insert_single_sql", String.format("INSERT INTO %s (address, name, cluster_name, ip, coord) values (?, ?, ?, ?, ?)", tableName),
                     "select_all_pingdata_sql", String.format("SELECT address, name, ip, coord FROM %s WHERE cluster_name=?", tableName),
                     // This guarantees cleanup of stale data
                     "remove_all_data_on_view_change", "true",


### PR DESCRIPTION
Closes #48329

Manually test with:

* DB create with KC Nightly
* Then running this change against the DB -> no JDBC Ping errors

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
