### PR TITLE
Upgrade webauthn4j to 0.30.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,8 +227,7 @@
         </testframework.surefire.args>
 
         <!-- webauthn support -->
-        <webauthn4j.version>0.29.3.RELEASE</webauthn4j.version>
-        <org.apache.kerby.kerby-asn1.version>2.0.3</org.apache.kerby.kerby-asn1.version>
+        <webauthn4j.version>0.30.3.RELEASE</webauthn4j.version>
 
         <!-- Used to test SAML Galleon feature-pack layers discovery -->
         <version.org.wildfly.glow>1.0.0.Alpha8</version.org.wildfly.glow>
@@ -1212,11 +1211,6 @@
                 <groupId>com.webauthn4j</groupId>
                 <artifactId>webauthn4j-util</artifactId>
                 <version>${webauthn4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kerby</groupId>
-                <artifactId>kerby-asn1</artifactId>
-                <version>${org.apache.kerby.kerby-asn1.version}</version>
             </dependency>
 
             <!-- used in server-dist build while provisioning the distribution -->

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -514,16 +514,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.kerby</groupId>
-            <artifactId>kerby-asn1</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <exclusions>

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -170,7 +170,7 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
 
         Origin origin = new Origin(baseUrl);
         Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
-        ServerProperty server = new ServerProperty(origin, rpId, challenge, null);
+        ServerProperty server = new ServerProperty(origin, rpId, challenge);
 
         byte[] credentialId = Base64Url.decode(params.getFirst(WebAuthnConstants.CREDENTIAL_ID));
         byte[] clientDataJSON = Base64Url.decode(params.getFirst(WebAuthnConstants.CLIENT_DATA_JSON));

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -247,7 +247,7 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                 .collect(Collectors.toSet());
         allOrigins.add(origin);
         Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
-        ServerProperty serverProperty = new ServerProperty(allOrigins, rpId, challenge, null);
+        ServerProperty serverProperty = new ServerProperty(allOrigins, rpId, challenge);
         // check User Verification by considering a malicious user might modify the result of calling WebAuthn API
         boolean isUserVerificationRequired = policy.getUserVerificationRequirement().equals(Constants.WEBAUTHN_POLICY_OPTION_REQUIRED);
 


### PR DESCRIPTION
- Closes #48420
- Upgrade to the `webauthn4j` 0.30.3
- Contains minimum changes - more wider work can be followed to get rid of deprecations
- The latest release 0.31.3 requires Jackson version 3, and we're not there yet - IMHO, we should plan it for Keycloak 27.0.0
- Remove unnecessary `kerby-asn1` dependency (it was required in version [0.27.0](https://mvnrepository.com/artifact/com.webauthn4j/webauthn4j-core/0.27.0.RELEASE/dependencies), but not anymore in version [0.30.3](https://mvnrepository.com/artifact/com.webauthn4j/webauthn4j-core/0.30.3.RELEASE/dependencies))
- previous versions of the artifact exist in the PNC, but the new one needs to be productized (cc: @pskopek)

cc: @keycloak/core-authn 
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
