### PR TITLE
fix: trigger `INVITE_ORG` and `REGISTER` event when a new user is invited to an organization

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/actiontoken/inviteorg/InviteOrgActionTokenHandler.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/inviteorg/InviteOrgActionTokenHandler.java
@@ -117,7 +117,9 @@ public class InviteOrgActionTokenHandler extends AbstractActionTokenHandler<Invi
         AuthenticationSessionModel authSession = tokenContext.getAuthenticationSession();
         EventBuilder event = tokenContext.getEvent();
 
-        event.event(EventType.INVITE_ORG).detail(Details.USERNAME, user.getUsername());
+        event.event(EventType.INVITE_ORG)
+                .detail(Details.USERNAME, user.getUsername())
+                .detail(Details.ORG_ID, token.getOrgId());
 
         OrganizationModel organization = orgProvider.getById(token.getOrgId());
 

--- a/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
+++ b/services/src/main/java/org/keycloak/authentication/forms/RegistrationUserCreation.java
@@ -363,12 +363,19 @@ public class RegistrationUserCreation implements FormAction, FormActionFactory {
                 OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
                 OrganizationModel orgModel = provider.getById(token.getOrgId());
                 provider.addManagedMember(orgModel, user);
-                context.getEvent().detail(Details.ORG_ID, orgModel.getId());
                 context.getAuthenticationSession().setRedirectUri(token.getRedirectUri());
 
                 // Delete the invitation since it has been used
                 InvitationManager invitationManager = provider.getInvitationManager();
                 invitationManager.remove(token.getId());
+
+                context.getEvent()
+                    .clone()
+                    .event(EventType.INVITE_ORG)
+                    .user(user)
+                    .detail(Details.USERNAME, user.getUsername())
+                    .detail(Details.ORG_ID, orgModel.getId())
+                    .success();
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -828,8 +828,11 @@ public class LoginActionsService {
         AuthenticationManager.expireIdentityCookie(session);
 
         if (Profile.isFeatureEnabled(Profile.Feature.ORGANIZATION) && tokenString != null) {
-            //this call should extract orgId from token and set the organization to the session context
+            // this call should extract orgId from token and set the organization to the session context
             Response response = preHandleActionToken(tokenString);
+            // restore event type because handleActionToken() overwrites it to EXECUTE_ACTION_TOKEN
+            event.event(EventType.REGISTER);
+
             if (response != null) {
                 return response;
             }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationLinkTest.java
@@ -37,12 +37,15 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.keycloak.admin.client.resource.OrganizationResource;
 import org.keycloak.common.util.UriUtils;
 import org.keycloak.cookie.CookieType;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSBuilder;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
 import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
+import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.MemberRepresentation;
 import org.keycloak.representations.idm.MembershipType;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
@@ -50,6 +53,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testsuite.AbstractAuthenticationTest;
+import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.authentication.PushButtonAuthenticatorFactory;
 import org.keycloak.testsuite.pages.InfoPage;
@@ -85,6 +89,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
+
+    @Rule
+    public AssertEvents events = new AssertEvents(this);
 
     @Rule
     public GreenMailRule greenMail = new GreenMailRule();
@@ -250,10 +257,35 @@ public class OrganizationInvitationLinkTest extends AbstractOrganizationTest {
         String firstName = "Homer";
         String lastName = "Simpson";
 
-        OrganizationResource organization = managedRealm.admin().organizations().get(createOrganization().getId());
+        String orgId = createOrganization().getId();
+        OrganizationResource organization = managedRealm.admin().organizations().get(orgId);
         organization.members().inviteUser(email, firstName, lastName).close();
 
         registerUser(organization, email);
+
+        // Assert INVITE_ORG event fires when user is added to the organization
+        EventRepresentation inviteEvent = events.expect(EventType.INVITE_ORG)
+                .client("account")
+                .user(Matchers.notNullValue(String.class))
+                .detail(Details.ORG_ID, orgId)
+                .assertEvent();
+
+        // Assert REGISTER event fires during new user registration via organization invite
+        events.expect(EventType.REGISTER)
+                .client("account")
+                .user(inviteEvent.getUserId())
+                .detail(Details.EMAIL, email)
+                .detail(Details.REGISTER_METHOD, "form")
+                .assertEvent();
+
+        // Assert LOGIN event fires after registration completes
+        events.expectLogin()
+                .client("account")
+                .user(inviteEvent.getUserId())
+                .removeDetail(Details.REDIRECT_URI)
+                .removeDetail(Details.CONSENT)
+                .session(AssertEvents.isSessionId())
+                .assertEvent();
 
         List<UserRepresentation> users = managedRealm.admin().users().searchByEmail(email, true);
         assertThat(users, not(empty()));


### PR DESCRIPTION
Closes: #48610 

- Fire `INVITE_ORG` event in `RegistrationUserCreation.addOrganizationMember()` using a cloned `EventBuilder`
- Restore `event.event(EventType.REGISTER)` after `preHandleActionToken()` in `LoginActionsService.registerRequest()`
- Added event assertions (`INVITE_ORG`, `REGISTER`, `LOGIN`)