### PR TITLE
IdP backchannel logout: read sid claim from ID token to support backchannel logout

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/OIDCIdentityProvider.java
@@ -622,8 +622,20 @@ public class OIDCIdentityProvider extends AbstractOAuth2IdentityProvider<OIDCIde
         }
 
         identity.setUsername(preferredUsername);
-        if (tokenResponse != null && tokenResponse.getSessionState() != null) {
-            identity.setBrokerSessionId(getConfig().getAlias() + "." + tokenResponse.getSessionState());
+        // Prefer the sid claim from the ID token over session_state from the token response.
+        // Per the OpenID Connect Back-Channel Logout spec, the logout token sid must match
+        // the sid in the ID token, so sid takes precedence when present.
+        // See: https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation
+        String sidClaim = (String) idToken.getOtherClaims().get(IDToken.SESSION_ID);
+        String sessionState = tokenResponse != null ? tokenResponse.getSessionState() : null;
+        if (sidClaim != null) {
+            if (sessionState != null && !sidClaim.equals(sessionState)) {
+                logger.warnf("IdP '%s': sid claim '%s' differs from session_state '%s'; using sid for backchannel logout.",
+                        getConfig().getAlias(), sidClaim, sessionState);
+            }
+            identity.setBrokerSessionId(getConfig().getAlias() + "." + sidClaim);
+        } else if (sessionState != null) {
+            identity.setBrokerSessionId(getConfig().getAlias() + "." + sessionState);
         }
         if (tokenResponse != null) identity.getContextData().put(FEDERATED_ACCESS_TOKEN_RESPONSE, tokenResponse);
         if (tokenResponse != null) processAccessTokenResponse(identity, tokenResponse);

--- a/services/src/test/java/org/keycloak/test/broker/oidc/OIDCIdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/oidc/OIDCIdentityProviderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.test.broker.oidc;
+
+import java.io.IOException;
+
+import org.keycloak.broker.oidc.OIDCIdentityProvider;
+import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
+import org.keycloak.broker.provider.BrokeredIdentityContext;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.representations.AccessTokenResponse;
+import org.keycloak.representations.JsonWebToken;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link OIDCIdentityProvider#extractIdentity} covering how the broker session ID
+ * is resolved from the sid claim in the ID token and the session_state in the token response.
+ */
+public class OIDCIdentityProviderTest {
+
+    private static final String IDP_ALIAS = "test-idp";
+    private static final String SUBJECT = "user-subject-123";
+    private static final String SID_FROM_ID_TOKEN = "sid-from-id-token";
+    private static final String SESSION_STATE_FROM_TOKEN_RESPONSE = "session-state-from-token-response";
+
+    @Test
+    public void extractIdentity_sidInIdToken_noSessionState_usesSid() throws IOException {
+        TestOIDCIdentityProvider provider = createProvider();
+
+        JsonWebToken idToken = buildIdToken(SUBJECT, SID_FROM_ID_TOKEN);
+        BrokeredIdentityContext identity = provider.extractIdentity(null, null, idToken);
+
+        Assert.assertEquals(IDP_ALIAS + "." + SID_FROM_ID_TOKEN, identity.getBrokerSessionId());
+    }
+
+    @Test
+    public void extractIdentity_sidInIdToken_sessionStateInTokenResponse_prefersSid() throws IOException {
+        TestOIDCIdentityProvider provider = createProvider();
+
+        JsonWebToken idToken = buildIdToken(SUBJECT, SID_FROM_ID_TOKEN);
+        AccessTokenResponse tokenResponse = buildTokenResponse(SESSION_STATE_FROM_TOKEN_RESPONSE);
+
+        BrokeredIdentityContext identity = provider.extractIdentity(tokenResponse, null, idToken);
+
+        Assert.assertEquals(IDP_ALIAS + "." + SID_FROM_ID_TOKEN, identity.getBrokerSessionId());
+    }
+
+    @Test
+    public void extractIdentity_noSidInIdToken_sessionStateInTokenResponse_usesSessionState() throws IOException {
+        TestOIDCIdentityProvider provider = createProvider();
+
+        JsonWebToken idToken = buildIdToken(SUBJECT, null);
+        AccessTokenResponse tokenResponse = buildTokenResponse(SESSION_STATE_FROM_TOKEN_RESPONSE);
+
+        BrokeredIdentityContext identity = provider.extractIdentity(tokenResponse, null, idToken);
+
+        Assert.assertEquals(IDP_ALIAS + "." + SESSION_STATE_FROM_TOKEN_RESPONSE, identity.getBrokerSessionId());
+    }
+
+    @Test
+    public void extractIdentity_noSidNoSessionState_brokerSessionIdIsNull() throws IOException {
+        TestOIDCIdentityProvider provider = createProvider();
+
+        JsonWebToken idToken = buildIdToken(SUBJECT, null);
+
+        BrokeredIdentityContext identity = provider.extractIdentity(null, null, idToken);
+
+        Assert.assertNull(identity.getBrokerSessionId());
+    }
+
+    @Test
+    public void extractIdentity_sidMatchesSessionState_noWarningSideEffect() throws IOException {
+        TestOIDCIdentityProvider provider = createProvider();
+
+        JsonWebToken idToken = buildIdToken(SUBJECT, SID_FROM_ID_TOKEN);
+        AccessTokenResponse tokenResponse = buildTokenResponse(SID_FROM_ID_TOKEN);
+
+        BrokeredIdentityContext identity = provider.extractIdentity(tokenResponse, null, idToken);
+
+        Assert.assertEquals(IDP_ALIAS + "." + SID_FROM_ID_TOKEN, identity.getBrokerSessionId());
+    }
+
+    private TestOIDCIdentityProvider createProvider() {
+        IdentityProviderModel model = new IdentityProviderModel();
+        OIDCIdentityProviderConfig config = new OIDCIdentityProviderConfig(model);
+        config.setAlias(IDP_ALIAS);
+        config.setEnabled(true);
+        config.setDisableUserInfoService(true); // avoid HTTP calls to userinfo endpoint
+        return new TestOIDCIdentityProvider(config);
+    }
+
+    private static class TestOIDCIdentityProvider extends OIDCIdentityProvider {
+
+        TestOIDCIdentityProvider(OIDCIdentityProviderConfig config) {
+            super(null, config);
+        }
+
+        @Override
+        public BrokeredIdentityContext extractIdentity(AccessTokenResponse tokenResponse,
+                String accessToken, JsonWebToken idToken) throws IOException {
+            return super.extractIdentity(tokenResponse, accessToken, idToken);
+        }
+    }
+
+    private JsonWebToken buildIdToken(String subject, String sid) {
+        JsonWebToken token = new JsonWebToken();
+        token.subject(subject);
+        if (sid != null) {
+            token.getOtherClaims().put("sid", sid);
+        }
+        return token;
+    }
+
+    private AccessTokenResponse buildTokenResponse(String sessionState) {
+        AccessTokenResponse response = new AccessTokenResponse();
+        response.setSessionState(sessionState);
+        return response;
+    }
+}


### PR DESCRIPTION
Fixes #12142

<Fix is as well suggested by @mposolda on the above issue>

Description:

When an external IdP includes a sid claim in the ID token (as required by [the OIDC Back-Channel Logout spec](https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation)), Keycloak was ignoring it and only reading session_state from the token response. This left brokerSessionId as null, causing backchannel logout requests to silently no-op, the session was never found and never terminated.

This fix reads sid from the ID token and prefers it over session_state when setting brokerSessionId. A WARN is logged if both are present but differ.

Manual verification:

Inspired from and updated on top of: https://github.com/keycloak/keycloak/issues/12142#issuecomment-2252511934

- Setup: Keycloak  + navikt/mock-oauth2-server running in Docker, configured to issue sid in the ID token. Realm target federated via the mock IdP.
- Logged in as a federated user via the mock IdP, entering session-id (which the mock IdP embeds as the sid claim in the ID token, simulating the real-world scenario described in the issue)
- Confirmed active session visible in the Keycloak Admin UI under Sessions for the user
- Confirmed broker_session_id = mock-idp.{session-id} in the offline_user_session table (Postgres)
- Triggered backchannel logout via POST /realms/target/protocol/openid-connect/logout/backchannel-logout with a logout token carrying sid={session-id}
- Confirmed HTTP 200 response, session gone from the Admin UI, and session row deleted from Postgres
- Server logs showed corresponding events

(Issue was also reproduced in the same setup without the fix: broker_session_id was NULL in Postgres, backchannel logout returned 200 but the session remained active in the Admin UI.)
