### PR TITLE
Fix virtual thread check

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/infinispan/util/InfinispanUtils.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/util/InfinispanUtils.java
@@ -101,13 +101,15 @@ public final class InfinispanUtils {
     }
 
     public static boolean isVirtualThreadsEnabled() {
-        return Boolean.parseBoolean(System.getProperty(INFINISPAN_VIRTUAL_THREADS_PROP));
+        return Boolean.parseBoolean(System.getProperty(INFINISPAN_VIRTUAL_THREADS_PROP, "true"));
     }
 
     public static void configureVirtualThreads() {
         // enable Infinispan and JGroups virtual threads by default
-        if (System.getProperty(INFINISPAN_VIRTUAL_THREADS_PROP) == null && getParallelism() >= MIN_VT_POOL_SIZE)
-            System.setProperty(INFINISPAN_VIRTUAL_THREADS_PROP, "true");
+        if (System.getProperty(INFINISPAN_VIRTUAL_THREADS_PROP) == null) {
+            // if the user doesn't set this system properties, we are free to enable/disable as we wish.
+            System.setProperty(INFINISPAN_VIRTUAL_THREADS_PROP, Boolean.toString(getParallelism() >= MIN_VT_POOL_SIZE));
+        }
     }
 
     public static void ensureVirtualThreadsParallelism() {


### PR DESCRIPTION
Virtual threads are enabled by default, but they must not be enabled when CPU count is less than 4

Closes #48792 
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
