### PR TITLE
[quarkus-next] TracingProviderTest.spanInfo fails due to OTel 1.60 W3…

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/tracing/TracingProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/tracing/TracingProviderTest.java
@@ -13,7 +13,6 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.data.ExceptionEventData;
 import io.opentelemetry.sdk.trace.data.StatusData;
@@ -84,7 +83,7 @@ public class TracingProviderTest {
 
                 var context = current.getSpanContext();
                 assertThat(context, is(span.getSpanContext()));
-                assertThat(context.getTraceFlags(), is(TraceFlags.getSampled()));
+                assertThat(context.getTraceFlags().isSampled(), is(true));
                 assertThat(current.isRecording(), is(true));
 
                 assertThat(current instanceof ReadableSpan, is(true));


### PR DESCRIPTION
…C random trace flag

This deliberately targets quakus-next, hence it does not close its parent issue and should not be merged to main earlier than 3.35.0.CR1.

Parent issue: https://github.com/keycloak/keycloak/issues/48552
