### PR TITLE
Fix broken SAML 2.0 specification links in documentation

### DIFF
--- a/docs/documentation/server_admin/topics/overview/how.adoc
+++ b/docs/documentation/server_admin/topics/overview/how.adoc
@@ -3,7 +3,7 @@
 
 {project_name} is a separate server that you manage on your network.  Applications are configured to point to and
 be secured by this server.  {project_name} uses open protocol standards like link:https://openid.net/developers/how-connect-works/[OpenID Connect]
-or link:https://saml.xml.org/saml-specifications[SAML 2.0] to secure
+or link:https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html[SAML 2.0] to secure
 your applications.  Browser applications redirect a user's browser from the application to the {project_name} authentication
 server where they enter their credentials.  This redirection is important because users are completely isolated from applications and
 applications never see a user's credentials.  Applications instead are given an identity token or assertion that is cryptographically

--- a/docs/documentation/server_admin/topics/sso-protocols/con-saml.adoc
+++ b/docs/documentation/server_admin/topics/sso-protocols/con-saml.adoc
@@ -4,7 +4,7 @@
 
 === SAML
 [role="_abstract"]
-link:https://saml.xml.org/saml-specifications[SAML 2.0] is a similar specification to OIDC but more mature.  It is descended from SOAP and web service messaging specifications so is generally more verbose than OIDC.  SAML 2.0 is an authentication protocol that exchanges XML documents between authentication servers and applications.  XML signatures and encryption are used to verify requests and responses.
+link:https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html[SAML 2.0] is a similar specification to OIDC but more mature.  It is descended from SOAP and web service messaging specifications so is generally more verbose than OIDC.  SAML 2.0 is an authentication protocol that exchanges XML documents between authentication servers and applications.  XML signatures and encryption are used to verify requests and responses.
 
 In general, SAML implements two use cases. 
 


### PR DESCRIPTION
Fixes the broken SAML 2.0 specification link in two files:
- [`docs/documentation/server_admin/topics/overview/how.adoc`](https://github.com/keycloak/keycloak/blob/main/docs/documentation/server_admin/topics/overview/how.adoc)
- [`docs/documentation/server_admin/topics/sso-protocols/con-saml.adoc`](https://github.com/keycloak/keycloak/blob/main/docs/documentation/server_admin/topics/sso-protocols/con-saml.adoc)

The link [`https://saml.xml.org/saml-specifications`](https://saml.xml.org/saml-specifications) returns a dead page. Replaced with [`https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html`](https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html).

Closes #48611