### PR TITLE
Added validation to client_session_host

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -129,6 +129,12 @@ will now be logged.
 Users of `ssl-cert-chain-prefix` should instead make use of `--spi-x509cert-lookup--haproxy--ssl-cert-chain`.
 See the link:{client_certificate_lookup_link}[Reverse Proxy guide] for more details.
 
+=== Validation of client_session_host parameter
+The `client_session_host` parameter is now validated against the client's registered nodes and management URL.
+This parameter is sent by clients during token refresh and is used when the `${application.session.host}` placeholder is present in a client's backchannel logout URL configuration.
+It was primarily used by legacy adapters that have been removed.
+This improves security by ensuring that only trusted, pre-registered hosts can be used in backchannel logout URLs.
+
 // ------------------------ Removed features ------------------------ //
 == Removed features
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -52,6 +52,8 @@ import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorManager;
 import org.keycloak.protocol.oidc.rar.InvalidAuthorizationDetailsException;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
+import org.keycloak.protocol.oidc.utils.ClientHostUtils;
+import org.keycloak.rar.AuthorizationRequestContext;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;
@@ -232,9 +234,21 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
                 clientSession.setNote(AdapterConstants.CLIENT_SESSION_STATE, adapterSessionId);
             }
 
-            String oldClientSessionHost = clientSession.getNote(AdapterConstants.CLIENT_SESSION_HOST);
-            if (!Objects.equals(adapterSessionHost, oldClientSessionHost)) {
-                clientSession.setNote(AdapterConstants.CLIENT_SESSION_HOST, adapterSessionHost);
+            if ((adapterSessionHost != null) && (!adapterSessionHost.trim().isEmpty())) {
+                // CVE-2026-4874 - client_session_host requires validation as an external field that is stored in client
+                // session and can be used to generate logout callback URL.
+                if (!ClientHostUtils.isHostAllowedForClient(adapterSessionHost, client, session)) {
+                    logger.warnf("Adapter Session '%s' not valid in ClientSession for client '%s'. Host is '%s' and has been removed.",
+                            adapterSessionId, client.getClientId(), adapterSessionHost);
+                    return;
+                }
+
+                String oldClientSessionHost = clientSession.getNote(AdapterConstants.CLIENT_SESSION_HOST);
+                if (!Objects.equals(adapterSessionHost, oldClientSessionHost)) {
+                    clientSession.setNote(AdapterConstants.CLIENT_SESSION_HOST, adapterSessionHost);
+                    logger.debugf("Adapter Session '%s' saved in ClientSession for client '%s'. Host is '%s'",
+                            adapterSessionId, client.getClientId(), adapterSessionHost);
+                }
             }
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -53,7 +53,6 @@ import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorManager;
 import org.keycloak.protocol.oidc.rar.InvalidAuthorizationDetailsException;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
 import org.keycloak.protocol.oidc.utils.ClientHostUtils;
-import org.keycloak.rar.AuthorizationRequestContext;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/ClientHostUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/ClientHostUtils.java
@@ -23,7 +23,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Optional;
 
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
@@ -42,11 +42,11 @@ public class ClientHostUtils {
     private static final Logger logger = Logger.getLogger(ClientHostUtils.class);
 
     /**
-     * Validates that a hostname matches one of the client's registered URLs
-     * (redirect URIs, root URL, management URL, base URL).
-     * This validation prevents SSRF attacks by ensuring that only hosts that
-     * administrators have explicitly configured for the client can be used.
-     *
+     * Validates that a hostname matches one of the client's registered nodes
+     * or the  management URL/Admin URL.
+     * This validation prevents SSRF attacks by ensuring that
+     * [1] only hostnames within the Management/Admin URL can be used.
+     * [2] hostnames matching registered clustered nodes can be used.
      * @param hostname the hostname to validate
      * @param client the client model containing registered URLs
      * @param session the Keycloak session for URL resolution
@@ -64,16 +64,11 @@ public class ClientHostUtils {
         // Extract just the hostname (strip port if present)
         String bareHostname = extractHostname(hostname);
 
-        // Extract allowed hosts from client's configured URLs
-        List<String> allowedHosts = new ArrayList<>();
-        addHostFromUrl(client.getRootUrl(), client, session, allowedHosts);
-        addHostFromUrl(client.getManagementUrl(), client, session, allowedHosts);
-        addHostFromUrl(client.getBaseUrl(), client, session, allowedHosts);
+        // Extract hostname from the list of managed hosts (if any)
+        List<String> allowedHosts = extractHostsFromClientManagedHosts(client, hostname);
 
-        // Extract from redirect URIs - returns true if wildcard match found
-        if (extractHostsFromRedirectUris(client, session, hostname, allowedHosts)) {
-            return true;
-        }
+        // Extract allowed hosts from managed/admin URL
+        addHostFromUrl(client.getManagementUrl(), client, session, allowedHosts);
 
         // Check if the hostname matches any allowed host (case-insensitive)
         for (String allowedHost : allowedHosts) {
@@ -102,23 +97,6 @@ public class ClientHostUtils {
         }
     }
 
-    private static void addHostFromUri(String uri, List<String> hosts) {
-        if (uri == null || uri.isEmpty()) {
-            return;
-        }
-
-        try {
-            String host = new URI(uri).getHost();
-            if (host != null) {
-                if (!hosts.contains(host)) {
-                    hosts.add(host);
-                }
-            }
-        } catch (URISyntaxException e) {
-            logger.debugf("Could not extract host from URI: %s", uri);
-        }
-    }
-
     private static void addHostFromUrl(String url, ClientModel client, KeycloakSession session, List<String> hosts) {
         if (url == null || url.isEmpty()) {
             return;
@@ -137,26 +115,15 @@ public class ClientHostUtils {
         }
     }
 
-    private static boolean extractHostsFromRedirectUris(ClientModel client, KeycloakSession session,
-                                                        String hostname, List<String> allowedHosts) {
-        Set<String> redirectUris = client.getRedirectUris();
-        if (redirectUris == null || redirectUris.isEmpty()) {
-            return false;
+    private static List<String> extractHostsFromClientManagedHosts(ClientModel client, String hostname) {
+        List<String> allowedHosts = new ArrayList<>();
+        if (hostname == null || hostname.trim().isEmpty()) {
+            return allowedHosts;
         }
-
-        Set<String> resolvedRedirects = RedirectUtils.resolveValidRedirects(
-                session, client.getRootUrl(), redirectUris
-        );
-
-        for (String redirectUri : resolvedRedirects) {
-            if ("*".equals(redirectUri)) {
-                logger.debugf("Client '%s' has wildcard redirect URI - allowing host '%s'",
-                        client.getClientId(), hostname);
-                return true;
-            }
-            addHostFromUri(redirectUri, allowedHosts);
-        }
-        return false;
+        Optional.ofNullable(client.getRegisteredNodes())
+                .ifPresent(nodes -> nodes.forEach((host, timestamp) -> {
+                    allowedHosts.add(host);
+                }));
+        return allowedHosts;
     }
-
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/ClientHostUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/ClientHostUtils.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.utils;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.util.ResolveRelative;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Utility class for validating client host values against a client's registered URLs.
+ * Used to prevent SSRF attacks by ensuring that dynamic host values (like client_session_host)
+ * only reference hosts that are already configured and trusted for the client.
+ * Resolves [CVE-2026-4874] Server-Side Request Forgery via OIDC token endpoint
+ */
+public class ClientHostUtils {
+
+    private static final Logger logger = Logger.getLogger(ClientHostUtils.class);
+
+    /**
+     * Validates that a hostname matches one of the client's registered URLs
+     * (redirect URIs, root URL, management URL, base URL).
+     * This validation prevents SSRF attacks by ensuring that only hosts that
+     * administrators have explicitly configured for the client can be used.
+     *
+     * @param hostname the hostname to validate
+     * @param client the client model containing registered URLs
+     * @param session the Keycloak session for URL resolution
+     * @return true if the hostname matches a registered client URL, false otherwise
+     */
+    public static boolean isHostAllowedForClient(String hostname, ClientModel client, KeycloakSession session) {
+        if (hostname == null || hostname.trim().isEmpty()) {
+            return false;
+        }
+
+        if (client == null) {
+            return false;
+        }
+
+        // Extract just the hostname (strip port if present)
+        String bareHostname = extractHostname(hostname);
+
+        // Extract allowed hosts from client's configured URLs
+        List<String> allowedHosts = new ArrayList<>();
+        addHostFromUrl(client.getRootUrl(), client, session, allowedHosts);
+        addHostFromUrl(client.getManagementUrl(), client, session, allowedHosts);
+        addHostFromUrl(client.getBaseUrl(), client, session, allowedHosts);
+
+        // Extract from redirect URIs - returns true if wildcard match found
+        if (extractHostsFromRedirectUris(client, session, hostname, allowedHosts)) {
+            return true;
+        }
+
+        // Check if the hostname matches any allowed host (case-insensitive)
+        for (String allowedHost : allowedHosts) {
+            if (allowedHost != null && allowedHost.equalsIgnoreCase(bareHostname)) {
+                logger.debugf("Host '%s' matches allowed host '%s' for client '%s'",
+                        hostname, allowedHost, client.getClientId());
+                return true;
+            }
+        }
+        logger.debugf("Host '%s' does not match any registered URL for client '%s'. Allowed hosts: %s",
+                hostname, client.getClientId(), allowedHosts);
+        return false;
+    }
+
+    private static String extractHostname(String hostPort) {
+        if (hostPort == null) {
+            return null;
+        }
+
+        try {
+            // Prepend a scheme since input is hostname:port, not full URI
+            return new URI("https://" + hostPort).getHost();
+        } catch (URISyntaxException e) {
+            logger.debugf("Could not parse hostname: %s", hostPort);
+            return null;
+        }
+    }
+
+    private static void addHostFromUri(String uri, List<String> hosts) {
+        if (uri == null || uri.isEmpty()) {
+            return;
+        }
+
+        try {
+            String host = new URI(uri).getHost();
+            if (host != null) {
+                if (!hosts.contains(host)) {
+                    hosts.add(host);
+                }
+            }
+        } catch (URISyntaxException e) {
+            logger.debugf("Could not extract host from URI: %s", uri);
+        }
+    }
+
+    private static void addHostFromUrl(String url, ClientModel client, KeycloakSession session, List<String> hosts) {
+        if (url == null || url.isEmpty()) {
+            return;
+        }
+
+        try {
+            String resolved = ResolveRelative.resolveRelativeUri(session, client.getRootUrl(), url);
+            String host = new URL(resolved).getHost();
+            if (host != null) {
+                if (!hosts.contains(host)) {
+                    hosts.add(host);
+                }
+            }
+        } catch (MalformedURLException e) {
+            logger.debugf("Could not extract host from URL: %s", url);
+        }
+    }
+
+    private static boolean extractHostsFromRedirectUris(ClientModel client, KeycloakSession session,
+                                                        String hostname, List<String> allowedHosts) {
+        Set<String> redirectUris = client.getRedirectUris();
+        if (redirectUris == null || redirectUris.isEmpty()) {
+            return false;
+        }
+
+        Set<String> resolvedRedirects = RedirectUtils.resolveValidRedirects(
+                session, client.getRootUrl(), redirectUris
+        );
+
+        for (String redirectUri : resolvedRedirects) {
+            if ("*".equals(redirectUri)) {
+                logger.debugf("Client '%s' has wildcard redirect URI - allowing host '%s'",
+                        client.getClientId(), hostname);
+                return true;
+            }
+            addHostFromUri(redirectUri, allowedHosts);
+        }
+        return false;
+    }
+
+}

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -46,6 +46,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.utils.ClientHostUtils;
 import org.keycloak.representations.LogoutToken;
 import org.keycloak.representations.adapters.action.GlobalRequestResult;
 import org.keycloak.representations.adapters.action.LogoutAction;
@@ -181,12 +182,6 @@ public class ResourceAdminManager {
         // KEYCLOAK-748)
         if (backchannelLogoutUrl.contains(CLIENT_SESSION_HOST_PROPERTY)) {
             String host = clientSession.getNote(AdapterConstants.CLIENT_SESSION_HOST);
-            if (host != null) {
-                String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
-                return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
-            }
-        }
-        return sendBackChannelLogoutRequestToClientUri(resource, clientSession, backchannelLogoutUrl);
             if (StringUtil.isNullOrEmpty(host)) {
                 // Host placeholder in backchannel logout URL cannot be resolved. Usually the client did not send
                 // both 'client_session_host' and 'client_session_state' on its token request.
@@ -199,8 +194,18 @@ public class ResourceAdminManager {
             logger.debugf("Attempting backchannel-logout for client with host from client session. " +
                           "clientId='%s' clientSessionId='%s' host='%s' backchannelLogoutUrl='%s'",
                     resource.getClientId(), clientSession.getId(), host, backchannelLogoutUrl);
-            String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
-            return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
+            if (ClientHostUtils.isHostAllowedForClient(host, resource, session)) {
+                String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
+                return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
+            } else {
+                logger.warnf("Unable to peform backchannel-logout for client. " +
+                                "clientId='%s' clientSessionId='%s' backchannelLogoutUrl='%s'",
+                        resource.getClientId(), clientSession.getId(), backchannelLogoutUrl);
+                throw new IllegalStateException(String.format(
+                        "Cannot resolve '%s' for backchannel-logout. No matching registered node, or management url. " +
+                                "clientId='%s' clientSessionId='%s' client_session_host='%s'",
+                        CLIENT_SESSION_HOST_PROPERTY, resource.getClientId(), clientSession.getId(), host));
+            }
         } else {
             logger.debugf("Attempting backchannel-logout for client. " +
                           "clientId='%s' clientSessionId='%s' backchannelLogoutUrl='%s'",

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -194,18 +194,18 @@ public class ResourceAdminManager {
             logger.debugf("Attempting backchannel-logout for client with host from client session. " +
                           "clientId='%s' clientSessionId='%s' host='%s' backchannelLogoutUrl='%s'",
                     resource.getClientId(), clientSession.getId(), host, backchannelLogoutUrl);
-            if (ClientHostUtils.isHostAllowedForClient(host, resource, session)) {
-                String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
-                return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
-            } else {
-                logger.warnf("Unable to peform backchannel-logout for client. " +
-                                "clientId='%s' clientSessionId='%s' backchannelLogoutUrl='%s'",
-                        resource.getClientId(), clientSession.getId(), backchannelLogoutUrl);
+
+            if (StringUtil.isNullOrEmpty(host) || !ClientHostUtils.isHostAllowedForClient(host, resource, session)) {
+                // Host placeholder in backchannel logout URL cannot be resolved or is not allowed. Usually the client did not send
+                // both 'client_session_host' and 'client_session_state' on its token request.
+                String adapterSessionId = clientSession.getNote(AdapterConstants.CLIENT_SESSION_STATE);
                 throw new IllegalStateException(String.format(
-                        "Cannot resolve '%s' for backchannel-logout. No matching registered node, or management url. " +
-                                "clientId='%s' clientSessionId='%s' client_session_host='%s'",
-                        CLIENT_SESSION_HOST_PROPERTY, resource.getClientId(), clientSession.getId(), host));
+                        "Cannot resolve '%s' for backchannel-logout or it was not allowed by the client. " +
+                                "clientId='%s' clientSessionId='%s' client_session_host='%s' client_session_state='%s'",
+                        CLIENT_SESSION_HOST_PROPERTY, resource.getClientId(), clientSession.getId(), host, adapterSessionId));
             }
+            String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
+            return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
         } else {
             logger.debugf("Attempting backchannel-logout for client. " +
                           "clientId='%s' clientSessionId='%s' backchannelLogoutUrl='%s'",

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -181,6 +181,12 @@ public class ResourceAdminManager {
         // KEYCLOAK-748)
         if (backchannelLogoutUrl.contains(CLIENT_SESSION_HOST_PROPERTY)) {
             String host = clientSession.getNote(AdapterConstants.CLIENT_SESSION_HOST);
+            if (host != null) {
+                String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
+                return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
+            }
+        }
+        return sendBackChannelLogoutRequestToClientUri(resource, clientSession, backchannelLogoutUrl);
             if (StringUtil.isNullOrEmpty(host)) {
                 // Host placeholder in backchannel logout URL cannot be resolved. Usually the client did not send
                 // both 'client_session_host' and 'client_session_state' on its token request.

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/ClientHostUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/ClientHostUtilsTest.java
@@ -1,6 +1,8 @@
 package org.keycloak.protocol.oidc.utils;
 
 import java.net.URI;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -29,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class for ClientHostUtils methods validating client_session_host against client URLs.
- *
+ * Note: when registering cluster nodes in admin client, some symbols '/', ':' etc. are not allowed.
  * @author Keycloak Security Team
  */
 public class ClientHostUtilsTest {
@@ -48,13 +50,10 @@ public class ClientHostUtilsTest {
     }
 
     @Test
-    public void testHostMatchesRedirectUri() {
+    public void testHostMatchesManagedNodesOnly() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "https://app.example.com/callback",
-                "https://app2.example.com/auth"
-        ).collect(Collectors.toSet()));
-
+        client.registerNode("app.example.com", (int) Instant.now().getEpochSecond());
+        client.registerNode("app2.example.com", (int) Instant.now().getEpochSecond());
         assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("app2.example.com", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
@@ -62,73 +61,32 @@ public class ClientHostUtilsTest {
     }
 
     @Test
-    public void testHostMatchesRedirectUriWithPort() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "https://app.example.com:8443/callback"
-        ).collect(Collectors.toSet()));
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com:8443", client, session));
-    }
-
-    @Test
-    public void testHostMatchesRootUrl() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRootUrl("https://root.example.com");
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("root.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("other.example.com", client, session));
-    }
-
-    @Test
-    public void testHostMatchesManagementUrl() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setManagementUrl("https://admin.example.com/management");
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("admin.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
-    }
-
-    @Test
-    public void testHostMatchesBaseUrl() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setBaseUrl("https://base.example.com");
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("base.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
-    }
-
-    @Test
-    public void testHostMatchesAnyConfiguredUrl() {
+    public void testHostMatchesManagementUrlOnly() {
         TestClientModel client = new TestClientModel("test-client");
         client.setRedirectUris(Stream.of("https://app.example.com/callback").collect(Collectors.toSet()));
-        client.setRootUrl("https://root.example.com");
-        client.setManagementUrl("https://admin.example.com/mgmt");
-        client.setBaseUrl("https://base.example.com");
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("root.example.com", client, session));
+        client.setManagementUrl("https://admin.example.com/management");
         assertTrue(ClientHostUtils.isHostAllowedForClient("admin.example.com", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("base.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
     }
 
     @Test
-    public void testWildcardRedirectUri() {
+    public void testHostMatchesAnyManagedNodeOrManagementUrl() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of("*").collect(Collectors.toSet()));
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("any.example.com", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
+        client.setRedirectUris(Stream.of("https://app3.example.com/callback").collect(Collectors.toSet()));
+        client.registerNode("app.example.com", (int) Instant.now().getEpochSecond());
+        client.registerNode("app2.example.com", (int) Instant.now().getEpochSecond());
+        client.setManagementUrl("https://admin.example.com/mgmt");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app2.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("admin.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("app3.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
     }
 
     @Test
     public void testNullAndEmptyHosts() {
         TestClientModel client = new TestClientModel("test-client");
         client.setRedirectUris(Stream.of("https://app.example.com/callback").collect(Collectors.toSet()));
-
         assertFalse(ClientHostUtils.isHostAllowedForClient(null, client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("   ", client, session));
@@ -140,64 +98,20 @@ public class ClientHostUtilsTest {
     }
 
     @Test
-    public void testNoUrlsConfigured() {
+    public void testLocalhostHostsInManagementUrl() {
         TestClientModel client = new TestClientModel("test-client");
-
-        assertFalse(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
-    }
-
-    @Test
-    public void testLocalhostHosts() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://localhost:8080/callback",
-                "http://127.0.0.1:8080/callback"
-        ).collect(Collectors.toSet()));
-
+        client.registerNode("127.0.0.1", (int) Instant.now().getEpochSecond());
+        client.registerNode("app2.example.com", (int) Instant.now().getEpochSecond());
+        client.setManagementUrl("http://localhost:8080/mgmt");
         assertTrue(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("localhost:8080", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1:8080", client, session));
-    }
-
-    @Test
-    public void testRelativeRedirectUris() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of("/callback").collect(Collectors.toSet()));
-        client.setRootUrl("https://root.example.com");
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("root.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
-    }
-
-    @Test
-    public void testSubdomainsDontMatch() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of("https://app.example.com/callback").collect(Collectors.toSet()));
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("sub.app.example.com", client, session));
-    }
-
-    @Test
-    public void testHttpsAndHttpDifferentSchemes() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "https://app.example.com/callback",
-                "http://dev.example.com/callback"
-        ).collect(Collectors.toSet()));
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("dev.example.com", client, session));
     }
 
     @Test
     public void testSSRFAttackPrevention() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of("https://public.example.com/callback").collect(Collectors.toSet()));
-
+        client.setManagementUrl("https://public.example.com/callback");
         assertTrue(ClientHostUtils.isHostAllowedForClient("public.example.com", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("internal.company.local", client, session));
@@ -208,26 +122,22 @@ public class ClientHostUtilsTest {
     @Test
     public void testIPv6WithBracketsAndPort() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://[::1]:8080/callback",
-                "http://[2001:db8::1]:8443/callback"
-        ).collect(Collectors.toSet()));
 
+        client.setManagementUrl( "http://[::1]:8080/callback");
         assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]:8443", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
+        client.setManagementUrl("http://[2001:db8::1]:8443/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]:8443", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]", client, session));
     }
 
     @Test
     public void testIPv6WithBracketsNoPort() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://[::1]/callback",
-                "http://[fe80::1]/auth"
-        ).collect(Collectors.toSet()));
-
+        client.setManagementUrl("http://[::1]/callback");
         assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
+        client.setManagementUrl("http://[fe80::1]/auth");
         assertTrue(ClientHostUtils.isHostAllowedForClient("[fe80::1]", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("fe80::1", client, session));
     }
@@ -235,10 +145,7 @@ public class ClientHostUtilsTest {
     @Test
     public void testIPv6BareAddress() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://[2001:db8:85a3::8a2e:370:7334]/callback"
-        ).collect(Collectors.toSet()));
-
+        client.setManagementUrl("http://[2001:db8:85a3::8a2e:370:7334]/callback");
         assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8:85a3::8a2e:370:7334]", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("2001:db8:85a3::8a2e:370:7334", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8:85a3::8a2e:370:7334]:443", client, session));
@@ -247,10 +154,7 @@ public class ClientHostUtilsTest {
     @Test
     public void testIPv6LinkLocal() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://[fe80::a00:27ff:fe4e:66a1]:3000/callback"
-        ).collect(Collectors.toSet()));
-
+        client.setManagementUrl("http://[fe80::a00:27ff:fe4e:66a1]:3000/callback");
         assertTrue(ClientHostUtils.isHostAllowedForClient("[fe80::a00:27ff:fe4e:66a1]:3000", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("[fe80::a00:27ff:fe4e:66a1]", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("fe80::a00:27ff:fe4e:66a1", client, session));
@@ -259,73 +163,137 @@ public class ClientHostUtilsTest {
     @Test
     public void testIPv6DoesNotMatchDifferentAddress() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://[::1]/callback"
-        ).collect(Collectors.toSet()));
-
+        client.setManagementUrl("http://[::1]/callback");
         assertFalse(ClientHostUtils.isHostAllowedForClient("::1", client, session)); // brackets required
         assertFalse(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]", client, session));
         assertFalse(ClientHostUtils.isHostAllowedForClient("2001:db8::1", client, session));
     }
 
     @Test
-    public void testMixedIPv4AndIPv6() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of(
-                "http://127.0.0.1:8080/callback",
-                "http://[::1]:8080/callback",
-                "https://localhost:8443/auth"
-        ).collect(Collectors.toSet()));
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1:8080", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("::1", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost:443", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost:8443", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.1.1", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("[fe80::1]", client, session));
-    }
-
-    @Test
-    public void testHostWithOnlyRootUrlNoRedirectUris() {
-        TestClientModel client = new TestClientModel("test-client");
-        client.setRootUrl("https://app.example.com");
-        // No redirect URIs set
-
-        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
-        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
-    }
-
-    @Test
     public void testCaseInsensitiveMatching() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRedirectUris(Stream.of("https://App.Example.COM/callback").collect(Collectors.toSet()));
-
+        client.setManagementUrl("https://App.Example.COM/callback");
         assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("APP.EXAMPLE.COM", client, session));
         assertTrue(ClientHostUtils.isHostAllowedForClient("App.Example.Com", client, session));
     }
 
     @Test
-    public void testIPv6InRootUrl() {
+    public void testMalformedURL() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setRootUrl("http://[::1]:8080");
-
-        assertFalse(ClientHostUtils.isHostAllowedForClient("::1", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
+        client.setManagementUrl("https:///App.Example.COM/callback");
+        assertFalse(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
     }
 
     @Test
-    public void testIPv6InManagementUrl() {
+    public void testDuplicatedManagedNodes() {
         TestClientModel client = new TestClientModel("test-client");
-        client.setManagementUrl("http://[2001:db8::1]:9990/management");
+        client.registerNode("Node1", (int) Instant.now().getEpochSecond());
+        client.registerNode("node1", (int) Instant.now().getEpochSecond());
+        client.registerNode("node2", (int) Instant.now().getEpochSecond());
+        client.setManagementUrl("https://app.example.com/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("node1", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("node2", client, session));
+    }
 
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]", client, session));
-        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]:9990", client, session));
+    @Test
+    public void testNoManagedNodesAndNoManagementURLSet() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("https://app3.example.com/callback").collect(Collectors.toSet()));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("app3", client, session));
+    }
+
+    @Test
+    public void testIPv4WithPort() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://192.168.1.100:8080/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100:8080", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100", client, session));
+        client.setManagementUrl("https://10.0.0.5:443/mgmt");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.5:443", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.5", client, session));
+    }
+
+    @Test
+    public void testIPv4WithoutPort() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://192.168.1.100/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100", client, session));
+        client.setManagementUrl("http://172.16.0.1/auth");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("172.16.0.1", client, session));
+    }
+
+    @Test
+    public void testIPv4PrivateRanges() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://10.0.0.1:8080/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.1", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.1:8080", client, session));
+        client.setManagementUrl("http://172.16.0.1/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("172.16.0.1", client, session));
+        client.setManagementUrl("http://192.168.1.1/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.1", client, session));
+    }
+
+    @Test
+    public void testIPv4PublicAddresses() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://8.8.8.8:53/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("8.8.8.8", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("8.8.8.8:53", client, session));
+        client.setManagementUrl("https://1.1.1.1/auth");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("1.1.1.1", client, session));
+    }
+
+    @Test
+    public void testIPv4DoesNotMatchDifferentAddress() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://192.168.1.100/callback");
+        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.1.101", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.2.100", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("10.0.0.1", client, session));
+    }
+
+    @Test
+    public void testIPv4InManagedNodes() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.registerNode("192.168.1.100", (int) Instant.now().getEpochSecond());
+        client.registerNode("10.0.0.5", (int) Instant.now().getEpochSecond());
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.5", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.1.101", client, session));
+    }
+
+    @Test
+    public void testIPv4WithNonStandardPorts() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://192.168.1.100:3000/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100:3000", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100", client, session));
+        client.setManagementUrl("http://10.0.0.1:9090/mgmt");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.1:9090", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.1", client, session));
+    }
+
+    @Test
+    public void testIPv4LoopbackAddresses() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://127.0.0.2:8080/callback");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.2", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.2:8080", client, session));
+    }
+
+    @Test
+    public void testIPv4MixedWithHostnames() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.registerNode("app.example.com", (int) Instant.now().getEpochSecond());
+        client.registerNode("192.168.1.100", (int) Instant.now().getEpochSecond());
+        client.setManagementUrl("http://10.0.0.5:8080/mgmt");
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("192.168.1.100", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("10.0.0.5", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.1.101", client, session));
     }
 
     /**
@@ -338,7 +306,7 @@ public class ClientHostUtilsTest {
         private String rootUrl;
         private String managementUrl;
         private String baseUrl;
-
+        protected Map<String, Integer> managedNodes = new HashMap<String, Integer>();
         public TestClientModel(String clientId) {
             this.clientId = clientId;
         }
@@ -593,13 +561,19 @@ public class ClientHostUtilsTest {
         public void setNotBefore(int notBefore) { }
 
         @Override
-        public Map<String, Integer> getRegisteredNodes() { return null; }
+        public Map<String, Integer> getRegisteredNodes() {
+            return managedNodes;
+        }
 
         @Override
-        public void registerNode(String nodeHost, int registrationTime) { }
+        public void registerNode(String nodeHost, int registrationTime) {
+            managedNodes.put(nodeHost, registrationTime);
+        }
 
         @Override
-        public void unregisterNode(String nodeHost) { }
+        public void unregisterNode(String nodeHost) {
+            managedNodes.remove(nodeHost);
+        }
 
         @Override
         public Stream<ProtocolMapperModel> getProtocolMappersStream() {

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/ClientHostUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/ClientHostUtilsTest.java
@@ -1,0 +1,649 @@
+package org.keycloak.protocol.oidc.utils;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.keycloak.common.Profile;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.services.resteasy.HttpRequestImpl;
+import org.keycloak.services.resteasy.ResteasyKeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+import org.keycloak.storage.client.UnsupportedOperationsClientStorageAdapter;
+
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test class for ClientHostUtils methods validating client_session_host against client URLs.
+ *
+ * @author Keycloak Security Team
+ */
+public class ClientHostUtilsTest {
+
+    private static KeycloakSession session;
+
+    @BeforeAll
+    public static void beforeAll() {
+        HttpRequest httpRequest = new HttpRequestImpl(MockHttpRequest.create("GET", URI.create("https://keycloak.org/"), URI.create("https://keycloak.org")));
+        Profile.defaults();
+        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
+        ResteasyKeycloakSessionFactory sessionFactory = new ResteasyKeycloakSessionFactory();
+        sessionFactory.init();
+        session = new ResteasyKeycloakSession(sessionFactory);
+        session.getContext().setHttpRequest(httpRequest);
+    }
+
+    @Test
+    public void testHostMatchesRedirectUri() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "https://app.example.com/callback",
+                "https://app2.example.com/auth"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app2.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("other.example.com", client, session));
+    }
+
+    @Test
+    public void testHostMatchesRedirectUriWithPort() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "https://app.example.com:8443/callback"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com:8443", client, session));
+    }
+
+    @Test
+    public void testHostMatchesRootUrl() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRootUrl("https://root.example.com");
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("root.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("other.example.com", client, session));
+    }
+
+    @Test
+    public void testHostMatchesManagementUrl() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("https://admin.example.com/management");
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("admin.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+    }
+
+    @Test
+    public void testHostMatchesBaseUrl() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setBaseUrl("https://base.example.com");
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("base.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+    }
+
+    @Test
+    public void testHostMatchesAnyConfiguredUrl() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("https://app.example.com/callback").collect(Collectors.toSet()));
+        client.setRootUrl("https://root.example.com");
+        client.setManagementUrl("https://admin.example.com/mgmt");
+        client.setBaseUrl("https://base.example.com");
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("root.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("admin.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("base.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+    }
+
+    @Test
+    public void testWildcardRedirectUri() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("*").collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("any.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
+    }
+
+    @Test
+    public void testNullAndEmptyHosts() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("https://app.example.com/callback").collect(Collectors.toSet()));
+
+        assertFalse(ClientHostUtils.isHostAllowedForClient(null, client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("   ", client, session));
+    }
+
+    @Test
+    public void testNullClient() {
+        assertFalse(ClientHostUtils.isHostAllowedForClient("any.example.com", null, session));
+    }
+
+    @Test
+    public void testNoUrlsConfigured() {
+        TestClientModel client = new TestClientModel("test-client");
+
+        assertFalse(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
+    }
+
+    @Test
+    public void testLocalhostHosts() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://localhost:8080/callback",
+                "http://127.0.0.1:8080/callback"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost:8080", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1:8080", client, session));
+    }
+
+    @Test
+    public void testRelativeRedirectUris() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("/callback").collect(Collectors.toSet()));
+        client.setRootUrl("https://root.example.com");
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("root.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+    }
+
+    @Test
+    public void testSubdomainsDontMatch() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("https://app.example.com/callback").collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("sub.app.example.com", client, session));
+    }
+
+    @Test
+    public void testHttpsAndHttpDifferentSchemes() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "https://app.example.com/callback",
+                "http://dev.example.com/callback"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("dev.example.com", client, session));
+    }
+
+    @Test
+    public void testSSRFAttackPrevention() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("https://public.example.com/callback").collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("public.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("internal.company.local", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.1.1", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("169.254.169.254", client, session));
+    }
+
+    @Test
+    public void testIPv6WithBracketsAndPort() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://[::1]:8080/callback",
+                "http://[2001:db8::1]:8443/callback"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]:8443", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]", client, session));
+    }
+
+    @Test
+    public void testIPv6WithBracketsNoPort() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://[::1]/callback",
+                "http://[fe80::1]/auth"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[fe80::1]", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("fe80::1", client, session));
+    }
+
+    @Test
+    public void testIPv6BareAddress() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://[2001:db8:85a3::8a2e:370:7334]/callback"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8:85a3::8a2e:370:7334]", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("2001:db8:85a3::8a2e:370:7334", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8:85a3::8a2e:370:7334]:443", client, session));
+    }
+
+    @Test
+    public void testIPv6LinkLocal() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://[fe80::a00:27ff:fe4e:66a1]:3000/callback"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[fe80::a00:27ff:fe4e:66a1]:3000", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[fe80::a00:27ff:fe4e:66a1]", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("fe80::a00:27ff:fe4e:66a1", client, session));
+    }
+
+    @Test
+    public void testIPv6DoesNotMatchDifferentAddress() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://[::1]/callback"
+        ).collect(Collectors.toSet()));
+
+        assertFalse(ClientHostUtils.isHostAllowedForClient("::1", client, session)); // brackets required
+        assertFalse(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("2001:db8::1", client, session));
+    }
+
+    @Test
+    public void testMixedIPv4AndIPv6() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of(
+                "http://127.0.0.1:8080/callback",
+                "http://[::1]:8080/callback",
+                "https://localhost:8443/auth"
+        ).collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("127.0.0.1:8080", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("::1", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost:443", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("localhost:8443", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("192.168.1.1", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("[fe80::1]", client, session));
+    }
+
+    @Test
+    public void testHostWithOnlyRootUrlNoRedirectUris() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRootUrl("https://app.example.com");
+        // No redirect URIs set
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertFalse(ClientHostUtils.isHostAllowedForClient("evil.com", client, session));
+    }
+
+    @Test
+    public void testCaseInsensitiveMatching() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRedirectUris(Stream.of("https://App.Example.COM/callback").collect(Collectors.toSet()));
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("app.example.com", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("APP.EXAMPLE.COM", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("App.Example.Com", client, session));
+    }
+
+    @Test
+    public void testIPv6InRootUrl() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setRootUrl("http://[::1]:8080");
+
+        assertFalse(ClientHostUtils.isHostAllowedForClient("::1", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[::1]:8080", client, session));
+    }
+
+    @Test
+    public void testIPv6InManagementUrl() {
+        TestClientModel client = new TestClientModel("test-client");
+        client.setManagementUrl("http://[2001:db8::1]:9990/management");
+
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]", client, session));
+        assertTrue(ClientHostUtils.isHostAllowedForClient("[2001:db8::1]:9990", client, session));
+    }
+
+    /**
+     * Minimal test implementation of ClientModel for testing purposes.
+     * Only implements methods needed for ClientHostUtils validation.
+     */
+    private static class TestClientModel extends UnsupportedOperationsClientStorageAdapter {
+        private final String clientId;
+        private Set<String> redirectUris = Set.of();
+        private String rootUrl;
+        private String managementUrl;
+        private String baseUrl;
+
+        public TestClientModel(String clientId) {
+            this.clientId = clientId;
+        }
+
+        @Override
+        public void updateClient() {
+        }
+
+        @Override
+        public String getId() {
+            return "";
+        }
+
+        @Override
+        public String getClientId() {
+            return clientId;
+        }
+
+        @Override
+        public void setClientId(String clientId) { }
+
+        @Override
+        public String getName() { return ""; }
+
+        @Override
+        public void setName(String name) { }
+
+        @Override
+        public String getDescription() { return ""; }
+
+        @Override
+        public void setDescription(String description) { }
+
+        @Override
+        public boolean isEnabled() { return false; }
+
+        @Override
+        public void setEnabled(boolean enabled) { }
+
+        @Override
+        public boolean isAlwaysDisplayInConsole() { return false; }
+
+        @Override
+        public void setAlwaysDisplayInConsole(boolean alwaysDisplayInConsole) { }
+
+        @Override
+        public boolean isSurrogateAuthRequired() { return false; }
+
+        @Override
+        public void setSurrogateAuthRequired(boolean surrogateAuthRequired) { }
+
+        @Override
+        public Set<String> getWebOrigins() { return null; }
+
+        @Override
+        public void setWebOrigins(Set<String> webOrigins) { }
+
+        @Override
+        public void addWebOrigin(String webOrigin) { }
+
+        @Override
+        public void removeWebOrigin(String webOrigin) { }
+
+        @Override
+        public Set<String> getRedirectUris() { return redirectUris; }
+
+        public void setRedirectUris(Set<String> redirectUris) {
+            this.redirectUris = redirectUris;
+        }
+
+        @Override
+        public void addRedirectUri(String redirectUri) { }
+
+        @Override
+        public void removeRedirectUri(String redirectUri) { }
+
+        @Override
+        public String getManagementUrl() {
+            return managementUrl;
+        }
+
+        public void setRootUrl(String rootUrl) {
+            this.rootUrl = rootUrl;
+        }
+
+        @Override
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        public void setManagementUrl(String managementUrl) {
+            this.managementUrl = managementUrl;
+        }
+
+        @Override
+        public String getRootUrl() {
+            return rootUrl;
+        }
+
+        public void setBaseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        @Override
+        public boolean isBearerOnly() {
+            return false;
+        }
+
+        @Override
+        public void setBearerOnly(boolean only) { }
+
+        @Override
+        public int getNodeReRegistrationTimeout() { return 0; }
+
+        @Override
+        public void setNodeReRegistrationTimeout(int timeout) { }
+
+        @Override
+        public String getClientAuthenticatorType() { return ""; }
+
+        @Override
+        public void setClientAuthenticatorType(String clientAuthenticatorType) { }
+
+        @Override
+        public boolean validateSecret(String secret) { return false; }
+
+        @Override
+        public String getSecret() {
+            return "";
+        }
+
+        @Override
+        public void setSecret(String secret) { }
+
+        @Override
+        public String getRegistrationToken() {
+            return "";
+        }
+
+        @Override
+        public void setRegistrationToken(String registrationToken) { }
+
+        @Override
+        public String getProtocol() {
+            return "";
+        }
+
+        @Override
+        public void setProtocol(String protocol) { }
+
+        @Override
+        public void setAttribute(String name, String value) { }
+
+        @Override
+        public void removeAttribute(String name) { }
+
+        @Override
+        public String getAttribute(String name) {
+            return "";
+        }
+
+        @Override
+        public Map<String, String> getAttributes() {
+            return Map.of();
+        }
+
+        @Override
+        public String getAuthenticationFlowBindingOverride(String binding) {
+            return "";
+        }
+
+        @Override
+        public Map<String, String> getAuthenticationFlowBindingOverrides() {
+            return Map.of();
+        }
+
+        @Override
+        public void removeAuthenticationFlowBindingOverride(String binding) { }
+
+        @Override
+        public void setAuthenticationFlowBindingOverride(String binding, String flowId) { }
+
+        @Override
+        public boolean isFrontchannelLogout() { return false; }
+
+        @Override
+        public void setFrontchannelLogout(boolean flag) { }
+
+        @Override
+        public boolean isFullScopeAllowed() { return false; }
+
+        @Override
+        public void setFullScopeAllowed(boolean value) { }
+
+        @Override
+        public boolean isPublicClient() { return false; }
+
+        @Override
+        public void setPublicClient(boolean flag) { }
+
+        @Override
+        public boolean isConsentRequired() { return false; }
+
+        @Override
+        public void setConsentRequired(boolean consentRequired) { }
+
+        @Override
+        public boolean isStandardFlowEnabled() { return false; }
+
+        @Override
+        public void setStandardFlowEnabled(boolean standardFlowEnabled) { }
+
+        @Override
+        public boolean isImplicitFlowEnabled() { return false; }
+
+        @Override
+        public void setImplicitFlowEnabled(boolean implicitFlowEnabled) { }
+
+        @Override
+        public boolean isDirectAccessGrantsEnabled() { return false; }
+
+        @Override
+        public void setDirectAccessGrantsEnabled(boolean directAccessGrantsEnabled) { }
+
+        @Override
+        public boolean isServiceAccountsEnabled() { return false; }
+
+        @Override
+        public void setServiceAccountsEnabled(boolean serviceAccountsEnabled) { }
+
+        @Override
+        public RealmModel getRealm() { return null; }
+
+        @Override
+        public void addClientScope(ClientScopeModel clientScope, boolean defaultScope) { }
+
+        @Override
+        public void addClientScopes(Set<ClientScopeModel> clientScopes, boolean defaultScope) { }
+
+        @Override
+        public void removeClientScope(ClientScopeModel clientScope) { }
+
+        @Override
+        public Map<String, ClientScopeModel> getClientScopes(boolean defaultScope) {
+            return Map.of();
+        }
+
+        @Override
+        public int getNotBefore() { return 0; }
+
+        @Override
+        public void setNotBefore(int notBefore) { }
+
+        @Override
+        public Map<String, Integer> getRegisteredNodes() { return null; }
+
+        @Override
+        public void registerNode(String nodeHost, int registrationTime) { }
+
+        @Override
+        public void unregisterNode(String nodeHost) { }
+
+        @Override
+        public Stream<ProtocolMapperModel> getProtocolMappersStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public ProtocolMapperModel addProtocolMapper(ProtocolMapperModel model) {
+            return null;
+        }
+
+        @Override
+        public void removeProtocolMapper(ProtocolMapperModel mapping) { }
+
+        @Override
+        public void updateProtocolMapper(ProtocolMapperModel mapping) { }
+
+        @Override
+        public ProtocolMapperModel getProtocolMapperById(String id) {
+            return null;
+        }
+
+        @Override
+        public ProtocolMapperModel getProtocolMapperByName(String protocol, String name) {
+            return null;
+        }
+
+        @Override
+        public Stream<RoleModel> getScopeMappingsStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public Stream<RoleModel> getRealmScopeMappingsStream() {
+            return Stream.empty();
+        }
+
+        @Override
+        public void addScopeMapping(RoleModel role) { }
+
+        @Override
+        public void deleteScopeMapping(RoleModel role) { }
+
+        @Override
+        public boolean hasScope(RoleModel role) { return false; }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -483,7 +483,6 @@ public class LogoutTest extends AbstractKeycloakTest {
         rep.getAttributes().put(
                 OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL,
                 "https://${application.session.host}/testing/test-app/admin/backchannelLogout");
-               //oauth.APP_ROOT + "/admin/backchannelLogout");
         clientResource.update(rep);
 
         try {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -477,15 +477,10 @@ public class LogoutTest extends AbstractKeycloakTest {
      */
     @Test
     public void adminLogoutDoesNotUseMaliciousClientSessionHost() throws Exception {
-        ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
-        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
-        ClientResource clientResource = clients.get(rep.getId());
-        rep.getAttributes().put(
-                OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL,
-                "https://${application.session.host}/testing/test-app/admin/backchannelLogout");
-        clientResource.update(rep);
+        try (ClientAttributeUpdater clientUpdater = ClientAttributeUpdater.forClient(adminClient, oauth.getRealm(), oauth.getClientId())
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "https://${application.session.host}/testing/test-app/admin/backchannelLogout")
+                .update()) {
 
-        try {
             oauth.doLogin("test-user@localhost", "password");
             String code = oauth.parseLoginResponse().getCode();
 
@@ -501,9 +496,6 @@ public class LogoutTest extends AbstractKeycloakTest {
 
             assertNull(testingClient.testApp().getBackChannelRawLogoutToken(),
                     "There should be no Backchannel logout token for an untrusted client session host");
-        } finally {
-            rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "");
-            clientResource.update(rep);
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/LogoutTest.java
@@ -472,6 +472,43 @@ public class LogoutTest extends AbstractKeycloakTest {
     }
 
     /**
+     * Test for CVE-2026-4874: Verify that malicious client_session_host values
+     * are rejected during token refresh and don't cause SSRF during admin logout.
+     */
+    @Test
+    public void adminLogoutDoesNotUseMaliciousClientSessionHost() throws Exception {
+        ClientsResource clients = adminClient.realm(oauth.getRealm()).clients();
+        ClientRepresentation rep = clients.findByClientId(oauth.getClientId()).get(0);
+        ClientResource clientResource = clients.get(rep.getId());
+        rep.getAttributes().put(
+                OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL,
+                "https://${application.session.host}/testing/test-app/admin/backchannelLogout");
+               //oauth.APP_ROOT + "/admin/backchannelLogout");
+        clientResource.update(rep);
+
+        try {
+            oauth.doLogin("test-user@localhost", "password");
+            String code = oauth.parseLoginResponse().getCode();
+
+            AccessTokenResponse tokenResponse = oauth.accessTokenRequest(code)
+                    .param(AdapterConstants.CLIENT_SESSION_STATE, "client_session")
+                    .param(AdapterConstants.CLIENT_SESSION_HOST, "evil.com:8180")
+                    .send();
+
+            List<UserRepresentation> users = adminClient.realm("test")
+                    .users()
+                    .search("test-user@localhost");
+            adminClient.realm("test").users().get(users.get(0).getId()).logout();
+
+            assertNull(testingClient.testApp().getBackChannelRawLogoutToken(),
+                    "There should be no Backchannel logout token for an untrusted client session host");
+        } finally {
+            rep.getAttributes().put(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, "");
+            clientResource.update(rep);
+        }
+    }
+
+    /**
      * Validate the token matches the spec at <a href="https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken">OpenID Connect Back-Channel Logout 1.0 incorporating errata set 1</a>
      */
     private void validateLogoutToken(LogoutToken backChannelLogoutToken) {


### PR DESCRIPTION
### Security Context (CVE-2026-4874):
Because Keycloak stores the user-provided **client_session_host** value without strict validation, an authenticated attacker can pass an internal IP address or alternative hostname (e.g., client_session_host=127.0.0.1:8080) during the refresh token request. When a logout is triggered, Keycloak can execute an outbound request to that internal address, resulting in an SSRF exploit.

The client in Keycloak must have the **backchannel.logout.url** attribute configured with **_${application.session.host}_** .  Then Keycloak will pull in the **client_session_host** value from the session to perform a string substitution for this specific placeholder.  This value is only used when a logout is triggered (user initiated, admin, session terminated).  

**FIx**: Added validation to **client_session_host** to check that the hostname matches other Admin created URLs in root/management/base/redirect.  If there is no match then the backchannel.logout.url attribute configured with **_${application.session.host}_** is not updated with this host name and a warning is generated. 

**Note**: This only affects when backchannel.logout.url contains ${application.session.host} and client_session_host has a non-admin validated URL. Which can affect per-host backchannel logouts. 

Logout  to valid hosts, standard backchannel logout, session cleanup etc. continues as normal. 

Closes #47935