### PR TITLE
[CVE-2026-7500] Improper Access Control on Keycloak Server 

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -115,6 +115,8 @@ public class AccountLoader {
     }
 
     private AccountRestService getAccountRestService(ClientModel client, String versionStr) {
+        AccountRestService.checkAccountApiEnabled();
+
         AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
                 .authenticate();
         if (authResult == null) {

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -496,7 +496,7 @@ public class AccountRestService {
 
     // TODO Logs
 
-    private static void checkAccountApiEnabled() {
+    public static void checkAccountApiEnabled() {
         if (!Profile.isFeatureEnabled(Profile.Feature.ACCOUNT_API)) {
             throw new NotFoundException();
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AbstractRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/AbstractRestServiceTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.account;
 import java.io.IOException;
 import java.util.List;
 
+import org.keycloak.common.enums.AccountRestApiVersion;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.representations.account.SessionRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
@@ -41,6 +42,8 @@ import org.junit.Test;
 import static org.keycloak.common.Profile.Feature.ACCOUNT_API;
 import static org.keycloak.testsuite.util.oauth.OAuthClient.APP_ROOT;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -136,6 +139,14 @@ public abstract class AbstractRestServiceTest extends AbstractTestRealmKeycloakT
     @Test
     @DisableFeature(value = ACCOUNT_API, skipRestart = true)
     public void testFeatureDoesntWorkWhenDisabled() {
+        checkIfFeatureWorks(false);
+    }
+
+    @Test
+    @DisableFeature(value = ACCOUNT_API, skipRestart = true)
+    public void testVersionedApiDoesntWorkWhenDisabled() {
+        apiVersion = AccountRestApiVersion.DEFAULT.getStrVersion();
+        assertThat(getAccountUrl(""), containsString(apiVersion));
         checkIfFeatureWorks(false);
     }
 


### PR DESCRIPTION
[CVE-2026-7500] Improper Access Control on Keycloak Server when the account Account API feature is disabled

- Closes #48709

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
