### PR TITLE
[OAuth] Prefer authorization error on redirect_uri

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -46,6 +46,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.ClientData;
 import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.utils.LogoutUtil;
@@ -57,6 +58,7 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.adapters.action.PushNotBeforeAction;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -436,8 +438,8 @@ public class OIDCLoginProtocol implements LoginProtocol {
         try {
             checker.checkResponseType();
             checker.checkRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            ex.throwAsErrorPageException(null);
+        } catch (AuthorizationCheckException ex) {
+            throw new ErrorPageException(session, ex.getError(), ex.getStatus(), ex.getErrorMessage(), ex.getParameters());
         }
 
         setupResponseTypeAndMode(clientData.getResponseType(), clientData.getResponseMode());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationCheckException.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationCheckException.java
@@ -1,0 +1,49 @@
+package org.keycloak.protocol.oidc.endpoints;
+
+import java.text.MessageFormat;
+
+import jakarta.ws.rs.core.Response;
+
+// Exception propagated to the caller, which will allow caller to send proper error response based on the context (Browser OIDC Authorization Endpoint, PAR etc)
+public class AuthorizationCheckException extends Exception {
+
+    private final Response.Status status;
+    private final String error;
+    private final String errorMessage;
+    private final Object[] parameters;
+
+    public AuthorizationCheckException(Response.Status status, String error, String errorDescription) {
+        this(error, status, errorDescription);
+    }
+
+    public AuthorizationCheckException(String error, Response.Status status, String errorMessage, Object... params) {
+        this.status = status;
+        this.error = error;
+        this.errorMessage = errorMessage;
+        this.parameters = params;
+    }
+
+    public Response.Status getStatus() {
+        return status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorDescription() {
+        String errorDescription = errorMessage;
+        if (parameters.length > 0) {
+            errorDescription = MessageFormat.format(errorMessage, parameters);
+        }
+        return errorDescription;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Object[] getParameters() {
+        return parameters;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -17,8 +17,12 @@
 
 package org.keycloak.protocol.oidc.endpoints;
 
+import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.BiConsumer;
 
 import jakarta.ws.rs.Consumes;
@@ -48,12 +52,14 @@ import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor.EndpointType;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
 import org.keycloak.protocol.oidc.grants.device.endpoints.DeviceEndpoint;
 import org.keycloak.protocol.oidc.utils.AcrUtils;
 import org.keycloak.protocol.oidc.utils.OIDCRedirectUriBuilder;
 import org.keycloak.protocol.oidc.utils.OIDCResponseMode;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -65,6 +71,7 @@ import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.services.util.LocaleUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
 import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
@@ -80,6 +87,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
     public static final String CODE_AUTH_TYPE = "code";
 
+    // Prefer error delivery on `redirect_uri` - rather than as HTML error page
+    public static final String AUTHORIZATION_PREFER_ERROR_ON_REDIRECT = "authorization.preferErrorOnRedirect";
+
     /**
      * Prefix used to store additional HTTP GET params from original client request into {@link AuthenticationSessionModel} note to be available later in Authenticators, RequiredActions etc. Prefix is used to
      * prevent collisions with internally used notes.
@@ -93,6 +103,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private ClientModel client;
+    private AuthorizationEndpointChecker checker;
     private AuthenticationSessionModel authenticationSession;
 
     private Action action;
@@ -100,7 +111,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     private OIDCResponseMode parsedResponseMode;
 
     private AuthorizationEndpointRequest request;
-    private String redirectUri;
+    private String parsedRedirectUri;
 
     public AuthorizationEndpoint(KeycloakSession session, EventBuilder event) {
         super(session, event);
@@ -132,52 +143,58 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private Response process(final MultivaluedMap<String, String> params) {
-        String clientId = AuthorizationEndpointRequestParserProcessor.getClientId(event, session, params);
-
-        checkSsl();
-        checkRealm();
 
         try {
-            session.clientPolicy().triggerOnEvent(new PreAuthorizationRequestContext(clientId, params));
-        } catch (ClientPolicyException cpe) {
-            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
-            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
-            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
-            event.error(cpe.getError());
-            throw new ErrorPageException(session, authenticationSession, cpe.getErrorStatus(), cpe.getErrorDetail());
+            String clientId = AuthorizationEndpointRequestParserProcessor.getClientId(event, session, params);
+
+            checkSsl();
+            checkRealm();
+
+            try {
+                session.clientPolicy().triggerOnEvent(new PreAuthorizationRequestContext(clientId, params));
+            } catch (ClientPolicyException cpe) {
+                event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
+                event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
+                event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+                event.error(cpe.getError());
+                throw new ErrorPageException(session, cpe.getError(), cpe.getErrorStatus(), cpe.getErrorDetail());
+            }
+            checkClient(clientId);
+
+            request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, EndpointType.OIDC_AUTH_ENDPOINT);
+
+        } catch (ErrorPageException ex) {
+            buildAuthorizationEndpointChecker(params);
+            return handleErrorPageException(ex);
         }
-        checkClient(clientId);
 
-        request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, AuthorizationEndpointRequestParserProcessor.EndpointType.OIDC_AUTH_ENDPOINT);
-
-        AuthorizationEndpointChecker checker = new AuthorizationEndpointChecker()
-                .event(event)
-                .client(client)
-                .realm(realm)
-                .request(request)
-                .session(session)
-                .params(params);
+        buildAuthorizationEndpointChecker(params);
 
         try {
             checker.checkRedirectUri();
-            this.redirectUri = checker.getRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            ex.throwAsErrorPageException(authenticationSession);
+            parsedRedirectUri = checker.getRedirectUri();
+        } catch (AuthorizationCheckException ex) {
+            ErrorPageException epex = new ErrorPageException(session, ex.getError(), ex.getStatus(), ex.getErrorMessage(), ex.getParameters());
+            return handleErrorPageException(epex);
         }
 
         try {
             checker.checkResponseType();
-            this.parsedResponseType = checker.getParsedResponseType();
-            this.parsedResponseMode = checker.getParsedResponseMode();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            OIDCResponseMode responseMode;
+            parsedResponseType = checker.getParsedResponseType();
+            parsedResponseMode = checker.getParsedResponseMode();
+        } catch (AuthorizationCheckException ex) {
             if (checker.isInvalidResponseType(ex)) {
-                responseMode = OIDCResponseMode.parseWhenInvalidResponseType(request.getResponseMode());
-            } else {
-                responseMode = checker.getParsedResponseMode() != null ? checker.getParsedResponseMode() : OIDCResponseMode.QUERY;
+                parsedResponseMode = OIDCResponseMode.parseWhenInvalidResponseType(request.getResponseMode());
             }
-            return redirectErrorToClient(responseMode, ex.getError(), ex.getErrorDescription());
+            if (parsedResponseMode == null) {
+                parsedResponseMode = checker.getParsedResponseMode();
+            }
+            if (parsedResponseMode == null) {
+                parsedResponseMode = OIDCResponseMode.QUERY;
+            }
+            return handleRedirectErrorToClient(ex.getError(), ex.getErrorDescription());
         }
+
         if (action == null) {
             action = AuthorizationEndpoint.Action.CODE;
         }
@@ -191,8 +208,8 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             checker.checkValidResource();
             checker.checkOIDCParams();
             checker.checkPKCEParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            return redirectErrorToClient(parsedResponseMode, ex.getError(), ex.getErrorDescription());
+        } catch (AuthorizationCheckException ex) {
+            return handleRedirectErrorToClient(ex.getError(), ex.getErrorDescription());
         }
 
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
@@ -205,14 +222,14 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         authenticationSession = createAuthenticationSession(client, request.getState());
 
         try {
-            session.clientPolicy().triggerOnEvent(new AuthorizationRequestContext(parsedResponseType, request, redirectUri, params, authenticationSession));
+            session.clientPolicy().triggerOnEvent(new AuthorizationRequestContext(parsedResponseType, request, parsedRedirectUri, params, authenticationSession));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
             event.error(cpe.getError());
             new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authenticationSession, false);
-            return redirectErrorToClient(parsedResponseMode, cpe.getError(), cpe.getErrorDetail());
+            return handleRedirectErrorToClient(cpe.getError(), cpe.getErrorDetail());
         }
 
         updateAuthenticationSession();
@@ -239,6 +256,19 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
 
         throw new RuntimeException("Unknown action " + action);
+    }
+
+    private AuthorizationEndpointChecker buildAuthorizationEndpointChecker(MultivaluedMap<String, String> params) {
+        if (checker == null) {
+            checker = new AuthorizationEndpointChecker()
+                    .event(event)
+                    .client(client)
+                    .realm(realm)
+                    .request(request)
+                    .session(session)
+                    .params(params);
+        }
+        return checker;
     }
 
     public AuthorizationEndpoint register(String tokenString) {
@@ -271,7 +301,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         return this;
     }
 
-    private void checkClient(String clientId) {
+    private ClientModel checkClient(String clientId) {
         if (clientId == null) {
             event.detail(Details.REASON, "Missing parameter: " + OIDCLoginProtocol.CLIENT_ID_PARAM);
             event.error(Errors.INVALID_REQUEST);
@@ -309,24 +339,83 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
 
         session.getContext().setClient(client);
+        return client;
     }
 
-    private Response redirectErrorToClient(OIDCResponseMode responseMode, String error, String errorDescription) {
+    private Response handleErrorPageException(ErrorPageException epex) {
+
+        // Prefer authorization error on redirect_uri
+        // https://github.com/keycloak/keycloak/issues/48542
+        boolean preferErrorOnRedirect = realm.getAttribute(AUTHORIZATION_PREFER_ERROR_ON_REDIRECT, false);
+        if (!preferErrorOnRedirect)
+            throw epex;
+
+        Response.Status status = epex.getStatus();
+
+        // Get the localized error message (english)
+        //
+        String errorMessage = epex.getErrorMessage();
+        try {
+            Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
+            Properties localizedMessages = theme.getEnhancedMessages(realm, Locale.ENGLISH);
+            if (localizedMessages.containsKey(errorMessage)) {
+                errorMessage = localizedMessages.getProperty(errorMessage);
+                Object[] params = epex.getParameters();
+                if (params.length > 0) {
+                    errorMessage = MessageFormat.format(errorMessage, params);
+                }
+            }
+        } catch (IOException ioe) {
+            // ignore
+        }
+
+        // Do a second pass trying to obtain the required parameters for a valid redirect
+        //
+        try {
+            MultivaluedMap<String, String> params = checker.getRequestParams();
+            AuthorizationEndpointRequest request = checker.getAuthorizationEndpointRequest();
+            if (client == null) {
+                String clientId = request != null ? request.getClientId() : params.getFirst(OIDCLoginProtocol.CLIENT_ID_PARAM);
+                client = checkClient(clientId);
+                checker.client(client);
+            }
+            if (parsedRedirectUri == null) {
+                checker.checkRedirectUri();
+                parsedRedirectUri = checker.getRedirectUri();
+            }
+            if (parsedResponseType == null || parsedResponseMode == null) {
+                checker.checkResponseType();
+                parsedResponseType = checker.getParsedResponseType();
+                parsedResponseMode = checker.getParsedResponseMode();
+            }
+        } catch (Exception aux) {
+            // ignore
+        }
+
+        if (client != null && parsedRedirectUri != null && parsedResponseType != null && parsedResponseMode != null) {
+            return handleRedirectErrorToClient(epex.getError(), errorMessage);
+        }
+
+        // [TODO >>>] Should we throw an ErrorResponseException instead?
+        var errRep = new OAuth2ErrorRepresentation(epex.getError(), errorMessage);
+        return Response.status(status).entity(errRep).type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+
+    private Response handleRedirectErrorToClient(String error, String errorDescription) {
         CacheControlUtil.noBackButtonCacheControlHeader(session);
 
-        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(redirectUri, responseMode, session, null)
+        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(parsedRedirectUri, parsedResponseMode, session, null)
                 .addParam(OAuth2Constants.ERROR, error);
 
         if (errorDescription != null) {
             errorResponseBuilder.addParam(OAuth2Constants.ERROR_DESCRIPTION, errorDescription);
         }
 
-        if (request.getState() != null) {
+        if (request != null && request.getState() != null) {
             errorResponseBuilder.addParam(OAuth2Constants.STATE, request.getState());
         }
 
-        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
-        if (!clientConfig.isExcludeIssuerFromAuthResponse()) {
+        if (client != null && !OIDCAdvancedConfigWrapper.fromClientModel(client).isExcludeIssuerFromAuthResponse()) {
             errorResponseBuilder.addParam(OAuth2Constants.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
         }
 
@@ -335,7 +424,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
     private void updateAuthenticationSession() {
         authenticationSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        authenticationSession.setRedirectUri(redirectUri);
+        authenticationSession.setRedirectUri(parsedRedirectUri);
         authenticationSession.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
         authenticationSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, request.getResponseType());
         authenticationSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, request.getRedirectUriParam());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -48,12 +48,10 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.cors.Cors;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.DPoPUtil;
-import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
 import org.keycloak.utils.StringUtil;
 
@@ -127,25 +125,35 @@ public class AuthorizationEndpointChecker {
         return parsedResponseMode;
     }
 
+    public MultivaluedMap<String, String> getRequestParams() {
+        return params;
+    }
+
+    public AuthorizationEndpointRequest getAuthorizationEndpointRequest() {
+        return request;
+    }
+
     public void checkRedirectUri() throws AuthorizationCheckException {
-        String redirectUriParam = request.getRedirectUriParam();
-        boolean isOIDCRequest = TokenUtil.isOIDCRequest(request.getScope());
+        String redirectUriParam = request != null ? request.getRedirectUriParam() : params.getFirst(OIDCLoginProtocol.REDIRECT_URI_PARAM);
+        String scope = request != null ? request.getScope() : params.getFirst(OIDCLoginProtocol.SCOPE_PARAM);
+
+        // The redirect_uri parameter is required for OIDC, but optional for OAuth2
+        boolean isOIDCRequest = TokenUtil.isOIDCRequest(scope);
 
         event.detail(Details.REDIRECT_URI, redirectUriParam);
 
-        // redirect_uri parameter is required per OpenID Connect, but optional per OAuth2
         this.redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client, isOIDCRequest);
         if (redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+            throw new AuthorizationCheckException(OAuthErrorException.INVALID_REDIRECT_URI, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
         }
     }
 
-
     public void checkResponseType() throws AuthorizationCheckException {
-        String responseType = request.getResponseType();
+        String responseTypeParam = request != null ? request.getResponseType() : params.getFirst(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+        String responseModeParam = request != null ? request.getResponseMode() : params.getFirst(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
 
-        if (responseType == null) {
+        if (responseTypeParam == null) {
             ServicesLogger.LOGGER.missingParameter(OAuth2Constants.RESPONSE_TYPE);
             String errorMessage = "Missing parameter: response_type";
             event.detail(Details.REASON, errorMessage);
@@ -153,19 +161,21 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        event.detail(Details.RESPONSE_TYPE, responseType);
+        event.detail(Details.RESPONSE_TYPE, responseTypeParam);
 
         try {
-            this.parsedResponseType = OIDCResponseType.parse(responseType);
+            parsedResponseType = OIDCResponseType.parse(responseTypeParam);
         } catch (IllegalArgumentException iae) {
-            event.detail(Details.REASON, iae.getMessage());
+            ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+            String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_TYPE_PARAM;
+            event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, null);
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, errorMessage);
         }
 
-        OIDCResponseMode parsedResponseMode = null;
+        OIDCResponseMode responseMode;
         try {
-            parsedResponseMode = OIDCResponseMode.parse(request.getResponseMode(), parsedResponseType);
+            responseMode = OIDCResponseMode.parse(responseModeParam, parsedResponseType);
         } catch (IllegalArgumentException iae) {
             ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
             String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_MODE_PARAM;
@@ -174,10 +184,10 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        event.detail(Details.RESPONSE_MODE, parsedResponseMode.toString().toLowerCase());
+        event.detail(Details.RESPONSE_MODE, responseMode.toString().toLowerCase());
 
         // Disallowed by OIDC specs
-        if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY) {
+        if (parsedResponseType.isImplicitOrHybridFlow() && responseMode == OIDCResponseMode.QUERY) {
             ServicesLogger.LOGGER.responseModeQueryNotAllowed();
             String errorMessage = "Response_mode 'query' not allowed for implicit or hybrid flow";
             event.detail(Details.REASON, errorMessage);
@@ -185,9 +195,9 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        this.parsedResponseMode = parsedResponseMode;
+        parsedResponseMode = responseMode;
 
-        if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY_JWT &&
+        if (parsedResponseType.isImplicitOrHybridFlow() && responseMode == OIDCResponseMode.QUERY_JWT &&
                 (!StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ALG)) ||
                 !StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ENC)))) {
             ServicesLogger.LOGGER.responseModeQueryJwtNotAllowed();
@@ -224,14 +234,14 @@ public class AuthorizationEndpointChecker {
         }
     }
 
-    public boolean isInvalidResponseType(AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+    public boolean isInvalidResponseType(AuthorizationCheckException ex) {
         return "Missing parameter: response_type".equals(ex.getErrorDescription()) || OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE.equals(ex.getError());
     }
 
     public void checkInvalidRequestMessage() throws AuthorizationCheckException {
         if (request.getInvalidRequestMessage() != null) {
             event.error(Errors.INVALID_REQUEST);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Errors.INVALID_REQUEST, request.getInvalidRequestMessage());
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, request.getInvalidRequestMessage());
         }
     }
 
@@ -248,7 +258,7 @@ public class AuthorizationEndpointChecker {
                 new AuthorizationDetailsProcessorManager(session).validateAuthorizationDetail(authDetailsParam);
             } catch (Exception e) {
                 event.error(Errors.INVALID_REQUEST);
-                throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Errors.INVALID_REQUEST, e.getMessage());
+                throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, e.getMessage());
             }
         }
     }
@@ -437,35 +447,8 @@ public class AuthorizationEndpointChecker {
         }
     }
 
-
-    // Exception propagated to the caller, which will allow caller to send proper error response based on the context (Browser OIDC Authorization Endpoint, PAR etc)
-    public class AuthorizationCheckException extends Exception {
-
-        private final Response.Status status;
-        private final String error;
-        private final String errorDescription;
-
-        public AuthorizationCheckException(Response.Status status, String error, String errorDescription) {
-            this.status = status;
-            this.error = error;
-            this.errorDescription = errorDescription;
-        }
-
-        public void throwAsErrorPageException(AuthenticationSessionModel authenticationSession) {
-            throw new ErrorPageException(session, authenticationSession, status, error, errorDescription);
-        }
-
-        public void throwAsCorsErrorResponseException(Cors cors) {
-            AuthorizationEndpointChecker.this.event.detail("detail", errorDescription).error(error);
-            throw new CorsErrorResponseException(cors, error, errorDescription, status);
-        }
-
-        public String getError() {
-            return error;
-        }
-
-        public String getErrorDescription() {
-            return errorDescription;
-        }
+    public void throwAsCorsErrorResponseException(Cors cors, AuthorizationCheckException ex) {
+        event.detail("detail", ex.getErrorDescription()).error(ex.getError());
+        throw new CorsErrorResponseException(cors, ex.getError(), ex.getErrorDescription(), ex.getStatus());
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
@@ -50,6 +50,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
@@ -145,7 +146,7 @@ public class DeviceEndpoint extends AuthorizationEndpointBase implements RealmRe
 
         try {
             checker.checkPKCEParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             throw new ErrorResponseException(ex.getError(), ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -42,6 +42,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.par.ParResponse;
@@ -123,23 +124,23 @@ public class ParEndpoint extends AbstractParEndpoint {
 
         try {
             checker.checkRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: redirect_uri", Response.Status.BAD_REQUEST);
         }
 
         try {
             checker.checkResponseType();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             if (ex.getError().equals(OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE)) {
                 throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Unsupported response type", Response.Status.BAD_REQUEST);
             } else {
-                ex.throwAsCorsErrorResponseException(cors);
+                checker.throwAsCorsErrorResponseException(cors, ex);
             }
         }
 
         try {
             checker.checkValidScope();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             // PAR throws this as "invalid_request" error
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
@@ -150,8 +151,8 @@ public class ParEndpoint extends AbstractParEndpoint {
             checker.checkOIDCParams();
             checker.checkPKCEParams();
             checker.checkParDPoPParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            ex.throwAsCorsErrorResponseException(cors);
+        } catch (AuthorizationCheckException ex) {
+            checker.throwAsCorsErrorResponseException(cors, ex);
         }
 
         try {

--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -23,20 +23,53 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
+import static org.keycloak.OAuthErrorException.INVALID_REQUEST;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class ErrorPageException extends WebApplicationException {
 
+    private String error;
+    private String errorMessage;
+    private Object[] parameters;
+
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
-        super(errorMessage, ErrorPage.error(session, null, status, errorMessage, parameters));
+        this(session, INVALID_REQUEST, status, errorMessage, parameters);
+    }
+
+    public ErrorPageException(KeycloakSession session, String error, Response.Status status, String errorMessage, Object... parameters) {
+        this(session, null, error, status, errorMessage, parameters);
     }
 
     public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, Response.Status status, String errorMessage, Object... parameters) {
+        this(session, authSession, INVALID_REQUEST, status, errorMessage, parameters);
+    }
+
+    public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, String error, Response.Status status, String errorMessage, Object... parameters) {
         super(errorMessage, ErrorPage.error(session, authSession, status, errorMessage, parameters));
+        this.error = error;
+        this.errorMessage = errorMessage;
+        this.parameters = parameters;
     }
 
     public ErrorPageException(Response response) {
         super((Throwable) null, response);
+    }
+
+    public Response.Status getStatus() {
+        return Response.Status.fromStatusCode(getResponse().getStatus());
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Object[] getParameters() {
+        return parameters;
     }
 }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -475,22 +475,22 @@ public class LoginActionsService {
         if (clientID == null) {
             if (redirectUriParam != null) {
                 logger.warn("Unsupported to send 'redirect_uri' parameter without providing 'client_id' parameter.");
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, OIDCLoginProtocol.CLIENT_ID_PARAM);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, OIDCLoginProtocol.CLIENT_ID_PARAM);
             }
             client = SystemClientUtil.getSystemClient(realm);
             redirectUri = Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
         } else {
             client = session.clients().getClientByClientId(realm, clientID);
             if (client == null) {
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
             }
             if (!client.isEnabled()) {
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
             }
             if (redirectUriParam != null) {
                 redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client);
                 if (redirectUri == null) {
-                    throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+                    throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
                 }
             }
         }


### PR DESCRIPTION
closes #48542

This PR tries to be as unintrusive as possible. While processing an authorization request there are potential errors coming from 

1. checks in client policies
2. various request parsers (e.g. url query, request object, request_uri)
3. checks on request_uri, response_type, response_mode

most of these errors map to an unchecked ErrorPageException, which then displays an html error page.

When the request passes the above, errors tend to be reported back to the caller via redirect_uri already.

This PR proposes to first catch these ErrorPageExceptions and then (when configured to do so) make a "best effort" to use the redirect_uri path - otherwise, the error is returned to the caller as json object.

Without the `authorization.preferErrorOnRedirect` attribute on the realm, this PR changes nothing. As a result, no test cases needed to be touched. That was in fact the hard bit: change nothing, unless the headless error path is wanted.

Automated conformance tests are headless - they prefer errors to be delivered on the redirect_uri when possible.

If this approach gets accepted, we would likely want to expose that switch on the admin UI, which is not (yet) part of this PR.

This PR is at the bottom of all other HAIP conformance work.
