### PR TITLE
fix: Identity providers should not be hidden from login page when the user goes back from the reset credentials page

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -34,6 +34,8 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
+import static org.keycloak.authentication.authenticators.resetcred.ResetCredentialChooseUser.RESET_CREDENTIAL_USER_CHOSEN;
+
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
  * @version $Revision: 1 $
@@ -87,6 +89,7 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
         MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
         String loginHint = context.getAuthenticationSession().getClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM);
 
+        clearUserIfComingFromResetPassword(context);
         String rememberMeUsername = AuthenticationManager.getRememberMeUsername(context.getSession());
 
         if (context.getUser() != null) {
@@ -117,6 +120,12 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
         }
         Response challengeResponse = challenge(context, formData);
         context.challenge(challengeResponse);
+    }
+
+    private void clearUserIfComingFromResetPassword(AuthenticationFlowContext context) {
+        if ("true".equals(context.getAuthenticationSession().getAuthNote(RESET_CREDENTIAL_USER_CHOSEN))) {
+            context.clearUser();
+        }
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/UsernamePasswordForm.java
@@ -125,6 +125,7 @@ public class UsernamePasswordForm extends AbstractUsernameFormAuthenticator impl
     private void clearUserIfComingFromResetPassword(AuthenticationFlowContext context) {
         if ("true".equals(context.getAuthenticationSession().getAuthNote(RESET_CREDENTIAL_USER_CHOSEN))) {
             context.clearUser();
+            context.getAuthenticationSession().removeAuthNote(RESET_CREDENTIAL_USER_CHOSEN);
         }
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
@@ -55,6 +55,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
     private static final Logger logger = Logger.getLogger(ResetCredentialChooseUser.class);
 
     public static final String PROVIDER_ID = "reset-credentials-choose-user";
+    public static final String RESET_CREDENTIAL_USER_CHOSEN = "RESET_CREDENTIAL_USER_CHOSEN";
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
@@ -109,7 +110,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
         }
 
         username = username.trim();
-        
+
         RealmModel realm = context.getRealm();
         UserModel user = context.getSession().users().getUserByUsername(realm, username);
         if (user == null && realm.isLoginWithEmailAllowed() && username.contains("@")) {
@@ -131,6 +132,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
                     .user(user).error(Errors.USER_DISABLED);
             context.clearUser();
         } else {
+            context.getAuthenticationSession().setAuthNote(RESET_CREDENTIAL_USER_CHOSEN, "true");
             context.setUser(user);
         }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -196,10 +196,10 @@ public class IdentityProviderBean {
                         .map(FederatedIdentityModel::getIdentityProvider)
                         .collect(Collectors.toSet());
 
-                if (!federatedIdentities.isEmpty() || organizationsDisabled(realm))
+                if (!federatedIdentities.isEmpty() || organizationsDisabled(realm)) {
                     // if orgs are enabled, we don't want to return an empty set - we want the organization IDPs to be shown if those are available.
                     result = new HashSet<>(federatedIdentities);
-
+                }
             }
         }
         return result;

--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/LoginPasswordResetPage.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/LoginPasswordResetPage.java
@@ -16,6 +16,9 @@ public class LoginPasswordResetPage extends AbstractLoginPage {
     @FindBy(id = "kc-reset-password-form")
     private WebElement formResetPassword;
 
+    @FindBy(partialLinkText = "Back to Login")
+    private WebElement backToLogin;
+
     public LoginPasswordResetPage(ManagedWebDriver driver) {
         super(driver);
     }
@@ -25,6 +28,10 @@ public class LoginPasswordResetPage extends AbstractLoginPage {
         usernameInput.sendKeys(username);
 
         submitButton.click();
+    }
+
+    public void backToLogin() {
+        backToLogin.click();
     }
 
     public String getFormUrl() {

--- a/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/RegisterPage.java
+++ b/test-framework/ui/src/main/java/org/keycloak/testframework/ui/page/RegisterPage.java
@@ -62,6 +62,9 @@ public class RegisterPage extends AbstractLoginPage {
     @FindBy(css = "input[type=\"submit\"]")
     private WebElement submitButton;
 
+    @FindBy(linkText = "« Back to Login")
+    private WebElement backToLoginLink;
+
     public RegisterPage(ManagedWebDriver driver) {
         super(driver);
     }
@@ -186,5 +189,9 @@ public class RegisterPage extends AbstractLoginPage {
     @Override
     public String getExpectedPageId() {
         return "login-register";
+    }
+
+    public void clickBackToLogin() {
+        backToLoginLink.click();
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/forms/ResetPasswordTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/forms/ResetPasswordTest.java
@@ -1,0 +1,257 @@
+package org.keycloak.tests.forms;
+
+import java.io.IOException;
+
+import jakarta.mail.internet.MimeMessage;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.representations.idm.EventRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.mail.MailServer;
+import org.keycloak.testframework.mail.annotations.InjectMailServer;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.IdentityProviderBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.page.LoginPasswordResetPage;
+import org.keycloak.testframework.ui.page.LoginPasswordUpdatePage;
+import org.keycloak.testframework.ui.page.RegisterPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+import org.keycloak.tests.utils.MailUtils;
+import org.keycloak.testsuite.util.MailServerConfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@KeycloakIntegrationTest
+public class ResetPasswordTest {
+
+
+    protected static final String CONSUMER_REALM_NAME = "consumer";
+    protected static final String PROVIDER_REALM_NAME = "provider";
+    protected static final String IDP_ALIAS = "test-identity-provider";
+    protected static final String IDP_CLIENT_ID = "test-idp-client";
+    protected static final String IDP_CLIENT_SECRET = "test-idp-secret";
+    protected static final String USER_LOGIN = "testuser";
+    protected static final String USER_EMAIL = "spam@vnagy.eu";
+    protected static final String USER_PASSWORD = "password";
+    protected static final String BROKER_APP_CLIENT_ID = "broker-app";
+    protected static final String BASE_URL = "http://localhost:8080";
+
+    @InjectRealm(ref = PROVIDER_REALM_NAME, config = ProviderRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    protected ManagedRealm providerRealm;
+
+    @InjectRealm(ref = CONSUMER_REALM_NAME, config = ConsumerRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    protected ManagedRealm consumerRealm;
+
+    @InjectOAuthClient(realmRef = CONSUMER_REALM_NAME, config = BrokerAppClientConfig.class, lifecycle = LifeCycle.METHOD)
+    protected OAuthClient oauth;
+
+    @InjectPage
+    protected LoginPage loginPage;
+
+    @InjectPage
+    protected LoginPasswordResetPage resetPasswordPage;
+
+    @InjectPage
+    protected LoginPasswordUpdatePage updatePasswordPage;
+
+    @InjectPage
+    protected RegisterPage registerPage;
+
+    @InjectWebDriver
+    protected ManagedWebDriver driver;
+
+    @InjectMailServer
+    MailServer mailServer;
+
+    @InjectEvents(realmRef = CONSUMER_REALM_NAME)
+    protected Events events;
+
+//    @InjectPage
+//    protected ResetPasswordPage updatePasswordPage;
+
+    @Test
+    public void shouldOfferAllOidcOptionOnLoginPageUserTriesToResetTheirPasswordAndGoesBack() {
+        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
+            .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+            .alias(IDP_ALIAS)
+            .attribute("clientId", IDP_CLIENT_ID)
+            .attribute("clientSecret", IDP_CLIENT_SECRET)
+            .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+            .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
+            .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
+            .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
+            .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
+            .build();
+
+        consumerRealm.admin().identityProviders().create(idp).close();
+        consumerRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
+
+        oauth.loginForm().open();
+        loginPage.assertCurrent();
+        loginPage.resetPassword();
+
+        resetPasswordPage.assertCurrent();
+        resetPasswordPage.backToLogin();
+        String urlWhenBackFromRegistrationPage = driver.getCurrentUrl();
+        loginPage.assertCurrent();
+        assertDoesNotThrow(() -> loginPage.findSocialButton(IDP_ALIAS));
+
+        loginPage.resetPassword();
+        resetPasswordPage.changePassword(USER_LOGIN);
+        driver.driver().navigate().back();
+        driver.driver().navigate().back();
+        String urlWhenWentBackFromResetPassword = driver.getCurrentUrl();
+        assertEquals(
+            "The user clicks the back button twice. Their browser sends them to the same URL where they were previously",
+            urlWhenBackFromRegistrationPage, urlWhenWentBackFromResetPassword
+        );
+        loginPage.assertCurrent();
+        assertDoesNotThrow(() -> loginPage.findSocialButton(IDP_ALIAS));
+    }
+
+
+    @Test
+    public void testLoginPageClearsUserFromContextIfUserNavigatesBackFromResetPassword() {
+        oauth.openLoginForm();
+        loginPage.clickRegister();
+        registerPage.clickBackToLogin();
+        loginPage.assertCurrent();
+
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+        resetPasswordPage.changePassword(USER_LOGIN);
+
+        driver.driver().navigate().back();
+        driver.driver().navigate().back();
+        // we're at the login page now, and if we go back, the register page opens correctly
+        driver.driver().navigate().back();
+
+        registerPage.assertCurrent();
+    }
+
+    @Test
+    public void resetPasswordEmailLinkWorksAfterNavigatingBackToLoginPage() throws IOException {
+        final var user = consumerRealm.admin().users().search(USER_LOGIN).get(0);
+        oauth.openLoginForm();
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+        resetPasswordPage.backToLogin();
+
+        String urlWhenBackFromRegistrationPage = driver.getCurrentUrl();
+
+        loginPage.assertCurrent();
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+
+        resetPasswordPage.changePassword(USER_LOGIN);
+
+        EventRepresentation sendResetPasswordEvent = events.poll();
+        EventAssertion.assertSuccess(sendResetPasswordEvent)
+            .type(EventType.SEND_RESET_PASSWORD)
+            .sessionId(sendResetPasswordEvent.getSessionId())
+            .userId(user.getId())
+            .details(Details.USERNAME, USER_LOGIN)
+            .details(Details.EMAIL, USER_EMAIL);
+
+
+        MimeMessage message = mailServer.getReceivedMessages()[0];
+        String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
+
+        // Navigate back to the login page, which triggers UsernamePasswordForm to clear the user from the auth session
+        driver.driver().navigate().back();
+        driver.driver().navigate().back();
+        String urlWhenWentBackFromResetPassword = driver.getCurrentUrl();
+        assertEquals(urlWhenBackFromRegistrationPage, urlWhenWentBackFromResetPassword);
+        loginPage.assertCurrent();
+
+        events.clear();
+        driver.driver().navigate().to(changePasswordUrl.trim());
+
+        updatePasswordPage.assertCurrent();
+        assertEquals("You need to change your password.", updatePasswordPage.getFeedbackMessage());
+        updatePasswordPage.changePassword("resetPassword", "resetPassword");
+
+        EventRepresentation updatePasswordEvent = events.poll();
+        EventAssertion.assertSuccess(updatePasswordEvent)
+            .type(EventType.UPDATE_PASSWORD)
+            .details(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE)
+            .details(Details.USERNAME, USER_LOGIN)
+            .userId(user.getId());
+
+
+        EventRepresentation updateCredentialEvent = events.poll();
+        EventAssertion.assertSuccess(updateCredentialEvent)
+            .type(EventType.UPDATE_CREDENTIAL)
+            .details(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE)
+            .details(Details.USERNAME, USER_LOGIN)
+            .userId(user.getId());
+
+        assertTrue(driver.page().getPageSource().contains("Happy days"));
+    }
+
+    static class ConsumerRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm
+                .users(UserBuilder.create(USER_LOGIN)
+                    .name("Vilmos", "Szabó-Nagy")
+                    .email(USER_EMAIL)
+                    .emailVerified(true)
+                    .password(USER_PASSWORD))
+                .resetPasswordAllowed(true)
+                .registrationAllowed(true)
+                .smtp(MailServerConfiguration.HOST, Integer.parseInt(MailServerConfiguration.PORT), MailServerConfiguration.FROM);
+        }
+    }
+
+
+    static class ProviderRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm
+                .users(UserBuilder.create(USER_LOGIN)
+                    .name("Vilmos", "Szabó-Nagy")
+                    .email(USER_EMAIL)
+                    .emailVerified(true)
+                    .password(USER_PASSWORD))
+                .clients(ClientBuilder.create()
+                    .clientId(IDP_CLIENT_ID)
+                    .secret(IDP_CLIENT_SECRET)
+                    .redirectUris(BASE_URL + "/realms/" + CONSUMER_REALM_NAME + "/broker/" + IDP_ALIAS + "/endpoint*")
+                    .build());
+        }
+    }
+
+    static class BrokerAppClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                .clientId(BROKER_APP_CLIENT_ID)
+                .publicClient()
+                .redirectUris(BASE_URL + "/*");
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/forms/ResetPasswordTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/forms/ResetPasswordTest.java
@@ -89,9 +89,6 @@ public class ResetPasswordTest {
     @InjectEvents(realmRef = CONSUMER_REALM_NAME)
     protected Events events;
 
-//    @InjectPage
-//    protected ResetPasswordPage updatePasswordPage;
-
     @Test
     public void shouldOfferAllOidcOptionOnLoginPageUserTriesToResetTheirPasswordAndGoesBack() {
         IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
@@ -131,7 +128,6 @@ public class ResetPasswordTest {
         loginPage.assertCurrent();
         assertDoesNotThrow(() -> loginPage.findSocialButton(IDP_ALIAS));
     }
-
 
     @Test
     public void testLoginPageClearsUserFromContextIfUserNavigatesBackFromResetPassword() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -454,6 +454,45 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         final var socialButton = this.loginPage.findSocialButton(bc.getIDPAlias());
     }
 
+    @Test
+    public void shouldOfferAllOidcOptionOnLoginPageUserTriesToResetTheirPasswordAndGoesBack() {
+        configureSMTPServer();
+        final var realmRepresentation = adminClient.realm(bc.consumerRealmName()).toRepresentation();
+        realmRepresentation.setResetPasswordAllowed(true);
+        adminClient.realm(bc.consumerRealmName()).update(realmRepresentation);
+
+        createUser(bc.consumerRealmName(), "user-without-idp", "password", "Vilmos", "Szabó-Nagy", "spam@vnagy.eu");
+
+        oauth.client("broker-app");
+        loginPage.open(bc.consumerRealmName());
+        loginPage.assertCurrent(bc.consumerRealmName());
+
+        System.out.println(driver.getCurrentUrl());
+
+        // loginPage.clickResetLogin(); does not work somehow?
+        driver.findElement(By.linkText("Forgot Password?")).click();
+        loginPasswordResetPage.assertCurrent();
+
+        loginPasswordResetPage.backToLogin();
+
+        String urlWhenBackFromRegistrationPage = driver.getCurrentUrl();
+        log.debug("Social button should be visible");
+        final var socialButton = this.loginPage.findSocialButton(bc.getIDPAlias());
+
+        // loginPage.clickResetLogin(); does not work somehow?
+        driver.findElement(By.linkText("Forgot Password?")).click();
+        loginPasswordResetPage.assertCurrent();
+
+        loginPasswordResetPage.changePassword("user-without-idp");
+        driver.navigate().back();
+        driver.navigate().back();
+        String urlWhenWentBackFromResetPassword = driver.getCurrentUrl();
+        assertEquals(urlWhenBackFromRegistrationPage, urlWhenWentBackFromResetPassword);
+
+        log.debug("Should not fail here... We're still not logged in, so the IDP should be shown on the login page.");
+        assertTrue(driver.getPageSource().contains("Sign in to your account"), "We should be on the login page.");
+        final var socialButtonAfterPasswordReset = this.loginPage.findSocialButton(bc.getIDPAlias());
+    }
 
     @Test
     public void testDisplayName() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -455,42 +455,6 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
     }
 
     @Test
-    public void shouldOfferAllOidcOptionOnLoginPageUserTriesToResetTheirPasswordAndGoesBack() {
-        configureSMTPServer();
-        final var realmRepresentation = adminClient.realm(bc.consumerRealmName()).toRepresentation();
-        realmRepresentation.setResetPasswordAllowed(true);
-        adminClient.realm(bc.consumerRealmName()).update(realmRepresentation);
-
-        createUser(bc.consumerRealmName(), "user-without-idp", "password", "Vilmos", "Szabó-Nagy", "spam@vnagy.eu");
-
-        oauth.client("broker-app");
-        loginPage.open(bc.consumerRealmName());
-        loginPage.assertCurrent(bc.consumerRealmName());
-
-        loginPage.resetPassword();
-        loginPasswordResetPage.assertCurrent();
-
-        loginPasswordResetPage.backToLogin();
-
-        String urlWhenBackFromRegistrationPage = driver.getCurrentUrl();
-        log.debug("Social button should be visible");
-        final var socialButton = this.loginPage.findSocialButton(bc.getIDPAlias());
-
-        loginPage.resetPassword();
-        loginPasswordResetPage.assertCurrent();
-
-        loginPasswordResetPage.changePassword("user-without-idp");
-        driver.navigate().back();
-        driver.navigate().back();
-        String urlWhenWentBackFromResetPassword = driver.getCurrentUrl();
-        assertEquals(urlWhenBackFromRegistrationPage, urlWhenWentBackFromResetPassword);
-
-        log.debug("Should not fail here... We're still not logged in, so the IDP should be shown on the login page.");
-        assertTrue(driver.getPageSource().contains("Sign in to your account"), "We should be on the login page.");
-        final var socialButtonAfterPasswordReset = this.loginPage.findSocialButton(bc.getIDPAlias());
-    }
-
-    @Test
     public void testDisplayName() {
 
         updateExecutions(AbstractBrokerTest::enableUpdateProfileOnFirstLogin);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/KcOidcFirstBrokerLoginTest.java
@@ -467,10 +467,7 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         loginPage.open(bc.consumerRealmName());
         loginPage.assertCurrent(bc.consumerRealmName());
 
-        System.out.println(driver.getCurrentUrl());
-
-        // loginPage.clickResetLogin(); does not work somehow?
-        driver.findElement(By.linkText("Forgot Password?")).click();
+        loginPage.resetPassword();
         loginPasswordResetPage.assertCurrent();
 
         loginPasswordResetPage.backToLogin();
@@ -479,8 +476,7 @@ public class KcOidcFirstBrokerLoginTest extends AbstractFirstBrokerLoginTest {
         log.debug("Social button should be visible");
         final var socialButton = this.loginPage.findSocialButton(bc.getIDPAlias());
 
-        // loginPage.clickResetLogin(); does not work somehow?
-        driver.findElement(By.linkText("Forgot Password?")).click();
+        loginPage.resetPassword();
         loginPasswordResetPage.assertCurrent();
 
         loginPasswordResetPage.changePassword("user-without-idp");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -823,25 +823,6 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
                 .withoutDetails(Details.USERNAME, Details.EMAIL);
     }
 
-    @Test
-    public void testLoginPageClearsUserFromContextIfUserNavigatesBackFromResetPassword() {
-        oauth.openLoginForm();
-        loginPage.clickRegister();
-        registerPage.clickBackToLogin();
-        loginPage.assertCurrent(managedRealm.admin().toRepresentation().getRealm());
-
-        loginPage.resetPassword();
-        resetPasswordPage.assertCurrent();
-        resetPasswordPage.changePassword("test-user@localhost");
-
-        driver.navigate().back();
-        driver.navigate().back();
-        events.clear();
-        driver.navigate().back();
-
-        registerPage.assertCurrent();
-    }
-
     protected RealmAttributeUpdater configureRealmRegistrationEmailAsUsername(final boolean value) {
         return getRealmAttributeUpdater().setRegistrationEmailAsUsername(value);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/RegisterTest.java
@@ -55,7 +55,6 @@ import org.keycloak.testsuite.pages.RegisterPage;
 import org.keycloak.testsuite.updaters.RealmAttributeUpdater;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.FlowUtil;
-import org.keycloak.testsuite.util.UIUtils;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.hamcrest.Matchers;
@@ -129,7 +128,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
                 .details(Details.USERNAME, "rolerichuser")
                 .details(Details.EMAIL, "registerexistinguser@email");
     }
- 
+
     @Test
     public void registerExistingEmailForbidden() {
         oauth.openLoginForm();
@@ -151,7 +150,7 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
 
         EventAssertion.expectRegisterError(events.poll()).error("email_in_use").clientId(oauth.getClientId()).details(Details.USERNAME, "registerexistinguser").details(Details.EMAIL, "test-user@localhost");
     }
- 
+
     @Test
     public void registerExistingEmailAllowed() throws IOException {
         try (RealmAttributeUpdater rau = setDuplicateEmailsAllowed(true).update()) {
@@ -800,6 +799,34 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
     public void testRegisterShouldFailBeforeUserCreationWhenUserIsInContext() {
         oauth.openLoginForm();
         loginPage.clickRegister();
+        String registrationUrl = driver.getCurrentUrl();
+
+        registerPage.clickBackToLogin();
+        loginPage.assertCurrent(managedRealm.admin().toRepresentation().getRealm());
+
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+        resetPasswordPage.changePassword("test-user@localhost");
+
+        events.clear();
+
+        driver.navigate().to(registrationUrl);
+        errorPage.assertCurrent();
+        Assertions.assertEquals("Action expired. Please continue with login now.", errorPage.getError());
+
+        EventAssertion.assertError(events.poll())
+                .type(EventType.REGISTER_ERROR)
+                .error(Errors.GENERIC_AUTHENTICATION_ERROR)
+                .clientId(oauth.getClientId())
+                .details(Details.EXISTING_USER, "test-user@localhost")
+                .details(Details.AUTHENTICATION_ERROR_DETAIL, Errors.DIFFERENT_USER_AUTHENTICATING)
+                .withoutDetails(Details.USERNAME, Details.EMAIL);
+    }
+
+    @Test
+    public void testLoginPageClearsUserFromContextIfUserNavigatesBackFromResetPassword() {
+        oauth.openLoginForm();
+        loginPage.clickRegister();
         registerPage.clickBackToLogin();
         loginPage.assertCurrent(managedRealm.admin().toRepresentation().getRealm());
 
@@ -810,17 +837,9 @@ public class RegisterTest extends AbstractTestRealmKeycloakTest {
         driver.navigate().back();
         driver.navigate().back();
         events.clear();
+        driver.navigate().back();
 
-        UIUtils.navigateBackWithRefresh(driver, errorPage);
-        Assertions.assertEquals("Action expired. Please continue with login now.", errorPage.getError());
-
-        EventAssertion.assertError(events.poll())
-                .type(EventType.REGISTER_ERROR)
-                .error(Errors.GENERIC_AUTHENTICATION_ERROR)
-                .clientId(oauth.getClientId())
-                .details(Details.EXISTING_USER, "test-user@localhost")
-                .details(Details.AUTHENTICATION_ERROR_DETAIL, Errors.DIFFERENT_USER_AUTHENTICATING)
-                .withoutDetails(Details.USERNAME, Details.EMAIL);
+        registerPage.assertCurrent();
     }
 
     protected RealmAttributeUpdater configureRealmRegistrationEmailAsUsername(final boolean value) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -523,58 +523,6 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
     }
 
-    @Test
-    public void resetPasswordEmailLinkWorksAfterNavigatingBackToLoginPage() throws IOException {
-        oauth.openLoginForm();
-        loginPage.resetPassword();
-        resetPasswordPage.assertCurrent();
-        resetPasswordPage.backToLogin();
-
-        String urlWhenBackFromRegistrationPage = driver.getCurrentUrl();
-
-        loginPage.assertCurrent();
-        loginPage.resetPassword();
-        resetPasswordPage.assertCurrent();
-
-        resetPasswordPage.changePassword("login-test");
-        expectedMessagesCount++;
-
-        events.expectRequiredAction(EventType.SEND_RESET_PASSWORD)
-                .user(userId)
-                .detail(Details.USERNAME, "login-test")
-                .detail(Details.EMAIL, "login@test.com")
-                .session((String) null)
-                .assertEvent();
-
-        assertEquals(expectedMessagesCount, greenMail.getReceivedMessages().length);
-        MimeMessage message = greenMail.getReceivedMessages()[greenMail.getReceivedMessages().length - 1];
-        String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
-
-        // Navigate back to the login page, which triggers UsernamePasswordForm to clear the user from the auth session
-        driver.navigate().back();
-        driver.navigate().back();
-        String urlWhenWentBackFromResetPassword = driver.getCurrentUrl();
-        assertEquals(urlWhenBackFromRegistrationPage, urlWhenWentBackFromResetPassword);
-        loginPage.assertCurrent();
-
-        events.clear();
-        driver.navigate().to(changePasswordUrl.trim());
-
-        updatePasswordPage.assertCurrent();
-        assertEquals("You need to change your password.", updatePasswordPage.getFeedbackMessage());
-        updatePasswordPage.changePassword("resetPassword", "resetPassword");
-
-        events.expectRequiredAction(EventType.UPDATE_PASSWORD)
-                .detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE)
-                .user(userId).detail(Details.USERNAME, "login-test").assertEvent();
-        events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
-                .detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE)
-                .user(userId).detail(Details.USERNAME, "login-test").assertEvent();
-
-        assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
-        driver.getCurrentUrl();
-    }
-
     private void configureForceLogin(String value) {
         AuthenticationExecutionInfoRepresentation sendEmailExec = managedRealm.admin()
                 .flows()

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/ResetPasswordTest.java
@@ -523,6 +523,58 @@ public class ResetPasswordTest extends AbstractTestRealmKeycloakTest {
         loginPage.assertCurrent();
     }
 
+    @Test
+    public void resetPasswordEmailLinkWorksAfterNavigatingBackToLoginPage() throws IOException {
+        oauth.openLoginForm();
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+        resetPasswordPage.backToLogin();
+
+        String urlWhenBackFromRegistrationPage = driver.getCurrentUrl();
+
+        loginPage.assertCurrent();
+        loginPage.resetPassword();
+        resetPasswordPage.assertCurrent();
+
+        resetPasswordPage.changePassword("login-test");
+        expectedMessagesCount++;
+
+        events.expectRequiredAction(EventType.SEND_RESET_PASSWORD)
+                .user(userId)
+                .detail(Details.USERNAME, "login-test")
+                .detail(Details.EMAIL, "login@test.com")
+                .session((String) null)
+                .assertEvent();
+
+        assertEquals(expectedMessagesCount, greenMail.getReceivedMessages().length);
+        MimeMessage message = greenMail.getReceivedMessages()[greenMail.getReceivedMessages().length - 1];
+        String changePasswordUrl = MailUtils.getPasswordResetEmailLink(message);
+
+        // Navigate back to the login page, which triggers UsernamePasswordForm to clear the user from the auth session
+        driver.navigate().back();
+        driver.navigate().back();
+        String urlWhenWentBackFromResetPassword = driver.getCurrentUrl();
+        assertEquals(urlWhenBackFromRegistrationPage, urlWhenWentBackFromResetPassword);
+        loginPage.assertCurrent();
+
+        events.clear();
+        driver.navigate().to(changePasswordUrl.trim());
+
+        updatePasswordPage.assertCurrent();
+        assertEquals("You need to change your password.", updatePasswordPage.getFeedbackMessage());
+        updatePasswordPage.changePassword("resetPassword", "resetPassword");
+
+        events.expectRequiredAction(EventType.UPDATE_PASSWORD)
+                .detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE)
+                .user(userId).detail(Details.USERNAME, "login-test").assertEvent();
+        events.expectRequiredAction(EventType.UPDATE_CREDENTIAL)
+                .detail(Details.CREDENTIAL_TYPE, PasswordCredentialModel.TYPE)
+                .user(userId).detail(Details.USERNAME, "login-test").assertEvent();
+
+        assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        driver.getCurrentUrl();
+    }
+
     private void configureForceLogin(String value) {
         AuthenticationExecutionInfoRepresentation sendEmailExec = managedRealm.admin()
                 .flows()


### PR DESCRIPTION
Reopens #33254, closes #33204.

First of all, sorry for disappearing — a newborn arrived ~1.5 years ago and I never found the time to get back to this. Big thanks to @mposolda for keeping the previous PR open as long as he did.

I rebased the commits from #33254 and verified that the tests from last year still fail against the current `main` branch, so the issue is still present and the fix is still needed. I also tried to address the review discussion from last year. Specifically:


- **Cleared the `RESET_CREDENTIAL_USER_CHOSEN` auth note** after calling `context.clearUser()`, so that subsequent renders of the login page within the same auth session don't needlessly clear the user again.
- **Added `ResetPasswordTest::resetPasswordEmailLinkWorksAfterNavigatingBackToLoginPage`** to cover the scenario @mposolda raised: the user initiates a password reset, navigates back to the login page (which now clears the user from the auth session), and then clicks the email link. The test verifies the reset flow still completes successfully — it seems that a user who navigates back and then clicks the email link can still change their password and get logged in, which appears fine from a security standpoint. This test was roughly half AI-generated and half hand-reworked, using the tests I wrote for the previous PR as reference — all other code in this PR is hand-written from last year.


## What the fix does

When a user submits a username on the "Forgot Password?" page, Keycloak sets that user on the authentication session. If the user then navigates back to the login page without completing the reset flow, Keycloak was showing only the identity providers linked to that specific user's account — leaking which social providers they had connected, which is a user enumeration vulnerability per the [OWASP Forgot Password Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html).

The fix detects the `RESET_CREDENTIAL_USER_CHOSEN` auth note in `UsernamePasswordForm` and clears the user from context before rendering the login page, so all configured IDPs are shown regardless of which user was identified during the reset flow.
