### PR TITLE
Fix duplicate invitation sending email before checking constraints

### DIFF
--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationInvitationResource.java
@@ -170,6 +170,22 @@ public class OrganizationInvitationResource {
             throw ErrorResponse.error("User does not have an email address", Status.BAD_REQUEST);
         }
 
+        if (organization.isMember(user)) {
+            throw ErrorResponse.error("User already a member of the organization", Status.CONFLICT);
+        }
+
+        OrganizationProvider invitationProvider = session.getProvider(OrganizationProvider.class);
+        InvitationManager invitationManager = invitationProvider.getInvitationManager();
+        OrganizationInvitationModel existingInvitation = invitationManager.getByEmail(organization, user.getEmail());
+
+        if (existingInvitation != null) {
+            if (!existingInvitation.isExpired()) {
+                throw ErrorResponse.error("User already has a pending invitation", Status.CONFLICT);
+            } else {
+                invitationManager.remove(existingInvitation.getId());
+            }
+        }
+
         return sendInvitation(user);
     }
 


### PR DESCRIPTION
Closes: #45553

## Problem

`inviteExistingUser()` (the API that invites a user by ID) was missing validation checks that `inviteUser()` already had:

- No check for whether the user is already a member of the organization
- No check for whether the user already has a pending invitation

In both cases, the DB unique constraint (`UK_ORG_INVITATION_EMAIL`) would eventually reject the duplicate at transaction commit time. However, since JPA's `em.persist()` does not flush immediately, **the invitation email was sent before the constraint violation was detected**. The end result: the admin sees an error, but the user still receives an invalid invitation email that shows "Action expired" when clicked.

## Fix

Added the same pre-send validation to `inviteExistingUser()` that `inviteUser()` already performs:

1. **`organization.isMember(user)`** — reject invitations to existing members with 409 CONFLICT
2. **`invitationManager.getByEmail()`** — reject invitations when a pending one already exists with 409 CONFLICT (expired invitations are removed and re-invitation is allowed)

These checks run before `sendInvitation()`, preventing unnecessary emails from being sent.

---
AI-assisted development was used in this PR with Claude Code. All changes have been reviewed and are understood by the author.