### PR TITLE
Enhance quick-theme JAR generation with rendered names and descriptions

### DIFF
--- a/core/src/main/java/org/keycloak/representations/info/ThemeInfoRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/info/ThemeInfoRepresentation.java
@@ -26,6 +26,7 @@ package org.keycloak.representations.info;
 public class ThemeInfoRepresentation {
 
     private String name;
+    private String renderedName;
     private String[] locales;
     private String description;
 
@@ -35,6 +36,14 @@ public class ThemeInfoRepresentation {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getRenderedName() {
+        return renderedName;
+    }
+
+    public void setRenderedName(String renderedName) {
+        this.renderedName = renderedName;
     }
 
     public String[] getLocales() {

--- a/docs/guides/ui-customization/themes.adoc
+++ b/docs/guides/ui-customization/themes.adoc
@@ -403,11 +403,14 @@ The contents of `META-INF/keycloak-themes.json` in this case would be:
 {
     "themes": [{
         "name" : "mytheme",
+        "renderedName" : "My Theme",
         "types": [ "login", "email" ]
     }]
 }
 ----
 +
+`renderedName` is optional. If present, Keycloak uses it as the user-facing label in theme selection dropdowns, while `name` remains the canonical theme id used for resolution and resource loading.
+
 A single archive can contain multiple themes and each theme can support one or more types.
 
 To deploy the archive to {project_name}, add it to the `providers/` directory of

--- a/js/apps/admin-ui/src/clients/add/LoginSettingsPanel.tsx
+++ b/js/apps/admin-ui/src/clients/add/LoginSettingsPanel.tsx
@@ -30,7 +30,10 @@ export const LoginSettingsPanel = ({ access }: { access?: boolean }) => {
         }}
         options={[
           { key: "", value: t("choose") },
-          ...loginThemes.map(({ name }) => ({ key: name, value: name })),
+          ...loginThemes.map(({ name, renderedName }) => ({
+            key: name,
+            value: renderedName || name,
+          })),
         ]}
       />
       <DefaultSwitchControl

--- a/js/apps/admin-ui/src/realm-settings/themes/QuickTheme.tsx
+++ b/js/apps/admin-ui/src/realm-settings/themes/QuickTheme.tsx
@@ -28,7 +28,9 @@ export const QuickTheme = ({ realm, theme }: QuickThemeProps) => {
     const zip = new JSZip();
 
     const styles = JSON.parse(realm.attributes?.style ?? "{}");
-    const { favicon, logo, bgimage, fileName } = realm;
+    const { favicon, logo, bgimage, fileName, themeName } = realm;
+    const themeId = "quick-theme";
+    const renderedThemeName = themeName?.trim() || themeId;
 
     const logoName =
       "img/logo" + logo?.name?.substring(logo?.name?.lastIndexOf("."));
@@ -115,6 +117,7 @@ styles=css/login.css css/theme-styles.css
       `{
   "themes": [{
       "name" : "${themeNameClean}",
+      "renderedName" : ${JSON.stringify(renderedThemeName)},
       "types": [ "login", "account", "admin", "common" ]
   }]
 }`,

--- a/js/apps/admin-ui/src/realm-settings/themes/ThemeSettings.tsx
+++ b/js/apps/admin-ui/src/realm-settings/themes/ThemeSettings.tsx
@@ -56,7 +56,7 @@ export const ThemeSettingsTab = ({ realm, save }: ThemeSettingsTabProps) => {
             options={appendEmptyChoice(
               themeTypes.login.map((theme) => ({
                 key: theme.name,
-                value: theme.name,
+                value: theme.renderedName || theme.name,
                 description: theme.description,
               })),
             )}
@@ -71,7 +71,7 @@ export const ThemeSettingsTab = ({ realm, save }: ThemeSettingsTabProps) => {
             options={appendEmptyChoice(
               themeTypes.account.map((theme) => ({
                 key: theme.name,
-                value: theme.name,
+                value: theme.renderedName || theme.name,
                 description: theme.description,
               })),
             )}
@@ -86,7 +86,7 @@ export const ThemeSettingsTab = ({ realm, save }: ThemeSettingsTabProps) => {
             options={appendEmptyChoice(
               themeTypes.admin.map((theme) => ({
                 key: theme.name,
-                value: theme.name,
+                value: theme.renderedName || theme.name,
                 description: theme.description,
               })),
             )}
@@ -101,7 +101,7 @@ export const ThemeSettingsTab = ({ realm, save }: ThemeSettingsTabProps) => {
             options={appendEmptyChoice(
               themeTypes.email.map((theme) => ({
                 key: theme.name,
-                value: theme.name,
+                value: theme.renderedName || theme.name,
                 description: theme.description,
               })),
             )}

--- a/js/libs/keycloak-admin-client/src/defs/serverInfoRepesentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/serverInfoRepesentation.ts
@@ -31,6 +31,7 @@ export interface ServerInfoRepresentation {
 
 export interface ThemeInfoRepresentation {
   name: string;
+  renderedName?: string;
   locales?: string[];
   description?: string;
 }

--- a/server-spi/src/main/java/org/keycloak/theme/Theme.java
+++ b/server-spi/src/main/java/org/keycloak/theme/Theme.java
@@ -38,6 +38,10 @@ public interface Theme {
 
     String getName();
 
+    default String getRenderedName() {
+        return getName();
+    }
+
     String getParentName();
 
     String getImportName();

--- a/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/info/ServerInfoAdminResource.java
@@ -246,6 +246,7 @@ public class ServerInfoAdminResource {
                     if (theme != null && name.equals(theme.getName()) && !theme.isAbstract()) {
                         ThemeInfoRepresentation ti = new ThemeInfoRepresentation();
                         ti.setName(name);
+                        ti.setRenderedName(theme.getRenderedName());
 
                         String locales = theme.getProperties().getProperty("locales");
                         if (locales != null) {

--- a/services/src/main/java/org/keycloak/theme/ClassLoaderTheme.java
+++ b/services/src/main/java/org/keycloak/theme/ClassLoaderTheme.java
@@ -35,6 +35,8 @@ public class ClassLoaderTheme extends FileBasedTheme {
 
     private String name;
 
+    private String renderedName;
+
     private String parentName;
 
     private String importName;
@@ -52,11 +54,20 @@ public class ClassLoaderTheme extends FileBasedTheme {
     private Properties properties;
 
     public ClassLoaderTheme(String name, Type type, ClassLoader classLoader) throws IOException {
-        init(name, type, classLoader);
+        this(name, name, type, classLoader);
+    }
+
+    public ClassLoaderTheme(String name, String renderedName, Type type, ClassLoader classLoader) throws IOException {
+        init(name, renderedName, type, classLoader);
     }
 
     public void init(String name, Type type, ClassLoader classLoader) throws IOException {
+        init(name, name, type, classLoader);
+    }
+
+    public void init(String name, String renderedName, Type type, ClassLoader classLoader) throws IOException {
         this.name = name;
+        this.renderedName = renderedName == null ? name : renderedName;
         this.type = type;
         this.classLoader = classLoader;
 
@@ -83,6 +94,11 @@ public class ClassLoaderTheme extends FileBasedTheme {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getRenderedName() {
+        return renderedName;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/theme/ClasspathThemeProviderFactory.java
+++ b/services/src/main/java/org/keycloak/theme/ClasspathThemeProviderFactory.java
@@ -47,6 +47,7 @@ public class ClasspathThemeProviderFactory implements ThemeProviderFactory {
 
     public static class ThemeRepresentation {
         private String name;
+        private String renderedName;
         private String[] types;
 
         public String getName() {
@@ -55,6 +56,14 @@ public class ClasspathThemeProviderFactory implements ThemeProviderFactory {
 
         public void setName(String name) {
             this.name = name;
+        }
+
+        public String getRenderedName() {
+            return renderedName;
+        }
+
+        public void setRenderedName(String renderedName) {
+            this.renderedName = renderedName;
         }
 
         public String[] getTypes() {
@@ -116,7 +125,7 @@ public class ClasspathThemeProviderFactory implements ThemeProviderFactory {
                     if (!themes.containsKey(type)) {
                         themes.put(type, new HashMap<>());
                     }
-                    themes.get(type).put(themeRep.getName(), new ClassLoaderTheme(themeRep.getName(), type, classLoader));
+                    themes.get(type).put(themeRep.getName(), new ClassLoaderTheme(themeRep.getName(), themeRep.getRenderedName(), type, classLoader));
                 }
             }
         } catch (Exception e) {

--- a/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
@@ -194,6 +194,11 @@ public class DefaultThemeManager implements ThemeManager {
         }
 
         @Override
+        public String getRenderedName() {
+            return themes.get(0).getRenderedName();
+        }
+
+        @Override
         public String getParentName() {
             return themes.get(0).getParentName();
         }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ServerInfoTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ServerInfoTest.java
@@ -70,6 +70,8 @@ public class ServerInfoTest {
         Assert.assertNames(info.getThemes().get("email"), "keycloak");
         Assert.assertNames(info.getThemes().get("login"), "keycloak", "keycloak.v2");
         Assert.assertNames(info.getThemes().get("welcome"), "keycloak");
+        info.getThemes().values().forEach(themes ->
+                themes.forEach(theme -> assertEquals(theme.getName(), theme.getRenderedName())));
 
         assertNotNull(info.getEnums());
 


### PR DESCRIPTION
## Summary

This PR enhances quick-theme export so custom themes can be imported and displayed more cleanly in Keycloak. The main user-facing feature is to allow the user's inputted theme name to be displayed on theme selection dropdowns.

Changes included:
- generate theme archives with a sanitized dynamic theme id instead of always using `quick-theme`
- store an optional `renderedName` in `META-INF/keycloak-themes.json`
- persist theme descriptions in `messages_en.properties` for login, account, and admin themes
- expose `renderedName` through server info
- show rendered names in admin theme selectors and client login theme selection while still using the canonical theme id internally

This allows admins to see their originally inputted custom theme names rather than a default quick-theme in theme selectors.

Closes [#47866](https://github.com/keycloak/keycloak/issues/47866#issue-4226447415)