### PR TITLE
Document rejection of empty resource parameter in 26.6.1

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_1.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_1.adoc
@@ -14,6 +14,12 @@ Once you upgraded to 26.6.1, you should see in the built-in browser flow the `Or
 Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
 In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
 
+=== Authorization requests with empty resource parameter
+
+Starting with Keycloak 26.6.1, authorization requests containing an empty `resource` parameter (`resource=`) are rejected as invalid requests.
+
+Previously, empty values may have been treated as absent or ignored. Clients should either omit the parameter entirely or provide a valid resource identifier.
+
 === Outgoing HTTP connections do not follow redirects
 
 Since this release, the HTTP connections originated from the {project_name} server do not follow redirects by default. The HTTP result will be the redirect status (`3xx`) code, and the `Location` header will not be automatically fetched. With this change, the server avoids retrieving unwanted redirects that can bypass allowed URLs defined by client policies or other future configurations.


### PR DESCRIPTION
Document breaking change for empty resource parameter in 26.6.1

This PR documents a breaking behavior change introduced in 26.6.1 where authorization requests containing an empty `resource` parameter (`resource=`) are rejected as invalid requests.

Previously, empty values may have been treated as absent or ignored. Clients should either omit the parameter entirely or provide a valid resource identifier.

Closes #48870

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
