### PR TITLE
fix: correctly handle duplicate values in setAttribute()

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserAdapter.java
@@ -198,8 +198,8 @@ public class UserAdapter implements CachedUserModel {
             value = KeycloakModelUtils.toLowerCaseSafe(value);
         }
         if (updated == null) {
-            Set<String> oldEntries = getAttributeStream(name).collect(Collectors.toSet());
-            Set<String> newEntries = value != null ? Set.of(value) : Collections.emptySet();
+            List<String> oldEntries = getAttributeStream(name).sorted().collect(Collectors.toList());
+            List<String> newEntries = value == null ? List.of() : List.of(value);
             if (CollectionUtil.collectionEquals(oldEntries, newEntries)) {
                 return;
             }
@@ -215,13 +215,8 @@ public class UserAdapter implements CachedUserModel {
             if (lowerCasedFirstValue != null) values = Collections.singletonList(lowerCasedFirstValue);
         }
         if (updated == null) {
-            Set<String> oldEntries = getAttributeStream(name).collect(Collectors.toSet());
-            Set<String> newEntries;
-            if (values == null) {
-                newEntries = new HashSet<>();
-            } else {
-                newEntries = new HashSet<>(values);
-            }
+            List<String> oldEntries = getAttributeStream(name).sorted().collect(Collectors.toList());
+            List<String> newEntries = values == null ? List.of() : values.stream().sorted().toList();
             if (CollectionUtil.collectionEquals(oldEntries, newEntries)) {
                 return;
             }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/UserAdapter.java
@@ -18,12 +18,10 @@
 package org.keycloak.models.jpa;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -154,8 +152,8 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
         if (value == null) {
             removeAttribute(name);
         } else {
-            Set<String> oldEntries = getAttributeStream(name).collect(Collectors.toSet());
-            Set<String> newEntries = Set.of(value);
+            List<String> oldEntries = getAttributeStream(name).sorted().collect(Collectors.toList());
+            List<String> newEntries = List.of(value);
             if (CollectionUtil.collectionEquals(oldEntries, newEntries)) {
                 return;
             }
@@ -205,13 +203,8 @@ public class UserAdapter implements UserModel, JpaModel<UserEntity> {
             return;
         }
 
-        Set<String> oldEntries = getAttributeStream(name).collect(Collectors.toSet());
-        Set<String> newEntries;
-        if (values == null) {
-            newEntries = new HashSet<>();
-        } else {
-            newEntries = new HashSet<>(values);
-        }
+        List<String> oldEntries = getAttributeStream(name).sorted().collect(Collectors.toList());
+        List<String> newEntries = values == null ? List.of() : values.stream().sorted().toList();
         if (CollectionUtil.collectionEquals(oldEntries, newEntries)) {
             return;
         }

--- a/tests/base/src/test/java/org/keycloak/tests/model/UserModelTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/model/UserModelTest.java
@@ -341,6 +341,54 @@ public class UserModelTest {
     }
 
     @TestOnServer
+    public void testUpdateUserAttributeMultipleSameValues(KeycloakSession session) {
+        String key = "foo";
+
+        // Testing "setAttribute"
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session.getContext(), (KeycloakSession currentSession) -> {
+            RealmModel realm = currentSession.realms().getRealmByName("original");
+            UserModel user = currentSession.users().addUser(realm, "user");
+
+            user.setAttribute(key, List.of("bar", "bar"));
+
+            List<String> expected = List.of("bar", "bar");
+            assertThat(user.getAttributes().get(key), equalTo(expected));
+        });
+
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session.getContext(), (KeycloakSession currentSession) -> {
+            RealmModel realm = currentSession.realms().getRealmByName("original");
+            UserModel user = currentSession.users().getUserByUsername(realm, "user");
+
+            user.setAttribute(key, List.of("bar"));
+
+            List<String> expected = List.of("bar");
+            assertThat(user.getAttributes().get(key), equalTo(expected));
+        });
+
+        // Testing "setSingleAttribute"
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session.getContext(), (KeycloakSession currentSession) -> {
+            RealmModel realm = currentSession.realms().getRealmByName("original");
+            UserModel user = currentSession.users().getUserByUsername(realm, "user");
+
+            user.setAttribute(key, List.of("bar", "bar"));
+
+            List<String> expected = List.of("bar", "bar");
+            assertThat(user.getAttributes().get(key), equalTo(expected));
+        });
+
+        KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session.getContext(), (KeycloakSession currentSession) -> {
+            RealmModel realm = currentSession.realms().getRealmByName("original");
+            UserModel user = currentSession.users().getUserByUsername(realm, "user");
+
+            user.setSingleAttribute(key, "bar");
+
+            List<String> expected = List.of("bar");
+            assertThat(user.getAttributes().get(key), equalTo(expected));
+        });
+
+    }
+
+    @TestOnServer
     public void testSearchByString(KeycloakSession session) {
 
         KeycloakModelUtils.runJobInTransaction(session.getKeycloakSessionFactory(), session.getContext(), (KeycloakSession sesSearchString1) -> {


### PR DESCRIPTION
When an attribute holds duplicate values (e.g. ["bar", "bar"]) and the caller reduces the count (e.g. to ["bar"]), the change was silently dropped. Both the infinispan cache adapter and the JPA adapter compared old and new values as Sets, so ["bar", "bar"] and ["bar"] both collapsed to {"bar"} and the equality check returned true, causing an early return without persisting any change.

The infinispan adapter's check is the primary failure point in real deployments: it guards the call to getDelegateForUpdate(), so the JPA layer was never reached at all.

Fix: replace Set-based comparison with List-based comparison in both adapters. CollectionUtil.collectionEquals already counts duplicates correctly when given Lists, so ["bar", "bar"] vs. ["bar"] correctly evaluates to not-equal and the update proceeds.

Includes a regression test that verifies duplicate-value reduction is persisted correctly across transaction boundaries.

closes #38526

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
