### PR TITLE
Duplicated flows can have illegal characters in step name

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -410,6 +410,7 @@ public class AuthenticationManagementResource {
         auth.realm().requireManageRealm();
 
         String newName = data.get("newName");
+        ReservedCharValidator.validate(newName);
         if (realm.getFlowByAlias(newName) != null) {
             throw ErrorResponse.exists("New flow alias name already exists");
         }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/FlowTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/FlowTest.java
@@ -417,6 +417,18 @@ public class FlowTest extends AbstractAuthenticationTest {
     }
 
     @Test
+    public void testCopyFlowWithRestrictedCharInAlias() {
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("newName", "copy/of(browser)");
+
+        try (Response response = authMgmtResource.copy("browser", params)) {
+            Assertions.assertEquals(400, response.getStatus());
+            OAuth2ErrorRepresentation error = response.readEntity(OAuth2ErrorRepresentation.class);
+            Assertions.assertEquals("Character '/' not allowed.", error.getError());
+        }
+    }
+
+    @Test
     @DatabaseTest
     public void testCopyFlow() {
 


### PR DESCRIPTION
- Closes #47061

cc: @keycloak/core-authn 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
