### PR TITLE
Add custom client target to organization invites

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -125,6 +125,15 @@ public interface OrganizationMembersResource {
                         @FormParam("lastName") String lastName);
 
     @POST
+    @Path("invite-user")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    Response inviteUser(@FormParam("email") String email,
+                        @FormParam("firstName") String firstName,
+                        @FormParam("lastName") String lastName,
+                        @QueryParam("client_id") String clientId,
+                        @QueryParam("redirect_uri") String redirectUri);
+
+    @POST
     @Path("invite-existing-user")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     Response inviteExistingUser(@FormParam("id") String id);

--- a/js/libs/keycloak-admin-client/src/resources/organizations.ts
+++ b/js/libs/keycloak-admin-client/src/resources/organizations.ts
@@ -128,10 +128,18 @@ export class Organizations extends Resource<{ realm?: string }> {
     urlParamKeys: ["userId"],
   });
 
-  public invite = this.makeUpdateRequest<{ orgId: string }, FormData>({
+  public invite = this.makeUpdateRequest<
+    { orgId: string; clientId?: string; redirectUri?: string },
+    FormData
+  >({
     method: "POST",
     path: "/{orgId}/members/invite-user",
     urlParamKeys: ["orgId"],
+    queryParamKeys: ["clientId", "redirectUri"],
+    keyTransform: {
+      clientId: "client_id",
+      redirectUri: "redirect_uri",
+    },
   });
 
   public inviteExistingUser = this.makeUpdateRequest<

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -52,6 +52,7 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ServicesLogger;
@@ -97,6 +98,10 @@ public class OrganizationInvitationResource {
     }
 
     public Response inviteUser(String email, String firstName, String lastName) {
+        return inviteUser(email, firstName, lastName, null, null);
+    }
+
+    public Response inviteUser(String email, String firstName, String lastName, String clientId, String redirectUri) {
         auth.orgs().requireManage();
 
         if (!organization.isEnabled()) {
@@ -111,6 +116,8 @@ public class OrganizationInvitationResource {
         if (!Validation.isEmailValid(email)) {
             throw ErrorResponse.error("Invalid email format", Status.BAD_REQUEST);
         }
+
+        InvitationTarget invitationTarget = resolveInvitationTarget(clientId, redirectUri);
 
         OrganizationProvider invitationProvider = session.getProvider(OrganizationProvider.class);
         InvitationManager invitationManager = invitationProvider.getInvitationManager();
@@ -131,7 +138,7 @@ public class OrganizationInvitationResource {
                 throw ErrorResponse.error("User already a member of the organization", Status.CONFLICT);
             }
 
-            return sendInvitation(user);
+            return sendInvitation(user, invitationTarget);
         }
 
         // Create temporary user for new registrations
@@ -143,7 +150,7 @@ public class OrganizationInvitationResource {
             user.setLastName(lastName);
         }
 
-        return sendInvitation(user);
+        return sendInvitation(user, invitationTarget);
     }
 
     public Response inviteExistingUser(String id) {
@@ -167,10 +174,10 @@ public class OrganizationInvitationResource {
             throw ErrorResponse.error("User does not have an email address", Status.BAD_REQUEST);
         }
 
-        return sendInvitation(user);
+        return sendInvitation(user, resolveInvitationTarget(null, null));
     }
 
-    private Response sendInvitation(UserModel user) {
+    private Response sendInvitation(UserModel user, InvitationTarget invitationTarget) {
         OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
         InvitationManager invitationManager = provider.getInvitationManager();
         // Create persistent invitation record
@@ -182,8 +189,8 @@ public class OrganizationInvitationResource {
         );
 
         String link = user.getId() == null ?
-            createRegistrationLink(user, invitation) :
-            createInvitationLink(user, invitation);
+            createRegistrationLink(user, invitation, invitationTarget) :
+            createInvitationLink(user, invitation, invitationTarget);
         invitation.setInviteLink(link);
 
         try {
@@ -205,46 +212,89 @@ public class OrganizationInvitationResource {
         return realm.getActionTokenGeneratedByAdminLifespan();
     }
 
-    private String createInvitationLink(UserModel user, OrganizationInvitationModel invitation) {
+    private String createInvitationLink(UserModel user, OrganizationInvitationModel invitation, InvitationTarget invitationTarget) {
         return LoginActionsService.actionTokenProcessor(session.getContext().getUri())
-                .queryParam("key", createToken(user, invitation))
+                .queryParam("key", createToken(user, invitation, invitationTarget))
                 .build(realm.getName()).toString();
     }
 
-    private String createRegistrationLink(UserModel user, OrganizationInvitationModel invitation) {
+    private String createRegistrationLink(UserModel user, OrganizationInvitationModel invitation, InvitationTarget invitationTarget) {
         return OIDCLoginProtocolService.registrationsUrl(session.getContext().getUri().getBaseUriBuilder())
                 .queryParam(OAuth2Constants.RESPONSE_TYPE, OIDCResponseType.CODE)
-                .queryParam(Constants.CLIENT_ID, Constants.ACCOUNT_MANAGEMENT_CLIENT_ID)
-                .queryParam(Constants.TOKEN, createToken(user, invitation))
+                .queryParam(Constants.CLIENT_ID, invitationTarget.clientId)
+                .queryParam(Constants.TOKEN, createToken(user, invitation, invitationTarget))
                 .buildFromMap(Map.of("realm", realm.getName(), "protocol", OIDCLoginProtocol.LOGIN_PROTOCOL)).toString();
     }
 
-    private String createToken(UserModel user, OrganizationInvitationModel invitation) {
-        InviteOrgActionToken token = new InviteOrgActionToken(user.getId(), invitation.getExpiresAt(), user.getEmail(), Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
+    private String createToken(UserModel user, OrganizationInvitationModel invitation, InvitationTarget invitationTarget) {
+        InviteOrgActionToken token = new InviteOrgActionToken(user.getId(), invitation.getExpiresAt(), user.getEmail(), invitationTarget.clientId);
 
         token.setOrgId(organization.getId());
         token.id(invitation.getId());
-
-        if (organization.getRedirectUrl() == null || organization.getRedirectUrl().isBlank()) {
-            token.setRedirectUri(resolveAccountClientBaseUrl());
-        } else {
-            token.setRedirectUri(organization.getRedirectUrl());
-        }
+        token.setRedirectUri(invitationTarget.redirectUri);
 
         return token.serialize(session, realm, session.getContext().getUri());
     }
 
-    private String resolveAccountClientBaseUrl() {
-        ClientModel accountClient = realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
+    private InvitationTarget resolveInvitationTarget(String clientId, String redirectUri) {
+        clientId = StringUtil.isBlank(clientId) ? Constants.ACCOUNT_MANAGEMENT_CLIENT_ID : clientId.trim();
+        redirectUri = StringUtil.isBlank(redirectUri) ? null : redirectUri.trim();
 
-        if (accountClient != null) {
-            String baseUrl = accountClient.getBaseUrl();
-            if (baseUrl != null && !baseUrl.isBlank()) {
-                return ResolveRelative.resolveRelativeUri(session, accountClient.getRootUrl(), baseUrl);
-            }
+        ClientModel client = realm.getClientByClientId(clientId);
+
+        if (client == null) {
+            throw ErrorResponse.error("Client doesn't exist", Status.BAD_REQUEST);
         }
 
-        return Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
+        if (!client.isEnabled()) {
+            throw ErrorResponse.error("Client is not enabled", Status.BAD_REQUEST);
+        }
+
+        return new InvitationTarget(client.getClientId(), resolveRedirectUri(client, redirectUri));
+    }
+
+    private String resolveRedirectUri(ClientModel client, String redirectUri) {
+        if (redirectUri != null) {
+            String verifiedRedirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client);
+
+            if (verifiedRedirectUri == null) {
+                throw ErrorResponse.error("Invalid redirect uri.", Status.BAD_REQUEST);
+            }
+
+            return verifiedRedirectUri;
+        }
+
+        if (!StringUtil.isBlank(organization.getRedirectUrl())) {
+            return organization.getRedirectUrl();
+        }
+
+        String baseUrl = client.getBaseUrl();
+
+        if (!StringUtil.isBlank(baseUrl)) {
+            return ResolveRelative.resolveRelativeUri(session, client.getRootUrl(), baseUrl);
+        }
+
+        String defaultRedirectUri = RedirectUtils.verifyRedirectUri(session, null, client, false);
+
+        if (defaultRedirectUri != null) {
+            return defaultRedirectUri;
+        }
+
+        if (Constants.ACCOUNT_MANAGEMENT_CLIENT_ID.equals(client.getClientId())) {
+            return Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
+        }
+
+        return null;
+    }
+
+    private static class InvitationTarget {
+        final String clientId;
+        final String redirectUri;
+
+        private InvitationTarget(String clientId, String redirectUri) {
+            this.clientId = clientId;
+            this.redirectUri = redirectUri;
+        }
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -46,6 +46,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.MembershipType;
@@ -135,7 +136,9 @@ public class OrganizationMemberResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Invites an existing user or sends a registration link to a new user, based on the provided e-mail address.",
-            description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link.")
+            description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link. " +
+                    "The client_id and redirect_uri query parameters are optional. If no client_id is provided, the account client is used. " +
+                    "If no redirect_uri is provided, the organization redirect URL is used when configured, otherwise the selected client's base URL is used.")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -145,8 +148,10 @@ public class OrganizationMemberResource {
     })
     public Response inviteUser(@FormParam("email") String email,
                                @FormParam("firstName") String firstName,
-                               @FormParam("lastName") String lastName) {
-        return new OrganizationInvitationResource(session, organization, adminEvent, auth).inviteUser(email, firstName, lastName);
+                               @FormParam("lastName") String lastName,
+                               @Parameter(description = "Client id") @QueryParam(OIDCLoginProtocol.CLIENT_ID_PARAM) String clientId,
+                               @Parameter(description = "Redirect uri") @QueryParam(OIDCLoginProtocol.REDIRECT_URI_PARAM) String redirectUri) {
+        return new OrganizationInvitationResource(session, organization, adminEvent, auth).inviteUser(email, firstName, lastName, clientId, redirectUri);
     }
 
     @POST

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -199,6 +199,37 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
     }
 
     @Test
+    public void testInviteExistingUserWithEmailCustomClientAndRedirectUri() throws IOException, MessagingException {
+        UserRepresentation user = createUser("invitedWithMatchingEmailCustomClient", "invitedWithMatchingEmailCustomClient@myemail.com");
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (Response response = organization.members().inviteUser(user.getEmail(), "Homer", "Simpson", "broker-app", OAuthClient.APP_AUTH_ROOT)) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            acceptInvitation(organization, user, "AUTH_RESPONSE");
+        }
+    }
+
+    @Test
+    public void testInviteExistingUserWithEmailCustomClient() throws IOException, MessagingException {
+        UserRepresentation user = createUser("invitedWithMatchingEmailCustomClientOnly", "invitedWithMatchingEmailCustomClientOnly@myemail.com");
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (
+            ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                .setBaseUrl(OAuthClient.APP_AUTH_ROOT)
+                .update();
+            Response response = organization.members().inviteUser(user.getEmail(), "Homer", "Simpson", "broker-app", null)
+        ) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            acceptInvitation(organization, user, "AUTH_RESPONSE");
+        }
+    }
+
+    @Test
     public void testInviteWithAccountClientCustomBaseUrl() throws IOException, MessagingException {
         UserRepresentation user = createUser("invited", "invited@myemail.com");
 
@@ -369,6 +400,38 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
             getCleanup().addCleanup(() -> managedRealm.admin().users().get(users.get(0).getId()).remove());
 
             // authenticated to the app
+            assertThat(driver.getTitle(), containsString("AUTH_RESPONSE"));
+        }
+    }
+
+    @Test
+    public void testInviteNewUserRegistrationCustomClientAndRedirectUri() throws IOException, MessagingException {
+        String email = "invitedcustomclient@email";
+        String firstName = "Homer";
+        String lastName = "Simpson";
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (Response response = organization.members().inviteUser(email, firstName, lastName, "broker-app", OAuthClient.APP_AUTH_ROOT)) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            URI link = URI.create(getInvitationLinkFromEmail());
+            NameValuePair clientIdParam = URLEncodedUtils.parse(link, StandardCharsets.UTF_8).stream()
+                    .filter((np) -> Constants.CLIENT_ID.equals(np.getName()))
+                    .findAny().orElse(null);
+
+            assertThat(clientIdParam, notNullValue());
+            assertThat(clientIdParam.getValue(), equalTo("broker-app"));
+
+            registerUser(organization, email);
+
+            List<UserRepresentation> users = managedRealm.admin().users().searchByEmail(email, true);
+            assertThat(users, not(empty()));
+            MemberRepresentation member = organization.members().member(users.get(0).getId()).toRepresentation();
+            Assertions.assertNotNull(member);
+            assertThat(member.getMembershipType(), equalTo(MembershipType.MANAGED));
+            getCleanup().addCleanup(() -> managedRealm.admin().users().get(users.get(0).getId()).remove());
+
             assertThat(driver.getTitle(), containsString("AUTH_RESPONSE"));
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -28,6 +28,7 @@ import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.updaters.OrganizationAttributeUpdater;
 import org.keycloak.testsuite.util.MailServer;
 
@@ -390,6 +391,33 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
                 assertThat(response.getStatus(), equalTo(400));
                 assertThat(response.readEntity(String.class), containsString("Organization is disabled"));
             }
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithInvalidClient() {
+        try (Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "missing-client", null)) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Client doesn't exist"));
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithDisabledClient() throws Exception {
+        try (
+                ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app").setEnabled(false).update();
+                Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "broker-app", null)
+        ) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Client is not enabled"));
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithInvalidRedirectUri() {
+        try (Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "broker-app", "https://invalid.example.com/callback")) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Invalid redirect uri."));
         }
     }
 


### PR DESCRIPTION
 ## Description
 
 Closes #43741
 
 This adds optional `client_id` and `redirect_uri` query parameters to the organization `invite-user` admin endpoint:
 
 `POST /admin/realms/{realm}/organizations/{org-id}/members/invite-user`
 
 When provided, the selected client is used for generated organization invitation tokens and new-user registration links. The redirect URI is validated against the selected client before the invitation email is sent.
 
 Existing behavior is preserved when the new parameters are omitted:
 - invitations continue to use the `account` client by default
 - organization redirect URL still takes precedence when configured
 - account client base URL fallback remains unchanged
 
 The Java admin client and JS admin client were updated to expose the new optional parameters.
 
 ## Testing
 
 - `./mvnw -pl services,integration/admin-client -am -DskipTests compile -q`
 - `./mvnw -pl testsuite/integration-arquillian/tests/base -DskipTests -P-check-dev-dependencies test-compile -q`
 - `./mvnw -pl testsuite/integration-arquillian/tests/base -Dtest=OrganizationInvitationManagementTest -P-check-dev-dependencies test -q`
 - `./mvnw -pl testsuite/integration-arquillian/tests/base -Dtest=OrganizationInvitationLinkTest#testInviteExistingUserWithEmailCustomClient+testInviteExistingUserWithEmailCustomClientAndRedirectUri+testInviteNewUserRegistrationCustomClientAndRedirectUri -P-check-dev-dependencies test -q`
 - `cd js && pnpm --filter @keycloak/keycloak-admin-client build`
 - `cd js && pnpm --filter @keycloak/keycloak-admin-client lint`
 - `./mvnw spotless:check -q`
 