### PR TITLE
[26.4] No escape approach for JS code inside the FTL pages

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RPInitiatedFrontChannelLogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RPInitiatedFrontChannelLogoutTest.java
@@ -123,6 +123,36 @@ public class RPInitiatedFrontChannelLogoutTest extends AbstractChangeImportedUse
     }
 
     @Test
+    public void testFrontChannelLogoutRedirectUriIsEscapedInJs() throws Exception {
+        String specialCharsUri = OAuthClient.APP_ROOT + "/');alert(document.cookie);//";
+        try (ClientAttributeUpdater updater = ClientAttributeUpdater
+                .forClient(adminClient, oauth.getRealm(), oauth.getClientId())
+                .setFrontchannelLogout(true)
+                .setAttribute(OIDCConfigAttributes.FRONT_CHANNEL_LOGOUT_URI, OAuthClient.APP_ROOT + "/admin/frontchannelLogout")
+                .setAttribute(OIDCConfigAttributes.POST_LOGOUT_REDIRECT_URIS, OAuthClient.APP_ROOT + "/*")
+                .update()) {
+            oauth.doLogin("test-user@localhost", getPassword("test-user@localhost"));
+            String code = oauth.parseLoginResponse().getCode();
+            AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(code);
+            String logoutUrl = oauth.logoutForm().idTokenHint(tokenResponse.getIdToken())
+                    .postLogoutRedirectUri(specialCharsUri).build();
+
+            // XHR to get raw HTML before the JS redirect in frontchannel-logout.ftl fires
+            driver.get(getAuthServerRoot().toString());
+            String pageSource = (String) ((org.openqa.selenium.JavascriptExecutor) driver).executeScript(
+                    "var xhr = new XMLHttpRequest();" +
+                    "xhr.open('GET', arguments[0], false);" +
+                    "xhr.send();" +
+                    "return xhr.responseText;", logoutUrl);
+
+            Assert.assertFalse("Redirect URI must not be rendered in a single-quoted JS string",
+                    pageSource.contains("window.location.replace('"));
+            Assert.assertTrue("Redirect URI should be rendered as a double-quoted JS string via FreeMarker ?c outputformat escaping",
+                    pageSource.contains("window.location.replace(\"" + specialCharsUri + "\")"));
+        }
+    }
+
+    @Test
     public void testFrontChannelLogoutCustomCSP() throws Exception {
         try (RealmAttributeUpdater realmUpdater = new RealmAttributeUpdater(adminClient.realm(oauth.getRealm()))
                 .setBrowserSecurityHeader(BrowserSecurityHeaders.CONTENT_SECURITY_POLICY.getKey(),

--- a/themes/src/main/resources/theme/base/login/frontchannel-logout.ftl
+++ b/themes/src/main/resources/theme/base/login/frontchannel-logout.ftl
@@ -14,12 +14,14 @@
         </ul>
         <#if logout.logoutRedirectUri?has_content>
             <script>
+                <#outputformat "JavaScript">
                 function readystatechange(event) {
                     if (document.readyState=='complete') {
-                        window.location.replace('${logout.logoutRedirectUri}');
+                        window.location.replace(${logout.logoutRedirectUri?c});
                     }
                 }
                 document.addEventListener('readystatechange', readystatechange);
+                </#outputformat>
             </script>
             <a id="continue" class="btn btn-primary" href="${logout.logoutRedirectUri}">${msg("doContinue")}</a>
         </#if>


### PR DESCRIPTION
- Closes #48313

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
Co-authored-by: Ricardo Martin <rmartinc@redhat.com>
(cherry picked from commit 6250f9d57c8c474d38c067882e3cf9eca9f8d8bb)
