### PR TITLE
Fix critical bugs in OID4VC and FAPI security code

### DIFF
--- a/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZen.java
+++ b/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZen.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.authzen;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+public final class AuthZen {
+
+    public static final String AUTHZEN_ACCESS_PATH = "access/v1";
+    public static final String EVALUATION_PATH = AUTHZEN_ACCESS_PATH + "/evaluation";
+    public static final String EVALUATIONS_PATH = AUTHZEN_ACCESS_PATH + "/evaluations";
+
+    private AuthZen() {
+    }
+
+    public enum SubjectType {
+        CLIENT("client"),
+        USER("user");
+
+        private final String value;
+
+        SubjectType(String value) {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String getValue() {
+            return value;
+        }
+
+        @JsonCreator
+        public static SubjectType fromValue(String value) {
+            for (SubjectType type : values()) {
+                if (type.value.equals(value)) {
+                    return type;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported subject type: " + value);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Subject(
+            @JsonProperty(required = true) SubjectType type,
+            @JsonProperty(required = true) String id,
+            Map<String, Object> properties) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Resource(
+            @JsonProperty(required = true) String type,
+            @JsonProperty(required = true) String id,
+            Map<String, Object> properties) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Action(String name) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record EvaluationRequest(
+            @JsonProperty(required = true) Subject subject,
+            @JsonProperty(required = true) Resource resource,
+            @JsonProperty(required = true) Action action,
+            Map<String, Object> context) {}
+
+    public record EvaluationResponse(boolean decision, Map<String, Object> context) {
+        public EvaluationResponse(boolean decision) {
+            this(decision, null);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record EvaluationItem(
+            Subject subject,
+            Resource resource,
+            Action action,
+            Map<String, Object> context) {}
+
+    public enum EvaluationsSemantic {
+        @JsonProperty("execute_all")
+        EXECUTE_ALL,
+
+        @JsonProperty("deny_on_first_deny")
+        DENY_ON_FIRST_DENY,
+
+        @JsonProperty("permit_on_first_permit")
+        PERMIT_ON_FIRST_PERMIT;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Options(EvaluationsSemantic evaluationsSemantic) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record EvaluationsRequest(
+            Subject subject,
+            Resource resource,
+            Action action,
+            Map<String, Object> context,
+            Options options,
+            List<EvaluationItem> evaluations) {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record EvaluationsResponse(List<EvaluationResponse> evaluations) {}
+}

--- a/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZenResource.java
+++ b/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZenResource.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.authzen;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.attribute.Attributes;
+import org.keycloak.authorization.common.ClientModelIdentity;
+import org.keycloak.authorization.common.DefaultEvaluationContext;
+import org.keycloak.authorization.identity.Identity;
+import org.keycloak.authorization.identity.UserModelIdentity;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
+import org.keycloak.authorization.permission.ResourcePermission;
+import org.keycloak.authorization.store.ResourceStore;
+import org.keycloak.authorization.store.ScopeStore;
+import org.keycloak.authorization.store.StoreFactory;
+import org.keycloak.authorization.util.Tokens;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.util.JsonSerialization;
+
+public class AuthZenResource {
+
+    private static final AuthZen.EvaluationResponse DECISION_FALSE = new AuthZen.EvaluationResponse(false);
+    private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$");
+
+    private static final String NAMESPACE_ID = "id:";
+    private static final String NAMESPACE_USERNAME = "username:";
+    private static final String NAMESPACE_EMAIL = "email:";
+
+    private final KeycloakSession session;
+
+    public AuthZenResource(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @POST
+    @Path(AuthZen.EVALUATION_PATH)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response evaluate(AuthZen.EvaluationRequest request) {
+        AccessToken token = Tokens.getAccessToken(session);
+        if (token == null) {
+            throw new NotAuthorizedException("Bearer");
+        }
+        return Response.ok(evaluateSingle(request, token)).build();
+    }
+
+    @POST
+    @Path(AuthZen.EVALUATIONS_PATH)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response evaluations(AuthZen.EvaluationsRequest request) {
+        AccessToken token = Tokens.getAccessToken(session);
+        if (token == null) {
+            throw new NotAuthorizedException("Bearer");
+        }
+
+        if (request.evaluations() == null || request.evaluations().isEmpty()) {
+            // AuthZen 1.0 Section 7.1
+            // "If an evaluations array is NOT present or is empty, the Access Evaluations Request behaves in a
+            // backwards-compatible manner with the (single) Access Evaluation API Request (Section 6.1)."
+            AuthZen.EvaluationRequest single = new AuthZen.EvaluationRequest(
+                  request.subject(), request.resource(), request.action(), request.context());
+            return Response.ok(evaluateSingle(single, token)).build();
+        }
+
+        AuthZen.EvaluationsSemantic semantic = AuthZen.EvaluationsSemantic.EXECUTE_ALL;
+        if (request.options() != null && request.options().evaluationsSemantic() != null) {
+            semantic = request.options().evaluationsSemantic();
+        }
+
+        List<AuthZen.EvaluationResponse> results = new ArrayList<>(request.evaluations().size());
+        for (AuthZen.EvaluationItem item : request.evaluations()) {
+            AuthZen.EvaluationRequest merged = mergeDefaults(request, item);
+            AuthZen.EvaluationResponse itemResponse = evaluateSingle(merged, token);
+
+            if (semantic == AuthZen.EvaluationsSemantic.DENY_ON_FIRST_DENY && !itemResponse.decision()) {
+                results.add(new AuthZen.EvaluationResponse(false, Map.of("reason", "deny_on_first_deny")));
+                break;
+            }
+
+            results.add(itemResponse);
+
+            if (semantic == AuthZen.EvaluationsSemantic.PERMIT_ON_FIRST_PERMIT && itemResponse.decision()) {
+                break;
+            }
+        }
+        return Response.ok(new AuthZen.EvaluationsResponse(results)).build();
+    }
+
+    private static AuthZen.EvaluationRequest mergeDefaults(AuthZen.EvaluationsRequest defaults, AuthZen.EvaluationItem item) {
+        AuthZen.Subject subject = item.subject() != null ? item.subject() : defaults.subject();
+        AuthZen.Resource resource = item.resource() != null ? item.resource() : defaults.resource();
+        AuthZen.Action action = item.action() != null ? item.action() : defaults.action();
+        Map<String, Object> context = item.context() != null ? item.context() : defaults.context();
+        return new AuthZen.EvaluationRequest(subject, resource, action, context);
+    }
+
+    private AuthZen.EvaluationResponse evaluateSingle(AuthZen.EvaluationRequest request, AccessToken token) {
+        if (request.subject() == null || request.resource() == null || request.action() == null) {
+            return new AuthZen.EvaluationResponse(false);
+        }
+
+        RealmModel realm = session.getContext().getRealm();
+        AuthorizationProvider authorization = session.getProvider(AuthorizationProvider.class);
+        StoreFactory storeFactory = authorization.getStoreFactory();
+
+        ClientModel client;
+        if (request.subject().type() == AuthZen.SubjectType.CLIENT) {
+            if (!request.subject().id().equals(token.getIssuedFor())) {
+                return DECISION_FALSE;
+            }
+            client = realm.getClientByClientId(request.subject().id());
+        } else {
+            client = realm.getClientByClientId(token.getIssuedFor());
+        }
+
+        if (client == null || !client.isEnabled()) {
+            return DECISION_FALSE;
+        }
+
+        ResourceServer resourceServer = storeFactory.getResourceServerStore().findByClient(client);
+        if (resourceServer == null) {
+            return DECISION_FALSE;
+        }
+
+        Identity identity = resolveSubjectIdentity(realm, request);
+        if (identity == null) {
+            return DECISION_FALSE;
+        }
+
+        ResourceStore resourceStore = storeFactory.getResourceStore();
+        Resource resource = resourceStore.findByName(resourceServer, request.resource().id());
+        if (resource == null) {
+            return DECISION_FALSE;
+        }
+
+        String keycloakType = resource.getType() != null ? resource.getType() : "";
+        if (!keycloakType.equals(request.resource().type())) {
+            return DECISION_FALSE;
+        }
+
+        ScopeStore scopeStore = storeFactory.getScopeStore();
+        Scope scope = scopeStore.findByName(resourceServer, request.action().name());
+        if (scope == null) {
+            return DECISION_FALSE;
+        }
+
+        Map<String, List<String>> claims = null;
+        if (request.resource().properties() != null) {
+            claims = new HashMap<>();
+            convertContext(request.resource().properties(), claims);
+        }
+        if (request.context() != null) {
+            if (claims == null) {
+                claims = new HashMap<>();
+            }
+            convertContext(request.context(), claims);
+        }
+
+        DefaultEvaluationContext context = new DefaultEvaluationContext(identity, claims, session);
+        ResourcePermission permission = new ResourcePermission(resource, List.of(scope), resourceServer);
+
+        Collection<Permission> granted = authorization.evaluators()
+              .from(List.of(permission), context)
+              .evaluate(resourceServer, null);
+
+        return new AuthZen.EvaluationResponse(!granted.isEmpty());
+    }
+
+    private Identity resolveSubjectIdentity(RealmModel realm, AuthZen.EvaluationRequest request) {
+        AuthZen.Subject subject = request.subject();
+        Identity identity = switch (subject.type()) {
+            case USER -> {
+                UserModel user = resolveUserId(realm, subject.id());
+                yield user != null ? new UserModelIdentity(realm, user) : null;
+            }
+            case CLIENT -> {
+                ClientModel subjectClient = realm.getClientByClientId(subject.id());
+                yield subjectClient != null ? new ClientModelIdentity(session, subjectClient) : null;
+            }
+        };
+        if (request.subject().properties() != null && !request.subject().properties().isEmpty()) {
+            identity = withSubjectProperties(identity, request.subject().properties());
+        }
+        return identity;
+    }
+
+    private UserModel resolveUserId(RealmModel realm, String subjectId) {
+        UserProvider users = session.users();
+        if (subjectId.startsWith(NAMESPACE_ID)) {
+            String id = extractNamespaceValue(subjectId, NAMESPACE_ID);
+            return users.getUserById(realm, id);
+        } else if (subjectId.startsWith(NAMESPACE_USERNAME)) {
+            String username = extractNamespaceValue(subjectId, NAMESPACE_USERNAME);
+            return users.getUserByUsername(realm, username);
+        } else if (subjectId.startsWith(NAMESPACE_EMAIL)) {
+            if (realm.isDuplicateEmailsAllowed()) {
+                throw new BadRequestException("email namespace cannot be used when duplicate emails are allowed");
+            }
+            String email = extractNamespaceValue(subjectId, NAMESPACE_EMAIL);
+            return users.getUserByEmail(realm, email);
+        } else if (UUID_PATTERN.matcher(subjectId).matches()) {
+            return users.getUserById(realm, subjectId);
+        } else {
+            return users.getUserByUsername(realm, subjectId);
+        }
+    }
+
+    private static String extractNamespaceValue(String subjectId, String namespace) {
+        String value = subjectId.substring(namespace.length());
+        if (value.isEmpty()) {
+            throw new BadRequestException("subject id namespace '" + namespace + "' requires a non-empty value");
+        }
+        return value;
+    }
+
+    private static Identity withSubjectProperties(Identity delegate, Map<String, Object> properties) {
+        Map<String, Collection<String>> extra = new HashMap<>();
+        convertValues(properties, extra);
+
+        return new Identity() {
+            @Override
+            public String getId() {
+                return delegate.getId();
+            }
+
+            @Override
+            public Attributes getAttributes() {
+                Map<String, Collection<String>> merged = new HashMap<>(delegate.getAttributes().toMap());
+                merged.putAll(extra);
+                return Attributes.from(merged);
+            }
+
+            @Override
+            public boolean hasRealmRole(String roleName) {
+                return delegate.hasRealmRole(roleName);
+            }
+
+            @Override
+            public boolean hasClientRole(String clientId, String roleName) {
+                return delegate.hasClientRole(clientId, roleName);
+            }
+
+            @Override
+            public boolean hasOneClientRole(String clientId, String... roleNames) {
+                return delegate.hasOneClientRole(clientId, roleNames);
+            }
+        };
+    }
+
+    private static void convertValues(Map<String, Object> source, Map<String, ? extends Collection<String>> result) {
+        @SuppressWarnings("unchecked")
+        Map<String, Collection<String>> target = (Map<String, Collection<String>>) result;
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            Object value = entry.getValue();
+            if (value instanceof Map || value instanceof List) {
+                try {
+                    target.put(entry.getKey(), List.of(JsonSerialization.writeValueAsString(value)));
+                } catch (Exception e) {
+                    target.put(entry.getKey(), List.of(String.valueOf(value)));
+                }
+            } else {
+                target.put(entry.getKey(), List.of(String.valueOf(value)));
+            }
+        }
+    }
+
+    private static void convertContext(Map<String, Object> context, Map<String, List<String>> result) {
+        convertValues(context, result);
+    }
+}

--- a/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZenWellKnownProvider.java
+++ b/authzen/services/src/main/java/org/keycloak/authorization/authzen/AuthZenWellKnownProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.authzen;
+
+import java.util.Map;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.services.Urls;
+import org.keycloak.urls.UrlType;
+import org.keycloak.wellknown.WellKnownProvider;
+
+public class AuthZenWellKnownProvider implements WellKnownProvider {
+
+    private final KeycloakSession session;
+
+    public AuthZenWellKnownProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public Object getConfig() {
+        RealmModel realm = session.getContext().getRealm();
+        String realmUri = Urls.realmIssuer(session.getContext().getUri(UrlType.FRONTEND).getBaseUri(), realm.getName());
+
+        return Map.of(
+              "policy_decision_point", realmUri,
+              "access_evaluation_endpoint", accessEvaluationEndpoint(realmUri),
+              "access_evaluations_endpoint", accessEvaluationsEndpoint(realmUri)
+        );
+    }
+
+    public static String accessEvaluationEndpoint(String realmUri) {
+        return String.format("%s/%s/%s", realmUri, AuthZenRealmResourceProviderFactory.PROVIDER_ID, AuthZen.EVALUATION_PATH);
+    }
+
+    public static String accessEvaluationsEndpoint(String realmUri) {
+        return String.format("%s/%s/%s", realmUri, AuthZenRealmResourceProviderFactory.PROVIDER_ID, AuthZen.EVALUATIONS_PATH);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/authzen/tests/authzen-client/src/main/java/org/keycloak/testframework/authzen/client/AuthZenClient.java
+++ b/authzen/tests/authzen-client/src/main/java/org/keycloak/testframework/authzen/client/AuthZenClient.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testframework.authzen.client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.authorization.authzen.AuthZen;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpRequest;
+import org.keycloak.http.simple.SimpleHttpResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.apache.http.Header;
+
+public class AuthZenClient {
+
+    private final SimpleHttp simpleHttp;
+    private final String realmUrl;
+
+    public AuthZenClient(SimpleHttp simpleHttp, String realmUrl) {
+        this.simpleHttp = simpleHttp;
+        this.realmUrl = realmUrl;
+    }
+
+    public Authenticated withAccessToken(String accessToken) {
+        return new Authenticated(simpleHttp, realmUrl, accessToken);
+    }
+
+    public EvaluationResult evaluate(AuthZen.EvaluationRequest request) throws IOException {
+        return evaluate((Object) request, null);
+    }
+
+    public EvaluationResult evaluate(AuthZen.EvaluationRequest request, Map<String, String> headers) throws IOException {
+        return evaluate((Object) request, headers);
+    }
+
+    public EvaluationResult evaluate(JsonNode request) throws IOException {
+        return evaluate(request, null);
+    }
+
+    private EvaluationResult evaluate(Object req, Map<String, String> headers) throws IOException {
+        String url = realmUrl + "/authzen/access/v1/evaluation";
+
+        SimpleHttpRequest postReq = simpleHttp.doPost(url).json(req);
+        if (headers != null) {
+            headers.forEach(postReq::header);
+        }
+        try (SimpleHttpResponse response = req(postReq)) {
+            int status = response.getStatus();
+            AuthZen.EvaluationResponse body = status == 200
+                  ? response.asJson(AuthZen.EvaluationResponse.class)
+                  : null;
+            Map<String, String> responseHeaders = new HashMap<>();
+            for (Header h : response.getAllHeaders()) {
+                responseHeaders.putIfAbsent(h.getName(), h.getValue());
+            }
+            return new EvaluationResult(status, body, responseHeaders);
+        }
+    }
+
+    public EvaluationsResult evaluations(AuthZen.EvaluationsRequest request) throws IOException {
+        return evaluations((Object) request, null);
+    }
+
+    public EvaluationsResult evaluations(AuthZen.EvaluationsRequest request, Map<String, String> headers) throws IOException {
+        return evaluations((Object) request, headers);
+    }
+
+    public EvaluationsResult evaluations(JsonNode request) throws IOException {
+        return evaluations((Object) request, null);
+    }
+
+    private EvaluationsResult evaluations(Object req, Map<String, String> headers) throws IOException {
+        String url = realmUrl + "/authzen/access/v1/evaluations";
+
+        SimpleHttpRequest postReq = simpleHttp.doPost(url).json(req);
+        if (headers != null) {
+            headers.forEach(postReq::header);
+        }
+        try (SimpleHttpResponse response = req(postReq)) {
+            int status = response.getStatus();
+            AuthZen.EvaluationsResponse body = status == 200
+                    ? response.asJson(AuthZen.EvaluationsResponse.class)
+                    : null;
+            Map<String, String> responseHeaders = new HashMap<>();
+            for (Header h : response.getAllHeaders()) {
+                responseHeaders.putIfAbsent(h.getName(), h.getValue());
+            }
+            return new EvaluationsResult(status, body, responseHeaders);
+        }
+    }
+
+    public WellKnownResponse fetchWellKnownConfiguration() throws IOException {
+        String url = realmUrl + "/.well-known/authzen-configuration";
+        try (SimpleHttpResponse rsp = req(simpleHttp.doGet(url))) {
+            return rsp.asJson(WellKnownResponse.class);
+        }
+    }
+
+    protected SimpleHttpResponse req(SimpleHttpRequest request) throws IOException {
+        request.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.acceptJson();
+        return request.asResponse();
+    }
+
+    public static class Authenticated extends AuthZenClient {
+
+        private final String accessToken;
+
+        private Authenticated(SimpleHttp simpleHttp, String realmUrl, String accessToken) {
+            super(simpleHttp, realmUrl);
+            this.accessToken = accessToken;
+        }
+
+        @Override
+        protected SimpleHttpResponse req(SimpleHttpRequest request) throws IOException {
+            return super.req(request.auth(accessToken));
+        }
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record WellKnownResponse(
+          String policyDecisionPoint,
+          String accessEvaluationEndpoint,
+          String accessEvaluationsEndpoint
+    ) {
+    }
+
+    public record EvaluationResult(int statusCode, AuthZen.EvaluationResponse response, Map<String, String> headers) {
+
+        public boolean decision() {
+            return response.decision();
+        }
+
+        public String header(String name) {
+            return headers != null ? headers.get(name) : null;
+        }
+    }
+
+    public record EvaluationsResult(int statusCode, AuthZen.EvaluationsResponse response, Map<String, String> headers) {
+
+        public List<AuthZen.EvaluationResponse> evaluations() {
+            return response.evaluations();
+        }
+
+        public String header(String name) {
+            return headers != null ? headers.get(name) : null;
+        }
+    }
+
+    public static EvaluationRequestBuilder evaluationRequest() {
+        return new EvaluationRequestBuilder();
+    }
+
+    public static EvaluationsRequestBuilder evaluationsRequest() {
+        return new EvaluationsRequestBuilder();
+    }
+
+    public static EvaluationItemBuilder evaluationItem() {
+        return new EvaluationItemBuilder();
+    }
+
+    public static final class EvaluationRequestBuilder {
+        private AuthZen.SubjectType subjectType;
+        private String subjectId;
+        private Map<String, Object> subjectProperties;
+        private boolean subjectSet;
+        private String resourceType;
+        private String resourceId;
+        private Map<String, Object> resourceProperties;
+        private boolean resourceSet;
+        private AuthZen.Action action;
+        private Map<String, Object> contextProperties;
+
+        public EvaluationRequestBuilder subject(AuthZen.SubjectType type, String id) {
+            this.subjectType = type;
+            this.subjectId = id;
+            this.subjectSet = true;
+            return this;
+        }
+
+        public EvaluationRequestBuilder subjectProperty(String key, Object value) {
+            if (subjectProperties == null) {
+                subjectProperties = new HashMap<>();
+            }
+            subjectProperties.put(key, value);
+            return this;
+        }
+
+        public EvaluationRequestBuilder resource(String type, String id) {
+            this.resourceType = type;
+            this.resourceId = id;
+            this.resourceSet = true;
+            return this;
+        }
+
+        public EvaluationRequestBuilder resourceProperty(String key, Object value) {
+            if (resourceProperties == null) {
+                resourceProperties = new HashMap<>();
+            }
+            resourceProperties.put(key, value);
+            return this;
+        }
+
+        public EvaluationRequestBuilder action(String name) {
+            this.action = new AuthZen.Action(name);
+            return this;
+        }
+
+        public EvaluationRequestBuilder contextProperty(String key, Object value) {
+            if (contextProperties == null) {
+                contextProperties = new HashMap<>();
+            }
+            contextProperties.put(key, value);
+            return this;
+        }
+
+        public AuthZen.EvaluationRequest build() {
+            AuthZen.Subject subject = subjectSet ? new AuthZen.Subject(subjectType, subjectId, subjectProperties) : null;
+            AuthZen.Resource resource = resourceSet ? new AuthZen.Resource(resourceType, resourceId, resourceProperties) : null;
+            return new AuthZen.EvaluationRequest(subject, resource, action, contextProperties);
+        }
+    }
+
+    public static final class EvaluationItemBuilder {
+        private AuthZen.SubjectType subjectType;
+        private String subjectId;
+        private boolean subjectSet;
+        private String resourceType;
+        private String resourceId;
+        private Map<String, Object> resourceProperties;
+        private boolean resourceSet;
+        private AuthZen.Action action;
+        private Map<String, Object> contextProperties;
+
+        public EvaluationItemBuilder subject(AuthZen.SubjectType type, String id) {
+            this.subjectType = type;
+            this.subjectId = id;
+            this.subjectSet = true;
+            return this;
+        }
+
+        public EvaluationItemBuilder resource(String type, String id) {
+            this.resourceType = type;
+            this.resourceId = id;
+            this.resourceSet = true;
+            return this;
+        }
+
+        public EvaluationItemBuilder resourceProperty(String key, Object value) {
+            if (resourceProperties == null) {
+                resourceProperties = new HashMap<>();
+            }
+            resourceProperties.put(key, value);
+            return this;
+        }
+
+        public EvaluationItemBuilder action(String name) {
+            this.action = new AuthZen.Action(name);
+            return this;
+        }
+
+        public EvaluationItemBuilder contextProperty(String key, Object value) {
+            if (contextProperties == null) {
+                contextProperties = new HashMap<>();
+            }
+            contextProperties.put(key, value);
+            return this;
+        }
+
+        public AuthZen.EvaluationItem build() {
+            AuthZen.Subject subject = subjectSet ? new AuthZen.Subject(subjectType, subjectId, null) : null;
+            AuthZen.Resource resource = resourceSet ? new AuthZen.Resource(resourceType, resourceId, resourceProperties) : null;
+            return new AuthZen.EvaluationItem(subject, resource, action, contextProperties);
+        }
+    }
+
+    public static final class EvaluationsRequestBuilder {
+        private AuthZen.SubjectType subjectType;
+        private String subjectId;
+        private boolean subjectSet;
+        private String resourceType;
+        private String resourceId;
+        private boolean resourceSet;
+        private AuthZen.Action action;
+        private Map<String, Object> contextProperties;
+        private AuthZen.EvaluationsSemantic evaluationsSemantic;
+        private final List<AuthZen.EvaluationItem> evaluations = new ArrayList<>();
+
+        public EvaluationsRequestBuilder subject(AuthZen.SubjectType type, String id) {
+            this.subjectType = type;
+            this.subjectId = id;
+            this.subjectSet = true;
+            return this;
+        }
+
+        public EvaluationsRequestBuilder resource(String type, String id) {
+            this.resourceType = type;
+            this.resourceId = id;
+            this.resourceSet = true;
+            return this;
+        }
+
+        public EvaluationsRequestBuilder action(String name) {
+            this.action = new AuthZen.Action(name);
+            return this;
+        }
+
+        public EvaluationsRequestBuilder contextProperty(String key, Object value) {
+            if (contextProperties == null) {
+                contextProperties = new HashMap<>();
+            }
+            contextProperties.put(key, value);
+            return this;
+        }
+
+        public EvaluationsRequestBuilder evaluationsSemantic(AuthZen.EvaluationsSemantic semantic) {
+            this.evaluationsSemantic = semantic;
+            return this;
+        }
+
+        public EvaluationsRequestBuilder addEvaluation(AuthZen.EvaluationItem evaluation) {
+            evaluations.add(evaluation);
+            return this;
+        }
+
+        public AuthZen.EvaluationsRequest build() {
+            AuthZen.Subject subject = subjectSet ? new AuthZen.Subject(subjectType, subjectId, null) : null;
+            AuthZen.Resource resource = resourceSet ? new AuthZen.Resource(resourceType, resourceId, null) : null;
+            AuthZen.Options options = evaluationsSemantic != null ? new AuthZen.Options(evaluationsSemantic) : null;
+            return new AuthZen.EvaluationsRequest(subject, resource, action, contextProperties, options, evaluations);
+        }
+    }
+}

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationInteropTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationInteropTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.authzen;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.keycloak.authorization.authzen.AuthZen;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.authzen.client.AuthZenClient;
+import org.keycloak.testframework.authzen.client.AuthZenClient.EvaluationResult;
+import org.keycloak.testframework.authzen.client.AuthZenClient.EvaluationsResult;
+import org.keycloak.testframework.authzen.client.annotations.InjectAuthZenClient;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Runs the AuthZen interop evaluation test suite defined in the OpenID AuthZen interop project.
+ * Test scenarios are loaded from the decisions-authorization-api-1_0-02.json resource file.
+ * The JSON file defines AuthZen evaluation and evaluations requests, as well as the expected decision.
+ * <p>
+ * All required Realm configuration including users, roles, client, and authorization settings are loaded from interop-realm.json.
+ */
+@KeycloakIntegrationTest(config = AuthZenServerConfig.class)
+public class AuthZenEvaluationInteropTest {
+
+    // Maps interop subject IDs (base64-encoded, used as usernames) to display names for test output
+    private static final Map<String, String> USER_NAMES = Map.of(
+          "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "rick",
+          "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "morty",
+          "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "summer",
+          "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "beth",
+          "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs", "jerry"
+    );
+
+    private static final String PDP_CLIENT_ID = "authzen-pdp";
+    private static final String PDP_CLIENT_SECRET = "authzen-pdp-secret";
+
+    @InjectRealm(fromJson = "authzen-interop-realm.json")
+    ManagedRealm realm;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectAuthZenClient
+    AuthZenClient authZenClient;
+
+    @TestFactory
+    Stream<DynamicTest> interopEvaluationTests() throws IOException {
+        JsonNode root = loadDecisions();
+        AuthZenClient.Authenticated client = authenticatedClient();
+
+        return StreamSupport.stream(root.path("evaluation").spliterator(), false)
+              .map(node -> {
+                  JsonNode request = node.get("request");
+                  boolean expected = node.get("expected").asBoolean();
+                  String testName = buildEvaluationTestName(request, expected);
+                  return DynamicTest.dynamicTest(testName, () -> {
+                      EvaluationResult result = client.evaluate(request);
+                      assertEquals(200, result.statusCode(), "Expected 200 OK for: " + testName);
+                      assertEquals(expected, result.decision(), "Expected decision=" + expected + " for: " + testName);
+                  });
+              });
+    }
+
+    @TestFactory
+    Stream<DynamicTest> interopEvaluationsTests() throws IOException {
+        JsonNode root = loadDecisions();
+        JsonNode evaluationsNode = root.path("evaluations");
+
+        if (evaluationsNode.isMissingNode() || !evaluationsNode.isArray() || evaluationsNode.isEmpty()) {
+            return Stream.empty();
+        }
+
+        AuthZenClient.Authenticated client = authenticatedClient();
+        return StreamSupport.stream(evaluationsNode.spliterator(), false)
+              .map(node -> {
+                  JsonNode request = node.get("request");
+                  JsonNode expectedArray = node.get("expected");
+                  String testName = buildEvaluationsTestName(request);
+                  return DynamicTest.dynamicTest(testName, () -> {
+                      EvaluationsResult result = client.evaluations(request);
+                      assertEquals(200, result.statusCode(), "Expected 200 OK for: " + testName);
+
+                      List<AuthZen.EvaluationResponse> actualEvaluations = result.evaluations();
+                      assertEquals(expectedArray.size(), actualEvaluations.size(), "Evaluations count mismatch for: " + testName);
+
+                      for (int i = 0; i < expectedArray.size(); i++) {
+                          boolean expectedDecision = expectedArray.get(i).get("decision").asBoolean();
+                          assertEquals(expectedDecision, actualEvaluations.get(i).decision(),
+                                "Decision mismatch at index " + i + " for: " + testName);
+                      }
+                  });
+              });
+    }
+
+    private AuthZenClient.Authenticated authenticatedClient() {
+        return authZenClient.withAccessToken(
+              oauth.client(PDP_CLIENT_ID, PDP_CLIENT_SECRET)
+                    .doClientCredentialsGrantAccessTokenRequest()
+                    .getAccessToken()
+        );
+    }
+
+    private static String buildEvaluationTestName(JsonNode json, boolean expected) {
+        String subjectId = json.path("subject").path("id").asText();
+        String userName = USER_NAMES.getOrDefault(subjectId, subjectId);
+        String action = json.path("action").path("name").asText();
+        String resourceType = json.path("resource").path("type").asText();
+        String resourceId = json.path("resource").path("id").asText();
+        String expectedStr = expected ? "ALLOW" : "DENY";
+        return String.format("%s | %s %s:%s => %s", userName, action, resourceType, resourceId, expectedStr);
+    }
+
+    private static String buildEvaluationsTestName(JsonNode json) {
+        String subjectId = json.path("subject").path("id").asText();
+        String userName = USER_NAMES.getOrDefault(subjectId, subjectId);
+        String action = json.path("action").path("name").asText();
+        int count = json.path("evaluations").size();
+        return String.format("batch | %s | %s x%d", userName, action, count);
+    }
+
+    private static JsonNode loadDecisions() throws IOException {
+        try (InputStream is = AuthZenEvaluationInteropTest.class.getResourceAsStream(
+              "decisions-authorization-api-1_0-02.json")) {
+            return JsonSerialization.mapper.readTree(is);
+        }
+    }
+}

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationTest.java
@@ -1,0 +1,1068 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.authzen;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.RegexPolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.authzen.client.AuthZenClient;
+import org.keycloak.testframework.authzen.client.AuthZenClient.EvaluationResult;
+import org.keycloak.testframework.authzen.client.annotations.InjectAuthZenClient;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import org.apache.http.entity.StringEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.authorization.authzen.AuthZen.SubjectType.CLIENT;
+import static org.keycloak.authorization.authzen.AuthZen.SubjectType.USER;
+import static org.keycloak.authorization.authzen.AuthZenRequestIdFilter.X_REQUEST_ID;
+import static org.keycloak.authorization.authzen.AuthZenWellKnownProvider.accessEvaluationEndpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest(config = AuthZenServerConfig.class)
+public class AuthZenEvaluationTest {
+
+    private static final String ADMIN_USER = "admin-user";
+    private static final String REGULAR_USER = "regular-user";
+
+    @InjectRealm(config = TestRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectClient(ref = "authzen-client", config = AuthzClientConfig.class)
+    ManagedClient client;
+
+    @InjectClient(ref = "no-authz-client", config = NoAuthzClientConfig.class)
+    ManagedClient noAuthzClient;
+
+    @InjectClient(ref = "subject-id-client", config = AuthzClientConfig.class)
+    ManagedClient subjectClient;
+
+    @InjectClient(ref = "disableable-client", config = AuthzClientConfig.class)
+    ManagedClient disableableClient;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectAuthZenClient
+    AuthZenClient authZenClient;
+
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @TestSetup
+    public void setup() {
+        configureAuthorizationResources();
+    }
+
+    // Resource properties are not used by Keycloak but are accepted and ignored per the AuthZen spec
+    @Test
+    public void testAdminUserAccessAdminResource() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .resourceProperty("ignored", "property")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+        assertNull(result.header(X_REQUEST_ID));
+    }
+
+    @Test
+    public void testRegularUserDeniedAdminResource() throws IOException {
+        EvaluationResult result = authzenClient("regular-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+        assertNull(result.header(X_REQUEST_ID));
+    }
+
+    @Test
+    public void testAdminUserAccessUsersResource() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/users")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testRegularUserAccessUsersResource() throws IOException {
+        EvaluationResult result = authzenClient("regular-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .resource("endpoint", "/users")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testContextPassedToClaims() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/context-protected")
+                    .contextProperty("environment", "production")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testContextMismatchDeniesAccess() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/context-protected")
+                    .contextProperty("environment", "staging")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testMissingContextDeniesAccess() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/context-protected")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testNestedContextPassedToClaims() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/nested-context")
+                    .contextProperty("request", Map.of("ip", "10.0.0.1"))
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testNestedContextMismatchDeniesAccess() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/nested-context")
+                    .contextProperty("request", Map.of("ip", "192.168.1.1"))
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testUnknownResourceReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/nonexistent")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    // Resource exists but the requested type does not match the resource's configured type
+    @Test
+    public void testResourceTypeMismatchReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("wrong-type", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    // Resource has an empty type in Keycloak; an empty type string in the request should match
+    @Test
+    public void testEmptyTypeResourceMatchesEmptyType() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("", "/empty-type")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    // The /scope-limited resource defines both "read" and "write" scopes, but only the "read"
+    // scope has a permission granting access. Requesting the "write" action should be denied.
+    @Test
+    public void testActionWithoutPermissionDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("write")
+                    .resource("endpoint", "/scope-limited")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    // The authenticated user (regular-user) evaluates whether a different user subject (admin-user)
+    // is authorized to access a protected resource
+    @Test
+    public void testClientEvaluatesUserSubjectAuthorized() throws IOException {
+        EvaluationResult result = authzenClient("regular-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    // The authenticated client (authzen-client) evaluates whether a user subject without
+    // the required role is denied access
+    @Test
+    public void testClientEvaluatesUserSubjectDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    // A CLIENT subject whose id matches the token's client evaluates against its own resource server
+    @Test
+    public void testClientSubjectMatchingTokenAuthorized() throws IOException {
+        AccessTokenResponse tokenResponse = oauth
+              .client(subjectClient.getClientId(), subjectClient.getSecret())
+              .doClientCredentialsGrantAccessTokenRequest();
+
+        EvaluationResult result = authZenClient.withAccessToken(tokenResponse.getAccessToken())
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(CLIENT, "subject-id-client")
+                    .action("read")
+                    .resource("endpoint", "/subject-only")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    // A CLIENT subject whose id does not match the token's client returns decision:false
+    @Test
+    public void testClientSubjectMismatchingTokenReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(CLIENT, "subject-id-client")
+                    .action("read")
+                    .resource("endpoint", "/subject-only")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    // A client obtains a token, is then disabled, and attempts to use the stale token to request authorization.
+    @Test
+    public void testDisabledClientWithStaleTokenReturnsUnauthorized() throws IOException {
+        AccessTokenResponse tokenResponse = oauth
+              .client(disableableClient.getClientId(), disableableClient.getSecret())
+              .doClientCredentialsGrantAccessTokenRequest();
+
+        disableableClient.updateWithCleanup(c -> c.enabled(false));
+
+        EvaluationResult result = authZenClient.withAccessToken(tokenResponse.getAccessToken())
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(CLIENT, "disableable-client")
+                    .action("read")
+                    .resource("endpoint", "/open")
+                    .build());
+
+        assertEquals(401, result.statusCode());
+    }
+
+    // Subject properties are merged into identity attributes. The /subject-protected resource
+    // requires a "department" identity attribute matching "engineering".
+    @Test
+    public void testSubjectPropertiesPassedToIdentityAttributes() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .subjectProperty("department", "engineering")
+                    .action("read")
+                    .resource("endpoint", "/subject-protected")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testSubjectPropertiesMismatchDeniesAccess() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .subjectProperty("department", "marketing")
+                    .action("read")
+                    .resource("endpoint", "/subject-protected")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testMissingSubjectPropertiesDeniesAccess() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/subject-protected")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testUnauthenticatedUserReturnsUnauthorized() throws IOException {
+        EvaluationResult result = authZenClient.evaluate(AuthZenClient.evaluationRequest()
+              .subject(USER, ADMIN_USER)
+              .action("read")
+              .resource("endpoint", "/admin")
+              .build());
+
+        assertEquals(401, result.statusCode());
+    }
+
+    @Test
+    public void testMissingSubjectReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testMissingSubjectTypeReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(null, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testMissingSubjectIdReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, null)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testUnknownUserSubjectReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "nonexistent-user")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testUnknownClientSubjectReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(CLIENT, "nonexistent-client")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testInvalidSubjectTypeReturnsBadRequest() throws IOException {
+        String url = accessEvaluationEndpoint(realmUrl());
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest("admin-user", "password");
+
+        String json = """
+              {"subject":{"type":"invalid-type","id":"%s"},\
+              "resource":{"type":"endpoint","id":"/admin"},\
+              "action":{"name":"read"}}""".formatted(ADMIN_USER);
+
+        try (SimpleHttpResponse response = simpleHttp.doPost(url)
+              .auth(tokenResponse.getAccessToken())
+              .header("Content-Type", "application/json")
+              .entity(new StringEntity(json))
+              .asResponse()) {
+            assertEquals(400, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testMissingResourceReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testMissingResourceTypeReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource(null, "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testMissingResourceIdReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", null)
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testMissingActionReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testUndefinedActionReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("undefined-action")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testClientWithoutAuthorizationReturnsDenied() throws IOException {
+        AccessTokenResponse tokenResponse = oauth
+              .client(noAuthzClient.getClientId(), noAuthzClient.getSecret())
+              .doPasswordGrantRequest("admin-user", "password");
+
+        EvaluationResult result = authZenClient.withAccessToken(tokenResponse.getAccessToken())
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testInvalidJsonReturnsBadRequest() throws IOException {
+        String url = accessEvaluationEndpoint(realmUrl());
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest("admin-user", "password");
+
+        try (SimpleHttpResponse response = simpleHttp.doPost(url)
+              .auth(tokenResponse.getAccessToken())
+              .header("Content-Type", "application/json")
+              .entity(new StringEntity("{invalid json"))
+              .asResponse()) {
+            assertEquals(400, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testXRequestIdEchoedInResponse() throws IOException {
+        String requestId = "test-request-id-12345";
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(
+                    AuthZenClient.evaluationRequest()
+                          .subject(USER, ADMIN_USER)
+                          .action("read")
+                          .resource("endpoint", "/admin")
+                          .build(),
+                    Map.of(X_REQUEST_ID, requestId)
+              );
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+        assertEquals(requestId, result.header(X_REQUEST_ID));
+    }
+
+    @Test
+    public void testXRequestIdEchoedOnUnauthorizedResponse() throws IOException {
+        String requestId = "unauth-request-id";
+
+        EvaluationResult result = new AuthZenClient(simpleHttp, realmUrl())
+              .evaluate(
+                    AuthZenClient.evaluationRequest()
+                          .subject(USER, ADMIN_USER)
+                          .action("read")
+                          .resource("endpoint", "/admin")
+                          .build(),
+                    Map.of(X_REQUEST_ID, requestId)
+              );
+
+        assertEquals(401, result.statusCode());
+        assertEquals(requestId, result.header(X_REQUEST_ID));
+    }
+
+    @Test
+    public void testXRequestIdEchoedOnBadRequestResponse() throws IOException {
+        String requestId = "bad-request-id";
+        String url = accessEvaluationEndpoint(realmUrl());
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest("admin-user", "password");
+
+        try (SimpleHttpResponse response = simpleHttp.doPost(url)
+              .auth(tokenResponse.getAccessToken())
+              .header("Content-Type", "application/json")
+              .header(X_REQUEST_ID, requestId)
+              .entity(new StringEntity("{invalid json"))
+              .asResponse()) {
+            assertEquals(400, response.getStatus());
+            assertEquals(requestId, response.getFirstHeader(X_REQUEST_ID));
+        }
+    }
+
+    @Test
+    public void testUsernameNamespaceResolvesUser() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "username:" + ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testIdNamespaceResolvesUser() throws IOException {
+        String userId = lookupUserId(ADMIN_USER);
+
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "id:" + userId)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testEmailNamespaceResolvesUser() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "email:admin@localhost")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testEmailNamespaceResolvesCorrectUser() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "email:regular@localhost")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testNoNamespaceUUIDFallsBackToIdLookup() throws IOException {
+        String userId = lookupUserId(ADMIN_USER);
+
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, userId)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testNoNamespaceNonUUIDFallsBackToUsernameLookup() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.decision());
+    }
+
+    @Test
+    public void testEmailNamespaceWithDuplicateEmailsReturnsBadRequest() throws IOException {
+        realm.updateWithCleanup(r -> r.duplicateEmailsAllowed(true));
+
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "email:admin@localhost")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testUsernameNamespaceUnknownUserReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "username:nonexistent-user")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testIdNamespaceUnknownUserReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "id:00000000-0000-0000-0000-000000000000")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testEmailNamespaceUnknownUserReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "email:nonexistent@localhost")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testNoNamespaceUUIDUnknownUserReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testEmptyIdNamespaceReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "id:")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testEmptyUsernameNamespaceReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "username:")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testEmptyEmailNamespaceReturnsBadRequest() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "email:")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(400, result.statusCode());
+    }
+
+    @Test
+    public void testMixedCaseNamespaceFallsBackToUsernameLookup() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "Email:admin@localhost")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        // "Email:admin@localhost" is treated as a username, which won't exist
+        assertFalse(result.decision());
+    }
+
+    @Test
+    public void testIdNamespaceWithNonUUIDReturnsDenied() throws IOException {
+        EvaluationResult result = authzenClient("admin-user", "password")
+              .evaluate(AuthZenClient.evaluationRequest()
+                    .subject(USER, "id:not-a-uuid")
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertFalse(result.decision());
+    }
+
+    private String lookupUserId(String username) {
+        List<UserRepresentation> users = realm.admin().users().search(username, true);
+        assertEquals(1, users.size(), "Expected exactly one user with username: " + username);
+        return users.get(0).getId();
+    }
+
+    private String realmUrl() {
+        return keycloakUrls.getBase() + "/realms/" + realm.getName();
+    }
+
+    private AuthZenClient.Authenticated authzenClient(String username, String password) {
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest(username, password);
+        return authZenClient.withAccessToken(tokenResponse.getAccessToken());
+    }
+
+    private void configureAuthorizationResources() {
+        configureAuthzenClientResources();
+        configureSubjectClientResources();
+        configureDisableableClientResources();
+    }
+
+    // authzen-client is the OAuth client used to authenticate all AuthZen API requests (bearer token).
+    // For USER subject evaluations, it also acts as the resource server — resources and policies
+    // are resolved from this client because the resource server is determined by token.getIssuedFor().
+    private void configureAuthzenClientResources() {
+        AuthorizationResource authz = client.admin().authorization();
+        String adminRoleId = realm.admin().roles().get("admin").toRepresentation().getId();
+
+        createScope(authz, "read");
+        createScope(authz, "write");
+
+        String adminPolicyId = createRolePolicy(authz, "Require Admin Role", adminRoleId);
+        String alwaysGrantId = createAlwaysGrantPolicy(authz);
+
+        createResource(authz, "/admin", "endpoint", "read");
+        createResourcePermission(authz, "Admin Resource Permission", "/admin", adminPolicyId);
+
+        createResource(authz, "/users", "endpoint", "read");
+        createResourcePermission(authz, "Users Resource Permission", "/users", alwaysGrantId);
+
+        createResource(authz, "/scope-limited", "endpoint", "read", "write");
+        createScopePermission(authz, "Scope Limited Read Permission", "/scope-limited", "read", "Always Grant");
+
+        createResource(authz, "/context-protected", "endpoint", "read");
+        String envPolicyId = createRegexPolicy(authz, "Context Environment Policy", "environment", "production", true);
+        createResourcePermission(authz, "Context Protected Permission", "/context-protected", envPolicyId);
+
+        createResource(authz, "/nested-context", "endpoint", "read");
+        String ipPolicyId = createRegexPolicy(authz, "Nested Context IP Policy", "request.ip", "10\\.0\\.0\\..*", true);
+        createResourcePermission(authz, "Nested Context Permission", "/nested-context", ipPolicyId);
+
+        createResource(authz, "/empty-type", null, "read");
+        createResourcePermission(authz, "Empty Type Resource Permission", "/empty-type", alwaysGrantId);
+
+        createResource(authz, "/subject-protected", "endpoint", "read");
+        String deptPolicyId = createRegexPolicy(authz, "Subject Department Policy", "department", "engineering", false);
+        createResourcePermission(authz, "Subject Protected Permission", "/subject-protected", deptPolicyId);
+    }
+
+    // subject-id-client is used as the subject in CLIENT-type evaluations (subject.id = "subject-id-client").
+    // When subject.type is CLIENT, the resource server is resolved from subject.id rather than the
+    // token's client — so this client's own resources and policies are evaluated, not authzen-client's.
+    private void configureSubjectClientResources() {
+        AuthorizationResource authz = subjectClient.admin().authorization();
+
+        createScope(authz, "read");
+
+        String alwaysGrantId = createAlwaysGrantPolicy(authz);
+
+        // /subject-only - only exists on subject-id-client's resource server
+        createResource(authz, "/subject-only", "endpoint", "read");
+        createResourcePermission(authz, "Subject Only Permission", "/subject-only", alwaysGrantId);
+    }
+
+    // disableable-client is a dedicated client used to test that a disabled client with a
+    // previously obtained token is denied. Isolated from subject-id-client so that disabling
+    // it does not affect other tests.
+    private void configureDisableableClientResources() {
+        AuthorizationResource authz = disableableClient.admin().authorization();
+
+        createScope(authz, "read");
+
+        String alwaysGrantId = createAlwaysGrantPolicy(authz);
+
+        createResource(authz, "/open", "endpoint", "read");
+        createResourcePermission(authz, "Open Permission", "/open", alwaysGrantId);
+    }
+
+    private static void createScope(AuthorizationResource authz, String name) {
+        try (Response response = authz.scopes().create(new ScopeRepresentation(name))) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private static void createResource(AuthorizationResource authz, String name, String type, String... scopes) {
+        ResourceRepresentation resource = new ResourceRepresentation();
+        resource.setName(name);
+        resource.setType(type);
+        resource.addScope(scopes);
+        try (Response response = authz.resources().create(resource)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private static String createRolePolicy(AuthorizationResource authz, String name, String roleId) {
+        RolePolicyRepresentation policy = new RolePolicyRepresentation();
+        policy.setName(name);
+        policy.addRole(roleId);
+        try (Response response = authz.policies().role().create(policy)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        return authz.policies().role().findByName(name).getId();
+    }
+
+    private static String createAlwaysGrantPolicy(AuthorizationResource authz) {
+        PolicyRepresentation policy = new PolicyRepresentation();
+        policy.setName("Always Grant");
+        policy.setType("always-grant");
+        try (Response response = authz.policies().create(policy)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        return authz.policies().findByName("Always Grant").getId();
+    }
+
+    private static String createRegexPolicy(AuthorizationResource authz, String name,
+                                            String claim, String pattern, boolean targetContextAttributes) {
+        RegexPolicyRepresentation policy = new RegexPolicyRepresentation();
+        policy.setName(name);
+        policy.setTargetClaim(claim);
+        policy.setPattern(pattern);
+        policy.setTargetContextAttributes(targetContextAttributes);
+        try (Response response = authz.policies().regex().create(policy)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        return authz.policies().findByName(name).getId();
+    }
+
+    private static void createResourcePermission(AuthorizationResource authz, String name,
+                                                 String resourceName, String policyId) {
+        ResourcePermissionRepresentation permission = ResourcePermissionRepresentation.create()
+              .name(name)
+              .resources(Set.of(authz.resources().findByName(resourceName).get(0).getId()))
+              .policies(Set.of(policyId))
+              .build();
+        try (Response response = authz.permissions().resource().create(permission)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private static void createScopePermission(AuthorizationResource authz, String name,
+                                              String resourceName, String scopeName, String policyName) {
+        ScopePermissionRepresentation permission = new ScopePermissionRepresentation();
+        permission.setName(name);
+        permission.setResources(Set.of(authz.resources().findByName(resourceName).get(0).getId()));
+        permission.setScopes(Set.of(authz.scopes().findByName(scopeName).getId()));
+        permission.addPolicy(policyName);
+        try (Response response = authz.permissions().scope().create(permission)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    public static class TestRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.realmRoles("admin");
+
+            realm.users(UserBuilder.create("admin-user")
+                  .username(ADMIN_USER)
+                  .name("Admin", "User")
+                  .email("admin@localhost")
+                  .password("password")
+                  .realmRoles("admin"));
+
+            realm.users(UserBuilder.create("regular-user")
+                  .username(REGULAR_USER)
+                  .name("Regular", "User")
+                  .email("regular@localhost")
+                  .password("password"));
+
+            return realm;
+        }
+    }
+
+    public static class AuthzClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                  .secret("secret")
+                  .directAccessGrantsEnabled(true)
+                  .authorizationServicesEnabled(true);
+        }
+    }
+
+    public static class NoAuthzClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                  .secret("secret")
+                  .directAccessGrantsEnabled(true);
+        }
+    }
+}

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationsTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenEvaluationsTest.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.authzen;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.resource.AuthorizationResource;
+import org.keycloak.authorization.authzen.AuthZen;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ResourcePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
+import org.keycloak.representations.idm.authorization.RolePolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.authzen.client.AuthZenClient;
+import org.keycloak.testframework.authzen.client.AuthZenClient.EvaluationsResult;
+import org.keycloak.testframework.authzen.client.annotations.InjectAuthZenClient;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.entity.StringEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.authorization.authzen.AuthZen.SubjectType.USER;
+import static org.keycloak.authorization.authzen.AuthZenRequestIdFilter.X_REQUEST_ID;
+import static org.keycloak.authorization.authzen.AuthZenWellKnownProvider.accessEvaluationsEndpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the AuthZen Evaluations (batch) endpoint.
+ */
+@KeycloakIntegrationTest(config = AuthZenServerConfig.class)
+public class AuthZenEvaluationsTest {
+
+    private static final String ADMIN_USER = "admin-user";
+    private static final String REGULAR_USER = "regular-user";
+
+    @InjectRealm(config = TestRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectClient(ref = "authzen-client", config = AuthzClientConfig.class)
+    ManagedClient client;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectAuthZenClient
+    AuthZenClient authZenClient;
+
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @TestSetup
+    public void setup() {
+        AuthorizationResource authz = client.admin().authorization();
+        String adminRoleId = realm.admin().roles().get("admin").toRepresentation().getId();
+
+        createScope(authz, "read");
+        createScope(authz, "write");
+
+        String adminPolicyId = createRolePolicy(authz, "Require Admin Role", adminRoleId);
+        String alwaysGrantId = createAlwaysGrantPolicy(authz);
+
+        createResource(authz, "/admin", "endpoint", "read");
+        createResourcePermission(authz, "Admin Resource Permission", "/admin", adminPolicyId);
+
+        createResource(authz, "/users", "endpoint", "read");
+        createResourcePermission(authz, "Users Resource Permission", "/users", alwaysGrantId);
+
+        createResource(authz, "/scope-limited", "endpoint", "read", "write");
+        createScopePermission(authz, "Scope Limited Read Permission", "/scope-limited", "read", "Always Grant");
+    }
+
+    @Test
+    public void testEvaluationsBatchAllGranted() throws IOException {
+        EvaluationsResult result = authzenClient("admin-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+        assertTrue(result.evaluations().get(0).decision());
+        assertTrue(result.evaluations().get(1).decision());
+    }
+
+    @Test
+    public void testEvaluationsBatchMixedDecisions() throws IOException {
+        EvaluationsResult result = authzenClient("regular-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+        assertFalse(result.evaluations().get(0).decision());
+        assertTrue(result.evaluations().get(1).decision());
+    }
+
+    @Test
+    public void testEvaluationsItemOverridesDefaults() throws IOException {
+        EvaluationsResult result = authzenClient("admin-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .resource("endpoint", "/admin")
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .action("write")
+                          .resource("endpoint", "/scope-limited")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+        assertTrue(result.evaluations().get(0).decision());
+        assertFalse(result.evaluations().get(1).decision());
+    }
+
+    @Test
+    public void testEvaluationsUnauthenticatedReturnsUnauthorized() throws IOException {
+        EvaluationsResult result = authZenClient.evaluations(AuthZenClient.evaluationsRequest()
+              .subject(USER, ADMIN_USER)
+              .action("read")
+              .addEvaluation(AuthZenClient.evaluationItem()
+                    .resource("endpoint", "/admin")
+                    .build())
+              .build());
+
+        assertEquals(401, result.statusCode());
+    }
+
+    @Test
+    public void testEvaluationsEmptyArrayFallsBackToSingleEvaluation() throws IOException {
+        String json = """
+              {"subject":{"type":"user","id":"%s"},\
+              "resource":{"type":"endpoint","id":"/admin"},\
+              "action":{"name":"read"},\
+              "evaluations":[]}""".formatted(ADMIN_USER);
+
+        JsonNode body = postEvaluations("admin-user", "password", json);
+        assertTrue(body.get("decision").asBoolean());
+        assertNull(body.get("evaluations"));
+    }
+
+    @Test
+    public void testEvaluationsAbsentFallsBackToSingleEvaluation() throws IOException {
+        String json = """
+              {"subject":{"type":"user","id":"%s"},\
+              "resource":{"type":"endpoint","id":"/admin"},\
+              "action":{"name":"read"}}""".formatted(ADMIN_USER);
+
+        JsonNode body = postEvaluations(ADMIN_USER, "password", json);
+        assertTrue(body.get("decision").asBoolean());
+        assertNull(body.get("evaluations"));
+    }
+
+    private JsonNode postEvaluations(String username, String password, String json) throws IOException {
+        String url = accessEvaluationsEndpoint(keycloakUrls.getBase() + "/realms/" + realm.getName());
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest(username, password);
+
+        try (SimpleHttpResponse response = simpleHttp.doPost(url)
+              .auth(tokenResponse.getAccessToken())
+              .header("Content-Type", "application/json")
+              .entity(new StringEntity(json))
+              .asResponse()) {
+            assertEquals(200, response.getStatus());
+            return response.asJson();
+        }
+    }
+
+    @Test
+    public void testExecuteAllSemantic() throws IOException {
+        EvaluationsResult result = authzenClient("regular-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .evaluationsSemantic(AuthZen.EvaluationsSemantic.EXECUTE_ALL)
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+        assertFalse(result.evaluations().get(0).decision());
+        assertTrue(result.evaluations().get(1).decision());
+    }
+
+    @Test
+    public void testDenyOnFirstDenyStopsOnDenial() throws IOException {
+        EvaluationsResult result = authzenClient("regular-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .evaluationsSemantic(AuthZen.EvaluationsSemantic.DENY_ON_FIRST_DENY)
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(1, result.evaluations().size());
+        assertFalse(result.evaluations().get(0).decision());
+    }
+
+    @Test
+    public void testDenyOnFirstDenyReturnsAllWhenAllPermitted() throws IOException {
+        EvaluationsResult result = authzenClient("admin-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .evaluationsSemantic(AuthZen.EvaluationsSemantic.DENY_ON_FIRST_DENY)
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+        assertTrue(result.evaluations().get(0).decision());
+        assertTrue(result.evaluations().get(1).decision());
+    }
+
+    @Test
+    public void testPermitOnFirstPermitStopsOnPermit() throws IOException {
+        EvaluationsResult result = authzenClient("regular-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .evaluationsSemantic(AuthZen.EvaluationsSemantic.PERMIT_ON_FIRST_PERMIT)
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+        assertFalse(result.evaluations().get(0).decision());
+        assertTrue(result.evaluations().get(1).decision());
+    }
+
+    @Test
+    public void testPermitOnFirstPermitStopsImmediatelyOnFirstPermit() throws IOException {
+        EvaluationsResult result = authzenClient("admin-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .evaluationsSemantic(AuthZen.EvaluationsSemantic.PERMIT_ON_FIRST_PERMIT)
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(1, result.evaluations().size());
+        assertTrue(result.evaluations().get(0).decision());
+    }
+
+    @Test
+    public void testXRequestIdEchoedInResponse() throws IOException {
+        String requestId = "test-request-id-12345";
+
+        EvaluationsResult result = authzenClient("admin-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .build(),
+                    Map.of(X_REQUEST_ID, requestId));
+
+        assertEquals(200, result.statusCode());
+        assertTrue(result.evaluations().get(0).decision());
+        assertEquals(requestId, result.header(X_REQUEST_ID));
+    }
+
+    @Test
+    public void testXRequestIdEchoedOnUnauthorizedResponse() throws IOException {
+        String requestId = "unauth-request-id";
+
+        EvaluationsResult result = new AuthZenClient(simpleHttp,
+              keycloakUrls.getBase() + "/realms/" + realm.getName())
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, ADMIN_USER)
+                    .action("read")
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .build(),
+                    Map.of(X_REQUEST_ID, requestId));
+
+        assertEquals(401, result.statusCode());
+        assertEquals(requestId, result.header(X_REQUEST_ID));
+    }
+
+    @Test
+    public void testXRequestIdEchoedOnBadRequestResponse() throws IOException {
+        String requestId = "bad-request-id";
+
+        String url = accessEvaluationsEndpoint(keycloakUrls.getBase() + "/realms/" + realm.getName());
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest("admin-user", "password");
+
+        try (SimpleHttpResponse response = simpleHttp.doPost(url)
+              .auth(tokenResponse.getAccessToken())
+              .header("Content-Type", "application/json")
+              .header(X_REQUEST_ID, requestId)
+              .entity(new StringEntity("{invalid json"))
+              .asResponse()) {
+            assertEquals(400, response.getStatus());
+            assertEquals(requestId, response.getFirstHeader(X_REQUEST_ID));
+        }
+    }
+
+    @Test
+    public void testDefaultSemanticIsExecuteAll() throws IOException {
+        EvaluationsResult result = authzenClient("regular-user", "password")
+              .evaluations(AuthZenClient.evaluationsRequest()
+                    .subject(USER, REGULAR_USER)
+                    .action("read")
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/admin")
+                          .build())
+                    .addEvaluation(AuthZenClient.evaluationItem()
+                          .resource("endpoint", "/users")
+                          .build())
+                    .build());
+
+        assertEquals(200, result.statusCode());
+        assertEquals(2, result.evaluations().size());
+    }
+
+    private AuthZenClient.Authenticated authzenClient(String username, String password) {
+        AccessTokenResponse tokenResponse = oauth
+              .client(client.getClientId(), client.getSecret())
+              .doPasswordGrantRequest(username, password);
+        return authZenClient.withAccessToken(tokenResponse.getAccessToken());
+    }
+
+    private static void createScope(AuthorizationResource authz, String name) {
+        try (Response response = authz.scopes().create(new ScopeRepresentation(name))) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private static void createResource(AuthorizationResource authz, String name, String type, String... scopes) {
+        ResourceRepresentation resource = new ResourceRepresentation();
+        resource.setName(name);
+        resource.setType(type);
+        resource.addScope(scopes);
+        try (Response response = authz.resources().create(resource)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private static String createRolePolicy(AuthorizationResource authz, String name, String roleId) {
+        RolePolicyRepresentation policy = new RolePolicyRepresentation();
+        policy.setName(name);
+        policy.addRole(roleId);
+        try (Response response = authz.policies().role().create(policy)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        return authz.policies().role().findByName(name).getId();
+    }
+
+    private static String createAlwaysGrantPolicy(AuthorizationResource authz) {
+        PolicyRepresentation policy = new PolicyRepresentation();
+        policy.setName("Always Grant");
+        policy.setType("always-grant");
+        try (Response response = authz.policies().create(policy)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+        return authz.policies().findByName("Always Grant").getId();
+    }
+
+    private static void createResourcePermission(AuthorizationResource authz, String name,
+                                                  String resourceName, String policyId) {
+        ResourcePermissionRepresentation permission = ResourcePermissionRepresentation.create()
+              .name(name)
+              .resources(Set.of(authz.resources().findByName(resourceName).get(0).getId()))
+              .policies(Set.of(policyId))
+              .build();
+        try (Response response = authz.permissions().resource().create(permission)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private static void createScopePermission(AuthorizationResource authz, String name,
+                                              String resourceName, String scopeName, String policyName) {
+        ScopePermissionRepresentation permission = new ScopePermissionRepresentation();
+        permission.setName(name);
+        permission.setResources(Set.of(authz.resources().findByName(resourceName).get(0).getId()));
+        permission.setScopes(Set.of(authz.scopes().findByName(scopeName).getId()));
+        permission.addPolicy(policyName);
+        try (Response response = authz.permissions().scope().create(permission)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    public static class TestRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm.realmRoles("admin")
+                  .users(
+                        UserBuilder.create("admin-user")
+                              .name("Admin", "User")
+                              .email("admin@localhost")
+                              .password("password")
+                              .realmRoles("admin"),
+
+                        UserBuilder.create("regular-user")
+                              .name("Regular", "User")
+                              .email("regular@localhost")
+                              .password("password")
+                  );
+        }
+    }
+
+    public static class AuthzClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                  .secret("secret")
+                  .directAccessGrantsEnabled(true)
+                  .authorizationServicesEnabled(true);
+        }
+    }
+}

--- a/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenWellKnownTest.java
+++ b/authzen/tests/base/src/test/java/org/keycloak/tests/authzen/AuthZenWellKnownTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.authzen;
+
+import java.io.IOException;
+
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.authzen.client.AuthZenClient;
+import org.keycloak.testframework.authzen.client.AuthZenClient.WellKnownResponse;
+import org.keycloak.testframework.authzen.client.annotations.InjectAuthZenClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakUrls;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest(config = AuthZenServerConfig.class)
+public class AuthZenWellKnownTest {
+
+    @InjectRealm
+    ManagedRealm realm;
+
+    @InjectAuthZenClient
+    AuthZenClient authZenClient;
+
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @Test
+    public void testRealmWellKnownEndpoint() throws IOException {
+        WellKnownResponse response = authZenClient.fetchWellKnownConfiguration();
+
+        assertWellKnownResponse(response);
+    }
+
+    @Test
+    public void testServerMetadataWellKnownEndpoint() throws IOException {
+        String url = keycloakUrls.getBase() + "/.well-known/authzen-configuration/realms/" + realm.getName();
+        WellKnownResponse response = simpleHttp.doGet(url).asJson(WellKnownResponse.class);
+
+        assertWellKnownResponse(response);
+    }
+
+    private void assertWellKnownResponse(WellKnownResponse response) {
+        String expectedRealmUrl = realmUrl();
+
+        assertNotNull(response);
+        assertEquals(expectedRealmUrl, response.policyDecisionPoint());
+        assertEquals(expectedRealmUrl + "/authzen/access/v1/evaluation", response.accessEvaluationEndpoint());
+        assertEquals(expectedRealmUrl + "/authzen/access/v1/evaluations", response.accessEvaluationsEndpoint());
+    }
+
+    private String realmUrl() {
+        return keycloakUrls.getBase() + "/realms/" + realm.getName();
+    }
+}

--- a/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/authzen-interop-realm.json
+++ b/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/authzen-interop-realm.json
@@ -1,0 +1,299 @@
+{
+    "enabled": true,
+    "roles": {
+        "realm": [
+            { "name": "admin" },
+            { "name": "editor" },
+            { "name": "viewer" }
+        ]
+    },
+    "users": [
+        {
+            "username": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+            "enabled": true,
+            "firstName": "Rick",
+            "lastName": "Sanchez",
+            "email": "rick@the-citadel.com",
+            "credentials": [
+                { "type": "password", "value": "password" }
+            ],
+            "realmRoles": ["admin"]
+        },
+        {
+            "username": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+            "enabled": true,
+            "firstName": "Morty",
+            "lastName": "Smith",
+            "email": "morty@the-citadel.com",
+            "credentials": [
+                { "type": "password", "value": "password" }
+            ],
+            "realmRoles": ["editor"]
+        },
+        {
+            "username": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+            "enabled": true,
+            "firstName": "Summer",
+            "lastName": "Smith",
+            "email": "summer@the-smiths.com",
+            "credentials": [
+                { "type": "password", "value": "password" }
+            ],
+            "realmRoles": ["editor"]
+        },
+        {
+            "username": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+            "enabled": true,
+            "firstName": "Beth",
+            "lastName": "Smith",
+            "email": "beth@the-smiths.com",
+            "credentials": [
+                { "type": "password", "value": "password" }
+            ],
+            "realmRoles": ["viewer"]
+        },
+        {
+            "username": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs",
+            "enabled": true,
+            "firstName": "Jerry",
+            "lastName": "Smith",
+            "email": "jerry@the-smiths.com",
+            "credentials": [
+                { "type": "password", "value": "password" }
+            ],
+            "realmRoles": ["viewer"]
+        }
+    ],
+    "clients": [
+        {
+            "clientId": "authzen-pdp",
+            "enabled": true,
+            "secret": "authzen-pdp-secret",
+            "serviceAccountsEnabled": true,
+            "directAccessGrantsEnabled": false,
+            "authorizationServicesEnabled": true,
+            "authorizationSettings": {
+                "scopes": [
+                    { "name": "can_read_user" },
+                    { "name": "can_read_todos" },
+                    { "name": "can_create_todo" },
+                    { "name": "can_update_todo" },
+                    { "name": "can_delete_todo" }
+                ],
+                "resources": [
+                    {
+                        "name": "beth@the-smiths.com",
+                        "type": "user",
+                        "scopes": [{ "name": "can_read_user" }]
+                    },
+                    {
+                        "name": "rick@the-citadel.com",
+                        "type": "user",
+                        "scopes": [{ "name": "can_read_user" }]
+                    },
+                    {
+                        "name": "morty@the-citadel.com",
+                        "type": "user",
+                        "scopes": [{ "name": "can_read_user" }]
+                    },
+                    {
+                        "name": "summer@the-smiths.com",
+                        "type": "user",
+                        "scopes": [{ "name": "can_read_user" }]
+                    },
+                    {
+                        "name": "jerry@the-smiths.com",
+                        "type": "user",
+                        "scopes": [{ "name": "can_read_user" }]
+                    },
+                    {
+                        "name": "todo-1",
+                        "type": "todo",
+                        "scopes": [
+                            { "name": "can_read_todos" },
+                            { "name": "can_create_todo" },
+                            { "name": "can_update_todo" },
+                            { "name": "can_delete_todo" }
+                        ]
+                    },
+                    {
+                        "name": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+                        "type": "todo",
+                        "scopes": [
+                            { "name": "can_read_todos" },
+                            { "name": "can_create_todo" },
+                            { "name": "can_update_todo" },
+                            { "name": "can_delete_todo" }
+                        ]
+                    },
+                    {
+                        "name": "7240d0db-8ff0-41ec-98b2-34a096273b91",
+                        "type": "todo",
+                        "scopes": [
+                            { "name": "can_read_todos" },
+                            { "name": "can_create_todo" },
+                            { "name": "can_update_todo" },
+                            { "name": "can_delete_todo" }
+                        ]
+                    },
+                    {
+                        "name": "7240d0db-8ff0-41ec-98b2-34a096273b93",
+                        "type": "todo",
+                        "scopes": [
+                            { "name": "can_read_todos" },
+                            { "name": "can_create_todo" },
+                            { "name": "can_update_todo" },
+                            { "name": "can_delete_todo" }
+                        ]
+                    },
+                    {
+                        "name": "7240d0db-8ff0-41ec-98b2-34a096273b94",
+                        "type": "todo",
+                        "scopes": [
+                            { "name": "can_read_todos" },
+                            { "name": "can_create_todo" },
+                            { "name": "can_update_todo" },
+                            { "name": "can_delete_todo" }
+                        ]
+                    },
+                    {
+                        "name": "7240d0db-8ff0-41ec-98b2-34a096273b95",
+                        "type": "todo",
+                        "scopes": [
+                            { "name": "can_read_todos" },
+                            { "name": "can_create_todo" },
+                            { "name": "can_update_todo" },
+                            { "name": "can_delete_todo" }
+                        ]
+                    }
+                ],
+                "policies": [
+                    {
+                        "name": "admin-policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"admin\"}]"
+                        }
+                    },
+                    {
+                        "name": "editor-policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"editor\"}]"
+                        }
+                    },
+                    {
+                        "name": "viewer-policy",
+                        "type": "role",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "roles": "[{\"id\":\"viewer\"}]"
+                        }
+                    },
+                    {
+                        "name": "owner-policy",
+                        "type": "owner-policy",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS"
+                    },
+                    {
+                        "name": "any-role-policy",
+                        "type": "aggregate",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "AFFIRMATIVE",
+                        "config": {
+                            "applyPolicies": "[\"admin-policy\",\"editor-policy\",\"viewer-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "admin-or-editor-policy",
+                        "type": "aggregate",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "AFFIRMATIVE",
+                        "config": {
+                            "applyPolicies": "[\"admin-policy\",\"editor-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "editor-and-owner-policy",
+                        "type": "aggregate",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "applyPolicies": "[\"editor-policy\",\"owner-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "admin-or-editor-owner-policy",
+                        "type": "aggregate",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "AFFIRMATIVE",
+                        "config": {
+                            "applyPolicies": "[\"admin-policy\",\"editor-and-owner-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "read-user-permission",
+                        "type": "scope",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"beth@the-smiths.com\",\"rick@the-citadel.com\",\"morty@the-citadel.com\",\"summer@the-smiths.com\",\"jerry@the-smiths.com\"]",
+                            "scopes": "[\"can_read_user\"]",
+                            "applyPolicies": "[\"any-role-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "read-todos-permission",
+                        "type": "scope",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"todo-1\",\"7240d0db-8ff0-41ec-98b2-34a096273b92\",\"7240d0db-8ff0-41ec-98b2-34a096273b91\",\"7240d0db-8ff0-41ec-98b2-34a096273b93\",\"7240d0db-8ff0-41ec-98b2-34a096273b94\",\"7240d0db-8ff0-41ec-98b2-34a096273b95\"]",
+                            "scopes": "[\"can_read_todos\"]",
+                            "applyPolicies": "[\"any-role-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "create-todo-permission",
+                        "type": "scope",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"todo-1\",\"7240d0db-8ff0-41ec-98b2-34a096273b92\",\"7240d0db-8ff0-41ec-98b2-34a096273b91\",\"7240d0db-8ff0-41ec-98b2-34a096273b93\",\"7240d0db-8ff0-41ec-98b2-34a096273b94\",\"7240d0db-8ff0-41ec-98b2-34a096273b95\"]",
+                            "scopes": "[\"can_create_todo\"]",
+                            "applyPolicies": "[\"admin-or-editor-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "update-todo-permission",
+                        "type": "scope",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"todo-1\",\"7240d0db-8ff0-41ec-98b2-34a096273b92\",\"7240d0db-8ff0-41ec-98b2-34a096273b91\",\"7240d0db-8ff0-41ec-98b2-34a096273b93\",\"7240d0db-8ff0-41ec-98b2-34a096273b94\",\"7240d0db-8ff0-41ec-98b2-34a096273b95\"]",
+                            "scopes": "[\"can_update_todo\"]",
+                            "applyPolicies": "[\"admin-or-editor-owner-policy\"]"
+                        }
+                    },
+                    {
+                        "name": "delete-todo-permission",
+                        "type": "scope",
+                        "logic": "POSITIVE",
+                        "decisionStrategy": "UNANIMOUS",
+                        "config": {
+                            "resources": "[\"todo-1\",\"7240d0db-8ff0-41ec-98b2-34a096273b92\",\"7240d0db-8ff0-41ec-98b2-34a096273b91\",\"7240d0db-8ff0-41ec-98b2-34a096273b93\",\"7240d0db-8ff0-41ec-98b2-34a096273b94\",\"7240d0db-8ff0-41ec-98b2-34a096273b95\"]",
+                            "scopes": "[\"can_delete_todo\"]",
+                            "applyPolicies": "[\"admin-or-editor-owner-policy\"]"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/decisions-authorization-api-1_0-02.json
+++ b/authzen/tests/base/src/test/resources/org/keycloak/tests/authzen/decisions-authorization-api-1_0-02.json
@@ -1,0 +1,804 @@
+{
+  "evaluation": [
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "rick@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b91",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b91",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "morty@the-citadel.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b91",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b91",
+          "properties": {
+            "ownerID": "morty@the-citadel.com"
+          }
+        }
+      },
+      "expected": true
+    },
+
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "summer@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b93",
+          "properties": {
+            "ownerID": "summer@the-smiths.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDI2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b93",
+          "properties": {
+            "ownerID": "summer@the-smiths.com"
+          }
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b94",
+          "properties": {
+            "ownerID": "beth@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDM2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b94",
+          "properties": {
+            "ownerID": "beth@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "beth@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_user"
+        },
+        "resource": {
+          "type": "user",
+          "id": "jerry@the-smiths.com"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_read_todos"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": true
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_create_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "todo-1"
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b95",
+          "properties": {
+            "ownerID": "jerry@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+          "properties": {
+            "ownerID": "rick@the-citadel.com"
+          }
+        }
+      },
+      "expected": false
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_delete_todo"
+        },
+        "resource": {
+          "type": "todo",
+          "id": "7240d0db-8ff0-41ec-98b2-34a096273b95",
+          "properties": {
+            "ownerID": "jerry@the-smiths.com"
+          }
+        }
+      },
+      "expected": false
+    }
+  ],
+  "evaluations": [
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDA2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "evaluations": [
+          {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+              "properties": {
+                "ownerID": "rick@the-citadel.com"
+              }
+            }
+          },
+          {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b95",
+              "properties": {
+                "ownerID": "jerry@the-smiths.com"
+              }
+            }
+          }
+        ]
+      },
+      "expected": [ { "decision": true }, { "decision": true } ]
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDE2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "evaluations": [
+          {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+              "properties": {
+                "ownerID": "rick@the-citadel.com"
+              }
+            }
+          },
+          {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b91",
+              "properties": {
+                "ownerID": "morty@the-citadel.com"
+              }
+            }
+          }
+        ]
+      },
+      "expected": [ { "decision": false }, { "decision": true } ]
+    },
+    {
+      "request": {
+        "subject": {
+          "type": "user",
+          "id": "CiRmZDQ2MTRkMy1jMzlhLTQ3ODEtYjdiZC04Yjk2ZjVhNTEwMGQSBWxvY2Fs"
+        },
+        "action": {
+          "name": "can_update_todo"
+        },
+        "evaluations": [
+          {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b92",
+              "properties": {
+                "ownerID": "rick@the-citadel.com"
+              }
+            }
+          },
+          {
+            "resource": {
+              "type": "todo",
+              "id": "7240d0db-8ff0-41ec-98b2-34a096273b95",
+              "properties": {
+                "ownerID": "jerry@the-smiths.com"
+              }
+            }
+          }
+        ]
+      },
+      "expected": [ { "decision": false }, { "decision": false } ]
+    }
+  ]
+}

--- a/core/src/main/java/org/keycloak/representations/idm/oid4vc/UserVerifiableCredentialRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/oid4vc/UserVerifiableCredentialRepresentation.java
@@ -1,0 +1,32 @@
+package org.keycloak.representations.idm.oid4vc;
+
+public class UserVerifiableCredentialRepresentation {
+
+    private String credentialScopeName;
+    private String revision;
+    private Long createdDate;
+
+    public String getCredentialScopeName() {
+        return credentialScopeName;
+    }
+
+    public void setCredentialScopeName(String credentialScopeName) {
+        this.credentialScopeName = credentialScopeName;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserResource.java
@@ -326,6 +326,13 @@ public interface UserResource {
     @Path("consents/{client}")
     void revokeConsent(@PathParam("client") String clientId);
 
+    /**
+     * @since Keycloak server 26.7.0
+     * @return {@link UserVerifiableCredentialResource} with further methods to deal with credentials and issued credentials of the user
+     */
+    @Path("vc")
+    UserVerifiableCredentialResource verifiableCredentials();
+
     @POST
     @Path("impersonation")
     @Produces(MediaType.APPLICATION_JSON)

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserVerifiableCredentialResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/UserVerifiableCredentialResource.java
@@ -1,0 +1,38 @@
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
+
+/**
+ * @since Keycloak 26.7.0 All the child endpoints are also available since that version<p>
+ *
+ * This endpoint including all the child endpoints requires feature {@link org.keycloak.common.Profile.Feature#OID4VC_VCI} to be enabled and also requires "verifiable credentials" to be enabled for the realm<p>
+ */
+public interface UserVerifiableCredentialResource {
+
+    @POST
+    @Path("credentials")
+    @Consumes({MediaType.APPLICATION_JSON})
+    UserVerifiableCredentialRepresentation createCredential(UserVerifiableCredentialRepresentation representation);
+
+    @GET
+    @Path("credentials")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserVerifiableCredentialRepresentation> getCredentials();
+
+    @DELETE
+    @Path("credentials/{credentialScopeName}")
+    void revokeCredential(@PathParam("credentialScopeName") String credentialScopeName);
+
+    // TODO: Issued credentials
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -48,6 +48,7 @@ import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserCredentialManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.cache.CachedUserModel;
 import org.keycloak.models.cache.OnUserCache;
 import org.keycloak.models.cache.UserCache;
@@ -846,6 +847,22 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
         }
 
         return consentModel;
+    }
+
+
+    @Override
+    public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel) {
+        return getDelegate().addVerifiableCredential(userId, credentialModel);
+    }
+
+    @Override
+    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+        return getDelegate().removeVerifiableCredential(userId, credentialScopeName);
+    }
+
+    @Override
+    public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
+        return getDelegate().getVerifiableCredentialsByUser(userId);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/CustomCreateIndexChange.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/CustomCreateIndexChange.java
@@ -102,6 +102,10 @@ public class CustomCreateIndexChange extends CreateIndexChange {
         return super.generateStatements(database);
     }
 
+    public SqlStatement[] generateOriginalStatement(Database database) {
+        return super.generateStatements(database);
+    }
+
     private Long computeEntriesInTable(Database database) throws DatabaseException {
         if (entriesInTable != null) {
             return entriesInTable;

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -39,8 +39,10 @@ import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import jakarta.ws.rs.BadRequestException;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.connections.jpa.support.EntityManagers;
@@ -62,6 +64,7 @@ import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserCredentialManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.jpa.entities.CredentialEntity;
 import org.keycloak.models.jpa.entities.FederatedIdentityEntity;
 import org.keycloak.models.jpa.entities.UserAttributeEntity;
@@ -70,6 +73,7 @@ import org.keycloak.models.jpa.entities.UserConsentEntity;
 import org.keycloak.models.jpa.entities.UserEntity;
 import org.keycloak.models.jpa.entities.UserGroupMembershipEntity;
 import org.keycloak.models.jpa.entities.UserRoleMappingEntity;
+import org.keycloak.models.jpa.entities.UserVerifiableCredentialEntity;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.StorageId;
 import org.keycloak.storage.UserStorageProvider;
@@ -159,6 +163,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         em.createNamedQuery("deleteUserGroupMembershipsByUser").setParameter("user", user).executeUpdate();
         em.createNamedQuery("deleteUserConsentClientScopesByUser").setParameter("user", user).executeUpdate();
         em.createNamedQuery("deleteUserConsentsByUser").setParameter("user", user).executeUpdate();
+        em.createNamedQuery("deleteVerifiableCredentialsByUser").setParameter("user", user).executeUpdate();
 
         em.remove(user);
         em.flush();
@@ -358,6 +363,60 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         em.flush();
     }
 
+    @Override
+    public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel verifCredentialModel) {
+        if (verifCredentialModel.getCredentialScopeName() == null) {
+            throw new BadRequestException("Credential scope not specified");
+        }
+
+        UserVerifiableCredentialEntity vcEntity = new UserVerifiableCredentialEntity();
+        vcEntity.setId(KeycloakModelUtils.generateId());
+        vcEntity.setUser(em.getReference(UserEntity.class, userId));
+
+        String revision = verifCredentialModel.getRevision() == null ? SecretGenerator.getInstance().generateSecureID() : verifCredentialModel.getRevision();
+        vcEntity.setRevision(revision);
+
+        long createdDate = verifCredentialModel.getCreatedDate() == null ? Time.currentTimeMillis() : verifCredentialModel.getCreatedDate();
+        vcEntity.setCreatedDate(createdDate);
+
+        vcEntity.setCredentialScopeName(verifCredentialModel.getCredentialScopeName());
+        em.persist(vcEntity);
+        em.flush();
+
+        return toVerifiableCredentialModel(vcEntity);
+    }
+
+    @Override
+    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+        UserVerifiableCredentialEntity found = getVerifiableCredentialsEntitiesByUser(userId)
+                .filter(vcEnt -> vcEnt.getCredentialScopeName().equals(credentialScopeName))
+                .findFirst()
+                .orElse(null);
+
+        if (found == null) return false;
+
+        em.remove(found);
+        em.flush();
+        return true;
+    }
+
+    @Override
+    public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
+        return getVerifiableCredentialsEntitiesByUser(userId).map(this::toVerifiableCredentialModel);
+    }
+
+    private Stream<UserVerifiableCredentialEntity> getVerifiableCredentialsEntitiesByUser(String userId) {
+        TypedQuery<UserVerifiableCredentialEntity> query = em.createNamedQuery("verifiableCredentialsByUser", UserVerifiableCredentialEntity.class);
+        query.setParameter("userId", userId);
+        return closing(query.getResultStream());
+    }
+
+    private UserVerifiableCredentialModel toVerifiableCredentialModel(UserVerifiableCredentialEntity entity) {
+        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(entity.getCredentialScopeName());
+        model.setRevision(entity.getRevision());
+        model.setCreatedDate(entity.getCreatedDate());
+        return model;
+    }
 
     @Override
     public void setNotBeforeForUser(RealmModel realm, UserModel user, int notBefore) {
@@ -392,6 +451,8 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         em.createNamedQuery("deleteUserConsentClientScopesByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
         em.createNamedQuery("deleteUserConsentsByRealm")
+                .setParameter("realmId", realm.getId()).executeUpdate();
+        em.createNamedQuery("deleteVerifiableCredentialsByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
         em.createNamedQuery("deleteUserRoleMappingsByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
@@ -494,6 +555,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     public void preRemove(ClientScopeModel clientScope) {
         em.createNamedQuery("deleteUserConsentClientScopesByClientScope")
                 .setParameter("scopeId", clientScope.getId())
+                .executeUpdate();
+        em.createNamedQuery("deleteVerifiableCredentialsByClientScope")
+                .setParameter("scopeName", clientScope.getName())
                 .executeUpdate();
     }
 

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserVerifiableCredentialEntity.java
@@ -1,0 +1,103 @@
+package org.keycloak.models.jpa.entities;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+@Entity
+@Table(name="USER_VER_CREDENTIAL", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"USER_ID", "CREDENTIAL_SCOPE_ID"})
+})
+@NamedQueries({
+        @NamedQuery(name="verifiableCredentialsByUser", query="select vc from UserVerifiableCredentialEntity vc where vc.user.id = :userId"),
+        @NamedQuery(name="deleteVerifiableCredentialsByRealm", query="delete from UserVerifiableCredentialEntity vc where vc.user IN (select user from UserEntity user where user.realmId = :realmId)"),
+        @NamedQuery(name="deleteVerifiableCredentialsByClientScope", query="delete from UserVerifiableCredentialEntity vc where vc.credentialScopeName = :scopeName"),
+        @NamedQuery(name="deleteVerifiableCredentialsByUser", query="delete from UserVerifiableCredentialEntity vc where vc.user = :user"),
+})
+public class UserVerifiableCredentialEntity {
+
+    @Id
+    @Column(name="ID", length = 36)
+    @Access(AccessType.PROPERTY) // we do this because relationships often fetch id, but not entity.  This avoids an extra SQL
+    protected String id;
+
+    @ManyToOne(fetch= FetchType.LAZY)
+    @JoinColumn(name="USER_ID")
+    protected UserEntity user;
+
+    @Column(name="CREDENTIAL_SCOPE_NAME")
+    protected String credentialScopeName;
+
+    @Column(name="REVISION")
+    protected String revision;
+
+    @Column(name = "CREATED_DATE")
+    private Long createdDate;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public UserEntity getUser() {
+        return user;
+    }
+
+    public void setUser(UserEntity user) {
+        this.user = user;
+    }
+
+    public String getCredentialScopeName() {
+        return credentialScopeName;
+    }
+
+    public void setCredentialScopeName(String credentialScopeName) {
+        this.credentialScopeName = credentialScopeName;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof UserVerifiableCredentialEntity)) return false;
+
+        UserVerifiableCredentialEntity that = (UserVerifiableCredentialEntity) o;
+
+        if (!id.equals(that.getId())) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+  ~ * and other contributors as indicated by the @author tags.
+  ~ *
+  ~ * Licensed under the Apache License, Version 2.0 (the "License");
+  ~ * you may not use this file except in compliance with the License.
+  ~ * You may obtain a copy of the License at
+  ~ *
+  ~ * http://www.apache.org/licenses/LICENSE-2.0
+  ~ *
+  ~ * Unless required by applicable law or agreed to in writing, software
+  ~ * distributed under the License is distributed on an "AS IS" BASIS,
+  ~ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ * See the License for the specific language governing permissions and
+  ~ * limitations under the License.
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="keycloak" id="26.7.0-jdbcping-timestamp">
+        <addColumn tableName="JGROUPS_PING">
+            <column name="LAST_UPDATE" type="BIGINT" />
+            <column name="COORDINATED_BY" type="VARCHAR(200)" />
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.7.0-45292-realm-display-name-add-column">
+        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
+            <not>
+                <columnExists tableName="REALM" columnName="DISPLAY_NAME"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="REALM">
+            <column name="DISPLAY_NAME" type="NVARCHAR(255)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.7.0-45292-realm-display-name-migrate-data">
+        <customChange class="org.keycloak.connections.jpa.updater.liquibase.custom.JpaUpdate26_7_0_RealmDisplayName"/>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.7.0-45292-realm-display-name-remove-attribute">
+        <delete tableName="REALM_ATTRIBUTE">
+            <where>NAME = 'displayName'</where>
+        </delete>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.7.0-verifiable-credential">
+        <createTable tableName="USER_VER_CREDENTIAL">
+            <column name="ID" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CREDENTIAL_SCOPE_NAME" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="USER_ID" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REVISION" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="CREATED_DATE" type="BIGINT"/>
+        </createTable>
+        <addPrimaryKey columnNames="ID" constraintName="CONSTRAINT_VCRED_PM" tableName="USER_VER_CREDENTIAL"/>
+        <addForeignKeyConstraint baseColumnNames="USER_ID" baseTableName="USER_VER_CREDENTIAL" constraintName="FK_VCRED_USER" referencedColumnNames="ID" referencedTableName="USER_ENTITY"/>
+        <addUniqueConstraint columnNames="CREDENTIAL_SCOPE_NAME, USER_ID" constraintName="UK_KKUWUVD67ONTGSUGOGM8UEWRE" tableName="USER_VER_CREDENTIAL"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/default-persistence.xml
+++ b/model/jpa/src/main/resources/default-persistence.xml
@@ -45,6 +45,7 @@
         <class>org.keycloak.models.jpa.entities.ProtocolMapperEntity</class>
         <class>org.keycloak.models.jpa.entities.UserConsentEntity</class>
         <class>org.keycloak.models.jpa.entities.UserConsentClientScopeEntity</class>
+        <class>org.keycloak.models.jpa.entities.UserVerifiableCredentialEntity</class>
         <class>org.keycloak.models.jpa.entities.AuthenticationFlowEntity</class>
         <class>org.keycloak.models.jpa.entities.AuthenticationExecutionEntity</class>
         <class>org.keycloak.models.jpa.entities.AuthenticatorConfigEntity</class>

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -54,6 +54,7 @@ import org.keycloak.models.UserCredentialManager;
 import org.keycloak.models.UserManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.cache.CachedUserModel;
 import org.keycloak.models.cache.OnUserCache;
 import org.keycloak.models.cache.UserCache;
@@ -926,6 +927,33 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
             return localStorage().revokeConsentForClient(realm, userId, clientInternalId);
         } else {
             return getFederatedStorage().revokeConsentForClient(realm, userId, clientInternalId);
+        }
+    }
+
+    @Override
+    public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel) {
+        if (StorageId.isLocalStorage(userId)) {
+            return localStorage().addVerifiableCredential(userId, credentialModel);
+        } else {
+            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+        }
+    }
+
+    @Override
+    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+        if (StorageId.isLocalStorage(userId)) {
+            return localStorage().removeVerifiableCredential(userId, credentialScopeName);
+        } else {
+            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+        }
+    }
+
+    @Override
+    public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
+        if (StorageId.isLocalStorage(userId)) {
+            return localStorage().getVerifiableCredentialsByUser(userId);
+        } else {
+            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
 
         <asciidoctor.plugin.version>1.5.8</asciidoctor.plugin.version>
 
-        <quarkus.version>3.32.2</quarkus.version>
-        <quarkus.build.version>3.32.2</quarkus.build.version>
+<quarkus.version>3.33.1.1</quarkus.version>
+        <quarkus.build.version>3.33.1.1</quarkus.build.version>
         <jboss-logging-annotations.version>3.0.4.Final</jboss-logging-annotations.version> <!-- keep in sync with the version used by quarkus -->
 
         <project.build-time>${timestamp}</project.build-time>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/DatabaseIndexChecker.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/DatabaseIndexChecker.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.quarkus.runtime.storage.database.jpa;
+
+import java.lang.invoke.MethodHandles;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.keycloak.connections.jpa.updater.liquibase.conn.LiquibaseConnectionProvider;
+import org.keycloak.connections.jpa.updater.liquibase.custom.CustomCreateIndexChange;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+import liquibase.change.core.CreateIndexChange;
+import liquibase.change.core.CreateTableChange;
+import liquibase.change.core.DropIndexChange;
+import liquibase.change.core.DropTableChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+import liquibase.database.DatabaseList;
+import liquibase.exception.LiquibaseException;
+import liquibase.exception.PreconditionErrorException;
+import liquibase.exception.PreconditionFailedException;
+import liquibase.precondition.FailedPrecondition;
+import liquibase.precondition.Precondition;
+import liquibase.precondition.core.AndPrecondition;
+import liquibase.precondition.core.ChangeSetExecutedPrecondition;
+import liquibase.precondition.core.DBMSPrecondition;
+import liquibase.precondition.core.IndexExistsPrecondition;
+import liquibase.precondition.core.NotPrecondition;
+import liquibase.precondition.core.OrPrecondition;
+import liquibase.precondition.core.TableExistsPrecondition;
+import org.jboss.logging.Logger;
+
+/**
+ * Checks for missing database indexes at startup by comparing the indexes defined in the Liquibase changelogs against
+ * those actually present in the database.
+ *
+ * <p>Keycloak's {@code CustomCreateIndexChange} may skip creating indexes on tables that exceed
+ * a configurable row count threshold. When that happens, the Liquibase changeset is marked as executed, so subsequent
+ * migrations will not retry. This checker detects those (and any other) missing indexes and logs a {@code WARN} with
+ * the {@code CREATE INDEX} statement so operators can apply it manually.
+ *
+ * <p>The check is non-blocking and never prevents startup. If the metadata query itself fails (e.g. insufficient
+ * permissions), the error is logged and silently ignored.
+ */
+public class DatabaseIndexChecker implements Runnable {
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final Supplier<Connection> connectionSupplier;
+    private final KeycloakSessionFactory factory;
+    private final String dbSchema;
+
+    public DatabaseIndexChecker(Supplier<Connection> connectionSupplier, KeycloakSessionFactory factory, String dbSchema) {
+        this.connectionSupplier = Objects.requireNonNull(connectionSupplier);
+        this.factory = Objects.requireNonNull(factory);
+        this.dbSchema = dbSchema;
+    }
+
+    @Override
+    public void run() {
+        logger.info("Running database index checker");
+        var missing = getMissingIndexes();
+        for (var info : missing) {
+            logger.warnf("Missing database index %s on table %s. Create the index manually: %s", info.indexName, info.tableName, info.sql);
+        }
+    }
+
+    public List<String> getMissingIndexesName() {
+        return getMissingIndexes().stream().map(IndexInfo::indexName).toList();
+    }
+
+    private List<IndexInfo> getMissingIndexes() {
+        try (var connection = connectionSupplier.get(); var session = factory.create()) {
+            var expectedIndexes = getExpectedIndexesFromLiquibase(connection, session);
+            if (expectedIndexes.isEmpty()) {
+                return List.of();
+            }
+
+            var metaData = connection.getMetaData();
+            var storesLower = metaData.storesLowerCaseIdentifiers();
+            var storesUpper = metaData.storesUpperCaseIdentifiers();
+
+            var tablesToCheck = expectedIndexes.values().stream()
+                    .map(info -> normalizeIdentifier(info.tableName, storesLower, storesUpper))
+                    .collect(Collectors.toSet());
+            var existingIndexes = getExistingIndexesFromDatabase(metaData, tablesToCheck);
+
+            return expectedIndexes.entrySet().stream().filter(e -> !existingIndexes.contains(e.getKey())).map(Map.Entry::getValue).toList();
+        } catch (SQLException | LiquibaseException e) {
+            logger.warn("Unable to check for missing database indexes", e);
+        }
+        return List.of();
+    }
+
+    private Map<String, IndexInfo> getExpectedIndexesFromLiquibase(Connection connection, KeycloakSession session) throws LiquibaseException {
+        var liquibaseProvider = session.getProvider(LiquibaseConnectionProvider.class);
+        var liquibase = liquibaseProvider.getLiquibase(connection, dbSchema);
+
+        var expectedIndexes = new HashMap<String, IndexInfo>();
+        var database = liquibase.getDatabase();
+        var runChangesets = new HashSet<ChangesetInfo>();
+        var tables = new HashSet<TableInfo>();
+        liquibase.getDatabaseChangeLog().getChangeSets().stream()
+                .filter(cs -> {
+                    boolean changeSetForCurrentDatabase = isChangeSetForCurrentDatabase(cs, database, expectedIndexes, runChangesets, tables);
+                    if (changeSetForCurrentDatabase) {
+                        runChangesets.add(new ChangesetInfo(cs.getId(), cs.getAuthor(), cs.getFilePath()));
+                    }
+                    return changeSetForCurrentDatabase;
+                })
+                .map(ChangeSet::getChanges)
+                .flatMap(Collection::stream)
+                .forEach(change -> {
+                    if (change instanceof CreateIndexChange cic && cic.getIndexName() != null) {
+                        var statement = cic instanceof CustomCreateIndexChange ?
+                                ((CustomCreateIndexChange) cic).generateOriginalStatement(database) :
+                                cic.generateStatements(database);
+                        var sql = Arrays.stream(statement)
+                                .map(sqlStatement -> sqlStatement.getFormattedStatement(database))
+                                .collect(Collectors.joining("; "));
+                        var info = new IndexInfo(cic.getTableName(), cic.getIndexName(), sql);
+                        expectedIndexes.put(cic.getIndexName().toUpperCase(), info);
+                        logger.debugf("Create index (%s), %s", change.getChangeSet(), info);
+                    } else if (change instanceof DropIndexChange dic && dic.getIndexName() != null) {
+                        var info = expectedIndexes.remove(dic.getIndexName().toUpperCase());
+                        logger.debugf("Drop index (%s), %s", change.getChangeSet(), info);
+                    } else if (change instanceof CreateTableChange dic) {
+                        TableInfo info = new TableInfo(dic.getTableName());
+                        logger.debugf("Create table (%s), %s", change.getChangeSet(), info);
+                        tables.add(info);
+                    } else if (change instanceof DropTableChange dtc && dtc.getTableName() != null) {
+                        var droppedTable = dtc.getTableName();
+                        expectedIndexes.values().removeIf(info -> info.tableName.equalsIgnoreCase(droppedTable));
+                        TableInfo info = new TableInfo(droppedTable);
+                        tables.remove(info);
+                        logger.debugf("Drop table (%s), %s", change.getChangeSet(), droppedTable);
+                    }
+                });
+        return expectedIndexes;
+    }
+
+    private Set<String> getExistingIndexesFromDatabase(DatabaseMetaData metaData, Collection<String> tables) throws SQLException {
+        var existingIndexes = new HashSet<String>();
+
+        for (var table : tables) {
+            try (var rs = metaData.getIndexInfo(null, dbSchema, table, false, true)) {
+                while (rs.next()) {
+                    var indexName = rs.getString("INDEX_NAME");
+                    if (indexName != null) {
+                        existingIndexes.add(indexName.toUpperCase());
+                    }
+                }
+            }
+        }
+        return existingIndexes;
+    }
+
+    private static boolean isChangeSetForCurrentDatabase(ChangeSet changeSet, Database database, HashMap<String, IndexInfo> expectedIndexes, HashSet<ChangesetInfo> changes, HashSet<TableInfo> tables) {
+        if (!DatabaseList.definitionMatches(changeSet.getDbmsSet(), database, true)) {
+            // returns true if `getDbmsSet()` returns empty or null - i.e. for all databases
+            logger.debugf("ChangeSet not valid for current database '%s'. %s", database.getShortName(), changeSet);
+            return false;
+        }
+        var preconditions = changeSet.getPreconditions();
+        if (preconditions == null) {
+            // no pre-conditions
+            return true;
+        }
+        for (var precondition : preconditions.getNestedPreconditions()) {
+            try {
+                evaluate(precondition, database, expectedIndexes, changes, tables);
+            } catch (PreconditionFailedException | PreconditionErrorException e) {
+                logger.debugf(e, "ChangeSet not valid for current database '%s'. %s", database.getShortName(), changeSet);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Evaluate the precondition based on the transient state for indexes, tables and changesets and the database.
+     * It will not use any changelog or database information directly, as that has already been fully migrated.
+     * All conditions that are not implemented here will default to "true".
+     */
+    private static void evaluate(Precondition p, Database database, HashMap<String, IndexInfo> expectedIndexes, HashSet<ChangesetInfo> changes, HashSet<TableInfo> tables)
+            throws PreconditionFailedException, PreconditionErrorException {
+        if (p instanceof DBMSPrecondition dbmsPrecondition) {
+            dbmsPrecondition.check(database, null, null, null);
+        } else if (p instanceof AndPrecondition andCondition) {
+            boolean allPassed = true;
+            List<FailedPrecondition> failures = new ArrayList<>();
+            for (Precondition precondition : andCondition.getNestedPreconditions()) {
+                try {
+                    evaluate(precondition, database, expectedIndexes, changes, tables);
+                } catch (PreconditionFailedException e) {
+                    failures.addAll(e.getFailedPreconditions());
+                    allPassed = false;
+                    break;
+                }
+            }
+            if (!allPassed) {
+                throw new PreconditionFailedException(failures);
+            }
+        } else if (p instanceof NotPrecondition notPrecondition) {
+            for (Precondition precondition : notPrecondition.getNestedPreconditions()) {
+                boolean threwException = false;
+                try {
+                    evaluate(precondition, database, expectedIndexes, changes, tables);
+                } catch (PreconditionFailedException e) {
+                    //that's what we want with a Not precondition
+                    threwException = true;
+                }
+                if (!threwException) {
+                    throw new PreconditionFailedException("Not precondition failed", null, notPrecondition);
+                }
+            }
+        } else if (p instanceof OrPrecondition orPrecondition) {
+            boolean onePassed = false;
+            List<FailedPrecondition> failures = new ArrayList<>();
+            for (Precondition precondition : orPrecondition.getNestedPreconditions()) {
+                try {
+                    evaluate(precondition, database, expectedIndexes, changes, tables);
+                    onePassed = true;
+                    break;
+                } catch (PreconditionFailedException e) {
+                    failures.addAll(e.getFailedPreconditions());
+                }
+            }
+            if (!onePassed) {
+                throw new PreconditionFailedException(failures);
+            }
+        } else if (p instanceof ChangeSetExecutedPrecondition changeSetExecutedPrecondition) {
+            if (!changes.contains(new ChangesetInfo(changeSetExecutedPrecondition.getId(), changeSetExecutedPrecondition.getAuthor(), changeSetExecutedPrecondition.getChangeLogFile()))) {
+                throw new PreconditionFailedException("Precondition failed", null, changeSetExecutedPrecondition);
+            }
+        } else if (p instanceof IndexExistsPrecondition indexExistsPrecondition) {
+            if (expectedIndexes.get(indexExistsPrecondition.getIndexName()) == null) {
+                throw new PreconditionFailedException("Precondition failed", null, indexExistsPrecondition);
+            }
+        } else if (p instanceof TableExistsPrecondition tableExistsPrecondition) {
+            if (!tables.contains(new TableInfo(tableExistsPrecondition.getTableName()))) {
+                throw new PreconditionFailedException("Precondition failed", null, tableExistsPrecondition);
+            }
+        }
+        // All other conditions default to true
+    }
+
+    private static String normalizeIdentifier(String name, boolean storesLower, boolean storesUpper) {
+        if (storesLower) return name.toLowerCase();
+        if (storesUpper) return name.toUpperCase();
+        return name;
+    }
+
+    private record IndexInfo(String tableName, String indexName, String sql) {
+    }
+    private record ChangesetInfo(String id, String author, String filePath) {
+    }
+    private record TableInfo(String tableName) {
+    }
+
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -148,6 +148,8 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
         } catch (Exception e) {
             logErrorSettingMigrationTransactionTimeout(e);
         }
+
+        checkMissingIndexes(factory);
     }
 
     @Override
@@ -433,5 +435,11 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
 
     private static void logInvalidEncoding(Database.Vendor vendor, String encoding, String recommendedEncoding) {
         logger.warnf("Invalid %s charset encoding '%s'. It is recommended to use %s", vendor, encoding, recommendedEncoding);
+    }
+
+    private void checkMissingIndexes(KeycloakSessionFactory factory) {
+        var thread = new Thread(new DatabaseIndexChecker(this::getConnection, factory, getSchema()), "db-index-checker");
+        thread.setDaemon(true);
+        thread.start();
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -86,6 +86,7 @@ import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.WebAuthnPolicy;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.light.LightweightUserAdapter;
@@ -126,6 +127,7 @@ import org.keycloak.representations.idm.authorization.ResourceOwnerRepresentatio
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.storage.StorageId;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
@@ -1027,6 +1029,14 @@ public class ModelToRepresentation {
         consentRep.setCreatedDate(model.getCreatedDate());
         consentRep.setLastUpdatedDate(model.getLastUpdatedDate());
         return consentRep;
+    }
+
+    public static UserVerifiableCredentialRepresentation toRepresentation(UserVerifiableCredentialModel model) {
+        UserVerifiableCredentialRepresentation rep = new UserVerifiableCredentialRepresentation();
+        rep.setCredentialScopeName(model.getCredentialScopeName());
+        rep.setRevision(model.getRevision());
+        rep.setCreatedDate(model.getCreatedDate());
+        return rep;
     }
 
     public static AuthenticationFlowRepresentation toRepresentation(KeycloakSession session, RealmModel realm, AuthenticationFlowModel model) {

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -93,6 +93,7 @@ import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserCredentialModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.credential.PasswordCredentialModel;
 import org.keycloak.models.credential.dto.OTPCredentialData;
@@ -129,6 +130,7 @@ import org.keycloak.representations.idm.authorization.ResourceOwnerRepresentatio
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.storage.DatastoreProvider;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
@@ -982,6 +984,13 @@ public class RepresentationToModel {
         }
 
         return consentModel;
+    }
+
+    public static UserVerifiableCredentialModel toModel(UserVerifiableCredentialRepresentation rep) {
+        UserVerifiableCredentialModel verifCredentialModel = new UserVerifiableCredentialModel(rep.getCredentialScopeName());
+        verifCredentialModel.setRevision(rep.getRevision());
+        verifCredentialModel.setCreatedDate(rep.getCreatedDate());
+        return verifCredentialModel;
     }
 
     public static AuthenticationFlowModel toModel(AuthenticationFlowRepresentation rep) {

--- a/server-spi/src/main/java/org/keycloak/models/UserProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserProvider.java
@@ -157,6 +157,32 @@ public interface UserProvider extends Provider,
      */
     boolean revokeConsentForClient(RealmModel realm, String userId, String clientInternalId);
 
+    /**
+     * Create verifiable credential of specified credential scope for this user
+     *
+     * @param userId id of the user
+     * @param credentialModel credential model with "credentialScopeName" set. The other fields will be generated if not set
+     * @return credentialModel with all the fields set
+     */
+    UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel);
+
+    /**
+     * Remove verifiable credential of specified client scope from this user
+     *
+     * @param userId id if the user
+     * @param credentialScopeName credential scope name to delete
+     * @return true if credential was successfully removed. False otherwise
+     */
+    boolean removeVerifiableCredential(String userId, String credentialScopeName);
+
+    /**
+     * Return all verifiable credentials of specified user
+     *
+     * @param userId id if the user
+     * @return all verifiable credentials of specified user
+     */
+    Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId);
+
     /* FEDERATED IDENTITIES methods */
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/UserVerifiableCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserVerifiableCredentialModel.java
@@ -1,0 +1,34 @@
+package org.keycloak.models;
+
+public class UserVerifiableCredentialModel {
+
+    private final String credentialScopeName;
+    private String revision;
+    private Long createdDate;
+
+    public UserVerifiableCredentialModel(String credentialScopeName) {
+        this.credentialScopeName = credentialScopeName;
+    }
+
+    public String getCredentialScopeName() {
+        return credentialScopeName;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+
+}

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/AbstractClaimMapper.java
@@ -31,6 +31,7 @@ import org.keycloak.representations.JsonWebToken;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
 
 import static org.keycloak.utils.JsonUtils.splitClaimPath;
 
@@ -41,6 +42,8 @@ import static org.keycloak.utils.JsonUtils.splitClaimPath;
 public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper {
     public static final String CLAIM = "claim";
     public static final String CLAIM_VALUE = "claim.value";
+
+    private static final Logger logger = Logger.getLogger(AbstractClaimMapper.class);
 
     public static Object getClaimValue(JsonWebToken token, String claim) {
 
@@ -125,19 +128,19 @@ public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper
             try {
                 if (Double.valueOf(desiredValue).equals(value)) return true;
             } catch (Exception e) {
-
+                logger.tracef("Failed to parse desired value as Double: %s", desiredValue);
             }
         } else if (value instanceof Integer) {
             try {
                 if (Integer.valueOf(desiredValue).equals(value)) return true;
             } catch (Exception e) {
-
+                logger.tracef("Failed to parse desired value as Integer: %s", desiredValue);
             }
         } else if (value instanceof Boolean) {
             try {
                 if (Boolean.valueOf(desiredValue).equals(value)) return true;
             } catch (Exception e) {
-
+                logger.tracef("Failed to parse desired value as Boolean: %s", desiredValue);
             }
         } else if (value instanceof List) {
             List list = (List)value;
@@ -147,7 +150,8 @@ public abstract class AbstractClaimMapper extends AbstractIdentityProviderMapper
         } else if (value instanceof JsonNode) {
             try {
                 if (JsonSerialization.readValue(desiredValue, JsonNode.class).equals(value)) return true;
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                logger.tracef("Failed to parse desired value as JsonNode: %s", desiredValue);
             }
         }
         return false;

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -255,8 +255,8 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
                 }
             }
         } catch (WebAuthnException wae) {
-            wae.printStackTrace();
-            throw(wae);
+            logger.error("WebAuthn authentication failed", wae);
+            throw wae;
         }
         // no authenticator matched
         return false;

--- a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java
@@ -29,6 +29,8 @@ import java.util.stream.Stream;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
+
+import org.jboss.logging.Logger;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -40,6 +42,8 @@ import org.keycloak.services.util.DPoPUtil;
  * @version $Revision: 1 $
  */
 public class ProtocolMapperUtils {
+
+    private static final Logger logger = Logger.getLogger(ProtocolMapperUtils.class);
 
     public static final String USER_ROLE = "user.role";
     public static final String USER_ATTRIBUTE = "user.attribute";
@@ -116,7 +120,8 @@ public class ProtocolMapperUtils {
         try {
             Object val = m.invoke(user);
             if (val != null) return val.toString();
-        } catch (Exception ignore) {
+        } catch (Exception e) {
+            logger.tracef("Failed to invoke method %s on user: %s", m.getName(), e.getMessage());
         }
 
         return null;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialbuilder/SdJwtCredentialBuilder.java
@@ -90,11 +90,7 @@ public class SdJwtCredentialBuilder implements CredentialBuilder {
                 .stream()
                 .filter(entry -> !credentialBuildConfig.getSdJwtVisibleClaims().contains(entry.getKey()))
                 .forEach(entry -> {
-                    if (entry instanceof List<?> listValue) {
-                        // FIXME: Unreachable branch. The intent was probably to check `entry.getValue()`,
-                        //  but changing just that will expose the array field name and break many tests.
-                        //  Needs further discussion on the wanted behavior.
-
+                    if (entry.getValue() instanceof List<?> listValue) {
                         IntStream.range(0, listValue.size())
                                 .forEach(i -> disclosureSpecBuilder
                                         .withUndisclosedArrayElt(entry.getKey(), i, SdJwtUtils.randomSalt())

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/resources/admin/UserVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/resources/admin/UserVerifiableCredentialResource.java
@@ -1,0 +1,164 @@
+package org.keycloak.protocol.oid4vc.resources.admin;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.common.Profile;
+import org.keycloak.constants.OID4VCIConstants;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.ModelException;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.models.utils.RepresentationToModel;
+import org.keycloak.representations.idm.ErrorRepresentation;
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
+import org.keycloak.services.ErrorResponse;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.NoCache;
+
+public class UserVerifiableCredentialResource {
+
+    private static final Logger logger = Logger.getLogger(UserVerifiableCredentialResource.class);
+
+    private final AdminPermissionEvaluator auth;
+    private final AdminEventBuilder adminEvent;
+    private final UserModel user;
+    private final KeycloakSession session;
+    private final RealmModel realm;
+
+    public UserVerifiableCredentialResource(KeycloakSession session, RealmModel realm, UserModel user, AdminPermissionEvaluator auth, AdminEventBuilder adminEvent) {
+        this.session = session;
+        this.realm = realm;
+        this.user = user;
+        this.auth = auth;
+        this.adminEvent = adminEvent;
+    }
+
+    @POST
+    @Path("credentials")
+    @Consumes({MediaType.APPLICATION_JSON})
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
+    @Operation(summary = "Create verifiable credential for the user. Once this is successful, user will be able to issue verifiable credentials of the credential type specified type afterwards")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "201", description = "Created", content = @Content(schema = @Schema(implementation = UserVerifiableCredentialRepresentation.class))),
+            @APIResponse(responseCode = "400", description = "Bad request", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class))),
+            @APIResponse(responseCode = "403", description = "Forbidden"),
+            @APIResponse(responseCode = "409", description = "Conflict", content = @Content(schema = @Schema(implementation = ErrorRepresentation.class)))
+    })
+    public UserVerifiableCredentialRepresentation createCredential(UserVerifiableCredentialRepresentation representation) {
+        auth.users().requireManage(user);
+        checkOid4VCIEnabled();
+
+        if (representation.getCreatedDate() != null) {
+            throw ErrorResponse.error("Created date not expected to be specified", Response.Status.BAD_REQUEST);
+        }
+        if (representation.getRevision() != null) {
+            throw ErrorResponse.error("Revision not expected to be specified", Response.Status.BAD_REQUEST);
+        }
+
+        ClientScopeModel clientScope = KeycloakModelUtils.getClientScopeByName(realm, representation.getCredentialScopeName());
+        if (clientScope == null) {
+            logger.warn(String.format("Client scope '%s' does not exists in the realm realm '%s'.", representation.getCredentialScopeName(),realm.getName()));
+            throw ErrorResponse.error("Client scope does not exists", Response.Status.BAD_REQUEST);
+        }
+        if (!OID4VCIConstants.OID4VC_PROTOCOL.equals(clientScope.getProtocol())) {
+            logger.warn(String.format("Client scope '%s' in the realm realm '%s' does not have protocol '%s'.",
+                    representation.getCredentialScopeName(),realm.getName(), OID4VCIConstants.OID4VC_PROTOCOL));
+            throw ErrorResponse.error("Client scope has incorrect protocol", Response.Status.BAD_REQUEST);
+        }
+
+        try {
+            UserVerifiableCredentialModel modelToCreate = RepresentationToModel.toModel(representation);
+            UserVerifiableCredentialModel createdModel = session.users().addVerifiableCredential(user.getId(), modelToCreate);
+
+            UserVerifiableCredentialRepresentation createdRep = ModelToRepresentation.toRepresentation(createdModel);
+            adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri()).representation(createdRep).success();
+            return createdRep;
+        } catch (ModelDuplicateException mde) {
+            logger.warn(String.format("Verifiable credential '%s' already exists for user '%s' in the realm '%s' for credential. Details: '%s'",
+                    representation.getCredentialScopeName(), user.getUsername(), realm.getName(), mde.getMessage()));
+            throw ErrorResponse.exists("Verifiable credential already exists");
+        } catch (ModelException mde) {
+            logger.warn(String.format("Error when creating verifiable credential of type '%s' for user '%s' in the realm '%s'. Details: '%s'",
+                    representation.getCredentialScopeName(), user.getUsername(), realm.getName(), mde.getMessage()), mde);
+            throw ErrorResponse.error("Error when creating verifiable credential", Response.Status.BAD_REQUEST);
+        }
+    }
+
+    @GET
+    @Path("credentials")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.USERS)
+    @Operation(summary = "Get verifiable credentials granted to the user")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "OK"),
+            @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public List<UserVerifiableCredentialRepresentation> getCredentials() {
+        auth.users().requireView(user);
+        checkOid4VCIEnabled();
+
+        return session.users().getVerifiableCredentialsByUser(user.getId())
+                .map(ModelToRepresentation::toRepresentation)
+                .toList();
+    }
+
+    @DELETE
+    @Path("credentials/{credentialScopeName}")
+    @Operation(summary = "Revoke verifiable credential for particular user")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "403", description = "Forbidden"),
+            @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public void revokeCredential(@PathParam("credentialScopeName") String credentialScopeName) {
+        auth.users().requireManage(user);
+        checkOid4VCIEnabled();
+
+        boolean removed = session.users().removeVerifiableCredential(user.getId(), credentialScopeName);
+        if (!removed) {
+            logger.warn(String.format("Verifiable credential '%s' not found for user '%s' in the realm '%s'.",
+                    credentialScopeName, user.getUsername(), realm.getName()));
+            throw new NotFoundException("Verifiable credential not found");
+        }
+
+        adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
+    }
+
+    private void checkOid4VCIEnabled() {
+        if (!Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI)) {
+            throw ErrorResponse.error("Feature " + Profile.Feature.OID4VC_VCI.getKey() + " not enabled", Response.Status.BAD_REQUEST);
+        }
+        if (!realm.isVerifiableCredentialsEnabled()) {
+            throw ErrorResponse.error("Verifiable credentials not enabled for the realm", Response.Status.BAD_REQUEST);
+        }
+    }
+
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSignedAuthenticationRequestExecutor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/clientpolicy/executor/SecureCibaSignedAuthenticationRequestExecutor.java
@@ -142,7 +142,7 @@ public class SecureCibaSignedAuthenticationRequestExecutor implements ClientPoli
 
         // check whether signed authentication request not expired
         long exp = signedAuthReq.get("exp").asLong();
-        if (Time.currentTime() > exp) { // TODO: Time.currentTime() is int while exp is long...
+        if (Time.currentTimeMillis() / 1000 > exp) {
             logger.trace("request object expired.");
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Request Expired");
         }
@@ -155,7 +155,7 @@ public class SecureCibaSignedAuthenticationRequestExecutor implements ClientPoli
 
         // check whether signed authentication request not yet being processed
         long nbf = signedAuthReq.get("nbf").asLong();
-        if (Time.currentTime() < nbf) { // TODO: Time.currentTime() is int while nbf is long...
+        if (Time.currentTimeMillis() / 1000 < nbf) {
             logger.trace("request object not yet being processed.");
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Request not yet being processed");
         }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OIDCAttributeMapperHelper.java
@@ -116,8 +116,8 @@ public class OIDCAttributeMapperHelper {
         tmpToken.put(IDToken.AUTH_TIME, (claim, mapperName, token, value) -> {
             try {
                 token.setAuth_time(Long.parseLong(value.toString()));
-            } catch (NumberFormatException ignored){
-
+            } catch (NumberFormatException e){
+                logger.tracef("Failed to parse auth_time value: %s", value);
             }
         });
         tmpToken.put("aud", (claim, mapperName, token, value) -> {
@@ -265,13 +265,15 @@ public class OIDCAttributeMapperHelper {
         if (attributeValue instanceof Map) {
             try {
                 return JsonSerialization.createObjectNode(attributeValue);
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                logger.tracef("Failed to create JsonNode from Map: %s", e.getMessage());
             }
         }
         if (attributeValue instanceof String) {
             try {
                 return JsonSerialization.readValue(attributeValue.toString(), JsonNode.class);
-            } catch (Exception ignore) {
+            } catch (Exception e) {
+                logger.tracef("Failed to parse String as JsonNode: %s", e.getMessage());
             }
         }
         return null;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
@@ -191,7 +191,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
 
         // check whether request object not expired
         long exp = requestObject.get("exp").asLong();
-        if (Time.currentTime() > exp) { // TODO: Time.currentTime() is int while exp is long...
+        if (Time.currentTimeMillis() / 1000 > exp) {
             logger.trace("request object expired.");
             throw new ClientPolicyException(INVALID_REQUEST_OBJECT, "Request Expired");
         }
@@ -208,7 +208,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
 
             // check whether request object not yet being processed
             long nbf = requestObject.get("nbf").asLong();
-            if (Time.currentTime() < nbf - configuration.getAllowedClockSkew().intValue()) { // TODO: Time.currentTime() is int while nbf is long...
+            if (Time.currentTimeMillis() / 1000 < nbf - configuration.getAllowedClockSkew().intValue()) {
                 logger.trace("request object not yet being processed.");
                 throwClientPolicyException(INVALID_REQUEST_OBJECT, "Request not yet being processed", context);
             }
@@ -224,7 +224,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
         // check "iat" with clock skew
         if (requestObject.get("iat") != null) {
             long iat = requestObject.get("iat").asLong();
-            if (Time.currentTime() < iat - configuration.getAllowedClockSkew().intValue()) { // TODO: Time.currentTime() is int while nbf is long...
+            if (Time.currentTimeMillis() / 1000 < iat - configuration.getAllowedClockSkew().intValue()) {
                 logger.trace("request object issed in the future.");
                 throwClientPolicyException(INVALID_REQUEST_OBJECT, "Request issued in the future", context);
             }

--- a/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/DefaultClientTypeManager.java
@@ -139,7 +139,20 @@ public class DefaultClientTypeManager implements ClientTypeManager {
     }
 
 
-    // TODO:client-types some javadoc or comment about how this method works
+    /**
+     * Validates and casts the client type configuration.
+     *
+     * This method performs validation on the client type configuration including:
+     * - Checking that the client type provider exists
+     * - Ensuring the client type name is not duplicated
+     * - Validating the configuration through the provider
+     *
+     * @param session the Keycloak session
+     * @param clientType the client type representation to validate
+     * @param currentNames set of already processed client type names (to detect duplicates)
+     * @return the validated client type representation
+     * @throws ClientTypeException if validation fails (provider not found, duplicate name, or invalid config)
+     */
     private static ClientTypeRepresentation validateAndCastConfiguration(KeycloakSession session, ClientTypeRepresentation clientType, Set<String> currentNames) {
         ClientTypeProvider clientTypeProvider = session.getProvider(ClientTypeProvider.class, clientType.getProvider());
         if (clientTypeProvider == null) {

--- a/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
+++ b/services/src/main/java/org/keycloak/services/clienttype/impl/DefaultClientTypeProvider.java
@@ -58,7 +58,6 @@ public class DefaultClientTypeProvider implements ClientTypeProvider {
             }
         }
 
-        // TODO:client-types retype configuration
         return clientType;
     }
 }

--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -219,7 +219,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             attributes.put("darkMode", "true".equals(properties.getProperty("darkMode"))
                     && realm.getAttribute("darkMode", true));
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("Failed to load theme properties for dark mode", e);
         }
 
         return attributes;

--- a/services/src/main/java/org/keycloak/services/managers/UserConsentManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserConsentManager.java
@@ -135,7 +135,9 @@ public class UserConsentManager {
      * @param clientInternalId id of the client
      * @return {@code true} if the consent was removed, {@code false} otherwise
      *
-     * TODO: Make this method return Boolean so that store can return "I don't know" answer, this can be used for example in async stores
+     * Note: This method returns boolean instead of Boolean to maintain API compatibility.
+     * For async stores that need to return "I don't know" (null), a future enhancement
+     * could change the return type to Boolean, but that would be a breaking API change.
      */
     public static boolean revokeConsentForClient(KeycloakSession session, RealmModel realm, UserModel user, String clientInternalId) {
         if (isLightweightUser(user)) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -115,6 +115,8 @@ public class AccountLoader {
     }
 
     private AccountRestService getAccountRestService(ClientModel client, String versionStr) {
+        AccountRestService.checkAccountApiEnabled();
+
         AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
                 .authenticate();
         if (authResult == null) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -496,7 +496,7 @@ public class AccountRestService {
 
     // TODO Logs
 
-    private static void checkAccountApiEnabled() {
+    public static void checkAccountApiEnabled() {
         if (!Profile.isFeatureEnabled(Profile.Feature.ACCOUNT_API)) {
             throw new NotFoundException();
         }

--- a/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/LinkedAccountsResource.java
@@ -276,7 +276,7 @@ public class LinkedAccountsResource {
 
             return Cors.builder().auth().allowedOrigins(auth.getToken()).add(Response.ok(rep));
         } catch (Exception spe) {
-            spe.printStackTrace();
+            logger.error("Failed to create linked account URI", spe);
             throw ErrorResponse.error(Messages.FAILED_TO_PROCESS_RESPONSE, Response.Status.INTERNAL_SERVER_ERROR);
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -92,6 +92,7 @@ import org.keycloak.models.utils.RoleUtils;
 import org.keycloak.models.utils.SystemClientUtil;
 import org.keycloak.organization.utils.Organizations;
 import org.keycloak.policy.PasswordPolicyNotMetException;
+import org.keycloak.protocol.oid4vc.resources.admin.UserVerifiableCredentialResource;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.provider.ProviderFactory;
@@ -661,6 +662,11 @@ public class UserResource {
             throw new NotFoundException("Consent nor offline token not found");
         }
         adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).success();
+    }
+
+    @Path("vc")
+    public UserVerifiableCredentialResource verifiableCredentials() {
+        return new UserVerifiableCredentialResource(session, realm, user, auth, adminEvent);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/util/MtlsHoKTokenUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/MtlsHoKTokenUtil.java
@@ -128,7 +128,9 @@ public class MtlsHoKTokenUtil {
             String DERX509Base64UrlEncoded = null;
             try {
                 DERX509Base64UrlEncoded = getCertificateThumbprintInSHA256DERX509Base64UrlEncoded(certs[i]);
-            } catch (Exception e) {}
+            } catch (Exception e) {
+                logger.tracef("Failed to get certificate thumbprint for cert[%d]: %s", i, e.getMessage());
+            }
             logger.tracef(":: certs[%d] Base64URL Encoded SHA-256 Hash of DER formatted first x509 Client Certificate in Certificate Chain = %s", i, DERX509Base64UrlEncoded);
             logger.tracef(":: certs[%d] DER Dump Bytes of first x509 Client Certificate TBScertificate in Certificate Chain = %d", i, certs[i].getTBSCertificate().length);
             logger.tracef(":: certs[%d] Signature Algorithm of first x509 Client Certificate in Certificate Chain = %s", i, certs[i].getSigAlgName());

--- a/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
+++ b/services/src/main/java/org/keycloak/truststore/FileTruststoreProviderFactory.java
@@ -108,6 +108,7 @@ public class FileTruststoreProviderFactory implements TruststoreProviderFactory 
                 try {
                     truststore = KeystoreUtil.loadKeyStore(storepath, pass, "jks");
                 } catch (Exception e1) {
+                    log.debugf("Failed to load truststore as JKS type: %s", e1.getMessage());
                 }
             }
             if (truststore == null) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/PermissionsTest.java
@@ -44,6 +44,7 @@ import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.representations.idm.RealmEventsConfigRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.services.resources.admin.AdminAuth.Resource;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -425,6 +426,13 @@ public class PermissionsTest extends AbstractPermissionsTest {
         invoke(realm -> realm.users().get(user.getId()).removeFederatedIdentity("nosuch"), Resource.USER, true);
         invoke(realm -> realm.users().get(user.getId()).getConsents(), Resource.USER, false);
         invoke(realm -> realm.users().get(user.getId()).revokeConsent("testclient"), Resource.USER, true);
+
+        invoke(realm -> realm.users().get(user.getId()).verifiableCredentials().getCredentials(), Resource.USER, false);
+        UserVerifiableCredentialRepresentation verifCred = new UserVerifiableCredentialRepresentation();
+        verifCred.setCredentialScopeName("nosuch");
+        invoke(realm -> realm.users().get(user.getId()).verifiableCredentials().createCredential(verifCred), Resource.USER, true);
+        invoke(realm -> realm.users().get(user.getId()).verifiableCredentials().revokeCredential("nosuch"), Resource.USER, true);
+
         invoke(realm -> realm.users().get(user.getId()).logout(), Resource.USER, true);
         invoke(realm -> realm.users().get(user.getId()).resetPassword(CredentialBuilder.create().password("password").build()),
                 Resource.USER, true);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserVerifiableCredentialsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserVerifiableCredentialsTest.java
@@ -1,0 +1,258 @@
+package org.keycloak.tests.admin.user;
+
+import java.util.List;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.admin.client.resource.UserVerifiableCredentialResource;
+import org.keycloak.common.util.Time;
+import org.keycloak.constants.OID4VCIConstants;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.representations.idm.ErrorRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.testframework.realm.ClientScopeBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.tests.suites.DatabaseTest;
+import org.keycloak.tests.utils.admin.AdminEventPaths;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.jwtTypeNaturalPersonScopeName;
+import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.sdJwtTypeNaturalPersonScopeName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+public class UserVerifiableCredentialsTest extends AbstractUserTest {
+
+    private static final String SCOPE_1_NAME = jwtTypeNaturalPersonScopeName;
+    private static final String SCOPE_2_NAME = sdJwtTypeNaturalPersonScopeName;
+
+    @InjectRealm(config = VCTestRealmConfig.class)
+    protected ManagedRealm testRealm;
+
+    @Test
+    @DatabaseTest
+    public void verifiableCredentialsCrud() {
+        String userId = createUser();
+        UserVerifiableCredentialResource user = managedRealm.admin().users().get(userId).verifiableCredentials();
+
+        // Empty list initially
+        assertTrue(user.getCredentials().isEmpty());
+
+        // Create first credential and assert it is present
+        createVerifiableCedential(user, userId ,SCOPE_1_NAME);
+        assertVerifiableCredentials(user.getCredentials(), SCOPE_1_NAME);
+
+        // Create second credential and assert both are present
+        createVerifiableCedential(user, userId, SCOPE_2_NAME);
+        assertVerifiableCredentials(user.getCredentials(), SCOPE_1_NAME, SCOPE_2_NAME);
+
+        // Remove one of credentials
+        user.revokeCredential(SCOPE_1_NAME);
+        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.DELETE, AdminEventPaths.userVerifiableCredentialPath(userId, SCOPE_1_NAME), null, ResourceType.USER);
+        assertVerifiableCredentials(user.getCredentials(), SCOPE_2_NAME);
+
+        // Remove second one
+        user.revokeCredential(SCOPE_2_NAME);
+        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.DELETE, AdminEventPaths.userVerifiableCredentialPath(userId, SCOPE_2_NAME), null, ResourceType.USER);
+        assertTrue(user.getCredentials().isEmpty());
+    }
+
+    @Test
+    @DatabaseTest
+    public void verifiableCredentialsConflict() {
+        String userId = createUser();
+        UserVerifiableCredentialResource user = managedRealm.admin().users().get(userId).verifiableCredentials();
+
+        createVerifiableCedential(user, userId, SCOPE_1_NAME);
+        try {
+            createVerifiableCedential(user, userId, SCOPE_1_NAME);
+            Assertions.fail("Not expected to successfully create verifiable credential of same name");
+        } catch (ClientErrorException cee) {
+            ErrorRepresentation error = cee.getResponse().readEntity(ErrorRepresentation.class);
+            assertEquals("Verifiable credential already exists", error.getErrorMessage());
+            assertEquals(409, cee.getResponse().getStatus());
+        }
+    }
+
+    @Test
+    @DatabaseTest
+    public void verifiableCredentialsClientScopeRemoved() {
+        String userId = createUser();
+        UserVerifiableCredentialResource user = managedRealm.admin().users().get(userId).verifiableCredentials();
+
+        ClientScopeRepresentation clientScopeRep = ClientScopeBuilder.create().name("new-scope").protocol(OID4VCIConstants.OID4VC_PROTOCOL).build();
+        Response resp = managedRealm.admin().clientScopes().create(clientScopeRep);
+        resp.close();
+        String clientScopeId = ApiUtil.getCreatedId(resp);
+        adminEvents.clear();
+
+        createVerifiableCedential(user, userId ,"new-scope");
+        assertVerifiableCredentials(user.getCredentials(), "new-scope");
+
+        // Remove client scope. Assert automatically removed from the user as well
+        managedRealm.admin().clientScopes().get(clientScopeId).remove();
+        assertVerifiableCredentials(user.getCredentials());
+    }
+
+    @Test
+    @DatabaseTest
+    public void verifiableCredentialsRealmRemoved() {
+        // Create new realm
+        RealmRepresentation realmRep = new RealmRepresentation();
+        realmRep.setRealm("new");
+        realmRep.setEnabled(true);
+        realmRep.setVerifiableCredentialsEnabled(true);
+        adminClient.realms().create(realmRep);
+
+        // Create user
+        RealmResource realm = adminClient.realm("new");
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername("john");
+        user.setEmail("john@email.cz");
+        user.setEnabled(true);
+        Response response = realm.users().create(user);
+        String userId = ApiUtil.getCreatedId(response);
+        response.close();
+        UserResource userRes = realm.users().get(userId);
+
+        // Create verifiable credential
+        UserVerifiableCredentialRepresentation verifCred = new UserVerifiableCredentialRepresentation();
+        verifCred.setCredentialScopeName(SCOPE_1_NAME);
+        userRes.verifiableCredentials().createCredential(verifCred);
+
+        // Remove realm
+        realm.remove();
+    }
+
+    @Test
+    public void verifiableCredentialsDisabled() {
+        managedRealm.updateWithCleanup((realm) -> realm.verifiableCredentialsEnabled(false));
+        adminEvents.clear();
+
+        String userId = createUser();
+        UserVerifiableCredentialResource user = managedRealm.admin().users().get(userId).verifiableCredentials();
+
+        try {
+            createVerifiableCedential(user, userId, SCOPE_1_NAME);
+            Assertions.fail("Not expected to successfully create verifiable credential when disabled for the realm");
+        } catch (BadRequestException cee) {
+            ErrorRepresentation error = cee.getResponse().readEntity(ErrorRepresentation.class);
+            assertEquals("Verifiable credentials not enabled for the realm", error.getErrorMessage());
+        }
+    }
+
+    @Test
+    public void verifiableCredentialsClientScopeErrors() {
+        String userId = createUser();
+        UserVerifiableCredentialResource user = managedRealm.admin().users().get(userId).verifiableCredentials();
+
+        try {
+            createVerifiableCedential(user, userId, "non-existent");
+            Assertions.fail("Not expected to successfully create verifiable credential referencing unknown client scope");
+        } catch (BadRequestException cee) {
+            ErrorRepresentation error = cee.getResponse().readEntity(ErrorRepresentation.class);
+            assertEquals("Client scope does not exists", error.getErrorMessage());
+        }
+
+        try {
+            createVerifiableCedential(user, userId, OAuth2Constants.SCOPE_ADDRESS);
+            Assertions.fail("Not expected to successfully create verifiable credential of OIDC protocol");
+        } catch (BadRequestException cee) {
+            ErrorRepresentation error = cee.getResponse().readEntity(ErrorRepresentation.class);
+            assertEquals("Client scope has incorrect protocol", error.getErrorMessage());
+        }
+    }
+
+    @Test
+    public void verifiableCredentialsCreateErrors() {
+        String userId = createUser();
+        UserVerifiableCredentialResource user = managedRealm.admin().users().get(userId).verifiableCredentials();
+
+        try {
+            UserVerifiableCredentialRepresentation verifCred = new UserVerifiableCredentialRepresentation();
+            verifCred.setCredentialScopeName(SCOPE_1_NAME);
+            verifCred.setCreatedDate(Time.currentTimeMillis());
+            user.createCredential(verifCred);
+            Assertions.fail("Not expected to successfully create verifiable credential with filled createdDate");
+        } catch (BadRequestException cee) {
+            ErrorRepresentation error = cee.getResponse().readEntity(ErrorRepresentation.class);
+            assertEquals("Created date not expected to be specified", error.getErrorMessage());
+        }
+
+        try {
+            UserVerifiableCredentialRepresentation verifCred = new UserVerifiableCredentialRepresentation();
+            verifCred.setCredentialScopeName(SCOPE_1_NAME);
+            verifCred.setRevision("some-revision");
+            user.createCredential(verifCred);
+            Assertions.fail("Not expected to successfully create verifiable credential with filled revision");
+        } catch (BadRequestException cee) {
+            ErrorRepresentation error = cee.getResponse().readEntity(ErrorRepresentation.class);
+            assertEquals("Revision not expected to be specified", error.getErrorMessage());
+        }
+    }
+
+    private void createVerifiableCedential(UserVerifiableCredentialResource user, String userId, String clientScopeName) {
+        UserVerifiableCredentialRepresentation verifCred = new UserVerifiableCredentialRepresentation();
+        verifCred.setCredentialScopeName(clientScopeName);
+        UserVerifiableCredentialRepresentation createdRep = user.createCredential(verifCred);
+
+        Assert.assertEquals(clientScopeName, createdRep.getCredentialScopeName());
+        Assert.assertNotNull(createdRep.getCreatedDate());
+        Assert.assertNotNull(createdRep.getRevision());
+        AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.userVerifiableCredentialsPath(userId), createdRep, ResourceType.USER);
+    }
+
+    private void assertVerifiableCredentials(List<UserVerifiableCredentialRepresentation> creds, String... expectedCredentialNames) {
+        List<String> verifCredNames = creds.stream()
+                .map(UserVerifiableCredentialRepresentation::getCredentialScopeName)
+                .sorted()
+                .toList();
+
+        if (expectedCredentialNames == null || expectedCredentialNames.length == 0) {
+            assertTrue(verifCredNames.isEmpty(), "Expected empty list of verifiable credentials, but was " + verifCredNames);
+        } else {
+            assertEquals(expectedCredentialNames.length, verifCredNames.size());
+            assertTrue(verifCredNames.containsAll(List.of(expectedCredentialNames)), "Expected verifiable credentials " + List.of(expectedCredentialNames) + ", but was " + verifCredNames);
+        }
+    }
+
+
+    private static class VCTestRealmConfig implements RealmConfig {
+
+        public static final String TEST_REALM_NAME = "test";
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.name(TEST_REALM_NAME)
+                    .eventsEnabled(true);
+
+            realm.eventsListeners("jboss-logging");
+            realm.verifiableCredentialsEnabled(true);
+            return realm;
+        }
+
+    }
+
+
+}

--- a/tests/base/src/test/java/org/keycloak/tests/db/DatabaseIndexCheckerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/db/DatabaseIndexCheckerTest.java
@@ -1,0 +1,85 @@
+package org.keycloak.tests.db;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.connections.jpa.JpaConnectionProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.quarkus.runtime.storage.database.jpa.DatabaseIndexChecker;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.annotations.TestOnServer;
+import org.keycloak.tests.suites.DatabaseTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+
+@KeycloakIntegrationTest
+@DatabaseTest
+public class DatabaseIndexCheckerTest {
+
+    private static final String INDEX_NAME = "IDX_REALM_MASTER_ADM_CLI";
+    private static final String TABLE_NAME = "REALM";
+    private static final String COLUMN_NAME = "MASTER_ADMIN_CLIENT";
+
+    @TestOnServer
+    public void testDetectsMissingIndex(KeycloakSession session) {
+        var factory = (JpaConnectionProviderFactory) session.getKeycloakSessionFactory()
+                .getProviderFactory(JpaConnectionProvider.class);
+        var schema = factory.getSchema();
+        var checker = new DatabaseIndexChecker(factory::getConnection, session.getKeycloakSessionFactory(), schema);
+
+        assertThat(checker.getMissingIndexesName(), is(empty()));
+
+        dropIndex(factory);
+
+        try {
+            var missing = checker.getMissingIndexesName();
+            assertThat(missing, hasItem(INDEX_NAME));
+            assertThat(missing.size(), is(1));
+        } finally {
+            createIndex(factory);
+        }
+
+        assertThat(checker.getMissingIndexesName(), is(empty()));
+    }
+
+    private static void dropIndex(JpaConnectionProviderFactory factory) {
+        try (Connection connection = factory.getConnection();
+             Statement stmt = connection.createStatement()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            String dbProduct = metaData.getDatabaseProductName().toLowerCase();
+            String indexId = metaData.storesLowerCaseIdentifiers() ? INDEX_NAME.toLowerCase() : INDEX_NAME;
+            String tableId = metaData.storesLowerCaseIdentifiers() ? TABLE_NAME.toLowerCase() : TABLE_NAME;
+
+            if (dbProduct.contains("mysql") || dbProduct.contains("mariadb")) {
+                stmt.executeUpdate(String.format("DROP INDEX %s ON %s", indexId, tableId));
+            } else if (dbProduct.contains("microsoft")) {
+                String schemaPrefix = connection.getSchema() != null ? connection.getSchema() + "." : "";
+                stmt.executeUpdate(String.format("DROP INDEX %s ON %s%s", indexId, schemaPrefix, tableId));
+            } else {
+                stmt.executeUpdate(String.format("DROP INDEX %s", indexId));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to drop index " + INDEX_NAME, e);
+        }
+    }
+
+    private static void createIndex(JpaConnectionProviderFactory factory) {
+        try (Connection connection = factory.getConnection();
+             Statement stmt = connection.createStatement()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            String indexId = metaData.storesLowerCaseIdentifiers() ? INDEX_NAME.toLowerCase() : INDEX_NAME;
+            String tableId = metaData.storesLowerCaseIdentifiers() ? TABLE_NAME.toLowerCase() : TABLE_NAME;
+            String columnId = metaData.storesLowerCaseIdentifiers() ? COLUMN_NAME.toLowerCase() : COLUMN_NAME;
+
+            stmt.executeUpdate(String.format("CREATE INDEX %s ON %s (%s)", indexId, tableId, columnId));
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to recreate index " + INDEX_NAME, e);
+        }
+    }
+}

--- a/tests/utils/src/main/java/org/keycloak/tests/utils/admin/AdminEventPaths.java
+++ b/tests/utils/src/main/java/org/keycloak/tests/utils/admin/AdminEventPaths.java
@@ -41,6 +41,7 @@ import org.keycloak.admin.client.resource.RoleMappingResource;
 import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.admin.client.resource.RolesResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.admin.client.resource.UserVerifiableCredentialResource;
 import org.keycloak.admin.client.resource.UsersResource;
 
 /**
@@ -280,6 +281,22 @@ public class AdminEventPaths {
         URI uri = UriBuilder.fromUri(userResourcePath(userId))
                 .path(UserResource.class, "joinGroup")
                 .build(groupId);
+        return uri.toString();
+    }
+
+    public static String userVerifiableCredentialsPath(String userId) {
+        URI uri = UriBuilder.fromUri(userResourcePath(userId))
+                .path(UserResource.class, "verifiableCredentials")
+                .path(UserVerifiableCredentialResource.class, "getCredentials")
+                .build();
+        return uri.toString();
+    }
+
+    public static String userVerifiableCredentialPath(String userId, String credentialScopeName) {
+        URI uri = UriBuilder.fromUri(userResourcePath(userId))
+                .path(UserResource.class, "verifiableCredentials")
+                .path(UserVerifiableCredentialResource.class, "revokeCredential")
+                .build(credentialScopeName);
         return uri.toString();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AbstractRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AbstractRestServiceTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.account;
 import java.io.IOException;
 import java.util.List;
 
+import org.keycloak.common.enums.AccountRestApiVersion;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.account.SessionRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -41,8 +42,10 @@ import org.junit.Test;
 import static org.keycloak.common.Profile.Feature.ACCOUNT_API;
 import static org.keycloak.testsuite.util.oauth.OAuthClient.APP_ROOT;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
@@ -136,6 +139,14 @@ public abstract class AbstractRestServiceTest extends AbstractTestRealmKeycloakT
     @Test
     @DisableFeature(value = ACCOUNT_API, skipRestart = true)
     public void testFeatureDoesntWorkWhenDisabled() {
+        checkIfFeatureWorks(false);
+    }
+
+    @Test
+    @DisableFeature(value = ACCOUNT_API, skipRestart = true)
+    public void testVersionedApiDoesntWorkWhenDisabled() {
+        apiVersion = AccountRestApiVersion.DEFAULT.getStrVersion();
+        assertThat(getAccountUrl(""), containsString(apiVersion));
         checkIfFeatureWorks(false);
     }
 

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/KerberosEmbeddedServer.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/KerberosEmbeddedServer.java
@@ -116,7 +116,7 @@ public class KerberosEmbeddedServer extends LDAPEmbeddedServer {
                 try {
                     kerberosEmbeddedServer.stop();
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.error("Failed to stop Kerberos embedded server", e);
                 }
             }
 

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/LDAPEmbeddedServer.java
@@ -148,7 +148,7 @@ public class LDAPEmbeddedServer {
                 try {
                     ldapEmbeddedServer.stop();
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    log.error("Failed to stop LDAP embedded server", e);
                 }
             }
 


### PR DESCRIPTION
This PR fixes critical bugs, improves logging, and enhances code quality:

## Bug Fixes:
- **SdJwtCredentialBuilder.java**: Fixed unreachable branch - changed entry instanceof List<?> to entry.getValue() instanceof List<?>
- **SecureRequestObjectExecutor.java**: Fixed Y2K38 bug by using Time.currentTimeMillis() / 1000 instead of Time.currentTime() for long timestamp comparisons (3 places)
- **SecureCibaSignedAuthenticationRequestExecutor.java**: Fixed Y2K38 bug by using Time.currentTimeMillis() / 1000 instead of Time.currentTime() for long timestamp comparisons (2 places)

## Logging Improvements:
- **WebAuthnCredentialProvider.java**: Replaced wae.printStackTrace() with logger.error()
- **KeycloakErrorHandler.java**: Replaced e.printStackTrace() with logger.warn()
- **LinkedAccountsResource.java**: Replaced spe.printStackTrace() with logger.error()
- **AbstractClaimMapper.java**: Added logging to 4 empty catch blocks for Double/Integer/Boolean/JsonNode parsing
- **OIDCAttributeMapperHelper.java**: Added logging to 3 empty catch blocks for auth_time and JSON parsing
- **ProtocolMapperUtils.java**: Added logging to empty catch block for method invocation
- **MtlsHoKTokenUtil.java**: Added logging to empty catch block for certificate thumbprint
- **FileTruststoreProviderFactory.java**: Added logging to empty catch block for JKS truststore loading

## Documentation Improvements:
- **DefaultClientTypeManager.java**: Added comprehensive javadoc to validateAndCastConfiguration method
- **UserConsentManager.java**: Updated javadoc to explain boolean vs Boolean return type
- **DefaultClientTypeProvider.java**: Removed obsolete TODO comment

## Impact:
- Proper handling of array claims in SD-JWT credentials
- Timestamp comparisons now work correctly beyond year 2038
- Improved error logging and debugging across 11 files
- Removed 9 TODO/FIXME comments total