### PR TITLE
Reject CORS requests with invalid Origin before endpoint logic runs

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_3.adoc
@@ -1,0 +1,10 @@
+== Notable changes
+
+Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
+It also lists significant changes to internal APIs.
+
+=== CORS requests with an invalid Origin are now rejected before endpoint logic runs
+
+Cross-origin requests sent to OIDC endpoints (such as the token, userinfo, token revocation, logout, and PAR endpoints) are now validated against the client's configured Web Origins before the endpoint reaches its authentication and request-processing logic. Previously, requests carrying an `Origin` header that did not match any of the client's allowed Web Origins could be processed up to the point where the response was about to be returned, which could result in inconsistent error responses depending on how far the request progressed.
+
+After this change, such requests are rejected immediately with a CORS failure returning Forbidden (403) HTTP error status. There is no behavior change for same-origin requests (no `Origin` header) or for cross-origin requests whose `Origin` is already permitted by the client's Web Origins configuration.

--- a/docs/documentation/upgrading/topics/changes/changes.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes.adoc
@@ -5,6 +5,14 @@
 
 include::changes-26_7_0.adoc[leveloffset=2]
 
+=== Migrating to 26.6.3
+
+include::changes-26_6_3.adoc[leveloffset=2]
+
+=== Migrating to 26.6.2
+
+include::changes-26_6_2.adoc[leveloffset=2]
+
 === Migrating to 26.6.1
 
 include::changes-26_6_1.adoc[leveloffset=2]

--- a/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/cors/Cors.java
@@ -69,19 +69,19 @@ public interface Cors extends Provider {
 
     Cors auth();
 
-    Cors failOnInvalidOrigin();
-
     Cors allowAllOrigins();
 
-    Cors allowedOrigins(KeycloakSession session, ClientModel client);
+    /**
+     * Sets the allowed origins from the client's configured web origins and checks the
+     * incoming Origin header against them. Throws {@link jakarta.ws.rs.ForbiddenException}
+     * (HTTP 403) on a mismatch so the request stops before any side effects. Preflight and
+     * same-origin requests pass through without a check.
+     */
+    Cors checkAllowedOrigins(KeycloakSession session, ClientModel client);
 
-    Cors allowedOrigins(AccessToken token);
+    Cors checkAllowedOrigins(AccessToken token);
 
-    Cors allowedOrigins(String... allowedOrigins);
-
-    Cors allowedOrigins(List<String> allowedOrigins);
-
-    Cors addAllowedOrigins(List<String> allowedOrigins);
+    Cors checkAllowedOrigins(List<String> allowedOrigins);
 
     Cors allowedMethods(String... allowedMethods);
 

--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -289,7 +289,7 @@ public class AuthorizationTokenService {
 
     private Response createSuccessfulResponse(Object response, KeycloakAuthorizationRequest request) {
         return Cors.builder()
-                .allowedOrigins(request.getKeycloakSession(), request.getKeycloakSession().getContext().getClient())
+                .checkAllowedOrigins(request.getKeycloakSession(), request.getKeycloakSession().getContext().getClient())
                 .allowedMethods(HttpMethod.POST)
                 .exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS)
                 .add(Response.status(Status.OK).type(MediaType.APPLICATION_JSON_TYPE).entity(response));

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -460,7 +460,7 @@ public class OID4VCIssuerEndpoint {
                 .detail(Details.CREDENTIAL_TYPE, credentialConfigurationId)
                 .detail(Details.USERNAME, targetUser);
 
-        cors.allowedOrigins(session, clientModel);
+        cors.checkAllowedOrigins(session, clientModel);
         checkIsOid4vciEnabled(eventBuilder);
         checkClientEnabled(eventBuilder);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -713,7 +713,7 @@ public class LogoutEndpoint {
 
     private ClientModel authorizeClient() {
         ClientModel client = AuthorizeClientUtil.authorizeClient(session, event, cors).getClient();
-        cors.allowedOrigins(session, client);
+        cors.checkAllowedOrigins(session, client);
 
         if (client.isBearerOnly()) {
             throw new CorsErrorResponseException(cors, Errors.INVALID_CLIENT, "Bearer-only not allowed", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -195,7 +195,7 @@ public class TokenEndpoint {
         clientAuthAttributes = clientAuth.getClientAuthAttributes();
         clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
 
-        cors.allowedOrigins(session, client);
+        cors.checkAllowedOrigins(session, client);
 
         if (client.isBearerOnly()) {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Bearer-only not allowed", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -170,7 +170,7 @@ public class TokenRevocationEndpoint {
 
         event.client(client);
 
-        cors.allowedOrigins(session, client);
+        cors.checkAllowedOrigins(session, client);
 
         if (client.isBearerOnly()) {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Bearer-only not allowed",

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -209,7 +209,7 @@ public class UserInfoEndpoint {
                 throw error.invalidToken("Client not found");
             }
 
-            cors.allowedOrigins(session, clientModel);
+            cors.checkAllowedOrigins(session, clientModel);
 
             TokenVerifier.createWithoutSignature(token)
                     .withChecks(NotBeforeCheck.forModel(clientModel), new TokenManager.TokenRevocationCheck(session))

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -274,7 +274,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
         clientAuthAttributes = clientAuth.getClientAuthAttributes();
         clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
 
-        cors.allowedOrigins(session, client);
+        cors.checkAllowedOrigins(session, client);
 
         if (client.isBearerOnly()) {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Bearer-only not allowed", Response.Status.BAD_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java
@@ -71,7 +71,7 @@ public class PermissionGrantType extends OAuth2GrantTypeBase {
                     // from the access token anyway in order to set correct CORS headers.
                     AccessToken invalidToken = new JWSInput(accessTokenString).readJsonContent(AccessToken.class);
                     ClientModel client = realm.getClientByClientId(invalidToken.getIssuedFor());
-                    cors.allowedOrigins(session, client);
+                    cors.checkAllowedOrigins(session, client);
                     event.client(client);
                 } catch (JWSInputException ignore) {
                 }
@@ -83,7 +83,7 @@ public class PermissionGrantType extends OAuth2GrantTypeBase {
 
             session.getContext().setClient(client);
 
-            cors.allowedOrigins(session, client);
+            cors.checkAllowedOrigins(session, client);
             event.client(client);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/AbstractParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/AbstractParEndpoint.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuthErrorException;
@@ -68,11 +69,13 @@ public abstract class AbstractParEndpoint {
 
             this.event.client(client);
 
-            cors.allowedOrigins(session, client);
+            cors.checkAllowedOrigins(session, client);
 
             if (client == null) {
                 throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Client not allowed.", Response.Status.FORBIDDEN);
             }
+        } catch (ForbiddenException e) {
+            throw e;
         } catch (Exception e) {
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Authentication failed.", Response.Status.UNAUTHORIZED);
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/AuthorizeClientUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/AuthorizeClientUtil.java
@@ -68,7 +68,7 @@ public class AuthorizeClientUtil {
         }
 
         if (cors != null) {
-            cors.allowedOrigins(session, client);
+            cors.checkAllowedOrigins(session, client);
         }
 
         String protocol = client.getProtocol();

--- a/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/AbstractClientRegistrationProvider.java
@@ -315,11 +315,13 @@ public abstract class AbstractClientRegistrationProvider implements ClientRegist
     }
 
     protected List<String> getAllowedOrigins() {
+        auth.init();
         List<String> allowedOrigins = new LinkedList<>();
         AccessToken jwt = auth.getJwt();
         if (jwt != null && jwt.getAllowedOrigins() != null) {
             allowedOrigins.addAll(jwt.getAllowedOrigins());
         }
+        allowedOrigins.addAll(ClientRegistrationPolicyManager.getAllowedOrigins(session, auth.resolveRegistrationAuth()));
         return allowedOrigins;
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
@@ -69,6 +69,7 @@ public class ClientRegistrationAuth {
     private String kid;
     private String token;
     private String endpoint;
+    private boolean initialized;
 
     public ClientRegistrationAuth(KeycloakSession session, ClientRegistrationProvider provider, EventBuilder event, String endpoint) {
         this.session = session;
@@ -77,7 +78,11 @@ public class ClientRegistrationAuth {
         this.endpoint = endpoint;
     }
 
-    private void init() {
+    void init() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
         realm = session.getContext().getRealm();
 
         String authorizationHeader = session.getContext().getRequestHeaders().getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION);
@@ -228,6 +233,17 @@ public class ClientRegistrationAuth {
     public RegistrationAuth getRegistrationAuth() {
         String str = (String) jwt.getOtherClaims().get(RegistrationAccessToken.REGISTRATION_AUTH);
         return RegistrationAuth.fromString(str);
+    }
+
+    public RegistrationAuth resolveRegistrationAuth() {
+        init();
+        if (jwt == null) {
+            return RegistrationAuth.ANONYMOUS;
+        }
+        if (isRegistrationAccessToken()) {
+            return getRegistrationAuth();
+        }
+        return RegistrationAuth.AUTHENTICATED;
     }
 
     public RegistrationAuth requireUpdate(ClientRegistrationContext context, ClientModel client) {

--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
@@ -85,6 +85,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response createOIDC(OIDCClientRepresentation clientOIDC) {
+        Cors cors = cors();
         if (clientOIDC.getClientId() != null) {
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier included", Response.Status.BAD_REQUEST);
         }
@@ -104,7 +105,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
             URI uri = getRegistrationClientUri(clientModel);
             clientOIDC = DescriptionConverter.toExternalResponse(session, client, uri);
             clientOIDC.setClientIdIssuedAt(Time.currentTime());
-            return cors().add(Response.created(uri).entity(clientOIDC));
+            return cors.add(Response.created(uri).entity(clientOIDC));
         } catch (ClientRegistrationException cre) {
             ServicesLogger.LOGGER.clientRegistrationException(cre.getMessage());
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client metadata invalid", Response.Status.BAD_REQUEST);
@@ -115,12 +116,13 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @Path("{clientId}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getOIDC(@PathParam("clientId") String clientId) {
+        Cors cors = cors();
         ClientModel client = session.getContext().getRealm().getClientByClientId(clientId);
 
         ClientRepresentation clientRepresentation = get(client);
 
         OIDCClientRepresentation clientOIDC = DescriptionConverter.toExternalResponse(session, clientRepresentation, getRegistrationClientUri(client));
-        return cors().add(Response.ok(clientOIDC));
+        return cors.add(Response.ok(clientOIDC));
     }
 
     @PUT
@@ -128,6 +130,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateOIDC(@PathParam("clientId") String clientId, OIDCClientRepresentation clientOIDC) {
+        Cors cors = cors();
         try {
             ClientRepresentation client = DescriptionConverter.toInternal(session, clientOIDC);
 
@@ -152,7 +155,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
 
             URI uri = getRegistrationClientUri(clientModel);
             clientOIDC = DescriptionConverter.toExternalResponse(session, client, uri);
-            return cors().add(Response.ok(clientOIDC));
+            return cors.add(Response.ok(clientOIDC));
         } catch (ClientRegistrationException cre) {
             ServicesLogger.LOGGER.clientRegistrationException(cre.getMessage());
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client metadata invalid", Response.Status.BAD_REQUEST);
@@ -162,12 +165,13 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @DELETE
     @Path("{clientId}")
     public Response deleteOIDC(@PathParam("clientId") String clientId) {
+        Cors cors = cors();
         delete(clientId);
-        return cors().add(Response.noContent());
+        return cors.add(Response.noContent());
     }
 
     private Cors cors() {
-        return Cors.builder().failOnInvalidOrigin().auth().addAllowedOrigins(getAllowedOrigins());
+        return Cors.builder().auth().checkAllowedOrigins(getAllowedOrigins());
     }
 
     private void updatePairwiseSubMappers(ClientModel clientModel, SubjectType subjectType, String sectorIdentifierUri) {

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/ClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/ClientRegistrationPolicy.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.services.clientregistration.policy;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.keycloak.models.ClientModel;
 import org.keycloak.provider.Provider;
 import org.keycloak.services.clientregistration.ClientRegistrationContext;
@@ -38,6 +41,15 @@ public interface ClientRegistrationPolicy extends Provider {
     void beforeView(ClientRegistrationProvider provider, ClientModel clientModel) throws ClientRegistrationPolicyException;
 
     void beforeDelete(ClientRegistrationProvider provider, ClientModel clientModel) throws ClientRegistrationPolicyException;
+
+    /**
+     * Extra web origins this policy contributes to the CORS allow-list for responses produced
+     * by the client registration endpoints. Origins are collected up-front so validation can
+     * happen in a single {@code checkAllowedOrigins} call before the handler runs.
+     */
+    default Collection<String> getAllowedOrigins() {
+        return Collections.emptyList();
+    }
 
     @Override
     default void close() {

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/ClientRegistrationPolicyManager.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/ClientRegistrationPolicyManager.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.services.clientregistration.policy;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.keycloak.component.ComponentModel;
@@ -95,6 +97,21 @@ public class ClientRegistrationPolicyManager {
     }
 
 
+
+    public static List<String> getAllowedOrigins(KeycloakSession session, RegistrationAuth authType) {
+        RealmModel realm = session.getContext().getRealm();
+        String policyTypeKey = getComponentTypeKey(authType);
+        List<String> origins = new ArrayList<>();
+        realm.getComponentsStream(realm.getId(), ClientRegistrationPolicy.class.getName())
+                .filter(componentModel -> Objects.equals(componentModel.getSubType(), policyTypeKey))
+                .forEach(policyModel -> {
+                    ClientRegistrationPolicy policy = session.getProvider(ClientRegistrationPolicy.class, policyModel);
+                    if (policy != null) {
+                        origins.addAll(policy.getAllowedOrigins());
+                    }
+                });
+        return origins;
+    }
 
     private static void triggerPolicies(KeycloakSession session, ClientRegistrationProvider provider, RegistrationAuth authType,
                                         String opDescription, ClientRegOperation op) throws ClientRegistrationPolicyException {

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicy.java
@@ -1,5 +1,7 @@
 package org.keycloak.services.clientregistration.policy.impl;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.keycloak.component.ComponentModel;
@@ -9,21 +11,17 @@ import org.keycloak.services.clientregistration.ClientRegistrationContext;
 import org.keycloak.services.clientregistration.ClientRegistrationProvider;
 import org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy;
 import org.keycloak.services.clientregistration.policy.ClientRegistrationPolicyException;
-import org.keycloak.services.cors.Cors;
 
 public class RegistrationWebOriginsPolicy implements ClientRegistrationPolicy {
 
-    private final KeycloakSession session;
     private final List<String> allowedWebOrigins;
 
     public RegistrationWebOriginsPolicy(KeycloakSession session, ComponentModel model) {
-        this.session = session;
         allowedWebOrigins = model.getConfig().getList(RegistrationWebOriginsPolicyFactory.WEB_ORIGINS);
     }
 
     @Override
     public void beforeRegister(ClientRegistrationContext context) throws ClientRegistrationPolicyException {
-        addOrigins();
     }
 
     @Override
@@ -32,7 +30,6 @@ public class RegistrationWebOriginsPolicy implements ClientRegistrationPolicy {
 
     @Override
     public void beforeUpdate(ClientRegistrationContext context, ClientModel clientModel) throws ClientRegistrationPolicyException {
-        addOrigins();
     }
 
     @Override
@@ -41,18 +38,15 @@ public class RegistrationWebOriginsPolicy implements ClientRegistrationPolicy {
 
     @Override
     public void beforeView(ClientRegistrationProvider provider, ClientModel clientModel) throws ClientRegistrationPolicyException {
-        addOrigins();
     }
 
     @Override
     public void beforeDelete(ClientRegistrationProvider provider, ClientModel clientModel) throws ClientRegistrationPolicyException {
-        addOrigins();
     }
 
-    private void addOrigins() {
-        if (allowedWebOrigins != null && !allowedWebOrigins.isEmpty()) {
-            session.getProvider(Cors.class).addAllowedOrigins(allowedWebOrigins);
-        }
+    @Override
+    public Collection<String> getAllowedOrigins() {
+        return allowedWebOrigins != null ? allowedWebOrigins : Collections.emptyList();
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/cors/DefaultCors.java
+++ b/services/src/main/java/org/keycloak/services/cors/DefaultCors.java
@@ -55,7 +55,6 @@ public class DefaultCors implements Cors {
 
     private boolean preflight;
     private boolean auth;
-    private boolean failOnInvalidOrigin;
 
     DefaultCors(KeycloakSession session, String allowedHeaders) {
         this.session = session;
@@ -83,56 +82,50 @@ public class DefaultCors implements Cors {
     }
 
     @Override
-    public Cors failOnInvalidOrigin() {
-        failOnInvalidOrigin = true;
-        return this;
-    }
-
-    @Override
     public Cors allowAllOrigins() {
         allowedOrigins = Collections.singleton(ACCESS_CONTROL_ALLOW_ORIGIN_WILDCARD);
         return this;
     }
 
     @Override
-    public Cors allowedOrigins(KeycloakSession session, ClientModel client) {
+    public Cors checkAllowedOrigins(KeycloakSession session, ClientModel client) {
         if (client != null) {
             allowedOrigins = WebOriginsUtils.resolveValidWebOrigins(session, client);
         }
+        checkOrigin();
         return this;
     }
 
     @Override
-    public Cors allowedOrigins(AccessToken token) {
+    public Cors checkAllowedOrigins(AccessToken token) {
         if (token != null) {
             allowedOrigins = token.getAllowedOrigins();
+            if (allowedOrigins == null || allowedOrigins.isEmpty()) {
+                ClientModel client = resolveClient(token);
+                if (client != null) {
+                    return checkAllowedOrigins(session, client);
+                }
+            }
         }
+        checkOrigin();
         return this;
     }
 
-    @Override
-    public Cors allowedOrigins(String... allowedOrigins) {
-        if (allowedOrigins != null && allowedOrigins.length > 0) {
-            this.allowedOrigins = new HashSet<>(Arrays.asList(allowedOrigins));
+    private ClientModel resolveClient(AccessToken token) {
+        String clientId = token.getIssuedFor();
+        if (clientId == null) {
+            return null;
         }
-        return this;
+        var realm = session.getContext().getRealm();
+        return realm == null ? null : realm.getClientByClientId(clientId);
     }
 
     @Override
-    public Cors allowedOrigins(List<String> allowedOrigins) {
+    public Cors checkAllowedOrigins(List<String> allowedOrigins) {
         if (allowedOrigins != null && !allowedOrigins.isEmpty()) {
             this.allowedOrigins = new HashSet<>(allowedOrigins);
         }
-        return this;
-    }
-
-    @Override
-    public Cors addAllowedOrigins(List<String> allowedOrigins) {
-        if (this.allowedOrigins == null) {
-            this.allowedOrigins = new HashSet<>(allowedOrigins);
-        } else {
-            this.allowedOrigins.addAll(allowedOrigins);
-        }
+        checkOrigin();
         return this;
     }
 
@@ -169,16 +162,8 @@ public class DefaultCors implements Cors {
             return;
         }
 
-        if (!preflight && (allowedOrigins == null || (!allowedOrigins.contains(origin) && !allowedOrigins.contains(ACCESS_CONTROL_ALLOW_ORIGIN_WILDCARD)))) {
-            String requestOrigin = UriUtils.getOrigin(session.getContext().getUri().getRequestUri());
-            if (!origin.equals(requestOrigin) && logger.isDebugEnabled()) {
-                logger.debugv("Invalid CORS request: origin {0} not in allowed origins {1}", origin, allowedOrigins);
-            }
-
-            if (failOnInvalidOrigin) {
-                throw new ForbiddenException("Invalid origin");
-            }
-
+        if (!preflight && !isOriginAllowed(origin)) {
+            logInvalidOrigin(origin);
             return;
         }
 
@@ -208,6 +193,43 @@ public class DefaultCors implements Cors {
 
         if (preflight) {
             response.setHeader(ACCESS_CONTROL_MAX_AGE, String.valueOf(DEFAULT_MAX_AGE));
+        }
+    }
+
+    private void checkOrigin() {
+        if (preflight) {
+            return;
+        }
+
+        String origin = request.getHttpHeaders().getRequestHeaders().getFirst(ORIGIN_HEADER);
+        if (origin == null || isOriginAllowed(origin)) {
+            return;
+        }
+
+        String requestOrigin = UriUtils.getOrigin(session.getContext().getUri().getRequestUri());
+        if (origin.equals(requestOrigin)) {
+            return;
+        }
+
+        logInvalidOrigin(origin, requestOrigin);
+        throw new ForbiddenException("Invalid origin");
+    }
+
+    private boolean isOriginAllowed(String origin) {
+        return allowedOrigins != null
+                && (allowedOrigins.contains(origin) || allowedOrigins.contains(ACCESS_CONTROL_ALLOW_ORIGIN_WILDCARD));
+    }
+
+    private void logInvalidOrigin(String origin) {
+        if (logger.isDebugEnabled()) {
+            String requestOrigin = UriUtils.getOrigin(session.getContext().getUri().getRequestUri());
+            logInvalidOrigin(origin, requestOrigin);
+        }
+    }
+
+    private void logInvalidOrigin(String origin, String requestOrigin) {
+        if (logger.isDebugEnabled() && !origin.equals(requestOrigin)) {
+            logger.debugv("Invalid CORS request: origin {0} not in allowed origins {1}", origin, allowedOrigins);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -509,7 +509,7 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
         // authenticate client
         AuthorizeClientUtil.ClientAuthResult clientAuth = AuthorizeClientUtil.authorizeClient(session, event, cors);
         ClientModel client = clientAuth.getClient();
-        cors.allowedOrigins(session, client);
+        cors.checkAllowedOrigins(session, client);
         event.client(client);
         session.getContext().setClient(client);
         if (client.isPublicClient()) {
@@ -1546,7 +1546,7 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
     }
 
     private Response corsResponse(Response response, ClientModel clientModel) {
-        return Cors.builder().auth().allowedOrigins(session, clientModel).add(Response.fromResponse(response));
+        return Cors.builder().auth().checkAllowedOrigins(session, clientModel).add(Response.fromResponse(response));
     }
 
     private void fireErrorEvent(String message, Throwable throwable) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -136,7 +136,7 @@ public class AccountLoader {
 
         Auth auth = new Auth(session.getContext().getRealm(), accessToken, authResult.user(), client, authResult.session(), false);
 
-        Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
+        Cors.builder().checkAllowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
 
         if (authResult.user().getServiceAccountClientLink() != null) {
             throw new NotAuthorizedException("Service accounts are not allowed to access this service");

--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -130,7 +130,7 @@ public class LinkedAccountsResource {
         // TODO: remove this statement once the console and the LinkedAccountsRestServiceTest are updated - this is only here for backwards compatibility
         if (linked == null) {
             List<LinkedAccountRepresentation> linkedAccounts = getLinkedAccounts(this.session, this.realm, this.user);
-            return Cors.builder().auth().allowedOrigins(auth.getToken()).add(Response.ok(linkedAccounts));
+            return Cors.builder().auth().checkAllowedOrigins(auth.getToken()).add(Response.ok(linkedAccounts));
         }
 
         List<LinkedAccountRepresentation> linkedAccounts;
@@ -158,7 +158,7 @@ public class LinkedAccountsResource {
                     .map(idp -> this.toLinkedAccount(idp, null, null))
                     .toList();
         }
-        return Cors.builder().auth().allowedOrigins(auth.getToken()).add(Response.ok(linkedAccounts));
+        return Cors.builder().auth().checkAllowedOrigins(auth.getToken()).add(Response.ok(linkedAccounts));
     }
 
     private LinkedAccountRepresentation toLinkedAccount(IdentityProviderModel provider, String fedIdentity, Set<IdentityProviderShowInAccountConsole> includedShowInAccountConsoleValues) {
@@ -274,7 +274,7 @@ public class LinkedAccountsResource {
         try {
             AccountLinkUriRepresentation rep = BrokerUtil.createClientInitiatedLinkURI(ACCOUNT_CONSOLE_CLIENT_ID, redirectUri, providerAlias, realm.getName(), auth.getSession().getId(), this.session.getContext().getUri().getBaseUri());
 
-            return Cors.builder().auth().allowedOrigins(auth.getToken()).add(Response.ok(rep));
+            return Cors.builder().auth().checkAllowedOrigins(auth.getToken()).add(Response.ok(rep));
         } catch (Exception spe) {
             spe.printStackTrace();
             throw ErrorResponse.error(Messages.FAILED_TO_PROCESS_RESPONSE, Response.Status.INTERNAL_SERVER_ERROR);
@@ -320,7 +320,7 @@ public class LinkedAccountsResource {
                 .detail(Details.IDENTITY_PROVIDER_USERNAME, link.getUserName())
                 .success();
 
-        return Cors.builder().auth().allowedOrigins(auth.getToken()).add(Response.noContent());
+        return Cors.builder().auth().checkAllowedOrigins(auth.getToken()).add(Response.noContent());
     }
 
     private String checkCommonPreconditions(String providerAlias) {

--- a/services/src/main/java/org/keycloak/services/resources/account/OrganizationsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/OrganizationsResource.java
@@ -54,7 +54,7 @@ public class OrganizationsResource {
     public Response getOrganizations() {
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);
         return Cors.builder().auth()
-                .allowedOrigins(auth.getToken())
+                .checkAllowedOrigins(auth.getToken())
                 .add(Response.ok(session.getProvider(OrganizationProvider.class)
                         .getByMember(user)
                         .map(this::toRepresentation))

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminConsole.java
@@ -262,7 +262,7 @@ public class AdminConsole {
         Locale locale = session.getContext().resolveLocale(user);
 
         return Cors.builder()
-                .allowedOrigins(authResult.token())
+                .checkAllowedOrigins(authResult.token())
                 .allowedMethods("GET")
                 .auth()
                 .add(Response.ok(new WhoAmI(user.getId(), realm.getName(), displayName, createRealm, realmAccess, locale, Boolean.parseBoolean(user.getFirstAttribute(IS_TEMP_ADMIN_ATTR_NAME)))));

--- a/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AdminRoot.java
@@ -248,7 +248,7 @@ public class AdminRoot {
             }
         }
 
-        Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").exposedHeaders("Location").auth().add();
+        Cors.builder().checkAllowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").exposedHeaders("Location").auth().add();
 
         return new RealmsAdminResource(session, auth, tokenManager);
     }
@@ -292,7 +292,7 @@ public class AdminRoot {
             logger.debugf("authenticated admin access for: %s", auth.getUser().getUsername());
         }
 
-        Cors.builder().allowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
+        Cors.builder().checkAllowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
 
         return new ServerInfoAdminResource(session, auth);
     }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractHttpPostRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractHttpPostRequest.java
@@ -61,7 +61,10 @@ public abstract class AbstractHttpPostRequest<T, R> {
     public R send() {
         post = new HttpPost(endpoint != null ? endpoint : getEndpoint());
         post.addHeader("Accept", getAccept());
-        post.addHeader("Origin", client.config().getOrigin());
+        String origin = client.config().getOrigin();
+        if (origin != null) {
+            post.addHeader("Origin", origin);
+        }
 
         authorization();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutCorsTest.java
@@ -55,6 +55,7 @@ public class LogoutCorsTest extends AbstractKeycloakTest {
     @Before
     public void clientConfiguration() {
         ClientManager.realm(adminClient.realm("test")).clientId("test-app").addWebOrigins(VALID_CORS_URL);
+        oauth.origin(null);
     }
 
     @Override
@@ -83,7 +84,7 @@ public class LogoutCorsTest extends AbstractKeycloakTest {
         oauth.origin(INVALID_CORS_URL);
 
         LogoutResponse response = oauth.doLogout(refreshTokenString);
-        assertTrue(response.isSuccess());
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertNotCors(response);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenEndpointCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenEndpointCorsTest.java
@@ -50,6 +50,7 @@ public class TokenEndpointCorsTest extends AbstractKeycloakTest {
         testRealms.add(realm);
     }
 
+
     @Test
     public void preflightRequest() throws Exception {
         Map<String, String> responseHeaders = getTokenEndpointPreflightResponseHeaders(oauth);
@@ -83,9 +84,9 @@ public class TokenEndpointCorsTest extends AbstractKeycloakTest {
 
         // Invalid origin
         oauth.origin(INVALID_CORS_URL);
-        response = oauth.doRefreshTokenRequest(response.getRefreshToken());
-        assertEquals(200, response.getStatusCode());
-        assertNotCors(response);
+        AccessTokenResponse invalidOriginResponse = oauth.doRefreshTokenRequest(response.getRefreshToken());
+        assertEquals(403, invalidOriginResponse.getStatusCode());
+        assertNotCors(invalidOriginResponse);
         oauth.origin(VALID_CORS_URL);
 
         // No session
@@ -139,7 +140,7 @@ public class TokenEndpointCorsTest extends AbstractKeycloakTest {
         // Successful token request with bad origin - cors should NOT work
         oauth.origin(INVALID_CORS_URL);
         response = oauth.doPasswordGrantRequest("test-user@localhost", "password");
-        assertEquals(200, response.getStatusCode());
+        assertEquals(403, response.getStatusCode());
         assertNotCors(response);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenRevocationCorsTest.java
@@ -54,6 +54,7 @@ public class TokenRevocationCorsTest extends AbstractKeycloakTest {
         testRealms.add(realm);
     }
 
+
     @Test
     public void testTokenRevocationCorsRequestWithValidUrl() throws Exception {
         oauth.realm("test");
@@ -80,10 +81,8 @@ public class TokenRevocationCorsTest extends AbstractKeycloakTest {
 
         oauth.origin(INVALID_CORS_URL);
         TokenRevocationResponse response = oauth.tokenRevocationRequest(tokenResponse.getRefreshToken()).refreshToken().send();
-        assertTrue(response.isSuccess());
+        assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatusCode());
         assertNotCors(response);
-
-        isTokenDisabled(tokenResponse);
     }
 
     private static void assertCors(TokenRevocationResponse response) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/UserInfoEndpointCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/UserInfoEndpointCorsTest.java
@@ -36,6 +36,7 @@ public class UserInfoEndpointCorsTest extends AbstractKeycloakTest {
         testRealms.add(realm);
     }
 
+
     @Test
     public void userInfoCorsValidRequestWithValidUrl() throws Exception {
 
@@ -108,7 +109,7 @@ public class UserInfoEndpointCorsTest extends AbstractKeycloakTest {
                     .header("Origin", INVALID_CORS_URL) // manually trigger CORS handling
                     .get();
 
-            UserInfoClientUtil.testSuccessfulUserInfoResponse(userInfoResponse, "test-user@localhost", "test-user@localhost");
+            assertEquals(Response.Status.FORBIDDEN.getStatusCode(), userInfoResponse.getStatus());
 
             assertNotCors(userInfoResponse);
         } finally {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
@@ -1224,12 +1224,8 @@ public class ParTest extends AbstractClientPoliciesTest {
             oauth.redirectUri(VALID_CORS_URL + "/realms/master/app");
             oauth.origin(INVALID_CORS_URL);
             ParResponse pResp = oauth.doPushedAuthorizationRequest();
-            assertEquals(201, pResp.getStatusCode());
+            assertEquals(403, pResp.getStatusCode());
             assertNotCors(pResp);
-            String requestUri = pResp.getRequestUri();
-
-            doNormalAuthzProcess(requestUri, VALID_CORS_URL + "/realms/master/app", clientId, clientSecret);
-
         } finally {
             oauth.origin(null);
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCCredentialOfferCorsTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oid4vc/issuance/signing/OID4VCCredentialOfferCorsTest.java
@@ -138,8 +138,7 @@ public class OID4VCCredentialOfferCorsTest extends OID4VCIssuerEndpointTest {
                 .preAuthorized(false)
                 .send();
 
-        // Should still return 200 OK but without CORS headers
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
         assertNoCorsHeaders(response);
     }
 


### PR DESCRIPTION
Closes  #45957 

This PR chnages CORS handling from late response to early request validation for endpoints that already know their allowed origins.

Before this change, and invalid Origin could still reach the endpoint logic and trigger work, with CORS only failing later when response header were added. After this change, request with an invalid Origin are rejected immediatly with 403, before endpoint logic runs


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
