### PR TITLE
Fix missing representation and detail in organization invitation admin events

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -199,7 +199,10 @@ public class OrganizationInvitationResource {
             throw ErrorResponse.error("Failed to send invite email", Status.INTERNAL_SERVER_ERROR);
         }
 
-        adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).success();
+        adminEvent.operation(OperationType.ACTION)
+                .representation(toMinimalRepresentation(invitation))
+                .resourcePath(session.getContext().getUri())
+                .success();
 
         return Response.noContent().build();
     }
@@ -326,9 +329,12 @@ public class OrganizationInvitationResource {
         OrganizationProvider provider = session.getProvider(OrganizationProvider.class);
         InvitationManager invitationManager = provider.getInvitationManager();
 
-        verifyInvitationById(invitationManager, id);
+        OrganizationInvitationModel invitation = verifyInvitationById(invitationManager, id);
         invitationManager.remove(id);
-        adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
+        adminEvent.operation(OperationType.DELETE)
+                .representation(toMinimalRepresentation(invitation))
+                .resourcePath(session.getContext().getUri())
+                .success();
 
         return Response.noContent().build();
     }
@@ -385,6 +391,16 @@ public class OrganizationInvitationResource {
                 PENDING;
         rep.setStatus(dynamicStatus);
 
+        return rep;
+    }
+
+    private OrganizationInvitationRepresentation toMinimalRepresentation(OrganizationInvitationModel model) {
+        if (model == null) return null;
+
+        OrganizationInvitationRepresentation rep = new OrganizationInvitationRepresentation();
+        rep.setId(model.getId());
+        rep.setEmail(model.getEmail());
+        rep.setOrganizationId(model.getOrganizationId());
         return rep;
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/admin/OrganizationInvitationManagementTest.java
@@ -25,6 +25,8 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
 import org.keycloak.representations.idm.OrganizationInvitationRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -60,6 +62,8 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
         OrganizationRepresentation orgRep = createOrganization("test-org", "test-org.com");
         organizationId = orgRep.getId();
         organization = managedRealm.admin().organizations().get(organizationId);
+
+        assertAdminEvents.clear();
     }
 
     @Override
@@ -100,13 +104,24 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
     public void testGetInvitationById() {
         // Create invitation
         sendInvitation("user@test-org.com", "Test", "User");
-        
+
         // Get invitations list
         List<OrganizationInvitationRepresentation> invitations = organization.invitations().list();
         assertThat(invitations, hasSize(1));
-        
+
         String invitationId = invitations.get(0).getId();
-        
+
+        assertAdminEvents.expect()
+                .realmId(TEST_REALM_NAME)
+                .operationType(OperationType.ACTION)
+                .resourceType(ResourceType.ORGANIZATION_MEMBERSHIP)
+                .resourcePath("organizations/" + organizationId + "/members/invite-user")
+                .representation(Map.of(
+                        "id", invitationId,
+                        "email", "user@test-org.com",
+                        "organizationId", organizationId))
+                .assertEvent();
+
         // Get invitation by ID
         OrganizationInvitationRepresentation invitation = organization.invitations().get(invitationId);
         
@@ -158,15 +173,37 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
     public void testDeleteInvitation() {
         // Create invitation
         sendInvitation("user@test-org.com", "Test", "User");
-        
+
         List<OrganizationInvitationRepresentation> invitations = organization.invitations().list();
         String invitationId = invitations.get(0).getId();
-        
+
+        assertAdminEvents.expect()
+                .realmId(TEST_REALM_NAME)
+                .operationType(OperationType.ACTION)
+                .resourceType(ResourceType.ORGANIZATION_MEMBERSHIP)
+                .resourcePath("organizations/" + organizationId + "/members/invite-user")
+                .representation(Map.of(
+                        "id", invitationId,
+                        "email", "user@test-org.com",
+                        "organizationId", organizationId))
+                .assertEvent();
+
         // Delete invitation
         try (Response response = organization.invitations().delete(invitationId)) {
             assertThat(response.getStatus(), equalTo(204));
         }
-        
+
+        assertAdminEvents.expect()
+                .realmId(TEST_REALM_NAME)
+                .operationType(OperationType.DELETE)
+                .resourceType(ResourceType.ORGANIZATION_MEMBERSHIP)
+                .resourcePath("organizations/" + organizationId + "/invitations/" + invitationId)
+                .representation(Map.of(
+                        "id", invitationId,
+                        "email", "user@test-org.com",
+                        "organizationId", organizationId))
+                .assertEvent();
+
         // Verify invitation is deleted
         try {
             OrganizationInvitationRepresentation invitation = organization.invitations().get(invitationId);
@@ -175,7 +212,7 @@ public class OrganizationInvitationManagementTest extends AbstractOrganizationTe
             // Expected - invitation should not be found
             assertThat(e.getMessage(), containsString("404"));
         }
-        
+
         // Verify it's not in the list
         List<OrganizationInvitationRepresentation> updatedInvitations = organization.invitations().list();
         assertThat(updatedInvitations, empty());


### PR DESCRIPTION
Closes: #48645 

- The ACTION (invite) and DELETE (remove invitation) admin events for `ORGANIZATION_MEMBERSHIP` were missing `representation` and `detail` fields
- Add organization representation and invited user's email to both events for consistency with other membership events

### Before

| Method | Operation | representation | detail |
|--------|-----------|---------------|--------|
| `OrganizationMemberResource.addMember()` | CREATE | organization | USERNAME, EMAIL |
| `OrganizationMemberResource.delete()` | DELETE | organization | USERNAME, EMAIL |
| `OrganizationInvitationResource.sendInvitation()` | ACTION | **null** | **null** |
| `OrganizationInvitationResource.deleteInvitation()` | DELETE | **null** | **null** |

### After

| Method | Operation | representation | detail |
|--------|-----------|---------------|--------|
| `OrganizationMemberResource.addMember()` | CREATE | organization | USERNAME, EMAIL |
| `OrganizationMemberResource.delete()` | DELETE | organization | USERNAME, EMAIL |
| `OrganizationInvitationResource.sendInvitation()` | ACTION | ~~organization~~ **invitation** | ~~EMAIL~~ **null** |
| `OrganizationInvitationResource.deleteInvitation()` | DELETE | ~~organization~~ **invitation** | ~~EMAIL~~ **null** |

ACTION/DELETE operation events use EMAIL only (no USERNAME) with the following reason:
  
- ACTION: The invited user may not exist yet
 - DELETE: It requires additional DB access to get username

---
AI-assisted development was used in this PR with Claude Code. All changes have been reviewed and are understood by the author.