### PR TITLE
Account ResourceService user endpoint returns excessive user data in …

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -42,10 +42,9 @@ import org.keycloak.models.AccountRoles;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.managers.Auth;
 import org.keycloak.utils.MediaType;
-
-import static org.keycloak.models.utils.ModelToRepresentation.toRepresentation;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -104,7 +103,13 @@ public class ResourceService extends AbstractResourceService {
     public Response user(@QueryParam("value") String value) {
         try {
             final UserModel user = getUser(value);
-            return Response.ok(toRepresentation(provider.getKeycloakSession(), provider.getRealm(), user)).build();
+            UserRepresentation rep = new UserRepresentation();
+            rep.setId(user.getId());
+            rep.setUsername(user.getUsername());
+            rep.setFirstName(user.getFirstName());
+            rep.setLastName(user.getLastName());
+            rep.setEmail(user.getEmail());
+            return Response.ok(rep).build();
         } catch (NotFoundException e) {
             return Response.noContent().build();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
@@ -96,9 +96,9 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
 
         testRealm.setUserManagedAccessAllowed(true);
 
-        testRealm.getUsers().add(createUser("alice", "password"));
-        testRealm.getUsers().add(createUser("jdoe", "password"));
-        testRealm.getUsers().add(createUser("bob", "password"));
+        testRealm.getUsers().add(createUser("alice", "password", "Alice", "A", "alice@localhost"));
+        testRealm.getUsers().add(createUser("jdoe", "password", "John", "Doe", "jdoe@localhost"));
+        testRealm.getUsers().add(createUser("bob", "password", "Bob", "B", "bob@localhost"));
         testRealm.getUsers().add(UserBuilder.create().username("test-authz-user@localhost").password("password")
                 .roles("uma_authorization", "uma_protection")
                 .clientRoles("my-resource-server", "uma_protection")
@@ -335,6 +335,30 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
 
         response = doGet("/" + encodePathAsIs(getMyResources().get(0).getId()), authzClient.obtainAccessToken("jdoe", "password").getToken(), OAuth2ErrorRepresentation.class);
         assertEquals("invalid_resource", response.getError());
+    }
+
+    @Test
+    public void testUserLookupReturnsMinimalData() {
+        Resource resource = getMyResources().get(0);
+
+        UserRepresentation user = doGet("/" + encodePathAsIs(resource.getId()) + "/user?value=alice", UserRepresentation.class);
+
+        assertNotNull(user);
+        assertNotNull(user.getId());
+        assertEquals("alice", user.getUsername());
+        assertEquals("Alice", user.getFirstName());
+        assertEquals("A", user.getLastName());
+        assertEquals("alice@localhost", user.getEmail());
+
+        assertNull(user.getAttributes(), "User attributes should not be exposed");
+        assertNull(user.isTotp(), "TOTP status should not be exposed");
+        assertNull(user.getRequiredActions(), "Required actions should not be exposed");
+        assertNull(user.getDisableableCredentialTypes(), "Disableable credential types should not be exposed");
+        assertNull(user.getCreatedTimestamp(), "Created timestamp should not be exposed");
+        assertNull(user.isEnabled(), "Enabled status should not be exposed");
+        assertNull(user.isEmailVerified(), "Email verified should not be exposed");
+        assertNull(user.getFederationLink(), "Federation link should not be exposed");
+        assertNull(user.getNotBefore(), "NotBefore should not be exposed");
     }
 
     @Test
@@ -737,11 +761,15 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
                         credentials, httpClient));
     }
 
-    private UserRepresentation createUser(String userName, String password) {
+    private UserRepresentation createUser(String userName, String password, String firstName, String lastName, String email) {
         return UserBuilder.create()
                 .username(userName)
                 .enabled(true)
                 .password(password)
+                .firstName(firstName)
+                .lastName(lastName)
+                .email(email)
+                .attribute("secret-attr", "secret-value")
                 .clientRoles("account", AccountRoles.MANAGE_ACCOUNT)
                 .build();
     }


### PR DESCRIPTION
…UMA-enabled realms

I deliberately didn't changed this part of the issue "Additionally, the endpoint returns HTTP 200 for existing users and HTTP 204 for non-existent users." as there is no improved security when returning 200 with empty response or 204. Users can be enumerated either way. Additionally, usage of 204 is consistent across the account endpoints, it's not just this one endpoint.   

Closes #47036

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
