### PR TITLE
[quarkus-next] Model tests fail due to ByteBuddy removal from Hiberna…

### DIFF
--- a/testsuite/model/pom.xml
+++ b/testsuite/model/pom.xml
@@ -124,6 +124,11 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Quarkus excludes byte-buddy from hibernate-core; model tests need it at runtime -->
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
…te runtime classpath

Closes: #48559

Although this change will become a hard requirement with Quarkus version 3.35.0.CR1, I think it can go directly to main immediately. ByteBuddy is already a transitive dependency of hibernate-core, so adding it explicitly is harmless and make us prepared. 
