### PR TITLE
Fix OpenAPI spec key reordering on incremental builds

### DIFF
--- a/js/libs/keycloak-admin-client/openapi.yaml
+++ b/js/libs/keycloak-admin-client/openapi.yaml
@@ -46,12 +46,14 @@ components:
           uniqueItems: true
           items:
             type: string
+            pattern: \S
           description: URIs that the browser can redirect to after login
         roles:
           type: array
           uniqueItems: true
           items:
             type: string
+            pattern: \S
           description: Roles associated with this client
         protocol:
           type: string
@@ -91,12 +93,14 @@ components:
           uniqueItems: true
           items:
             type: string
+            pattern: \S
           description: Web origins that are allowed to make requests to this client
         serviceAccountRoles:
           type: array
           uniqueItems: true
           items:
             type: string
+            pattern: \S
           description: Roles assigned to the service account
         protocol:
           type: string
@@ -157,7 +161,6 @@ components:
       description: Bearer token authentication using a Keycloak access token
 tags:
 - name: Clients (v2)
-  x-smallrye-profile-admin: ""
 paths:
   /admin/api/{realmName}/clients/{version}:
     get:

--- a/rest/admin-v2/services/pom.xml
+++ b/rest/admin-v2/services/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Use OpenAPI 4.x compatible plugin version -->
-        <smallrye.openapi.generator.plugin.version>4.2.4</smallrye.openapi.generator.plugin.version>
+        <smallrye.openapi.generator.plugin.version>4.3.1</smallrye.openapi.generator.plugin.version>
     </properties>
 
     <dependencies>
@@ -81,36 +81,11 @@
                     </compilerArgument>
                 </configuration>
             </plugin>
-            <!-- FIXME: drop this when the smallrye-open-api-maven-plugin exposes enableStandardStaticFiles,
-                 see https://github.com/keycloak/keycloak/pull/48371 -->
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>remove-stale-openapi-from-classpath</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <configuration>
-                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                            <filesets>
-                                <fileset>
-                                    <directory>${project.build.directory}/classes/META-INF</directory>
-                                    <includes>
-                                        <include>openapi.yaml</include>
-                                        <include>openapi.json</include>
-                                    </includes>
-                                </fileset>
-                            </filesets>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-maven-plugin</artifactId>
                 <configuration>
+                    <enableStandardStaticFiles>false</enableStandardStaticFiles>
                     <scanPackages>org.keycloak.representations.admin.v2,org.keycloak.admin.api</scanPackages>
                     <filter>org.keycloak.admin.internal.openapi.OASModelFilter</filter>
                     <outputDirectory>${project.build.directory}</outputDirectory>

--- a/rest/admin-v2/services/pom.xml
+++ b/rest/admin-v2/services/pom.xml
@@ -81,6 +81,32 @@
                     </compilerArgument>
                 </configuration>
             </plugin>
+            <!-- FIXME: drop this when the smallrye-open-api-maven-plugin exposes enableStandardStaticFiles,
+                 see https://github.com/keycloak/keycloak/pull/48371 -->
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>remove-stale-openapi-from-classpath</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/classes/META-INF</directory>
+                                    <includes>
+                                        <include>openapi.yaml</include>
+                                        <include>openapi.json</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>smallrye-open-api-maven-plugin</artifactId>


### PR DESCRIPTION
Closes: #48366

Incremental builds and test runs (via `-am`) only reach the test phase, which is before `prepare-package`, so no stale META-INF copy exists on the classpath. The only edge case is `mvn` `package`/`install` without `clean` followed by an incremental build - we could solve it fully by adding a `maven-clean-plugin` execution to remove stale `META-INF/openapi.*` before generation, but I am not sure whether we want/need to do so. I guess it's not a practical concern since these commands are typically run with `clean`. 

So this small change should be sufficient for all the more standard scenarios.
