### PR TITLE
Add invite-user workflow step

### DIFF
--- a/docs/documentation/server_admin/topics/workflows/defining-steps.adoc
+++ b/docs/documentation/server_admin/topics/workflows/defining-steps.adoc
@@ -92,7 +92,13 @@ on the realm resource associated with the event, so that each realm resource typ
 ** `*` to unlink user from all linked Identity Providers
 | `disable-user` | Disable the user | None
 | `delete-user` | Delete the user | None
+| `invite-user` | Send an invitation email with an action token link to the user a|
+* `actions`: Required action names the user must complete. Defaults to `UPDATE_PASSWORD` and `VERIFY_EMAIL`.
+* `client-id`: Client id associated with the action token. Defaults to the realm's system client.
+* `redirect-uri`: Where to redirect the user after completing the required actions. Requires `client-id`.
 |===
+
+The `invite-user` step builds links from the configured hostname (`--hostname` or the realm `frontendUrl`). If neither is set, the step is skipped.
 
 [[_workflow_client_steps_]]
 == Client steps

--- a/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
+++ b/services/src/main/java/org/keycloak/authentication/actiontoken/DefaultActionToken.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.authentication.actiontoken;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -149,14 +150,24 @@ public class DefaultActionToken extends DefaultActionTokenKey implements SingleU
      * <li>{@code issuer}: URI of the given realm</li>
      * <li>{@code audience}: URI of the given realm (same as issuer)</li>
      * </ul>
-     *
-     * @param session
-     * @param realm
-     * @param uri
-     * @return
      */
     public String serialize(KeycloakSession session, RealmModel realm, UriInfo uri) {
-        String issuerUri = getIssuer(realm, uri);
+        return serialize(session, realm, uri.getBaseUri());
+    }
+
+    /**
+     * Variant of {@link #serialize(KeycloakSession, RealmModel, UriInfo)} that accepts the
+     * Keycloak base URI directly. Useful for callers that do not have access to a
+     * {@link UriInfo} (e.g. code that runs outside of an HTTP request, such as scheduled
+     * tasks or workflow executors).
+     *
+     * @param session the Keycloak session
+     * @param realm the realm the issuer URI is derived from
+     * @param baseUri the Keycloak base URI (e.g. {@code https://auth.example.com/})
+     * @return the signed JWT representation of this token
+     */
+    public String serialize(KeycloakSession session, RealmModel realm, URI baseUri) {
+        String issuerUri = Urls.realmIssuer(baseUri, realm.getName());
         String id = getId();
 
         if (id == null) {
@@ -170,10 +181,6 @@ public class DefaultActionToken extends DefaultActionTokenKey implements SingleU
           .audience(issuerUri);
 
         return session.tokens().encode(this);
-    }
-
-    private String getIssuer(RealmModel realm, UriInfo uri) {
-        return Urls.realmIssuer(uri.getBaseUri(), realm.getName());
     }
 
 }

--- a/services/src/main/java/org/keycloak/email/ActionTokenEmail.java
+++ b/services/src/main/java/org/keycloak/email/ActionTokenEmail.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.email;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.keycloak.authentication.actiontoken.execactions.ExecuteActionsActionToken;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.SystemClientUtil;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
+import org.keycloak.services.Urls;
+import org.keycloak.services.resources.LoginActionsService;
+
+/**
+ * Shared helper for sending an "execute actions" email to a user.
+ * <p>
+ * Centralises the logic that was previously inlined in
+ * {@code UserResource.executeActionsEmail()} and that workflow steps (e.g.
+ * {@code InviteUserStepProvider}) would otherwise have to copy:
+ * <ul>
+ *   <li>resolving the target client (explicit {@code clientId} or the realm
+ *   {@linkplain SystemClientUtil#getSystemClient(RealmModel) system client});</li>
+ *   <li>validating the optional redirect URI against the resolved client;</li>
+ *   <li>building the action-token URL and serialising the token;</li>
+ *   <li>invoking {@link EmailTemplateProvider#sendExecuteActions(String, long)}
+ *   with the standard template attributes.</li>
+ * </ul>
+ * The helper is intentionally HTTP-agnostic: it returns rich {@link Result}
+ * values and throws {@link EmailException} / {@link IllegalArgumentException}
+ * so callers can map outcomes onto either HTTP status codes (admin endpoints)
+ * or silent skips (background workflow executors).
+ */
+public final class ActionTokenEmail {
+
+    private ActionTokenEmail() {
+    }
+
+    /**
+     * Resolved parameters for a single {@code execute-actions} email.
+     */
+    public static final class Params {
+        private final ClientModel client;
+        private final String redirectUri;
+        private final int lifespanSeconds;
+
+        Params(ClientModel client, String redirectUri, int lifespanSeconds) {
+            this.client = client;
+            this.redirectUri = redirectUri;
+            this.lifespanSeconds = lifespanSeconds;
+        }
+
+        public ClientModel getClient() {
+            return client;
+        }
+
+        public String getRedirectUri() {
+            return redirectUri;
+        }
+
+        public int getLifespanSeconds() {
+            return lifespanSeconds;
+        }
+    }
+
+    /**
+     * Outcomes of {@link #resolveParams} that indicate a user is ineligible
+     * for an action-token email. These are <em>not</em> errors: admin endpoints
+     * may translate them into {@code 400 Bad Request}, while background
+     * executors may silently skip the user.
+     */
+    public enum Ineligibility {
+        /** The user has no email address set. */
+        USER_HAS_NO_EMAIL,
+        /** The user account is disabled. */
+        USER_DISABLED,
+        /** The resolved client does not exist or is not enabled. */
+        CLIENT_UNAVAILABLE,
+        /** The supplied {@code redirectUri} is not valid for the resolved client. */
+        INVALID_REDIRECT_URI,
+    }
+
+    /**
+     * Result of {@link #resolveParams}: either successfully resolved
+     * {@link Params} or a structured {@link Ineligibility} reason.
+     */
+    public static final class Result {
+        private final Params params;
+        private final Ineligibility ineligibility;
+
+        private Result(Params params, Ineligibility ineligibility) {
+            this.params = params;
+            this.ineligibility = ineligibility;
+        }
+
+        public Optional<Params> getParams() {
+            return Optional.ofNullable(params);
+        }
+
+        public Optional<Ineligibility> getIneligibility() {
+            return Optional.ofNullable(ineligibility);
+        }
+    }
+
+    /**
+     * Resolves the parameters needed to send an action-token email to
+     * {@code user}. Returns a structured {@link Result} so callers can
+     * differentiate between
+     * <ul>
+     *   <li>successful resolution → {@link Params};</li>
+     *   <li>user/client/redirect ineligibility → {@link Ineligibility};</li>
+     *   <li>caller-supplied invalid configuration (e.g. {@code redirectUri}
+     *   without a {@code clientId}) → {@link IllegalArgumentException}.</li>
+     * </ul>
+     *
+     * @param session                 the Keycloak session
+     * @param realm                   the realm the user belongs to
+     * @param user                    the recipient
+     * @param clientId                explicit client id, or {@code null} for the realm system client
+     * @param redirectUri             optional post-action redirect URI; requires {@code clientId} when supplied
+     * @param overrideLifespanSeconds explicit lifespan override; {@code null} falls back to
+     *                                {@link RealmModel#getActionTokenGeneratedByAdminLifespan()}
+     * @throws IllegalArgumentException when {@code redirectUri} is supplied without {@code clientId}
+     */
+    public static Result resolveParams(KeycloakSession session, RealmModel realm, UserModel user,
+                                       String clientId, String redirectUri,
+                                       Integer overrideLifespanSeconds) {
+        if (user.getEmail() == null) {
+            return new Result(null, Ineligibility.USER_HAS_NO_EMAIL);
+        }
+        if (!user.isEnabled()) {
+            return new Result(null, Ineligibility.USER_DISABLED);
+        }
+        if (redirectUri != null && clientId == null) {
+            throw new IllegalArgumentException("'redirect-uri' requires 'client-id' to be set");
+        }
+
+        ClientModel client = clientId != null
+                ? realm.getClientByClientId(clientId)
+                : SystemClientUtil.getSystemClient(realm);
+        if (client == null || !client.isEnabled()) {
+            return new Result(null, Ineligibility.CLIENT_UNAVAILABLE);
+        }
+
+        String resolvedRedirectUri = redirectUri;
+        if (resolvedRedirectUri != null) {
+            resolvedRedirectUri = RedirectUtils.verifyRedirectUri(session, resolvedRedirectUri, client);
+            if (resolvedRedirectUri == null) {
+                return new Result(null, Ineligibility.INVALID_REDIRECT_URI);
+            }
+        }
+
+        int lifespan = overrideLifespanSeconds != null
+                ? overrideLifespanSeconds
+                : realm.getActionTokenGeneratedByAdminLifespan();
+
+        return new Result(new Params(client, resolvedRedirectUri, lifespan), null);
+    }
+
+    /**
+     * Builds the action-token URL using the active HTTP request's base URI and
+     * sends the email. Equivalent to {@link #send(KeycloakSession, RealmModel,
+     * UserModel, Params, List, URI)} with {@code uriInfo.getBaseUri()}.
+     */
+    public static void send(KeycloakSession session, RealmModel realm, UserModel user,
+                            Params params, List<String> actions, UriInfo uriInfo) throws EmailException {
+        send(session, realm, user, params, actions, uriInfo.getBaseUri());
+    }
+
+    /**
+     * Builds the action-token URL using {@code baseUri} and sends the email.
+     * <p>
+     * Use this overload from contexts that do not have an active HTTP request
+     * (e.g. workflow executors) and therefore cannot supply a {@link UriInfo}.
+     */
+    public static void send(KeycloakSession session, RealmModel realm, UserModel user,
+                            Params params, List<String> actions, URI baseUri) throws EmailException {
+        int expiration = Time.currentTime() + params.lifespanSeconds;
+        ExecuteActionsActionToken token = new ExecuteActionsActionToken(
+                user.getId(), user.getEmail(), expiration, actions,
+                params.redirectUri, params.client.getClientId());
+
+        UriBuilder builder = Urls.loginActionsBase(baseUri)
+                .path(LoginActionsService.class, "executeActionToken");
+        String link = builder
+                .queryParam("key", token.serialize(session, realm, baseUri))
+                .build(realm.getName())
+                .toString();
+
+        session.getProvider(EmailTemplateProvider.class)
+                .setAttribute(Constants.TEMPLATE_ATTR_REQUIRED_ACTIONS, token.getRequiredActions())
+                .setAttribute(Constants.IGNORE_ACCEPT_LANGUAGE_HEADER, true)
+                .setRealm(realm)
+                .setUser(user)
+                .sendExecuteActions(link, TimeUnit.SECONDS.toMinutes(params.lifespanSeconds));
+    }
+}

--- a/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProvider.java
+++ b/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProvider.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.workflow;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import org.keycloak.authentication.actiontoken.execactions.ExecuteActionsActionToken;
+import org.keycloak.common.util.Time;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.email.EmailException;
+import org.keycloak.email.EmailTemplateProvider;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.SystemClientUtil;
+import org.keycloak.protocol.oidc.utils.RedirectUtils;
+import org.keycloak.services.resources.LoginActionsService;
+
+import org.jboss.logging.Logger;
+
+public class InviteUserStepProvider implements WorkflowStepProvider {
+
+    public static final String CONFIG_ACTIONS = "actions";
+    public static final String CONFIG_CLIENT_ID = "client-id";
+    public static final String CONFIG_REDIRECT_URI = "redirect-uri";
+
+    private static final List<String> DEFAULT_ACTIONS = List.of(
+            UserModel.RequiredAction.UPDATE_PASSWORD.name(),
+            UserModel.RequiredAction.VERIFY_EMAIL.name()
+    );
+
+    private final KeycloakSession session;
+    private final ComponentModel stepModel;
+    private final Logger log = Logger.getLogger(InviteUserStepProvider.class);
+
+    public InviteUserStepProvider(KeycloakSession session, ComponentModel model) {
+        this.session = session;
+        this.stepModel = model;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void run(WorkflowExecutionContext context) {
+        RealmModel realm = session.getContext().getRealm();
+        UserModel user = session.users().getUserById(realm, context.getResourceId());
+
+        if (user == null || user.getEmail() == null || !user.isEnabled()) {
+            return;
+        }
+
+        String clientId = stepModel.getConfig().getFirst(CONFIG_CLIENT_ID);
+        ClientModel client = clientId == null
+                ? SystemClientUtil.getSystemClient(realm)
+                : realm.getClientByClientId(clientId);
+
+        if (client == null || !client.isEnabled()) {
+            return;
+        }
+
+        String redirectUri = stepModel.getConfig().getFirst(CONFIG_REDIRECT_URI);
+        if (redirectUri != null) {
+            redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client);
+            if (redirectUri == null) {
+                return;
+            }
+        }
+
+        UriInfo uriInfo = resolveUriInfo();
+        if (uriInfo == null) {
+            return;
+        }
+
+        List<String> actions = stepModel.getConfig().getOrDefault(CONFIG_ACTIONS, DEFAULT_ACTIONS);
+        int lifespan = realm.getActionTokenGeneratedByAdminLifespan();
+        int expiration = Time.currentTime() + lifespan;
+
+        ExecuteActionsActionToken token = new ExecuteActionsActionToken(
+                user.getId(), user.getEmail(), expiration, actions, redirectUri, client.getClientId());
+
+        String link = LoginActionsService.actionTokenProcessor(uriInfo)
+                .queryParam("key", token.serialize(session, realm, uriInfo))
+                .build(realm.getName())
+                .toString();
+
+        try {
+            session.getProvider(EmailTemplateProvider.class)
+                    .setAttribute(Constants.TEMPLATE_ATTR_REQUIRED_ACTIONS, token.getRequiredActions())
+                    .setAttribute(Constants.IGNORE_ACCEPT_LANGUAGE_HEADER, true)
+                    .setRealm(realm)
+                    .setUser(user)
+                    .sendExecuteActions(link, TimeUnit.SECONDS.toMinutes(lifespan));
+        } catch (EmailException e) {
+            log.errorv(e, "Failed to send invite email to user {0} ({1})", user.getUsername(), user.getEmail());
+        }
+    }
+
+    private UriInfo resolveUriInfo() {
+        try {
+            return session.getContext().getUri();
+        } catch (NullPointerException e) {
+            // No active HTTP request and neither --hostname=<full URL> nor realm frontendUrl set:
+            // KeycloakUriInfo cannot resolve a base URI. Skip rather than crash the workflow.
+            log.warn("Cannot build invite link without --hostname or realm frontendUrl configured");
+            return null;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProvider.java
+++ b/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProvider.java
@@ -17,24 +17,17 @@
 
 package org.keycloak.models.workflow;
 
+import java.net.URI;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import jakarta.ws.rs.core.UriInfo;
-
-import org.keycloak.authentication.actiontoken.execactions.ExecuteActionsActionToken;
-import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.email.ActionTokenEmail;
 import org.keycloak.email.EmailException;
-import org.keycloak.email.EmailTemplateProvider;
-import org.keycloak.models.ClientModel;
-import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.utils.SystemClientUtil;
-import org.keycloak.protocol.oidc.utils.RedirectUtils;
-import org.keycloak.services.resources.LoginActionsService;
+import org.keycloak.urls.HostnameProvider;
+import org.keycloak.urls.UrlType;
 
 import org.jboss.logging.Logger;
 
@@ -44,14 +37,24 @@ public class InviteUserStepProvider implements WorkflowStepProvider {
     public static final String CONFIG_CLIENT_ID = "client-id";
     public static final String CONFIG_REDIRECT_URI = "redirect-uri";
 
+    /**
+     * Operator-facing message describing the configuration that this step requires.
+     * Used by both runtime warnings ({@link #run}) and configuration validation
+     * ({@link InviteUserStepProviderFactory#validateConfiguration}).
+     */
+    static final String HOSTNAME_NOT_CONFIGURED_MESSAGE =
+            "invite-user requires a configured Keycloak hostname: set --hostname=<full URL> "
+                    + "or the realm 'frontendUrl' attribute";
+
     private static final List<String> DEFAULT_ACTIONS = List.of(
             UserModel.RequiredAction.UPDATE_PASSWORD.name(),
             UserModel.RequiredAction.VERIFY_EMAIL.name()
     );
 
+    private static final Logger LOG = Logger.getLogger(InviteUserStepProvider.class);
+
     private final KeycloakSession session;
     private final ComponentModel stepModel;
-    private final Logger log = Logger.getLogger(InviteUserStepProvider.class);
 
     public InviteUserStepProvider(KeycloakSession session, ComponentModel model) {
         this.session = session;
@@ -66,64 +69,68 @@ public class InviteUserStepProvider implements WorkflowStepProvider {
     public void run(WorkflowExecutionContext context) {
         RealmModel realm = session.getContext().getRealm();
         UserModel user = session.users().getUserById(realm, context.getResourceId());
-
-        if (user == null || user.getEmail() == null || !user.isEnabled()) {
+        if (user == null) {
             return;
         }
 
         String clientId = stepModel.getConfig().getFirst(CONFIG_CLIENT_ID);
-        ClientModel client = clientId == null
-                ? SystemClientUtil.getSystemClient(realm)
-                : realm.getClientByClientId(clientId);
+        String redirectUri = stepModel.getConfig().getFirst(CONFIG_REDIRECT_URI);
 
-        if (client == null || !client.isEnabled()) {
+        ActionTokenEmail.Result resolved;
+        try {
+            resolved = ActionTokenEmail.resolveParams(session, realm, user, clientId, redirectUri, null);
+        } catch (IllegalArgumentException e) {
+            // Caller-supplied invalid configuration. The factory validates this at create
+            // time, so reaching here means the configuration was changed after creation.
+            LOG.warnf("Skipping invite for user %s: %s", user.getUsername(), e.getMessage());
+            return;
+        }
+        if (resolved.getParams().isEmpty()) {
+            // User/client/redirect ineligible — silently skip, this is normal for workflows
+            // (e.g. user has no email, account disabled, etc.).
             return;
         }
 
-        String redirectUri = stepModel.getConfig().getFirst(CONFIG_REDIRECT_URI);
-        if (redirectUri != null) {
-            redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client);
-            if (redirectUri == null) {
-                return;
-            }
-        }
-
-        UriInfo uriInfo = resolveUriInfo();
-        if (uriInfo == null) {
+        URI baseUri = resolveBaseUri(session);
+        if (baseUri == null) {
+            // Should be unreachable because the factory rejects this configuration up-front,
+            // but keep a defensive log in case hostname configuration changes at runtime.
+            LOG.warnf("Skipping invite for user %s: %s", user.getUsername(), HOSTNAME_NOT_CONFIGURED_MESSAGE);
             return;
         }
 
         List<String> actions = stepModel.getConfig().getOrDefault(CONFIG_ACTIONS, DEFAULT_ACTIONS);
-        int lifespan = realm.getActionTokenGeneratedByAdminLifespan();
-        int expiration = Time.currentTime() + lifespan;
-
-        ExecuteActionsActionToken token = new ExecuteActionsActionToken(
-                user.getId(), user.getEmail(), expiration, actions, redirectUri, client.getClientId());
-
-        String link = LoginActionsService.actionTokenProcessor(uriInfo)
-                .queryParam("key", token.serialize(session, realm, uriInfo))
-                .build(realm.getName())
-                .toString();
 
         try {
-            session.getProvider(EmailTemplateProvider.class)
-                    .setAttribute(Constants.TEMPLATE_ATTR_REQUIRED_ACTIONS, token.getRequiredActions())
-                    .setAttribute(Constants.IGNORE_ACCEPT_LANGUAGE_HEADER, true)
-                    .setRealm(realm)
-                    .setUser(user)
-                    .sendExecuteActions(link, TimeUnit.SECONDS.toMinutes(lifespan));
+            ActionTokenEmail.send(session, realm, user, resolved.getParams().get(), actions, baseUri);
         } catch (EmailException e) {
-            log.errorv(e, "Failed to send invite email to user {0} ({1})", user.getUsername(), user.getEmail());
+            LOG.errorv(e, "Failed to send invite email to user {0} ({1})", user.getUsername(), user.getEmail());
         }
     }
 
-    private UriInfo resolveUriInfo() {
+    /**
+     * Resolves the Keycloak base URI suitable for building absolute action-token URLs.
+     * <p>
+     * Workflow steps may run on a thread without an active HTTP request, so we cannot
+     * rely on {@link org.keycloak.models.KeycloakContext#getUri()} (it is request-scoped).
+     * The {@link HostnameProvider} can still produce a base URI provided that
+     * {@code --hostname=<full URL>} or the realm {@code frontendUrl} attribute is
+     * configured; otherwise it has no fallback and indicates this by throwing a
+     * {@link NullPointerException} when called with a {@code null} {@code originalUriInfo}.
+     * <p>
+     * Note: {@code org.keycloak.ssf.transmitter.support.SsfUtil#getIssuerUrl} solves a
+     * closely related problem for the Shared Signals Framework, with its own fallback
+     * chain (realm {@code frontendUrl} → {@code KC_HOSTNAME_URL} env → {@code hostname}
+     * config → request URI). Unifying both into a single public helper would be a useful
+     * follow-up refactoring but is intentionally out of scope for this change.
+     *
+     * @return the resolved base URI, or {@code null} when no static hostname is configured
+     */
+    static URI resolveBaseUri(KeycloakSession session) {
         try {
-            return session.getContext().getUri();
+            return session.getProvider(HostnameProvider.class).getBaseUri(null, UrlType.FRONTEND);
         } catch (NullPointerException e) {
-            // No active HTTP request and neither --hostname=<full URL> nor realm frontendUrl set:
-            // KeycloakUriInfo cannot resolve a base URI. Skip rather than crash the workflow.
-            log.warn("Cannot build invite link without --hostname or realm frontendUrl configured");
+            LOG.debugv(e, "HostnameProvider could not resolve a base URI without an active request");
             return null;
         }
     }

--- a/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProviderFactory.java
+++ b/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProviderFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.models.workflow;
+
+import java.util.List;
+import java.util.Set;
+
+import org.keycloak.authentication.requiredactions.util.RequiredActionsValidator;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.component.ComponentValidationException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.urls.HostnameProvider;
+import org.keycloak.urls.UrlType;
+
+public class InviteUserStepProviderFactory implements WorkflowStepProviderFactory<InviteUserStepProvider> {
+
+    public static final String ID = "invite-user";
+
+    @Override
+    public InviteUserStepProvider create(KeycloakSession session, ComponentModel model) {
+        return new InviteUserStepProvider(session, model);
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public Set<ResourceType> getSupportedResourceTypes() {
+        return Set.of(ResourceType.USERS);
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Sends an invitation email with an action link to the user";
+    }
+
+    @Override
+    public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel model)
+            throws ComponentValidationException {
+        String clientId = model.get(InviteUserStepProvider.CONFIG_CLIENT_ID);
+        String redirectUri = model.get(InviteUserStepProvider.CONFIG_REDIRECT_URI);
+
+        if (redirectUri != null && clientId == null) {
+            throw new ComponentValidationException("'redirect-uri' requires 'client-id' to be set");
+        }
+        if (clientId != null && realm.getClientByClientId(clientId) == null) {
+            throw new ComponentValidationException("Client '" + clientId + "' does not exist");
+        }
+
+        List<String> actions = model.getConfig().get(InviteUserStepProvider.CONFIG_ACTIONS);
+        if (actions != null && !RequiredActionsValidator.validRequiredActions(session, actions)) {
+            throw new ComponentValidationException("Invalid required action configured for 'actions'");
+        }
+
+        try {
+            session.getProvider(HostnameProvider.class).getBaseUri(null, UrlType.FRONTEND);
+        } catch (NullPointerException e) {
+            throw new ComponentValidationException(
+                    "invite-user requires a configured hostname: set --hostname=<full URL> or the realm 'frontendUrl' attribute");
+        }
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                    .name(InviteUserStepProvider.CONFIG_ACTIONS)
+                    .label("Required Actions")
+                    .helpText("Required actions the user must complete after clicking the invitation link. " +
+                            "Defaults to UPDATE_PASSWORD and VERIFY_EMAIL.")
+                    .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+                    .add()
+                .property()
+                    .name(InviteUserStepProvider.CONFIG_CLIENT_ID)
+                    .label("Client ID")
+                    .helpText("Client id to associate with the action token. Defaults to the realm's system client.")
+                    .type(ProviderConfigProperty.STRING_TYPE)
+                    .add()
+                .property()
+                    .name(InviteUserStepProvider.CONFIG_REDIRECT_URI)
+                    .label("Redirect URI")
+                    .helpText("Where to send the user after completing the required actions. " +
+                            "Must be a valid redirect URI for the configured client.")
+                    .type(ProviderConfigProperty.STRING_TYPE)
+                    .add()
+                .build();
+    }
+}

--- a/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProviderFactory.java
+++ b/services/src/main/java/org/keycloak/models/workflow/InviteUserStepProviderFactory.java
@@ -27,8 +27,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
-import org.keycloak.urls.HostnameProvider;
-import org.keycloak.urls.UrlType;
 
 public class InviteUserStepProviderFactory implements WorkflowStepProviderFactory<InviteUserStepProvider> {
 
@@ -72,11 +70,13 @@ public class InviteUserStepProviderFactory implements WorkflowStepProviderFactor
             throw new ComponentValidationException("Invalid required action configured for 'actions'");
         }
 
-        try {
-            session.getProvider(HostnameProvider.class).getBaseUri(null, UrlType.FRONTEND);
-        } catch (NullPointerException e) {
-            throw new ComponentValidationException(
-                    "invite-user requires a configured hostname: set --hostname=<full URL> or the realm 'frontendUrl' attribute");
+        // The step may run on a workflow executor thread without an active HTTP request,
+        // so the HostnameProvider must be able to resolve a base URI without an
+        // 'original' UriInfo. That requires either --hostname=<full URL> or the realm
+        // 'frontendUrl' attribute to be configured. Reject the configuration up-front
+        // so the operator gets a meaningful error instead of silently dropped invites.
+        if (InviteUserStepProvider.resolveBaseUri(session) == null) {
+            throw new ComponentValidationException(InviteUserStepProvider.HOSTNAME_NOT_CONFIGURED_MESSAGE);
         }
     }
 

--- a/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowsResource.java
+++ b/services/src/main/java/org/keycloak/workflow/admin/resource/WorkflowsResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.Profile;
 import org.keycloak.common.Profile.Feature;
+import org.keycloak.component.ComponentValidationException;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.workflow.Workflow;
@@ -70,6 +71,10 @@ public class WorkflowsResource {
             return Response.created(session.getContext().getUri().getRequestUriBuilder().path(workflow.getId()).build()).build();
         } catch (ModelException me) {
             throw ErrorResponse.error(me.getMessage(), Response.Status.BAD_REQUEST);
+        } catch (ComponentValidationException cve) {
+            // Surfaced by WorkflowStepProviderFactory.validateConfiguration() when the step
+            // configuration is invalid - report it as a client error instead of leaking a 500.
+            throw ErrorResponse.error(cve.getMessage(), Response.Status.BAD_REQUEST);
         }
     }
 

--- a/services/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowStepProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.models.workflow.WorkflowStepProviderFactory
@@ -27,5 +27,6 @@ org.keycloak.models.workflow.GrantRoleStepProviderFactory
 org.keycloak.models.workflow.RevokeRoleStepProviderFactory
 org.keycloak.models.workflow.JoinGroupStepProviderFactory
 org.keycloak.models.workflow.LeaveGroupStepProviderFactory
+org.keycloak.models.workflow.InviteUserStepProviderFactory
 org.keycloak.models.workflow.client.DeleteClientStepProviderFactory
 org.keycloak.models.workflow.client.DisableClientStepProviderFactory

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/config/InviteUserStepServerConfig.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/config/InviteUserStepServerConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.workflow.config;
+
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+public class InviteUserStepServerConfig implements KeycloakServerConfig {
+
+    public static final String HOSTNAME_URL = "http://localhost:8080";
+
+    @Override
+    public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+        return config
+                .option("spi-workflow--default--executor-blocking", Boolean.TRUE.toString())
+                .option("hostname", HOSTNAME_URL);
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/workflow/step/InviteUserStepTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/workflow/step/InviteUserStepTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.workflow.step;
+
+import java.io.IOException;
+
+import jakarta.mail.internet.MimeMessage;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.models.workflow.InviteUserStepProvider;
+import org.keycloak.models.workflow.InviteUserStepProviderFactory;
+import org.keycloak.models.workflow.events.UserCreatedWorkflowEventFactory;
+import org.keycloak.representations.workflows.WorkflowRepresentation;
+import org.keycloak.representations.workflows.WorkflowStepRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.mail.MailServer;
+import org.keycloak.testframework.mail.annotations.InjectMailServer;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.tests.utils.MailUtils;
+import org.keycloak.tests.workflow.AbstractWorkflowTest;
+import org.keycloak.tests.workflow.config.InviteUserStepServerConfig;
+
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.tests.workflow.util.EmailTestUtils.findEmailByRecipient;
+import static org.keycloak.tests.workflow.util.EmailTestUtils.findEmailByRecipientContaining;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest(config = InviteUserStepServerConfig.class)
+public class InviteUserStepTest extends AbstractWorkflowTest {
+
+    @InjectMailServer
+    private MailServer mailServer;
+
+    @Test
+    public void testInviteEmailSentOnUserCreation() throws IOException {
+        managedRealm.admin().workflows().create(WorkflowRepresentation.withName("invite")
+                .onEvent(UserCreatedWorkflowEventFactory.ID)
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(InviteUserStepProviderFactory.ID).build()
+                ).build()).close();
+
+        managedRealm.admin().users().create(UserBuilder.create()
+                .username("newuser").email("newuser@example.com").build()).close();
+
+        mailServer.waitForIncomingEmail(10_000, 1);
+        MimeMessage message = findEmailByRecipient(mailServer, "newuser@example.com");
+        assertNotNull(message);
+
+        String link = MailUtils.getLink(MailUtils.getBody(message).getHtml());
+        assertThat(link, startsWith(InviteUserStepServerConfig.HOSTNAME_URL
+                + "/realms/" + managedRealm.getName() + "/login-actions/action-token"));
+        assertThat(link, containsString("key="));
+    }
+
+    @Test
+    public void testInviteSkippedForUserWithoutEmail() {
+        managedRealm.admin().workflows().create(WorkflowRepresentation.withName("invite")
+                .onEvent(UserCreatedWorkflowEventFactory.ID)
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(InviteUserStepProviderFactory.ID).build()
+                ).build()).close();
+
+        managedRealm.admin().users().create(UserBuilder.create().username("noemail").build()).close();
+
+        assertNull(findEmailByRecipientContaining(mailServer, "noemail"));
+    }
+
+    @Test
+    public void testCreateFailsWhenActionUnknown() {
+        try (Response response = managedRealm.admin().workflows().create(WorkflowRepresentation.withName("invite-bad")
+                .onEvent(UserCreatedWorkflowEventFactory.ID)
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(InviteUserStepProviderFactory.ID)
+                                .withConfig(InviteUserStepProvider.CONFIG_ACTIONS, "NOT_AN_ACTION")
+                                .build()
+                ).build())) {
+            assertThat(response.getStatus(), is(Response.Status.BAD_REQUEST.getStatusCode()));
+        }
+    }
+
+    @Test
+    public void testCreateFailsWhenRedirectUriHasNoClient() {
+        try (Response response = managedRealm.admin().workflows().create(WorkflowRepresentation.withName("invite-bad")
+                .onEvent(UserCreatedWorkflowEventFactory.ID)
+                .withSteps(
+                        WorkflowStepRepresentation.create().of(InviteUserStepProviderFactory.ID)
+                                .withConfig(InviteUserStepProvider.CONFIG_REDIRECT_URI, "https://app.example.com/")
+                                .build()
+                ).build())) {
+            assertThat(response.getStatus(), is(Response.Status.BAD_REQUEST.getStatusCode()));
+        }
+    }
+}


### PR DESCRIPTION
Adds a new `invite-user` workflow step that sends an invitation email to a newly
created user with a one-time action token link.

### Usage

```yaml
name: Invite user on creation
on: user-created
steps:
  - uses: invite-user
    with:
      actions:
        - UPDATE_PASSWORD
        - VERIFY_EMAIL
      client-id: my-app
      redirect-uri: https://app.example.com/welcome
      lifespan: 12h
```

