### PR TITLE
Fix NPE in OrganizationGroupMembershipMapper when no organization scope is requested

### DIFF
--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationGroupMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationGroupMembershipMapper.java
@@ -137,6 +137,10 @@ public class OrganizationGroupMembershipMapper extends AbstractOIDCProtocolMappe
         String rawScopes = context.getScopeString(true);
         OrganizationScope scope = OrganizationScope.valueOfScope(session, rawScopes);
 
+        if (scope == null) {
+            return Stream.empty();
+        }
+
         return scope.resolveOrganizations(userSession.getUser(), rawScopes, session);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationGroupMembershipOIDCMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/organization/mapper/OrganizationGroupMembershipOIDCMapperTest.java
@@ -395,4 +395,24 @@ public class OrganizationGroupMembershipOIDCMapperTest extends AbstractOrganizat
         assertThat(groups, hasSize(1));
         assertThat(groups, hasItem("/engineering"));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testNoNpeWhenOrganizationScopeNotRequested() throws Exception {
+        OrganizationRepresentation orgRep = createOrganization("acme");
+        OrganizationResource org = managedRealm.admin().organizations().get(orgRep.getId());
+        addMember(org);
+
+        // Authenticate WITHOUT organization scope - should not throw NPE
+        oauth.client("direct-grant", "password");
+        oauth.scope("openid email profile");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(memberEmail, memberPassword);
+
+        // Token exchange must succeed (no HTTP 500 / NPE)
+        assertThat(response.getAccessToken(), notNullValue());
+
+        // Organization claims should not be present since org scope was not requested
+        AccessToken token = TokenVerifier.create(response.getAccessToken(), AccessToken.class).getToken();
+        assertThat(token.getOtherClaims(), not(hasKey(OAuth2Constants.ORGANIZATION)));
+    }
 }


### PR DESCRIPTION
Closes #48834

## Problem
OrganizationGroupMembershipMapper.resolveFromRequestedScopes() throws a NullPointerException when the authorization request does not include an organization:* scope. This is a regression introduced in 26.6.0 via #45511.

OrganizationScope.valueOfScope() returns null when no organization-related scope is present in the request. resolveFromRequestedScopes() then calls .resolveOrganizations() on the null reference, causing:


java.lang.NullPointerException: Cannot invoke "...OrganizationScope.resolveOrganizations(...)" because "scope" is null    at ...OrganizationGroupMembershipMapper.resolveFromRequestedScopes(OrganizationGroupMembershipMapper.java:129)
This breaks any auth code flow on realms with Organizations enabled when the client does not request an organization: scope and the user has no existing session (HTTP 500, {"error":"unknown_error"}).

## Fix
Add a null guard for the return value of OrganizationScope.valueOfScope(), returning Stream.empty() when null. This mirrors the existing null check in OrganizationMembershipMapper.resolveFromRequestedScopes().

A regression test (testNoNpeWhenOrganizationScopeNotRequested) is added to OrganizationGroupMembershipOIDCMapperTest.

## AI disclosure
AI tools (GitHub Copilot) were used to assist with locating the bug, drafting the issue, and reviewing the fix. The contributor understands the change and all code submitted.