### PR TITLE
 Added PushTheButtonPage for AuthenticatorSubflowsTest2

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest2.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/AuthenticatorSubflowsTest2.java
@@ -34,13 +34,12 @@ import org.keycloak.testsuite.authentication.PushButtonAuthenticatorFactory;
 import org.keycloak.testsuite.pages.AppPage;
 import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.pages.LoginPage;
+import org.keycloak.testsuite.pages.PushTheButtonPage;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
-import org.openqa.selenium.By;
 
 /**
  * @author <a href="mailto:n1330@me.com">Tomohiro Nagai</a>
@@ -58,6 +57,9 @@ public class AuthenticatorSubflowsTest2 extends AbstractChangeImportedUserPasswo
 
     @Page
     protected ErrorPage errorPage;
+
+    @Page
+    protected PushTheButtonPage pushTheButtonPage;
 
     @Before
     public void setupFlows() {
@@ -179,10 +181,10 @@ public class AuthenticatorSubflowsTest2 extends AbstractChangeImportedUserPasswo
 
         // Fill username+password. I am redirected push the button.
         oauth.fillLoginForm("test-user@localhost", getPassword("test-user@localhost"));
-        Assertions.assertEquals("PushTheButton", driver.getTitle());
+        pushTheButtonPage.assertCurrent();
 
         // Push the button. I am successfully authenticated.
-        driver.findElement(By.name("submit1")).click();
+        pushTheButtonPage.submit();
         appPage.assertCurrent();
 
         events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();


### PR DESCRIPTION
 Closes #47477 

Flaky test is caused by AppPage not being fully loaded, before check kicks in - added PushTheButtonPage which will wait for the page to load. 