### PR TITLE
Warn when running in a container without being PID 1

### DIFF
--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -67,9 +67,7 @@ do
           OPT=$(esceval "$1")
           case "$1" in
             -D*) SERVER_OPTS="$SERVER_OPTS ${OPT}";;
-            -*) CONFIG_ARGS="$CONFIG_ARGS ${OPT}";;
             *) CONFIG_ARGS="$CONFIG_ARGS ${OPT}"
-               [ -z "$KC_CMD" ] && KC_CMD="$1"
                ;;
           esac
           ;;
@@ -155,17 +153,13 @@ esceval_args() {
 
 JAVA_RUN_OPTS=$(echo "$JAVA_OPTS" | xargs printf '%s\n' | esceval_args)
 
+# Capture the pid so that we can wWarn if running in a container without being PID 1, as signals may not be forwarded correctly and graceful shutdown may not work
 # The property 'java.util.concurrent.ForkJoinPool.common.threadFactory' is set here, as a Java Agent or enabling JMX might initialize the factory before Quarkus can set the property in JDK21+.
-JAVA_RUN_OPTS="-Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory $JAVA_RUN_OPTS $SERVER_OPTS -cp $CLASSPATH_OPTS io.quarkus.bootstrap.runner.QuarkusEntryPoint ${CONFIG_ARGS#?}"
+JAVA_RUN_OPTS="-Dkc.script.pid=$$ -Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory $JAVA_RUN_OPTS $SERVER_OPTS -cp $CLASSPATH_OPTS io.quarkus.bootstrap.runner.QuarkusEntryPoint ${CONFIG_ARGS#?}"
 
 if [ "$PRINT_ENV" = "true" ]; then
   echo "Using JAVA_OPTS: $JAVA_OPTS"
   echo "Using JAVA_RUN_OPTS: $JAVA_RUN_OPTS"
-fi
-
-# Warn if running in a container without being PID 1, as signals may not be forwarded correctly and graceful shutdown may not work
-if [ "$KC_RUN_IN_CONTAINER" = "true" ] && [ "$$" != "1" ] && { [ "$KC_CMD" = "start" ] || [ "$KC_CMD" = "start-dev" ]; }; then
-    echo "WARNING: Keycloak is running inside a container, but is not PID 1. Graceful shutdown may not work. Use 'exec' in your entrypoint script to ensure signals are forwarded correctly. See https://www.keycloak.org/server/containers for more details."
 fi
 
 # trap the signals that should be forwarded to the java process

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -153,7 +153,7 @@ esceval_args() {
 
 JAVA_RUN_OPTS=$(echo "$JAVA_OPTS" | xargs printf '%s\n' | esceval_args)
 
-# Capture the pid so that we can wWarn if running in a container without being PID 1, as signals may not be forwarded correctly and graceful shutdown may not work
+# Capture the pid so that we can warn if running in a container without being PID 1, as signals may not be forwarded correctly and graceful shutdown may not work
 # The property 'java.util.concurrent.ForkJoinPool.common.threadFactory' is set here, as a Java Agent or enabling JMX might initialize the factory before Quarkus can set the property in JDK21+.
 JAVA_RUN_OPTS="-Dkc.script.pid=$$ -Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory $JAVA_RUN_OPTS $SERVER_OPTS -cp $CLASSPATH_OPTS io.quarkus.bootstrap.runner.QuarkusEntryPoint ${CONFIG_ARGS#?}"
 

--- a/quarkus/dist/src/main/content/bin/kc.sh
+++ b/quarkus/dist/src/main/content/bin/kc.sh
@@ -67,7 +67,9 @@ do
           OPT=$(esceval "$1")
           case "$1" in
             -D*) SERVER_OPTS="$SERVER_OPTS ${OPT}";;
+            -*) CONFIG_ARGS="$CONFIG_ARGS ${OPT}";;
             *) CONFIG_ARGS="$CONFIG_ARGS ${OPT}"
+               [ -z "$KC_CMD" ] && KC_CMD="$1"
                ;;
           esac
           ;;
@@ -159,6 +161,11 @@ JAVA_RUN_OPTS="-Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quark
 if [ "$PRINT_ENV" = "true" ]; then
   echo "Using JAVA_OPTS: $JAVA_OPTS"
   echo "Using JAVA_RUN_OPTS: $JAVA_RUN_OPTS"
+fi
+
+# Warn if running in a container without being PID 1, as signals may not be forwarded correctly and graceful shutdown may not work
+if [ "$KC_RUN_IN_CONTAINER" = "true" ] && [ "$$" != "1" ] && { [ "$KC_CMD" = "start" ] || [ "$KC_CMD" = "start-dev" ]; }; then
+    echo "WARNING: Keycloak is running inside a container, but is not PID 1. Graceful shutdown may not work. Use 'exec' in your entrypoint script to ensure signals are forwarded correctly. See https://www.keycloak.org/server/containers for more details."
 fi
 
 # trap the signals that should be forwarded to the java process

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/Environment.java
@@ -38,7 +38,9 @@ import io.smallrye.config.SmallRyeConfig;
 
 public final class Environment {
 
+    public static final String KC_RUN_IN_CONTAINER = "KC_RUN_IN_CONTAINER";
     public static final String KC_CONFIG_REBUILD_CHECK = "kc.config.rebuild-check";
+    public static final String KC_SCRIPT_PID = "kc.script.pid";
     public static final String KC_CONFIG_BUILT = "kc.config.built";
     public static final String KC_HOME_DIR = "kc.home.dir";
     public static final String PROFILE ="kc.profile";
@@ -208,5 +210,16 @@ public final class Environment {
 
     public static void setRebuild() {
         System.setProperty("quarkus.launch.rebuild", "true");
+    }
+    
+    /**
+     * The process id of the script used to launch the server. Will be null if a script other than kc.sh is used
+     */
+    public static Optional<String> getScriptPid() {
+        return Optional.ofNullable(System.getProperty(KC_SCRIPT_PID));
+    }
+    
+    public static boolean isRunInContainer() {
+        return Configuration.getOptionalBooleanKcValue("run-in-container").orElse(false);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/Picocli.java
@@ -352,7 +352,7 @@ public class Picocli {
                 if (newValue == null || oldValue == null) {
                     changed = true;
                 } else if (!warnedTimestampChanged && timestampChanged(oldValue, newValue)) {
-                    if (Configuration.getOptionalBooleanKcValue("run-in-container").orElse(false)) {
+                    if (Environment.isRunInContainer()) {
                         warnedTimestampChanged = true;
                         warn(PROVIDER_TIMESTAMP_WARNING);
                     } else {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractAutoBuildCommand.java
@@ -101,6 +101,9 @@ public abstract class AbstractAutoBuildCommand extends AbstractCommand {
 
     @Override
     protected void runCommand() {
+        if (isServing() && Environment.isRunInContainer() && Environment.getScriptPid().filter(v -> !v.equals("1")).isPresent()) {
+            picocli.warn("Keycloak is running inside a container, but is not PID 1. Graceful shutdown may not work. Use 'exec' in your entrypoint script to ensure signals are forwarded correctly. See https://www.keycloak.org/server/containers for more details.");
+        }
         doBeforeRun();
         validateConfig();
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/HttpPropertyMappers.java
@@ -71,7 +71,7 @@ public final class HttpPropertyMappers implements PropertyMapperGrouping {
             return value;
         }
         // account for modes that always need to be all interfaces
-        if (Boolean.parseBoolean(System.getenv("KC_RUN_IN_CONTAINER")) || LaunchMode.current().isRemoteDev()
+        if (Environment.isRunInContainer() || LaunchMode.current().isRemoteDev()
                 || isWSL()) {
             return "0.0.0.0";
         }

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -572,7 +572,7 @@ public class PicocliTest extends AbstractConfigurationTest {
     public void warnProviderChanged() {
         build("build", "--db=dev-file");
 
-        putEnvVar("KC_RUN_IN_CONTAINER", "true");
+        putEnvVar(Environment.KC_RUN_IN_CONTAINER, "true");
         String key = PersistedConfigSource.getInstance().getConfigValueProperties().keySet().stream().filter(k -> k.startsWith(Picocli.KC_PROVIDER_FILE_PREFIX)).findAny().orElseThrow();
         addPersistedConfigValues(Map.of(key, "1")); // change to a fake timestamp
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
@@ -21,6 +21,7 @@ import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.DryRun;
 import org.keycloak.it.junit5.extension.RawDistOnly;
 import org.keycloak.it.junit5.extension.WithEnvVars;
+import org.keycloak.quarkus.runtime.Environment;
 
 import io.quarkus.test.junit.main.Launch;
 import io.quarkus.test.junit.main.LaunchResult;
@@ -128,6 +129,7 @@ public class JavaOptsScriptTest {
     @WithEnvVars({"KC_RUN_IN_CONTAINER", "true"})
     @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "kc.sh is not used on Windows")
     void testContainerNonPid1Warning(LaunchResult result) {
+        assertThat(result.getOutput(), containsString("-D" + Environment.KC_SCRIPT_PID));
         assertThat(result.getOutput(), containsString("WARNING: Keycloak is running inside a container, but is not PID 1."));
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java
@@ -123,6 +123,29 @@ public class JavaOptsScriptTest {
         assertThat(output, containsString("DefaultFactory: groovy Closures in annotations are disabled and will not be loaded"));
     }
 
+    @Test
+    @Launch({"start", "--optimized"})
+    @WithEnvVars({"KC_RUN_IN_CONTAINER", "true"})
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "kc.sh is not used on Windows")
+    void testContainerNonPid1Warning(LaunchResult result) {
+        assertThat(result.getOutput(), containsString("WARNING: Keycloak is running inside a container, but is not PID 1."));
+    }
+
+    @Test
+    @Launch({"start", "--optimized"})
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "kc.sh is not used on Windows")
+    void testNoContainerNonPid1Warning(LaunchResult result) {
+        assertThat(result.getOutput(), not(containsString("WARNING: Keycloak is running inside a container")));
+    }
+
+    @Test
+    @Launch({"export", "--dir", "/tmp"})
+    @WithEnvVars({"KC_RUN_IN_CONTAINER", "true"})
+    @EnabledOnOs(value = { OS.LINUX, OS.MAC }, disabledReason = "kc.sh is not used on Windows")
+    void testContainerNonPid1WarningAbsentForNonServerCommands(LaunchResult result) {
+        assertThat(result.getOutput(), not(containsString("WARNING: Keycloak is running inside a container")));
+    }
+
     @EnabledOnOs(value = { OS.WINDOWS }, disabledReason = "different path behaviour on Windows.")
     @Test
     @Launch({"start-dev", "--optimized"})


### PR DESCRIPTION
## Summary

When `KC_RUN_IN_CONTAINER=true` but the Keycloak process is not PID 1, graceful shutdown may fail silently because signals such as `SIGTERM` are not forwarded correctly. This can lead to cache inconsistencies or data loss.

This change adds a startup warning in `kc.sh` to alert users to use `exec` in their entrypoint scripts, with a link to the existing container documentation that already describes the correct approach. The warning is only emitted for server commands (`start`, `start-dev`) and is skipped for non-server commands such as `import`, `export`, and `bootstrap-admin`.

## Changes

- `quarkus/dist/src/main/content/bin/kc.sh` — added PID 1 check with warning message printed at startup when running in a container without being PID 1; command detection refined to identify the first non-flag argument so that flags like `-v` or `-cf` preceding the subcommand are handled correctly
- `quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/JavaOptsScriptTest.java` — added three tests covering the presence and absence of the warning

## Test plan

- [x] `testContainerNonPid1Warning` — asserts warning appears when `KC_RUN_IN_CONTAINER=true` and command is `start`
- [x] `testNoContainerNonPid1Warning` — asserts warning is absent when env var is not set
- [x] `testContainerNonPid1WarningAbsentForNonServerCommands` — asserts warning is absent for non-server commands (e.g. `export`)
- [x] All existing `JavaOptsScriptTest` tests pass
- [x] `spotless:check` passes

## Notes

Claude Code was used to assist in writing the code, tests, and PR description for this contribution. All changes have been reviewed and are fully understood by the author.

Closes #48059
