### PR TITLE
fix: refining startup, and adding a log on async start error

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/KeycloakMain.java
@@ -18,8 +18,10 @@
 package org.keycloak.quarkus.runtime;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Consumer;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
@@ -57,6 +59,7 @@ import static org.keycloak.quarkus.runtime.Environment.hasEarlyExitLaunchMode;
 public class KeycloakMain implements QuarkusApplication {
 
     private static AbstractNonServerCommand COMMAND;
+    private static Consumer<Throwable> ERROR_HANDLER;
 
     static {
         InfinispanUtils.configureVirtualThreads();
@@ -132,6 +135,9 @@ public class KeycloakMain implements QuarkusApplication {
 
     public static void start(Picocli picocli, AbstractNonServerCommand command, ExecutionExceptionHandler errorHandler) {
         COMMAND = command; // it would be nice to not do this statically - start quarkus with an instance of KeycloakMain, rather than a class for example
+        ERROR_HANDLER = cause -> errorHandler.error(picocli.getErrWriter(),
+                String.format("Failed to start server in (%s) mode", getKeycloakModeFromProfile(org.keycloak.common.util.Environment.getProfile())),
+                cause.getCause());
         try {
             Quarkus.run(KeycloakMain.class, (exitCode, cause) -> {
                 if (cause != null) {
@@ -145,6 +151,9 @@ public class KeycloakMain implements QuarkusApplication {
             errorHandler.error(picocli.getErrWriter(),
                     String.format("Unexpected error when starting the server in (%s) mode", getKeycloakModeFromProfile(org.keycloak.common.util.Environment.getProfile())),
                     cause.getCause());
+        } finally {
+            ERROR_HANDLER = null;
+            COMMAND = null;
         }
         picocli.exit(CommandLine.ExitCode.SOFTWARE);
     }
@@ -169,5 +178,10 @@ public class KeycloakMain implements QuarkusApplication {
 
         return ApplicationLifecycleManager.getExitCode();
     }
-
+    
+    public static void asyncExit(int exitCode, Throwable t) {
+        Optional.ofNullable(ERROR_HANDLER).ifPresent(h -> h.accept(t));
+        Quarkus.asyncExit(exitCode);
+    }
+    
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/jaxrs/QuarkusKeycloakApplication.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.quarkus.runtime.integration.jaxrs;
 
+import java.util.concurrent.CompletableFuture;
+
 import jakarta.enterprise.event.Observes;
 import jakarta.ws.rs.ApplicationPath;
 
@@ -25,6 +27,7 @@ import org.keycloak.config.ServerOptions;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.quarkus.runtime.Environment;
+import org.keycloak.quarkus.runtime.KeycloakMain;
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 import org.keycloak.quarkus.runtime.configuration.PropertyMappingInterceptor;
@@ -37,11 +40,11 @@ import org.keycloak.services.resources.KeycloakApplication;
 import org.keycloak.utils.StringUtil;
 
 import io.quarkus.arc.Arc;
-import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.ShutdownDelayInitiatedEvent;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.common.annotation.Blocking;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.common.util.Environment.isDevMode;
@@ -65,13 +68,20 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         });
     }
 
-    @Override
-    protected void exit(Throwable cause) {
-        Quarkus.asyncExit(1);
-    }
-
     void onStartupEvent(@Observes StartupEvent event) {
-        startup();
+        var asyncBootstrap = Configuration.getOptionalKcValue(ServerOptions.SERVER_ASYNC_BOOTSTRAP)
+                .map(Boolean::parseBoolean)
+                .orElse(Boolean.TRUE);
+        // skip async bootstrap in dev and non-server mode
+        if (isDevMode() || isNonServerMode() || hasEarlyExitLaunchMode() || !asyncBootstrap) {
+            startup();      
+        } else {
+            ManagedExecutor executor = Arc.container().instance(ManagedExecutor.class).get();
+            CompletableFuture.runAsync(this::startup, executor).exceptionally(cause -> {
+                KeycloakMain.asyncExit(1, cause);
+                return null;
+            });        
+        }
     }
 
     void onShutdownEvent(@Observes ShutdownEvent event) {
@@ -85,11 +95,6 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
     @Override
     public DefaultKeycloakSessionFactory createSessionFactory() {
         return Arc.container().instance(QuarkusKeycloakSessionFactory.class).get();
-    }
-
-    @Override
-    protected void initAndStart() {
-        // no need - is handled by Quarkus logic and onStartupEvent
     }
 
     @Override
@@ -111,15 +116,6 @@ public class QuarkusKeycloakApplication extends KeycloakApplication {
         } catch (NumberFormatException e) {
             throw new RuntimeException("Invalid admin expiration value provided. An integer is expected.", e);
         }
-    }
-
-    @Override
-    protected boolean supportsAsyncInitialization() {
-        var asyncBootstrap = Configuration.getOptionalKcValue(ServerOptions.SERVER_ASYNC_BOOTSTRAP)
-                .map(Boolean::parseBoolean)
-                .orElse(Boolean.TRUE);
-        // skip async bootstrap in dev and non-server mode
-        return !isDevMode() && !isNonServerMode() && !hasEarlyExitLaunchMode() && asyncBootstrap;
     }
 
     @Override

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResourceFactory.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/resource/realm/TestRealmResourceFactory.java
@@ -28,6 +28,7 @@ import org.keycloak.services.resource.RealmResourceProviderFactory;
  */
 public class TestRealmResourceFactory implements RealmResourceProviderFactory {
     public static final String ID = "test-resources";
+    private boolean fail;
 
     @Override
     public RealmResourceProvider create(KeycloakSession session) {
@@ -36,12 +37,14 @@ public class TestRealmResourceFactory implements RealmResourceProviderFactory {
 
     @Override
     public void init(Config.Scope config) {
-
+        fail = Boolean.parseBoolean(config.get("fail", null));
     }
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-
+        if (fail) {
+            throw new RuntimeException("I've failed");
+        }
     }
 
     @Override

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -17,16 +17,22 @@
 
 package org.keycloak.it.cli.dist;
 
+import java.util.concurrent.TimeUnit;
+
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.DryRun;
 import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.TestProvider;
 import org.keycloak.it.junit5.extension.WithEnvVars;
+import org.keycloak.it.resource.realm.TestRealmResourceTestProvider;
 import org.keycloak.it.utils.KeycloakDistribution;
 import org.keycloak.it.utils.RawDistributionLifecycleManager;
+import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.main.Launch;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -279,4 +285,19 @@ public class StartCommandDistTest {
         cliResult.assertNoBuild();
         cliResult.assertStarted();
     }
+    
+    @RawDistOnly(reason = "Containers are immutable")
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    void testAsyncBootstrapFails(KeycloakDistribution dist) {
+        RawKeycloakDistribution rawDist = dist.unwrap(RawKeycloakDistribution.class);
+        dist.setManualStop(true);
+        CLIResult result = dist.run("start", "--server-async-bootstrap=true", "--hostname-strict=false", "--db=dev-file", "--http-enabled=true", "--spi-realm-restapi-extension--test-resources--fail=true");
+        Awaitility.await().atMost(2, TimeUnit.MINUTES).until(() -> !rawDist.isRunning());
+        dist.stop();
+        result.assertMessage("Failed to start server");
+        result.assertMessage("I've failed");
+        assertEquals(1, dist.getExitCode());
+    }
+
 }

--- a/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/junit5/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -477,7 +477,7 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
         return socketFactory;
     }
 
-    private boolean isRunning() {
+    public boolean isRunning() {
         return keycloak != null && keycloak.isAlive();
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
+++ b/services/src/main/java/org/keycloak/services/resources/KeycloakApplication.java
@@ -19,8 +19,6 @@ package org.keycloak.services.resources;
 import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.ws.rs.core.Application;
@@ -54,16 +52,6 @@ public abstract class KeycloakApplication extends Application {
 
     private static volatile DefaultKeycloakSessionFactory sessionFactory;
 
-    public KeycloakApplication() {
-        try {
-            initTmpDirectory();
-            logger.debugv("Application: {0}", this.getClass().getName());
-            initAndStart();
-        } catch (Throwable t) {
-            exit(t);
-        }
-    }
-
     public static String getTmpDirectory() {
         return System.getProperty(KC_TMPDIR, System.getProperty("java.io.tmpdir"));
     }
@@ -80,34 +68,19 @@ public abstract class KeycloakApplication extends Application {
         System.setProperty(KC_TMPDIR, tmpDir.getAbsolutePath());
     }
 
-    protected abstract void exit(Throwable t);
-
     protected abstract String getDataDir();
 
-    protected void startup() {
+    // synchronized to prevent shutdown while running bootstrapping
+    protected synchronized void startup() {
+        logger.debugv("Application: {0}", this.getClass().getName());
+        initTmpDirectory();
         Profile.getInstance().logUnsupportedFeatures();
         CryptoIntegration.init(KeycloakApplication.class.getClassLoader());
         KeycloakApplication.sessionFactory = createSessionFactory();
-
-        if (supportsAsyncInitialization()) {
-            final var executor = Executors.newSingleThreadExecutor();
-            CompletableFuture.runAsync(() -> runBootstrap(KeycloakApplication.sessionFactory), executor)
-                    .exceptionally(throwable -> {
-                        exit(throwable);
-                        return null;
-                    })
-                    .thenRun(executor::shutdown);
-            return;
-        }
-
         runBootstrap(KeycloakApplication.sessionFactory);
     }
 
-    protected boolean supportsAsyncInitialization() {
-        return false;
-    }
-
-    private synchronized void runBootstrap(DefaultKeycloakSessionFactory keycloakSessionFactory) {
+    private void runBootstrap(DefaultKeycloakSessionFactory keycloakSessionFactory) {
         var startTime = System.nanoTime();
 
         keycloakSessionFactory.init();
@@ -189,10 +162,12 @@ public abstract class KeycloakApplication extends Application {
 
     protected abstract void createTemporaryAdmin(KeycloakSession session);
 
-    protected abstract void initAndStart();
-
     protected abstract DefaultKeycloakSessionFactory createSessionFactory();
 
+    /**
+     * WARNING: This method is for use by test logic. Will return null if there is no current KeycloakApplication, or if the
+     * startup has not yet reached the point of setting this value.
+     */
     public static DefaultKeycloakSessionFactory getSessionFactory() {
         return sessionFactory;
     }

--- a/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
@@ -68,16 +68,18 @@ public class ResteasyKeycloakApplication extends KeycloakApplication {
             // an endpoint for the load balancer to gather information whether this site should receive requests or not.
             classes.add(LoadBalancerResource.class);
         }
+        Config.init(new JsonConfigProviderFactory().create()
+                .orElseThrow(() -> new RuntimeException("Failed to load Keycloak configuration")));
+        Profile.configure(
+                new PropertiesProfileConfigResolver(System.getProperties()),
+                new PropertiesFileProfileConfigResolver()
+        );
+        startup();
     }
 
     @Override
     protected String getDataDir() {
         return System.getProperty("project.build.directory");
-    }
-
-    @Override
-    protected void exit(Throwable cause) {
-        throw new RuntimeException(cause);
     }
 
     @Override
@@ -98,17 +100,6 @@ public class ResteasyKeycloakApplication extends KeycloakApplication {
     @Override
     protected void createTemporaryAdmin(KeycloakSession session) {
         // do nothing
-    }
-
-    @Override
-    protected void initAndStart() {
-        Config.init(new JsonConfigProviderFactory().create()
-                .orElseThrow(() -> new RuntimeException("Failed to load Keycloak configuration")));
-        Profile.configure(
-                new PropertiesProfileConfigResolver(System.getProperties()),
-                new PropertiesFileProfileConfigResolver()
-        );
-        startup();
     }
 
     @Override


### PR DESCRIPTION
closes: #48438

@pruivo the analysis of @vramik is correct, we're at least missing a log on an async startup error.

For the backport that could be a one line change, but moving forward I'd like to consider doing something like this PR to further simplify how we're doing the async starts. There is a lot of coupling between what thread to use (I think we should be using a managed one for full continutity with non-async starts), the exit handling, and the determination of whether async should be used, such that it would be clearer just to have all that logic in the same place.

Not added yet, but to test this scenario currently we either need a failing migration or to add a custom provider via the quarkus test logic that fails in postInit.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
