### PR TITLE
Issue-48394: Proper handling of unknown signature algorithm in action tokens

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -18,6 +18,7 @@ package org.keycloak.services.resources;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -626,7 +627,7 @@ public class LoginActionsService {
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
 
-            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(kid);
+            SignatureVerifierContext signatureVerifier = getSignatureProvider(algorithm).verifier(kid);
             verifier.verifierContext(signatureVerifier);
 
             verifier.verify();
@@ -720,6 +721,11 @@ public class LoginActionsService {
         } catch (VerificationException ex) {
             return handleActionTokenVerificationException(tokenContext, ex, eventError, defaultErrorMessage);
         }
+    }
+
+    private SignatureProvider getSignatureProvider(String algorithm) throws ExplainedTokenVerificationException {
+        return Optional.ofNullable(session.getProvider(SignatureProvider.class, algorithm))
+                .orElseThrow(() -> new ExplainedTokenVerificationException(null, Errors.NOT_ALLOWED, Messages.INVALID_REQUEST));
     }
 
     private Response processFlowFromPath(String flowPath, AuthenticationSessionModel authSession, String errorMessage) {


### PR DESCRIPTION
During JWT verification, Keycloak attempts to resolve a SignatureProvider based on the alg value from the JWT header.
If no provider matches the requested algorithm, an exception is thrown and not fully handled at the boundary of the authentication flow, resulting in a 500 response instead of a client error.

closes https://github.com/keycloak/keycloak/issues/48394

I've to admin, I'm not completely sure about  the thrown exception and its parameters