### PR TITLE
Allow to query users with both `search` and `q` parameters

### DIFF
--- a/federation/ipatuura/pom.xml
+++ b/federation/ipatuura/pom.xml
@@ -59,6 +59,11 @@
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/federation/ipatuura/src/main/java/org/keycloak/ipatuura_user_spi/IpatuuraUserStorageProvider.java
+++ b/federation/ipatuura/src/main/java/org/keycloak/ipatuura_user_spi/IpatuuraUserStorageProvider.java
@@ -59,6 +59,14 @@ import org.jboss.logging.Logger;
  */
 public class IpatuuraUserStorageProvider implements UserStorageProvider, UserLookupProvider, CredentialInputValidator,
         CredentialAuthentication, UserRegistrationProvider, UserQueryProvider, ImportedUserValidation {
+    private static final Set<String> SUPPORTED_USER_QUERY_PARAMETERS = Set.of(
+            UserModel.SEARCH,
+            UserModel.INCLUDE_SERVICE_ACCOUNT,
+            UserModel.ENABLED,
+            UserModel.EMAIL_VERIFIED,
+            UserModel.CREATED_AFTER,
+            UserModel.CREATED_BEFORE);
+
     protected KeycloakSession session;
     protected ComponentModel model;
     protected Ipatuura ipatuura;
@@ -287,9 +295,40 @@ public class IpatuuraUserStorageProvider implements UserStorageProvider, UserLoo
             Integer maxResults) {
         String search = params.get(UserModel.SEARCH);
         /* only supports searching by username */
-        if (search == null)
+        if (search == null || !supportsSearchParameters(params))
             return Stream.empty();
-        return performSearch(realm, search);
+        return performSearch(realm, search)
+                .filter(user -> matchesStandardFilters(params, user.isEnabled(), user.isEmailVerified(),
+                        user.getCreatedTimestamp()));
+    }
+
+    static boolean supportsSearchParameters(Map<String, String> params) {
+        return SUPPORTED_USER_QUERY_PARAMETERS.containsAll(params.keySet());
+    }
+
+    static boolean matchesStandardFilters(Map<String, String> params, boolean enabled, boolean emailVerified,
+            Long createdTimestamp) {
+        String enabledFilter = params.get(UserModel.ENABLED);
+        if (enabledFilter != null && enabled != Boolean.parseBoolean(enabledFilter)) {
+            return false;
+        }
+
+        String emailVerifiedFilter = params.get(UserModel.EMAIL_VERIFIED);
+        if (emailVerifiedFilter != null && emailVerified != Boolean.parseBoolean(emailVerifiedFilter)) {
+            return false;
+        }
+
+        String createdAfter = params.get(UserModel.CREATED_AFTER);
+        if (createdAfter != null && (createdTimestamp == null || createdTimestamp < Long.parseLong(createdAfter))) {
+            return false;
+        }
+
+        String createdBefore = params.get(UserModel.CREATED_BEFORE);
+        if (createdBefore != null && (createdTimestamp == null || createdTimestamp > Long.parseLong(createdBefore))) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/federation/ipatuura/src/test/java/org/keycloak/ipatuura_user_spi/IpatuuraUserStorageProviderTest.java
+++ b/federation/ipatuura/src/test/java/org/keycloak/ipatuura_user_spi/IpatuuraUserStorageProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.ipatuura_user_spi;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.keycloak.models.UserModel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IpatuuraUserStorageProviderTest {
+
+    @Test
+    public void matchesEnabledFilter() {
+        assertTrue(matches(Map.of(UserModel.ENABLED, "true"), true, false, 1000L));
+        assertFalse(matches(Map.of(UserModel.ENABLED, "true"), false, false, 1000L));
+        assertTrue(matches(Map.of(UserModel.ENABLED, "false"), false, false, 1000L));
+    }
+
+    @Test
+    public void matchesEmailVerifiedFilter() {
+        assertTrue(matches(Map.of(UserModel.EMAIL_VERIFIED, "true"), true, true, 1000L));
+        assertFalse(matches(Map.of(UserModel.EMAIL_VERIFIED, "true"), true, false, 1000L));
+        assertTrue(matches(Map.of(UserModel.EMAIL_VERIFIED, "false"), true, false, 1000L));
+    }
+
+    @Test
+    public void matchesInclusiveCreatedTimestampFilters() {
+        assertTrue(matches(Map.of(UserModel.CREATED_AFTER, "1000"), true, false, 1000L));
+        assertFalse(matches(Map.of(UserModel.CREATED_AFTER, "1001"), true, false, 1000L));
+        assertTrue(matches(Map.of(UserModel.CREATED_BEFORE, "1000"), true, false, 1000L));
+        assertFalse(matches(Map.of(UserModel.CREATED_BEFORE, "999"), true, false, 1000L));
+    }
+
+    @Test
+    public void doesNotMatchCreatedTimestampFiltersWithoutTimestamp() {
+        assertFalse(matches(Map.of(UserModel.CREATED_AFTER, "1000"), true, false, null));
+        assertFalse(matches(Map.of(UserModel.CREATED_BEFORE, "1000"), true, false, null));
+    }
+
+    @Test
+    public void combinesStandardFiltersWithLogicalAnd() {
+        Map<String, String> filters = Map.of(
+                UserModel.ENABLED, "true",
+                UserModel.EMAIL_VERIFIED, "false",
+                UserModel.CREATED_AFTER, "1000",
+                UserModel.CREATED_BEFORE, "2000");
+
+        assertTrue(matches(filters, true, false, 1500L));
+        assertFalse(matches(filters, false, false, 1500L));
+        assertFalse(matches(filters, true, true, 1500L));
+        assertFalse(matches(filters, true, false, 999L));
+        assertFalse(matches(filters, true, false, 2001L));
+    }
+
+    @Test
+    public void matchesWhenNoStandardFiltersAreSupplied() {
+        assertTrue(matches(Collections.emptyMap(), true, false, null));
+    }
+
+    @Test
+    public void rejectsUnsupportedCustomAttributes() {
+        assertFalse(IpatuuraUserStorageProvider.supportsSearchParameters(Map.of(
+                UserModel.SEARCH, "alice",
+                "department", "IT")));
+        assertTrue(IpatuuraUserStorageProvider.supportsSearchParameters(Map.of(
+                UserModel.SEARCH, "alice",
+                UserModel.INCLUDE_SERVICE_ACCOUNT, "false",
+                UserModel.ENABLED, "true",
+                UserModel.EMAIL_VERIFIED, "false",
+                UserModel.CREATED_AFTER, "1000",
+                UserModel.CREATED_BEFORE, "2000")));
+    }
+
+    private static boolean matches(Map<String, String> params, boolean enabled, boolean emailVerified,
+            Long createdTimestamp) {
+        return IpatuuraUserStorageProvider.matchesStandardFilters(params, enabled, emailVerified, createdTimestamp);
+    }
+}

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -123,6 +123,10 @@ public class LDAPStorageProvider implements UserStorageProvider,
         UserProfileDecorator {
     private static final Logger logger = Logger.getLogger(LDAPStorageProvider.class);
     private static final int DEFAULT_MAX_RESULTS = Integer.MAX_VALUE >> 1;
+    private static final Set<String> MODEL_FILTERED_USER_QUERY_PARAMETERS = Set.of(
+            UserModel.EMAIL_VERIFIED,
+            UserModel.CREATED_AFTER,
+            UserModel.CREATED_BEFORE);
     public static final List<String> INTERNAL_ATTRIBUTES = List.of(UserModel.LOCALE);
 
     protected LDAPStorageProviderFactory factory;
@@ -398,19 +402,47 @@ public class LDAPStorageProvider implements UserStorageProvider,
      */
     @Override
     public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
-        String search = params.get(UserModel.SEARCH);
-        Stream<LDAPObject> result = search != null ?
-                searchLDAP(realm, search, firstResult, maxResults) :
-                searchLDAPByAttributes(realm, params, firstResult, maxResults);
+        Map<String, String> ldapParams = new HashMap<>(params);
+        Map<String, String> modelFilters = new HashMap<>();
+        MODEL_FILTERED_USER_QUERY_PARAMETERS.forEach(parameter -> {
+            String value = ldapParams.remove(parameter);
+            if (value != null) {
+                modelFilters.put(parameter, value);
+            }
+        });
+
+        Integer ldapFirstResult = modelFilters.isEmpty() ? firstResult : null;
+        Integer ldapMaxResults = modelFilters.isEmpty() ? maxResults : null;
+        Stream<LDAPObject> result = searchLDAPByAttributes(realm, ldapParams, ldapFirstResult, ldapMaxResults);
 
         if (model.isImportEnabled()) {
             result = result.filter(filterLocalUsers(realm));
         }
-        return StreamsUtil.paginatedStream(
+        Stream<UserModel> users = result
                 // search users but not force import returning null as they were returned before by the DB
-                result.map(ldapObject -> importUserFromLDAP(session, realm, ldapObject, ImportType.NOT_FORCED_RETURN_NULL))
-                        .filter(Objects::nonNull),
-                firstResult, maxResults);
+                .map(ldapObject -> importUserFromLDAP(session, realm, ldapObject, ImportType.NOT_FORCED_RETURN_NULL))
+                .filter(Objects::nonNull);
+        if (!modelFilters.isEmpty()) {
+            users = users.filter(user -> matchesModelFilters(user, modelFilters));
+        }
+        return StreamsUtil.paginatedStream(users, firstResult, maxResults);
+    }
+
+    private boolean matchesModelFilters(UserModel user, Map<String, String> filters) {
+        String emailVerified = filters.get(UserModel.EMAIL_VERIFIED);
+        if (emailVerified != null && user.isEmailVerified() != Boolean.parseBoolean(emailVerified)) {
+            return false;
+        }
+
+        Long createdTimestamp = user.getCreatedTimestamp();
+        String createdAfter = filters.get(UserModel.CREATED_AFTER);
+        if (createdAfter != null && (createdTimestamp == null || createdTimestamp < Long.parseLong(createdAfter))) {
+            return false;
+        }
+
+        String createdBefore = filters.get(UserModel.CREATED_BEFORE);
+        return createdBefore == null
+                || createdTimestamp != null && createdTimestamp <= Long.parseLong(createdBefore);
     }
 
     @Override
@@ -554,7 +586,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
             for (Map.Entry<String, String> entry : attributes.entrySet()) {
                 String attrName = entry.getKey();
-                if (LDAPConstants.LDAP_ID.equals(attrName)) {
+                if (UserModel.SEARCH.equals(attrName)) {
+                    addSearchConditions(ldapQuery, conditionsBuilder, entry.getValue());
+                } else if (LDAPConstants.LDAP_ID.equals(attrName)) {
                     String uuidLDAPAttributeName = this.ldapIdentityStore.getConfig().getUuidLDAPAttributeName();
                     Condition usernameCondition = conditionsBuilder.equal(uuidLDAPAttributeName, entry.getValue());
                     ldapQuery.addWhereCondition(usernameCondition);
@@ -599,45 +633,25 @@ public class LDAPStorageProvider implements UserStorageProvider,
         }
     }
 
-    /**
-     * Searches LDAP using logical disjunction of params. It supports
-     * <ul>
-     *     <li>{@link UserModel#FIRST_NAME}</li>
-     *     <li>{@link UserModel#LAST_NAME}</li>
-     *     <li>{@link UserModel#EMAIL}</li>
-     *     <li>{@link UserModel#USERNAME}</li>
-     * </ul>
-     *
-     * It uses multiple LDAP calls and results are combined together with respect to firstResult and maxResults
-     *
-     * This method serves for {@code search} param of {@link org.keycloak.services.resources.admin.UsersResource#getUsers}
-     */
-    private Stream<LDAPObject> searchLDAP(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-
-        try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm)) {
-            LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
-
-            for (String s : search.split("\\s+")) {
-                boolean equals = false;
-                List<Condition> conditions = new LinkedList<>();
-                if (s.startsWith("\"") && s.endsWith("\"")) {
-                    // exact search
-                    s = s.substring(1, s.length() - 1);
-                    equals = true;
-                } else if (!s.endsWith("*")) {
-                    // default to prefix search
-                    s += "*";
-                }
-
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.USERNAME, equals, s));
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.EMAIL, equals, s));
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.FIRST_NAME, equals, s));
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.LAST_NAME, equals, s));
-
-                ldapQuery.addWhereCondition(conditionsBuilder.orCondition(conditions.toArray(Condition[]::new)));
+    private void addSearchConditions(LDAPQuery ldapQuery, LDAPQueryConditionsBuilder conditionsBuilder, String search) {
+        for (String s : search.split("\\s+")) {
+            boolean equals = false;
+            List<Condition> conditions = new LinkedList<>();
+            if (s.startsWith("\"") && s.endsWith("\"")) {
+                // exact search
+                s = s.substring(1, s.length() - 1);
+                equals = true;
+            } else if (!s.endsWith("*")) {
+                // default to prefix search
+                s += "*";
             }
 
-            return paginatedSearchLDAP(ldapQuery, firstResult, maxResults);
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.USERNAME, equals, s));
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.EMAIL, equals, s));
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.FIRST_NAME, equals, s));
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.LAST_NAME, equals, s));
+
+            ldapQuery.addWhereCondition(conditionsBuilder.orCondition(conditions.toArray(Condition[]::new)));
         }
     }
 

--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProvider.java
@@ -123,6 +123,10 @@ public class LDAPStorageProvider implements UserStorageProvider,
         UserProfileDecorator {
     private static final Logger logger = Logger.getLogger(LDAPStorageProvider.class);
     private static final int DEFAULT_MAX_RESULTS = Integer.MAX_VALUE >> 1;
+    private static final Set<String> MODEL_FILTERED_USER_QUERY_PARAMETERS = Set.of(
+            UserModel.EMAIL_VERIFIED,
+            UserModel.CREATED_AFTER,
+            UserModel.CREATED_BEFORE);
     public static final List<String> INTERNAL_ATTRIBUTES = List.of(UserModel.LOCALE);
 
     protected LDAPStorageProviderFactory factory;
@@ -398,19 +402,47 @@ public class LDAPStorageProvider implements UserStorageProvider,
      */
     @Override
     public Stream<UserModel> searchForUserStream(RealmModel realm, Map<String, String> params, Integer firstResult, Integer maxResults) {
-        String search = params.get(UserModel.SEARCH);
-        Stream<LDAPObject> result = search != null ?
-                searchLDAP(realm, search, firstResult, maxResults) :
-                searchLDAPByAttributes(realm, params, firstResult, maxResults);
+        Map<String, String> ldapParams = new HashMap<>(params);
+        Map<String, String> modelFilters = new HashMap<>();
+        MODEL_FILTERED_USER_QUERY_PARAMETERS.forEach(parameter -> {
+            String value = ldapParams.remove(parameter);
+            if (value != null) {
+                modelFilters.put(parameter, value);
+            }
+        });
+
+        Integer ldapFirstResult = modelFilters.isEmpty() ? firstResult : null;
+        Integer ldapMaxResults = modelFilters.isEmpty() ? maxResults : null;
+        Stream<LDAPObject> result = searchLDAPByAttributes(realm, ldapParams, ldapFirstResult, ldapMaxResults);
 
         if (model.isImportEnabled()) {
             result = result.filter(filterLocalUsers(realm));
         }
-        return StreamsUtil.paginatedStream(
+        Stream<UserModel> users = result
                 // search users but not force import returning null as they were returned before by the DB
-                result.map(ldapObject -> importUserFromLDAP(session, realm, ldapObject, ImportType.NOT_FORCED_RETURN_NULL))
-                        .filter(Objects::nonNull),
-                firstResult, maxResults);
+                .map(ldapObject -> importUserFromLDAP(session, realm, ldapObject, ImportType.NOT_FORCED_RETURN_NULL))
+                .filter(Objects::nonNull);
+        if (!modelFilters.isEmpty()) {
+            users = users.filter(user -> matchesModelFilters(user, modelFilters));
+        }
+        return StreamsUtil.paginatedStream(users, firstResult, maxResults);
+    }
+
+    private boolean matchesModelFilters(UserModel user, Map<String, String> filters) {
+        String emailVerified = filters.get(UserModel.EMAIL_VERIFIED);
+        if (emailVerified != null && user.isEmailVerified() != Boolean.parseBoolean(emailVerified)) {
+            return false;
+        }
+
+        Long createdTimestamp = user.getCreatedTimestamp();
+        String createdAfter = filters.get(UserModel.CREATED_AFTER);
+        if (createdAfter != null && (createdTimestamp == null || createdTimestamp < Long.parseLong(createdAfter))) {
+            return false;
+        }
+
+        String createdBefore = filters.get(UserModel.CREATED_BEFORE);
+        return createdBefore == null
+                || createdTimestamp != null && createdTimestamp <= Long.parseLong(createdBefore);
     }
 
     @Override
@@ -554,7 +586,9 @@ public class LDAPStorageProvider implements UserStorageProvider,
 
             for (Map.Entry<String, String> entry : attributes.entrySet()) {
                 String attrName = entry.getKey();
-                if (LDAPConstants.LDAP_ID.equals(attrName)) {
+                if (UserModel.SEARCH.equals(attrName)) {
+                    addSearchConditions(ldapQuery, conditionsBuilder, entry.getValue());
+                } else if (LDAPConstants.LDAP_ID.equals(attrName)) {
                     String uuidLDAPAttributeName = this.ldapIdentityStore.getConfig().getUuidLDAPAttributeName();
                     Condition usernameCondition = conditionsBuilder.equal(uuidLDAPAttributeName, entry.getValue());
                     ldapQuery.addWhereCondition(usernameCondition);
@@ -593,45 +627,25 @@ public class LDAPStorageProvider implements UserStorageProvider,
         }
     }
 
-    /**
-     * Searches LDAP using logical disjunction of params. It supports
-     * <ul>
-     *     <li>{@link UserModel#FIRST_NAME}</li>
-     *     <li>{@link UserModel#LAST_NAME}</li>
-     *     <li>{@link UserModel#EMAIL}</li>
-     *     <li>{@link UserModel#USERNAME}</li>
-     * </ul>
-     *
-     * It uses multiple LDAP calls and results are combined together with respect to firstResult and maxResults
-     *
-     * This method serves for {@code search} param of {@link org.keycloak.services.resources.admin.UsersResource#getUsers}
-     */
-    private Stream<LDAPObject> searchLDAP(RealmModel realm, String search, Integer firstResult, Integer maxResults) {
-
-        try (LDAPQuery ldapQuery = LDAPUtils.createQueryForUserSearch(this, realm)) {
-            LDAPQueryConditionsBuilder conditionsBuilder = new LDAPQueryConditionsBuilder();
-
-            for (String s : search.split("\\s+")) {
-                boolean equals = false;
-                List<Condition> conditions = new LinkedList<>();
-                if (s.startsWith("\"") && s.endsWith("\"")) {
-                    // exact search
-                    s = s.substring(1, s.length() - 1);
-                    equals = true;
-                } else if (!s.endsWith("*")) {
-                    // default to prefix search
-                    s += "*";
-                }
-
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.USERNAME, equals, s));
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.EMAIL, equals, s));
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.FIRST_NAME, equals, s));
-                conditions.add(createSearchCondition(conditionsBuilder, UserModel.LAST_NAME, equals, s));
-
-                ldapQuery.addWhereCondition(conditionsBuilder.orCondition(conditions.toArray(Condition[]::new)));
+    private void addSearchConditions(LDAPQuery ldapQuery, LDAPQueryConditionsBuilder conditionsBuilder, String search) {
+        for (String s : search.split("\\s+")) {
+            boolean equals = false;
+            List<Condition> conditions = new LinkedList<>();
+            if (s.startsWith("\"") && s.endsWith("\"")) {
+                // exact search
+                s = s.substring(1, s.length() - 1);
+                equals = true;
+            } else if (!s.endsWith("*")) {
+                // default to prefix search
+                s += "*";
             }
 
-            return paginatedSearchLDAP(ldapQuery, firstResult, maxResults);
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.USERNAME, equals, s));
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.EMAIL, equals, s));
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.FIRST_NAME, equals, s));
+            conditions.add(createSearchCondition(conditionsBuilder, UserModel.LAST_NAME, equals, s));
+
+            ldapQuery.addWhereCondition(conditionsBuilder.orCondition(conditions.toArray(Condition[]::new)));
         }
     }
 

--- a/server-spi/src/main/java/org/keycloak/storage/user/UserQueryMethodsProvider.java
+++ b/server-spi/src/main/java/org/keycloak/storage/user/UserQueryMethodsProvider.java
@@ -82,7 +82,7 @@ public interface UserQueryMethodsProvider {
      * <p/>
      * Valid parameters are:
      * <ul>
-     *     <li>{@link UserModel#SEARCH} - search for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace, when {@code SEARCH} is set all other params are ignored</li>
+     *     <li>{@link UserModel#SEARCH} - search for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace; all other supplied parameters are combined with {@code SEARCH} using a logical AND</li>
      *     <li>{@link UserModel#FIRST_NAME} - first name (case insensitive string)</li>
      *     <li>{@link UserModel#LAST_NAME} - last name (case insensitive string)</li>
      *     <li>{@link UserModel#EMAIL} - email (case insensitive string)</li>
@@ -116,7 +116,7 @@ public interface UserQueryMethodsProvider {
      * <p/>
      * Valid parameters are:
      * <ul>
-     *     <li>{@link UserModel#SEARCH} - search for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace, when {@code SEARCH} is set all other params are ignored</li>
+     *     <li>{@link UserModel#SEARCH} - search for users whose username, email, first name or last name contain any of the strings in {@code search} separated by whitespace; all other supplied parameters are combined with {@code SEARCH} using a logical AND</li>
      *     <li>{@link UserModel#FIRST_NAME} - first name (case insensitive string)</li>
      *     <li>{@link UserModel#LAST_NAME} - last name (case insensitive string)</li>
      *     <li>{@link UserModel#EMAIL} - email (case insensitive string)</li>

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -302,25 +302,29 @@ public class UsersResource {
 
         Stream<UserModel> userModels = Stream.empty();
         if (search != null) {
+            Map<String, String> attributes = new HashMap<>(searchAttributes);
+            if (enabled != null) {
+                attributes.put(UserModel.ENABLED, enabled.toString());
+            }
+            if (emailVerified != null) {
+                attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
+            }
+            addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
+
             SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
             if (prefix != null) {
-                userModels = Arrays.stream(prefix.splitTerms(search))
-                        .map(term -> prefix.lookup(session.users(), realm, term))
-                        .filter(Objects::nonNull);
+                userModels = searchForUsersByPrefix(search, prefix, realm, attributes);
                 if (AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
                     userModels = userModels.filter(userPermissionEvaluator::canView);
                 }
+                if (firstResult > 0) {
+                    userModels = userModels.skip(firstResult);
+                }
+                if (maxResults >= 0) {
+                    userModels = userModels.limit(maxResults);
+                }
             } else {
-                Map<String, String> attributes = new HashMap<>();
                 attributes.put(UserModel.SEARCH, search.trim());
-                if (enabled != null) {
-                    attributes.put(UserModel.ENABLED, enabled.toString());
-                }
-                if (emailVerified != null) {
-                    attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
-                }
-                addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
-
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
                         maxResults, false);
             }
@@ -375,10 +379,12 @@ public class UsersResource {
      * 1. Don't specify any criteria and pass {@code null}. The number of all
      * users within that realm will be returned.
      * <p>
-     * 2. If {@code search} is specified other criteria such as {@code last} will
-     * be ignored even though you set them. The {@code search} string will be
-     * matched against the first and last name, the username and the email of a
-     * user.
+     * 2. If {@code search} is specified, it is combined with {@code q},
+     * {@code enabled}, {@code emailVerified}, {@code createdAfter}, and
+     * {@code createdBefore} using a logical AND. Other criteria such as
+     * {@code last} will be ignored even though you set them. The {@code search}
+     * string will be matched against the first and last name, the username and
+     * the email of a user.
      * <p>
      * 3. If {@code search} is unspecified but any of {@code last}, {@code first},
      * {@code email} or {@code username} those criteria are matched against their
@@ -410,7 +416,7 @@ public class UsersResource {
             summary = "Returns the number of users that match the given criteria.",
             description = "It can be called in three different ways. " +
                     "1. Don’t specify any criteria and pass {@code null}. The number of all users within that realm will be returned. <p> " +
-                    "2. If {@code search} is specified other criteria such as {@code last} will be ignored even though you set them. The {@code search} string will be matched against the first and last name, the username and the email of a user. <p> " +
+                    "2. If {@code search} is specified, it is combined with {@code q}, {@code enabled}, {@code emailVerified}, {@code createdAfter}, and {@code createdBefore} using a logical AND. Other criteria such as {@code last} will be ignored even though you set them. The {@code search} string will be matched against the first and last name, the username and the email of a user. <p> " +
                     "3. If {@code search} is unspecified but any of {@code last}, {@code first}, {@code email} or {@code username} those criteria are matched against their respective fields on a user entity. Combined with a logical and.")
     public Integer getUsersCount(
             @Parameter(description = "A String contained in username, first or last name, or email. Default search behavior is prefix-based (e.g., foo or foo*). Use *foo* for infix search and \"foo\" for exact search.") @QueryParam("search") String search,
@@ -433,18 +439,7 @@ public class UsersResource {
                 ? Collections.emptyMap()
                 : SearchQueryUtils.getFields(searchQuery);
         if (search != null) {
-            SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
-            if (prefix != null) {
-                return (int) Arrays.stream(prefix.splitTerms(search))
-                        .map(term -> prefix.lookup(session.users(), realm, term))
-                        .filter(Objects::nonNull)
-                        .filter(userPermissionEvaluator::canView)
-                        .count();
-            }
-
-            Map<String, String> parameters = new HashMap<>();
-            parameters.put(UserModel.SEARCH, search.trim());
-
+            Map<String, String> parameters = new HashMap<>(searchAttributes);
             if (enabled != null) {
                 parameters.put(UserModel.ENABLED, enabled.toString());
             }
@@ -452,6 +447,15 @@ public class UsersResource {
                 parameters.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
             }
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
+
+            SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
+            if (prefix != null) {
+                return (int) searchForUsersByPrefix(search, prefix, realm, parameters)
+                        .filter(userPermissionEvaluator::canView)
+                        .count();
+            }
+
+            parameters.put(UserModel.SEARCH, search.trim());
             // search /users equivalent to this doesn't include service-accounts so counting shouldn't as well
             parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
             if (userPermissionEvaluator.canView()) {
@@ -532,6 +536,24 @@ public class UsersResource {
     @Path("profile")
     public UserProfileResource userProfile() {
         return new UserProfileResource(session, auth, adminEvent);
+    }
+
+    private Stream<UserModel> searchForUsersByPrefix(String search, SearchQueryUtils.UserSearchPrefix prefix,
+            RealmModel realm, Map<String, String> searchAttributes) {
+        List<UserModel> candidates = Arrays.stream(prefix.splitTerms(search))
+                .map(term -> prefix.lookup(session.users(), realm, term))
+                .filter(Objects::nonNull)
+                .toList();
+        if (candidates.isEmpty() || searchAttributes.isEmpty()) {
+            return candidates.stream();
+        }
+
+        return candidates.stream().filter(candidate -> {
+            Map<String, String> candidateAttributes = new HashMap<>(searchAttributes);
+            candidateAttributes.put(UserModel.SEARCH, String.format("\"%s\"", candidate.getUsername()));
+            return session.users().searchForUserStream(realm, candidateAttributes)
+                    .anyMatch(user -> candidate.getId().equals(user.getId()));
+        });
     }
 
     private static void addCreatedTimestampConditions(Map<String, String> attributes, String createdAfter, String createdBefore) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -305,25 +305,29 @@ public class UsersResource {
 
         Stream<UserModel> userModels = Stream.empty();
         if (search != null) {
+            Map<String, String> attributes = new HashMap<>(searchAttributes);
+            if (enabled != null) {
+                attributes.put(UserModel.ENABLED, enabled.toString());
+            }
+            if (emailVerified != null) {
+                attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
+            }
+            addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
+
             SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
             if (prefix != null) {
-                userModels = Arrays.stream(prefix.splitTerms(search))
-                        .map(term -> prefix.lookup(session.users(), realm, term))
-                        .filter(Objects::nonNull);
+                userModels = searchForUsersByPrefix(search, prefix, realm, attributes);
                 if (AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
                     userModels = userModels.filter(userPermissionEvaluator::canView);
                 }
+                if (firstResult > 0) {
+                    userModels = userModels.skip(firstResult);
+                }
+                if (maxResults >= 0) {
+                    userModels = userModels.limit(maxResults);
+                }
             } else {
-                Map<String, String> attributes = new HashMap<>();
                 attributes.put(UserModel.SEARCH, search.trim());
-                if (enabled != null) {
-                    attributes.put(UserModel.ENABLED, enabled.toString());
-                }
-                if (emailVerified != null) {
-                    attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
-                }
-                addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
-
                 return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
                         maxResults, false);
             }
@@ -378,10 +382,12 @@ public class UsersResource {
      * 1. Don't specify any criteria and pass {@code null}. The number of all
      * users within that realm will be returned.
      * <p>
-     * 2. If {@code search} is specified other criteria such as {@code last} will
-     * be ignored even though you set them. The {@code search} string will be
-     * matched against the first and last name, the username and the email of a
-     * user.
+     * 2. If {@code search} is specified, it is combined with {@code q},
+     * {@code enabled}, {@code emailVerified}, {@code createdAfter}, and
+     * {@code createdBefore} using a logical AND. Other criteria such as
+     * {@code last} will be ignored even though you set them. The {@code search}
+     * string will be matched against the first and last name, the username and
+     * the email of a user.
      * <p>
      * 3. If {@code search} is unspecified but any of {@code last}, {@code first},
      * {@code email} or {@code username} those criteria are matched against their
@@ -413,7 +419,7 @@ public class UsersResource {
             summary = "Returns the number of users that match the given criteria.",
             description = "It can be called in three different ways. " +
                     "1. Don’t specify any criteria and pass {@code null}. The number of all users within that realm will be returned. <p> " +
-                    "2. If {@code search} is specified other criteria such as {@code last} will be ignored even though you set them. The {@code search} string will be matched against the first and last name, the username and the email of a user. <p> " +
+                    "2. If {@code search} is specified, it is combined with {@code q}, {@code enabled}, {@code emailVerified}, {@code createdAfter}, and {@code createdBefore} using a logical AND. Other criteria such as {@code last} will be ignored even though you set them. The {@code search} string will be matched against the first and last name, the username and the email of a user. <p> " +
                     "3. If {@code search} is unspecified but any of {@code last}, {@code first}, {@code email} or {@code username} those criteria are matched against their respective fields on a user entity. Combined with a logical and.")
     public Integer getUsersCount(
             @Parameter(description = "A String contained in username, first or last name, or email. Default search behavior is prefix-based (e.g., foo or foo*). Use *foo* for infix search and \"foo\" for exact search.") @QueryParam("search") String search,
@@ -436,18 +442,7 @@ public class UsersResource {
                 ? Collections.emptyMap()
                 : SearchQueryUtils.getFields(searchQuery);
         if (search != null) {
-            SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
-            if (prefix != null) {
-                return (int) Arrays.stream(prefix.splitTerms(search))
-                        .map(term -> prefix.lookup(session.users(), realm, term))
-                        .filter(Objects::nonNull)
-                        .filter(userPermissionEvaluator::canView)
-                        .count();
-            }
-
-            Map<String, String> parameters = new HashMap<>();
-            parameters.put(UserModel.SEARCH, search.trim());
-
+            Map<String, String> parameters = new HashMap<>(searchAttributes);
             if (enabled != null) {
                 parameters.put(UserModel.ENABLED, enabled.toString());
             }
@@ -455,6 +450,15 @@ public class UsersResource {
                 parameters.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
             }
             addCreatedTimestampConditions(parameters, createdAfter, createdBefore);
+
+            SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
+            if (prefix != null) {
+                return (int) searchForUsersByPrefix(search, prefix, realm, parameters)
+                        .filter(userPermissionEvaluator::canView)
+                        .count();
+            }
+
+            parameters.put(UserModel.SEARCH, search.trim());
             // search /users equivalent to this doesn't include service-accounts so counting shouldn't as well
             parameters.put(UserModel.INCLUDE_SERVICE_ACCOUNT, "false");
             if (userPermissionEvaluator.canView()) {
@@ -535,6 +539,24 @@ public class UsersResource {
     @Path("profile")
     public UserProfileResource userProfile() {
         return new UserProfileResource(session, auth, adminEvent);
+    }
+
+    private Stream<UserModel> searchForUsersByPrefix(String search, SearchQueryUtils.UserSearchPrefix prefix,
+            RealmModel realm, Map<String, String> searchAttributes) {
+        List<UserModel> candidates = Arrays.stream(prefix.splitTerms(search))
+                .map(term -> prefix.lookup(session.users(), realm, term))
+                .filter(Objects::nonNull)
+                .toList();
+        if (candidates.isEmpty() || searchAttributes.isEmpty()) {
+            return candidates.stream();
+        }
+
+        return candidates.stream().filter(candidate -> {
+            Map<String, String> candidateAttributes = new HashMap<>(searchAttributes);
+            candidateAttributes.put(UserModel.SEARCH, String.format("\"%s\"", candidate.getUsername()));
+            return session.users().searchForUserStream(realm, candidateAttributes)
+                    .anyMatch(user -> candidate.getId().equals(user.getId()));
+        });
     }
 
     private static void addCreatedTimestampConditions(Map<String, String> attributes, String createdAfter, String createdBefore) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -135,6 +135,101 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
+    public void searchUserWithQueryParameter() {
+        createUsers();
+
+        String query = mapToSearchQuery(Map.of("test", "test1"));
+        assertThat(managedRealm.admin().users().searchByAttributes(query), hasSize(1));
+        List<UserRepresentation> users = managedRealm.admin().users().search("username", null, null, null, null, null, null, query);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("username1"));
+        assertThat(managedRealm.admin().users().count("username", null, null, null, null, null, null, query), is(1));
+
+        UserRepresentation standardFilterUser = new UserRepresentation();
+        standardFilterUser.setUsername("standard-filter-user");
+        standardFilterUser.setEnabled(false);
+        standardFilterUser.setEmailVerified(true);
+        standardFilterUser.setRequiredActions(Collections.emptyList());
+        standardFilterUser.setAttributes(Map.of("test", List.of("standard-filter")));
+        createUser(standardFilterUser);
+
+        String standardFilterQuery = mapToSearchQuery(Map.of("test", "standard-filter"));
+        users = managedRealm.admin().users().search("standard-filter-user", null, null, null, true, null, false,
+                standardFilterQuery);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("standard-filter-user"));
+        assertThat(managedRealm.admin().users().count("standard-filter-user", null, null, null, true, null, false,
+                standardFilterQuery), is(1));
+        assertThat(managedRealm.admin().users().search("standard-filter-user", null, null, null, true, null, true,
+                standardFilterQuery), hasSize(0));
+        assertThat(managedRealm.admin().users().count("standard-filter-user", null, null, null, true, null, true,
+                standardFilterQuery), is(0));
+        assertThat(managedRealm.admin().users().search("standard-filter-user", null, null, null, false, null, false,
+                standardFilterQuery), hasSize(0));
+        assertThat(managedRealm.admin().users().count("standard-filter-user", null, null, null, false, null, false,
+                standardFilterQuery), is(0));
+
+        users = managedRealm.admin().users().search("username:standard-filter-user", null, null, null, true, null,
+                false, standardFilterQuery);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("standard-filter-user"));
+        assertThat(managedRealm.admin().users().count("username:standard-filter-user", null, null, null, true, null,
+                false, standardFilterQuery), is(1));
+        assertThat(managedRealm.admin().users().search("username:standard-filter-user", null, null, null, true, null,
+                true, standardFilterQuery), hasSize(0));
+        assertThat(managedRealm.admin().users().count("username:standard-filter-user", null, null, null, true, null,
+                true, standardFilterQuery), is(0));
+        assertThat(managedRealm.admin().users().search("username:standard-filter-user", null, null, null, false, null,
+                false, standardFilterQuery), hasSize(0));
+        assertThat(managedRealm.admin().users().count("username:standard-filter-user", null, null, null, false, null,
+                false, standardFilterQuery), is(0));
+
+        assertThat(managedRealm.admin().users().search("username2", null, null, null, null, null, null, query), hasSize(0));
+        assertThat(managedRealm.admin().users().count("username2", null, null, null, null, null, null, query), is(0));
+
+        String reservedSearchQuery = mapToSearchQuery(Map.of(UserModel.SEARCH, "username2", "test", "test1"));
+        users = managedRealm.admin().users().search("username1", null, null, null, null, null, null,
+                reservedSearchQuery);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("username1"));
+        assertThat(managedRealm.admin().users().count("username1", null, null, null, null, null, null,
+                reservedSearchQuery), is(1));
+
+        users = managedRealm.admin().users().search("username:username1", null, null, null, null, null, null, query);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("username1"));
+        assertThat(managedRealm.admin().users().count("username:username1", null, null, null, null, null, null, query), is(1));
+        assertThat(managedRealm.admin().users().search("username:username2", null, null, null, null, null, null, query), hasSize(0));
+        assertThat(managedRealm.admin().users().count("username:username2", null, null, null, null, null, null, query), is(0));
+
+        users = managedRealm.admin().users().search("username:username1 username2", null, null, null, null, null, null,
+                query);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("username1"));
+        assertThat(managedRealm.admin().users().count("username:username1 username2", null, null, null, null, null,
+                null, query), is(1));
+
+        users = managedRealm.admin().users().search("username:username1", null, null, null, null, null, null,
+                reservedSearchQuery);
+        assertThat(users, hasSize(1));
+        assertThat(users.get(0).getUsername(), is("username1"));
+        assertThat(managedRealm.admin().users().count("username:username1", null, null, null, null, null, null,
+                reservedSearchQuery), is(1));
+
+        String standardParameterQuery = mapToSearchQuery(Map.of(UserModel.EMAIL_VERIFIED, "false"));
+        assertThat(managedRealm.admin().users().search("username:username1", null, null, null, null, null, null,
+                standardParameterQuery), hasSize(1));
+        assertThat(managedRealm.admin().users().count("username:username1", null, null, null, null, null, null,
+                standardParameterQuery), is(1));
+
+        standardParameterQuery = mapToSearchQuery(Map.of(UserModel.EMAIL_VERIFIED, "true"));
+        assertThat(managedRealm.admin().users().search("username:username1", null, null, null, null, null, null,
+                standardParameterQuery), hasSize(0));
+        assertThat(managedRealm.admin().users().count("username:username1", null, null, null, null, null, null,
+                standardParameterQuery), is(0));
+    }
+
+    @Test
     public void searchByMultipleAttributes() {
         createUsers();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
@@ -1126,6 +1126,76 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
     }
 
     @Test
+    public void testSearchWithCustomAttributes() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "combinedsearch1", "Combined1", "Search1", "combined1@email.org", null, "13101");
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "combinedsearch2", "Combined2", "Search2", "combined2@email.org", null, "13102");
+
+            Map<String, String> matching = Map.of(UserModel.SEARCH, "combinedsearch", "postal_code", "13101");
+            Assertions.assertEquals(1, session.users().searchForUserStream(appRealm, matching).count());
+
+            Map<String, String> disjoint = Map.of(UserModel.SEARCH, "combinedsearch2", "postal_code", "13101");
+            Assertions.assertEquals(0, session.users().searchForUserStream(appRealm, disjoint).count());
+        });
+    }
+
+    @Test
+    public void testSearchWithNonLDAPStandardAttributes() {
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ctx.getLdapModel().put(LDAPConstants.TRUST_EMAIL, "true");
+            appRealm.updateComponent(ctx.getLdapModel());
+
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "modelverifiedmatch", "Model", "Verified", "verified-match@email.org", null, "13201");
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "modelverifiedmismatch", "Model", "Verified", "verified-mismatch@email.org", null, "13202");
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "modelcreatedafter", "Model", "Created", "created-after@email.org", null, "13203");
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "modelcreatedbefore", "Model", "Created", "created-before@email.org", null, "13204");
+        });
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            Map<String, String> verifiedMatch = Map.of(UserModel.SEARCH, "modelverifiedmatch", UserModel.EMAIL_VERIFIED, "true");
+            Assertions.assertEquals(1, ctx.getLdapProvider().searchForUserStream(appRealm, verifiedMatch, 0, 1).count());
+
+            Map<String, String> verifiedMismatch = Map.of(UserModel.SEARCH, "modelverifiedmismatch", UserModel.EMAIL_VERIFIED, "false");
+            Assertions.assertEquals(0, ctx.getLdapProvider().searchForUserStream(appRealm, verifiedMismatch, 0, 1).count());
+
+            Map<String, String> createdAfter = Map.of(UserModel.SEARCH, "modelcreatedafter", UserModel.CREATED_AFTER, "0");
+            Assertions.assertEquals(1, ctx.getLdapProvider().searchForUserStream(appRealm, createdAfter, 0, 1).count());
+
+            Map<String, String> createdBefore = Map.of(UserModel.SEARCH, "modelcreatedbefore", UserModel.CREATED_BEFORE, "0");
+            Assertions.assertEquals(0, ctx.getLdapProvider().searchForUserStream(appRealm, createdBefore, 0, 1).count());
+        });
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+            ctx.getLdapModel().put(LDAPConstants.TRUST_EMAIL, "false");
+            appRealm.updateComponent(ctx.getLdapModel());
+
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "modelunverifiedmatch", "Model", "Unverified", "unverified-match@email.org", null, "13205");
+            LDAPTestUtils.addLDAPUser(ctx.getLdapProvider(), appRealm, "modelunverifiedmismatch", "Model", "Unverified", "unverified-mismatch@email.org", null, "13206");
+        });
+
+        testingClient.server().run(session -> {
+            LDAPTestContext ctx = LDAPTestContext.init(session);
+            RealmModel appRealm = ctx.getRealm();
+
+            Map<String, String> unverifiedMatch = Map.of(UserModel.SEARCH, "modelunverifiedmatch", UserModel.EMAIL_VERIFIED, "false");
+            Assertions.assertEquals(1, ctx.getLdapProvider().searchForUserStream(appRealm, unverifiedMatch, 0, 1).count());
+
+            Map<String, String> unverifiedMismatch = Map.of(UserModel.SEARCH, "modelunverifiedmismatch", UserModel.EMAIL_VERIFIED, "true");
+            Assertions.assertEquals(0, ctx.getLdapProvider().searchForUserStream(appRealm, unverifiedMismatch, 0, 1).count());
+        });
+    }
+
+    @Test
     public void testSearchWithCustomLDAPFilter() {
         // Add custom filter for searching users
         testingClient.server().run(session -> {


### PR DESCRIPTION
Closes #45345

Change is super simple and has no breaking changes, so I'm just throwing it in. Refer to issue and many related closed issues for more details.

I'm not sure if I should update anything in documentation, since old behavior is not mentioned there.

I used Codex AI agent for assistance.
