### PR TITLE
Avoid O(N) session-cache scan when removing a user

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -119,7 +119,8 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             return new PersistentUserSessionProvider(
                     session,
                     tx.userTx,
-                    tx.clientTx
+                    tx.clientTx,
+                    useBatches
             );
         }
         var tx = createVolatileTransaction(session);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -88,6 +89,7 @@ import org.infinispan.commons.api.AsyncCache;
 import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.util.ByRef;
 import org.infinispan.commons.util.concurrent.CompletionStages;
+import org.infinispan.context.Flag;
 import org.infinispan.factories.ComponentRegistry;
 import org.infinispan.persistence.manager.PersistenceManager;
 import org.jboss.logging.Logger;
@@ -114,10 +116,24 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
 
     protected final SessionEventsSenderTransaction clusterEventsSenderTx;
     protected final UserSessionPersisterProvider userSessionPersister;
+    /**
+     * When {@code true}, persistent session writes are batched asynchronously, meaning the cache may
+     * legitimately contain entries whose corresponding DB row has not yet been written. In that case
+     * cache eviction during user removal cannot rely solely on the persister to know which keys exist
+     * and must fall back to a full cache scan.
+     */
+    protected final boolean useBatches;
 
     public PersistentUserSessionProvider(KeycloakSession session,
                                          UserSessionPersistentChangelogBasedTransaction sessionTx,
                                          ClientSessionPersistentChangelogBasedTransaction clientSessionTx) {
+        this(session, sessionTx, clientSessionTx, false);
+    }
+
+    public PersistentUserSessionProvider(KeycloakSession session,
+                                         UserSessionPersistentChangelogBasedTransaction sessionTx,
+                                         ClientSessionPersistentChangelogBasedTransaction clientSessionTx,
+                                         boolean useBatches) {
         if (!MultiSiteUtils.isPersistentSessionsEnabled()) {
             throw new IllegalStateException("Persistent user sessions are not enabled");
         }
@@ -125,6 +141,7 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
         this.session = session;
         this.sessionTx = sessionTx;
         this.clientSessionTx = clientSessionTx;
+        this.useBatches = useBatches;
         this.clusterEventsSenderTx = new SessionEventsSenderTransaction(session);
 
         session.getTransactionManager().enlistAfterCompletion(clusterEventsSenderTx);
@@ -512,9 +529,24 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
     }
 
     protected void onUserRemoved(RealmModel realm, UserModel user) {
-        userSessionPersister.onUserRemoved(realm, user);
-        removeCachedUserAndClientSessionForUser(realm.getId(), user.getId(), true);
-        removeCachedUserAndClientSessionForUser(realm.getId(), user.getId(), false);
+        if (useBatches) {
+            // When async-batch persistence is enabled, the cache may hold entries whose INSERT is still in
+            // the writer queue and not yet visible to the persister. In that case we fall back to the
+            // full-cache-scan to remain correct at the cost of being slower.
+            userSessionPersister.onUserRemoved(realm, user);
+            removeCachedUserAndClientSessionForUser(realm.getId(), user.getId(), true);
+            removeCachedUserAndClientSessionForUser(realm.getId(), user.getId(), false);
+        } else {
+            // Replaces a previous full-cache-scan that scaled with total cached sessions and made deletes
+            // progressively slower as the offline-session cache filled up over time. We collect cache keys
+            // from the persister BEFORE the DB delete (otherwise the rows are gone), then run the DB delete,
+            // then evict only the known keys from the cache.
+            Map<String, Set<String>> offlineForRemoval = userSessionPersister.findUserSessionsByUserId(realm, user, true);
+            Map<String, Set<String>> onlineForRemoval = userSessionPersister.findUserSessionsByUserId(realm, user, false);
+            userSessionPersister.onUserRemoved(realm, user);
+            removeCachedUserAndClientSessions(offlineForRemoval, true);
+            removeCachedUserAndClientSessions(onlineForRemoval, false);
+        }
     }
 
     @Override
@@ -700,7 +732,7 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
             userSessionEntityToImport.getClientSessions().add(clientUUID);
         }
 
-        SessionEntityWrapper<UserSessionEntity>  wrappedUserSessionEntity = new SessionEntityWrapper<>(userSessionEntityToImport);
+        SessionEntityWrapper<UserSessionEntity> wrappedUserSessionEntity = new SessionEntityWrapper<>(userSessionEntityToImport);
 
         SessionEntityWrapper<UserSessionEntity> existingSession = sessionTx.importSession(realm, sessionId, wrappedUserSessionEntity, offline, lifespan, maxIdle);
         if (existingSession != null) {
@@ -960,7 +992,7 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
             return;
         }
         var clientSessionCache = clientSessionTx.getCache(false);
-        sessionEntityWrapper.getEntity().getClientSessions().forEach(clientId-> {
+        sessionEntityWrapper.getEntity().getClientSessions().forEach(clientId -> {
             var key = new EmbeddedClientSessionKey(sessionEntityWrapper.getEntity().getId(), clientId);
             SessionEntityWrapper<AuthenticatedClientSessionEntity> clientSession = clientSessionCache.get(key);
             if (clientSession != null) {
@@ -1010,6 +1042,36 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
         sessionTx.registerClientSession(cacheKey.userSessionId(), cacheKey.clientId(), offline);
     }
 
+
+    /**
+     * Removes the listed user-session and client-session entries directly from the Infinispan cache,
+     * bypassing {@link JpaChangesPerformer} so no per-key DB delete is issued.
+     * Cost is O(K) over the user's own sessions, independent of total cache size.
+     */
+    private void removeCachedUserAndClientSessions(Map<String, Set<String>> sessionsToRemove, boolean offline) {
+        if (getCache(offline) == null) {
+            // caching disabled
+            return;
+        }
+        var userSessionCache = getCache(offline).getAdvancedCache()
+                .withFlags(Flag.ZERO_LOCK_ACQUISITION_TIMEOUT, Flag.FAIL_SILENTLY, Flag.IGNORE_RETURN_VALUES);
+        var clientSessionCache = getClientSessionCache(offline).getAdvancedCache()
+                .withFlags(Flag.ZERO_LOCK_ACQUISITION_TIMEOUT, Flag.FAIL_SILENTLY, Flag.IGNORE_RETURN_VALUES);
+        sessionsToRemove.forEach((userSessionId, clientUUIDs) -> {
+            for (String clientUUID : clientUUIDs) {
+                clientSessionCache.remove(new EmbeddedClientSessionKey(userSessionId, clientUUID));
+            }
+            userSessionCache.remove(userSessionId);
+        });
+    }
+
+    /**
+     * Removes user-session and client-session entries from the Infinispan cache via full cache-scan.
+     * Cache-scan fallback used when async-batch persistence ({@code useBatches=true}) is active. In that
+     * mode the cache may hold entries whose INSERT is still in the writer queue and not yet visible to
+     * the persister, so we cannot rely on the persister to enumerate keys for eviction and must scan the
+     * cache directly. Cost is O(N) over all cached sessions.
+     */
     private void removeCachedUserAndClientSessionForUser(String realmId, String userId, boolean offline) {
         if (getCache(offline) == null) {
             // caching disabled
@@ -1022,7 +1084,7 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
                 .map(MapEntryToKeyMapper.getInstance())) {
             stream.forEach(RemoveKeyConsumer.getInstance());
         }
-        try (var stream = getClientSessionCache(offline) .getAdvancedCache()
+        try (var stream = getClientSessionCache(offline).getAdvancedCache()
                 .entrySet()
                 .stream()
                 .filter(new ClientSessionFilterByUser(realmId, userId))

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -367,7 +367,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         String offlineStr = offlineToString(offline);
 
         TypedQuery<PersistentUserSessionEntity> query = paginateQuery(
-                em.createNamedQuery("findUserSessionsByUserId", PersistentUserSessionEntity.class),
+                em.createNamedQuery("findUserSessionsByUserIdLastSessionRefresh", PersistentUserSessionEntity.class),
                 firstResult, maxResults);
 
         query.setParameter("offline", offlineStr);
@@ -376,6 +376,20 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         query.setParameter("lastSessionRefresh", calculateOldestSessionTime(realm, offline));
 
         return loadExactUserSessionsWithClientSessions(query, offlineStr);
+    }
+
+    @Override
+    public Map<String, Set<String>> findUserSessionsByUserId(RealmModel realm, UserModel user, boolean offline) {
+        final TypedQuery<Object[]> query = em.createNamedQuery("findUserSessionsByUserId", Object[].class)
+                .setParameter("offline", offlineToString(offline))
+                .setParameter("realmId", realm.getId())
+                .setParameter("userId", user.getId());
+        return closing(query.getResultStream())
+                .collect(Collectors.groupingBy(
+                        row -> (String) row[0],
+                        Collectors.mapping(
+                                row -> (String) row[1],
+                                Collectors.filtering(Objects::nonNull, Collectors.toSet()))));
     }
 
     public Stream<UserSessionModel> loadUserSessionsStream(Integer firstResult, Integer maxResults, boolean offline,

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -53,8 +53,11 @@ import org.hibernate.annotations.DynamicUpdate;
                 " order by sess.userSessionId"),
         @NamedQuery(name="findUserSession", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
                 " AND sess.userSessionId = :userSessionId AND sess.realmId = :realmId AND sess.lastSessionRefresh >= :lastSessionRefresh"),
-        @NamedQuery(name="findUserSessionsByUserId", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
+        @NamedQuery(name="findUserSessionsByUserIdLastSessionRefresh", query="select sess from PersistentUserSessionEntity sess where sess.offline = :offline" +
                 " AND sess.realmId = :realmId AND sess.userId = :userId AND sess.lastSessionRefresh >= :lastSessionRefresh ORDER BY sess.userSessionId"),
+        @NamedQuery(name="findUserSessionsByUserId", query="SELECT sess.userSessionId, cs.clientId FROM PersistentUserSessionEntity sess" +
+                " LEFT JOIN PersistentClientSessionEntity cs ON cs.userSessionId = sess.userSessionId AND cs.offline = sess.offline" +
+                " WHERE sess.offline = :offline AND sess.realmId = :realmId AND sess.userId = :userId"),
         @NamedQuery(name="findUserSessionsByBrokerSessionId", query="select sess from PersistentUserSessionEntity sess where sess.brokerSessionId = :brokerSessionId" +
                 " AND sess.realmId = :realmId AND sess.offline = :offline AND lastSessionRefresh >= :lastSessionRefresh ORDER BY sess.userSessionId"),
         @NamedQuery(name="findUserSessionsByClientId", query="SELECT sess FROM PersistentUserSessionEntity sess INNER JOIN PersistentClientSessionEntity clientSess " +

--- a/model/storage-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
+++ b/model/storage-private/src/main/java/org/keycloak/models/session/UserSessionPersisterProvider.java
@@ -19,6 +19,7 @@ package org.keycloak.models.session;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.keycloak.models.AuthenticatedClientSessionModel;
@@ -73,6 +74,19 @@ public interface UserSessionPersisterProvider extends Provider {
      * @return
      */
     Stream<UserSessionModel> loadUserSessionsStream(RealmModel realm, UserModel user, boolean offline, Integer firstResult, Integer maxResults);
+
+    /**
+     * Returns user-session ids and their associated client UUIDs for the given {@link UserModel}, without applying the
+     * {@code lastSessionRefresh} idle-timeout filter.
+     *
+     * @param realm   The {@link RealmModel}.
+     * @param user    The {@link UserModel} whose sessions are queried.
+     * @param offline If {@code true}, returns offline sessions, otherwise online sessions.
+     * @return A map of user-session id to the set of associated client UUIDs (the set may be empty).
+     */
+    default Map<String, Set<String>> findUserSessionsByUserId(RealmModel realm, UserModel user, boolean offline) {
+        throw new IllegalStateException("not implemented");
+    }
 
     /**
      * Loads the user sessions for the given {@link ClientModel} in the given {@link RealmModel} if present.

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionPersisterProviderTest.java
@@ -556,6 +556,85 @@ public class UserSessionPersisterProviderTest extends KeycloakModelTest {
         });
     }
 
+    @Test
+    public void testFindUserSessionsByUserId() {
+        // Verifies that findUserSessionsByUserId returns sessions for cache cleanup even when their
+        // lastSessionRefresh would exclude them from loadUserSessionsStream (which filters by idle timeout).
+        // Without this guarantee, a user delete could leave orphaned cache entries for a user whose
+        // sessions have been idle longer than the offline-session idle timeout.
+        AtomicReference<UserSessionModel[]> origSessionsAt = new AtomicReference<>();
+
+        inComittedTransaction(session -> {
+            origSessionsAt.set(createSessions(session, realmId));
+        });
+
+        inComittedTransaction(session -> {
+            RealmModel realm = session.realms().getRealm(realmId);
+            session.getContext().setRealm(realm);
+            UserSessionModel us1 = session.sessions().getUserSession(realm, origSessionsAt.get()[1].getId());
+            persistUserSession(session, us1, true);
+        });
+
+        withRealmConsumer(realmId, (session, realm) -> {
+            // Advance clock past the offline session idle timeout. The persisted session's lastSessionRefresh
+            // is now older than the idle threshold, so loadUserSessionsStream filters it out.
+            setTimeOffset(realm.getOfflineSessionIdleTimeout() + 86400);
+            try {
+                UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+                UserModel user1 = session.users().getUserByUsername(realm, "user1");
+
+                long activeStreamCount = persister.loadUserSessionsStream(realm, user1, true, null, null).count();
+                Assert.assertEquals("loadUserSessionsStream is expected to filter out idle-expired sessions",
+                        0L, activeStreamCount);
+
+                Map<String, Set<String>> forRemoval = persister.findUserSessionsByUserId(realm, user1, true);
+                Assert.assertEquals("findUserSessionsByUserId must return idle-expired sessions for cache cleanup",
+                        1, forRemoval.size());
+                Assert.assertTrue("returned map must include the persisted user session id",
+                        forRemoval.containsKey(origSessionsAt.get()[1].getId()));
+            } finally {
+                setTimeOffset(0);
+                session.getKeycloakSessionFactory().publish(new ResetTimeOffsetEvent());
+            }
+        });
+    }
+
+    @Test
+    public void testFindUserSessionsByUserIdWithoutClientSessions() {
+        // Regression guard for the LEFT JOIN in findUserSessionsByUserId: a user session can exist in the
+        // persister without any associated client session (e.g. when the last client session was removed,
+        // or during the brief race window between createUserSession and createClientSession). The query
+        // must still return the user-session id so cache eviction can clear orphaned user-session entries.
+        AtomicReference<UserSessionModel[]> origSessionsAt = new AtomicReference<>();
+
+        inComittedTransaction(session -> {
+            origSessionsAt.set(createSessions(session, realmId));
+        });
+
+        inComittedTransaction(session -> {
+            RealmModel realm = session.realms().getRealm(realmId);
+            session.getContext().setRealm(realm);
+            // Persist only the user session row, NOT its client sessions — this is what the LEFT JOIN
+            // in findUserSessionsByUserId must cope with.
+            UserSessionModel us = session.sessions().getUserSession(realm, origSessionsAt.get()[2].getId());
+            session.getProvider(UserSessionPersisterProvider.class).createUserSession(us, true);
+        });
+
+        withRealmConsumer(realmId, (session, realm) -> {
+            UserSessionPersisterProvider persister = session.getProvider(UserSessionPersisterProvider.class);
+            UserModel user2 = session.users().getUserByUsername(realm, "user2");
+
+            Map<String, Set<String>> result = persister.findUserSessionsByUserId(realm, user2, true);
+            Assert.assertEquals("user session without client sessions must still appear in result",
+                    1, result.size());
+            String userSessionId = origSessionsAt.get()[2].getId();
+            Assert.assertTrue("returned map must contain the persisted user-session id",
+                    result.containsKey(userSessionId));
+            Assert.assertEquals("client-id set must be empty when no client session exists",
+                    Collections.emptySet(), result.get(userSessionId));
+        });
+    }
+
     // KEYCLOAK-1999
     @Test
     public void testNoSessions() {


### PR DESCRIPTION
## Summary

Fixes per-user delete latency that grows with Infinispan session-cache size

## Problem

`PersistentUserSessionProvider.onUserRemoved` invokes a full `entrySet().stream()` over both the user-session and client-session caches (online and offline) to evict the user's entries. The scan cost scales with the **total** number of cached sessions, not with the user's own.

In a 26.x cluster with `PERSISTENT_USER_SESSIONS` enabled and many active offline-token users, the offline-session cache fills up over uptime as sessions are lazily loaded on refresh. Observed delete latency for a user with no sessions of their own:

| Uptime | DELETE /admin/realms/{realm}/users/{id} |
|---|---|
| just after restart | ~50ms |
| 1 day | ~150ms |
| 2 days | ~1.5s |
| until max cache size reached | ~6s |

Independent of how many users have been deleted, only of how full the cache is.

## Fix

Replace the full cache scan with O(K) targeted eviction:

1. Look up the user's user-session id's and associated client UUIDs via a new persister query `findUserSessionsByUserId` (no `lastSessionRefresh` filter — idle-expired-but-still-cached entries must also be evicted).
2. Run the existing bulk DB delete via `UserSessionPersisterProvider.onUserRemoved`.
3. Evict only the known cache keys directly via `getAdvancedCache().withFlags(...).remove`, bypassing `JpaChangesPerformer` so no per-key DB delete is issued.

Cost is now O(K) over the user's own sessions, independent of total cache size.

## Async-batch fallback

When `--spi-user-sessions--infinispan--use-batches=true` is active, the cache may legitimately hold entries whose INSERT is still in the writer queue and not yet visible to the persister. In that mode the previous full-cache-scan eviction path is retained as a fallback to remain correct.

## Naming convention

`@NamedQuery` names now make the `lastSessionRefresh` filter explicit:

- existing `findUserSessionsByUserId` (with filter) → renamed to `findUserSessionsByUserIdLastSessionRefresh`
- new query (no filter) → `findUserSessionsByUserId`

The persister method follows the same convention. Discussion item: the other `find*` queries with the same filter (`findUserSession`, `findUserSessionsByBrokerSessionId`, `findUserSessionsByClientId`, `findUserSessionsByExternalClientId`) could be renamed for consistency in a follow-up cleanup.

## Tests

- `UserSessionPersisterProviderTest.testFindUserSessionsByUserId` — verifies the new query returns idle-expired sessions that `loadUserSessionsStream` would filter out.
- `UserSessionPersisterProviderTest.testFindUserSessionsByUserIdWithoutClientSessions` — regression guard for the LEFT JOIN: a user session without any client session must still be returned (NULL clientId case).

## Reviewer notes

- The DB-side `UserSessionPersisterProvider.onUserRemoved` (bulk DELETE by `userId`) is unchanged — it remains the authoritative DB cleanup. The new code only changes the cache-eviction path.
- The new `findUserSessionsByUserId` persister method has a default implementation in the interface that throws `IllegalStateException`; only `JpaUserSessionPersisterProvider` and the persistent-session caller need the dedicated implementation.
- Index `IDX_OFFLINE_USS_BY_USER` (USER_ID, REALM_ID, OFFLINE_FLAG) on `OFFLINE_USER_SESSION` exists since 14.0.0 and supports the new query; no schema change needed.