### PR TITLE
Conditional modal for passkeys platform authenticator

### DIFF
--- a/docs/documentation/server_admin/topics/authentication/passkeys.adoc
+++ b/docs/documentation/server_admin/topics/authentication/passkeys.adoc
@@ -82,6 +82,8 @@ The *Passkey Mediation* setting in the *WebAuthn Passwordless Policy* controls h
 [NOTE]
 ====
 The behavior of the `mediation` option, although defined in the specification, can vary between browsers and authenticators. {project_name} simply passes this option during the registration process. The actual final behavior is beyond its control. For example, the support for `required` and `silent` mediation are known to be different among browsers. Refer to your target browser's documentation before relying on these values in production.
+
+When the *Authenticator Attachment* in the policy is set to `platform` and the device does not have a user-verifying platform authenticator available, the automatic passkey flow on page load is skipped regardless of the mediation value. The user can still authenticate using the *Sign in with Passkey* button or fall back to password login.
 ====
 
 ==== Setup

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -121,6 +121,7 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
         form.setAttribute(WebAuthnConstants.USER_VERIFICATION, userVerificationRequirement);
         form.setAttribute(WebAuthnConstants.SHOULD_DISPLAY_AUTHENTICATORS, shouldDisplayAuthenticators(context));
         form.setAttribute(WebAuthnConstants.MEDIATION, policy.getMediation());
+        form.setAttribute(WebAuthnConstants.AUTHENTICATOR_ATTACHMENT, policy.getAuthenticatorAttachment());
 
         return form;
     }

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/passwordless/PasskeysUsernameFormTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/passwordless/PasskeysUsernameFormTest.java
@@ -223,6 +223,33 @@ public class PasskeysUsernameFormTest extends AbstractWebAuthnVirtualTest {
                     .details(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true");
 
             logout();
+            events.clear();
+
+            // set authenticatorAttachment to platform with modal mediation;
+            // no platform authenticator is available so the modal must not be shown
+            managedRealm.updateWithCleanup(r -> r.webAuthnPolicyPasswordlessAuthenticatorAttachment("platform")
+                    .webAuthnPolicyPasswordlessMediation("optional"));
+
+            oAuthClient.openLoginForm();
+
+            loginPage.assertCurrent();
+            MatcherAssert.assertThat(loginPage.getUsernameAutocomplete(), Matchers.is("username webauthn"));
+            MatcherAssert.assertThat(driver.findElement(By.xpath("//form[@id='webauth']")), Matchers.notNullValue());
+
+            // no modal was shown, force login using webauthn link
+            webAuthnLoginPage.clickAuthenticate();
+            Assertions.assertNotNull(oAuthClient.parseLoginResponse().getCode());
+
+            EventAssertion.assertSuccess(events.poll())
+                    .type(EventType.LOGIN)
+                    .hasSessionId()
+                    .userId(user.getId())
+                    .isCodeId()
+                    .details(Details.USERNAME, user.getUsername())
+                    .details(Details.CREDENTIAL_TYPE, WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                    .details(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true");
+
+            logout();
         }
     }
 

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/passwordless/PasskeysUsernamePasswordFormTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/passwordless/PasskeysUsernamePasswordFormTest.java
@@ -200,6 +200,33 @@ public class PasskeysUsernamePasswordFormTest extends AbstractWebAuthnVirtualTes
                     .details(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true");
 
             logout();
+            events.clear();
+
+            // set authenticatorAttachment to platform with modal mediation;
+            // no platform authenticator is available so the modal must not be shown
+            managedRealm.updateWithCleanup(r -> r.webAuthnPolicyPasswordlessAuthenticatorAttachment("platform")
+                    .webAuthnPolicyPasswordlessMediation("optional"));
+
+            oAuthClient.openLoginForm();
+
+            loginPage.assertCurrent();
+            MatcherAssert.assertThat(loginPage.getUsernameAutocomplete(), Matchers.is("username webauthn"));
+            MatcherAssert.assertThat(driver.findElement(By.xpath("//form[@id='webauth']")), Matchers.notNullValue());
+
+            // no modal was shown, force login using webauthn link
+            webAuthnLoginPage.clickAuthenticate();
+            Assertions.assertNotNull(oAuthClient.parseLoginResponse().getCode());
+
+            EventAssertion.assertSuccess(events.poll())
+                    .type(EventType.LOGIN)
+                    .hasSessionId()
+                    .userId(user.getId())
+                    .isCodeId()
+                    .details(Details.USERNAME, user.getUsername())
+                    .details(Details.CREDENTIAL_TYPE, WebAuthnCredentialModel.TYPE_PASSWORDLESS)
+                    .details(WebAuthnConstants.USER_VERIFICATION_CHECKED, "true");
+
+            logout();
         }
     }
 

--- a/themes/src/main/resources/theme/base/login/passkeys.ftl
+++ b/themes/src/main/resources/theme/base/login/passkeys.ftl
@@ -27,6 +27,7 @@
                rpId : ${rpId?c},
                createTimeout : ${createTimeout?c},
                mediation : ${(mediation!'conditional')?c},
+               authenticatorAttachment : ${authenticatorAttachment?c},
            };
 
            document.addEventListener("DOMContentLoaded", (event) => initAuthenticate({errmsg : ${msg("passkey-unsupported-browser-text")?c}, ...args}));

--- a/themes/src/main/resources/theme/base/login/resources/js/passkeysConditionalAuth.js
+++ b/themes/src/main/resources/theme/base/login/resources/js/passkeysConditionalAuth.js
@@ -42,6 +42,12 @@ export async function initAuthenticate(input, availableCallback = () => {}) {
         return;
     }
 
+    if (input.authenticatorAttachment === 'platform'
+            && !await PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()) {
+        availableCallback(false);
+        return;
+    }
+
     // The isConditionalMediationAvailable() check is only relevant for
     // conditional (autofill) mediation — other modes do not depend on it.
     if (mediation === 'conditional') {


### PR DESCRIPTION
- Closes #29558
- As mentioned in the https://github.com/keycloak/keycloak/pull/46960#issuecomment-4303358476, for better UX, we could leverage the `isUserVerifyingPlatformAuthenticatorAvailable()`
- if only 'platform' authenticators can be accepted, the check is executed to find out if there's some available authenticator - if not, we don't need to show the modal whatsoever
- It prevents the bad UX when the modal is shown, but we know from the start it will not succeed

#### Other considerations
- @mposolda mentioned [here](https://github.com/keycloak/keycloak/issues/29558#issuecomment-3211036171) some other use cases, like behavior in the account console - those can be done as follow-ups
- as we added the support for different mediations recently ('optional'), it's the right time to be more opinionated, and do these changes, as it should not break any existing stuff
- not hiding the 'Sign in with passkeys' button for now, even though we know it will probably not succeed (but maybe the user can allow it somehow on their device, so keeping it there now - WDYT?)

Demo: 
- Considering the `optional`, or `required` mediation
- When  `platform`+`cross-platform` are accepted, the modal is shown
- When only `platform` authenticators are accepted, and I don't have any on my computer, the modal is not shown


https://github.com/user-attachments/assets/afa0e307-289d-4b38-ab90-bb447c4af3c0

@keycloak/core-authn @rmartinc @dasniko Could you please check this simple PR? Thanks!