### PR TITLE
[OID4VCI-FAPI2] Improved error messages in ConfidentialClientAcceptExecutor

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ConfidentialClientAcceptExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ConfidentialClientAcceptExecutor.java
@@ -58,13 +58,13 @@ public class ConfidentialClientAcceptExecutor implements ClientPolicyExecutorPro
     private void checkIsConfidentialClient() throws ClientPolicyException {
         ClientModel client = session.getContext().getClient();
         if (client == null) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "invalid client access type");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "no client in context");
         }
         if (client.isPublicClient()) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "invalid client access type");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "invalid client access type: public");
         }
         if (client.isBearerOnly()) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "invalid client access type");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_CLIENT, "invalid client access type: bearer only");
         }
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -2348,7 +2348,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
         AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(username).bindingMessage(bindingMessage).additionalParams(additionalParameters).send();
         assertThat(response.getStatusCode(), is(equalTo(400)));
         assertThat(response.getError(), is(OAuthErrorException.INVALID_CLIENT));
-        assertThat(response.getErrorDescription(), is("invalid client access type"));
+        assertThat(response.getErrorDescription(), is("invalid client access type: public"));
 
         String clientConfidentialId = generateSuffixedName("confidential-app");
         String clientConfidentialSecret = "app-secret";
@@ -2376,7 +2376,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
         AccessTokenResponse tokenRes = oauth.ciba().doBackchannelAuthenticationTokenRequest(response.getAuthReqId());
         assertThat(tokenRes.getStatusCode(), is(equalTo(400)));
         assertThat(tokenRes.getError(), is(OAuthErrorException.INVALID_GRANT));
-        assertThat(tokenRes.getErrorDescription(), is("invalid client access type"));
+        assertThat(tokenRes.getErrorDescription(), is("invalid client access type: public"));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
@@ -347,7 +347,7 @@ public class FAPI1Test extends AbstractFAPITest {
 
         // Should not be possible to login anymore with public client
         oauth.loginForm().nonce("123456").codeChallenge(pkceGenerator).open();
-        assertRedirectedToClientWithError(OAuthErrorException.INVALID_CLIENT, "invalid client access type");
+        assertRedirectedToClientWithError(OAuthErrorException.INVALID_CLIENT, "invalid client access type: public");
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -752,7 +752,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         oauth.client(clientPublicId);
         oauth.openLoginForm();
         assertEquals(OAuthErrorException.INVALID_CLIENT, oauth.parseLoginResponse().getError());
-        assertEquals("invalid client access type", oauth.parseLoginResponse().getErrorDescription());
+        assertEquals("invalid client access type: public", oauth.parseLoginResponse().getErrorDescription());
     }
 
     @Test


### PR DESCRIPTION
closes #48504
