### PR TITLE
[quarkus-next] Adapt LoggingDistTest to Quarkus access log masking an…

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/LoggingDistTest.java
@@ -386,7 +386,8 @@ public class LoggingDistTest {
         cliResult.assertStartedDevMode();
         cliResult.assertMessage("opentelemetry");
         cliResult.assertMessage("service.name=\"keycloak\"");
-        cliResult.assertMessage("Failed to export LogsRequestMarshaler.");
+        cliResult.assertMessage("Failed to export");
+        cliResult.assertMessage("error message: Connection refused");
     }
 
     @Test
@@ -443,10 +444,10 @@ public class LoggingDistTest {
 
         // Verify that sensitive cookie values are masked in the access log
         cliResult.assertMessage("[org.keycloak.http.access-log]");
-        cliResult.assertMessage("Authorization: Bearer ...");
-        cliResult.assertMessage("Authorization: DPoP ...");
+        cliResult.assertMessage("Authorization: Bearer <hidden>");
+        cliResult.assertMessage("Authorization: DPoP <hidden>");
         cliResult.assertMessage("Cookie: SOMETHING=something-not-sensitive");
         cliResult.assertMessage("Content-Language: cs");
-        HttpAccessLogOptions.DEFAULT_HIDDEN_COOKIES.forEach(cookie -> cliResult.assertMessage("Cookie: %s=...".formatted(cookie)));
+        HttpAccessLogOptions.DEFAULT_HIDDEN_COOKIES.forEach(cookie -> cliResult.assertMessage("Cookie: %s=<hidden>".formatted(cookie)));
     }
 }


### PR DESCRIPTION
…d OTel sender changes

This deliberately targets `quakus-next`, hence it does not close its parent issue and should not be merged to `main` earlier than `3.34.0.CR1`/`3.35.0.CR1`.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
