### PR TITLE
Ignore oasis-open.org in ExternalLinksTest (26.6)

### DIFF
--- a/docs/documentation/tests/src/test/resources/ignored-links
+++ b/docs/documentation/tests/src/test/resources/ignored-links
@@ -40,10 +40,5 @@ https://www.npmjs.com/package/*
 # Failing because of broken certificate, can likely be restored later.
 https://docs.kantarainitiative.org*
 https://saml.xml.org*
-
-# To be removed once KC 26.6.0 is released
-https://www.keycloak.org/securing-apps/dpop
-https://www.keycloak.org/server/reverseproxy#graceful-http-shutdown
-https://www.keycloak.org/server/db#_secure_the_database_connection
-https://www.keycloak.org/server/logging#customize-service-fields
-https://www.keycloak.org/server/configuration#kcraw-prefix
+# Blocks automated HTTP requests from CI runners (returns 403), but loads fine in a browser.
+https://www.oasis-open.org/standard/saml/


### PR DESCRIPTION
Fixes #48681

PR:             https://github.com/keycloak/keycloak/pull/48682
Commit:         https://github.com/keycloak/keycloak/commit/33edd62a781116e2f076d897f75553045b8c43b0
PR branch:      backport-48682-26.6
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.6

I have also deleted the lines for 26.6 as in upstream. It worked for me.