### PR TITLE
[26.6] Unhandled NPE with alg:none JWT in Bearer Authentication

### DIFF
--- a/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
+++ b/services/src/main/java/org/keycloak/crypto/CryptoUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.keycloak.common.VerificationException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.ProviderFactory;
 
@@ -34,6 +35,20 @@ import org.keycloak.provider.ProviderFactory;
  * @author <a href="https://github.com/forkimenjeckayang">Forkim Akwichek</a>
  */
 public class CryptoUtils {
+
+    /**
+     * Looks up a {@link SignatureProvider} for the given algorithm, throwing if none is registered.
+     */
+    public static SignatureProvider getSignatureProvider(KeycloakSession session, String algorithm) throws VerificationException {
+        if (algorithm == null) {
+            throw new VerificationException("Missing token algorithm");
+        }
+        SignatureProvider signatureProvider = session.getProvider(SignatureProvider.class, algorithm);
+        if (signatureProvider == null) {
+            throw new VerificationException("Unsupported token algorithm: " + algorithm);
+        }
+        return signatureProvider;
+    }
 
     /**
      * Returns the supported asymmetric signature algorithms.

--- a/services/src/main/java/org/keycloak/organization/utils/Organizations.java
+++ b/services/src/main/java/org/keycloak/organization/utils/Organizations.java
@@ -32,7 +32,7 @@ import org.keycloak.authentication.actiontoken.inviteorg.InviteOrgActionToken;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
 import org.keycloak.common.VerificationException;
-import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.Constants;
@@ -170,7 +170,7 @@ public class Organizations {
                 .withChecks(TokenVerifier.IS_ACTIVE,
                         new TokenVerifier.RealmUrlCheck(Urls.realmIssuer(context.getUri().getBaseUri(), realm.getName())));
 
-        SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+        SignatureVerifierContext verifierContext = CryptoUtils.getSignatureProvider(session, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
         verifier.verifierContext(verifierContext);
 
         return verifier.verify().getToken();

--- a/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/AccessTokenIntrospectionProvider.java
@@ -24,7 +24,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
-import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -226,7 +226,7 @@ public class AccessTokenIntrospectionProvider<T extends AccessToken> implements 
             TokenVerifier<T> verifier = TokenVerifier.create(tokenStr, getTokenClass())
                     .realmUrl(Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = CryptoUtils.getSignatureProvider(session, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             this.token = verifier.verify().getToken();

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -37,6 +37,7 @@ import org.keycloak.common.ClientConnection;
 import org.keycloak.common.VerificationException;
 import org.keycloak.crypto.CekManagementProvider;
 import org.keycloak.crypto.ContentEncryptionProvider;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
@@ -191,7 +192,7 @@ public class UserInfoEndpoint {
 
             verifier = DPoPUtil.withDPoPVerifier(verifier, realm, new DPoPUtil.Validator(session).request(request).uriInfo(session.getContext().getUri()).accessToken(tokenForUserInfo.getToken()));
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = CryptoUtils.getSignatureProvider(session, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             token = verifier.verify().getToken();

--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationTokenUtils.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationTokenUtils.java
@@ -25,6 +25,7 @@ import org.keycloak.TokenCategory;
 import org.keycloak.TokenVerifier;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
@@ -99,7 +100,7 @@ public class ClientRegistrationTokenUtils {
             TokenVerifier<AccessToken> verifier = TokenVerifier.create(token, AccessToken.class)
                     .withChecks(new TokenVerifier.RealmUrlCheck(getIssuer(session, realm)), TokenVerifier.IS_ACTIVE, new TokenRevocationCheck(session));
 
-            SignatureVerifierContext verifierContext = session.getProvider(SignatureProvider.class, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            SignatureVerifierContext verifierContext = CryptoUtils.getSignatureProvider(session, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
             verifier.verifierContext(verifierContext);
 
             kid = verifierContext.getKid();

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -66,6 +66,7 @@ import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.cookie.CookieProvider;
 import org.keycloak.cookie.CookieType;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.events.Details;
@@ -259,7 +260,7 @@ public class AuthenticationManager {
             String kid = verifier.getHeader().getKeyId();
             String algorithm = verifier.getHeader().getAlgorithm().name();
 
-            SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(kid);
+            SignatureVerifierContext signatureVerifier = CryptoUtils.getSignatureProvider(session, algorithm).verifier(kid);
             verifier.verifierContext(signatureVerifier);
 
             AccessToken token = verifier.verify().getToken();

--- a/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
@@ -39,6 +39,7 @@ import org.keycloak.TokenVerifier;
 import org.keycloak.common.Profile;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.CryptoUtils;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureVerifierContext;
@@ -208,7 +209,7 @@ public class DPoPUtil {
 
         key.setAlgorithm(header.getAlgorithm().name());
 
-        SignatureVerifierContext signatureVerifier = session.getProvider(SignatureProvider.class, algorithm).verifier(key);
+        SignatureVerifierContext signatureVerifier = CryptoUtils.getSignatureProvider(session, algorithm).verifier(key);
         verifier.verifierContext(signatureVerifier);
         verifier.withChecks(
                 DPoPClaimsCheck.INSTANCE,

--- a/services/src/test/java/org/keycloak/crypto/CryptoUtilsTest.java
+++ b/services/src/test/java/org/keycloak/crypto/CryptoUtilsTest.java
@@ -1,0 +1,40 @@
+package org.keycloak.crypto;
+
+import org.keycloak.common.VerificationException;
+import org.keycloak.utils.AbstractUtilSessionTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CryptoUtilsTest extends AbstractUtilSessionTest {
+
+    @Test
+    public void getSignatureProviderReturnsProviderForSupportedAlgorithm() throws VerificationException {
+        assertNotNull(CryptoUtils.getSignatureProvider(session, "RS256"));
+    }
+
+    @Test
+    public void getSignatureProviderThrowsForNoneAlgorithm() {
+        VerificationException thrown = assertThrows(VerificationException.class,
+                () -> CryptoUtils.getSignatureProvider(session, "none"));
+        assertThat(thrown.getMessage(), containsString("none"));
+    }
+
+    @Test
+    public void getSignatureProviderThrowsForUnknownAlgorithm() {
+        VerificationException thrown = assertThrows(VerificationException.class,
+                () -> CryptoUtils.getSignatureProvider(session, "FAKE256"));
+        assertThat(thrown.getMessage(), containsString("FAKE256"));
+    }
+
+    @Test
+    public void getSignatureProviderThrowsForNullAlgorithm() {
+        assertThrows(VerificationException.class,
+                () -> CryptoUtils.getSignatureProvider(session, null));
+    }
+
+}

--- a/services/src/test/java/org/keycloak/services/util/DPoPUtilTests.java
+++ b/services/src/test/java/org/keycloak/services/util/DPoPUtilTests.java
@@ -4,38 +4,21 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import org.keycloak.common.Profile;
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.crypto.CryptoIntegration;
-import org.keycloak.common.crypto.CryptoProvider;
 import org.keycloak.http.HttpRequest;
-import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.resteasy.HttpRequestImpl;
-import org.keycloak.services.resteasy.ResteasyKeycloakSession;
-import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+import org.keycloak.utils.AbstractUtilSessionTest;
 
 import org.jboss.resteasy.mock.MockHttpRequest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class DPoPUtilTests {
+public class DPoPUtilTests extends AbstractUtilSessionTest {
     private static final String URL = "http://localhost/test";
     private static final long IAT = 1_000_000_000L;
-
-    private static KeycloakSession session;
-
-    @BeforeAll
-    public static void beforeAll() {
-        Profile.defaults();
-        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
-        ResteasyKeycloakSessionFactory sessionFactory = new ResteasyKeycloakSessionFactory();
-        sessionFactory.init();
-        session = new ResteasyKeycloakSession(sessionFactory);
-    }
 
     @Test
     public void testRejectsUnsupportedJwkKeyType() {

--- a/services/src/test/java/org/keycloak/utils/AbstractUtilSessionTest.java
+++ b/services/src/test/java/org/keycloak/utils/AbstractUtilSessionTest.java
@@ -1,0 +1,27 @@
+package org.keycloak.utils;
+
+import org.keycloak.common.Profile;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Abstract class for tests using some test session
+ */
+public abstract class AbstractUtilSessionTest {
+
+    protected static KeycloakSession session;
+
+    @BeforeAll
+    public static void beforeAll() {
+        Profile.defaults();
+        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
+        ResteasyKeycloakSessionFactory sessionFactory = new ResteasyKeycloakSessionFactory();
+        sessionFactory.init();
+        session = new ResteasyKeycloakSession(sessionFactory);
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
@@ -1,0 +1,56 @@
+package org.keycloak.tests.oauth;
+
+import java.io.IOException;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.common.util.Time;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
+import org.keycloak.testsuite.util.oauth.UserInfoResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@KeycloakIntegrationTest
+public class TokenInputValidationTest {
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @Test
+    public void userInfoRejectsAlgNoneToken() {
+        String noneToken = new JWSBuilder().jsonContent(createDefaultToken()).none();
+        UserInfoResponse response = oauth.doUserInfoRequest(noneToken);
+
+        assertEquals(401, response.getStatusCode());
+        assertFalse(response.isSuccess());
+        assertEquals(OAuthErrorException.INVALID_TOKEN, response.getError());
+    }
+
+    @Test
+    public void introspectionRejectsAlgNoneToken() throws IOException {
+        String noneToken = new JWSBuilder().jsonContent(createDefaultToken()).none();
+        IntrospectionResponse response = oauth.doIntrospectionAccessTokenRequest(noneToken);
+
+        assertFalse(response.asJsonNode().get("active").asBoolean());
+    }
+
+    private JsonWebToken createDefaultToken() {
+        JsonWebToken token = new JsonWebToken();
+        token.id(SecretGenerator.getInstance().generateSecureID());
+        token.issuer("http://127.0.0.1:8500");
+        token.audience(oauth.getEndpoints().getIssuer());
+        token.iat((long) Time.currentTime());
+        token.exp((long) (Time.currentTime() + 300));
+        token.subject("attacker");
+        return token;
+    }
+
+}


### PR DESCRIPTION
* Unhandled NPE with alg:none JWT in Bearer Authentication

Closes #48744

Signed-off-by: Martin Bartoš <mabartos@redhat.com>

* Update test to create programatically token with alg:none

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
Co-authored-by: Ricardo Martin <rmartinc@redhat.com>

---------

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
Co-authored-by: Ricardo Martin <rmartinc@redhat.com>
(cherry picked from commit 1e99746a68c0990f2de8cb60a7dbf3a12fa94f12)


@rmartinc I suggest backporting it to 26.6 release, are you ok with that? 