### PR TITLE
Return 400 instead of 500 when role update has no name

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
@@ -164,6 +164,7 @@ public class RoleByIdResource extends RoleResource {
     @Operation(summary = "Update the role")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
     public void updateRole(final @Parameter(description = "id of role") @PathParam("role-id") String id, final RoleRepresentation rep) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -322,6 +322,7 @@ public class RoleContainerResource extends RoleResource {
     @Operation(summary = "Update a role by name")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
         @APIResponse(responseCode = "403", description = "Forbidden"),
         @APIResponse(responseCode = "404", description = "Not Found"),
         @APIResponse(responseCode = "409", description = "Conflict")

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.UriInfo;
 
@@ -62,6 +63,9 @@ public abstract class RoleResource {
     protected void updateRole(RoleRepresentation rep, RoleModel role, RealmModel realm,
             KeycloakSession session) {
         String newName = rep.getName();
+        if (newName == null) {
+            throw new BadRequestException("role has no name");
+        }
         String previousName = role.getName();
         if (!Objects.equals(previousName, newName)) {
             role.setName(newName);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
@@ -143,6 +143,15 @@ public class RoleByIdResourceTest {
     }
 
     @Test
+    public void updateRoleWithoutNameReturnsBadRequest() {
+        RoleRepresentation update = new RoleRepresentation();
+        update.setDescription("Role A updated description");
+
+        String id = roleIds.get(roleNameA);
+        assertThrows(BadRequestException.class, () -> resource.updateRole(id, update));
+    }
+
+    @Test
     @DatabaseTest
     public void deleteRole() {
         assertNotNull(resource.getRole(roleIds.get(roleNameA)));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmRolesCRUDTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmRolesCRUDTest.java
@@ -91,6 +91,17 @@ public class RealmRolesCRUDTest extends AbstractRealmRolesTest {
     }
 
     @Test
+    public void updateRoleWithoutNameReturnsBadRequest() {
+        RoleResource roleResource = managedRealm.admin().roles().get("role-a");
+
+        RoleRepresentation update = new RoleRepresentation();
+        update.setDescription("Role A updated description");
+        update.setAttributes(Collections.singletonMap("attrKey", Collections.singletonList("attrValue")));
+
+        Assertions.assertThrows(BadRequestException.class, () -> roleResource.update(update));
+    }
+
+    @Test
     public void deleteRole() {
         assertNotNull(managedRealm.admin().roles().get("role-a"));
         managedRealm.admin().roles().deleteRole("role-a");


### PR DESCRIPTION
## Problem

`PUT /admin/realms/{realm}/roles/{role-name}` and `PUT /admin/realms/{realm}/roles-by-id/{role-id}` return **500 Internal Server Error** with an unhelpful `NullPointerException` stack trace when the request body omits the `name` field:

    java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:233)
        at org.keycloak.models.cache.infinispan.events.RoleUpdatedEvent.<init>(RoleUpdatedEvent.java:42)
        ...
        at org.keycloak.models.cache.infinispan.RoleAdapter.setName(RoleAdapter.java:117)
        at org.keycloak.services.resources.admin.RoleResource.updateRole(RoleResource.java:67)

## Root Cause

In the shared protected `RoleResource.updateRole(...)`, when `rep.getName()` is `null`, the rename branch still executes (`Objects.equals(previousName, null)` is `false`). `RoleAdapter.setName(null)` then propagates `null` into `RoleUpdatedEvent`, whose constructor uses `Objects.requireNonNull` and throws.

## Fix

Validate `rep.getName()` at the top of the shared helper and throw `BadRequestException("role has no name")` when `null`. This:

- Returns a clear **400** to the client instead of a confusing 500.
- Matches the validation already performed by `RoleContainerResource.createRole`, keeping create/update behavior symmetric.
- Covers both endpoints (`/roles/{name}` and `/roles-by-id/{id}`) via the single shared helper — no duplication.

Additionally:
- Documents the new `400` response in the `@APIResponses` OpenAPI annotations on both endpoints.
- Adds two tests (`RealmRolesCRUDTest#updateRoleWithoutNameReturnsBadRequest` and `RoleByIdResourceTest#updateRoleWithoutNameReturnsBadRequest`) to prevent regressions on either path.


Closes #48459
