### PR TITLE
[OID4VCI-FAPI2] Pass fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -133,6 +133,7 @@ public class Profile {
 
         OID4VC_VCI("Support for the OID4VCI protocol as part of OID4VC.", Type.EXPERIMENTAL),
         OID4VC_VCI_PREAUTH_CODE("Support for credential offers with `pre-authorized_code` grant.", Type.EXPERIMENTAL, OID4VC_VCI),
+        OID4VC_HAIP("OpenID4VC High Assurance Interoperability Profile 1.0", Type.EXPERIMENTAL, OID4VC_VCI),
 
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -33,6 +33,7 @@ public interface Details {
     String ACTION = "action";
     String CODE_ID = "code_id";
     String REDIRECT_URI = "redirect_uri";
+    String REQUEST_URI = "request_uri";
     String RESPONSE_TYPE = "response_type";
     String RESPONSE_MODE = "response_mode";
     String GRANT_TYPE = "grant_type";

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -59,6 +60,9 @@ import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocol.Error;
 import org.keycloak.protocol.RestartLoginCookie;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
+import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
+import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
@@ -1239,10 +1243,23 @@ public class AuthenticationProcessor {
 
         String nextRequiredAction = nextRequiredAction();
         if (nextRequiredAction != null) {
-            return AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
+            Response response = AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
+            return response;
         } else {
             event.detail(Details.CODE_ID, authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
-            return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+            Response response = AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+
+            // Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+            // not at the point of visiting the authorization endpoint
+            String requestUri = authenticationSession.getAuthNote(Details.REQUEST_URI);
+            RequestUriType requestUriType = Optional.ofNullable(requestUri)
+                    .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
+                    .orElse(null);
+            if (requestUriType == RequestUriType.PAR) {
+                AuthzEndpointParParser.removeRequestObject(session, requestUri);
+            }
+
+            return response;
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -46,6 +46,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.ClientData;
 import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.utils.LogoutUtil;
@@ -57,6 +58,7 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.adapters.action.PushNotBeforeAction;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -436,8 +438,8 @@ public class OIDCLoginProtocol implements LoginProtocol {
         try {
             checker.checkResponseType();
             checker.checkRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            ex.throwAsErrorPageException(null);
+        } catch (AuthorizationCheckException ex) {
+            throw new ErrorPageException(session, ex.getError(), ex.getStatus(), ex.getErrorMessage(), ex.getParameters());
         }
 
         setupResponseTypeAndMode(clientData.getResponseType(), clientData.getResponseMode());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationCheckException.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationCheckException.java
@@ -1,0 +1,49 @@
+package org.keycloak.protocol.oidc.endpoints;
+
+import java.text.MessageFormat;
+
+import jakarta.ws.rs.core.Response;
+
+// Exception propagated to the caller, which will allow caller to send proper error response based on the context (Browser OIDC Authorization Endpoint, PAR etc)
+public class AuthorizationCheckException extends Exception {
+
+    private final Response.Status status;
+    private final String error;
+    private final String errorMessage;
+    private final Object[] parameters;
+
+    public AuthorizationCheckException(Response.Status status, String error, String errorDescription) {
+        this(error, status, errorDescription);
+    }
+
+    public AuthorizationCheckException(String error, Response.Status status, String errorMessage, Object... params) {
+        this.status = status;
+        this.error = error;
+        this.errorMessage = errorMessage;
+        this.parameters = params;
+    }
+
+    public Response.Status getStatus() {
+        return status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorDescription() {
+        String errorDescription = errorMessage;
+        if (parameters.length > 0) {
+            errorDescription = MessageFormat.format(errorMessage, parameters);
+        }
+        return errorDescription;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Object[] getParameters() {
+        return parameters;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -17,8 +17,12 @@
 
 package org.keycloak.protocol.oidc.endpoints;
 
+import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.BiConsumer;
 
 import jakarta.ws.rs.Consumes;
@@ -48,12 +52,14 @@ import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor.EndpointType;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
 import org.keycloak.protocol.oidc.grants.device.endpoints.DeviceEndpoint;
 import org.keycloak.protocol.oidc.utils.AcrUtils;
 import org.keycloak.protocol.oidc.utils.OIDCRedirectUriBuilder;
 import org.keycloak.protocol.oidc.utils.OIDCResponseMode;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -65,6 +71,7 @@ import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.services.util.LocaleUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
 import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
@@ -80,6 +87,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
     public static final String CODE_AUTH_TYPE = "code";
 
+    // Prefer error delivery on `redirect_uri` - rather than as HTML error page
+    public static final String AUTHORIZATION_PREFER_ERROR_ON_REDIRECT = "authorization.preferErrorOnRedirect";
+
     /**
      * Prefix used to store additional HTTP GET params from original client request into {@link AuthenticationSessionModel} note to be available later in Authenticators, RequiredActions etc. Prefix is used to
      * prevent collisions with internally used notes.
@@ -93,6 +103,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private ClientModel client;
+    private AuthorizationEndpointChecker checker;
     private AuthenticationSessionModel authenticationSession;
 
     private Action action;
@@ -100,7 +111,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     private OIDCResponseMode parsedResponseMode;
 
     private AuthorizationEndpointRequest request;
-    private String redirectUri;
+    private String parsedRedirectUri;
 
     public AuthorizationEndpoint(KeycloakSession session, EventBuilder event) {
         super(session, event);
@@ -132,52 +143,58 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private Response process(final MultivaluedMap<String, String> params) {
-        String clientId = AuthorizationEndpointRequestParserProcessor.getClientId(event, session, params);
-
-        checkSsl();
-        checkRealm();
 
         try {
-            session.clientPolicy().triggerOnEvent(new PreAuthorizationRequestContext(clientId, params));
-        } catch (ClientPolicyException cpe) {
-            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
-            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
-            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
-            event.error(cpe.getError());
-            throw new ErrorPageException(session, authenticationSession, cpe.getErrorStatus(), cpe.getErrorDetail());
+            String clientId = AuthorizationEndpointRequestParserProcessor.getClientId(event, session, params);
+
+            checkSsl();
+            checkRealm();
+
+            try {
+                session.clientPolicy().triggerOnEvent(new PreAuthorizationRequestContext(clientId, params));
+            } catch (ClientPolicyException cpe) {
+                event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
+                event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
+                event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+                event.error(cpe.getError());
+                throw new ErrorPageException(session, cpe.getError(), cpe.getErrorStatus(), cpe.getErrorDetail());
+            }
+            checkClient(clientId);
+
+            request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, EndpointType.OIDC_AUTH_ENDPOINT);
+
+        } catch (ErrorPageException ex) {
+            buildAuthorizationEndpointChecker(params);
+            return handleErrorPageException(ex);
         }
-        checkClient(clientId);
 
-        request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, AuthorizationEndpointRequestParserProcessor.EndpointType.OIDC_AUTH_ENDPOINT);
-
-        AuthorizationEndpointChecker checker = new AuthorizationEndpointChecker()
-                .event(event)
-                .client(client)
-                .realm(realm)
-                .request(request)
-                .session(session)
-                .params(params);
+        buildAuthorizationEndpointChecker(params);
 
         try {
             checker.checkRedirectUri();
-            this.redirectUri = checker.getRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            ex.throwAsErrorPageException(authenticationSession);
+            parsedRedirectUri = checker.getRedirectUri();
+        } catch (AuthorizationCheckException ex) {
+            ErrorPageException epex = new ErrorPageException(session, ex.getError(), ex.getStatus(), ex.getErrorMessage(), ex.getParameters());
+            return handleErrorPageException(epex);
         }
 
         try {
             checker.checkResponseType();
-            this.parsedResponseType = checker.getParsedResponseType();
-            this.parsedResponseMode = checker.getParsedResponseMode();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            OIDCResponseMode responseMode;
+            parsedResponseType = checker.getParsedResponseType();
+            parsedResponseMode = checker.getParsedResponseMode();
+        } catch (AuthorizationCheckException ex) {
             if (checker.isInvalidResponseType(ex)) {
-                responseMode = OIDCResponseMode.parseWhenInvalidResponseType(request.getResponseMode());
-            } else {
-                responseMode = checker.getParsedResponseMode() != null ? checker.getParsedResponseMode() : OIDCResponseMode.QUERY;
+                parsedResponseMode = OIDCResponseMode.parseWhenInvalidResponseType(request.getResponseMode());
             }
-            return redirectErrorToClient(responseMode, ex.getError(), ex.getErrorDescription());
+            if (parsedResponseMode == null) {
+                parsedResponseMode = checker.getParsedResponseMode();
+            }
+            if (parsedResponseMode == null) {
+                parsedResponseMode = OIDCResponseMode.QUERY;
+            }
+            return handleRedirectErrorToClient(ex.getError(), ex.getErrorDescription());
         }
+
         if (action == null) {
             action = AuthorizationEndpoint.Action.CODE;
         }
@@ -191,8 +208,8 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             checker.checkValidResource();
             checker.checkOIDCParams();
             checker.checkPKCEParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            return redirectErrorToClient(parsedResponseMode, ex.getError(), ex.getErrorDescription());
+        } catch (AuthorizationCheckException ex) {
+            return handleRedirectErrorToClient(ex.getError(), ex.getErrorDescription());
         }
 
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
@@ -205,14 +222,14 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         authenticationSession = createAuthenticationSession(client, request.getState());
 
         try {
-            session.clientPolicy().triggerOnEvent(new AuthorizationRequestContext(parsedResponseType, request, redirectUri, params, authenticationSession));
+            session.clientPolicy().triggerOnEvent(new AuthorizationRequestContext(parsedResponseType, request, parsedRedirectUri, params, authenticationSession));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
             event.error(cpe.getError());
             new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authenticationSession, false);
-            return redirectErrorToClient(parsedResponseMode, cpe.getError(), cpe.getErrorDetail());
+            return handleRedirectErrorToClient(cpe.getError(), cpe.getErrorDetail());
         }
 
         updateAuthenticationSession();
@@ -239,6 +256,19 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
 
         throw new RuntimeException("Unknown action " + action);
+    }
+
+    private AuthorizationEndpointChecker buildAuthorizationEndpointChecker(MultivaluedMap<String, String> params) {
+        if (checker == null) {
+            checker = new AuthorizationEndpointChecker()
+                    .event(event)
+                    .client(client)
+                    .realm(realm)
+                    .request(request)
+                    .session(session)
+                    .params(params);
+        }
+        return checker;
     }
 
     public AuthorizationEndpoint register(String tokenString) {
@@ -271,7 +301,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         return this;
     }
 
-    private void checkClient(String clientId) {
+    private ClientModel checkClient(String clientId) {
         if (clientId == null) {
             event.detail(Details.REASON, "Missing parameter: " + OIDCLoginProtocol.CLIENT_ID_PARAM);
             event.error(Errors.INVALID_REQUEST);
@@ -309,24 +339,83 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
 
         session.getContext().setClient(client);
+        return client;
     }
 
-    private Response redirectErrorToClient(OIDCResponseMode responseMode, String error, String errorDescription) {
+    private Response handleErrorPageException(ErrorPageException epex) {
+
+        // Prefer authorization error on redirect_uri
+        // https://github.com/keycloak/keycloak/issues/48542
+        boolean preferErrorOnRedirect = realm.getAttribute(AUTHORIZATION_PREFER_ERROR_ON_REDIRECT, false);
+        if (!preferErrorOnRedirect)
+            throw epex;
+
+        Response.Status status = epex.getStatus();
+
+        // Get the localized error message (english)
+        //
+        String errorMessage = epex.getErrorMessage();
+        try {
+            Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
+            Properties localizedMessages = theme.getEnhancedMessages(realm, Locale.ENGLISH);
+            if (localizedMessages.containsKey(errorMessage)) {
+                errorMessage = localizedMessages.getProperty(errorMessage);
+                Object[] params = epex.getParameters();
+                if (params.length > 0) {
+                    errorMessage = MessageFormat.format(errorMessage, params);
+                }
+            }
+        } catch (IOException ioe) {
+            // ignore
+        }
+
+        // Do a second pass trying to obtain the required parameters for a valid redirect
+        //
+        try {
+            MultivaluedMap<String, String> params = checker.getRequestParams();
+            AuthorizationEndpointRequest request = checker.getAuthorizationEndpointRequest();
+            if (client == null) {
+                String clientId = request != null ? request.getClientId() : params.getFirst(OIDCLoginProtocol.CLIENT_ID_PARAM);
+                client = checkClient(clientId);
+                checker.client(client);
+            }
+            if (parsedRedirectUri == null) {
+                checker.checkRedirectUri();
+                parsedRedirectUri = checker.getRedirectUri();
+            }
+            if (parsedResponseType == null || parsedResponseMode == null) {
+                checker.checkResponseType();
+                parsedResponseType = checker.getParsedResponseType();
+                parsedResponseMode = checker.getParsedResponseMode();
+            }
+        } catch (Exception aux) {
+            // ignore
+        }
+
+        if (client != null && parsedRedirectUri != null && parsedResponseType != null && parsedResponseMode != null) {
+            return handleRedirectErrorToClient(epex.getError(), errorMessage);
+        }
+
+        // [TODO >>>] Should we throw an ErrorResponseException instead?
+        var errRep = new OAuth2ErrorRepresentation(epex.getError(), errorMessage);
+        return Response.status(status).entity(errRep).type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+
+    private Response handleRedirectErrorToClient(String error, String errorDescription) {
         CacheControlUtil.noBackButtonCacheControlHeader(session);
 
-        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(redirectUri, responseMode, session, null)
+        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(parsedRedirectUri, parsedResponseMode, session, null)
                 .addParam(OAuth2Constants.ERROR, error);
 
         if (errorDescription != null) {
             errorResponseBuilder.addParam(OAuth2Constants.ERROR_DESCRIPTION, errorDescription);
         }
 
-        if (request.getState() != null) {
+        if (request != null && request.getState() != null) {
             errorResponseBuilder.addParam(OAuth2Constants.STATE, request.getState());
         }
 
-        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
-        if (!clientConfig.isExcludeIssuerFromAuthResponse()) {
+        if (client != null && !OIDCAdvancedConfigWrapper.fromClientModel(client).isExcludeIssuerFromAuthResponse()) {
             errorResponseBuilder.addParam(OAuth2Constants.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
         }
 
@@ -335,7 +424,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
     private void updateAuthenticationSession() {
         authenticationSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        authenticationSession.setRedirectUri(redirectUri);
+        authenticationSession.setRedirectUri(parsedRedirectUri);
         authenticationSession.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
         authenticationSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, request.getResponseType());
         authenticationSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, request.getRedirectUriParam());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -22,6 +22,7 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 
@@ -484,16 +485,22 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
     }
 
-    private Response buildAuthorizationCodeAuthorizationResponse(String requestUriParam) {
+    private Response buildAuthorizationCodeAuthorizationResponse(String requestUri) {
         this.event.event(EventType.LOGIN);
         authenticationSession.setAuthNote(Details.AUTH_TYPE, CODE_AUTH_TYPE);
+        authenticationSession.setAuthNote(Details.REQUEST_URI, requestUri);
 
-        // redirect if it is a PAR request because authentication can need a refresh (kerberos) and the single object is consumed now
-        final boolean redirectToAuthenticationIfParRequest = requestUriParam != null
-                && RequestUriType.PAR == AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUriParam);
+        RequestUriType requestUriType = Optional.ofNullable(requestUri)
+                .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
+                .orElse(null);
 
-        return handleBrowserAuthenticationRequest(authenticationSession, new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event),
-                TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE), redirectToAuthenticationIfParRequest);
+        // Redirect if it is a PAR request because authentication may need a refresh (kerberos) and the single object is consumed now
+        boolean redirectToAuthFlow = requestUriType == RequestUriType.PAR;
+
+        OIDCLoginProtocol loginProtocol = new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event);
+        boolean isPassive = TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE);
+        Response response = handleBrowserAuthenticationRequest(authenticationSession, loginProtocol, isPassive, redirectToAuthFlow);
+        return response;
     }
 
     private Response buildRegister() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -48,12 +48,10 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.cors.Cors;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.DPoPUtil;
-import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
 import org.keycloak.utils.StringUtil;
 
@@ -127,25 +125,35 @@ public class AuthorizationEndpointChecker {
         return parsedResponseMode;
     }
 
+    public MultivaluedMap<String, String> getRequestParams() {
+        return params;
+    }
+
+    public AuthorizationEndpointRequest getAuthorizationEndpointRequest() {
+        return request;
+    }
+
     public void checkRedirectUri() throws AuthorizationCheckException {
-        String redirectUriParam = request.getRedirectUriParam();
-        boolean isOIDCRequest = TokenUtil.isOIDCRequest(request.getScope());
+        String redirectUriParam = request != null ? request.getRedirectUriParam() : params.getFirst(OIDCLoginProtocol.REDIRECT_URI_PARAM);
+        String scope = request != null ? request.getScope() : params.getFirst(OIDCLoginProtocol.SCOPE_PARAM);
+
+        // The redirect_uri parameter is required for OIDC, but optional for OAuth2
+        boolean isOIDCRequest = TokenUtil.isOIDCRequest(scope);
 
         event.detail(Details.REDIRECT_URI, redirectUriParam);
 
-        // redirect_uri parameter is required per OpenID Connect, but optional per OAuth2
         this.redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client, isOIDCRequest);
         if (redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+            throw new AuthorizationCheckException(OAuthErrorException.INVALID_REDIRECT_URI, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
         }
     }
 
-
     public void checkResponseType() throws AuthorizationCheckException {
-        String responseType = request.getResponseType();
+        String responseTypeParam = request != null ? request.getResponseType() : params.getFirst(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+        String responseModeParam = request != null ? request.getResponseMode() : params.getFirst(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
 
-        if (responseType == null) {
+        if (responseTypeParam == null) {
             ServicesLogger.LOGGER.missingParameter(OAuth2Constants.RESPONSE_TYPE);
             String errorMessage = "Missing parameter: response_type";
             event.detail(Details.REASON, errorMessage);
@@ -153,19 +161,21 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        event.detail(Details.RESPONSE_TYPE, responseType);
+        event.detail(Details.RESPONSE_TYPE, responseTypeParam);
 
         try {
-            this.parsedResponseType = OIDCResponseType.parse(responseType);
+            parsedResponseType = OIDCResponseType.parse(responseTypeParam);
         } catch (IllegalArgumentException iae) {
-            event.detail(Details.REASON, iae.getMessage());
+            ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+            String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_TYPE_PARAM;
+            event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, null);
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, errorMessage);
         }
 
-        OIDCResponseMode parsedResponseMode = null;
+        OIDCResponseMode responseMode;
         try {
-            parsedResponseMode = OIDCResponseMode.parse(request.getResponseMode(), parsedResponseType);
+            responseMode = OIDCResponseMode.parse(responseModeParam, parsedResponseType);
         } catch (IllegalArgumentException iae) {
             ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
             String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_MODE_PARAM;
@@ -174,10 +184,10 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        event.detail(Details.RESPONSE_MODE, parsedResponseMode.toString().toLowerCase());
+        event.detail(Details.RESPONSE_MODE, responseMode.toString().toLowerCase());
 
         // Disallowed by OIDC specs
-        if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY) {
+        if (parsedResponseType.isImplicitOrHybridFlow() && responseMode == OIDCResponseMode.QUERY) {
             ServicesLogger.LOGGER.responseModeQueryNotAllowed();
             String errorMessage = "Response_mode 'query' not allowed for implicit or hybrid flow";
             event.detail(Details.REASON, errorMessage);
@@ -185,9 +195,9 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        this.parsedResponseMode = parsedResponseMode;
+        parsedResponseMode = responseMode;
 
-        if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY_JWT &&
+        if (parsedResponseType.isImplicitOrHybridFlow() && responseMode == OIDCResponseMode.QUERY_JWT &&
                 (!StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ALG)) ||
                 !StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ENC)))) {
             ServicesLogger.LOGGER.responseModeQueryJwtNotAllowed();
@@ -224,14 +234,14 @@ public class AuthorizationEndpointChecker {
         }
     }
 
-    public boolean isInvalidResponseType(AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+    public boolean isInvalidResponseType(AuthorizationCheckException ex) {
         return "Missing parameter: response_type".equals(ex.getErrorDescription()) || OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE.equals(ex.getError());
     }
 
     public void checkInvalidRequestMessage() throws AuthorizationCheckException {
         if (request.getInvalidRequestMessage() != null) {
             event.error(Errors.INVALID_REQUEST);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Errors.INVALID_REQUEST, request.getInvalidRequestMessage());
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, request.getInvalidRequestMessage());
         }
     }
 
@@ -248,7 +258,7 @@ public class AuthorizationEndpointChecker {
                 new AuthorizationDetailsProcessorManager(session).validateAuthorizationDetail(authDetailsParam);
             } catch (Exception e) {
                 event.error(Errors.INVALID_REQUEST);
-                throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Errors.INVALID_REQUEST, e.getMessage());
+                throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, e.getMessage());
             }
         }
     }
@@ -437,35 +447,8 @@ public class AuthorizationEndpointChecker {
         }
     }
 
-
-    // Exception propagated to the caller, which will allow caller to send proper error response based on the context (Browser OIDC Authorization Endpoint, PAR etc)
-    public class AuthorizationCheckException extends Exception {
-
-        private final Response.Status status;
-        private final String error;
-        private final String errorDescription;
-
-        public AuthorizationCheckException(Response.Status status, String error, String errorDescription) {
-            this.status = status;
-            this.error = error;
-            this.errorDescription = errorDescription;
-        }
-
-        public void throwAsErrorPageException(AuthenticationSessionModel authenticationSession) {
-            throw new ErrorPageException(session, authenticationSession, status, error, errorDescription);
-        }
-
-        public void throwAsCorsErrorResponseException(Cors cors) {
-            AuthorizationEndpointChecker.this.event.detail("detail", errorDescription).error(error);
-            throw new CorsErrorResponseException(cors, error, errorDescription, status);
-        }
-
-        public String getError() {
-            return error;
-        }
-
-        public String getErrorDescription() {
-            return errorDescription;
-        }
+    public void throwAsCorsErrorResponseException(Cors cors, AuthorizationCheckException ex) {
+        event.detail("detail", ex.getErrorDescription()).error(ex.getError());
+        throw new CorsErrorResponseException(cors, ex.getError(), ex.getErrorDescription(), ex.getStatus());
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequestParserProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthorizationEndpointRequestParserProcessor.java
@@ -135,7 +135,6 @@ public class AuthorizationEndpointRequestParserProcessor {
         if (requestUri == null) {
             throw new RuntimeException("'request_uri' parameter is null");
         }
-
         return requestUri.toLowerCase().startsWith("urn:ietf:params:oauth:request_uri:")
                        ? RequestUriType.PAR
                        : RequestUriType.REQUEST_OBJECT;

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
@@ -50,6 +50,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
@@ -145,7 +146,7 @@ public class DeviceEndpoint extends AuthorizationEndpointBase implements RealmRe
 
         try {
             checker.checkPKCEParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             throw new ErrorResponseException(ex.getError(), ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -42,6 +42,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.par.ParResponse;
@@ -123,23 +124,23 @@ public class ParEndpoint extends AbstractParEndpoint {
 
         try {
             checker.checkRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: redirect_uri", Response.Status.BAD_REQUEST);
         }
 
         try {
             checker.checkResponseType();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             if (ex.getError().equals(OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE)) {
                 throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Unsupported response type", Response.Status.BAD_REQUEST);
             } else {
-                ex.throwAsCorsErrorResponseException(cors);
+                checker.throwAsCorsErrorResponseException(cors, ex);
             }
         }
 
         try {
             checker.checkValidScope();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             // PAR throws this as "invalid_request" error
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
@@ -150,8 +151,8 @@ public class ParEndpoint extends AbstractParEndpoint {
             checker.checkOIDCParams();
             checker.checkPKCEParams();
             checker.checkParDPoPParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            ex.throwAsCorsErrorResponseException(cors);
+        } catch (AuthorizationCheckException ex) {
+            checker.throwAsCorsErrorResponseException(cors, ex);
         }
 
         try {

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -19,6 +19,7 @@
 package org.keycloak.protocol.oidc.par.endpoints.request;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.keycloak.common.Profile;
@@ -54,29 +55,18 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         super(session);
         this.session = session;
         this.client = client;
-        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        String key;
-        try {
-            key = requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
-        } catch (RuntimeException re) {
-            logger.warnf(re,"Unable to parse request_uri: %s", requestUri);
-            throw new RuntimeException("Unable to parse request_uri");
-        }
-        Map<String, String> retrievedRequest = singleUseStore.remove(CACHE_KEY_PREFIX + key);
-        if (retrievedRequest == null) {
-            throw new RuntimeException("PAR not found. not issued or used multiple times.");
-        }
-
         RealmModel realm = session.getContext().getRealm();
+        Map<String, String> parRequestParams = Optional.ofNullable(getRequestObject(session, requestUri))
+                .orElseThrow(() -> new RuntimeException("PAR not found, not issued or used multiple times."));
+        long created = Long.parseLong(parRequestParams.get(PAR_CREATED_TIME));
         int expiresIn = realm.getParPolicy().getRequestUriLifespan();
-        long created = Long.parseLong(retrievedRequest.get(PAR_CREATED_TIME));
-        if (System.currentTimeMillis() - created < (expiresIn * 1000)) {
-            requestParams = retrievedRequest;
+        if (System.currentTimeMillis() - created < expiresIn * 1000L) {
+            requestParams = parRequestParams;
         } else {
             throw new RuntimeException("PAR expired.");
         }
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
-        String dpopJkt = retrievedRequest.get(PAR_DPOP_PROOF_JKT);
+        String dpopJkt = parRequestParams.get(PAR_DPOP_PROOF_JKT);
         if (dpopJkt != null) {
             session.setAttribute(PAR_DPOP_PROOF_JKT, dpopJkt);
         }
@@ -88,7 +78,7 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
 
         if (requestParam != null) {
             // parses the request object if PAR was registered using JAR
-            // parameters from requets object have precedence over those sent directly in the request
+            // parameters from the request object have precedence over those sent directly in the request
             new ParEndpointRequestObjectParser(session, requestParam, client).parseRequest(request);
         } else {
             super.parseRequest(request);
@@ -122,6 +112,32 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
             return newVal;
         } else {
             return super.replaceIfNotNull(previousVal, newVal);
+        }
+    }
+
+    public static Map<String, String> getRequestObject(KeycloakSession session, String requestUri) {
+        String key = getRequestObjectKey(requestUri);
+        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
+        Map<String, String> retrievedRequest = singleUseStore.get(CACHE_KEY_PREFIX + key);
+        return retrievedRequest;
+    }
+
+    /**
+     * Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+     * not at the point of visiting the authorization endpoint
+     * OpenID CT: fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds
+     */
+    public static void removeRequestObject(KeycloakSession session, String requestUri) {
+        String key = getRequestObjectKey(requestUri);
+        session.singleUseObjects().remove(CACHE_KEY_PREFIX + key);
+    }
+
+    private static String getRequestObjectKey(String requestUri) {
+        try {
+            return requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
+        } catch (RuntimeException re) {
+            logger.warnf(re,"Unable to parse request_uri: %s", requestUri);
+            throw new RuntimeException("Unable to parse request_uri");
         }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -21,6 +21,7 @@ package org.keycloak.protocol.oidc.par.endpoints.request;
 import java.util.Map;
 import java.util.Set;
 
+import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -114,4 +115,13 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         return requestParams.keySet();
     }
 
+    protected <T> T replaceIfNotNull(T previousVal, T newVal) {
+        // FAPI says only parameters inside the request object should be used
+        // https://github.com/keycloak/keycloak/issues/48047
+        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_HAIP)) {
+            return newVal;
+        } else {
+            return super.replaceIfNotNull(previousVal, newVal);
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -23,20 +23,53 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
+import static org.keycloak.OAuthErrorException.INVALID_REQUEST;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class ErrorPageException extends WebApplicationException {
 
+    private String error;
+    private String errorMessage;
+    private Object[] parameters;
+
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
-        super(errorMessage, ErrorPage.error(session, null, status, errorMessage, parameters));
+        this(session, INVALID_REQUEST, status, errorMessage, parameters);
+    }
+
+    public ErrorPageException(KeycloakSession session, String error, Response.Status status, String errorMessage, Object... parameters) {
+        this(session, null, error, status, errorMessage, parameters);
     }
 
     public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, Response.Status status, String errorMessage, Object... parameters) {
+        this(session, authSession, INVALID_REQUEST, status, errorMessage, parameters);
+    }
+
+    public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, String error, Response.Status status, String errorMessage, Object... parameters) {
         super(errorMessage, ErrorPage.error(session, authSession, status, errorMessage, parameters));
+        this.error = error;
+        this.errorMessage = errorMessage;
+        this.parameters = parameters;
     }
 
     public ErrorPageException(Response response) {
         super((Throwable) null, response);
+    }
+
+    public Response.Status getStatus() {
+        return Response.Status.fromStatusCode(getResponse().getStatus());
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Object[] getParameters() {
+        return parameters;
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
@@ -30,7 +30,6 @@ import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
@@ -38,7 +37,7 @@ import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestObjectParser;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
-import org.keycloak.protocol.oidc.par.endpoints.ParEndpoint;
+import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -85,9 +84,7 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request_uri not included.");
         }
 
-        String key = requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
-        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        Map<String, String> requestParametersFromPAR = singleUseStore.get(ParEndpoint.CACHE_KEY_PREFIX + key);
+        Map<String, String> requestParametersFromPAR = AuthzEndpointParParser.getRequestObject(session, requestUri);
         if (requestParametersFromPAR == null) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR not found, not issued or used multiple times.");
         }
@@ -109,7 +106,7 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
         if (!Profile.isFeatureEnabled(Profile.Feature.OID4VC_HAIP)) {
             for (String queryParam : queryKeys) {
                 if (!requestParametersNameFromPAR.contains(queryParam)) {
-                    singleUseStore.remove(ParEndpoint.CACHE_KEY_PREFIX + key);
+                    AuthzEndpointParParser.removeRequestObject(session, requestUri);
                     throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_OBJECT, "PAR request did not include query parameter: " + queryParam);
                 }
             }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
@@ -18,6 +18,7 @@
 package org.keycloak.services.clientpolicy.executor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,6 +26,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -87,7 +89,7 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
         SingleUseObjectProvider singleUseStore = session.singleUseObjects();
         Map<String, String> requestParametersFromPAR = singleUseStore.get(ParEndpoint.CACHE_KEY_PREFIX + key);
         if (requestParametersFromPAR == null) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR not found. not issued or used multiple times.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR not found, not issued or used multiple times.");
         }
 
         Set<String> requestParametersNameFromPAR = new HashSet<>();
@@ -98,10 +100,18 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
             requestParametersNameFromPAR = requestParametersFromPAR.keySet();
         }
 
-        for (String queryParamName : requestParametersFromQuery.keySet()) {
-            if (!requestParametersNameFromPAR.contains(queryParamName) && !OIDCLoginProtocol.REQUEST_URI_PARAM.equals(queryParamName)) {
-                singleUseStore.remove(ParEndpoint.CACHE_KEY_PREFIX + key);
-                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request did not include necessary parameters");
+        List<String> queryKeys = requestParametersFromQuery.keySet().stream()
+                .filter(it -> !it.equals(OIDCLoginProtocol.REQUEST_URI_PARAM))
+                .toList();
+
+        // FAPI says only parameters inside the request object should be used
+        // https://github.com/keycloak/keycloak/issues/48047
+        if (!Profile.isFeatureEnabled(Profile.Feature.OID4VC_HAIP)) {
+            for (String queryParam : queryKeys) {
+                if (!requestParametersNameFromPAR.contains(queryParam)) {
+                    singleUseStore.remove(ParEndpoint.CACHE_KEY_PREFIX + key);
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_OBJECT, "PAR request did not include query parameter: " + queryParam);
+                }
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -475,22 +475,22 @@ public class LoginActionsService {
         if (clientID == null) {
             if (redirectUriParam != null) {
                 logger.warn("Unsupported to send 'redirect_uri' parameter without providing 'client_id' parameter.");
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, OIDCLoginProtocol.CLIENT_ID_PARAM);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, OIDCLoginProtocol.CLIENT_ID_PARAM);
             }
             client = SystemClientUtil.getSystemClient(realm);
             redirectUri = Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
         } else {
             client = session.clients().getClientByClientId(realm, clientID);
             if (client == null) {
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
             }
             if (!client.isEnabled()) {
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
             }
             if (redirectUriParam != null) {
                 redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client);
                 if (redirectUri == null) {
-                    throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+                    throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
                 }
             }
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2DPoPTest.java
@@ -252,11 +252,11 @@ public class FAPI2DPoPTest extends AbstractFAPI2Test {
                 .send();
         assertEquals(201, pResp.getStatusCode());
         oauth.loginForm().requestUri(pResp.getRequestUri()).param("custom", "value").open();
-        assertBrowserWithError("PAR request did not include necessary parameters");
+        assertBrowserWithError("PAR request did not include query parameter: custom");
 
         // duplicated usage of a PAR request - should fail
         oauth.loginForm().requestUri(pResp.getRequestUri()).open();
-        assertBrowserWithError("PAR not found. not issued or used multiple times.");
+        assertBrowserWithError("PAR not found, not issued or used multiple times.");
 
         // send a pushed authorization request
         // use RSA key for DPoP proof but not send dpop_jkt

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
@@ -189,11 +189,11 @@ public class FAPI2Test extends AbstractFAPI2Test {
         assertEquals(201, pResp.getStatusCode());
         requestUri = pResp.getRequestUri();
         oauth.loginForm().requestUri(requestUri).state("testFAPI2SecurityProfileLoginWithMTLS").open();
-        assertBrowserWithError("PAR request did not include necessary parameters");
+        assertBrowserWithError("PAR request did not include query parameter: state");
 
         // duplicated usage of a PAR request - should fail
         oauth.loginForm().requestUri(requestUri).state("testFAPI2SecurityProfileLoginWithMTLS").codeChallenge(pkceGenerator).open();
-        assertBrowserWithError("PAR not found. not issued or used multiple times.");
+        assertBrowserWithError("PAR not found, not issued or used multiple times.");
 
         // send a pushed authorization request
         pResp = oauth.pushedAuthorizationRequest().nonce("123456").codeChallenge(pkceGenerator).send();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExecutorTest.java
@@ -1650,10 +1650,10 @@ public class ClientPoliciesExecutorTest extends AbstractClientPoliciesTest {
         oauth.client(clientBetaId);
         oauth.loginForm().state("randomstatesomething").requestUri(requestUri).open();
         assertTrue(errorPage.isCurrent());
-        assertEquals("PAR request did not include necessary parameters", errorPage.getError());
-        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        "PAR request did not include necessary parameters").client((String) null)
+        assertEquals("PAR request did not include query parameter: state", errorPage.getError());
+        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        "PAR request did not include query parameter: state").client((String) null)
                 .user((String) null).assertEvent();
 
         oauth.client(clientBetaId, "secretBeta");
@@ -1699,10 +1699,10 @@ public class ClientPoliciesExecutorTest extends AbstractClientPoliciesTest {
         // only query parameters include state parameter
         oauth.loginForm().requestUri(requestUri).state("mystate2").open();
         assertTrue(errorPage.isCurrent());
-        assertEquals("PAR request did not include necessary parameters", errorPage.getError());
-        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        "PAR request did not include necessary parameters").client((String) null)
+        assertEquals("PAR request did not include query parameter: state", errorPage.getError());
+        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        "PAR request did not include query parameter: state").client((String) null)
                 .user((String) null).assertEvent();
 
         // Pushed Authorization Request with state parameter


### PR DESCRIPTION
closes #48072

depends on 

* https://github.com/keycloak/keycloak/pull/48326