### PR TITLE
fix: prevent NPE in AccountLoader when theme is unavailable

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -169,7 +169,7 @@ public class AccountLoader {
 
     private AccountResourceProvider getAccountResourceProvider(Theme theme) {
       try {
-        if (theme.getProperties().containsKey(Theme.ACCOUNT_RESOURCE_PROVIDER_KEY)) {
+        if (theme != null && theme.getProperties().containsKey(Theme.ACCOUNT_RESOURCE_PROVIDER_KEY)) {
           return session.getProvider(AccountResourceProvider.class, theme.getProperties().getProperty(Theme.ACCOUNT_RESOURCE_PROVIDER_KEY));
         }
       } catch (IOException ignore) {}


### PR DESCRIPTION
## Issue

Fixes #48806 - NPE when accessing Account UI and the ACCOUNT feature is disabled

## Problem

When the `ACCOUNT_V3` feature is disabled, accessing the account console endpoint throws a `NullPointerException` in `AccountLoader.getAccountResourceProvider()`.

### Root Cause
The `theme` parameter passed to `getAccountResourceProvider()` can be `null` when the account theme is unavailable (e.g., when account-v3 feature is disabled), but the method unconditionally calls `theme.getProperties()` without a null check.

### Stack Trace
```
java.lang.NullPointerException
  at org.keycloak.services.resources.account.AccountLoader.getAccountResourceProvider(AccountLoader.java:172)
  at org.keycloak.services.resources.account.AccountLoader.getAccountService(AccountLoader.java:87)
  ...
```

## Solution

Add a null check before accessing theme properties:

```java
// Before:
if (theme.getProperties().containsKey(Theme.ACCOUNT_RESOURCE_PROVIDER_KEY)) {

// After:
if (theme != null && theme.getProperties().containsKey(Theme.ACCOUNT_RESOURCE_PROVIDER_KEY)) {
```

This allows the method to gracefully handle the case when theme is null by returning the default provider.

## Testing

### Manual Test Steps
1. Start Keycloak with `--features-disabled=account-v3`
2. Navigate to the Admin Console
3. Click the user dropdown in the top-right navbar
4. Select "Manage account"
5. ✅ Should no longer throw NPE / 500 error
6. Behavior should be consistent with other unavailable features

### Expected Behavior
- No NPE thrown
- Request is handled gracefully
- Appropriate error or fallback behavior occurs

## Impact

- **Minimal Change:** Single line addition (null check)
- **No Behavioral Change:** Falls back to default provider when theme is null
- **Backward Compatible:** 100% compatible with existing code
- **Fixes Regression:** Resolves NPE that occurs when account feature is disabled

---

**Related Labels:** `kind/bug`, `area/account/api`, `priority/normal`, `help wanted`