### PR TITLE
Revert changes to KeycloakCompatibilityMetadataProvider and its test

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_2.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_2.adoc
@@ -10,3 +10,7 @@ The WebAuthn policy presents the option **Acceptable AAGUIDs** to restrict the a
 Since this release, when this option is set up, the attestation is required to be present and signed with a valid certificate for the {project_name} trust-store. The `None` attestation format is explicitly not permitted. Previously, there were some corner cases in which a self attestation was accepted. The change is expected to be harmless, but maybe there are combinations of authenticators and WebAuthn policies that can present issues.
 
 See chapter link:{adminguide_link}#_webauthn-policy[Managing policy] in the {adminguide_name} for more information.
+
+=== Workflow schedule synchronization across cluster nodes
+
+A new cluster event was introduced to synchronize workflow scheduled settings across cluster nodes. You might see errors when updating workflow definitions during a rolling update when upgrading from 26.6.x. Defer updating workflow definitions until the rolling update has completed.

--- a/services/src/main/java/org/keycloak/compatibility/KeycloakCompatibilityMetadataProvider.java
+++ b/services/src/main/java/org/keycloak/compatibility/KeycloakCompatibilityMetadataProvider.java
@@ -26,8 +26,7 @@ public class KeycloakCompatibilityMetadataProvider implements CompatibilityMetad
 
     @Override
     public Map<String, String> metadata() {
-        return Map.of(VERSION_KEY, version,
-                "new cluster event", "WorkflowScheduleClusterEvent");
+        return Map.of(VERSION_KEY, version);
     }
 
     @Override

--- a/services/src/test/java/org/keycloak/compatibility/KeycloakCompatibilityMetadataProviderTest.java
+++ b/services/src/test/java/org/keycloak/compatibility/KeycloakCompatibilityMetadataProviderTest.java
@@ -17,20 +17,17 @@ public class KeycloakCompatibilityMetadataProviderTest extends AbstractCompatibi
         KeycloakCompatibilityMetadataProvider compatibilityProvider = new KeycloakCompatibilityMetadataProvider("999.999.999-Final");
 
         // Test compatible
-        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.999-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.998-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.999-Final1", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.1-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-
-        // Test incompatible - other node has matching version but missing new cluster event metadata
-        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.999-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.999-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.998-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.999-Final1")));
+        assertCompatibility(CompatibilityResult.ExitCode.ROLLING, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.1-Final")));
 
         // Test incompatible
-        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.1000-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.998.999-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "998.999.999-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.998.998-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
-        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "998.999.998-Final", "new cluster event", "WorkflowScheduleClusterEvent")));
+        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.999.1000-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.998.999-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "998.999.999-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "999.998.998-Final")));
+        assertCompatibility(CompatibilityResult.ExitCode.RECREATE, compatibilityProvider.isCompatible(Map.of(VERSION_KEY, "998.999.998-Final")));
 
         Profile.reset();
     }


### PR DESCRIPTION
- Also add notable changes for 26.6.2 to inform admins to defer workflow definition changes until the rolling upgrade is completed.

Related to #48185

Closes #48536

Signed-off-by: Stefan Guilhen <sguilhen@redhat.com>

(cherry picked from commit 33651e42c4d9fb513cde5e4b1da506f8b99a40a2)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
