### PR TITLE
Add organization filter to github provider

### DIFF
--- a/services/src/main/java/org/keycloak/social/github/GitHubIdentityProvider.java
+++ b/services/src/main/java/org/keycloak/social/github/GitHubIdentityProvider.java
@@ -38,6 +38,7 @@ import org.keycloak.http.simple.SimpleHttpResponse;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.TokenExchangeContext;
 import org.keycloak.services.ErrorResponseException;
+import org.keycloak.services.messages.Messages;
 import org.keycloak.util.BasicAuthHelper;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -83,11 +84,14 @@ public class GitHubIdentityProvider extends AbstractOAuth2IdentityProvider imple
     protected static final String GITHUB_JSON_FORMAT_KEY = "githubJsonFormat";
     /** Email URL key in config map. */
     protected static final String EMAIL_URL_KEY = "emailUrl";
+    /** Organizations key in config map. Comma-separated list of GitHub organizations allowed to log in. */
+    protected static final String ORGANIZATIONS_KEY = "organizations";
 
     private final String authUrl;
     private final String tokenUrl;
     private final String profileUrl;
     private final String emailUrl;
+    private final String apiUrl;
     private final boolean githubJsonFormat;
 
     public GitHubIdentityProvider(KeycloakSession session, OAuth2IdentityProviderConfig config) {
@@ -98,6 +102,7 @@ public class GitHubIdentityProvider extends AbstractOAuth2IdentityProvider imple
 
         authUrl = baseUrl + AUTH_FRAGMENT;
         tokenUrl = baseUrl + TOKEN_FRAGMENT;
+        this.apiUrl = apiUrl;
         profileUrl = apiUrl + PROFILE_FRAGMENT;
         emailUrl = apiUrl + EMAIL_FRAGMENT;
 
@@ -180,9 +185,48 @@ public class GitHubIdentityProvider extends AbstractOAuth2IdentityProvider imple
                     if (user.getEmail() == null) {
                         user.setEmail(searchEmail(accessToken));
                     }
+
+                    checkOrganizationMembership(accessToken, user.getUsername());
+
                     return user;
+		} catch (IdentityBrokerException e) {
+			throw e;
 		} catch (Exception e) {
 			throw new IdentityBrokerException("Profile could not be retrieved from the github endpoint", e);
+		}
+	}
+
+	private void checkOrganizationMembership(String accessToken, String username) {
+		String orgsConfig = getConfig().getConfig().get(ORGANIZATIONS_KEY);
+		if (orgsConfig == null || orgsConfig.trim().isEmpty()) {
+			return;
+		}
+
+		String[] allowedOrgs = orgsConfig.split(",");
+		for (String org : allowedOrgs) {
+			String trimmedOrg = org.trim();
+			if (trimmedOrg.isEmpty()) continue;
+			if (isUserInOrganization(accessToken, username, trimmedOrg)) {
+				return;
+			}
+		}
+
+		logger.warnf("GitHub user '%s' is not a member of any required organization: %s", username, orgsConfig);
+		throw new IdentityBrokerException("User is not a member of any required GitHub organization")
+				.withMessageCode(Messages.ACCESS_DENIED);
+	}
+
+	private boolean isUserInOrganization(String accessToken, String username, String org) {
+		String orgMemberUrl = apiUrl + "/orgs/" + org + "/members/" + username;
+		try (SimpleHttpResponse response = SimpleHttp.create(session).doGet(orgMemberUrl)
+				.header("Authorization", "Bearer " + accessToken)
+				.header("Accept", "application/json")
+				.asResponse()) {
+			// GitHub returns 204 if the user is a member, 404 if not a member, 302 if the requester is not a member
+			return response.getStatus() == 204;
+		} catch (Exception e) {
+			logger.warnf(e, "Could not check organization membership for user %s in organization %s", username, org);
+			return false;
 		}
 	}
 
@@ -256,6 +300,10 @@ public class GitHubIdentityProvider extends AbstractOAuth2IdentityProvider imple
 
     @Override
 	protected String getDefaultScopes() {
+		String orgs = getConfig().getConfig().get(ORGANIZATIONS_KEY);
+		if (orgs != null && !orgs.trim().isEmpty()) {
+			return DEFAULT_SCOPE + " read:org";
+		}
 		return DEFAULT_SCOPE;
 	}
 }

--- a/services/src/main/java/org/keycloak/social/github/GitHubIdentityProviderFactory.java
+++ b/services/src/main/java/org/keycloak/social/github/GitHubIdentityProviderFactory.java
@@ -61,6 +61,8 @@ public class GitHubIdentityProviderFactory extends AbstractIdentityProviderFacto
                 .name(GitHubIdentityProvider.API_URL_KEY).label("API URL").helpText("Override the default API URL for this identity provider.")
                 .type(ProviderConfigProperty.STRING_TYPE).add().property()
                 .name(GitHubIdentityProvider.GITHUB_JSON_FORMAT_KEY).label("JSON Format").helpText("Enable to receive JSON format responses from GitHub. This is also required to automatically refresh access tokens retrieved from GitHub.")
-                .defaultValue(false).type(ProviderConfigProperty.BOOLEAN_TYPE).add().build();
+                .defaultValue(false).type(ProviderConfigProperty.BOOLEAN_TYPE).add().property()
+                .name(GitHubIdentityProvider.ORGANIZATIONS_KEY).label("Organizations").helpText("Comma-separated list of GitHub organization names. If specified, only members of at least one of these organizations will be allowed to log in. Requires the 'read:org' scope, which is automatically added when this field is set.")
+                .type(ProviderConfigProperty.STRING_TYPE).add().build();
     }
 }

--- a/services/src/test/java/org/keycloak/social/github/GitHubIdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/social/github/GitHubIdentityProviderTest.java
@@ -21,6 +21,7 @@ import org.keycloak.broker.oidc.OAuth2IdentityProviderConfig;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test for {@link org.keycloak.social.github.GitHubIdentityProvider}.
@@ -54,6 +55,43 @@ public class GitHubIdentityProviderTest {
         GitHubIdentityProvider idp = new GitHubIdentityProvider(null, config);
 
         validateUrls(idp, baseUrl, apiUrl);
+    }
+
+    /**
+     * Test that default scope does not include read:org when no organizations are configured.
+     */
+    @Test
+    public void testDefaultScopeWithoutOrganizations() {
+        OAuth2IdentityProviderConfig config = new OAuth2IdentityProviderConfig();
+        GitHubIdentityProvider idp = new GitHubIdentityProvider(null, config);
+
+        assertEquals(GitHubIdentityProvider.DEFAULT_SCOPE, idp.getDefaultScopes());
+    }
+
+    /**
+     * Test that read:org scope is added when organizations are configured.
+     */
+    @Test
+    public void testDefaultScopeWithOrganizations() {
+        OAuth2IdentityProviderConfig config = new OAuth2IdentityProviderConfig();
+        config.getConfig().put(GitHubIdentityProvider.ORGANIZATIONS_KEY, "my-org,another-org");
+        GitHubIdentityProvider idp = new GitHubIdentityProvider(null, config);
+
+        String scopes = idp.getDefaultScopes();
+        assertTrue("Scope should contain user:email", scopes.contains("user:email"));
+        assertTrue("Scope should contain read:org when organizations are configured", scopes.contains("read:org"));
+    }
+
+    /**
+     * Test that read:org scope is not added when organizations value is blank.
+     */
+    @Test
+    public void testDefaultScopeWithBlankOrganizations() {
+        OAuth2IdentityProviderConfig config = new OAuth2IdentityProviderConfig();
+        config.getConfig().put(GitHubIdentityProvider.ORGANIZATIONS_KEY, "   ");
+        GitHubIdentityProvider idp = new GitHubIdentityProvider(null, config);
+
+        assertEquals(GitHubIdentityProvider.DEFAULT_SCOPE, idp.getDefaultScopes());
     }
 
     protected void validateUrls(GitHubIdentityProvider idp, String baseUrl, String apiUrl) {


### PR DESCRIPTION
This change adds organization filter to github provider. Multiple, comma separated, github organizations are allowed. Setting github organization adds `read:org` scope to the oauth request.

Resolves discussion https://github.com/keycloak/keycloak/discussions/10006