### PR TITLE
Add organization-level session timeout overrides

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/OrganizationRepresentation.java
@@ -38,6 +38,10 @@ public class OrganizationRepresentation {
     private List<MemberRepresentation> members;
     private List<IdentityProviderRepresentation> identityProviders;
     private List<GroupRepresentation> groups;
+    private Integer sessionIdleTimeout;
+    private Integer sessionMaxLifespan;
+    private Integer sessionIdleTimeoutRememberMe;
+    private Integer sessionMaxLifespanRememberMe;
 
     public String getId() {
         return id;
@@ -173,6 +177,18 @@ public class OrganizationRepresentation {
         }
         groups.add(group);
     }
+
+    public Integer getSessionIdleTimeout() { return sessionIdleTimeout; }
+    public void setSessionIdleTimeout(Integer sessionIdleTimeout) { this.sessionIdleTimeout = sessionIdleTimeout; }
+
+    public Integer getSessionMaxLifespan() { return sessionMaxLifespan; }
+    public void setSessionMaxLifespan(Integer sessionMaxLifespan) { this.sessionMaxLifespan = sessionMaxLifespan; }
+
+    public Integer getSessionIdleTimeoutRememberMe() { return sessionIdleTimeoutRememberMe; }
+    public void setSessionIdleTimeoutRememberMe(Integer v) { this.sessionIdleTimeoutRememberMe = v; }
+
+    public Integer getSessionMaxLifespanRememberMe() { return sessionMaxLifespanRememberMe; }
+    public void setSessionMaxLifespanRememberMe(Integer v) { this.sessionMaxLifespanRememberMe = v; }
 
     @Override
     public boolean equals(Object o) {

--- a/js/apps/admin-ui/src/organizations/DetailOrganization.tsx
+++ b/js/apps/admin-ui/src/organizations/DetailOrganization.tsx
@@ -39,6 +39,7 @@ import {
 } from "./routes/EditOrganization";
 import { useAccess } from "../context/access/Access";
 import { AdminEvents } from "../events/AdminEvents";
+import { OrganizationSessionsTab } from "./OrganizationSessionsTab";
 import { useState } from "react";
 
 export default function DetailOrganization() {
@@ -87,6 +88,7 @@ export default function DetailOrganization() {
 
   const settingsTab = useTab("settings");
   const attributesTab = useTab("attributes");
+  const sessionsTab = useTab("sessions");
   const membersTab = useTab("members");
   const groupsTab = useTab("groups");
   const identityProvidersTab = useTab("identityProviders");
@@ -153,6 +155,16 @@ export default function DetailOrganization() {
                 }
                 name="attributes"
               />
+            </PageSection>
+          </Tab>
+          <Tab
+            id="sessions"
+            data-testid="sessionsTab"
+            title={<TabTitleText>{t("sessions")}</TabTitleText>}
+            {...sessionsTab}
+          >
+            <PageSection variant="light">
+              <OrganizationSessionsTab save={save} />
             </PageSection>
           </Tab>
           <Tab

--- a/js/apps/admin-ui/src/organizations/OrganizationForm.tsx
+++ b/js/apps/admin-ui/src/organizations/OrganizationForm.tsx
@@ -16,6 +16,11 @@ import { MultiLineInput } from "../components/multi-line-input/MultiLineInput";
 export type OrganizationFormType = AttributeForm &
   Omit<OrganizationRepresentation, "domains" | "attributes"> & {
     domains?: string[];
+    sessionIdleTimeout?: number;
+    sessionMaxLifespan?: number;
+    sessionIdleTimeoutRememberMe?: number;
+    sessionMaxLifespanRememberMe?: number;
+    rememberMe?: boolean;
   };
 
 export const convertToOrg = (

--- a/js/apps/admin-ui/src/organizations/OrganizationSessionsTab.tsx
+++ b/js/apps/admin-ui/src/organizations/OrganizationSessionsTab.tsx
@@ -1,0 +1,162 @@
+import {
+  ActionGroup,
+  Button,
+  FormGroup,
+  PageSection,
+} from "@patternfly/react-core";
+import { Controller, useFormContext } from "react-hook-form";
+import { useTranslation } from "react-i18next";
+import {
+  FormPanel,
+  HelpItem,
+  FormSubmitButton,
+} from "@keycloak/keycloak-ui-shared";
+import { FormAccess } from "../components/form/FormAccess";
+import { TimeSelector } from "../components/time-selector/TimeSelector";
+import { OrganizationFormType } from "./OrganizationForm";
+
+type OrganizationSessionsTabProps = {
+  save: (org: OrganizationFormType) => void;
+};
+
+export const OrganizationSessionsTab = ({
+  save,
+}: OrganizationSessionsTabProps) => {
+  const { t } = useTranslation();
+
+  const { control, handleSubmit, watch, formState } =
+    useFormContext<OrganizationFormType>();
+
+  const rememberMeEnabled = watch("rememberMe");
+
+  return (
+    <PageSection variant="light">
+      <FormPanel
+        title={t("SSOSessionSettings")}
+        className="kc-sso-session-template"
+      >
+        <FormAccess
+          isHorizontal
+          role="manage-realm"
+          onSubmit={handleSubmit(save)}
+        >
+          <FormGroup
+            label={t("SSOSessionIdle")}
+            fieldId="SSOSessionIdle"
+            labelIcon={
+              <HelpItem
+                helpText={t("ssoSessionIdle")}
+                fieldLabelId="SSOSessionIdle"
+              />
+            }
+          >
+            <Controller
+              name="sessionIdleTimeout"
+              control={control}
+              render={({ field }) => (
+                <TimeSelector
+                  className="kc-sso-session-idle"
+                  data-testid="organization-sso-session-idle-input"
+                  value={field.value || 0}
+                  onChange={field.onChange}
+                  units={["minute", "hour", "day"]}
+                />
+              )}
+            />
+          </FormGroup>
+
+          <FormGroup
+            label={t("SSOSessionMax")}
+            fieldId="SSOSessionMax"
+            labelIcon={
+              <HelpItem
+                helpText={t("ssoSessionMax")}
+                fieldLabelId="SSOSessionMax"
+              />
+            }
+          >
+            <Controller
+              name="sessionMaxLifespan"
+              control={control}
+              render={({ field }) => (
+                <TimeSelector
+                  className="kc-sso-session-max"
+                  data-testid="organization-sso-session-max-input"
+                  value={field.value || 0}
+                  onChange={field.onChange}
+                  units={["minute", "hour", "day"]}
+                />
+              )}
+            />
+          </FormGroup>
+
+          {rememberMeEnabled && (
+            <>
+              <FormGroup
+                label={t("SSOSessionIdleRememberMe")}
+                fieldId="SSOSessionIdleRememberMe"
+                labelIcon={
+                  <HelpItem
+                    helpText={t("ssoSessionIdleRememberMe")}
+                    fieldLabelId="SSOSessionIdleRememberMe"
+                  />
+                }
+              >
+                <Controller
+                  name="sessionIdleTimeoutRememberMe"
+                  control={control}
+                  render={({ field }) => (
+                    <TimeSelector
+                      className="kc-sso-session-idle-remember-me"
+                      data-testid="organization-sso-session-idle-remember-me-input"
+                      value={field.value || 0}
+                      onChange={field.onChange}
+                      units={["minute", "hour", "day"]}
+                    />
+                  )}
+                />
+              </FormGroup>
+
+              <FormGroup
+                label={t("SSOSessionMaxRememberMe")}
+                fieldId="SSOSessionMaxRememberMe"
+                labelIcon={
+                  <HelpItem
+                    helpText={t("ssoSessionMaxRememberMe")}
+                    fieldLabelId="SSOSessionMaxRememberMe"
+                  />
+                }
+              >
+                <Controller
+                  name="sessionMaxLifespanRememberMe"
+                  control={control}
+                  render={({ field }) => (
+                    <TimeSelector
+                      className="kc-sso-session-max-remember-me"
+                      data-testid="organization-sso-session-max-remember-me-input"
+                      value={field.value || 0}
+                      onChange={field.onChange}
+                      units={["minute", "hour", "day"]}
+                    />
+                  )}
+                />
+              </FormGroup>
+            </>
+          )}
+
+          <ActionGroup>
+            <FormSubmitButton
+              formState={formState}
+              data-testid="organization-sessions-save"
+            >
+              {t("save")}
+            </FormSubmitButton>
+            <Button variant="link" data-testid="organization-sessions-reset">
+              {t("reset")}
+            </Button>
+          </ActionGroup>
+        </FormAccess>
+      </FormPanel>
+    </PageSection>
+  );
+};

--- a/js/apps/admin-ui/src/organizations/routes/EditOrganization.tsx
+++ b/js/apps/admin-ui/src/organizations/routes/EditOrganization.tsx
@@ -6,6 +6,7 @@ import type { AppRouteObject } from "../../routes";
 export type OrganizationTab =
   | "settings"
   | "attributes"
+  | "sessions"
   | "members"
   | "groups"
   | "identityProviders"

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/CachedOrganization.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/CachedOrganization.java
@@ -44,6 +44,11 @@ public class CachedOrganization extends AbstractRevisioned implements InRealm {
     private final Set<OrganizationDomainModel> domains;
     private final Set<IdentityProviderModel> idps;
 
+    private int sessionIdleTimeout;
+    private int sessionMaxLifespan;
+    private int sessionIdleTimeoutRememberMe;
+    private int sessionMaxLifespanRememberMe;
+
     public CachedOrganization(long revision, RealmModel realm, OrganizationModel organization) {
         super(revision, organization.getId());
         this.realm = realm.getId();
@@ -55,6 +60,11 @@ public class CachedOrganization extends AbstractRevisioned implements InRealm {
         this.attributes = new DefaultLazyLoader<>(orgModel -> new MultivaluedHashMap<>(orgModel.getAttributes()), MultivaluedHashMap::new);
         this.domains = organization.getDomains().collect(Collectors.toSet());
         this.idps = organization.getIdentityProviders().collect(Collectors.toSet());
+
+	this.sessionIdleTimeout = organization.getSessionIdleTimeout();
+        this.sessionMaxLifespan = organization.getSessionMaxLifespan();
+        this.sessionIdleTimeoutRememberMe = organization.getSessionIdleTimeoutRememberMe();
+        this.sessionMaxLifespanRememberMe = organization.getSessionMaxLifespanRememberMe();
     }
 
     @Override
@@ -92,5 +102,22 @@ public class CachedOrganization extends AbstractRevisioned implements InRealm {
 
     public Stream<IdentityProviderModel> getIdentityProviders() {
         return idps.stream();
+    }
+
+    //add our getters, setters are not required since the cached object is read only
+    public int getSessionIdleTimeout() { 
+	return sessionIdleTimeout; 
+    }
+
+    public int getSessionMaxLifespan() { 
+	return sessionMaxLifespan; 
+    }
+
+    public int getSessionIdleTimeoutRememberMe() { 
+	return sessionIdleTimeoutRememberMe; 
+    }
+
+    public int getSessionMaxLifespanRememberMe() { 
+	return sessionMaxLifespanRememberMe; 
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/OrganizationAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/OrganizationAdapter.java
@@ -193,4 +193,52 @@ public class OrganizationAdapter implements OrganizationModel {
     public int hashCode() {
         return getId().hashCode();
     }
+
+    @Override
+    public Integer getSessionIdleTimeout() {
+        if (isUpdated()) return updated.getSessionIdleTimeout();
+        return cached.getSessionIdleTimeout();
+    }
+
+    @Override
+    public void setSessionIdleTimeout(Integer timeout) {
+        getDelegateForUpdate();
+        updated.setSessionIdleTimeout(timeout);
+    }
+
+    @Override
+    public Integer getSessionMaxLifespan() {
+        if (isUpdated()) return updated.getSessionMaxLifespan();
+        return cached.getSessionMaxLifespan();
+    }
+
+    @Override
+    public void setSessionMaxLifespan(Integer timeout) {
+        getDelegateForUpdate();
+        updated.setSessionMaxLifespan(timeout);
+    }
+
+    @Override
+    public Integer getSessionIdleTimeoutRememberMe() {
+        if (isUpdated()) return updated.getSessionIdleTimeoutRememberMe();
+        return cached.getSessionIdleTimeoutRememberMe();
+    }
+
+    @Override
+    public void setSessionIdleTimeoutRememberMe(Integer timeout) {
+        getDelegateForUpdate();
+        updated.setSessionIdleTimeoutRememberMe(timeout);
+    }
+
+    @Override
+    public Integer getSessionMaxLifespanRememberMe() {
+        if (isUpdated()) return updated.getSessionMaxLifespanRememberMe();
+        return cached.getSessionMaxLifespanRememberMe();
+    }
+
+    @Override
+    public void setSessionMaxLifespanRememberMe(Integer timeout) {
+        getDelegateForUpdate();
+        updated.setSessionMaxLifespanRememberMe(timeout);
+    }
 }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/OrganizationEntity.java
@@ -72,6 +72,18 @@ public class OrganizationEntity {
     @Column(name = "REALM_ID")
     private String realmId;
 
+    @Column(name = "SSO_SESSION_IDLE_TIMEOUT")
+    protected Integer sessionIdleTimeout;
+
+    @Column(name = "SSO_SESSION_MAX_LIFESPAN")
+    protected Integer sessionMaxLifespan;
+
+    @Column(name = "SSO_SESSION_IDLE_TIMEOUT_REMEMBER_ME")
+    protected Integer sessionIdleTimeoutRememberMe;
+
+    @Column(name = "SSO_SESSION_MAX_LIFESPAN_REMEMBER_ME")
+    protected Integer sessionMaxLifespanRememberMe;
+
     /**
      * References the internal Group used for organization membership.
      */
@@ -184,6 +196,38 @@ public class OrganizationEntity {
     public void removeGroup(GroupEntity group) {
         getGroups().remove(group);
         group.setOrganization(null);
+    }
+
+    public Integer getSessionIdleTimeout() { 
+        return sessionIdleTimeout; 
+    }
+    
+    public void setSessionIdleTimeout(Integer sessionIdleTimeout) { 
+        this.sessionIdleTimeout = sessionIdleTimeout; 
+    }
+
+    public Integer getSessionMaxLifespan() { 
+        return sessionMaxLifespan; 
+    }
+    
+    public void setSessionMaxLifespan(Integer sessionMaxLifespan) { 
+        this.sessionMaxLifespan = sessionMaxLifespan; 
+    }
+
+    public Integer getSessionIdleTimeoutRememberMe() { 
+        return sessionIdleTimeoutRememberMe; 
+    }
+    
+    public void setSessionIdleTimeoutRememberMe(Integer timeout) { 
+        this.sessionIdleTimeoutRememberMe = timeout; 
+    }
+
+    public Integer getSessionMaxLifespanRememberMe() { 
+        return sessionMaxLifespanRememberMe; 
+    }
+    
+    public void setSessionMaxLifespanRememberMe(Integer timeout) { 
+        this.sessionMaxLifespanRememberMe = timeout; 
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -201,7 +201,6 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
             }
         }
 
-        // create the remaining domains.
         for (OrganizationDomainModel model : modelMap.values()) {
             OrganizationDomainEntity domainEntity = new OrganizationDomainEntity();
             domainEntity.setId(KeycloakModelUtils.generateId());
@@ -264,6 +263,50 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
 
     private OrganizationDomainModel toModel(OrganizationDomainEntity entity) {
         return new OrganizationDomainModel(entity.getName(), entity.isVerified());
+    }
+
+    @Override
+        public Integer getSessionIdleTimeout() {
+        Integer v = entity.getSessionIdleTimeout();
+        return v != null ? v : -1;
+    }
+
+    @Override
+    public void setSessionIdleTimeout(Integer timeout) {
+        entity.setSessionIdleTimeout(timeout);
+    }
+
+    @Override
+    public Integer getSessionMaxLifespan() {
+        Integer v = entity.getSessionMaxLifespan();
+        return v != null ? v : -1;
+    }
+
+    @Override
+    public void setSessionMaxLifespan(Integer timeout) {
+        entity.setSessionMaxLifespan(timeout);
+    }
+
+    @Override
+    public Integer getSessionIdleTimeoutRememberMe() {
+        Integer v = entity.getSessionIdleTimeoutRememberMe();
+        return v != null ? v : -1;
+    }
+
+    @Override
+    public void setSessionIdleTimeoutRememberMe(Integer timeout) {
+        entity.setSessionIdleTimeoutRememberMe(timeout);
+    }
+
+    @Override
+    public Integer getSessionMaxLifespanRememberMe() {
+        Integer v = entity.getSessionMaxLifespanRememberMe();
+        return v != null ? v : -1;
+    }
+
+    @Override
+    public void setSessionMaxLifespanRememberMe(Integer timeout) {
+        entity.setSessionMaxLifespanRememberMe(timeout);
     }
 
     /**

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.6.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.6.0.xml
@@ -130,6 +130,19 @@
             <column name="REALM_ID" type="VARCHAR(255)" />
             <column name="CREATED_TIMESTAMP" type="BIGINT" />
         </createIndex>
+	
+    <changeSet author="keycloak" id="26.6.0-46549-session-timeout-per-organization">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <not>
+                <columnExists tableName="ORG" columnName="SSO_SESSION_IDLE_TIMEOUT"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="ORG">
+            <column name="SSO_SESSION_IDLE_TIMEOUT" type="INT"/>
+            <column name="SSO_SESSION_MAX_LIFESPAN" type="INT"/>
+            <column name="SSO_SESSION_IDLE_TIMEOUT_REMEMBER_ME" type="INT"/>
+            <column name="SSO_SESSION_MAX_LIFESPAN_REMEMBER_ME" type="INT"/>
+        </addColumn>
     </changeSet>
 
 </databaseChangeLog>

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -1437,6 +1437,11 @@ public class ModelToRepresentation {
         rep.setDescription(model.getDescription());
         model.getDomains().filter(Objects::nonNull).map(ModelToRepresentation::toRepresentation)
                 .forEach(rep::addDomain);
+
+        rep.setSessionIdleTimeout(model.getSessionIdleTimeout());
+        rep.setSessionMaxLifespan(model.getSessionMaxLifespan());
+        rep.setSessionIdleTimeoutRememberMe(model.getSessionIdleTimeoutRememberMe());
+        rep.setSessionMaxLifespanRememberMe(model.getSessionMaxLifespanRememberMe());
         return rep;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -1749,6 +1749,11 @@ public class RepresentationToModel {
                 .map(RepresentationToModel::toModel)
                 .collect(Collectors.toSet()));
 
+
+        model.setSessionIdleTimeout(rep.getSessionIdleTimeout());
+        model.setSessionMaxLifespan(rep.getSessionMaxLifespan());
+        model.setSessionIdleTimeoutRememberMe(rep.getSessionIdleTimeoutRememberMe());
+        model.setSessionMaxLifespanRememberMe(rep.getSessionMaxLifespanRememberMe());
         return model;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/SessionExpirationUtils.java
@@ -20,7 +20,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.utils.StringUtil;
 
@@ -184,6 +189,81 @@ public class SessionExpirationUtils {
             idle = Constants.DEFAULT_OFFLINE_SESSION_IDLE_TIMEOUT;
         }
         return idle;
+    }
+
+    /**
+     * Gets the SSO session max lifespan, preferring organization-specific value if available.
+     * @param realm The realm model
+     * @param userSession The user session (may be null)
+     * @param session The keycloak session
+     * @return The SSO session max lifespan in seconds
+     */
+    public static int getSsoSessionMaxLifespan(RealmModel realm, UserSessionModel userSession, KeycloakSession session) {
+        OrganizationModel org = getOrganizationForSession(userSession, session);
+        if (org != null && org.getSessionMaxLifespan() > 0) {
+            return org.getSessionMaxLifespan();
+        }
+        return getSsoSessionMaxLifespan(realm);
+    }
+
+    /**
+     * Gets the SSO session idle timeout, preferring organization-specific value if available.
+     * @param realm The realm model
+     * @param userSession The user session (may be null)
+     * @param session The keycloak session
+     * @return The SSO session idle timeout in seconds
+     */
+    public static int getSsoSessionIdleTimeout(RealmModel realm, UserSessionModel userSession, KeycloakSession session) {
+        OrganizationModel org = getOrganizationForSession(userSession, session);
+        if (org != null && org.getSessionIdleTimeout() > 0) {
+            return org.getSessionIdleTimeout();
+        }
+        return getSsoSessionIdleTimeout(realm);
+    }
+
+    /**
+     * Gets the SSO session max lifespan for remember me, preferring organization-specific value if available.
+     * @param realm The realm model
+     * @param userSession The user session (may be null)
+     * @param session The keycloak session
+     * @return The SSO session max lifespan for remember me in seconds
+     */
+    public static int getSsoSessionMaxLifespanRememberMe(RealmModel realm, UserSessionModel userSession, KeycloakSession session) {
+        OrganizationModel org = getOrganizationForSession(userSession, session);
+        if (org != null && org.getSessionMaxLifespanRememberMe() > 0) {
+            return org.getSessionMaxLifespanRememberMe();
+        }
+        return realm.getSsoSessionMaxLifespanRememberMe();
+    }
+
+    /**
+     * Gets the SSO session idle timeout for remember me, preferring organization-specific value if available.
+     * @param realm The realm model
+     * @param userSession The user session (may be null)
+     * @param session The keycloak session
+     * @return The SSO session idle timeout for remember me in seconds
+     */
+    public static int getSsoSessionIdleTimeoutRememberMe(RealmModel realm, UserSessionModel userSession, KeycloakSession session) {
+        OrganizationModel org = getOrganizationForSession(userSession, session);
+        if (org != null && org.getSessionIdleTimeoutRememberMe() > 0) {
+            return org.getSessionIdleTimeoutRememberMe();
+        }
+        return realm.getSsoSessionIdleTimeoutRememberMe();
+    }
+
+    /**
+     * Retrieves the organization for a user session.
+     * @param userSession The user session
+     * @param session The keycloak session
+     * @return The organization model if found, null otherwise
+     */
+    private static OrganizationModel getOrganizationForSession(UserSessionModel userSession, KeycloakSession session) {
+        if (userSession == null) return null;
+        OrganizationProvider orgProvider = session.getProvider(OrganizationProvider.class);
+        if (orgProvider == null) return null;
+        UserModel user = userSession.getUser();
+        if (user == null) return null;
+        return orgProvider.getByMember(user).findFirst().orElse(null);
     }
 
     private static long getClientAttributeTimeout(ClientModel client, String attr) {

--- a/server-spi-private/src/test/java/org/keycloak/models/KeycloakModelUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/KeycloakModelUtilsTest.java
@@ -404,5 +404,41 @@ public class KeycloakModelUtilsTest {
         public Stream<IdentityProviderModel> getIdentityProviders() {
             return Stream.empty();
         }
+
+	@Override
+        public Integer getSessionIdleTimeout() {
+            return -1;
+        }
+
+        @Override
+        public void setSessionIdleTimeout(Integer timeout) {
+        }
+
+        @Override
+        public Integer getSessionMaxLifespan() {
+            return -1;
+        }
+
+        @Override
+        public void setSessionMaxLifespan(Integer timeout) {
+        }
+
+        @Override
+        public Integer getSessionIdleTimeoutRememberMe() {
+            return -1;
+        }
+
+        @Override
+        public void setSessionIdleTimeoutRememberMe(Integer timeout) {
+        }
+        
+        @Override
+        public Integer getSessionMaxLifespanRememberMe() {
+            return -1;
+        }
+
+        @Override
+        public void setSessionMaxLifespanRememberMe(Integer timeout) {
+        }
     }
 }

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/SessionExpirationUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/SessionExpirationUtilsTest.java
@@ -20,11 +20,17 @@ package org.keycloak.models.utils;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 
 import org.junit.Assert;
@@ -39,8 +45,12 @@ public class SessionExpirationUtilsTest {
 
     private static final Map<String, Object> realmMap = new HashMap<>();
     private static final Map<String, Object> clientMap = new HashMap<>();
+    private static final Map<String, Object> orgMap = new HashMap<>();
+    private static final Map<String, Object> userSessionMap = new HashMap<>();
     private static final RealmModel realm = createRealm();
     private static final ClientModel client = createClient();
+    private static final OrganizationModel org = createOrg();
+    private static final UserSessionModel userSession = createUserSession();
 
     private static RealmModel createRealm() {
         RealmModel realmModel = (RealmModel) Proxy.newProxyInstance(SessionExpirationUtilsTest.class.getClassLoader(),
@@ -67,6 +77,53 @@ public class SessionExpirationUtilsTest {
         return clientModel;
     }
 
+    private static OrganizationModel createOrg() {
+        return (OrganizationModel) Proxy.newProxyInstance(SessionExpirationUtilsTest.class.getClassLoader(),
+                new Class[]{OrganizationModel.class}, (proxy, method, args) -> {
+            Object result = orgMap.get(method.getName());
+            if (result != null) {
+                return result;
+            }
+            throw new UnsupportedOperationException("Org method not in map: " + method.getName());
+        });
+    }
+    
+    private static UserModel createUser() {
+        return (UserModel) Proxy.newProxyInstance(SessionExpirationUtilsTest.class.getClassLoader(),
+                new Class[]{UserModel.class}, (proxy, method, args) -> null);
+    }
+    
+    private static UserSessionModel createUserSession() {
+        UserModel user = createUser();
+        return (UserSessionModel) Proxy.newProxyInstance(SessionExpirationUtilsTest.class.getClassLoader(),
+                new Class[]{UserSessionModel.class}, (proxy, method, args) -> {
+            if ("getUser".equals(method.getName())) return user;
+            Object result = userSessionMap.get(method.getName());
+            if (result != null) return result;
+            throw new UnsupportedOperationException("UserSession method not in map: " + method.getName());
+        });
+    }
+    
+    private static KeycloakSession createKeycloakSession(OrganizationModel orgToReturn) {
+        return (KeycloakSession) Proxy.newProxyInstance(SessionExpirationUtilsTest.class.getClassLoader(),
+                new Class[]{KeycloakSession.class}, (proxy, method, args) -> {
+            if ("getProvider".equals(method.getName()) && args[0] == OrganizationProvider.class) {
+                return createOrgProvider(orgToReturn);
+            }
+            throw new UnsupportedOperationException("KeycloakSession method not in map: " + method.getName());
+        });
+    }
+    
+    private static OrganizationProvider createOrgProvider(OrganizationModel orgToReturn) {
+        return (OrganizationProvider) Proxy.newProxyInstance(SessionExpirationUtilsTest.class.getClassLoader(),
+                new Class[]{OrganizationProvider.class}, (proxy, method, args) -> {
+            if ("getByMember".equals(method.getName())) {
+                return orgToReturn != null ? Stream.of(orgToReturn) : Stream.empty();
+            }
+            throw new UnsupportedOperationException("OrganizationProvider method not in map: " + method.getName());
+        });
+    }
+
     private static void resetRealm() {
         realmMap.put("isOfflineSessionMaxLifespanEnabled", false);
         realmMap.put("getOfflineSessionMaxLifespan", 0);
@@ -83,6 +140,13 @@ public class SessionExpirationUtilsTest {
 
     private static void resetClient() {
         clientMap.clear();
+    }
+
+    private static void resetOrg() {
+        orgMap.put("getSessionMaxLifespan", 0);
+        orgMap.put("getSessionIdleTimeout", 0);
+        orgMap.put("getSessionMaxLifespanRememberMe", 0);
+        orgMap.put("getSessionIdleTimeoutRememberMe", 0);
     }
 
     @Test
@@ -271,5 +335,125 @@ public class SessionExpirationUtilsTest {
         // set -1 in the client and should be not taken into account
         clientMap.put(OIDCConfigAttributes.CLIENT_OFFLINE_SESSION_IDLE_TIMEOUT, "-1");
         Assert.assertEquals(4000 * 1000L, SessionExpirationUtils.calculateClientSessionIdleTimestamp(true, false, t, realm, client) - t);
+    }
+
+    @Test
+    public void testGetSsoSessionMaxLifespan_noOrg_returnsRealmDefault() {
+        resetRealm();
+        realmMap.put("getSsoSessionMaxLifespan", 36000);
+        KeycloakSession session = createKeycloakSession(null);
+        Assert.assertEquals(36000, SessionExpirationUtils.getSsoSessionMaxLifespan(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionMaxLifespan_orgWithPositiveValue_returnsOrgValue() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionMaxLifespan", 36000);
+        orgMap.put("getSessionMaxLifespan", 3600);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(3600, SessionExpirationUtils.getSsoSessionMaxLifespan(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionMaxLifespan_orgWithZeroValue_returnsRealmDefault() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionMaxLifespan", 36000);
+        orgMap.put("getSessionMaxLifespan", 0);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(36000, SessionExpirationUtils.getSsoSessionMaxLifespan(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionMaxLifespan_nullUserSession_returnsRealmDefault() {
+        resetRealm();
+        realmMap.put("getSsoSessionMaxLifespan", 36000);
+        KeycloakSession session = createKeycloakSession(null);
+        Assert.assertEquals(36000, SessionExpirationUtils.getSsoSessionMaxLifespan(realm, null, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionIdleTimeout_noOrg_returnsRealmDefault() {
+        resetRealm();
+        realmMap.put("getSsoSessionIdleTimeout", 1800);
+        KeycloakSession session = createKeycloakSession(null);
+        Assert.assertEquals(1800, SessionExpirationUtils.getSsoSessionIdleTimeout(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionIdleTimeout_orgWithPositiveValue_returnsOrgValue() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionIdleTimeout", 1800);
+        orgMap.put("getSessionIdleTimeout", 900);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(900, SessionExpirationUtils.getSsoSessionIdleTimeout(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionIdleTimeout_orgWithZeroValue_returnsRealmDefault() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionIdleTimeout", 1800);
+        orgMap.put("getSessionIdleTimeout", 0);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(1800, SessionExpirationUtils.getSsoSessionIdleTimeout(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionMaxLifespanRememberMe_noOrg_returnsRealmDefault() {
+        resetRealm();
+        realmMap.put("getSsoSessionMaxLifespanRememberMe", 72000);
+        KeycloakSession session = createKeycloakSession(null);
+        Assert.assertEquals(72000, SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionMaxLifespanRememberMe_orgWithPositiveValue_returnsOrgValue() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionMaxLifespanRememberMe", 72000);
+        orgMap.put("getSessionMaxLifespanRememberMe", 14400);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(14400, SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionMaxLifespanRememberMe_orgWithZeroValue_returnsRealmDefault() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionMaxLifespanRememberMe", 72000);
+        orgMap.put("getSessionMaxLifespanRememberMe", 0);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(72000, SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionIdleTimeoutRememberMe_noOrg_returnsRealmDefault() {
+        resetRealm();
+        realmMap.put("getSsoSessionIdleTimeoutRememberMe", 7200);
+        KeycloakSession session = createKeycloakSession(null);
+        Assert.assertEquals(7200, SessionExpirationUtils.getSsoSessionIdleTimeoutRememberMe(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionIdleTimeoutRememberMe_orgWithPositiveValue_returnsOrgValue() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionIdleTimeoutRememberMe", 7200);
+        orgMap.put("getSessionIdleTimeoutRememberMe", 3600);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(3600, SessionExpirationUtils.getSsoSessionIdleTimeoutRememberMe(realm, userSession, session));
+    }
+    
+    @Test
+    public void testGetSsoSessionIdleTimeoutRememberMe_orgWithZeroValue_returnsRealmDefault() {
+        resetRealm();
+        resetOrg();
+        realmMap.put("getSsoSessionIdleTimeoutRememberMe", 7200);
+        orgMap.put("getSessionIdleTimeoutRememberMe", 0);
+        KeycloakSession session = createKeycloakSession(org);
+        Assert.assertEquals(7200, SessionExpirationUtils.getSsoSessionIdleTimeoutRememberMe(realm, userSession, session));
     }
 }

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -34,6 +34,12 @@ public interface OrganizationModel {
     String HIDE_IDP_ON_LOGIN_WHEN_ORGANIZATION_UNKNOWN = "kc.org.broker.login.hide-when-org-unknown";
     String SHOW_IDP_ON_LOGIN_WHEN_LINKED_ELSEWHERE = "kc.org.broker.login.show-when-linked-elsewhere";
 
+    String SESSION_IDLE_TIMEOUT = "org.sessionIdleTimeout";
+    String SESSION_MAX_LIFESPAN = "org.sessionMaxLifespan";
+    String SESSION_IDLE_TIMEOUT_REMEMBER_ME = "org.sessionIdleTimeoutRememberMe";
+    String SESSION_MAX_LIFESPAN_REMEMBER_ME = "org.sessionMaxLifespanRememberMe";
+
+
     enum IdentityProviderRedirectMode {
         EMAIL_MATCH("kc.org.broker.redirect.mode.email-matches");
 
@@ -135,4 +141,21 @@ public interface OrganizationModel {
     boolean isManaged(UserModel user);
 
     boolean isMember(UserModel user);
+
+
+    Integer getSessionIdleTimeout();
+
+    void setSessionIdleTimeout(Integer timeout);
+
+    Integer getSessionMaxLifespan();
+    
+    void setSessionMaxLifespan(Integer timeout);
+
+    Integer getSessionIdleTimeoutRememberMe();
+
+    void setSessionIdleTimeoutRememberMe(Integer timeout);
+
+    Integer getSessionMaxLifespanRememberMe();
+    
+    void setSessionMaxLifespanRememberMe(Integer timeout);
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -1104,7 +1104,7 @@ public class TokenManager {
         ClientScopeModel offlineAccessScope = KeycloakModelUtils.getClientScopeByName(realm, OAuth2Constants.OFFLINE_ACCESS);
         boolean offlineTokenRequested = offlineAccessScope == null ? false
                 : clientSessionCtx.getClientScopeIds().contains(offlineAccessScope.getId());
-        token.exp(getTokenExpiration(realm, client, userSession, clientSession, offlineTokenRequested));
+        token.exp(getTokenExpiration(session, realm, client, userSession, clientSession, offlineTokenRequested));
 
         // Tracing
         var tracing = session.getProvider(TracingProvider.class);
@@ -1118,7 +1118,7 @@ public class TokenManager {
         return token;
     }
 
-    private Long getTokenExpiration(RealmModel realm, ClientModel client, UserSessionModel userSession,
+    private Long getTokenExpiration(KeycloakSession session, RealmModel realm, ClientModel client, UserSessionModel userSession,
         AuthenticatedClientSessionModel clientSession, boolean offlineTokenRequested) {
         boolean implicitFlow = false;
         String responseType = clientSession.getNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
@@ -1142,9 +1142,9 @@ public class TokenManager {
         long expiration;
         if (tokenLifespan == -1) {
             expiration = TimeUnit.SECONDS.toMillis(userSession.getStarted() +
-                    (userSession.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0
-                            ? realm.getSsoSessionMaxLifespanRememberMe()
-                            : realm.getSsoSessionMaxLifespan()));
+                    (userSession.isRememberMe() && SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, userSession, session) > 0
+                            ? SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, userSession, session)
+                            : SessionExpirationUtils.getSsoSessionMaxLifespan(realm, userSession, session)));
         } else {
             expiration = Time.currentTimeMillis() + TimeUnit.SECONDS.toMillis(tokenLifespan);
         }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -839,10 +839,10 @@ public class AuthenticationManager {
             token.setSessionId(session.getId());
         }
 
-        if (session != null && session.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0) {
-            token.exp((long) Time.currentTime() + realm.getSsoSessionMaxLifespanRememberMe());
-        } else if (realm.getSsoSessionMaxLifespan() > 0) {
-            token.exp((long) Time.currentTime() + realm.getSsoSessionMaxLifespan());
+        if (session != null && session.isRememberMe() && SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, session, keycloakSession) > 0) {
+            token.exp((long) Time.currentTime() + SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, session, keycloakSession));
+        } else if (SessionExpirationUtils.getSsoSessionMaxLifespan(realm, session, keycloakSession) > 0) {
+            token.exp((long) Time.currentTime() + SessionExpirationUtils.getSsoSessionMaxLifespan(realm, session, keycloakSession));
         }
 
         String stateChecker = (String) keycloakSession.getAttribute(STATE_CHECKER);
@@ -862,7 +862,7 @@ public class AuthenticationManager {
         String encoded = keycloakSession.tokens().encode(identityCookieToken);
         int maxAge = NewCookie.DEFAULT_MAX_AGE;
         if (session.isRememberMe()) {
-            maxAge = realm.getSsoSessionMaxLifespanRememberMe() > 0 ? realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan();
+            maxAge = SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, session, keycloakSession) > 0 ? SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, session, keycloakSession) : SessionExpirationUtils.getSsoSessionMaxLifespan(realm, session, keycloakSession);
         }
         keycloakSession.getProvider(CookieProvider.class).set(CookieType.IDENTITY, encoded, maxAge);
 
@@ -870,7 +870,7 @@ public class AuthenticationManager {
 
         // THIS SHOULD NOT BE A HTTPONLY COOKIE!  It is used for OpenID Connect Iframe Session support!
         // Max age should be set to the max lifespan of the session as it's used to invalidate old-sessions on re-login
-        int sessionCookieMaxAge = session.isRememberMe() && realm.getSsoSessionMaxLifespanRememberMe() > 0 ? realm.getSsoSessionMaxLifespanRememberMe() : realm.getSsoSessionMaxLifespan();
+        int sessionCookieMaxAge = session.isRememberMe() && SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, session, keycloakSession) > 0 ? SessionExpirationUtils.getSsoSessionMaxLifespanRememberMe(realm, session, keycloakSession) : SessionExpirationUtils.getSsoSessionMaxLifespan(realm, session, keycloakSession);
         keycloakSession.getProvider(CookieProvider.class).set(CookieType.SESSION, sessionCookieValue, sessionCookieMaxAge);
     }
 


### PR DESCRIPTION
Allows administrators to configure session idle timeout and max lifespan at the organization level, overriding realm defaults for members of that organization. Includes JPA schema changes, cache layer updates, Admin REST API exposure, frontend UI tab, and unit tests.

List of some changes we made:
-First we edited the OrganizationModel interface to add timeout attributes + getter/setter methods
-Added columns into OrganizationEntity for JPA
-Updated Liquibase changelog
-Implemented getter/setters into both instances of OrganizationAdapter
-Also added the getter/setters into KeycloakModelUtilsTest
-Created helper and override methods in SessionExpirationUtils to check for organization timeout (defaults to realm default if no org timeout has been set)
-Made our api calls more accurate by updating representationToModel and modelToRepresentation util files
-Implemented frontend interface (shown in gif)

<img width="800" height="421" alt="keycloakOrgTimeoutDemo" src="https://github.com/user-attachments/assets/df84e177-98ee-4198-959b-ec5b6a1a0b4c" />

Note: Used Claude to help with development

Closes [#46549](https://github.com/keycloak/keycloak/issues/46549)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
