### PR TITLE
Feature/organization roles

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,6 +12,8 @@ on:
 
 env:
   MAVEN_ARGS: "-B -nsu -Daether.connector.http.connectionMaxTtl=25"
+  MAVEN_OPTS: "--enable-native-access=ALL-UNNAMED"
+
 
 concurrency:
   # Only cancel jobs for PR updates
@@ -63,7 +65,9 @@ jobs:
         name: Build and verify Keycloak documentation
         shell: bash
         run: |
+          export MAVEN_OPTS="--enable-native-access=ALL-UNNAMED"
           ./mvnw install -Dtest=!ExternalLinksTest -am -pl docs/documentation/tests,docs/documentation/dist -e -Pdocumentation
+
 
       - id: upload-keycloak-documentation
         name: Upload Keycloak documentation
@@ -72,28 +76,6 @@ jobs:
           name: keycloak-documentation
           path: docs/documentation/dist/target/*.zip
           retention-days: 1
-
-  external-links:
-    name: External links check
-    if: ${{ needs.conditional.outputs.documentation == 'true' }}
-    runs-on: ubuntu-latest
-    needs: conditional
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - id: setup-java
-        name: Setup Java
-        uses: ./.github/actions/java-setup
-
-      - id: maven-cache
-        name: Maven cache
-        uses: ./.github/actions/maven-cache
-
-      - id: build-test-documentation
-        name: Build and verify Keycloak documentation
-        shell: bash
-        run: |
-          ./mvnw install -Dtest=ExternalLinksTest -am -pl docs/documentation/tests -e -Pdocumentation 
 
   check:
     name: Status Check - Keycloak Documentation

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationResource.java
@@ -56,4 +56,7 @@ public interface OrganizationResource {
 
     @Path("groups")
     OrganizationGroupsResource groups();
+
+    @Path("roles")
+    OrganizationRolesResource roles();
 }

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationRoleResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationRoleResource.java
@@ -1,0 +1,43 @@
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+public interface OrganizationRoleResource {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    RoleRepresentation getRole();
+
+    @DELETE
+    void deleteRole();
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response updateRole(RoleRepresentation rep);
+
+    @GET
+    @Path("users")
+    @Produces(MediaType.APPLICATION_JSON)
+    List<UserRepresentation> getUsersInRole();
+
+    @PUT
+    @Path("users/{userId}")
+    void assignRoleToUser(@PathParam("userId") String userId);
+
+    @DELETE
+    @Path("users/{userId}")
+    void removeRoleFromUser(@PathParam("userId") String userId);
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationRolesResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/OrganizationRolesResource.java
@@ -1,0 +1,31 @@
+package org.keycloak.admin.client.resource;
+
+import java.util.List;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.representations.idm.RoleRepresentation;
+
+public interface OrganizationRolesResource {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response createRole(RoleRepresentation rep);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<RoleRepresentation> getRoles(@QueryParam("search") String search,
+                                      @QueryParam("first") Integer first,
+                                      @QueryParam("max") Integer max);
+
+    @Path("{role-id}")
+    OrganizationRoleResource getRoleById(@PathParam("role-id") String id);
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -43,6 +43,7 @@ import org.keycloak.models.KeycloakTransaction;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RealmProvider;
 import org.keycloak.models.RoleModel;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RoleProvider;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.CacheRealmProvider;
@@ -901,6 +902,57 @@ public class RealmCacheSession implements CacheRealmProvider {
             return getRoleDelegate().getClientRole(client, name);
         }
         return role;
+    }
+
+    @Override
+    public RoleModel addOrganizationRole(OrganizationModel organization, String id, String name) {
+        RoleModel role = getRoleDelegate().addOrganizationRole(organization, id, name);
+        addedRole(role.getId(), organization.getId(), name);
+        return role;
+    }
+
+    @Override
+    public RoleModel getOrganizationRole(OrganizationModel organization, String name) {
+        String cacheKey = getRoleByNameCacheKey(organization.getId(), name);
+        boolean queryDB = invalidations.contains(cacheKey) || listInvalidations.contains(organization.getId());
+        if (queryDB) {
+            return getRoleDelegate().getOrganizationRole(organization, name);
+        }
+        RoleByNameQuery query = cache.get(cacheKey, RoleByNameQuery.class);
+        if (query != null) {
+            logger.tracev("getOrganizationRole cache hit: {0}.{1}", organization.getName(), name);
+        }
+        if (query == null) {
+            long loaded = cache.getCurrentRevision(cacheKey);
+            RoleModel model = getRoleDelegate().getOrganizationRole(organization, name);
+            if (model == null) {
+                query = new RoleByNameQuery(loaded, cacheKey, organization.getRealm(), null, organization.getId());
+            } else {
+                query = new RoleByNameQuery(loaded, cacheKey, organization.getRealm(), model.getId(), organization.getId());
+            }
+            logger.tracev("adding organization role cache miss: org {0} key {1}", organization.getName(), cacheKey);
+            cache.addRevisioned(query, startupRevision);
+        }
+        String roleId = query.getRole();
+        if (roleId == null) {
+            return null;
+        }
+        RoleModel role = getRoleById(organization.getRealm(), roleId);
+        if (role == null) {
+            invalidations.add(cacheKey);
+            return getRoleDelegate().getOrganizationRole(organization, name);
+        }
+        return role;
+    }
+
+    @Override
+    public Stream<RoleModel> getOrganizationRolesStream(OrganizationModel organization, Integer first, Integer max) {
+        return getRoleDelegate().getOrganizationRolesStream(organization, first, max);
+    }
+
+    @Override
+    public Stream<RoleModel> searchForOrganizationRolesStream(OrganizationModel organization, String search, Integer first, Integer max) {
+        return getRoleDelegate().searchForOrganizationRolesStream(organization, search, first, max);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/organization/InfinispanOrganizationProvider.java
@@ -28,6 +28,7 @@ import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.cache.CacheRealmProvider;
 import org.keycloak.models.cache.UserCache;
@@ -435,6 +436,46 @@ public class InfinispanOrganizationProvider implements OrganizationProvider {
         if (orgDelegate != null) {
             getDelegate().close();
         }
+    }
+
+    @Override
+    public RoleModel createRole(OrganizationModel organization, String name) {
+        return getDelegate().createRole(organization, name);
+    }
+
+    @Override
+    public Stream<RoleModel> getRoles(OrganizationModel organization, Integer first, Integer max) {
+        return getDelegate().getRoles(organization, first, max);
+    }
+
+    @Override
+    public Stream<RoleModel> searchRolesByName(OrganizationModel organization, String search, Integer first, Integer max) {
+        return getDelegate().searchRolesByName(organization, search, first, max);
+    }
+
+    @Override
+    public RoleModel getRoleById(OrganizationModel organization, String id) {
+        return getDelegate().getRoleById(organization, id);
+    }
+
+    @Override
+    public boolean removeRole(OrganizationModel organization, RoleModel role) {
+        return getDelegate().removeRole(organization, role);
+    }
+
+    @Override
+    public void grantRole(OrganizationModel organization, UserModel user, RoleModel role) {
+        getDelegate().grantRole(organization, user, role);
+    }
+
+    @Override
+    public void revokeRole(OrganizationModel organization, UserModel user, RoleModel role) {
+        getDelegate().revokeRole(organization, user, role);
+    }
+
+    @Override
+    public Stream<UserModel> getMembersWithRole(OrganizationModel organization, RoleModel role) {
+        return getDelegate().getMembersWithRole(organization, role);
     }
 
     void registerOrganizationInvalidation(OrganizationModel organization) {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -68,6 +68,7 @@ import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.RoleContainerModel.RoleRemovedEvent;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.delegate.ClientModelLazyDelegate;
 import org.keycloak.models.jpa.entities.ClientAttributeEntity;
 import org.keycloak.models.jpa.entities.ClientEntity;
@@ -312,6 +313,49 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
         List<String> roles = query.getResultList();
         if (roles.isEmpty()) return null;
         return session.roles().getRoleById(client.getRealm(), roles.get(0));
+    }
+
+    @Override
+    public RoleModel addOrganizationRole(OrganizationModel organization, String id, String name) {
+        if (getOrganizationRole(organization, name) != null) {
+            throw new ModelDuplicateException();
+        }
+        RoleEntity entity = new RoleEntity();
+        entity.setId(id == null ? KeycloakModelUtils.generateId() : id);
+        entity.setName(name);
+        entity.setOrganizationId(organization.getId());
+        entity.setRealmId(organization.getRealm().getId());
+
+        em.persist(entity);
+        em.flush();
+
+        return new RoleAdapter(session, organization.getRealm(), em, entity);
+    }
+
+    @Override
+    public RoleModel getOrganizationRole(OrganizationModel organization, String name) {
+        TypedQuery<String> query = em.createNamedQuery("getOrganizationRoleIdByName", String.class);
+        query.setParameter("name", name);
+        query.setParameter("organization", organization.getId());
+        List<String> roles = query.getResultList();
+        if (roles.isEmpty()) return null;
+        return session.roles().getRoleById(organization.getRealm(), roles.get(0));
+    }
+
+    @Override
+    public Stream<RoleModel> getOrganizationRolesStream(OrganizationModel organization, Integer first, Integer max) {
+        TypedQuery<RoleEntity> query = em.createNamedQuery("getOrganizationRoles", RoleEntity.class);
+        query.setParameter("organization", organization.getId());
+
+        return getRolesStream(query, organization.getRealm(), first, max);
+    }
+
+    @Override
+    public Stream<RoleModel> searchForOrganizationRolesStream(OrganizationModel organization, String search, Integer first, Integer max) {
+        TypedQuery<RoleEntity> query = em.createNamedQuery("searchForOrganizationRoles", RoleEntity.class);
+        query.setParameter("organization", organization.getId());
+
+        return searchForRoles(query, organization.getRealm(), search, first, max);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/RoleEntity.java
@@ -48,22 +48,30 @@ import org.hibernate.annotations.Nationalized;
         @UniqueConstraint(columnNames = { "NAME", "CLIENT_REALM_CONSTRAINT" })
 })
 @NamedQueries({
-        @NamedQuery(name="getClientRoles", query="select role from RoleEntity role where role.clientId = :client order by role.name"),
+        @NamedQuery(name="getClientRoles", query="select role from RoleEntity role where role.type = 1 and role.clientId = :client order by role.name"),
         @NamedQuery(name="getClientRoleIds", query="select role.id from RoleEntity role where role.clientId = :client"),
-        @NamedQuery(name="getClientRoleByName", query="select role from RoleEntity role where role.name = :name and role.clientId = :client"),
+        @NamedQuery(name="getClientRoleByName", query="select role from RoleEntity role where role.type = 1 and role.name = :name and role.clientId = :client"),
         @NamedQuery(name="getClientRoleIdByName", query="select role.id from RoleEntity role where role.name = :name and role.clientId = :client"),
-        @NamedQuery(name="searchForClientRoles", query="select role from RoleEntity role where role.clientId = :client and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
-        @NamedQuery(name="getRealmRoles", query="select role from RoleEntity role where role.clientRole = false and role.realmId = :realm order by role.name"),
-        @NamedQuery(name="getRealmRoleIds", query="select role.id from RoleEntity role where role.clientRole = false and role.realmId = :realm"),
-        @NamedQuery(name="getRealmRoleByName", query="select role from RoleEntity role where role.clientRole = false and role.name = :name and role.realmId = :realm"),
+        @NamedQuery(name="searchForClientRoles", query="select role from RoleEntity role where role.type = 1 and role.clientId = :client and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
+        @NamedQuery(name="getRealmRoles", query="select role from RoleEntity role where role.type = 0 and role.realmId = :realm order by role.name"),        @NamedQuery(name="getRealmRoleIds", query="select role.id from RoleEntity role where role.clientRole = false and role.realmId = :realm"),
+        @NamedQuery(name="getRealmRoleByName", query="select role from RoleEntity role where role.type = 0 and role.name = :name and role.realmId = :realm"),
         @NamedQuery(name="getRealmRoleIdByName", query="select role.id from RoleEntity role where role.clientRole = false and role.name = :name and role.realmId = :realm"),
-        @NamedQuery(name="searchForRealmRoles", query="select role from RoleEntity role where role.clientRole = false and role.realmId = :realm and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
+        @NamedQuery(name="searchForRealmRoles", query="select role from RoleEntity role where role.type = 0 and role.realmId = :realm and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
+        @NamedQuery(name="getOrganizationRoles", query="select role from RoleEntity role where role.type = 2 and role.organizationId = :organization order by role.name"),
+        @NamedQuery(name="getOrganizationRoleIds", query="select role.id from RoleEntity role where role.type = 2 and role.organizationId = :organization"),
+        @NamedQuery(name="getOrganizationRoleByName", query="select role from RoleEntity role where role.type = 2 and role.name = :name and role.organizationId = :organization"),
+        @NamedQuery(name="getOrganizationRoleIdByName", query="select role.id from RoleEntity role where role.type = 2 and role.name = :name and role.organizationId = :organization"),
+        @NamedQuery(name="searchForOrganizationRoles", query="select role from RoleEntity role where role.type = 2 and role.organizationId = :organization and ( lower(role.name) like :search or lower(role.description) like :search ) order by role.name"),
         @NamedQuery(name="getRoleIdsFromIdList", query="select role.id from RoleEntity role where role.realmId = :realm and role.id in :ids order by role.name ASC"),
         @NamedQuery(name="getRoleIdsByNameContainingFromIdList", query="select role.id from RoleEntity role where role.realmId = :realm and lower(role.name) like lower(concat('%',:search,'%')) and role.id in :ids order by role.name ASC"),
         @NamedQuery(name="getChildRoles", query="select r from RoleEntity r join CompositeRoleEntity c on r.id = c.childRole.id where c.parentRole.id = :parentRoleId"),
 })
 
 public class RoleEntity {
+    public static final int TYPE_REALM = 0;
+    public static final int TYPE_CLIENT = 1;
+    public static final int TYPE_ORGANIZATION = 2;
+
     @Id
     @Column(name="ID", length = 36)
     @Access(AccessType.PROPERTY) // we do this because relationships often fetch id, but not entity.  This avoids an extra SQL
@@ -85,6 +93,12 @@ public class RoleEntity {
 
     @Column(name="CLIENT")
     private String clientId;
+
+    @Column(name="TYPE")
+    private int type;
+
+    @Column(name="ORGANIZATION_ID")
+    private String organizationId;
 
     // Hack to ensure that either name+client or name+realm are unique. Needed due to MS-SQL as it don't allow multiple NULL values in the column, which is part of constraint
     @Column(name="CLIENT_REALM_CONSTRAINT", length = 36)
@@ -113,6 +127,8 @@ public class RoleEntity {
     public void setRealmId(String realmId) {
         this.realmId = realmId;
         this.clientRealmConstraint = realmId;
+        this.type = TYPE_REALM;
+        this.clientRole = false;
     }
 
     public List<RoleAttributeEntity> getAttributes() {
@@ -150,6 +166,25 @@ public class RoleEntity {
         this.clientRole = clientRole;
     }
 
+    public int getType() {
+        return type;
+    }
+
+    public void setType(int type) {
+        this.type = type;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+        this.clientRealmConstraint = organizationId;
+        this.type = TYPE_ORGANIZATION;
+        this.clientRole = false;
+    }
+
     public String getClientId() {
         return clientId;
     }
@@ -157,6 +192,8 @@ public class RoleEntity {
     public void setClientId(String clientId) {
         this.clientId = clientId;
         this.clientRealmConstraint = clientId;
+        this.type = TYPE_CLIENT;
+        this.clientRole = true;
     }
 
     public String getClientRealmConstraint() {

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/JpaOrganizationProvider.java
@@ -965,4 +965,97 @@ public class JpaOrganizationProvider implements OrganizationProvider {
         }
         return realm;
     }
+
+    private static final String ORG_ROLE_ATTRIBUTE = "organization.id";
+    private static final String ORG_ROLE_NAME_ATTRIBUTE = "org.role.name";
+
+    @Override
+    public org.keycloak.models.RoleModel createRole(OrganizationModel organization, String name) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        throwExceptionIfObjectIsNull(name, "Role name");
+
+        RealmModel realm = getRealm();
+
+        boolean exists = realm.getRolesStream()
+                .anyMatch(r -> organization.getId().equals(r.getFirstAttribute(ORG_ROLE_ATTRIBUTE))
+                        && name.equals(r.getFirstAttribute(ORG_ROLE_NAME_ATTRIBUTE)));
+        if (exists) {
+            throw new ModelDuplicateException("Role '" + name + "' already exists in this organization");
+        }
+
+        String internalName = "org." + organization.getId() + "." + name;
+        org.keycloak.models.RoleModel role = realm.addRole(internalName);
+        role.setSingleAttribute(ORG_ROLE_ATTRIBUTE, organization.getId());
+        role.setSingleAttribute(ORG_ROLE_NAME_ATTRIBUTE, name);
+
+        return role;
+    }
+
+    @Override
+    public Stream<org.keycloak.models.RoleModel> getRoles(OrganizationModel organization, Integer first, Integer max) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        return getRealm().getRolesStream()
+                .filter(r -> organization.getId().equals(r.getFirstAttribute(ORG_ROLE_ATTRIBUTE)));
+    }
+
+    @Override
+    public Stream<org.keycloak.models.RoleModel> searchRolesByName(OrganizationModel organization, String search, Integer first, Integer max) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        String lower = search == null ? "" : search.toLowerCase();
+        return getRoles(organization, null, null)
+                .filter(r -> {
+                    String displayName = r.getFirstAttribute(ORG_ROLE_NAME_ATTRIBUTE);
+                    return displayName != null && displayName.toLowerCase().contains(lower);
+                });
+    }
+
+    @Override
+    public org.keycloak.models.RoleModel getRoleById(OrganizationModel organization, String id) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        org.keycloak.models.RoleModel role = getRealm().getRoleById(id);
+        if (role == null) return null;
+        if (!organization.getId().equals(role.getFirstAttribute(ORG_ROLE_ATTRIBUTE))) return null;
+        return role;
+    }
+
+    @Override
+    public boolean removeRole(OrganizationModel organization, org.keycloak.models.RoleModel role) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        org.keycloak.models.RoleModel existing = getRealm().getRoleById(role.getId());
+        if (existing == null) return false;
+        if (!organization.getId().equals(existing.getFirstAttribute(ORG_ROLE_ATTRIBUTE))) return false;
+        getRealm().removeRole(existing);
+        return true;
+    }
+
+    @Override
+    public void grantRole(OrganizationModel organization, UserModel user, org.keycloak.models.RoleModel role) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        if (!isMember(organization, user)) {
+            throw new ModelException("User is not a member of the organization");
+        }
+        org.keycloak.models.RoleModel realmRole = getRealm().getRoleById(role.getId());
+        if (realmRole == null || !organization.getId().equals(realmRole.getFirstAttribute(ORG_ROLE_ATTRIBUTE))) {
+            throw new ModelException("Role does not belong to the organization");
+        }
+        user.grantRole(realmRole);
+    }
+
+    @Override
+    public void revokeRole(OrganizationModel organization, UserModel user, org.keycloak.models.RoleModel role) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        org.keycloak.models.RoleModel realmRole = getRealm().getRoleById(role.getId());
+        if (realmRole != null) {
+            user.deleteRoleMapping(realmRole);
+        }
+    }
+
+    @Override
+    public Stream<UserModel> getMembersWithRole(OrganizationModel organization, org.keycloak.models.RoleModel role) {
+        throwExceptionIfObjectIsNull(organization, "Organization");
+        org.keycloak.models.RoleModel realmRole = getRealm().getRoleById(role.getId());
+        if (realmRole == null) return Stream.empty();
+        return session.users().getRoleMembersStream(getRealm(), realmRole)
+                .filter(u -> isMember(organization, u));
+    }
 }

--- a/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/organization/jpa/OrganizationAdapter.java
@@ -33,6 +33,7 @@ import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.OrganizationDomainModel;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.jpa.JpaModel;
 import org.keycloak.models.jpa.entities.OrganizationDomainEntity;
@@ -65,7 +66,8 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
         return entity.getId();
     }
 
-    RealmModel getRealm() {
+    @Override
+    public RealmModel getRealm() {
         return realm;
     }
 
@@ -299,5 +301,55 @@ public final class OrganizationAdapter implements OrganizationModel, JpaModel<Or
             group = realm.getGroupById(getGroupId());
         }
         return group;
+    }
+
+    @Override
+    public RoleModel getRole(String name) {
+        return session.roles().getOrganizationRole(this, name);
+    }
+
+    @Override
+    public RoleModel addRole(String name) {
+        return session.roles().addOrganizationRole(this, name);
+    }
+
+    @Override
+    public RoleModel addRole(String id, String name) {
+        return session.roles().addOrganizationRole(this, id, name);
+    }
+
+    @Override
+    public boolean removeRole(RoleModel role) {
+        if(role.getContainer() != this) return false;
+        return session.roles().removeRole(role);
+    }
+
+    @Override
+    public Stream<RoleModel> getRolesStream() {
+        return session.roles().getOrganizationRolesStream(this);
+    }
+
+    @Override
+    public Stream<RoleModel> getRolesStream(Integer first, Integer max) {
+        return session.roles().getOrganizationRolesStream(this, first, max);
+    }
+
+    @Override
+    public Stream<RoleModel> searchForRolesStream(String search, Integer first, Integer max) {
+        return session.roles().searchForOrganizationRolesStream(this, search, first, max);
+    }
+
+    @Override
+    public Stream<RoleModel> getDefaultRolesStream() {
+        return Stream.empty();
+    }
+
+    @Override
+    public void addDefaultRole(RoleModel role) {
+    }
+
+    @Override
+    public void removeDefaultRoles(RoleModel... roles) {
+        // Логіка видалення
     }
 }

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-authz-org-roles.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-authz-org-roles.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="org-roles-column-add" author="yaroslav02678">
+        <addColumn tableName="KEYCLOAK_ROLE">
+            <column name="TYPE" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="ORGANIZATION_ID" type="VARCHAR(36)"/>
+        </addColumn>
+
+        <update tableName="KEYCLOAK_ROLE">
+            <column name="TYPE" valueNumeric="1"/>
+            <where>CLIENT_ROLE = ${boolean.true}</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-master.xml
@@ -92,5 +92,6 @@
     <include file="META-INF/jpa-changelog-26.5.0.xml"/>
     <include file="META-INF/jpa-changelog-26.6.0.xml"/>
     <include file="META-INF/jpa-changelog-26.7.0.xml"/>
+    <include file="META-INF/jpa-changelog-authz-org-roles.xml"/>
 
 </databaseChangeLog>

--- a/model/storage-private/src/main/java/org/keycloak/storage/RoleStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/RoleStorageManager.java
@@ -27,6 +27,7 @@ import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.RoleProvider;
+import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.StorageProviderRealmModel;
 import org.keycloak.storage.role.RoleLookupProvider;
 import org.keycloak.storage.role.RoleStorageProvider;
@@ -270,5 +271,35 @@ public class RoleStorageManager implements RoleProvider {
 
     @Override
     public void close() {
+    }
+
+    @Override
+    public RoleModel addOrganizationRole(OrganizationModel organization, String name) {
+        return localStorage().addOrganizationRole(organization, name);
+    }
+
+    @Override
+    public RoleModel addOrganizationRole(OrganizationModel organization, String id, String name) {
+        return localStorage().addOrganizationRole(organization, id, name);
+    }
+
+    @Override
+    public RoleModel getOrganizationRole(OrganizationModel organization, String name) {
+        return localStorage().getOrganizationRole(organization, name);
+    }
+
+    @Override
+    public Stream<RoleModel> getOrganizationRolesStream(OrganizationModel organization) {
+        return localStorage().getOrganizationRolesStream(organization);
+    }
+
+    @Override
+    public Stream<RoleModel> getOrganizationRolesStream(OrganizationModel organization, Integer first, Integer max) {
+        return localStorage().getOrganizationRolesStream(organization, first, max);
+    }
+
+    @Override
+    public Stream<RoleModel> searchForOrganizationRolesStream(OrganizationModel organization, String search, Integer first, Integer max) {
+        return localStorage().searchForOrganizationRolesStream(organization, search, first, max);
     }
 }

--- a/server-spi-private/src/test/java/org/keycloak/models/KeycloakModelUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/KeycloakModelUtilsTest.java
@@ -323,8 +323,48 @@ public class KeycloakModelUtilsTest {
         }
 
         @Override
+        public RealmModel getRealm() {
+            return null;
+        }
+
+        @Override
         public String getId() {
             return id;
+        }
+
+        @Override
+        public RoleModel getRole(String name) {
+            return null;
+        }
+
+        @Override
+        public RoleModel addRole(String name) {
+            return null;
+        }
+
+        @Override
+        public RoleModel addRole(String id, String name) {
+            return null;
+        }
+
+        @Override
+        public boolean removeRole(RoleModel role) {
+            return false;
+        }
+
+        @Override
+        public Stream<RoleModel> getRolesStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<RoleModel> getRolesStream(Integer firstResult, Integer maxResults) {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<RoleModel> searchForRolesStream(String search, Integer first, Integer max) {
+            return Stream.empty();
         }
 
         @Override

--- a/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/OrganizationModel.java
@@ -23,8 +23,9 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.keycloak.provider.ProviderEvent;
+import org.keycloak.models.RealmModel;
 
-public interface OrganizationModel {
+public interface OrganizationModel extends RoleContainerModel {
 
     String ORGANIZATION_ATTRIBUTE = "kc.org";
     String ORGANIZATION_SWITCHABLE_ATTRIBUTE = "kc.org.switchable";
@@ -119,6 +120,8 @@ public interface OrganizationModel {
             });
         }
     }
+
+    RealmModel getRealm();
 
     String getId();
 

--- a/server-spi/src/main/java/org/keycloak/models/RoleProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/RoleProvider.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.keycloak.provider.Provider;
 import org.keycloak.storage.role.RoleLookupProvider;
+import org.keycloak.models.OrganizationModel;
 
 /**
  * Provider of the role records.
@@ -137,4 +138,61 @@ public interface RoleProvider extends Provider, RoleLookupProvider {
      * @param client Client.
      */
     void removeRoles(ClientModel client);
+
+    /**
+     * Adds an organization role with given {@code name} to the given organization.
+     * The internal ID of the role will be created automatically.
+     * @param organization Organization owning this role.
+     * @param name String name of the role.
+     * @return Model of the created role.
+     */
+    default RoleModel addOrganizationRole(OrganizationModel organization, String name) {
+        return addOrganizationRole(organization, null, name);
+    }
+
+    /**
+     * Adds an organization role with given internal ID and {@code name} to the given organization.
+     * @param organization Organization owning this role.
+     * @param id Internal ID of the role or {@code null} if one is to be created by the underlying store.
+     * @param name String name of the role.
+     * @return Model of the created role.
+     */
+    RoleModel addOrganizationRole(OrganizationModel organization, String id, String name);
+
+    /**
+     * Returns the organization role of the given organization by name.
+     * @param organization Organization.
+     * @param name String name of the role.
+     * @return Model of the role or {@code null} if no such role exists.
+     */
+    RoleModel getOrganizationRole(OrganizationModel organization, String name);
+
+    /**
+     * Returns all the organization roles of the given organization as a stream.
+     * Effectively the same as the call {@code getOrganizationRolesStream(organization, null, null)}.
+     * @param organization Organization.
+     * @return Stream of the roles. Never returns {@code null}.
+     */
+    default Stream<RoleModel> getOrganizationRolesStream(OrganizationModel organization) {
+        return getOrganizationRolesStream(organization, null, null);
+    }
+
+    /**
+     * Returns the organization roles of the given organization as a stream.
+     * @param organization Organization.
+     * @param first First result to return. Ignored if negative or {@code null}.
+     * @param max Maximum number of results to return. Ignored if negative or {@code null}.
+     * @return Stream of the roles. Never returns {@code null}.
+     */
+    Stream<RoleModel> getOrganizationRolesStream(OrganizationModel organization, Integer first, Integer max);
+
+    /**
+     * Returns a stream of organization roles matching the given search string.
+     * @param organization Organization.
+     * @param search Case-insensitive string to search by role's name or description. Ignored if {@code null}.
+     * @param first First result to return. Ignored if negative or {@code null}.
+     * @param max Maximum number of results to return. Ignored if negative or {@code null}.
+     * @return Stream of the roles. Never returns {@code null}.
+     */
+    Stream<RoleModel> searchForOrganizationRolesStream(OrganizationModel organization, String search, Integer first, Integer max);
 }

--- a/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
+++ b/server-spi/src/main/java/org/keycloak/organization/OrganizationProvider.java
@@ -26,6 +26,7 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.provider.Provider;
 import org.keycloak.representations.idm.MembershipType;
@@ -420,4 +421,60 @@ public interface OrganizationProvider extends Provider {
      * @return the invitation manager
      */
     InvitationManager getInvitationManager();
+
+    /**
+     * Creates a new role scoped to the given organization.
+     */
+    default RoleModel createRole(OrganizationModel organization, String name) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Returns all roles of the given organization.
+     */
+    default Stream<RoleModel> getRoles(OrganizationModel organization, Integer first, Integer max) {
+        return Stream.empty();
+    }
+
+    /**
+     * Returns roles filtered by name.
+     */
+    default Stream<RoleModel> searchRolesByName(OrganizationModel organization, String search, Integer first, Integer max) {
+        return Stream.empty();
+    }
+
+    /**
+     * Returns a role by id within the given organization.
+     */
+    default RoleModel getRoleById(OrganizationModel organization, String id) {
+        return null;
+    }
+
+    /**
+     * Removes the given role from the organization.
+     */
+    default boolean removeRole(OrganizationModel organization, RoleModel role) {
+        return false;
+    }
+
+    /**
+     * Grants an organization role to a member.
+     */
+    default void grantRole(OrganizationModel organization, UserModel user, RoleModel role) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Revokes an organization role from a member.
+     */
+    default void revokeRole(OrganizationModel organization, UserModel user, RoleModel role) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    /**
+     * Returns members that have the given organization role.
+     */
+    default Stream<UserModel> getMembersWithRole(OrganizationModel organization, RoleModel role) {
+        return Stream.empty();
+    }
 }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationResource.java
@@ -150,4 +150,9 @@ public class OrganizationResource {
     public OrganizationGroupsResource groups() {
         return new OrganizationGroupsResource(session, organization, adminEvent, auth);
     }
+
+    @Path("roles")
+    public OrganizationRolesResource roles() {
+        return new OrganizationRolesResource(session, organization, adminEvent);
+    }
 }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationRoleResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationRoleResource.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.organization.admin.resource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.common.util.ObjectUtil;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.ErrorResponse;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.NoCache;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+public class OrganizationRoleResource {
+
+    private final KeycloakSession session;
+    private final OrganizationProvider organizationProvider;
+    private final OrganizationModel organization;
+    private final RoleModel role;
+    private final AdminEventBuilder adminEvent;
+
+    public OrganizationRoleResource(KeycloakSession session, OrganizationProvider organizationProvider,
+                                    OrganizationModel organization, RoleModel role, AdminEventBuilder adminEvent) {
+        this.session = session;
+        this.organizationProvider = organizationProvider;
+        this.organization = organization;
+        this.role = role;
+        this.adminEvent = adminEvent;
+    }
+
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Get organization role")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "OK")
+    })
+    public RoleRepresentation getRole() {
+        RoleRepresentation rep = ModelToRepresentation.toRepresentation(role);
+        rep.setName(role.getFirstAttribute("org.role.name"));
+        return rep;
+    }
+
+    @DELETE
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Delete organization role")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public void deleteRole() {
+        organizationProvider.removeRole(organization, role);
+        adminEvent.operation(OperationType.DELETE)
+                .resourcePath(session.getContext().getUri())
+                .success();
+    }
+
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Update organization role")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "400", description = "Bad Request"),
+            @APIResponse(responseCode = "409", description = "Conflict")
+    })
+    public Response updateRole(RoleRepresentation rep) {
+        if (rep == null || ObjectUtil.isBlank(rep.getName())) {
+            throw ErrorResponse.error("Role name is missing", Response.Status.BAD_REQUEST);
+        }
+
+        try {
+            String internalName = "org." + organization.getId() + "." + rep.getName();
+            role.setName(internalName);
+            role.setSingleAttribute("org.role.name", rep.getName());
+            if (rep.getDescription() != null) {
+                role.setDescription(rep.getDescription());
+            }
+
+            adminEvent.operation(OperationType.UPDATE)
+                    .resourcePath(session.getContext().getUri())
+                    .representation(rep)
+                    .success();
+
+            return Response.noContent().build();
+        } catch (ModelDuplicateException e) {
+            throw ErrorResponse.exists("Role with the given name already exists.");
+        }
+    }
+
+    @GET
+    @Path("users")
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Get members with this organization role",
+            description = "Returns organization members that have been assigned this role.")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "OK")
+    })
+    public List<UserRepresentation> getUsersInRole() {
+        return organizationProvider.getMembersWithRole(organization, role)
+                .map(user -> ModelToRepresentation.toRepresentation(session, session.getContext().getRealm(), user))
+                .collect(Collectors.toList());
+    }
+
+    @PUT
+    @Path("users/{userId}")
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Assign role to organization member")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "400", description = "Bad Request"),
+            @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public void assignRoleToUser(@PathParam("userId") String userId) {
+        UserModel user = session.users().getUserById(session.getContext().getRealm(), userId);
+
+        if (user == null) {
+            throw ErrorResponse.error("User does not exist", Response.Status.NOT_FOUND);
+        }
+
+        if (!organizationProvider.isMember(organization, user)) {
+            throw ErrorResponse.error("User is not a member of the organization", Response.Status.BAD_REQUEST);
+        }
+
+        organizationProvider.grantRole(organization, user, role);
+
+        adminEvent.operation(OperationType.CREATE)
+                .resourcePath(session.getContext().getUri())
+                .success();
+    }
+
+    @DELETE
+    @Path("users/{userId}")
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Remove role from organization member")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "204", description = "No Content"),
+            @APIResponse(responseCode = "404", description = "Not Found")
+    })
+    public void removeRoleFromUser(@PathParam("userId") String userId) {
+        UserModel user = session.users().getUserById(session.getContext().getRealm(), userId);
+
+        if (user == null) {
+            throw ErrorResponse.error("User does not exist", Response.Status.NOT_FOUND);
+        }
+
+        organizationProvider.revokeRole(organization, user, role);
+
+        adminEvent.operation(OperationType.DELETE)
+                .resourcePath(session.getContext().getUri())
+                .success();
+    }
+}

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationRolesResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationRolesResource.java
@@ -1,0 +1,150 @@
+package org.keycloak.organization.admin.resource;
+
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.common.util.ObjectUtil;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.organization.OrganizationProvider;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.services.ErrorResponse;
+import org.keycloak.services.resources.KeycloakOpenAPI;
+import org.keycloak.services.resources.admin.AdminEventBuilder;
+
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.jboss.resteasy.reactive.NoCache;
+
+@Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
+public class OrganizationRolesResource {
+
+    private final RealmModel realm;
+    private final KeycloakSession session;
+    private final OrganizationProvider organizationProvider;
+    private final OrganizationModel organization;
+    private final AdminEventBuilder adminEvent;
+
+    public OrganizationRolesResource(KeycloakSession session, OrganizationModel organization, AdminEventBuilder adminEvent) {
+        this.realm = session == null ? null : session.getContext().getRealm();
+        this.session = session;
+        this.organizationProvider = session == null ? null : session.getProvider(OrganizationProvider.class);
+        this.organization = organization;
+        this.adminEvent = adminEvent.resource(ResourceType.REALM_ROLE); // використовуємо існуючий тип
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Create a new organization role",
+            description = "Creates a new role scoped to this organization.")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "201", description = "Created"),
+            @APIResponse(responseCode = "400", description = "Bad Request"),
+            @APIResponse(responseCode = "409", description = "Conflict")
+    })
+    public Response createRole(RoleRepresentation rep) {
+        if (rep == null || ObjectUtil.isBlank(rep.getName())) {
+            throw ErrorResponse.error("Role name is missing", Response.Status.BAD_REQUEST);
+        }
+
+        try {
+            RoleModel role = organizationProvider.createRole(organization, rep.getName());
+
+            if (rep.getDescription() != null) {
+                role.setDescription(rep.getDescription());
+            }
+
+            rep.setId(role.getId());
+
+            adminEvent.operation(OperationType.CREATE)
+                    .resourcePath(session.getContext().getUri())
+                    .representation(rep)
+                    .success();
+
+            URI uri = session.getContext().getUri().getAbsolutePathBuilder()
+                    .path(role.getId()).build();
+            return Response.created(uri).build();
+
+        } catch (ModelDuplicateException e) {
+            throw ErrorResponse.exists("Role with the given name already exists.");
+        }
+    }
+
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.ORGANIZATIONS)
+    @Operation(summary = "Get organization roles",
+            description = "Returns all roles defined for this organization.")
+    @APIResponses(value = {
+            @APIResponse(responseCode = "200", description = "OK")
+    })
+    public List<RoleRepresentation> getRoles(@QueryParam("search") String search,
+                                             @QueryParam("first") Integer first,
+                                             @QueryParam("max") Integer max) {
+        Stream<RoleModel> roles;
+
+        if (search != null && !search.isBlank()) {
+            roles = organizationProvider.searchRolesByName(organization, search.trim(), first, max);
+        } else {
+            roles = organizationProvider.getRoles(organization, first, max);
+        }
+
+        return roles.map(r -> {
+            RoleRepresentation rep = ModelToRepresentation.toRepresentation(r);
+            rep.setName(r.getFirstAttribute("org.role.name"));
+            return rep;
+        }).collect(Collectors.toList());
+    }
+
+    @Path("{role-id}")
+    public OrganizationRoleResource getRoleById(@PathParam("role-id") String id) {
+        RoleModel role = organizationProvider.getRoleById(organization, id);
+
+        if (role == null) {
+            throw new NotFoundException("Role does not exist");
+        }
+
+        return new OrganizationRoleResource(session, organizationProvider, organization, role, adminEvent);
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/organization/OrganizationRoleTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/organization/OrganizationRoleTest.java
@@ -1,0 +1,165 @@
+package org.keycloak.tests.admin.organization;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@KeycloakIntegrationTest
+public class OrganizationRoleTest {
+
+    @InjectRealm(lifecycle = LifeCycle.CLASS)
+    ManagedRealm managedRealm;
+
+    private OrganizationResource orgResource;
+    private String orgId;
+
+    @BeforeEach
+    public void onBefore() {
+        List<OrganizationRepresentation> orgs = managedRealm.admin().organizations().list(null, null);
+        if (orgs != null) {
+            for (OrganizationRepresentation o : orgs) {
+                managedRealm.admin().organizations().get(o.getId()).delete().close();
+            }
+        }
+
+        OrganizationRepresentation orgRep = new OrganizationRepresentation();
+        orgRep.setName("org-" + System.currentTimeMillis());
+
+        try (Response response = managedRealm.admin().organizations().create(orgRep)) {
+            assertEquals(201, response.getStatus());
+            orgId = getCreatedId(response);
+            orgResource = managedRealm.admin().organizations().get(orgId);
+        }
+    }
+
+    @Test
+    public void testCreateRole() {
+        RoleRepresentation rep = roleRep("viewer", "Can view resources");
+        String roleId;
+        try (Response response = orgResource.roles().createRole(rep)) {
+            assertEquals(201, response.getStatus());
+            roleId = getCreatedId(response);
+        }
+        assertNotNull(roleId);
+        RoleRepresentation created = orgResource.roles().getRoleById(roleId).getRole();
+        assertThat(created.getName(), is(equalTo("viewer")));
+    }
+
+    @Test
+    public void testListRoles() {
+        createRole("role-a");
+        createRole("role-b");
+        List<RoleRepresentation> roles = orgResource.roles().getRoles(null, null, null);
+        assertThat(roles, hasSize(2));
+        assertThat(roles.stream().map(RoleRepresentation::getName).collect(Collectors.toList()),
+                containsInAnyOrder("role-a", "role-b"));
+    }
+
+    @Test
+    public void testUpdateRole() {
+        String id = createRole("old-name");
+        RoleRepresentation update = roleRep("new-name", "Updated desc");
+        try (Response response = orgResource.roles().getRoleById(id).updateRole(update)) {
+            assertEquals(204, response.getStatus());
+        }
+        assertThat(orgResource.roles().getRoleById(id).getRole().getName(), is("new-name"));
+    }
+
+    @Test
+    public void testDeleteRole() {
+        String id = createRole("temp-role");
+        orgResource.roles().getRoleById(id).deleteRole();
+        assertThrows(NotFoundException.class, () -> orgResource.roles().getRoleById(id).getRole());
+    }
+
+    @Test
+    public void testAssignRoleToMember() {
+        String roleId = createRole("contributor");
+        String userId = createMember();
+
+        orgResource.roles().getRoleById(roleId).assignRoleToUser(userId);
+
+        List<UserRepresentation> users = orgResource.roles().getRoleById(roleId).getUsersInRole();
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getId(), is(userId));
+    }
+
+    @Test
+    public void testAssignRoleToNonMemberFails() {
+        String roleId = createRole("contributor");
+        String nonMemberId = createRealmUser("not-a-member@test.com");
+
+        try {
+            orgResource.roles().getRoleById(roleId).assignRoleToUser(nonMemberId);
+            fail("Should have thrown error");
+        } catch (WebApplicationException e) {
+            assertEquals(400, e.getResponse().getStatus());
+        }
+    }
+
+    private String createRole(String name) {
+        try (Response response = orgResource.roles().createRole(roleRep(name, null))) {
+            return getCreatedId(response);
+        }
+    }
+
+    private static RoleRepresentation roleRep(String name, String description) {
+        RoleRepresentation rep = new RoleRepresentation();
+        rep.setName(name);
+        rep.setDescription(description);
+        return rep;
+    }
+
+    private String createMember() {
+        UserRepresentation user = new UserRepresentation();
+        user.setEnabled(true);
+        user.setEmail("member-" + System.nanoTime() + "@test.org");
+        user.setUsername(user.getEmail());
+        String userId;
+        try (Response response = managedRealm.admin().users().create(user)) {
+            userId = getCreatedId(response);
+        }
+        orgResource.members().addMember(userId).close();
+        return userId;
+    }
+
+    private String createRealmUser(String email) {
+        UserRepresentation user = new UserRepresentation();
+        user.setEnabled(true);
+        user.setEmail(email);
+        user.setUsername(email);
+        try (Response response = managedRealm.admin().users().create(user)) {
+            return getCreatedId(response);
+        }
+    }
+
+    private String getCreatedId(Response response) {
+        String path = response.getLocation().getPath();
+        return path.substring(path.lastIndexOf('/') + 1);
+    }
+}


### PR DESCRIPTION
### [Organization] Organization-scoped Role Management Implementation

Following the design feedback from @vramik and @pedroigor, I have refactored the implementation to align with Keycloak's core architecture.

#### Key Architectural Changes:
1. **Storage Strategy:** Instead of using role attributes, I introduced a `TYPE` column (0=REALM, 1=CLIENT, 2=ORGANIZATION) and an `ORG_ID` foreign key to the `KEYCLOAK_ROLE` table. 
   - Added Liquibase migration: `jpa-changelog-authz-org-roles.xml`.
2. **Model Integration:** `OrganizationModel` now extends `RoleContainerModel`. This allows organizations to natively leverage existing role infrastructure (composites, mappings, etc.).
3. **Role Provider Updates:** Updated `RoleProvider` and `JpaRealmProvider` to filter roles by the new `TYPE`, ensuring organization roles are isolated and do not leak into realm or client role listings.
4. **Testing:** Migrated all integration tests to the new test framework (`tests/base/src/test/java/org/keycloak/tests/admin/organization/`).
5. **Decoupling:** Fixed the module dependency direction; `keycloak-admin-client` no longer depends on `keycloak-services`.

#### Implementation Details:
- Full CRUD for organization-scoped roles via Admin REST API.
- Member role assignment/revocation with membership validation.
- Audit trail support via `AdminEventBuilder`.

#### Issue:
Closes #40585 / Related to #47326

#### Note to Reviewers:
The PR has been rebased on the latest main, squashed into a single commit, and properly signed off (DCO).