### PR TITLE
fix: Re-authentication flow does not support re-authenticating brokered users with no local credentials set

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/idp/InfinispanIdentityProviderStorageProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/idp/InfinispanIdentityProviderStorageProvider.java
@@ -412,7 +412,7 @@ public class InfinispanIdentityProviderStorageProvider implements IdentityProvid
 
     private void registerIDPLoginInvalidation(IdentityProviderModel idp) {
         // only invalidate login caches if the IDP qualifies as a login IDP.
-        if (getLoginPredicate().test(idp, null)) {
+        if (getLoginPredicate().test(idp)) {
             for (FetchMode mode : FetchMode.values()) {
                 realmCache.registerInvalidation(cacheKeyForLogin(getRealm(), mode));
             }
@@ -433,11 +433,11 @@ public class InfinispanIdentityProviderStorageProvider implements IdentityProvid
      */
     private void registerIDPLoginInvalidationOnUpdate(IdentityProviderModel original, IdentityProviderModel updated) {
         // IDP isn't currently available for login and update preserves that - no need to invalidate.
-        if (!getLoginPredicate().test(original, null) && !getLoginPredicate().test(updated, null)) {
+        if (!getLoginPredicate().test(original) && !getLoginPredicate().test(updated)) {
             return;
         }
         // IDP is currently available for login and update preserves that, including organization link - no need to invalidate.
-        if (getLoginPredicate().test(original, null) && getLoginPredicate().test(updated, null)
+        if (getLoginPredicate().test(original) && getLoginPredicate().test(updated)
                 && Objects.equals(original.getOrganizationId(), updated.getOrganizationId())) {
             return;
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/idp/InfinispanIdentityProviderStorageProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/idp/InfinispanIdentityProviderStorageProvider.java
@@ -412,7 +412,7 @@ public class InfinispanIdentityProviderStorageProvider implements IdentityProvid
 
     private void registerIDPLoginInvalidation(IdentityProviderModel idp) {
         // only invalidate login caches if the IDP qualifies as a login IDP.
-        if (getLoginPredicate().test(idp)) {
+        if (getLoginPredicate().test(idp, null)) {
             for (FetchMode mode : FetchMode.values()) {
                 realmCache.registerInvalidation(cacheKeyForLogin(getRealm(), mode));
             }
@@ -433,11 +433,11 @@ public class InfinispanIdentityProviderStorageProvider implements IdentityProvid
      */
     private void registerIDPLoginInvalidationOnUpdate(IdentityProviderModel original, IdentityProviderModel updated) {
         // IDP isn't currently available for login and update preserves that - no need to invalidate.
-        if (!getLoginPredicate().test(original) && !getLoginPredicate().test(updated)) {
+        if (!getLoginPredicate().test(original, null) && !getLoginPredicate().test(updated, null)) {
             return;
         }
         // IDP is currently available for login and update preserves that, including organization link - no need to invalidate.
-        if (getLoginPredicate().test(original) && getLoginPredicate().test(updated)
+        if (getLoginPredicate().test(original, null) && getLoginPredicate().test(updated, null)
                 && Objects.equals(original.getOrganizationId(), updated.getOrganizationId())) {
             return;
         }

--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
@@ -19,11 +19,12 @@ package org.keycloak.models;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.provider.Provider;
+import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.Booleans;
 
 /**
@@ -235,17 +236,22 @@ public interface IdentityProviderStorageProvider extends Provider {
      */
     enum LoginFilter {
 
-        ENABLED(IdentityProviderModel.ENABLED, Boolean.TRUE.toString(), IdentityProviderModel::isEnabled),
+        ENABLED(IdentityProviderModel.ENABLED, Boolean.TRUE.toString(), (m, as) -> m.isEnabled()),
 
-        LINK_ONLY(IdentityProviderModel.LINK_ONLY, Boolean.FALSE.toString(), m -> Booleans.isFalse(m.isLinkOnly())),
+        LINK_ONLY(IdentityProviderModel.LINK_ONLY, Boolean.FALSE.toString(), (m, as) -> Booleans.isFalse(m.isLinkOnly())),
 
-        HIDE_ON_LOGIN(IdentityProviderModel.HIDE_ON_LOGIN, Boolean.FALSE.toString(), m -> Booleans.isFalse(m.isHideOnLogin()));
+        HIDE_ON_LOGIN(IdentityProviderModel.HIDE_ON_LOGIN, Boolean.FALSE.toString(), (m, as) -> {
+          if (as != null && Objects.equals(as.getAuthNote("FORCED_REAUTHENTICATION"), "true")) {
+            return true;
+          }
+          return Booleans.isFalse(m.isHideOnLogin());
+        });
 
         private final String key;
         private final String value;
-        private final Predicate<IdentityProviderModel> filter;
+        private final BiPredicate<IdentityProviderModel, AuthenticationSessionModel> filter;
 
-        LoginFilter(String key, String value, java.util.function.Predicate<IdentityProviderModel> filter) {
+        LoginFilter(String key, String value, BiPredicate<IdentityProviderModel, AuthenticationSessionModel> filter) {
             this.key = key;
             this.value = value;
             this.filter = filter;
@@ -259,7 +265,7 @@ public interface IdentityProviderStorageProvider extends Provider {
             return value;
         }
 
-        public Predicate<IdentityProviderModel> getFilter() {
+        public BiPredicate<IdentityProviderModel, AuthenticationSessionModel> getFilter() {
             return filter;
         }
 
@@ -267,9 +273,9 @@ public interface IdentityProviderStorageProvider extends Provider {
             return Stream.of(values()).collect(Collectors.toMap(LoginFilter::getKey, LoginFilter::getValue, (v1, v2) -> v1, LinkedHashMap::new));
         }
 
-        public static Predicate<IdentityProviderModel> getLoginPredicate() {
-            return ((Predicate<IdentityProviderModel>) Objects::nonNull)
-                    .and(Stream.of(values()).map(LoginFilter::getFilter).reduce(Predicate::and).get());
+        public static BiPredicate<IdentityProviderModel, AuthenticationSessionModel> getLoginPredicate() {
+            return ((BiPredicate<IdentityProviderModel, AuthenticationSessionModel>) (m, as) -> Objects.nonNull(m))
+                    .and(Stream.of(values()).map(LoginFilter::getFilter).reduce(BiPredicate::and).get());
         }
     }
 

--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
@@ -261,8 +261,23 @@ public interface IdentityProviderStorageProvider extends Provider {
             return value;
         }
 
-        public BiPredicate<IdentityProviderModel, Context> getFilter() {
+        BiPredicate<IdentityProviderModel, Context> getLoginFilter() {
             return filter;
+        }
+
+        /**
+         * Returns a {@link Predicate} that evaluates whether a given {@link IdentityProviderModel}
+         * satisfies the associated filter condition based on a standard context.
+         * <p>
+         * This method is deprecated and may be removed in future versions. Consider
+         * using {@link #getLoginFilter()) that returns a BiPredicate<IdentityProviderModel, Context> instead.
+         *
+         * @return a {@link Predicate} applied to an {@link IdentityProviderModel} using the standard context.
+         * @deprecated Use {@link #getLoginPredicate(Context)} instead for more explicit context handling.
+         */
+        @Deprecated
+        public Predicate<IdentityProviderModel> getFilter() {
+            return model -> filter.test(model, Context.standard());
         }
 
         public static Map<String, String> getLoginSearchOptions() {
@@ -290,7 +305,8 @@ public interface IdentityProviderStorageProvider extends Provider {
          * @return a {@link Predicate} applying all login filters with the given context.
          */
         public static Predicate<IdentityProviderModel> getLoginPredicate(Context ctx) {
-            return m -> Objects.nonNull(m) && Stream.of(values()).allMatch(f -> f.getFilter().test(m, ctx));
+            Objects.requireNonNull(ctx, "Context must not be null");
+            return m -> Objects.nonNull(m) && Stream.of(values()).allMatch(f -> f.getLoginFilter().test(m, ctx));
         }
 
         /**

--- a/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/IdentityProviderStorageProvider.java
@@ -20,11 +20,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.provider.Provider;
-import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.Booleans;
 
 /**
@@ -236,22 +236,18 @@ public interface IdentityProviderStorageProvider extends Provider {
      */
     enum LoginFilter {
 
-        ENABLED(IdentityProviderModel.ENABLED, Boolean.TRUE.toString(), (m, as) -> m.isEnabled()),
+        ENABLED(IdentityProviderModel.ENABLED, Boolean.TRUE.toString(), (m, ctx) -> m.isEnabled()),
 
-        LINK_ONLY(IdentityProviderModel.LINK_ONLY, Boolean.FALSE.toString(), (m, as) -> Booleans.isFalse(m.isLinkOnly())),
+        LINK_ONLY(IdentityProviderModel.LINK_ONLY, Boolean.FALSE.toString(), (m, ctx) -> Booleans.isFalse(m.isLinkOnly())),
 
-        HIDE_ON_LOGIN(IdentityProviderModel.HIDE_ON_LOGIN, Boolean.FALSE.toString(), (m, as) -> {
-          if (as != null && Objects.equals(as.getAuthNote("FORCED_REAUTHENTICATION"), "true")) {
-            return true;
-          }
-          return Booleans.isFalse(m.isHideOnLogin());
-        });
+        HIDE_ON_LOGIN(IdentityProviderModel.HIDE_ON_LOGIN, Boolean.FALSE.toString(), (m, ctx) ->
+                ctx.forcedReauth() || Booleans.isFalse(m.isHideOnLogin()));
 
         private final String key;
         private final String value;
-        private final BiPredicate<IdentityProviderModel, AuthenticationSessionModel> filter;
+        private final BiPredicate<IdentityProviderModel, Context> filter;
 
-        LoginFilter(String key, String value, BiPredicate<IdentityProviderModel, AuthenticationSessionModel> filter) {
+        LoginFilter(String key, String value, BiPredicate<IdentityProviderModel, Context> filter) {
             this.key = key;
             this.value = value;
             this.filter = filter;
@@ -265,7 +261,7 @@ public interface IdentityProviderStorageProvider extends Provider {
             return value;
         }
 
-        public BiPredicate<IdentityProviderModel, AuthenticationSessionModel> getFilter() {
+        public BiPredicate<IdentityProviderModel, Context> getFilter() {
             return filter;
         }
 
@@ -273,9 +269,40 @@ public interface IdentityProviderStorageProvider extends Provider {
             return Stream.of(values()).collect(Collectors.toMap(LoginFilter::getKey, LoginFilter::getValue, (v1, v2) -> v1, LinkedHashMap::new));
         }
 
-        public static BiPredicate<IdentityProviderModel, AuthenticationSessionModel> getLoginPredicate() {
-            return ((BiPredicate<IdentityProviderModel, AuthenticationSessionModel>) (m, as) -> Objects.nonNull(m))
-                    .and(Stream.of(values()).map(LoginFilter::getFilter).reduce(BiPredicate::and).get());
+        /**
+         * Returns a {@link Predicate} that accepts an {@link IdentityProviderModel} only when it passes all login
+         * filters using the standard (non-re-auth) context. Equivalent to calling
+         * {@link #getLoginPredicate(Context) getLoginPredicate(Context.standard())}.
+         *
+         * @return a {@link Predicate} applying all login filters with the standard context.
+         */
+        public static Predicate<IdentityProviderModel> getLoginPredicate() {
+            return getLoginPredicate(Context.standard());
+        }
+
+        /**
+         * Returns a {@link Predicate} that accepts an {@link IdentityProviderModel} only when it passes all login
+         * filters evaluated against the provided {@link Context}. The context controls filter behaviour that depends
+         * on the current authentication state — for example, the {@link #HIDE_ON_LOGIN} filter is bypassed when
+         * {@link Context#forcedReauth()} is {@code true}.
+         *
+         * @param ctx the {@link Context} describing the current authentication state; must not be {@code null}.
+         * @return a {@link Predicate} applying all login filters with the given context.
+         */
+        public static Predicate<IdentityProviderModel> getLoginPredicate(Context ctx) {
+            return m -> Objects.nonNull(m) && Stream.of(values()).allMatch(f -> f.getFilter().test(m, ctx));
+        }
+
+        /**
+         * Captures the authentication-state information that login filters may need to evaluate an
+         * {@link IdentityProviderModel}. Use {@link #standard()} for ordinary login flows and {@link #reauth()} when
+         * a forced re-authentication is in progress (e.g. an App-Initiated Action).
+         *
+         * @param forcedReauth {@code true} when the current flow is a forced re-authentication; {@code false} otherwise.
+         */
+        public record Context(boolean forcedReauth) {
+            public static Context standard() { return new Context(false); }
+            public static Context reauth()   { return new Context(true); }
         }
     }
 

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -36,6 +36,7 @@ import org.keycloak.common.Profile;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderStorageProvider;
+import org.keycloak.models.IdentityProviderStorageProvider.LoginFilter;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrderedModel;
 import org.keycloak.models.RealmModel;
@@ -235,14 +236,18 @@ public class IdentityProviderBean {
     }
 
     /**
-     * Returns a predicate that can filter out IDPs associated with the current user's federated identities before those
-     * are converted into {@link IdentityProvider}s. Subclasses may use this as a way to further refine the IDPs that are
-     * to be returned.
+     * Returns a predicate that applies the standard login filters (enabled, not link-only, not hidden on login page)
+     * to IDPs associated with the current user's federated identities before those are converted into
+     * {@link IdentityProvider}s. The {@code HIDE_ON_LOGIN} check is bypassed when a forced re-authentication is in
+     * progress, so that a user whose only IdP is hidden can still be redirected to it for re-auth.
+     * Subclasses may use this as a way to further refine the IDPs that are to be returned.
      *
-     * @return the custom {@link Predicate} used as a last filter before conversion into {@link IdentityProvider}
+     * @return the {@link Predicate} used as a last filter before conversion into {@link IdentityProvider}
      */
     protected Predicate<IdentityProviderModel> federatedProviderPredicate() {
-        return m -> IdentityProviderStorageProvider.LoginFilter.getLoginPredicate().test(m, context.getAuthenticationSession());
+        final var isReAuth = isForcedReauthentication();
+        final var ctx = isReAuth ? LoginFilter.Context.reauth() : LoginFilter.Context.standard();
+        return LoginFilter.getLoginPredicate(ctx);
     }
 
     /**

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/IdentityProviderBean.java
@@ -42,6 +42,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.services.Urls;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.theme.Theme;
@@ -73,6 +74,9 @@ public class IdentityProviderBean {
         if (this.providers == null) {
             String existingIDP = this.getExistingIDP(session, context);
             Set<String> federatedIdentities = this.getLinkedBrokerAliases(session, realm, context);
+            if (isForcedReauthentication() && federatedIdentities == null) {
+                federatedIdentities = Set.of();
+            }
             if (federatedIdentities != null) {
                 this.providers = getFederatedIdentityProviders(federatedIdentities, existingIDP);
             } else {
@@ -80,6 +84,13 @@ public class IdentityProviderBean {
             }
         }
         return this.providers;
+    }
+
+    private boolean isForcedReauthentication() {
+        if (context == null) {
+            return false;
+        }
+        return "true".equals(context.getAuthenticationSession().getAuthNote(AuthenticationManager.FORCED_REAUTHENTICATION));
     }
 
     public KeycloakSession getSession() {
@@ -231,7 +242,7 @@ public class IdentityProviderBean {
      * @return the custom {@link Predicate} used as a last filter before conversion into {@link IdentityProvider}
      */
     protected Predicate<IdentityProviderModel> federatedProviderPredicate() {
-        return IdentityProviderStorageProvider.LoginFilter.getLoginPredicate();
+        return m -> IdentityProviderStorageProvider.LoginFilter.getLoginPredicate().test(m, context.getAuthenticationSession());
     }
 
     /**

--- a/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
+++ b/services/src/main/java/org/keycloak/organization/forms/login/freemarker/model/OrganizationAwareIdentityProviderBean.java
@@ -34,6 +34,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
 import org.keycloak.organization.utils.Organizations;
+import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.util.Booleans;
 
 import static org.keycloak.models.IdentityProviderStorageProvider.FetchMode.ALL;
@@ -126,6 +127,8 @@ public class OrganizationAwareIdentityProviderBean extends IdentityProviderBean 
                 return idp.getOrganizationId() == null;
             } else if (onlyOrganizationBrokers) {
                 return isPublicOrganizationBroker(idp);
+            } else if (Objects.equals("true", context.getAuthenticationSession().getAuthNote(AuthenticationManager.FORCED_REAUTHENTICATION))) {
+                return true;
             } else {
                 return idp.getOrganizationId() == null || isPublicOrganizationBroker(idp);
             }

--- a/tests/base/src/test/java/org/keycloak/tests/organization/broker/AbstractBrokerReAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/broker/AbstractBrokerReAuthTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.organization.broker;
+
+import java.time.Instant;
+
+import org.keycloak.models.Constants;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.annotations.InjectWebDriver;
+import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.ui.webdriver.ManagedWebDriver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract class AbstractBrokerReAuthTest {
+
+    protected static final String CONSUMER_REALM_NAME = "consumer";
+    protected static final String PROVIDER_REALM_NAME = "provider";
+    protected static final String IDP_ALIAS = "test-identity-provider";
+    protected static final String IDP_CLIENT_ID = "test-idp-client";
+    protected static final String IDP_CLIENT_SECRET = "test-idp-secret";
+    protected static final String USER_LOGIN = "testuser";
+    // Domain must match the org domain used in OrganizationBrokerReAuthTest
+    protected static final String USER_EMAIL = "testuser@neworg.org";
+    protected static final String USER_PASSWORD = "password";
+    protected static final String BROKER_APP_CLIENT_ID = "broker-app";
+    protected static final String BASE_URL = "http://localhost:8080";
+
+    @InjectRealm(ref = PROVIDER_REALM_NAME, config = ProviderRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    protected ManagedRealm providerRealm;
+
+    @InjectOAuthClient(realmRef = CONSUMER_REALM_NAME, config = BrokerAppClientConfig.class, lifecycle = LifeCycle.METHOD)
+    protected OAuthClient oauth;
+
+    @InjectPage
+    protected LoginPage loginPage;
+
+    @InjectWebDriver
+    protected ManagedWebDriver driver;
+
+    /**
+     * Sets up the IdP in the consumer realm and completes the first broker login on the provider realm.
+     * The browser must be navigating away from the provider realm when this returns (i.e. credentials
+     * have been submitted). The base class handles the optional "Update Account Information" page and
+     * the "Happy days" assertion that follow.
+     *
+     * @param hideOnLogin subclass-specific: controls whether/when the IdP is hidden on the login page
+     * @return the {@link Instant} captured right after credentials were submitted to the provider realm
+     */
+    protected abstract Instant performFirstBrokerLogin(boolean hideOnLogin) throws InterruptedException;
+
+    protected abstract ManagedRealm getConsumerRealm();
+
+    @ParameterizedTest(name = "IdP hidden: {0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("Brokered user redirected to IdP for re-authentication when app-initiated action requires re-auth")
+    public void testBrokeredUserRedirectedToIdpForReAuthenticationWhenAppInitiatedActionRequiresReAuth(boolean hideOnLogin) throws InterruptedException {
+        Instant instantAfterLogin = performFirstBrokerLogin(hideOnLogin);
+
+        assertTrue(driver.page().getPageSource().contains("Happy days"));
+
+        ManagedRealm consumerRealm = getConsumerRealm();
+        RequiredActionProviderRepresentation updateEmailAction = consumerRealm.admin().flows().getRequiredActions()
+                .stream()
+                .filter(a -> UserModel.RequiredAction.UPDATE_EMAIL.name().equals(a.getProviderId()))
+                .findFirst()
+                .orElseThrow();
+        final var originalUpdateEmailEnabled = updateEmailAction.isEnabled();
+        updateEmailAction.getConfig().put(Constants.MAX_AUTH_AGE_KEY, "0");
+        updateEmailAction.setEnabled(true);
+        consumerRealm.admin().flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
+        consumerRealm.cleanup().add(r -> {
+            updateEmailAction.getConfig().remove(Constants.MAX_AUTH_AGE_KEY);
+            updateEmailAction.setEnabled(originalUpdateEmailEnabled);
+            r.flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
+        });
+
+        while (Instant.now().isBefore(instantAfterLogin.plusSeconds(1))) {
+            Thread.sleep(100);
+        }
+        oauth.loginForm().kcAction(UserModel.RequiredAction.UPDATE_EMAIL.name()).open();
+
+        loginPage.assertCurrent();
+        Assertions.assertTrue(driver.page().getPageSource().contains("Please re-authenticate to continue"));
+
+        loginPage.findSocialButton(IDP_ALIAS).click();
+
+        Assertions.assertTrue(driver.getCurrentUrl().contains("/realms/" + CONSUMER_REALM_NAME + "/"),
+                "After re-authentication, should be redirected back to the consumer realm to update the email address");
+        Assertions.assertTrue(driver.getCurrentUrl().contains("execution=UPDATE_EMAIL"),
+                "After re-authentication, should land on the UPDATE_EMAIL execution");
+    }
+
+    static class ProviderRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm
+                    .users(UserBuilder.create(USER_LOGIN)
+                            .name("Test", "User")
+                            .email(USER_EMAIL)
+                            .emailVerified(true)
+                            .password(USER_PASSWORD))
+                    .clients(ClientBuilder.create()
+                            .clientId(IDP_CLIENT_ID)
+                            .secret(IDP_CLIENT_SECRET)
+                            .redirectUris(BASE_URL + "/realms/" + CONSUMER_REALM_NAME + "/broker/" + IDP_ALIAS + "/endpoint*")
+                            .build());
+        }
+    }
+
+    static class BrokerAppClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                    .clientId(BROKER_APP_CLIENT_ID)
+                    .publicClient()
+                    .redirectUris(BASE_URL + "/*");
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/organization/broker/BrokerReAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/broker/BrokerReAuthTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.organization.broker;
+
+import java.time.Instant;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.IdentityProviderBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+
+@KeycloakIntegrationTest
+@DisplayName("AIA Re-authentication with Brokered Users when organizations are disabled")
+public class BrokerReAuthTest extends AbstractBrokerReAuthTest {
+
+    @InjectRealm(ref = CONSUMER_REALM_NAME, lifecycle = LifeCycle.METHOD)
+    ManagedRealm consumerRealm;
+
+    @Override
+    protected ManagedRealm getConsumerRealm() {
+        return consumerRealm;
+    }
+
+    @Override
+    protected Instant performFirstBrokerLogin(boolean hideIdpAfterFirstLogin) {
+        // IdP is always created visible; hiding happens after the first login if requested
+        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
+                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+                .alias(IDP_ALIAS)
+                .attribute("clientId", IDP_CLIENT_ID)
+                .attribute("clientSecret", IDP_CLIENT_SECRET)
+                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+                .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
+                .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
+                .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
+                .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
+                .build();
+
+        consumerRealm.admin().identityProviders().create(idp).close();
+        consumerRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
+
+        oauth.openLoginForm();
+        loginPage.assertCurrent();
+        loginPage.findSocialButton(IDP_ALIAS).click();
+        Assertions.assertTrue(driver.getCurrentUrl().contains("/realms/" + PROVIDER_REALM_NAME + "/"),
+                "Should be redirected to provider realm for first broker login");
+        loginPage.fillLogin(USER_LOGIN, USER_PASSWORD);
+        loginPage.submit();
+        Instant instant = Instant.now();
+
+        // Simulates an admin hiding an IdP after users are already federated to it
+        if (hideIdpAfterFirstLogin) {
+            IdentityProviderRepresentation rep = consumerRealm.admin().identityProviders().get(IDP_ALIAS).toRepresentation();
+            rep.setHideOnLogin(true);
+            consumerRealm.admin().identityProviders().get(IDP_ALIAS).update(rep);
+        }
+
+        return instant;
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/organization/broker/OrganizationBrokerReAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/broker/OrganizationBrokerReAuthTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.organization.broker;
+
+import java.time.Instant;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.OrganizationModel;
+import org.keycloak.models.OrganizationModel.IdentityProviderRedirectMode;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.OrganizationDomainRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.IdentityProviderBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.LoginUsernamePage;
+import org.keycloak.testframework.util.ApiUtil;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+
+@KeycloakIntegrationTest
+@DisplayName("AIA Re-authentication with Brokered Users when organizations are enabled")
+public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
+
+    private static final String ORG_NAME = "neworg";
+    private static final String ORG_DOMAIN = "neworg.org"; // must match USER_EMAIL domain
+
+    @InjectRealm(ref = CONSUMER_REALM_NAME, config = ConsumerRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm consumerRealm;
+
+    @InjectPage
+    LoginUsernamePage loginUsernamePage;
+
+    @Override
+    protected ManagedRealm getConsumerRealm() {
+        return consumerRealm;
+    }
+
+    @Override
+    protected Instant performFirstBrokerLogin(boolean hideOnLogin) {
+        OrganizationRepresentation org = new OrganizationRepresentation();
+        org.setName(ORG_NAME);
+        org.setAlias(ORG_NAME);
+        org.addDomain(new OrganizationDomainRepresentation(ORG_DOMAIN));
+        String orgId;
+        try (Response response = consumerRealm.admin().organizations().create(org)) {
+            orgId = ApiUtil.getCreatedId(response);
+        }
+        consumerRealm.cleanup().add(r -> {
+            try { r.organizations().get(orgId).delete().close(); } catch (Exception ignored) {}
+        });
+
+        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
+                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+                .alias(IDP_ALIAS)
+                .attribute("clientId", IDP_CLIENT_ID)
+                .attribute("clientSecret", IDP_CLIENT_SECRET)
+                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+                .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
+                .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
+                .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
+                .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
+                .attribute(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, ORG_DOMAIN)
+                .attribute(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.TRUE.toString())
+                .build();
+        idp.setHideOnLogin(hideOnLogin);
+
+        consumerRealm.admin().identityProviders().create(idp).close();
+        consumerRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
+        consumerRealm.admin().organizations().get(orgId).identityProviders().addIdentityProvider(IDP_ALIAS).close();
+
+        oauth.openLoginForm();
+        loginUsernamePage.fillLoginWithUsernameOnly(USER_EMAIL);
+        loginUsernamePage.submit();
+        Assertions.assertTrue(driver.getCurrentUrl().contains("/realms/" + PROVIDER_REALM_NAME + "/"),
+                "Should be redirected to provider realm for first broker login");
+        loginPage.fillLogin(USER_LOGIN, USER_PASSWORD);
+        loginPage.submit();
+        return Instant.now();
+    }
+
+    static class ConsumerRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm.organizationsEnabled(true);
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/organization/broker/OrganizationBrokerReAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/broker/OrganizationBrokerReAuthTest.java
@@ -28,6 +28,7 @@ import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.OrganizationModel.IdentityProviderRedirectMode;
 import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
@@ -47,6 +48,7 @@ import org.keycloak.testframework.util.ApiUtil;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openqa.selenium.NoSuchElementException;
@@ -60,13 +62,23 @@ public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
     private static final String ORG_NAME = "neworg";
     private static final String ORG_DOMAIN = "neworg.org"; // must match USER_EMAIL domain
 
-    // Constants for the cross-org isolation test
+    // Constants for the cross-org isolation tests
     private static final String ORG_A_NAME = "org-a";
     private static final String ORG_A_DOMAIN = "org-a.org";
     private static final String ORG_B_NAME = "org-b";
     private static final String ORG_B_DOMAIN = "org-b.org";
     private static final String LOCAL_USER_LOGIN = "localuser";
     private static final String LOCAL_USER_EMAIL = "localuser@org-b.org";
+    private static final String IDP_A_ALIAS = "idp-a";
+    private static final String IDP_B_ALIAS = "idp-b";
+    private static final String IDP_A_CLIENT_ID = "idp-a-client";
+    private static final String IDP_A_CLIENT_SECRET = "idp-a-secret";
+    private static final String IDP_B_CLIENT_ID = "idp-b-client";
+    private static final String IDP_B_CLIENT_SECRET = "idp-b-secret";
+    private static final String USER_A_LOGIN = "user-a";
+    private static final String USER_A_EMAIL = "user-a@org-a.org";
+    private static final String USER_B_LOGIN = "user-b";
+    private static final String USER_B_EMAIL = "user-b@org-b.org";
 
     @InjectRealm(ref = CONSUMER_REALM_NAME, config = ConsumerRealmConfig.class, lifecycle = LifeCycle.METHOD)
     ManagedRealm consumerRealm;
@@ -81,36 +93,8 @@ public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
 
     @Override
     protected Instant performFirstBrokerLogin(boolean hideOnLogin) {
-        OrganizationRepresentation org = new OrganizationRepresentation();
-        org.setName(ORG_NAME);
-        org.setAlias(ORG_NAME);
-        org.addDomain(new OrganizationDomainRepresentation(ORG_DOMAIN));
-        String orgId;
-        try (Response response = consumerRealm.admin().organizations().create(org)) {
-            orgId = ApiUtil.getCreatedId(response);
-        }
-        consumerRealm.cleanup().add(r -> {
-            try { r.organizations().get(orgId).delete().close(); } catch (Exception ignored) {}
-        });
-
-        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
-                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
-                .alias(IDP_ALIAS)
-                .attribute("clientId", IDP_CLIENT_ID)
-                .attribute("clientSecret", IDP_CLIENT_SECRET)
-                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
-                .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
-                .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
-                .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
-                .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
-                .attribute(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, ORG_DOMAIN)
-                .attribute(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.TRUE.toString())
-                .build();
-        idp.setHideOnLogin(hideOnLogin);
-
-        consumerRealm.admin().identityProviders().create(idp).close();
-        consumerRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
-        consumerRealm.admin().organizations().get(orgId).identityProviders().addIdentityProvider(IDP_ALIAS).close();
+        String orgId = createOrg(ORG_NAME, ORG_DOMAIN);
+        createOidcIdp(IDP_ALIAS, IDP_CLIENT_ID, IDP_CLIENT_SECRET, ORG_DOMAIN, orgId, hideOnLogin);
 
         oauth.openLoginForm();
         loginUsernamePage.fillLoginWithUsernameOnly(USER_EMAIL);
@@ -128,44 +112,8 @@ public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
     public void testUserInDifferentOrgDoesNotSeeIdpDuringReAuth(boolean hideIdp) throws InterruptedException {
         String orgAId = createOrg(ORG_A_NAME, ORG_A_DOMAIN);
         String orgBId = createOrg(ORG_B_NAME, ORG_B_DOMAIN);
-
-        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
-                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
-                .alias(IDP_ALIAS)
-                .attribute("clientId", IDP_CLIENT_ID)
-                .attribute("clientSecret", IDP_CLIENT_SECRET)
-                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
-                .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
-                .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
-                .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
-                .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
-                .attribute(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, ORG_A_DOMAIN)
-                .attribute(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.TRUE.toString())
-                .build();
-        idp.setHideOnLogin(hideIdp);
-        consumerRealm.admin().identityProviders().create(idp).close();
-        consumerRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
-        consumerRealm.admin().organizations().get(orgAId).identityProviders().addIdentityProvider(IDP_ALIAS).close();
-
-        CredentialRepresentation credential = new CredentialRepresentation();
-        credential.setType(CredentialRepresentation.PASSWORD);
-        credential.setValue(USER_PASSWORD);
-        credential.setTemporary(false);
-
-        UserRepresentation localUser = new UserRepresentation();
-        localUser.setUsername(LOCAL_USER_LOGIN);
-        localUser.setEmail(LOCAL_USER_EMAIL);
-        localUser.setFirstName("Local");
-        localUser.setLastName("User");
-        localUser.setEmailVerified(true);
-        localUser.setEnabled(true);
-        localUser.setCredentials(List.of(credential));
-
-        String userId;
-        try (Response r = consumerRealm.admin().users().create(localUser)) {
-            userId = ApiUtil.getCreatedId(r);
-        }
-        consumerRealm.cleanup().add(r -> r.users().get(userId).remove());
+        createOidcIdp(IDP_ALIAS, IDP_CLIENT_ID, IDP_CLIENT_SECRET, ORG_A_DOMAIN, orgAId, hideIdp);
+        String userId = addConsumerUser(LOCAL_USER_LOGIN, LOCAL_USER_EMAIL);
         consumerRealm.admin().organizations().get(orgBId).members().addMember(userId);
 
         oauth.openLoginForm();
@@ -178,30 +126,162 @@ public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
         assertTrue(driver.page().getPageSource().contains("Happy days"));
         Instant instantAfterLogin = Instant.now();
 
-        RequiredActionProviderRepresentation updateEmailAction = consumerRealm.admin().flows().getRequiredActions()
-                .stream()
-                .filter(a -> UserModel.RequiredAction.UPDATE_EMAIL.name().equals(a.getProviderId()))
-                .findFirst()
-                .orElseThrow();
-        final var originalUpdateEmailEnabled = updateEmailAction.isEnabled();
-        updateEmailAction.getConfig().put(Constants.MAX_AUTH_AGE_KEY, "0");
-        updateEmailAction.setEnabled(true);
-        consumerRealm.admin().flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
-        consumerRealm.cleanup().add(r -> {
-            updateEmailAction.getConfig().remove(Constants.MAX_AUTH_AGE_KEY);
-            updateEmailAction.setEnabled(originalUpdateEmailEnabled);
-            r.flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
-        });
-
-        while (Instant.now().isBefore(instantAfterLogin.plusSeconds(1))) {
-            Thread.sleep(100);
-        }
+        configureUpdateEmailMaxAuthAge();
+        waitUntil(instantAfterLogin.plusSeconds(1));
         oauth.loginForm().kcAction(UserModel.RequiredAction.UPDATE_EMAIL.name()).open();
 
         loginPage.assertCurrent();
         Assertions.assertTrue(driver.page().getPageSource().contains("Please re-authenticate to continue"));
         Assertions.assertThrows(NoSuchElementException.class, () -> loginPage.findSocialButton(IDP_ALIAS),
                 "IdP linked to a different org should not be visible during re-authentication");
+    }
+
+    @Test
+    @DisplayName("During re-authentication each user sees only the IdP linked to their own org")
+    public void testEachUserSeesOnlyTheirOrgIdpDuringReAuth() throws InterruptedException {
+        String orgAId = createOrg(ORG_A_NAME, ORG_A_DOMAIN);
+        String orgBId = createOrg(ORG_B_NAME, ORG_B_DOMAIN);
+        createOidcIdp(IDP_A_ALIAS, IDP_A_CLIENT_ID, IDP_A_CLIENT_SECRET, ORG_A_DOMAIN, orgAId);
+        createOidcIdp(IDP_B_ALIAS, IDP_B_CLIENT_ID, IDP_B_CLIENT_SECRET, ORG_B_DOMAIN, orgBId);
+        addProviderUser(USER_A_LOGIN, USER_A_EMAIL);
+        addProviderUser(USER_B_LOGIN, USER_B_EMAIL);
+        addProviderClient(IDP_A_CLIENT_ID, IDP_A_CLIENT_SECRET, IDP_A_ALIAS);
+        addProviderClient(IDP_B_CLIENT_ID, IDP_B_CLIENT_SECRET, IDP_B_ALIAS);
+        configureUpdateEmailMaxAuthAge();
+
+        Instant afterUserALogin = doBrokerLogin(USER_A_EMAIL, USER_A_LOGIN);
+        waitUntil(afterUserALogin.plusSeconds(1));
+        oauth.loginForm().kcAction(UserModel.RequiredAction.UPDATE_EMAIL.name()).open();
+        loginPage.assertCurrent();
+        assertTrue(driver.page().getPageSource().contains("Please re-authenticate to continue"));
+        Assertions.assertDoesNotThrow(() -> loginPage.findSocialButton(IDP_A_ALIAS));
+        Assertions.assertThrows(NoSuchElementException.class, () -> loginPage.findSocialButton(IDP_B_ALIAS),
+                "User A should not see org B's IdP during re-authentication");
+
+        logoutUser(USER_A_EMAIL, USER_A_LOGIN);
+
+        Instant afterUserBLogin = doBrokerLogin(USER_B_EMAIL, USER_B_LOGIN);
+        waitUntil(afterUserBLogin.plusSeconds(1));
+        oauth.loginForm().kcAction(UserModel.RequiredAction.UPDATE_EMAIL.name()).open();
+        loginPage.assertCurrent();
+        assertTrue(driver.page().getPageSource().contains("Please re-authenticate to continue"));
+        Assertions.assertDoesNotThrow(() -> loginPage.findSocialButton(IDP_B_ALIAS));
+        Assertions.assertThrows(NoSuchElementException.class, () -> loginPage.findSocialButton(IDP_A_ALIAS),
+                "User B should not see org A's IdP during re-authentication");
+    }
+
+    private Instant doBrokerLogin(String email, String providerUsername) {
+        oauth.openLoginForm();
+        loginUsernamePage.assertCurrent();
+        loginUsernamePage.fillLoginWithUsernameOnly(email);
+        loginUsernamePage.submit();
+        Assertions.assertTrue(driver.getCurrentUrl().contains("/realms/" + PROVIDER_REALM_NAME + "/"),
+                "Should be redirected to provider realm for first broker login");
+        loginPage.fillLogin(providerUsername, USER_PASSWORD);
+        loginPage.submit();
+        assertTrue(driver.page().getPageSource().contains("Happy days"));
+        return Instant.now();
+    }
+
+    private void logoutUser(String email, String login) {
+        consumerRealm.admin().users().search(email).stream()
+                .findFirst()
+                .ifPresent(u -> consumerRealm.admin().users().get(u.getId()).logout());
+        providerRealm.admin().users().search(login).stream()
+                .findFirst()
+                .ifPresent(u -> providerRealm.admin().users().get(u.getId()).logout());
+        driver.runCleanup();
+        driver.cookies().deleteAll();
+    }
+
+    private static void waitUntil(Instant instant) throws InterruptedException {
+        while (Instant.now().isBefore(instant)) {
+            Thread.sleep(100);
+        }
+    }
+
+    private void configureUpdateEmailMaxAuthAge() {
+        RequiredActionProviderRepresentation updateEmailAction = consumerRealm.admin().flows().getRequiredActions()
+                .stream()
+                .filter(a -> UserModel.RequiredAction.UPDATE_EMAIL.name().equals(a.getProviderId()))
+                .findFirst()
+                .orElseThrow();
+        final boolean originalEnabled = updateEmailAction.isEnabled();
+        updateEmailAction.getConfig().put(Constants.MAX_AUTH_AGE_KEY, "0");
+        updateEmailAction.setEnabled(true);
+        consumerRealm.admin().flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
+        consumerRealm.cleanup().add(r -> {
+            updateEmailAction.getConfig().remove(Constants.MAX_AUTH_AGE_KEY);
+            updateEmailAction.setEnabled(originalEnabled);
+            r.flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
+        });
+    }
+
+    private void createOidcIdp(String alias, String clientId, String clientSecret, String orgDomain, String orgId) {
+        createOidcIdp(alias, clientId, clientSecret, orgDomain, orgId, false);
+    }
+
+    private void createOidcIdp(String alias, String clientId, String clientSecret, String orgDomain, String orgId, boolean hideOnLogin) {
+        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
+                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+                .alias(alias)
+                .attribute("clientId", clientId)
+                .attribute("clientSecret", clientSecret)
+                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+                .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
+                .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
+                .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
+                .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
+                .attribute(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, orgDomain)
+                .attribute(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.TRUE.toString())
+                .build();
+        idp.setHideOnLogin(hideOnLogin);
+        consumerRealm.admin().identityProviders().create(idp).close();
+        consumerRealm.cleanup().add(r -> r.identityProviders().get(alias).remove());
+        consumerRealm.admin().organizations().get(orgId).identityProviders().addIdentityProvider(alias).close();
+    }
+
+    private void addProviderUser(String login, String email) {
+        createUser(providerRealm, login, email);
+    }
+
+    private String addConsumerUser(String login, String email) {
+        return createUser(consumerRealm, login, email);
+    }
+
+    private String createUser(ManagedRealm realm, String login, String email) {
+        CredentialRepresentation cred = new CredentialRepresentation();
+        cred.setType(CredentialRepresentation.PASSWORD);
+        cred.setValue(USER_PASSWORD);
+        cred.setTemporary(false);
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(login);
+        user.setEmail(email);
+        user.setFirstName("Test");
+        user.setLastName("User");
+        user.setEmailVerified(true);
+        user.setEnabled(true);
+        user.setCredentials(List.of(cred));
+        String userId;
+        try (Response r = realm.admin().users().create(user)) {
+            userId = ApiUtil.getCreatedId(r);
+        }
+        realm.cleanup().add(r -> r.users().get(userId).remove());
+        return userId;
+    }
+
+    private void addProviderClient(String clientId, String secret, String idpAlias) {
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(clientId);
+        client.setSecret(secret);
+        client.setEnabled(true);
+        client.setPublicClient(false);
+        client.setRedirectUris(List.of(BASE_URL + "/realms/" + CONSUMER_REALM_NAME + "/broker/" + idpAlias + "/endpoint*"));
+        String id;
+        try (Response r = providerRealm.admin().clients().create(client)) {
+            id = ApiUtil.getCreatedId(r);
+        }
+        providerRealm.cleanup().add(r -> r.clients().get(id).remove());
     }
 
     private String createOrg(String name, String domain) {

--- a/tests/base/src/test/java/org/keycloak/tests/organization/broker/OrganizationBrokerReAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/broker/OrganizationBrokerReAuthTest.java
@@ -18,16 +18,22 @@
 package org.keycloak.tests.organization.broker;
 
 import java.time.Instant;
+import java.util.List;
 
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.broker.oidc.OIDCIdentityProviderFactory;
+import org.keycloak.models.Constants;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.OrganizationModel.IdentityProviderRedirectMode;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
 import org.keycloak.representations.idm.OrganizationDomainRepresentation;
 import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.injection.LifeCycle;
@@ -41,6 +47,11 @@ import org.keycloak.testframework.util.ApiUtil;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openqa.selenium.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest
 @DisplayName("AIA Re-authentication with Brokered Users when organizations are enabled")
@@ -48,6 +59,14 @@ public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
 
     private static final String ORG_NAME = "neworg";
     private static final String ORG_DOMAIN = "neworg.org"; // must match USER_EMAIL domain
+
+    // Constants for the cross-org isolation test
+    private static final String ORG_A_NAME = "org-a";
+    private static final String ORG_A_DOMAIN = "org-a.org";
+    private static final String ORG_B_NAME = "org-b";
+    private static final String ORG_B_DOMAIN = "org-b.org";
+    private static final String LOCAL_USER_LOGIN = "localuser";
+    private static final String LOCAL_USER_EMAIL = "localuser@org-b.org";
 
     @InjectRealm(ref = CONSUMER_REALM_NAME, config = ConsumerRealmConfig.class, lifecycle = LifeCycle.METHOD)
     ManagedRealm consumerRealm;
@@ -101,6 +120,103 @@ public class OrganizationBrokerReAuthTest extends AbstractBrokerReAuthTest {
         loginPage.fillLogin(USER_LOGIN, USER_PASSWORD);
         loginPage.submit();
         return Instant.now();
+    }
+
+    @ParameterizedTest(name = "IdP hidden: {0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("User in a different org does not see the other org's IdP during re-authentication")
+    public void testUserInDifferentOrgDoesNotSeeIdpDuringReAuth(boolean hideIdp) throws InterruptedException {
+        String orgAId = createOrg(ORG_A_NAME, ORG_A_DOMAIN);
+        String orgBId = createOrg(ORG_B_NAME, ORG_B_DOMAIN);
+
+        IdentityProviderRepresentation idp = IdentityProviderBuilder.create()
+                .providerId(OIDCIdentityProviderFactory.PROVIDER_ID)
+                .alias(IDP_ALIAS)
+                .attribute("clientId", IDP_CLIENT_ID)
+                .attribute("clientSecret", IDP_CLIENT_SECRET)
+                .attribute(IdentityProviderModel.SYNC_MODE, "IMPORT")
+                .attribute("authorizationUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/auth")
+                .attribute("tokenUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/token")
+                .attribute("jwksUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/certs")
+                .attribute("logoutUrl", BASE_URL + "/realms/" + PROVIDER_REALM_NAME + "/protocol/openid-connect/logout")
+                .attribute(OrganizationModel.ORGANIZATION_DOMAIN_ATTRIBUTE, ORG_A_DOMAIN)
+                .attribute(IdentityProviderRedirectMode.EMAIL_MATCH.getKey(), Boolean.TRUE.toString())
+                .build();
+        idp.setHideOnLogin(hideIdp);
+        consumerRealm.admin().identityProviders().create(idp).close();
+        consumerRealm.cleanup().add(r -> r.identityProviders().get(IDP_ALIAS).remove());
+        consumerRealm.admin().organizations().get(orgAId).identityProviders().addIdentityProvider(IDP_ALIAS).close();
+
+        CredentialRepresentation credential = new CredentialRepresentation();
+        credential.setType(CredentialRepresentation.PASSWORD);
+        credential.setValue(USER_PASSWORD);
+        credential.setTemporary(false);
+
+        UserRepresentation localUser = new UserRepresentation();
+        localUser.setUsername(LOCAL_USER_LOGIN);
+        localUser.setEmail(LOCAL_USER_EMAIL);
+        localUser.setFirstName("Local");
+        localUser.setLastName("User");
+        localUser.setEmailVerified(true);
+        localUser.setEnabled(true);
+        localUser.setCredentials(List.of(credential));
+
+        String userId;
+        try (Response r = consumerRealm.admin().users().create(localUser)) {
+            userId = ApiUtil.getCreatedId(r);
+        }
+        consumerRealm.cleanup().add(r -> r.users().get(userId).remove());
+        consumerRealm.admin().organizations().get(orgBId).members().addMember(userId);
+
+        oauth.openLoginForm();
+        loginUsernamePage.fillLoginWithUsernameOnly(LOCAL_USER_EMAIL);
+        loginUsernamePage.submit();
+        loginPage.fillPassword(USER_PASSWORD);
+        Assertions.assertThrows(NoSuchElementException.class, () -> loginPage.findSocialButton(IDP_ALIAS),
+                "IdP linked to a different org should not be visible during first authentication");
+        loginPage.submit();
+        assertTrue(driver.page().getPageSource().contains("Happy days"));
+        Instant instantAfterLogin = Instant.now();
+
+        RequiredActionProviderRepresentation updateEmailAction = consumerRealm.admin().flows().getRequiredActions()
+                .stream()
+                .filter(a -> UserModel.RequiredAction.UPDATE_EMAIL.name().equals(a.getProviderId()))
+                .findFirst()
+                .orElseThrow();
+        final var originalUpdateEmailEnabled = updateEmailAction.isEnabled();
+        updateEmailAction.getConfig().put(Constants.MAX_AUTH_AGE_KEY, "0");
+        updateEmailAction.setEnabled(true);
+        consumerRealm.admin().flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
+        consumerRealm.cleanup().add(r -> {
+            updateEmailAction.getConfig().remove(Constants.MAX_AUTH_AGE_KEY);
+            updateEmailAction.setEnabled(originalUpdateEmailEnabled);
+            r.flows().updateRequiredAction(UserModel.RequiredAction.UPDATE_EMAIL.name(), updateEmailAction);
+        });
+
+        while (Instant.now().isBefore(instantAfterLogin.plusSeconds(1))) {
+            Thread.sleep(100);
+        }
+        oauth.loginForm().kcAction(UserModel.RequiredAction.UPDATE_EMAIL.name()).open();
+
+        loginPage.assertCurrent();
+        Assertions.assertTrue(driver.page().getPageSource().contains("Please re-authenticate to continue"));
+        Assertions.assertThrows(NoSuchElementException.class, () -> loginPage.findSocialButton(IDP_ALIAS),
+                "IdP linked to a different org should not be visible during re-authentication");
+    }
+
+    private String createOrg(String name, String domain) {
+        OrganizationRepresentation org = new OrganizationRepresentation();
+        org.setName(name);
+        org.setAlias(name);
+        org.addDomain(new OrganizationDomainRepresentation(domain));
+        String orgId;
+        try (Response response = consumerRealm.admin().organizations().create(org)) {
+            orgId = ApiUtil.getCreatedId(response);
+        }
+        consumerRealm.cleanup().add(r -> {
+            try { r.organizations().get(orgId).delete().close(); } catch (Exception ignored) {}
+        });
+        return orgId;
     }
 
     static class ConsumerRealmConfig implements RealmConfig {


### PR DESCRIPTION
## Summary

When a brokered user (no local credentials) triggered an App-Initiated Action that required re-authentication, the re-auth login page did not show the user's identity provider, leaving them with no way to authenticate.

I tried to reproduce the scenario described in the issue, but I was only able to trigger the bug when the IdP's *Hide on login page* option is enabled. The first commit therefore adds four new tests covering all combinations of organization-enabled true/false and IdP hide-on-login true/false; the second commit contains the fix.

The fix threads `AuthenticationSessionModel` into `LoginFilter.getLoginPredicate()` (turning  the `Predicate` into a `BiPredicate`), so that the `HIDE_ON_LOGIN` filter is bypassed when  the `FORCED_REAUTHENTICATION` auth note is present on the session. Callers without an auth-session context (e.g. cache invalidation in `InfinispanIdentityProviderStorageProvider`) pass `null`, which preserves the original filtering behaviour.

I'm not fully confident this is the cleanest approach and left an inline comment on the `LoginFilter` change with the specific concerns — happy to hear better ideas.

## AI usage disclosure

The test scenarios and the fix were conceived and written by the author. Claude Code was used to migrate the tests from the legacy Arquillian-based framework to the new `@KeycloakIntegrationTest` framework.

Closes #42410