### PR TITLE
Fix #45068: Resolve localized client description in Account Applications

### DIFF
--- a/js/apps/account-ui/src/applications/Applications.tsx
+++ b/js/apps/account-ui/src/applications/Applications.tsx
@@ -197,7 +197,7 @@ export const Applications = () => {
                       {t("description")}
                     </DescriptionListTerm>
                     <DescriptionListDescription>
-                      {application.description}
+                      {label(t, application.description)}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 )}


### PR DESCRIPTION
Client descriptions in the Account Console Applications page were rendered as raw text.

As a result, localized placeholders such as ${username} appeared literally instead of being expanded.

Closes: https://github.com/keycloak/keycloak/issues/45068