### PR TITLE
Admin API v2: add stricter validation constrains for Client resource

### DIFF
--- a/js/libs/keycloak-admin-client/openapi.yaml
+++ b/js/libs/keycloak-admin-client/openapi.yaml
@@ -4,18 +4,26 @@ components:
   schemas:
     Auth:
       type: object
+      required:
+      - method
       properties:
         method:
           type: string
-          description: Which authentication method is used for this client
+          pattern: \S
+          description: "Which authentication method is used for this client. Validation:\
+            \ must not be blank; valid client authenticator type is required"
         secret:
           type: string
+          minLength: 6
+          maxLength: 255
           description: "Secret used to authenticate this client with Secret authentication.\
-            \ Validation: on update: Client secret must not be blank"
+            \ Validation: size must be between 6 and 255; on update: Client secret\
+            \ must not be blank"
         certificate:
           type: string
-          description: Public key used to authenticate this client with Signed JWT
-            authentication
+          maxLength: 65536
+          description: "Public key used to authenticate this client with Signed JWT\
+            \ authentication. Validation: size must be between 0 and 65536"
     BaseClientRepresentation:
       description: Base client representation with common properties for all client
         types
@@ -29,21 +37,29 @@ components:
         clientId:
           type: string
           pattern: \S
+          minLength: 1
+          maxLength: 255
           description: "ID uniquely identifying this client. Validation: must not\
-            \ be blank"
+            \ be blank; size must be between 1 and 255"
         displayName:
           type: string
-          description: Human readable name of the client
+          maxLength: 255
+          description: "Human readable name of the client. Validation: size must be\
+            \ between 0 and 255"
         description:
           type: string
-          description: Human readable description of the client
+          maxLength: 255
+          description: "Human readable description of the client. Validation: size\
+            \ must be between 0 and 255"
         enabled:
           type: boolean
           description: Whether this client is enabled
         appUrl:
           type: string
+          maxLength: 255
           description: "URL to the application's homepage that is represented by this\
-            \ client. Validation: must be a valid URL"
+            \ client. Validation: size must be between 0 and 255; must be a valid\
+            \ URL"
           format: uri
         redirectUris:
           type: array
@@ -51,16 +67,22 @@ components:
           items:
             type: string
             pattern: \S
+            maxLength: 255
+          maxItems: 100
           description: "URIs that the browser can redirect to after login. Validation:\
-            \ each element must not be blank; Invalid redirect URI"
+            \ size must be between 0 and 100; each element must not be blank, size\
+            \ must be between 0 and 255; Invalid redirect URI"
         roles:
           type: array
           uniqueItems: true
           items:
             type: string
             pattern: \S
-          description: "Roles associated with this client. Validation: each element\
-            \ must not be blank"
+            maxLength: 255
+          maxItems: 300
+          description: "Roles associated with this client. Validation: size must be\
+            \ between 0 and 300; each element must not be blank, size must be between\
+            \ 0 and 255"
         protocol:
           type: string
           pattern: \S
@@ -84,6 +106,13 @@ components:
       - TOKEN_EXCHANGE
       - DEVICE
       - CIBA
+    NameIdFormat:
+      type: string
+      enum:
+      - username
+      - email
+      - persistent
+      - transient
     OIDCClientRepresentation:
       type: object
       properties:
@@ -92,7 +121,10 @@ components:
           uniqueItems: true
           items:
             $ref: "#/components/schemas/Flow"
-          description: Login flows that are enabled for this client
+          description: "Login flows that are enabled for this client. Validation:\
+            \ SERVICE_ACCOUNT and TOKEN_EXCHANGE flows require a confidential client\
+            \ (auth must be specified); STANDARD and IMPLICIT flows require at least\
+            \ one redirect URI"
         auth:
           $ref: "#/components/schemas/Auth"
           description: Authentication configuration for this client
@@ -102,16 +134,24 @@ components:
           items:
             type: string
             pattern: \S
+            maxLength: 255
+          maxItems: 100
           description: "Web origins that are allowed to make requests to this client.\
-            \ Validation: each element must not be blank"
+            \ Validation: size must be between 0 and 100; each element must not be\
+            \ blank, size must be between 0 and 255, must be a valid web origin (scheme://host[:port]),\
+            \ or '+' to derive from redirect URIs, or '*' to allow all"
         serviceAccountRoles:
           type: array
           uniqueItems: true
           items:
             type: string
             pattern: \S
-          description: "Roles assigned to the service account. Validation: each element\
-            \ must not be blank"
+            maxLength: 255
+          maxItems: 300
+          description: "Roles assigned to the service account. Validation: size must\
+            \ be between 0 and 300; each element must not be blank, size must be between\
+            \ 0 and 255; serviceAccountRoles can only be set when SERVICE_ACCOUNT\
+            \ flow is enabled"
         protocol:
           type: string
       allOf:
@@ -121,9 +161,8 @@ components:
       type: object
       properties:
         nameIdFormat:
-          type: string
-          description: "Name ID format to use for the subject (e.g., 'username', 'email',\
-            \ 'transient', 'persistent')"
+          $ref: "#/components/schemas/NameIdFormat"
+          description: Name ID format to use for the subject
         forceNameIdFormat:
           type: boolean
           description: Force the specified Name ID format even if the client requests
@@ -147,15 +186,18 @@ components:
           type: boolean
           description: Use front-channel logout (browser redirect)
         signatureAlgorithm:
-          type: string
-          description: "Signature algorithm for signing SAML documents (e.g., 'RSA_SHA256',\
-            \ 'RSA_SHA512')"
+          $ref: "#/components/schemas/SignatureAlgorithm"
+          description: Signature algorithm for signing SAML documents
         signatureCanonicalizationMethod:
           type: string
-          description: Canonicalization method for XML signatures
+          description: "Canonicalization method for XML signatures. Validation: must\
+            \ be a valid XML canonicalization method URI (see javax.xml.crypto.dsig.CanonicalizationMethod\
+            \ constants)"
         signingCertificate:
           type: string
-          description: "X.509 certificate for signing (PEM format, without headers)"
+          maxLength: 65536
+          description: "X.509 certificate for signing (PEM format, without headers).\
+            \ Validation: size must be between 0 and 65536"
         allowEcpFlow:
           type: boolean
           description: Allow ECP (Enhanced Client or Proxy) flow
@@ -163,6 +205,15 @@ components:
           type: string
       allOf:
       - $ref: "#/components/schemas/BaseClientRepresentation"
+    SignatureAlgorithm:
+      type: string
+      enum:
+      - RSA_SHA1
+      - RSA_SHA256
+      - RSA_SHA256_MGF1
+      - RSA_SHA512
+      - RSA_SHA512_MGF1
+      - DSA_SHA1
   securitySchemes:
     bearer-auth:
       type: http

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/BaseClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/BaseClientRepresentation.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import org.keycloak.representations.admin.v2.validation.PatchClient;
 import org.keycloak.representations.admin.v2.validation.ProtocolUnmodified;
@@ -40,12 +41,15 @@ public abstract class BaseClientRepresentation extends BaseRepresentation implem
     protected String uuid;
 
     @NotBlank
+    @Size(min = 1, max = 255)
     @JsonPropertyDescription("ID uniquely identifying this client")
     protected String clientId;
 
+    @Size(max = 255)
     @JsonPropertyDescription("Human readable name of the client")
     private String displayName;
 
+    @Size(max = 255)
     @JsonPropertyDescription("Human readable description of the client")
     private String description;
 
@@ -53,16 +57,19 @@ public abstract class BaseClientRepresentation extends BaseRepresentation implem
     private Boolean enabled;
 
     @URL
+    @Size(max = 255)
     @JsonPropertyDescription("URL to the application's homepage that is represented by this client")
     private String appUrl;
 
+    @Size(max = 100)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("URIs that the browser can redirect to after login")
-    private Set<@NotBlank String> redirectUris = new LinkedHashSet<>();
+    private Set<@NotBlank @Size(max = 255) String> redirectUris = new LinkedHashSet<>();
 
+    @Size(max = 300)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Roles associated with this client")
-    private Set<@NotBlank String> roles = new LinkedHashSet<>();
+    private Set<@NotBlank @Size(max = 255) String> roles = new LinkedHashSet<>();
 
     @Override
     public String getUuid() {

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/OIDCClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/OIDCClientRepresentation.java
@@ -6,9 +6,15 @@ import java.util.Set;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import org.keycloak.representations.admin.v2.validation.ClientSecretNotBlank;
+import org.keycloak.representations.admin.v2.validation.ConfidentialFlowsRequireAuth;
 import org.keycloak.representations.admin.v2.validation.PutClient;
+import org.keycloak.representations.admin.v2.validation.RedirectFlowsRequireUris;
+import org.keycloak.representations.admin.v2.validation.ServiceAccountRolesRequireFlow;
+import org.keycloak.representations.admin.v2.validation.ValidAuthMethod;
+import org.keycloak.representations.admin.v2.validation.ValidWebOrigin;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonMerge;
@@ -16,6 +22,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema
+@ConfidentialFlowsRequireAuth
+@RedirectFlowsRequireUris
+@ServiceAccountRolesRequireFlow
 public class OIDCClientRepresentation extends BaseClientRepresentation {
     public static final String PROTOCOL = "openid-connect";
 
@@ -38,13 +47,15 @@ public class OIDCClientRepresentation extends BaseClientRepresentation {
     @JsonPropertyDescription("Authentication configuration for this client")
     private Auth auth;
 
+    @Size(max = 100)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Web origins that are allowed to make requests to this client")
-    private Set<@NotBlank String> webOrigins = new LinkedHashSet<>();
+    private Set<@NotBlank @Size(max = 255) @ValidWebOrigin String> webOrigins = new LinkedHashSet<>();
 
+    @Size(max = 300)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonPropertyDescription("Roles assigned to the service account")
-    private Set<@NotBlank String> serviceAccountRoles = new LinkedHashSet<>();
+    private Set<@NotBlank @Size(max = 255) String> serviceAccountRoles = new LinkedHashSet<>();
 
     public OIDCClientRepresentation() {}
 
@@ -92,12 +103,16 @@ public class OIDCClientRepresentation extends BaseClientRepresentation {
     @ClientSecretNotBlank(groups = PutClient.class, affectedFieldNames = {"secret"})
     public static class Auth extends BaseRepresentation {
 
+        @NotBlank
+        @ValidAuthMethod
         @JsonPropertyDescription("Which authentication method is used for this client")
         private String method;
 
+        @Size(min = 6, max = 255)
         @JsonPropertyDescription("Secret used to authenticate this client with Secret authentication")
         private String secret;
 
+        @Size(max = 65536)
         @JsonPropertyDescription("Public key used to authenticate this client with Signed JWT authentication")
         private String certificate;
 

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/SAMLClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/SAMLClientRepresentation.java
@@ -19,7 +19,13 @@ package org.keycloak.representations.admin.v2;
 
 import java.util.Objects;
 
+import jakarta.validation.constraints.Size;
+
+import org.keycloak.representations.admin.v2.validation.ValidCanonicalizationMethod;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -30,8 +36,31 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public class SAMLClientRepresentation extends BaseClientRepresentation {
     public static final String PROTOCOL = "saml";
 
-    @JsonPropertyDescription("Name ID format to use for the subject (e.g., 'username', 'email', 'transient', 'persistent')")
-    private String nameIdFormat;
+    public enum NameIdFormat {
+        USERNAME, EMAIL, PERSISTENT, TRANSIENT;
+
+        @JsonValue
+        public String toJson() {
+            return name().toLowerCase();
+        }
+
+        @JsonCreator
+        public static NameIdFormat fromJson(String value) {
+            return value == null ? null : valueOf(value.toUpperCase());
+        }
+    }
+
+    public enum SignatureAlgorithm {
+        RSA_SHA1, RSA_SHA256, RSA_SHA256_MGF1, RSA_SHA512, RSA_SHA512_MGF1, DSA_SHA1;
+
+        @JsonCreator
+        public static SignatureAlgorithm fromJson(String value) {
+            return value == null ? null : valueOf(value);
+        }
+    }
+
+    @JsonPropertyDescription("Name ID format to use for the subject")
+    private NameIdFormat nameIdFormat;
 
     @JsonPropertyDescription("Force the specified Name ID format even if the client requests a different one")
     private Boolean forceNameIdFormat;
@@ -54,12 +83,14 @@ public class SAMLClientRepresentation extends BaseClientRepresentation {
     @JsonPropertyDescription("Use front-channel logout (browser redirect)")
     private Boolean frontChannelLogout;
 
-    @JsonPropertyDescription("Signature algorithm for signing SAML documents (e.g., 'RSA_SHA256', 'RSA_SHA512')")
-    private String signatureAlgorithm;
+    @JsonPropertyDescription("Signature algorithm for signing SAML documents")
+    private SignatureAlgorithm signatureAlgorithm;
 
+    @ValidCanonicalizationMethod
     @JsonPropertyDescription("Canonicalization method for XML signatures")
     private String signatureCanonicalizationMethod;
 
+    @Size(max = 65536)
     @JsonPropertyDescription("X.509 certificate for signing (PEM format, without headers)")
     private String signingCertificate;
 
@@ -71,11 +102,11 @@ public class SAMLClientRepresentation extends BaseClientRepresentation {
         return PROTOCOL;
     }
 
-    public String getNameIdFormat() {
+    public NameIdFormat getNameIdFormat() {
         return nameIdFormat;
     }
 
-    public void setNameIdFormat(String nameIdFormat) {
+    public void setNameIdFormat(NameIdFormat nameIdFormat) {
         this.nameIdFormat = nameIdFormat;
     }
 
@@ -135,11 +166,11 @@ public class SAMLClientRepresentation extends BaseClientRepresentation {
         this.frontChannelLogout = frontChannelLogout;
     }
 
-    public String getSignatureAlgorithm() {
+    public SignatureAlgorithm getSignatureAlgorithm() {
         return signatureAlgorithm;
     }
 
-    public void setSignatureAlgorithm(String signatureAlgorithm) {
+    public void setSignatureAlgorithm(SignatureAlgorithm signatureAlgorithm) {
         this.signatureAlgorithm = signatureAlgorithm;
     }
 

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ConfidentialFlowsRequireAuth.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ConfidentialFlowsRequireAuth.java
@@ -1,0 +1,21 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+public @interface ConfidentialFlowsRequireAuth {
+    String message() default "SERVICE_ACCOUNT and TOKEN_EXCHANGE flows require a confidential client (auth must be specified)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String[] affectedFieldNames() default {"loginFlows"};
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/RedirectFlowsRequireUris.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/RedirectFlowsRequireUris.java
@@ -1,0 +1,22 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+public @interface RedirectFlowsRequireUris {
+    String message() default "STANDARD and IMPLICIT flows require at least one redirect URI";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    // TODO: add "redirectUris" once OASModelFilter supports class-level descriptions for inherited properties
+    String[] affectedFieldNames() default {"loginFlows"};
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ServiceAccountRolesRequireFlow.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ServiceAccountRolesRequireFlow.java
@@ -1,0 +1,21 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+public @interface ServiceAccountRolesRequireFlow {
+    String message() default "serviceAccountRoles can only be set when SERVICE_ACCOUNT flow is enabled";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String[] affectedFieldNames() default {"serviceAccountRoles"};
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ValidAuthMethod.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ValidAuthMethod.java
@@ -1,0 +1,20 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+public @interface ValidAuthMethod {
+    String message() default "valid client authenticator type is required";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ValidCanonicalizationMethod.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ValidCanonicalizationMethod.java
@@ -1,0 +1,20 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+public @interface ValidCanonicalizationMethod {
+    String message() default "must be a valid XML canonicalization method URI (see javax.xml.crypto.dsig.CanonicalizationMethod constants)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ValidWebOrigin.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/validation/ValidWebOrigin.java
@@ -1,0 +1,20 @@
+package org.keycloak.representations.admin.v2.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Target(ElementType.TYPE_USE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+@Documented
+public @interface ValidWebOrigin {
+    String message() default "must be a valid web origin (scheme://host[:port]), or '+' to derive from redirect URIs, or '*' to allow all";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/rest/admin-v2/services/pom.xml
+++ b/rest/admin-v2/services/pom.xml
@@ -98,7 +98,7 @@
                 <artifactId>smallrye-open-api-maven-plugin</artifactId>
                 <configuration>
                     <enableStandardStaticFiles>false</enableStandardStaticFiles>
-                    <scanPackages>org.keycloak.representations.admin.v2,org.keycloak.admin.api</scanPackages>
+                    <scanPackages>org.keycloak.representations.admin.v2,org.keycloak.admin.api,jakarta.validation.constraints</scanPackages>
                     <filter>org.keycloak.admin.internal.openapi.OASModelFilter</filter>
                     <outputDirectory>${project.build.directory}</outputDirectory>
                     <outputFileTypeFilter>ALL</outputFileTypeFilter>

--- a/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/ValidationAnnotationScanner.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/ValidationAnnotationScanner.java
@@ -144,7 +144,7 @@ public class ValidationAnnotationScanner {
 
         // Interpolate annotation parameters into the message (e.g., {min}, {max}, {value}, {regexp})
         if (annotation != null) {
-            for (AnnotationValue value : annotation.values()) {
+            for (AnnotationValue value : getAnnotationValues(annotation)) {
                 String placeholder = "{" + value.name() + "}";
                 if (resolved.contains(placeholder)) {
                     resolved = resolved.replace(placeholder, formatAnnotationValue(value));
@@ -153,6 +153,16 @@ public class ValidationAnnotationScanner {
         }
 
         return resolved;
+    }
+
+    private List<AnnotationValue> getAnnotationValues(AnnotationInstance annotation) {
+        try {
+            // some packages like Hibernate Validator are currently not present in the index, but we still
+            // care about the defaults of these that are there, like jakarta.validation.constraints.Size
+            return annotation.valuesWithDefaults(indexView);
+        } catch (IllegalArgumentException ignored) {
+            return annotation.values();
+        }
     }
 
     private String formatAnnotationValue(AnnotationValue value) {
@@ -306,7 +316,7 @@ public class ValidationAnnotationScanner {
      * @return map of field name to validation description
      */
     public Map<String, String> buildClassLevelDescriptions(ClassInfo classInfo) {
-        Map<String, String> fieldDescriptions = new HashMap<>();
+        Map<String, List<String>> collected = new HashMap<>();
 
         for (AnnotationInstance annotation : classInfo.annotations()) {
             if (annotation.target().kind() != AnnotationTarget.Kind.CLASS) {
@@ -328,10 +338,16 @@ public class ValidationAnnotationScanner {
             }
 
             for (String affected : affectedFields) {
-                fieldDescriptions.put(affected, context + message);
+                collected.computeIfAbsent(affected, k -> new ArrayList<>()).add(context + message);
             }
         }
 
+        Map<String, String> fieldDescriptions = new HashMap<>();
+        for (var entry : collected.entrySet()) {
+            List<String> descriptions = entry.getValue();
+            descriptions.sort(String::compareTo);
+            fieldDescriptions.put(entry.getKey(), String.join("; ", descriptions));
+        }
         return fieldDescriptions;
     }
 

--- a/rest/admin-v2/services/src/main/java/org/keycloak/models/mapper/SAMLClientModelMapper.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/models/mapper/SAMLClientModelMapper.java
@@ -56,7 +56,11 @@ public class SAMLClientModelMapper extends BaseClientModelMapper<SAMLClientRepre
     
     public SAMLClientModelMapper() {
         // Name ID settings
-        addAttributeMapping("nameIdFormat", SAML_NAME_ID_FORMAT, SAMLClientRepresentation::getNameIdFormat, SAMLClientRepresentation::setNameIdFormat);
+        addMapping("nameIdFormat",
+                rep -> rep.getNameIdFormat() != null ? rep.getNameIdFormat().toJson() : null,
+                (rep, value) -> rep.setNameIdFormat(SAMLClientRepresentation.NameIdFormat.fromJson(value)),
+                model -> model.getAttribute(SAML_NAME_ID_FORMAT),
+                (model, value) -> setAttributeIfNotNull(model, SAML_NAME_ID_FORMAT, value));
         addBooleanAttributeMapping("forceNameIdFormat", SAML_FORCE_NAME_ID_FORMAT, SAMLClientRepresentation::getForceNameIdFormat, SAMLClientRepresentation::setForceNameIdFormat);
         
         // Signature settings
@@ -64,7 +68,11 @@ public class SAMLClientModelMapper extends BaseClientModelMapper<SAMLClientRepre
         addBooleanAttributeMapping("signDocuments", SAML_SERVER_SIGNATURE, SAMLClientRepresentation::getSignDocuments, SAMLClientRepresentation::setSignDocuments);
         addBooleanAttributeMapping("signAssertions", SAML_ASSERTION_SIGNATURE, SAMLClientRepresentation::getSignAssertions, SAMLClientRepresentation::setSignAssertions);
         addBooleanAttributeMapping("clientSignatureRequired", SAML_CLIENT_SIGNATURE, SAMLClientRepresentation::getClientSignatureRequired, SAMLClientRepresentation::setClientSignatureRequired);
-        addAttributeMapping("signatureAlgorithm", SAML_SIGNATURE_ALGORITHM, SAMLClientRepresentation::getSignatureAlgorithm, SAMLClientRepresentation::setSignatureAlgorithm);
+        addMapping("signatureAlgorithm",
+                rep -> rep.getSignatureAlgorithm() != null ? rep.getSignatureAlgorithm().name() : null,
+                (rep, value) -> rep.setSignatureAlgorithm(SAMLClientRepresentation.SignatureAlgorithm.fromJson(value)),
+                model -> model.getAttribute(SAML_SIGNATURE_ALGORITHM),
+                (model, value) -> setAttributeIfNotNull(model, SAML_SIGNATURE_ALGORITHM, value));
         addAttributeMapping("signatureCanonicalizationMethod", SAML_SIGNATURE_CANONICALIZATION, SAMLClientRepresentation::getSignatureCanonicalizationMethod, SAMLClientRepresentation::setSignatureCanonicalizationMethod);
         addAttributeMapping("signingCertificate", SAML_SIGNING_CERTIFICATE, SAMLClientRepresentation::getSigningCertificate, SAMLClientRepresentation::setSigningCertificate);
 

--- a/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ConfidentialFlowsRequireAuthValidator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ConfidentialFlowsRequireAuthValidator.java
@@ -1,0 +1,37 @@
+package org.keycloak.representations.admin.v2.validators;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation.Flow;
+import org.keycloak.representations.admin.v2.validation.ConfidentialFlowsRequireAuth;
+
+public class ConfidentialFlowsRequireAuthValidator implements ConstraintValidator<ConfidentialFlowsRequireAuth, OIDCClientRepresentation> {
+
+    private static final Set<Flow> CONFIDENTIAL_FLOWS = Set.of(Flow.SERVICE_ACCOUNT, Flow.TOKEN_EXCHANGE);
+
+    @Override
+    public boolean isValid(OIDCClientRepresentation representation, ConstraintValidatorContext context) {
+        Set<Flow> loginFlows = representation.getLoginFlows();
+        if (loginFlows == null || loginFlows.isEmpty()) {
+            return true;
+        }
+        if (representation.getAuth() != null) {
+            return true;
+        }
+        for (Flow flow : CONFIDENTIAL_FLOWS) {
+            if (loginFlows.contains(flow)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(
+                                flow + " requires a confidential client (auth must be specified)")
+                        .addPropertyNode("loginFlows")
+                        .addConstraintViolation();
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/RedirectFlowsRequireUrisValidator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/RedirectFlowsRequireUrisValidator.java
@@ -1,0 +1,38 @@
+package org.keycloak.representations.admin.v2.validators;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation.Flow;
+import org.keycloak.representations.admin.v2.validation.RedirectFlowsRequireUris;
+
+public class RedirectFlowsRequireUrisValidator implements ConstraintValidator<RedirectFlowsRequireUris, OIDCClientRepresentation> {
+
+    private static final Set<Flow> REDIRECT_FLOWS = Set.of(Flow.STANDARD, Flow.IMPLICIT);
+
+    @Override
+    public boolean isValid(OIDCClientRepresentation representation, ConstraintValidatorContext context) {
+        Set<Flow> loginFlows = representation.getLoginFlows();
+        if (loginFlows == null || loginFlows.isEmpty()) {
+            return true;
+        }
+        Set<String> redirectUris = representation.getRedirectUris();
+        if (redirectUris != null && !redirectUris.isEmpty()) {
+            return true;
+        }
+        for (Flow flow : REDIRECT_FLOWS) {
+            if (loginFlows.contains(flow)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(
+                                flow + " requires at least one redirect URI")
+                        .addPropertyNode("redirectUris")
+                        .addConstraintViolation();
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ServiceAccountRolesRequireFlowValidator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ServiceAccountRolesRequireFlowValidator.java
@@ -1,0 +1,31 @@
+package org.keycloak.representations.admin.v2.validators;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation.Flow;
+import org.keycloak.representations.admin.v2.validation.ServiceAccountRolesRequireFlow;
+
+public class ServiceAccountRolesRequireFlowValidator implements ConstraintValidator<ServiceAccountRolesRequireFlow, OIDCClientRepresentation> {
+
+    @Override
+    public boolean isValid(OIDCClientRepresentation representation, ConstraintValidatorContext context) {
+        Set<String> serviceAccountRoles = representation.getServiceAccountRoles();
+        if (serviceAccountRoles == null || serviceAccountRoles.isEmpty()) {
+            return true;
+        }
+        Set<Flow> loginFlows = representation.getLoginFlows();
+        if (loginFlows != null && loginFlows.contains(Flow.SERVICE_ACCOUNT)) {
+            return true;
+        }
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(
+                        "serviceAccountRoles can only be set when SERVICE_ACCOUNT flow is enabled")
+                .addPropertyNode("serviceAccountRoles")
+                .addConstraintViolation();
+        return false;
+    }
+}

--- a/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ValidAuthMethodValidator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ValidAuthMethodValidator.java
@@ -1,0 +1,21 @@
+package org.keycloak.representations.admin.v2.validators;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.keycloak.authentication.ClientAuthenticator;
+import org.keycloak.representations.admin.v2.validation.ValidAuthMethod;
+import org.keycloak.validation.jakarta.ValidationContext;
+
+public class ValidAuthMethodValidator implements ConstraintValidator<ValidAuthMethod, String> {
+
+    @Override
+    public boolean isValid(String authMethod, ConstraintValidatorContext context) {
+        if (authMethod == null || authMethod.isBlank()) {
+            return true;
+        }
+        ValidationContext validationContext = ValidationContext.unwrap(context);
+        return validationContext.session().getKeycloakSessionFactory()
+                .getProviderFactory(ClientAuthenticator.class, authMethod) != null;
+    }
+}

--- a/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ValidCanonicalizationMethodValidator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ValidCanonicalizationMethodValidator.java
@@ -1,0 +1,29 @@
+package org.keycloak.representations.admin.v2.validators;
+
+import java.util.Set;
+import javax.xml.crypto.dsig.CanonicalizationMethod;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.keycloak.representations.admin.v2.validation.ValidCanonicalizationMethod;
+
+public class ValidCanonicalizationMethodValidator implements ConstraintValidator<ValidCanonicalizationMethod, String> {
+
+    private static final Set<String> VALID = Set.of(
+            CanonicalizationMethod.EXCLUSIVE,
+            CanonicalizationMethod.EXCLUSIVE_WITH_COMMENTS,
+            CanonicalizationMethod.INCLUSIVE,
+            CanonicalizationMethod.INCLUSIVE_WITH_COMMENTS,
+            CanonicalizationMethod.INCLUSIVE_11,
+            CanonicalizationMethod.INCLUSIVE_11_WITH_COMMENTS
+    );
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return VALID.contains(value);
+    }
+}

--- a/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ValidWebOriginValidator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/representations/admin/v2/validators/ValidWebOriginValidator.java
@@ -1,0 +1,25 @@
+package org.keycloak.representations.admin.v2.validators;
+
+import java.util.regex.Pattern;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import org.keycloak.representations.admin.v2.validation.ValidWebOrigin;
+
+public class ValidWebOriginValidator implements ConstraintValidator<ValidWebOrigin, String> {
+
+    private static final Pattern HOSTNAME_ORIGIN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*://[a-zA-Z0-9.-]+(:[0-9]+)?$");
+    private static final Pattern IPV6_ORIGIN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+.-]*://\\[[0-9a-fA-F:]+](:[0-9]+)?$");
+
+    @Override
+    public boolean isValid(String origin, ConstraintValidatorContext context) {
+        if (origin == null || origin.isBlank()) {
+            return false;
+        }
+        if ("*".equals(origin) || "+".equals(origin)) {
+            return true;
+        }
+        return HOSTNAME_ORIGIN.matcher(origin).matches() || IPV6_ORIGIN.matcher(origin).matches();
+    }
+}

--- a/rest/admin-v2/services/src/main/resources/META-INF/services/jakarta.validation.ConstraintValidator
+++ b/rest/admin-v2/services/src/main/resources/META-INF/services/jakarta.validation.ConstraintValidator
@@ -1,4 +1,10 @@
 org.keycloak.representations.admin.v2.validators.ClientSecretNotBlankValidator
+org.keycloak.representations.admin.v2.validators.ConfidentialFlowsRequireAuthValidator
 org.keycloak.representations.admin.v2.validators.ProtocolUnmodifiedValidator
+org.keycloak.representations.admin.v2.validators.RedirectFlowsRequireUrisValidator
+org.keycloak.representations.admin.v2.validators.ServiceAccountRolesRequireFlowValidator
 org.keycloak.representations.admin.v2.validators.UuidUnmodifiedValidator
+org.keycloak.representations.admin.v2.validators.ValidAuthMethodValidator
+org.keycloak.representations.admin.v2.validators.ValidCanonicalizationMethodValidator
 org.keycloak.representations.admin.v2.validators.ValidRedirectUrisValidator
+org.keycloak.representations.admin.v2.validators.ValidWebOriginValidator

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2ClientCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2ClientCLITest.java
@@ -123,7 +123,7 @@ public class KcAdmV2ClientCLITest extends AbstractKcAdmV2CLITest {
     void testAuthNestedObjectMerged() {
         CommandResult result = kcAdmV2Cmd("client", "create", "oidc",
                 "--client-id", "test-auth-nested",
-                "--auth-method", "client_secret",
+                "--auth-method", "client-secret",
                 "--auth-secret", "my-secret-value");
 
         assertThat("create should succeed: " + result.err(), result.exitCode(), is(0));
@@ -131,7 +131,7 @@ public class KcAdmV2ClientCLITest extends AbstractKcAdmV2CLITest {
         String id = extractId(result);
         CommandResult getResult = kcAdmV2Cmd("client", "get", id);
         assertThat("get should succeed", getResult.exitCode(), is(0));
-        assertThat(getResult.out(), containsString("client_secret"));
+        assertThat(getResult.out(), containsString("client-secret"));
         assertThat(getResult.out(), containsString("my-secret-value"));
     }
 
@@ -163,7 +163,7 @@ public class KcAdmV2ClientCLITest extends AbstractKcAdmV2CLITest {
         assertThat(result.out(), containsString("role2"));
         assertThat(result.out(), containsString("STANDARD"));
         assertThat(result.out(), containsString("SERVICE_ACCOUNT"));
-        assertThat(result.out(), containsString("client_secret"));
+        assertThat(result.out(), containsString("client-secret"));
     }
 
     @Test
@@ -795,7 +795,7 @@ public class KcAdmV2ClientCLITest extends AbstractKcAdmV2CLITest {
                 "--redirect-uris", "https://example.com/callback,https://example.com/logout",
                 "--roles", "role1,role2",
                 "--login-flows", "STANDARD,SERVICE_ACCOUNT",
-                "--auth-method", "client_secret");
+                "--auth-method", "client-secret");
         assertThat("create should succeed: " + result.err(), result.exitCode(), is(0));
         return extractId(result);
     }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -47,6 +47,7 @@ import org.keycloak.testframework.annotations.InjectHttpClient;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
 import org.keycloak.testframework.realm.ManagedClient;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmBuilder;
@@ -75,7 +76,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -99,7 +99,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
     @InjectAdminClient(ref = "noAccessClient", realmRef = "testRealm", client = "myclient", mode = InjectAdminClient.Mode.MANAGED_REALM)
     Keycloak noAccessAdminClient;
 
-    @InjectClient(realmRef = "testRealm")
+    @InjectClient(realmRef = "testRealm", config = TestClientConfig.class)
     ManagedClient testClient;
 
     @Override
@@ -270,6 +270,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         oidcRep.setDescription("OIDC client for mixed protocol test");
         // OIDC-specific fields
         oidcRep.setLoginFlows(Set.of(OIDCClientRepresentation.Flow.STANDARD, OIDCClientRepresentation.Flow.DIRECT_GRANT));
+        oidcRep.setRedirectUris(Set.of("http://localhost:3000/callback"));
         oidcRep.setWebOrigins(Set.of("http://localhost:3000", "http://localhost:4000"));
 
         try (var response = getClientsApi().createClient(oidcRep)) {
@@ -285,7 +286,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         samlRep.setClientId("mixed-test-saml");
         samlRep.setDescription("SAML client for mixed protocol test");
         // SAML-specific fields
-        samlRep.setNameIdFormat("email");
+        samlRep.setNameIdFormat(SAMLClientRepresentation.NameIdFormat.EMAIL);
         samlRep.setSignDocuments(true);
         samlRep.setSignAssertions(true);
         samlRep.setForcePostBinding(true);
@@ -323,7 +324,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
 
             assertThat("SAML client should be in the list", foundSaml, is(notNullValue()));
             assertThat(foundSaml.getDescription(), notNullValue());
-            assertThat(foundSaml.getNameIdFormat(), is("email"));
+            assertThat(foundSaml.getNameIdFormat(), is(SAMLClientRepresentation.NameIdFormat.EMAIL));
             assertThat(foundSaml.getSignDocuments(), is(true));
             assertThat(foundSaml.getSignAssertions(), is(true));
             assertThat(foundSaml.getForcePostBinding(), is(true));
@@ -341,7 +342,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         SAMLClientRepresentation samlClient = (SAMLClientRepresentation) getClientsApi().client(samlRep.getClientId()).getClient();
         assertEquals("mixed-test-saml", samlClient.getClientId());
         assertEquals("SAML client for mixed protocol test", samlClient.getDescription());
-        assertThat(samlClient.getNameIdFormat(), is("email"));
+        assertThat(samlClient.getNameIdFormat(), is(SAMLClientRepresentation.NameIdFormat.EMAIL));
         assertThat(samlClient.getSignDocuments(), is(true));
         assertThat(samlClient.getSignAssertions(), is(true));
         assertThat(samlClient.getForcePostBinding(), is(true));
@@ -382,7 +383,6 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
             var body = response.readEntity(ViolationExceptionResponse.class);
             assertThat(body.error(), is("Provided data is invalid"));
             var violations = body.violations();
-            assertThat(violations, hasSize(2));
             assertThat(violations, hasItem("clientId: must not be blank"));
             assertThat(violations, hasItem("appUrl: must be a valid URL"));
         }
@@ -401,8 +401,8 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
             var body = response.readEntity(ViolationExceptionResponse.class);
             assertThat(body.error(), is("Provided data is invalid"));
             var violations = body.violations();
-            assertThat(violations.size(), is(1));
-            assertThat(violations.iterator().next(), is("appUrl: must be a valid URL"));
+            assertThat(violations, hasItem("appUrl: must be a valid URL"));
+            assertThat(violations, hasItem(containsString("valid client authenticator type is required")));
         }
     }
 
@@ -493,6 +493,10 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         rep.setEnabled(true);
 
         rep.setLoginFlows(Set.of(OIDCClientRepresentation.Flow.SERVICE_ACCOUNT));
+        var auth = new OIDCClientRepresentation.Auth();
+        auth.setMethod("client-secret");
+        auth.setSecret("test-sa-secret");
+        rep.setAuth(auth);
         rep.setServiceAccountRoles(Set.of(defaultRealmRoles, "offline_access"));
 
         try (var response = getClientsApi().createClient(rep)) {
@@ -821,7 +825,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
 
         OIDCClientRepresentation.Auth auth = new OIDCClientRepresentation.Auth();
         auth.setMethod(authenticationMethod);
-        auth.setSecret("shush");
+        auth.setSecret("shushy");
 
         OIDCClientRepresentation.Auth createdAuth = getResultingAuthConfigPost(auth, clientId);
         assertThat(createdAuth, notNullValue());
@@ -843,7 +847,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
 
         OIDCClientRepresentation.Auth auth = new OIDCClientRepresentation.Auth();
         auth.setMethod(authenticationMethod);
-        auth.setSecret("shush");
+        auth.setSecret("shushy");
 
         OIDCClientRepresentation.Auth createdAuth = getResultingAuthConfigPost(auth, clientId);
         assertThat(createdAuth, notNullValue());
@@ -859,7 +863,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
 
         OIDCClientRepresentation.Auth auth = new OIDCClientRepresentation.Auth();
         auth.setMethod(ClientIdAndSecretAuthenticator.PROVIDER_ID);
-        auth.setSecret("shush");
+        auth.setSecret("shushy");
 
         OIDCClientRepresentation.Auth createdAuth = getResultingAuthConfigPost(auth, clientId);
         assertThat(createdAuth, notNullValue());
@@ -884,7 +888,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         String clientId = authenticationMethod + "-patched-other-fields";
         OIDCClientRepresentation.Auth auth = new OIDCClientRepresentation.Auth();
         auth.setMethod(authenticationMethod);
-        auth.setSecret("shush");
+        auth.setSecret("shushy");
 
         OIDCClientRepresentation.Auth createdAuth = getResultingAuthConfigPost(auth, clientId);
         assertThat(createdAuth, notNullValue());
@@ -988,6 +992,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         rep.setEnabled(true);
         rep.setClientId(clientId);
         rep.setDescription("I'm OIDC Client");
+        rep.setRedirectUris(Set.of("http://localhost/callback"));
         rep.setAuth(auth);
 
         if (additionalFields.length % 2 != 0) {
@@ -1100,6 +1105,13 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
                     .secret("mysecret")
                     .serviceAccountsEnabled(true));
             return realm;
+        }
+    }
+
+    public static class TestClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client.redirectUris("http://localhost/callback");
         }
     }
 }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientPoliciesV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientPoliciesV2Test.java
@@ -168,6 +168,7 @@ public class ClientPoliciesV2Test extends AbstractClientApiV2Test {
         rep.setAuth(auth);
         // Add a login flow to ensure it's treated as a confidential client
         rep.setLoginFlows(Set.of(OIDCClientRepresentation.Flow.STANDARD));
+        rep.setRedirectUris(Set.of("http://localhost/callback"));
 
         try (var response = getClientsApi().createClient(rep)) {
             int statusCode = response.getStatus();
@@ -193,6 +194,7 @@ public class ClientPoliciesV2Test extends AbstractClientApiV2Test {
         rep.setClientId("test-auto-config-client");
         rep.setEnabled(true);
         rep.setLoginFlows(Set.of(OIDCClientRepresentation.Flow.STANDARD));
+        rep.setRedirectUris(Set.of("http://localhost/callback"));
 
         try (var response = getClientsApi().createClient(rep)) {
             int statusCode = response.getStatus();

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/InteropTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/InteropTest.java
@@ -273,14 +273,14 @@ public class InteropTest extends AbstractClientApiV2Test {
         v2Client.setAppUrl("http://localhost:9000/saml");
         v2Client.setRedirectUris(Set.of("http://localhost:9000/saml/*"));
         v2Client.setFrontChannelLogout(true);
-        v2Client.setNameIdFormat("email");
+        v2Client.setNameIdFormat(SAMLClientRepresentation.NameIdFormat.EMAIL);
         v2Client.setForceNameIdFormat(true);
         v2Client.setIncludeAuthnStatement(true);
         v2Client.setSignDocuments(true);
         v2Client.setSignAssertions(true);
         v2Client.setClientSignatureRequired(false);
         v2Client.setForcePostBinding(true);
-        v2Client.setSignatureAlgorithm("RSA_SHA256");
+        v2Client.setSignatureAlgorithm(SAMLClientRepresentation.SignatureAlgorithm.RSA_SHA256);
 
         try (var response = getClientsApi().createClient(v2Client)) {
             assertThat(response.getStatus(), is(201));
@@ -338,7 +338,7 @@ public class InteropTest extends AbstractClientApiV2Test {
         v2Update.setSignDocuments(true);
         v2Update.setSignAssertions(true);
         v2Update.setForcePostBinding(true);
-        v2Update.setSignatureAlgorithm("RSA_SHA512");
+        v2Update.setSignatureAlgorithm(SAMLClientRepresentation.SignatureAlgorithm.RSA_SHA512);
 
         try (var httpResponse = getClientsApi().client("update-saml-client").createOrUpdateClient(v2Update)) {
             assertThat(httpResponse.getStatus(), is(200));

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/AbstractClientValidationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/AbstractClientValidationTest.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.tests.admin.client.v2.validation;
 
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 
@@ -479,6 +482,634 @@ public abstract class AbstractClientValidationTest extends AbstractClientApiV2Te
     }
 
     // ===========================================
+    // Size constraint tests (BaseClientRepresentation)
+    // ===========================================
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testDisplayNameMaxLength(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String longName = "n".repeat(256);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "displayName": "%s",
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), longName)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("displayName: size must be between 0 and 255"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testDescriptionMaxLength(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String longDesc = "d".repeat(256);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "description": "%s",
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), longDesc)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("description: size must be between 0 and 255"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testAppUrlMaxLength(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String longUrl = "http://example.com/" + "a".repeat(237);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "appUrl": "%s",
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), longUrl)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("appUrl: size must be between 0 and 255"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testRedirectUriElementMaxLength(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String longUri = "http://example.com/" + "a".repeat(237);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "redirectUris": ["%s"],
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), longUri)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("redirectUris[].<iterable element>: size must be between 0 and 255"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testRedirectUrisMaxSize(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String uris = IntStream.range(0, 101)
+                .mapToObj(i -> "\"http://example.com/redirect" + i + "\"")
+                .collect(Collectors.joining(", "));
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "redirectUris": [%s],
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), uris)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("redirectUris: size must be between 0 and 100"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testRolesElementMaxLength(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String longRole = "r".repeat(256);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "roles": ["%s"],
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), longRole)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("roles[].<iterable element>: size must be between 0 and 255"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testRolesMaxSize(String protocol) throws Exception {
+        boolean isOidc = protocol.equals(OIDCClientRepresentation.PROTOCOL);
+        var request = getRequest(isOidc);
+        setAuthHeader(request);
+
+        String roles = IntStream.range(0, 301)
+                .mapToObj(i -> "\"role-" + i + "\"")
+                .collect(Collectors.joining(", "));
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "roles": [%s],
+                    "enabled": true
+                }
+                """.formatted(protocol, getPayloadClientId(isOidc), roles)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("roles: size must be between 0 and 300"));
+        }
+    }
+
+    // ===========================================
+    // Size constraint tests (OIDCClientRepresentation)
+    // ===========================================
+
+    @Test
+    public void testWebOriginsElementMaxLength() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        String longOrigin = "http://example.com:" + "1".repeat(247);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "webOrigins": ["%s"],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(), longOrigin)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("webOrigins[].<iterable element>: size must be between 0 and 255"));
+        }
+    }
+
+    @Test
+    public void testWebOriginsMaxSize() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        String origins = IntStream.range(0, 101)
+                .mapToObj(i -> "\"http://origin" + i + ".example.com\"")
+                .collect(Collectors.joining(", "));
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "webOrigins": [%s],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(), origins)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("webOrigins: size must be between 0 and 100"));
+        }
+    }
+
+    @Test
+    public void testWebOriginsInvalidFormat() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "webOrigins": ["not-an-origin"],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("webOrigins")));
+            assertThat(body.violations(), hasItem(containsString("must be a valid web origin")));
+        }
+    }
+
+    @Test
+    public void testServiceAccountRolesElementMaxLength() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        String longRole = "r".repeat(256);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["SERVICE_ACCOUNT"],
+                    "auth": {"method": "client-secret", "secret": "my-test-secret-value"},
+                    "serviceAccountRoles": ["%s"],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(), longRole)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("serviceAccountRoles[].<iterable element>: size must be between 0 and 255"));
+        }
+    }
+
+    @Test
+    public void testServiceAccountRolesMaxSize() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        String roles = IntStream.range(0, 301)
+                .mapToObj(i -> "\"sa-role-" + i + "\"")
+                .collect(Collectors.joining(", "));
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["SERVICE_ACCOUNT"],
+                    "auth": {"method": "client-secret", "secret": "my-test-secret-value"},
+                    "serviceAccountRoles": [%s],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(), roles)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("serviceAccountRoles: size must be between 0 and 300"));
+        }
+    }
+
+    // ===========================================
+    // Auth field constraint tests (OIDC-only)
+    // ===========================================
+
+    @Test
+    public void testAuthMethodNotBlank() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "auth": {"method": "   ", "secret": "my-test-secret-value"},
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("auth.method: must not be blank"));
+        }
+    }
+
+    @Test
+    public void testAuthMethodInvalidProvider() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "auth": {"method": "nonexistent-provider", "secret": "my-test-secret-value"},
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("auth.method")));
+            assertThat(body.violations(), hasItem(containsString("valid client authenticator type is required")));
+        }
+    }
+
+    @Test
+    public void testSecretMinLength() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "auth": {"method": "client-secret", "secret": "ab"},
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("auth.secret: size must be between 6 and 255"));
+        }
+    }
+
+    @Test
+    public void testCertificateMaxLength() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        String longCert = "X".repeat(65537);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "auth": {"method": "client-jwt", "certificate": "%s"},
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(), longCert)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("auth.certificate: size must be between 0 and 65536"));
+        }
+    }
+
+    // ===========================================
+    // SAML field constraint tests (SAML-only)
+    // ===========================================
+
+    @Test
+    public void testNameIdFormatInvalidValue() throws Exception {
+        var request = getRequest(false);
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "saml",
+                    "clientId": "%s",
+                    "nameIdFormat": "foobar",
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(false))));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            String responseBody = EntityUtils.toString(response.getEntity());
+            switch (getHttpMethod()) {
+                case HttpPatch.METHOD_NAME -> assertThat(responseBody, containsString("Invalid values for these fields: nameIdFormat"));
+                default -> assertThat(responseBody, containsString("Cannot parse the JSON"));
+            }
+        }
+    }
+
+    @Test
+    public void testSignatureAlgorithmInvalidValue() throws Exception {
+        var request = getRequest(false);
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "saml",
+                    "clientId": "%s",
+                    "signatureAlgorithm": "INVALID_ALGO",
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(false))));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            String responseBody = EntityUtils.toString(response.getEntity());
+            if (getHttpMethod().equals(HttpPatch.METHOD_NAME)) {
+                assertThat(responseBody, containsString("Invalid values for these fields: signatureAlgorithm"));
+            } else {
+                assertThat(responseBody, containsString("Cannot parse the JSON"));
+            }
+        }
+    }
+
+    @Test
+    public void testCanonicalizationMethodInvalidValue() throws Exception {
+        var request = getRequest(false);
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "saml",
+                    "clientId": "%s",
+                    "signatureCanonicalizationMethod": "http://example.com/invalid",
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(false))));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("signatureCanonicalizationMethod")));
+            assertThat(body.violations(), hasItem(containsString("must be a valid XML canonicalization method URI")));
+        }
+    }
+
+    @Test
+    public void testSigningCertificateMaxLength() throws Exception {
+        var request = getRequest(false);
+        setAuthHeader(request);
+
+        String longCert = "X".repeat(65537);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "saml",
+                    "clientId": "%s",
+                    "signingCertificate": "%s",
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId(false), longCert)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("signingCertificate: size must be between 0 and 65536"));
+        }
+    }
+
+    // ===========================================
+    // Cross-field constraint tests (OIDC-only)
+    // ===========================================
+
+    @Test
+    public void testServiceAccountRequiresConfidentialClient() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["SERVICE_ACCOUNT"],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("SERVICE_ACCOUNT")));
+            assertThat(body.violations(), hasItem(containsString("requires a confidential client")));
+        }
+    }
+
+    @Test
+    public void testTokenExchangeRequiresConfidentialClient() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["TOKEN_EXCHANGE"],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("TOKEN_EXCHANGE")));
+            assertThat(body.violations(), hasItem(containsString("requires a confidential client")));
+        }
+    }
+
+    @Test
+    public void testStandardFlowRequiresRedirectUris() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["STANDARD"],
+                    "redirectUris": [],
+                    "auth": {"method": "client-secret", "secret": "my-test-secret-value"},
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("redirectUris")));
+            assertThat(body.violations(), hasItem(containsString("requires at least one redirect URI")));
+        }
+    }
+
+    @Test
+    public void testImplicitFlowRequiresRedirectUris() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["IMPLICIT"],
+                    "redirectUris": [],
+                    "auth": {"method": "client-secret", "secret": "my-test-secret-value"},
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("redirectUris")));
+            assertThat(body.violations(), hasItem(containsString("requires at least one redirect URI")));
+        }
+    }
+
+    @Test
+    public void testServiceAccountRolesRequireServiceAccountFlow() throws Exception {
+        var request = getRequest();
+        setAuthHeader(request);
+
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "openid-connect",
+                    "clientId": "%s",
+                    "loginFlows": ["STANDARD"],
+                    "auth": {"method": "client-secret", "secret": "my-test-secret-value"},
+                    "redirectUris": ["http://localhost/callback"],
+                    "serviceAccountRoles": ["some-role"],
+                    "enabled": true
+                }
+                """.formatted(getPayloadClientId())));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem(containsString("serviceAccountRoles can only be set when SERVICE_ACCOUNT flow is enabled")));
+        }
+    }
+
+    // ===========================================
     // Valid client creation (positive test)
     // ===========================================
 
@@ -623,6 +1254,7 @@ public abstract class AbstractClientValidationTest extends AbstractClientApiV2Te
         public ClientBuilder configure(ClientBuilder client) {
             return client.clientId("test-client-oidc")
                     .enabled(true)
+                    .redirectUris("http://localhost/callback")
                     .protocol("openid-connect");
         }
     }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/PostClientValidationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/PostClientValidationTest.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
 import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+import org.keycloak.services.error.ViolationExceptionResponse;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
@@ -62,6 +64,29 @@ public class PostClientValidationTest extends AbstractClientValidationTest {
 
             var rep = mapper.createParser(response.getEntity().getContent()).readValueAs(BaseClientRepresentation.class);
             assertThat(rep.getUuid(), not(is(uuid)));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {OIDCClientRepresentation.PROTOCOL, SAMLClientRepresentation.PROTOCOL})
+    public void testClientIdMaxLength(String protocol) throws Exception {
+        var request = getRequest(protocol.equals(OIDCClientRepresentation.PROTOCOL));
+        setAuthHeader(request);
+
+        String longClientId = "a".repeat(256);
+        request.setEntity(new StringEntity("""
+                {
+                    "protocol": "%s",
+                    "clientId": "%s",
+                    "enabled": true
+                }
+                """.formatted(protocol, longClientId)));
+
+        try (var response = client.execute(request)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            var body = mapper.createParser(response.getEntity().getContent()).readValueAs(ViolationExceptionResponse.class);
+            assertThat(body.error(), is("Provided data is invalid"));
+            assertThat(body.violations(), hasItem("clientId: size must be between 1 and 255"));
         }
     }
 

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/WebOriginValidationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/validation/WebOriginValidationTest.java
@@ -1,0 +1,182 @@
+package org.keycloak.tests.admin.client.v2.validation;
+
+import org.keycloak.representations.admin.v2.validators.ValidWebOriginValidator;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link ValidWebOriginValidator} covering web origin format validation
+ * per RFC 6454 (scheme://host[:port]) plus special values {@code *} and {@code +}.
+ */
+class WebOriginValidationTest {
+
+    private final ValidWebOriginValidator validator = new ValidWebOriginValidator();
+
+    @Nested
+    @DisplayName("Special values")
+    class SpecialValues {
+
+        @Test
+        @DisplayName("accepts wildcard - *")
+        void acceptsWildcard() {
+            assertTrue(validator.isValid("*", null));
+        }
+
+        @Test
+        @DisplayName("accepts plus (derive from redirects) - +")
+        void acceptsPlus() {
+            assertTrue(validator.isValid("+", null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Valid origins")
+    class ValidOrigins {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "https://example.com",
+                "http://example.com",
+                "https://example.com:8443",
+                "http://localhost:3000",
+                "http://127.0.0.1:8080",
+                "https://sub.domain.example.com",
+                "http://my-server.example.com",
+                "http://[::1]",
+                "http://[::1]:8080",
+                "http://[2001:db8::1]:443",
+                "https://example.com:443",
+                "myapp://auth"
+        })
+        @DisplayName("accepts valid scheme://host[:port] origins")
+        void acceptsValidOrigins(String origin) {
+            assertTrue(validator.isValid(origin, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("Invalid origins")
+    class InvalidOrigins {
+
+        @Test
+        @DisplayName("rejects null")
+        void rejectsNull() {
+            assertFalse(validator.isValid(null, null));
+        }
+
+        @Test
+        @DisplayName("rejects plain string without scheme - not-an-origin")
+        void rejectsPlainString() {
+            assertFalse(validator.isValid("not-an-origin", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with path - https://example.com/path")
+        void rejectsOriginWithPath() {
+            assertFalse(validator.isValid("https://example.com/path", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with trailing slash - https://example.com/")
+        void rejectsOriginWithTrailingSlash() {
+            assertFalse(validator.isValid("https://example.com/", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with query - https://example.com?foo=bar")
+        void rejectsOriginWithQuery() {
+            assertFalse(validator.isValid("https://example.com?foo=bar", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with fragment - https://example.com#section")
+        void rejectsOriginWithFragment() {
+            assertFalse(validator.isValid("https://example.com#section", null));
+        }
+
+        @Test
+        @DisplayName("rejects empty string")
+        void rejectsEmptyString() {
+            assertFalse(validator.isValid("", null));
+        }
+
+        @Test
+        @DisplayName("rejects blank string")
+        void rejectsBlankString() {
+            assertFalse(validator.isValid("   ", null));
+        }
+
+        @Test
+        @DisplayName("rejects scheme only - https://")
+        void rejectsSchemeOnly() {
+            assertFalse(validator.isValid("https://", null));
+        }
+
+        @Test
+        @DisplayName("rejects missing scheme - example.com")
+        void rejectsMissingScheme() {
+            assertFalse(validator.isValid("example.com", null));
+        }
+
+        @Test
+        @DisplayName("rejects scheme starting with digit - 1http://example.com")
+        void rejectsSchemeStartingWithDigit() {
+            assertFalse(validator.isValid("1http://example.com", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with path and wildcard - https://example.com/*")
+        void rejectsOriginWithPathAndWildcard() {
+            assertFalse(validator.isValid("https://example.com/*", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with userinfo - https://user:pass@example.com")
+        void rejectsOriginWithUserinfo() {
+            assertFalse(validator.isValid("https://user:pass@example.com", null));
+        }
+
+        @Test
+        @DisplayName("rejects origin with matrix parameter - https://example.com;param=value")
+        void rejectsOriginWithMatrixParam() {
+            assertFalse(validator.isValid("https://example.com;param=value", null));
+        }
+
+        @Test
+        @DisplayName("rejects brackets mid-hostname - http://a[b]c")
+        void rejectsBracketsMidHostname() {
+            assertFalse(validator.isValid("http://a[b]c", null));
+        }
+
+        @Test
+        @DisplayName("rejects space in hostname - http://exam ple.com")
+        void rejectsSpaceInHostname() {
+            assertFalse(validator.isValid("http://exam ple.com", null));
+        }
+
+        @Test
+        @DisplayName("rejects non-numeric port - http://example.com:abc")
+        void rejectsNonNumericPort() {
+            assertFalse(validator.isValid("http://example.com:abc", null));
+        }
+
+        @Test
+        @DisplayName("rejects underscore in hostname - http://my_server.com")
+        void rejectsUnderscoreInHostname() {
+            assertFalse(validator.isValid("http://my_server.com", null));
+        }
+
+        @Test
+        @DisplayName("rejects percent in hostname - http://example%20.com")
+        void rejectsPercentInHostname() {
+            assertFalse(validator.isValid("http://example%20.com", null));
+        }
+    }
+}

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/mapper/ClientRepresentationComparator.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/mapper/ClientRepresentationComparator.java
@@ -137,7 +137,8 @@ public class ClientRepresentationComparator {
         Map<String, String> attrs = v1.getAttributes();
         if (attrs == null) return;
 
-        compare("attr[saml_name_id_format]→nameIdFormat", attrs.get(SAML_NAME_ID_FORMAT_ATTRIBUTE), saml.getNameIdFormat());
+        compare("attr[saml_name_id_format]→nameIdFormat", attrs.get(SAML_NAME_ID_FORMAT_ATTRIBUTE),
+                saml.getNameIdFormat() != null ? saml.getNameIdFormat().toJson() : null);
         compareSamlBoolean(SAML_FORCE_NAME_ID_FORMAT_ATTRIBUTE, "forceNameIdFormat", saml.getForceNameIdFormat());
         compareSamlBoolean(SAML_AUTHNSTATEMENT, "includeAuthnStatement", saml.getIncludeAuthnStatement());
         compareSamlBoolean(SAML_SERVER_SIGNATURE, "signDocuments", saml.getSignDocuments());
@@ -145,7 +146,7 @@ public class ClientRepresentationComparator {
         compareSamlBoolean(SAML_CLIENT_SIGNATURE_ATTRIBUTE, "clientSignatureRequired", saml.getClientSignatureRequired());
         compareSamlBoolean(SAML_FORCE_POST_BINDING, "forcePostBinding", saml.getForcePostBinding());
         compareSamlBoolean(SAML_ALLOW_ECP_FLOW, "allowEcpFlow", saml.getAllowEcpFlow());
-        compare("attr[saml.signature.algorithm]→signatureAlgorithm", attrs.get(SAML_SIGNATURE_ALGORITHM), saml.getSignatureAlgorithm());
+        compare("attr[saml.signature.algorithm]→signatureAlgorithm", attrs.get(SAML_SIGNATURE_ALGORITHM), saml.getSignatureAlgorithm() != null ? saml.getSignatureAlgorithm().name() : null);
         compare("attr[saml_signature_canonicalization_method]→signatureCanonicalizationMethod", attrs.get(SAML_CANONICALIZATION_METHOD_ATTRIBUTE), saml.getSignatureCanonicalizationMethod());
         compare("attr[saml.signing.certificate]→signingCertificate", attrs.get(SAML_SIGNING_CERTIFICATE_ATTRIBUTE), saml.getSigningCertificate());
     }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/mapper/SAMLClientModelMapperTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/mapper/SAMLClientModelMapperTest.java
@@ -126,7 +126,7 @@ public class SAMLClientModelMapperTest {
             SAMLClientModelMapper mapper = getModelMapper(session);
             SAMLClientRepresentation rep = (SAMLClientRepresentation) mapper.fromModel(clientModel);
 
-            assertThat(rep.getNameIdFormat(), is("username"));
+            assertThat(rep.getNameIdFormat(), is(SAMLClientRepresentation.NameIdFormat.USERNAME));
             assertThat(rep.getForceNameIdFormat(), is(true));
         } finally {
             realm.removeClient(clientModel.getId());
@@ -156,7 +156,7 @@ public class SAMLClientModelMapperTest {
             assertThat(rep.getSignDocuments(), is(true));
             assertThat(rep.getSignAssertions(), is(true));
             assertThat(rep.getClientSignatureRequired(), is(true));
-            assertThat(rep.getSignatureAlgorithm(), is("RSA_SHA256"));
+            assertThat(rep.getSignatureAlgorithm(), is(SAMLClientRepresentation.SignatureAlgorithm.RSA_SHA256));
             assertThat(rep.getSignatureCanonicalizationMethod(), is("http://www.w3.org/2001/10/xml-exc-c14n#"));
             assertThat(rep.getSigningCertificate(), is("MIICertificate"));
         } finally {
@@ -271,7 +271,7 @@ public class SAMLClientModelMapperTest {
             rep.setEnabled(true);
             rep.setClientId("test-saml-tomodel-nameid");
             rep.setRedirectUris(Set.of());
-            rep.setNameIdFormat("email");
+            rep.setNameIdFormat(SAMLClientRepresentation.NameIdFormat.EMAIL);
             rep.setForceNameIdFormat(true);
 
             SAMLClientModelMapper mapper = getModelMapper(session);
@@ -299,7 +299,7 @@ public class SAMLClientModelMapperTest {
             rep.setSignDocuments(true);
             rep.setSignAssertions(true);
             rep.setClientSignatureRequired(true);
-            rep.setSignatureAlgorithm("RSA_SHA512");
+            rep.setSignatureAlgorithm(SAMLClientRepresentation.SignatureAlgorithm.RSA_SHA512);
             rep.setSignatureCanonicalizationMethod("http://www.w3.org/2001/10/xml-exc-c14n#WithComments");
             rep.setSigningCertificate("MIINewCertificate");
 


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/48786
* Changes:

| Schema#Property | New Validation Constraint | Reasoning |
|-----------------|--------------------------|-----------|
| BaseClientRepresentation#clientId | `@Size(min=1, max=255)` | DB VARCHAR(255) |
| BaseClientRepresentation#displayName | `@Size(max=255)` | DB NVARCHAR(255) |
| BaseClientRepresentation#description | `@Size(max=255)` | DB NVARCHAR(255) |
| BaseClientRepresentation#appUrl | `@Size(max=255)` | DB VARCHAR(255) |
| BaseClientRepresentation#redirectUris | `@Size(max=100)` on set, `@Size(max=255)` on elements | DB VARCHAR(255) per element, bound collection |
| BaseClientRepresentation#roles | `@Size(max=300)` on set, `@Size(max=255)` on elements | DB VARCHAR(255) per element, bound collection |
| OIDCClientRepresentation#webOrigins | `@Size(max=100)` on set, `@Size(max=255)` on elements | DB VARCHAR(255) per element, bound collection |
| OIDCClientRepresentation#webOrigins | `@ValidWebOrigin` | RFC 6454 format, invalid origins silently break CORS |
| OIDCClientRepresentation#serviceAccountRoles | `@Size(max=300)` on set, `@Size(max=255)` on elements | DB VARCHAR(255) per element, bound collection |
| OIDCClientRepresentation.Auth#method | `@NotBlank` | must be specified when auth object is present |
| OIDCClientRepresentation.Auth#method | `@ValidAuthMethod` | open SPI, dynamic check against registered providers |
| OIDCClientRepresentation.Auth#secret | `@Size(min=6, max=255)` | DB VARCHAR(255), min=6 prevents trivially weak secrets |
| OIDCClientRepresentation.Auth#certificate | `@Size(max=65536)` | NCLOB unlimited, adding at least upper bound |
| OIDCClientRepresentation (class-level) | `@ConfidentialFlowsRequireAuth` | SERVICE_ACCOUNT/TOKEN_EXCHANGE fail at runtime without auth |
| OIDCClientRepresentation (class-level) | `@RedirectFlowsRequireUris` | STANDARD/IMPLICIT fail at runtime without redirect URIs |
| OIDCClientRepresentation (class-level) | `@ServiceAccountRolesRequireFlow` | roles silently ignored without SERVICE_ACCOUNT flow |
| SAMLClientRepresentation#nameIdFormat | type changed to enum `NameIdFormat` | SAML 2.0 spec frozen since 2005, unlikely to change |
| SAMLClientRepresentation#signatureAlgorithm | type changed to enum `SignatureAlgorithm` | PQC may require enum update, but it is easy |
| SAMLClientRepresentation#signatureCanonicalizationMethod | `@ValidCanonicalizationMethod` | finite set from JDK constants, W3C standard unchanged since 2008 |
| SAMLClientRepresentation#signingCertificate | `@Size(max=65536)` | NCLOB unlimited, adding at least an upper bound |

I have full analysis of constrains I have considered but did not add if anyone is interested, shout.