### PR TITLE
feat(org): add client_id param to invite-user endpoint

### DIFF
--- a/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -194,6 +194,14 @@ public interface OrganizationMembersResource {
                         @FormParam("lastName") String lastName);
 
     @POST
+    @Path("invite-user")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    Response inviteUser(@FormParam("email") String email,
+                        @FormParam("firstName") String firstName,
+                        @FormParam("lastName") String lastName,
+                        @QueryParam("client_id") String clientId);
+
+    @POST
     @Path("invite-existing-user")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     Response inviteExistingUser(@FormParam("id") String id);

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationMembersResource.java
@@ -194,6 +194,14 @@ public interface OrganizationMembersResource {
                         @FormParam("lastName") String lastName);
 
     @POST
+    @Path("invite-user")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    Response inviteUser(@FormParam("email") String email,
+                        @FormParam("firstName") String firstName,
+                        @FormParam("lastName") String lastName,
+                        @QueryParam("client_id") String clientId);
+
+    @POST
     @Path("invite-existing-user")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     Response inviteExistingUser(@FormParam("id") String id);

--- a/js/libs/keycloak-admin-client/src/resources/organizations.ts
+++ b/js/libs/keycloak-admin-client/src/resources/organizations.ts
@@ -128,10 +128,17 @@ export class Organizations extends Resource<{ realm?: string }> {
     urlParamKeys: ["userId"],
   });
 
-  public invite = this.makeUpdateRequest<{ orgId: string }, FormData>({
+  public invite = this.makeUpdateRequest<
+    { orgId: string; clientId?: string },
+    FormData
+  >({
     method: "POST",
     path: "/{orgId}/members/invite-user",
     urlParamKeys: ["orgId"],
+    queryParamKeys: ["clientId"],
+    keyTransform: {
+      clientId: "client_id",
+    },
   });
 
   public inviteExistingUser = this.makeUpdateRequest<

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.organization.admin.resource;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -36,10 +37,13 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.authentication.actiontoken.inviteorg.InviteOrgActionToken;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.common.util.UriUtils;
 import org.keycloak.email.EmailException;
 import org.keycloak.email.EmailTemplateProvider;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -54,6 +58,7 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ServicesLogger;
@@ -96,10 +101,6 @@ public class OrganizationInvitationResource {
         this.organization = organization;
         this.adminEvent = adminEvent.resource(ResourceType.ORGANIZATION_MEMBERSHIP);
         this.auth = auth;
-    }
-
-    public Response inviteUser(String email, String firstName, String lastName) {
-        return inviteUser(email, firstName, lastName, null);
     }
 
     public Response inviteUser(String email, String firstName, String lastName, String clientId) {
@@ -288,6 +289,25 @@ public class OrganizationInvitationResource {
         throw ErrorResponse.error("Unable to resolve a redirect uri for the client", Status.BAD_REQUEST);
     }
 
+    private String resolveClientIdFromInviteLink(String inviteLink) {
+        if (StringUtil.isBlank(inviteLink)) {
+            return null;
+        }
+        try {
+            MultivaluedHashMap<String, String> params = UriUtils.decodeQueryString(URI.create(inviteLink).getRawQuery());
+            String tokenValue = params.getFirst(Constants.TOKEN);
+            if (tokenValue == null) {
+                tokenValue = params.getFirst("key");
+            }
+            if (tokenValue == null) {
+                return null;
+            }
+            return new JWSInput(tokenValue).readJsonContent(JsonWebToken.class).getIssuedFor();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private static class InvitationTarget {
         final String clientId;
         final String redirectUri;
@@ -403,8 +423,9 @@ public class OrganizationInvitationResource {
         InvitationManager invitationManager = provider.getInvitationManager();
 
         OrganizationInvitationModel invitation = verifyInvitationById(invitationManager, id);
+        String clientId = resolveClientIdFromInviteLink(invitation.getInviteLink());
         invitationManager.remove(id);
-        return inviteUser(invitation.getEmail(), invitation.getFirstName(), invitation.getLastName());
+        return inviteUser(invitation.getEmail(), invitation.getFirstName(), invitation.getLastName(), clientId);
     }
 
     private OrganizationInvitationModel verifyInvitationById(InvitationManager invitationManager, String id) {

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -53,6 +53,7 @@ import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ServicesLogger;
@@ -98,6 +99,10 @@ public class OrganizationInvitationResource {
     }
 
     public Response inviteUser(String email, String firstName, String lastName) {
+        return inviteUser(email, firstName, lastName, null);
+    }
+
+    public Response inviteUser(String email, String firstName, String lastName, String clientId) {
         auth.orgs().requireManage(organization);
 
         if (!organization.isEnabled()) {
@@ -112,6 +117,8 @@ public class OrganizationInvitationResource {
         if (!Validation.isEmailValid(email)) {
             throw ErrorResponse.error("Invalid email format", Status.BAD_REQUEST);
         }
+
+        InvitationTarget invitationTarget = resolveInvitationTarget(clientId);
 
         OrganizationProvider invitationProvider = session.getProvider(OrganizationProvider.class);
         InvitationManager invitationManager = invitationProvider.getInvitationManager();
@@ -132,7 +139,7 @@ public class OrganizationInvitationResource {
                 throw ErrorResponse.error("User already a member of the organization", Status.CONFLICT);
             }
 
-            return sendInvitation(user);
+            return sendInvitation(user, invitationTarget);
         }
 
         // Create temporary user for new registrations
@@ -144,7 +151,7 @@ public class OrganizationInvitationResource {
             user.setLastName(lastName);
         }
 
-        return sendInvitation(user);
+        return sendInvitation(user, invitationTarget);
     }
 
     public Response inviteExistingUser(String id) {
@@ -170,10 +177,10 @@ public class OrganizationInvitationResource {
             throw ErrorResponse.error("User does not have an email address", Status.BAD_REQUEST);
         }
 
-        return sendInvitation(user);
+        return sendInvitation(user, resolveInvitationTarget(null));
     }
 
-    private Response sendInvitation(UserModel user) {
+    private Response sendInvitation(UserModel user, InvitationTarget invitationTarget) {
         OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
         InvitationManager invitationManager = provider.getInvitationManager();
         // Create persistent invitation record
@@ -185,8 +192,8 @@ public class OrganizationInvitationResource {
         );
 
         String link = user.getId() == null ?
-            createRegistrationLink(user, invitation) :
-            createInvitationLink(user, invitation);
+            createRegistrationLink(user, invitation, invitationTarget) :
+            createInvitationLink(user, invitation, invitationTarget);
         invitation.setInviteLink(link);
 
         try {
@@ -211,46 +218,84 @@ public class OrganizationInvitationResource {
         return realm.getActionTokenGeneratedByAdminLifespan();
     }
 
-    private String createInvitationLink(UserModel user, OrganizationInvitationModel invitation) {
+    private String createInvitationLink(UserModel user, OrganizationInvitationModel invitation, InvitationTarget invitationTarget) {
         return LoginActionsService.actionTokenProcessor(session.getContext().getUri())
-                .queryParam("key", createToken(user, invitation))
+                .queryParam("key", createToken(user, invitation, invitationTarget))
                 .build(realm.getName()).toString();
     }
 
-    private String createRegistrationLink(UserModel user, OrganizationInvitationModel invitation) {
+    private String createRegistrationLink(UserModel user, OrganizationInvitationModel invitation, InvitationTarget invitationTarget) {
         return OIDCLoginProtocolService.registrationsUrl(session.getContext().getUri().getBaseUriBuilder())
                 .queryParam(OAuth2Constants.RESPONSE_TYPE, OIDCResponseType.CODE)
-                .queryParam(Constants.CLIENT_ID, Constants.ACCOUNT_MANAGEMENT_CLIENT_ID)
-                .queryParam(Constants.TOKEN, createToken(user, invitation))
+                .queryParam(Constants.CLIENT_ID, invitationTarget.clientId)
+                .queryParam(Constants.TOKEN, createToken(user, invitation, invitationTarget))
                 .buildFromMap(Map.of("realm", realm.getName(), "protocol", OIDCLoginProtocol.LOGIN_PROTOCOL)).toString();
     }
 
-    private String createToken(UserModel user, OrganizationInvitationModel invitation) {
-        InviteOrgActionToken token = new InviteOrgActionToken(user.getId(), invitation.getExpiresAt(), user.getEmail(), Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
+    private String createToken(UserModel user, OrganizationInvitationModel invitation, InvitationTarget invitationTarget) {
+        InviteOrgActionToken token = new InviteOrgActionToken(user.getId(), invitation.getExpiresAt(), user.getEmail(), invitationTarget.clientId);
 
         token.setOrgId(organization.getId());
         token.id(invitation.getId());
-
-        if (organization.getRedirectUrl() == null || organization.getRedirectUrl().isBlank()) {
-            token.setRedirectUri(resolveAccountClientBaseUrl());
-        } else {
-            token.setRedirectUri(organization.getRedirectUrl());
-        }
+        token.setRedirectUri(invitationTarget.redirectUri);
 
         return token.serialize(session, realm, session.getContext().getUri());
     }
 
-    private String resolveAccountClientBaseUrl() {
-        ClientModel accountClient = realm.getClientByClientId(Constants.ACCOUNT_MANAGEMENT_CLIENT_ID);
+    private InvitationTarget resolveInvitationTarget(String clientId) {
+        clientId = StringUtil.isBlank(clientId) ? null : clientId.trim();
 
-        if (accountClient != null) {
-            String baseUrl = accountClient.getBaseUrl();
-            if (baseUrl != null && !baseUrl.isBlank()) {
-                return ResolveRelative.resolveRelativeUri(session, accountClient.getRootUrl(), baseUrl);
-            }
+        if (clientId == null) {
+            clientId = Constants.ACCOUNT_MANAGEMENT_CLIENT_ID;
         }
 
-        return Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
+        ClientModel client = realm.getClientByClientId(clientId);
+
+        if (client == null) {
+            throw ErrorResponse.error("Client doesn't exist", Status.BAD_REQUEST);
+        }
+
+        if (!client.isEnabled()) {
+            throw ErrorResponse.error("Client is not enabled", Status.BAD_REQUEST);
+        }
+
+        return new InvitationTarget(client.getClientId(), resolveRedirectUri(client));
+    }
+
+    private String resolveRedirectUri(ClientModel client) {
+        boolean isAccountClient = Constants.ACCOUNT_MANAGEMENT_CLIENT_ID.equals(client.getClientId());
+
+        if (isAccountClient && !StringUtil.isBlank(organization.getRedirectUrl())) {
+            return organization.getRedirectUrl();
+        }
+
+        String baseUrl = client.getBaseUrl();
+
+        if (!StringUtil.isBlank(baseUrl)) {
+            return ResolveRelative.resolveRelativeUri(session, client.getRootUrl(), baseUrl);
+        }
+
+        String defaultRedirectUri = RedirectUtils.verifyRedirectUri(session, null, client, false);
+
+        if (defaultRedirectUri != null) {
+            return defaultRedirectUri;
+        }
+
+        if (isAccountClient) {
+            return Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
+        }
+
+        throw ErrorResponse.error("Unable to resolve a redirect uri for the client", Status.BAD_REQUEST);
+    }
+
+    private static class InvitationTarget {
+        final String clientId;
+        final String redirectUri;
+
+        private InvitationTarget(String clientId, String redirectUri) {
+            this.clientId = clientId;
+            this.redirectUri = redirectUri;
+        }
     }
 
     @GET

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -424,6 +424,7 @@ public class OrganizationInvitationResource {
 
         OrganizationInvitationModel invitation = verifyInvitationById(invitationManager, id);
         String clientId = resolveClientIdFromInviteLink(invitation.getInviteLink());
+        resolveInvitationTarget(clientId);
         invitationManager.remove(id);
         return inviteUser(invitation.getEmail(), invitation.getFirstName(), invitation.getLastName(), clientId);
     }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -47,6 +47,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.MembershipType;
@@ -131,7 +132,10 @@ public class OrganizationMemberResource {
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
     @Operation(summary = "Invites an existing user or sends a registration link to a new user, based on the provided e-mail address.",
-            description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link.")
+            description = "If the user with the given e-mail address exists, it sends an invitation link, otherwise it sends a registration link. " +
+                    "The client_id query parameter is optional. If no client_id is provided, the account client is used. " +
+                    "After accepting the invitation the user is redirected to the selected client's home URL; for the account client the " +
+                    "organization redirect URL is used instead when configured.")
     @APIResponses(value = {
         @APIResponse(responseCode = "204", description = "No Content"),
         @APIResponse(responseCode = "400", description = "Bad Request"),
@@ -141,8 +145,9 @@ public class OrganizationMemberResource {
     })
     public Response inviteUser(@FormParam("email") String email,
                                @FormParam("firstName") String firstName,
-                               @FormParam("lastName") String lastName) {
-        return new OrganizationInvitationResource(session, organization, adminEvent, auth).inviteUser(email, firstName, lastName);
+                               @FormParam("lastName") String lastName,
+                               @Parameter(description = "Client id") @QueryParam(OIDCLoginProtocol.CLIENT_ID_PARAM) String clientId) {
+        return new OrganizationInvitationResource(session, organization, adminEvent, auth).inviteUser(email, firstName, lastName, clientId);
     }
 
     @POST

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -207,6 +207,44 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
     }
 
     @Test
+    public void testInviteExistingUserWithEmailCustomClient() throws IOException, MessagingException {
+        UserRepresentation user = createUser("invitedWithMatchingEmailCustomClientOnly", "invitedWithMatchingEmailCustomClientOnly@myemail.com");
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (
+            ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                .setBaseUrl(OAuthClient.APP_AUTH_ROOT)
+                .update();
+            Response response = organization.members().inviteUser(user.getEmail(), "Homer", "Simpson", "broker-app")
+        ) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            acceptInvitation(organization, user, "AUTH_RESPONSE");
+        }
+    }
+
+    @Test
+    public void testInviteExistingUserCustomClientIgnoresOrgRedirectUrl() throws IOException, MessagingException {
+        UserRepresentation user = createUser("invitedCustomClientOrgRedirect", "invitedCustomClientOrgRedirect@myemail.com");
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (
+            OrganizationAttributeUpdater oau = new OrganizationAttributeUpdater(organization).setRedirectUrl("https://www.keycloak.org").update();
+            ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                .setBaseUrl(OAuthClient.APP_AUTH_ROOT)
+                .update();
+            Response response = organization.members().inviteUser(user.getEmail(), "Homer", "Simpson", "broker-app")
+        ) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            // the org redirect URL is ignored for a custom client; the user lands on the client base URL instead
+            acceptInvitation(organization, user, "AUTH_RESPONSE");
+        }
+    }
+
+    @Test
     public void testInviteWithAccountClientCustomBaseUrl() throws IOException, MessagingException {
         UserRepresentation user = createUser("invited", "invited@myemail.com");
 
@@ -349,6 +387,7 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         managedRealm.admin().update(realm);
         getCleanup().addCleanup(() -> {
             realm.setRegistrationFlow(DefaultAuthenticationFlows.REGISTRATION_FLOW);
+            managedRealm.admin().update(realm);
         });
 
         String email = "inviteduser@email";
@@ -397,6 +436,43 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
             getCleanup().addCleanup(() -> managedRealm.admin().users().get(users.get(0).getId()).remove());
 
             // authenticated to the app
+            assertThat(driver.getTitle(), containsString("AUTH_RESPONSE"));
+        }
+    }
+
+    @Test
+    public void testInviteNewUserRegistrationCustomClient() throws IOException, MessagingException {
+        String email = "invitedcustomclientonly@email";
+        String firstName = "Homer";
+        String lastName = "Simpson";
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (
+            ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                .setBaseUrl(OAuthClient.APP_AUTH_ROOT)
+                .update();
+            Response response = organization.members().inviteUser(email, firstName, lastName, "broker-app")
+        ) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            URI link = URI.create(getInvitationLinkFromEmail());
+            NameValuePair clientIdParam = URLEncodedUtils.parse(link, StandardCharsets.UTF_8).stream()
+                    .filter((np) -> Constants.CLIENT_ID.equals(np.getName()))
+                    .findAny().orElse(null);
+
+            assertThat(clientIdParam, notNullValue());
+            assertThat(clientIdParam.getValue(), equalTo("broker-app"));
+
+            registerUser(organization, email);
+
+            List<UserRepresentation> users = managedRealm.admin().users().searchByEmail(email, true);
+            assertThat(users, not(empty()));
+            MemberRepresentation member = organization.members().member(users.get(0).getId()).toRepresentation();
+            Assertions.assertNotNull(member);
+            assertThat(member.getMembershipType(), equalTo(MembershipType.MANAGED));
+            getCleanup().addCleanup(() -> managedRealm.admin().users().get(users.get(0).getId()).remove());
+
             assertThat(driver.getTitle(), containsString("AUTH_RESPONSE"));
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -478,6 +478,44 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
     }
 
     @Test
+    public void testResendInvitationPreservesCustomClientId() throws IOException, MessagingException {
+        String email = "invitedresendclient@email";
+        String firstName = "Homer";
+        String lastName = "Simpson";
+
+        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+
+        try (
+            ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                .setBaseUrl(OAuthClient.APP_AUTH_ROOT)
+                .update();
+            Response response = organization.members().inviteUser(email, firstName, lastName, "broker-app")
+        ) {
+            assertThat(response.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+
+            URI firstLink = URI.create(getInvitationLinkFromEmail());
+            NameValuePair firstClientIdParam = URLEncodedUtils.parse(firstLink, StandardCharsets.UTF_8).stream()
+                    .filter((np) -> Constants.CLIENT_ID.equals(np.getName()))
+                    .findAny().orElse(null);
+            assertThat(firstClientIdParam, notNullValue());
+            assertThat(firstClientIdParam.getValue(), equalTo("broker-app"));
+
+            List<OrganizationInvitationRepresentation> invitations = organization.invitations().list();
+            assertThat(invitations, Matchers.hasSize(1));
+            try (Response resendResponse = organization.invitations().resend(invitations.get(0).getId())) {
+                assertThat(resendResponse.getStatus(), equalTo(Response.Status.NO_CONTENT.getStatusCode()));
+            }
+
+            URI resendLink = URI.create(getInvitationLinkFromEmail());
+            NameValuePair resendClientIdParam = URLEncodedUtils.parse(resendLink, StandardCharsets.UTF_8).stream()
+                    .filter((np) -> Constants.CLIENT_ID.equals(np.getName()))
+                    .findAny().orElse(null);
+            assertThat(resendClientIdParam, notNullValue());
+            assertThat(resendClientIdParam.getValue(), equalTo("broker-app"));
+        }
+    }
+
+    @Test
     public void testRegistrationEnabledWhenInvitingNewUser() throws Exception {
         String email = "inviteduser@email";
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -30,6 +30,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.updaters.OrganizationAttributeUpdater;
 
 import org.junit.Before;
@@ -479,6 +480,25 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
                 assertThat(response.getStatus(), equalTo(400));
                 assertThat(response.readEntity(String.class), containsString("Organization is disabled"));
             }
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithInvalidClient() {
+        try (Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "missing-client")) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Client doesn't exist"));
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithDisabledClient() throws Exception {
+        try (
+                ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app").setEnabled(false).update();
+                Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "broker-app")
+        ) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Client is not enabled"));
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -516,6 +516,33 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
     }
 
     @Test
+    public void testResendInvitationPreservesOriginalWhenClientDisabled() throws Exception {
+        try (
+                ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                        .setBaseUrl("http://localhost:8180").update()
+        ) {
+            try (Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "broker-app")) {
+                assertThat(response.getStatus(), equalTo(204));
+            }
+
+            List<OrganizationInvitationRepresentation> invitations = organization.invitations().list();
+            assertThat(invitations, hasSize(1));
+            String invitationId = invitations.get(0).getId();
+
+            try (ClientAttributeUpdater disabler = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app")
+                    .setEnabled(false).update()) {
+                try (Response resendResponse = organization.invitations().resend(invitationId)) {
+                    assertThat(resendResponse.getStatus(), equalTo(400));
+                    assertThat(resendResponse.readEntity(String.class), containsString("Client is not enabled"));
+                }
+
+                List<OrganizationInvitationRepresentation> remaining = organization.invitations().list();
+                assertThat("Original invitation must survive a failed resend", remaining, hasSize(1));
+            }
+        }
+    }
+
+    @Test
     public void testResendInvitationToDisabledOrganization() throws Exception {
         sendInvitation("user@test-org.com", "John", "Doe");
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -30,6 +30,7 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
 import org.keycloak.testsuite.updaters.OrganizationAttributeUpdater;
 
 import org.junit.Before;
@@ -492,6 +493,25 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
                 assertThat(response.getStatus(), equalTo(400));
                 assertThat(response.readEntity(String.class), containsString("Organization is disabled"));
             }
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithInvalidClient() {
+        try (Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "missing-client")) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Client doesn't exist"));
+        }
+    }
+
+    @Test
+    public void testSendInvitationWithDisabledClient() throws Exception {
+        try (
+                ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, TEST_REALM_NAME, "broker-app").setEnabled(false).update();
+                Response response = organization.members().inviteUser("user@test-org.com", "John", "Doe", "broker-app")
+        ) {
+            assertThat(response.getStatus(), equalTo(400));
+            assertThat(response.readEntity(String.class), containsString("Client is not enabled"));
         }
     }
 


### PR DESCRIPTION
## Description

Closes #43741

Adds an optional `client_id` query parameter to the organization `invite-user` admin REST endpoint (`POST /admin/realms/{realm}/organizations/{id}/members/invite-user`).

### Problem

When an organization invitation email is sent, the registration/login link embedded in the email always targets the default client (`account-console`). This makes it impossible to configure invitations so users land on a specific application after completing registration.

### Solution

The endpoint now accepts an optional `client_id` query parameter selecting the client to use as the redirect target after registration/login. The redirect URI is resolved server-side from that client's configured home (base) URL - it is never taken from the request.

- If `client_id` is provided, the user is redirected to that client's configured home URL after accepting the invitation.
- For the account client, the organization redirect URL is used instead when configured.
- If the client is disabled or doesn't exist, a `400 Bad Request` is returned.
- If no `client_id` is provided, existing behaviour is preserved (no breaking change).

> **Note on `redirect_uri`:** an earlier revision of this PR also accepted a `redirect_uri` query parameter (mirroring `execute-actions-email`). It was dropped following review feedback: allowing a caller-supplied redirect URI on this endpoint is an open-redirect risk. The redirect target is now derived solely from the client's configured home URL. This keeps the endpoint stricter than the org-level redirect URL (#51138), which may itself be restricted later.

### Changes

- **`OrganizationInvitationResource`** - core logic: `resolveInvitationTarget()` validates the client and resolves the redirect URI from its configured home URL; token generation and registration link creation carry the resolved client/URI.
- **`OrganizationMemberResource`** - JAX-RS endpoint updated with `@QueryParam("client_id")`.
- **`OrganizationMembersResource` (admin-client)** - new `inviteUser` overload accepting `client_id`.
- **`organizations.ts` (JS admin client)** - `invite()` now accepts an optional `clientId`.
- **Tests** - integration tests covering the custom-client redirect flows and client validation error cases.
