### PR TITLE
Link authentication flow UsedBy clients to client settings

### DIFF
--- a/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
+++ b/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
@@ -15,7 +15,8 @@ import { Link } from "react-router-dom";
 import { useAdminClient } from "../../admin-client";
 import {
   fetchUsedBy,
-  type UsedByClientRef as FlowUsedByRow,
+  type UsedByClientRef,
+  type UsedByReference as FlowUsedByRow,
 } from "../../components/role-mapping/resource";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toClient } from "../../clients/routes/Client";
@@ -123,14 +124,14 @@ const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
                 cellRenderer: (row: FlowUsedByRow) => (
                   <ClientUsedByLink
                     id={row.id ?? undefined}
-                    clientId={row.clientId}
+                    clientId={row.label}
                   />
                 ),
               }
             : {
                 name: "name",
                 cellRenderer: (row: FlowUsedByRow) => (
-                  <strong>{row.clientId}</strong>
+                  <strong>{row.label}</strong>
                 ),
               },
         ]}
@@ -145,7 +146,7 @@ export const UsedBy = ({ authType: { id, usedBy } }: UsedByProps) => {
   const [open, toggle] = useToggle();
 
   const clientRefs = usedBy?.clientRefs;
-  const clientsOrFallback: FlowUsedByRow[] = useMemo(() => {
+  const clientsOrFallback: UsedByClientRef[] = useMemo(() => {
     if (!usedBy || usedBy.type !== "SPECIFIC_CLIENTS") {
       return [];
     }

--- a/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
+++ b/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
@@ -121,7 +121,10 @@ const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
                 name: "name",
                 displayKey: "name",
                 cellRenderer: (row: FlowUsedByRow) => (
-                  <ClientUsedByLink id={row.id ?? undefined} clientId={row.clientId} />
+                  <ClientUsedByLink
+                    id={row.id ?? undefined}
+                    clientId={row.clientId}
+                  />
                 ),
               }
             : {
@@ -182,7 +185,10 @@ export const UsedBy = ({ authType: { id, usedBy } }: UsedByProps) => {
                 {usedBy.type === "SPECIFIC_CLIENTS"
                   ? clientsOrFallback.map((ref, index) => (
                       <Fragment key={`${id}-used-${ref.clientId}-${index}`}>
-                        <ClientUsedByLink id={ref.id ?? undefined} clientId={ref.clientId} />
+                        <ClientUsedByLink
+                          id={ref.id ?? undefined}
+                          clientId={ref.clientId}
+                        />
                         {index < clientsOrFallback.length - 1 ? ", " : ""}
                       </Fragment>
                     ))

--- a/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
+++ b/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
@@ -9,14 +9,61 @@ import {
   TextVariants,
 } from "@patternfly/react-core";
 import { CheckCircleIcon } from "@patternfly/react-icons";
+import { Fragment, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
 import { useAdminClient } from "../../admin-client";
 import { fetchUsedBy } from "../../components/role-mapping/resource";
 import { useRealm } from "../../context/realm-context/RealmContext";
+import { toClient } from "../../clients/routes/Client";
 import useToggle from "../../utils/useToggle";
 import { AuthenticationType, REALM_FLOWS } from "../constants";
 
 import style from "./used-by.module.css";
+
+/** Resolves admin UI client route id from the flow-binding clientId string returned by authentication-management flows. */
+const ClientUsedByLink = ({ clientIdLabel }: { clientIdLabel: string }) => {
+  const { adminClient } = useAdminClient();
+  const { realm } = useRealm();
+  const [internalId, setInternalId] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const clients = await adminClient.clients.find({
+          clientId: clientIdLabel,
+        });
+        const match = clients.find((c) => c.clientId === clientIdLabel);
+        if (!cancelled && match?.id) {
+          setInternalId(match.id);
+        }
+      } catch {
+        /* keep plain label */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [adminClient, clientIdLabel]);
+
+  const label = <strong>{clientIdLabel}</strong>;
+  if (!internalId) {
+    return label;
+  }
+
+  return (
+    <Link
+      to={toClient({
+        realm,
+        clientId: internalId,
+        tab: "settings",
+      })}
+    >
+      {label}
+    </Link>
+  );
+};
 
 type UsedByProps = {
   authType: AuthenticationType;
@@ -86,9 +133,17 @@ const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
         ariaLabelKey="usedBy"
         searchPlaceholderKey="search"
         columns={[
-          {
-            name: "name",
-          },
+          isSpecificClient
+            ? {
+                name: "name",
+                displayKey: "name",
+                cellRenderer: (row: { name: string }) => (
+                  <ClientUsedByLink clientIdLabel={row.name} />
+                ),
+              }
+            : {
+                name: "name",
+              },
         ]}
       />
     </Modal>
@@ -128,10 +183,14 @@ export const UsedBy = ({ authType: { id, usedBy } }: UsedByProps) => {
                       : "Providers"),
                 )}{" "}
                 {usedBy.values.map((used, index) => (
-                  <>
-                    <strong>{used}</strong>
+                  <Fragment key={`${id}-used-${used}-${index}`}>
+                    {usedBy.type === "SPECIFIC_CLIENTS" ? (
+                      <ClientUsedByLink clientIdLabel={used} />
+                    ) : (
+                      <strong>{used}</strong>
+                    )}
                     {index < usedBy.values.length - 1 ? ", " : ""}
-                  </>
+                  </Fragment>
                 ))}
               </div>
             }

--- a/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
+++ b/js/apps/admin-ui/src/authentication/components/UsedBy.tsx
@@ -9,11 +9,14 @@ import {
   TextVariants,
 } from "@patternfly/react-core";
 import { CheckCircleIcon } from "@patternfly/react-icons";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useAdminClient } from "../../admin-client";
-import { fetchUsedBy } from "../../components/role-mapping/resource";
+import {
+  fetchUsedBy,
+  type UsedByClientRef as FlowUsedByRow,
+} from "../../components/role-mapping/resource";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { toClient } from "../../clients/routes/Client";
 import useToggle from "../../utils/useToggle";
@@ -21,42 +24,23 @@ import { AuthenticationType, REALM_FLOWS } from "../constants";
 
 import style from "./used-by.module.css";
 
-/** Resolves admin UI client route id from the flow-binding clientId string returned by authentication-management flows. */
-const ClientUsedByLink = ({ clientIdLabel }: { clientIdLabel: string }) => {
-  const { adminClient } = useAdminClient();
+const ClientUsedByLink = ({
+  id,
+  clientId,
+}: {
+  id?: string;
+  clientId: string;
+}) => {
   const { realm } = useRealm();
-  const [internalId, setInternalId] = useState<string | undefined>();
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const clients = await adminClient.clients.find({
-          clientId: clientIdLabel,
-        });
-        const match = clients.find((c) => c.clientId === clientIdLabel);
-        if (!cancelled && match?.id) {
-          setInternalId(match.id);
-        }
-      } catch {
-        /* keep plain label */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [adminClient, clientIdLabel]);
-
-  const label = <strong>{clientIdLabel}</strong>;
-  if (!internalId) {
+  const label = <strong>{clientId}</strong>;
+  if (!id) {
     return label;
   }
-
   return (
     <Link
       to={toClient({
         realm,
-        clientId: internalId,
+        clientId: id,
         tab: "settings",
       })}
     >
@@ -90,15 +74,14 @@ const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
     first?: number,
     max?: number,
     search?: string,
-  ): Promise<{ name: string }[]> => {
-    const result = await fetchUsedBy(adminClient, {
+  ): Promise<FlowUsedByRow[]> => {
+    return fetchUsedBy(adminClient, {
       id,
       type: isSpecificClient ? "clients" : "idp",
       first: first || 0,
       max: max || 10,
       search,
     });
-    return result.map((p) => ({ name: p }));
   };
 
   return (
@@ -137,12 +120,15 @@ const UsedByModal = ({ id, isSpecificClient, onClose }: UsedByModalProps) => {
             ? {
                 name: "name",
                 displayKey: "name",
-                cellRenderer: (row: { name: string }) => (
-                  <ClientUsedByLink clientIdLabel={row.name} />
+                cellRenderer: (row: FlowUsedByRow) => (
+                  <ClientUsedByLink id={row.id ?? undefined} clientId={row.clientId} />
                 ),
               }
             : {
                 name: "name",
+                cellRenderer: (row: FlowUsedByRow) => (
+                  <strong>{row.clientId}</strong>
+                ),
               },
         ]}
       />
@@ -154,6 +140,17 @@ export const UsedBy = ({ authType: { id, usedBy } }: UsedByProps) => {
   const { t } = useTranslation();
   const { realmRepresentation: realm } = useRealm();
   const [open, toggle] = useToggle();
+
+  const clientRefs = usedBy?.clientRefs;
+  const clientsOrFallback: FlowUsedByRow[] = useMemo(() => {
+    if (!usedBy || usedBy.type !== "SPECIFIC_CLIENTS") {
+      return [];
+    }
+    if (clientRefs && clientRefs.length > 0) {
+      return clientRefs;
+    }
+    return usedBy.values.map((clientId) => ({ clientId }));
+  }, [usedBy, clientRefs]);
 
   const key = Object.entries(realm!).find(
     (e) => e[1] === usedBy?.values[0],
@@ -182,16 +179,19 @@ export const UsedBy = ({ authType: { id, usedBy } }: UsedByProps) => {
                       ? "Clients"
                       : "Providers"),
                 )}{" "}
-                {usedBy.values.map((used, index) => (
-                  <Fragment key={`${id}-used-${used}-${index}`}>
-                    {usedBy.type === "SPECIFIC_CLIENTS" ? (
-                      <ClientUsedByLink clientIdLabel={used} />
-                    ) : (
-                      <strong>{used}</strong>
-                    )}
-                    {index < usedBy.values.length - 1 ? ", " : ""}
-                  </Fragment>
-                ))}
+                {usedBy.type === "SPECIFIC_CLIENTS"
+                  ? clientsOrFallback.map((ref, index) => (
+                      <Fragment key={`${id}-used-${ref.clientId}-${index}`}>
+                        <ClientUsedByLink id={ref.id ?? undefined} clientId={ref.clientId} />
+                        {index < clientsOrFallback.length - 1 ? ", " : ""}
+                      </Fragment>
+                    ))
+                  : usedBy.values.map((used, index) => (
+                      <Fragment key={`${id}-used-${used}-${index}`}>
+                        <strong>{used}</strong>
+                        {index < usedBy.values.length - 1 ? ", " : ""}
+                      </Fragment>
+                    ))}
               </div>
             }
           >

--- a/js/apps/admin-ui/src/authentication/constants.ts
+++ b/js/apps/admin-ui/src/authentication/constants.ts
@@ -1,10 +1,18 @@
 import AuthenticationFlowRepresentation from "@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation";
 import RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 
+import type { UsedByClientRef } from "../components/role-mapping/resource";
+
+export type { UsedByClientRef };
+
 type UsedBy = "SPECIFIC_CLIENTS" | "SPECIFIC_PROVIDERS" | "DEFAULT";
 
 export type AuthenticationType = AuthenticationFlowRepresentation & {
-  usedBy?: { type?: UsedBy; values: string[] };
+  usedBy?: {
+    type?: UsedBy;
+    values: string[];
+    clientRefs?: UsedByClientRef[];
+  };
   realm: RealmRepresentation;
 };
 

--- a/js/apps/admin-ui/src/components/role-mapping/resource.ts
+++ b/js/apps/admin-ui/src/components/role-mapping/resource.ts
@@ -154,10 +154,15 @@ export type UsedByClientRef = {
   clientId: string;
 };
 
+export type UsedByReference = {
+  id?: string | null;
+  label: string;
+};
+
 export const fetchUsedBy = (
   adminClient: KeycloakAdminClient,
   query: PaginatingQuery,
-): Promise<UsedByClientRef[]> =>
+): Promise<UsedByReference[]> =>
   fetchEndpoint(adminClient, {
     ...query,
     endpoint: "authentication-management",

--- a/js/apps/admin-ui/src/components/role-mapping/resource.ts
+++ b/js/apps/admin-ui/src/components/role-mapping/resource.ts
@@ -149,10 +149,15 @@ export const findUsers = (
     query as Record<string, string>,
   );
 
+export type UsedByClientRef = {
+  id?: string | null;
+  clientId: string;
+};
+
 export const fetchUsedBy = (
   adminClient: KeycloakAdminClient,
   query: PaginatingQuery,
-): Promise<string[]> =>
+): Promise<UsedByClientRef[]> =>
   fetchEndpoint(adminClient, {
     ...query,
     endpoint: "authentication-management",

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AuthenticationManagementResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AuthenticationManagementResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.keycloak.admin.ui.rest.model.Authentication;
 import org.keycloak.admin.ui.rest.model.AuthenticationMapper;
 import org.keycloak.admin.ui.rest.model.ConfigurableRequiredActionProviderRepresentation;
+import org.keycloak.admin.ui.rest.model.UsedByClientRef;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.models.AuthenticationFlowModel;
@@ -89,12 +90,12 @@ public class AuthenticationManagementResource extends RoleMappingResource {
             description = "",
             content = {@Content(
                     schema = @Schema(
-                            implementation = String.class,
+                            implementation = UsedByClientRef.class,
                             type = SchemaType.ARRAY
                     )
             )}
     )
-    public final List<String> listUsed(@PathParam("id") String id, @PathParam("type") String type, @QueryParam("first") @DefaultValue("0") int first,
+    public final List<UsedByClientRef> listUsed(@PathParam("id") String id, @PathParam("type") String type, @QueryParam("first") @DefaultValue("0") int first,
             @QueryParam("max") @DefaultValue("10") int max, @QueryParam("search") @DefaultValue("") String search) {
         auth.realm().requireViewAuthenticationFlows();
 
@@ -106,12 +107,13 @@ public class AuthenticationManagementResource extends RoleMappingResource {
                             c -> c.getAuthenticationFlowBindingOverrides().get("browser") != null && c.getAuthenticationFlowBindingOverrides()
                                     .get("browser").equals(flow.getId()) || c.getAuthenticationFlowBindingOverrides()
                                     .get("direct_grant") != null && c.getAuthenticationFlowBindingOverrides().get("direct_grant").equals(flow.getId()))
-                    .map(ClientModel::getClientId).filter(f -> f.contains(search))
+                    .map(c -> new UsedByClientRef(c.getId(), c.getClientId())).filter(ref -> ref.getClientId().contains(search))
                     .skip("".equals(search) ? first : 0).limit(max).collect(Collectors.toList());
         }
 
         if ("idp".equals(type)) {
-            return session.identityProviders().getByFlow(flow.getId(), search, first, max).toList();
+            return session.identityProviders().getByFlow(flow.getId(), search, first, max)
+                    .map(alias -> new UsedByClientRef(null, alias)).collect(Collectors.toList());
         }
 
         throw new IllegalArgumentException("Invalid type");

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AuthenticationManagementResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/AuthenticationManagementResource.java
@@ -17,7 +17,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.keycloak.admin.ui.rest.model.Authentication;
 import org.keycloak.admin.ui.rest.model.AuthenticationMapper;
 import org.keycloak.admin.ui.rest.model.ConfigurableRequiredActionProviderRepresentation;
-import org.keycloak.admin.ui.rest.model.UsedByClientRef;
+import org.keycloak.admin.ui.rest.model.UsedByReference;
 import org.keycloak.authentication.RequiredActionFactory;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.models.AuthenticationFlowModel;
@@ -90,12 +90,12 @@ public class AuthenticationManagementResource extends RoleMappingResource {
             description = "",
             content = {@Content(
                     schema = @Schema(
-                            implementation = UsedByClientRef.class,
+                            implementation = UsedByReference.class,
                             type = SchemaType.ARRAY
                     )
             )}
     )
-    public final List<UsedByClientRef> listUsed(@PathParam("id") String id, @PathParam("type") String type, @QueryParam("first") @DefaultValue("0") int first,
+    public final List<UsedByReference> listUsed(@PathParam("id") String id, @PathParam("type") String type, @QueryParam("first") @DefaultValue("0") int first,
             @QueryParam("max") @DefaultValue("10") int max, @QueryParam("search") @DefaultValue("") String search) {
         auth.realm().requireViewAuthenticationFlows();
 
@@ -107,13 +107,13 @@ public class AuthenticationManagementResource extends RoleMappingResource {
                             c -> c.getAuthenticationFlowBindingOverrides().get("browser") != null && c.getAuthenticationFlowBindingOverrides()
                                     .get("browser").equals(flow.getId()) || c.getAuthenticationFlowBindingOverrides()
                                     .get("direct_grant") != null && c.getAuthenticationFlowBindingOverrides().get("direct_grant").equals(flow.getId()))
-                    .map(c -> new UsedByClientRef(c.getId(), c.getClientId())).filter(ref -> ref.getClientId().contains(search))
-                    .skip("".equals(search) ? first : 0).limit(max).collect(Collectors.toList());
+                    .map(c -> new UsedByReference(c.getId(), c.getClientId())).filter(ref -> ref.getLabel().contains(search))
+                    .skip(first).limit(max).collect(Collectors.toList());
         }
 
         if ("idp".equals(type)) {
             return session.identityProviders().getByFlow(flow.getId(), search, first, max)
-                    .map(alias -> new UsedByClientRef(null, alias)).collect(Collectors.toList());
+                    .map(alias -> new UsedByReference(null, alias)).collect(Collectors.toList());
         }
 
         throw new IllegalArgumentException("Invalid type");

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/AuthenticationMapper.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/AuthenticationMapper.java
@@ -1,7 +1,9 @@
 package org.keycloak.admin.ui.rest.model;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,12 +31,16 @@ public class AuthenticationMapper {
 
         Stream<ClientModel> browserFlowOverridingClients = realm.searchClientByAuthenticationFlowBindingOverrides(Collections.singletonMap("browser", flow.getId()), 0, MAX_USED_BY);
         Stream<ClientModel> directGrantFlowOverridingClients = realm.searchClientByAuthenticationFlowBindingOverrides(Collections.singletonMap("direct_grant", flow.getId()), 0, MAX_USED_BY);
-        final List<String> usedClients = Stream.concat(browserFlowOverridingClients, directGrantFlowOverridingClients)
-                .limit(MAX_USED_BY)
-                .map(ClientModel::getClientId).collect(Collectors.toList());
+        Map<String, ClientModel> clientsByInternalId = new LinkedHashMap<>();
+        Stream.concat(browserFlowOverridingClients, directGrantFlowOverridingClients).forEach(c -> clientsByInternalId.putIfAbsent(c.getId(), c));
+
+        final List<ClientModel> clientModels = clientsByInternalId.values().stream().limit(MAX_USED_BY).collect(Collectors.toList());
+        final List<String> usedClients = clientModels.stream().map(ClientModel::getClientId).collect(Collectors.toList());
+        final List<UsedByClientRef> clientRefs = clientModels.stream()
+                .map(c -> new UsedByClientRef(c.getId(), c.getClientId())).collect(Collectors.toList());
 
         if (!usedClients.isEmpty()) {
-            authentication.setUsedBy(new UsedBy(UsedBy.UsedByType.SPECIFIC_CLIENTS, usedClients));
+            authentication.setUsedBy(new UsedBy(UsedBy.UsedByType.SPECIFIC_CLIENTS, usedClients, clientRefs));
         }
 
         final List<String> useAsDefault = Stream.of(realm.getBrowserFlow(), realm.getRegistrationFlow(), realm.getDirectGrantFlow(),

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/UsedBy.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/UsedBy.java
@@ -3,10 +3,17 @@ package org.keycloak.admin.ui.rest.model;
 import java.util.List;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 public class UsedBy {
     public UsedBy(UsedByType type, List<String> values) {
+        this(type, values, null);
+    }
+
+    public UsedBy(UsedByType type, List<String> values, List<UsedByClientRef> clientRefs) {
         this.type = type;
         this.values = values;
+        this.clientRefs = clientRefs;
     }
 
     public enum UsedByType {
@@ -15,6 +22,12 @@ public class UsedBy {
 
     private UsedByType type;
     private List<String> values;
+
+    /**
+     * Populated for {@link UsedByType#SPECIFIC_CLIENTS} flows so the admin UI can link to client settings without resolving clientId to internal id client-side.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<UsedByClientRef> clientRefs;
 
     public UsedByType getType() {
         return type;
@@ -32,6 +45,14 @@ public class UsedBy {
         this.values = values;
     }
 
+    public List<UsedByClientRef> getClientRefs() {
+        return clientRefs;
+    }
+
+    public void setClientRefs(List<UsedByClientRef> clientRefs) {
+        this.clientRefs = clientRefs;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -39,11 +60,12 @@ public class UsedBy {
         if (o == null || getClass() != o.getClass())
             return false;
         UsedBy usedBy = (UsedBy) o;
-        return type == usedBy.type && Objects.equals(values, usedBy.values);
+        return type == usedBy.type && Objects.equals(values, usedBy.values)
+                && Objects.equals(clientRefs, usedBy.clientRefs);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, values);
+        return Objects.hash(type, values, clientRefs);
     }
 }

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/UsedByClientRef.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/UsedByClientRef.java
@@ -1,0 +1,53 @@
+package org.keycloak.admin.ui.rest.model;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public class UsedByClientRef {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String id;
+    private String clientId;
+
+    public UsedByClientRef() {
+    }
+
+    public UsedByClientRef(String id, String clientId) {
+        this.id = id;
+        this.clientId = clientId;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UsedByClientRef that = (UsedByClientRef) o;
+        return Objects.equals(id, that.id) && Objects.equals(clientId, that.clientId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, clientId);
+    }
+}

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/UsedByReference.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/model/UsedByReference.java
@@ -1,0 +1,53 @@
+package org.keycloak.admin.ui.rest.model;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public class UsedByReference {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String id;
+    private String label;
+
+    public UsedByReference() {
+    }
+
+    public UsedByReference(String id, String label) {
+        this.id = id;
+        this.label = label;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UsedByReference that = (UsedByReference) o;
+        return Objects.equals(id, that.id) && Objects.equals(label, that.label);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, label);
+    }
+}


### PR DESCRIPTION
Closes #40211.

Problem:
The authentication flows table can show which clients override a flow, but the Admin UI only had the clientId label and could not link directly to the client settings page.

Root cause:
The existing used-by payload exposed display labels but not the internal client UUID required by the client settings route.

Solution:
- Include client references with internal id and clientId in the flows payload for client-specific used-by hints.
- Return neutral `{ id, label }` rows from the paginated used-by endpoint so both client and identity-provider results have a clear contract.
- Link client used-by rows when an internal id is available and keep identity-provider rows as plain labels.
- Preserve pagination while searching by applying `skip(first)` after filtering client rows.

Verification:
- `corepack pnpm exec prettier --check apps/admin-ui/src/authentication/components/UsedBy.tsx apps/admin-ui/src/components/role-mapping/resource.ts`
- `corepack pnpm --filter @keycloak/keycloak-admin-ui build`
- `.\mvnw.cmd -pl rest/admin-ui-ext -am -DskipTests -DskipITs compile`
- `git diff --check`