### PR TITLE
Remove form data from the registerNode and unregisterNode method signature

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
+++ b/services/src/main/java/org/keycloak/services/resources/ClientsManagementService.java
@@ -18,7 +18,6 @@ package org.keycloak.services.resources;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -91,14 +90,12 @@ public class ClientsManagementService {
     /**
      * URL invoked by adapter to register new client cluster node. Each application cluster node will invoke this URL once it joins cluster
      *
-     * @param authorizationHeader
-     * @param formData
      * @return
      */
     @Path("register-node")
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    public Response registerNode(@HeaderParam(HttpHeaders.AUTHORIZATION) String authorizationHeader, final MultivaluedMap<String, String> formData) {
+    public Response registerNode() {
         if (!checkSsl()) {
             throw new ForbiddenException("HTTPS required");
         }
@@ -110,6 +107,7 @@ public class ClientsManagementService {
             throw new NotAuthorizedException("Realm not enabled");
         }
 
+        MultivaluedMap<String, String> formData = request.getDecodedFormParameters();
         ClientModel client = authorizeClient();
         String nodeHost = getClientClusterHost(formData);
 
@@ -132,14 +130,12 @@ public class ClientsManagementService {
     /**
      * URL invoked by adapter to register new client cluster node. Each application cluster node will invoke this URL once it joins cluster
      *
-     * @param authorizationHeader
-     * @param formData
      * @return
      */
     @Path("unregister-node")
     @POST
     @Produces(MediaType.APPLICATION_JSON)
-    public Response unregisterNode(@HeaderParam(HttpHeaders.AUTHORIZATION) String authorizationHeader, final MultivaluedMap<String, String> formData) {
+    public Response unregisterNode() {
         if (!checkSsl()) {
             throw new ForbiddenException("HTTPS required");
         }
@@ -151,6 +147,7 @@ public class ClientsManagementService {
             throw new NotAuthorizedException("Realm not enabled");
         }
 
+        MultivaluedMap<String, String> formData = request.getDecodedFormParameters();
         ClientModel client = authorizeClient();
         String nodeHost = getClientClusterHost(formData);
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.tests.admin;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,7 +40,10 @@ import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ProtocolMappersResource;
 import org.keycloak.admin.client.resource.RoleMappingResource;
 import org.keycloak.admin.client.resource.RolesResource;
+import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
+import org.keycloak.authentication.authenticators.client.JWTClientSecretAuthenticator;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.AccountRoles;
@@ -47,6 +51,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
+import org.keycloak.protocol.oidc.client.authentication.JWTClientSecretCredentialsProvider;
 import org.keycloak.protocol.saml.SamlProtocol;
 import org.keycloak.representations.adapters.action.GlobalRequestResult;
 import org.keycloak.representations.adapters.action.PushNotBeforeAction;
@@ -79,6 +84,8 @@ import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.tests.utils.admin.AdminEventPaths;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.RegisterNodeResponse;
+import org.keycloak.testsuite.util.oauth.UnregisterNodeResponse;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -669,6 +676,52 @@ public class ClientTest {
 
         assertEquals(1, managedRealm.admin().clients().get(id).toRepresentation().getRegisteredNodes().size());
         managedRealm.admin().clients().get(id).unregisterNode(myhost);
+    }
+
+    @Test
+    public void nodesUsingClientEndpointAndJwt() throws MalformedURLException, InterruptedException {
+        testApp.kcAdmin().clear();
+
+        ClientResource clientResource = AdminApiUtil.findClientByClientId(managedRealm.admin(), "test-app");
+        ClientRepresentation clientRep = clientResource.toRepresentation();
+        clientRep.setClientAuthenticatorType(JWTClientSecretAuthenticator.PROVIDER_ID);
+        clientResource.update(clientRep);
+        managedRealm.cleanup().add(r -> {
+            clientRep.setClientAuthenticatorType(ClientIdAndSecretAuthenticator.PROVIDER_ID);
+            r.clients().get(clientRep.getId()).update(clientRep);
+        });
+
+        JWTClientSecretCredentialsProvider jwtProvider = new JWTClientSecretCredentialsProvider();
+        jwtProvider.setClientSecret(clientRep.getSecret(), Algorithm.HS256);
+        String jwt = jwtProvider.createSignedRequestToken("test-app", oauth.getEndpoints().getIssuer(), Algorithm.HS256);
+
+        // register the node
+        String myhost = URI.create(managedRealm.getBaseUrl()).getHost();
+        RegisterNodeResponse resgiterResponse = oauth.registerNodeRequest().clientClusterHost(myhost).clientJwt(jwt).send();
+        Assertions.assertTrue(resgiterResponse.isSuccess());
+        jwt = jwtProvider.createSignedRequestToken("test-app", oauth.getEndpoints().getIssuer(), Algorithm.HS256);
+        resgiterResponse = oauth.registerNodeRequest().clientClusterHost("invalid").clientJwt(jwt).send();
+        Assertions.assertTrue(resgiterResponse.isSuccess());
+        GlobalRequestResult result = managedRealm.admin().clients().get(clientRep.getId()).testNodesAvailable();
+        assertEquals(1, result.getSuccessRequests().size());
+        assertEquals(1, result.getFailedRequests().size());
+
+        // test availability and nodes are registered
+        TestAvailabilityAction testAvailable = testApp.kcAdmin().getTestAvailable();
+        assertEquals("test-app", testAvailable.getResource());
+        assertEquals(2, managedRealm.admin().clients().get(clientRep.getId()).toRepresentation().getRegisteredNodes().size());
+
+        // unregister the invalid node
+        jwt = jwtProvider.createSignedRequestToken("test-app", oauth.getEndpoints().getIssuer(), Algorithm.HS256);
+        UnregisterNodeResponse unregisterResponse = oauth.unregisterNodeRequest().clientClusterHost("invalid").clientJwt(jwt).send();
+        Assertions.assertTrue(unregisterResponse.isSuccess());
+        assertEquals(1, managedRealm.admin().clients().get(clientRep.getId()).toRepresentation().getRegisteredNodes().size());
+
+        // unregister the valid node
+        jwt = jwtProvider.createSignedRequestToken("test-app", oauth.getEndpoints().getIssuer(), Algorithm.HS256);
+        unregisterResponse = oauth.unregisterNodeRequest().clientClusterHost(myhost).clientJwt(jwt).send();
+        Assertions.assertTrue(unregisterResponse.isSuccess());
+        assertNull(managedRealm.admin().clients().get(clientRep.getId()).toRepresentation().getRegisteredNodes());
     }
 
     @Test

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
@@ -268,6 +268,14 @@ public abstract class AbstractOAuthClient<T> {
         return pushedAuthorizationRequest().send();
     }
 
+    public RegisterNodeRequest registerNodeRequest() {
+        return new RegisterNodeRequest(this);
+    }
+
+    public UnregisterNodeRequest unregisterNodeRequest() {
+        return new UnregisterNodeRequest(this);
+    }
+
     public <J extends JsonWebToken> J parseToken(String token, Class<J> clazz) {
         return tokensManager.parseToken(token, clazz);
     }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RegisterNodeRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RegisterNodeRequest.java
@@ -1,0 +1,49 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.keycloak.constants.AdapterConstants;
+import org.keycloak.services.resources.ClientsManagementService;
+import org.keycloak.services.resources.RealmsResource;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class RegisterNodeRequest extends AbstractHttpPostRequest<RegisterNodeRequest, RegisterNodeResponse> {
+
+    private String clientClusterHost;
+
+    RegisterNodeRequest(AbstractOAuthClient<?> client) {
+        super(client);
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return UriBuilder.fromUri(client.getBaseUrl())
+                .path(RealmsResource.class)
+                .path("{realm}/clients-managements")
+                .path(ClientsManagementService.class, "registerNode")
+                .build(client.getRealm())
+                .toString();
+    }
+
+    public RegisterNodeRequest clientClusterHost(String clientClusterHost) {
+        this.clientClusterHost = clientClusterHost;
+        return this;
+    }
+
+    @Override
+    protected void initRequest() {
+        parameter(AdapterConstants.CLIENT_CLUSTER_HOST, clientClusterHost);
+    }
+
+    @Override
+    protected RegisterNodeResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new RegisterNodeResponse(response);
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RegisterNodeResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RegisterNodeResponse.java
@@ -1,0 +1,25 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class RegisterNodeResponse extends AbstractHttpResponse {
+
+    public RegisterNodeResponse(CloseableHttpResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void parseContent() {
+    }
+
+    @Override
+    protected int getSuccessCode() {
+        return 204;
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/UnregisterNodeRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/UnregisterNodeRequest.java
@@ -1,0 +1,49 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.keycloak.constants.AdapterConstants;
+import org.keycloak.services.resources.ClientsManagementService;
+import org.keycloak.services.resources.RealmsResource;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class UnregisterNodeRequest extends AbstractHttpPostRequest<UnregisterNodeRequest, UnregisterNodeResponse> {
+
+    private String clientClusterHost;
+
+    UnregisterNodeRequest(AbstractOAuthClient<?> client) {
+        super(client);
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return UriBuilder.fromUri(client.getBaseUrl())
+                .path(RealmsResource.class)
+                .path("{realm}/clients-managements")
+                .path(ClientsManagementService.class, "unregisterNode")
+                .build(client.getRealm())
+                .toString();
+    }
+
+    public UnregisterNodeRequest clientClusterHost(String clientClusterHost) {
+        this.clientClusterHost = clientClusterHost;
+        return this;
+    }
+
+    @Override
+    protected void initRequest() {
+        parameter(AdapterConstants.CLIENT_CLUSTER_HOST, clientClusterHost);
+    }
+
+    @Override
+    protected UnregisterNodeResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new UnregisterNodeResponse(response);
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/UnregisterNodeResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/UnregisterNodeResponse.java
@@ -1,0 +1,25 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class UnregisterNodeResponse extends AbstractHttpResponse {
+
+    public UnregisterNodeResponse(CloseableHttpResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void parseContent() {
+    }
+
+    @Override
+    protected int getSuccessCode() {
+        return 204;
+    }
+}


### PR DESCRIPTION
Closes #48628

PR to remove the form data from the register and unregister node. The problem is that using it in the method signature makes the form decoded and is missing for the authentication of the client. This makes the method fail for authentications that require the form parameters (like `client_id`, `client_secret` or even the assertion when using a jwt authentication). Test added. I have added the two methods to the oauth client, let me know if this is OK for you.