### PR TITLE
[OID4VCI] Test in OID4VCActionTest for the correct client scenarios. …

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -348,6 +348,13 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
             CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
             offerState = Optional.ofNullable(offerStorage.getOfferStateById(credOfferId))
                     .orElseThrow(() -> new IllegalStateException("No credential offer state for: " + auxCredOfferId));
+
+            // Check same login client as the client for which the credential offer is target (in case of credential offer target for specific client only)
+            String offerClientId = offerState.getTargetClientId();
+            String loginClientId = clientSessionCtx.getClientSession().getClient().getClientId();
+            if (offerClientId != null && !offerClientId.equals(loginClientId)) {
+                throw new IllegalStateException("Credential offer target client '" + offerClientId + "' different from login client '" + loginClientId + "'");
+            }
         }
 
         return offerState;

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -306,9 +306,18 @@ public class OID4VCIssuerEndpoint {
         ClientModel client = clientSession.getClient();
 
         boolean oid4vciEnabled = Boolean.parseBoolean(client.getAttributes().get(OID4VCI_ENABLED_ATTRIBUTE_KEY));
+        boolean clientEnabled = client.isEnabled();
+        String errorDescription = null;
 
         if (!oid4vciEnabled) {
             LOGGER.debugf("Client '%s' is not enabled for OID4VCI features.", client.getClientId());
+            errorDescription = "Client not enabled for OID4VCI";
+        }
+        if (!clientEnabled) {
+            LOGGER.debugf("Client '%s' disabled.", client.getClientId());
+            errorDescription = "Client not enabled for OID4VCI";
+        }
+        if (!oid4vciEnabled || !clientEnabled) {
             if (eventBuilder != null) {
                 eventBuilder.client(client).error(ErrorType.INVALID_CLIENT.getValue());
             }
@@ -318,7 +327,7 @@ public class OID4VCIssuerEndpoint {
             throw new CorsErrorResponseException(
                     cors,
                     ErrorType.INVALID_CLIENT.getValue(),
-                    "Client not enabled for OID4VCI",
+                    errorDescription,
                     Response.Status.FORBIDDEN
             );
         }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import org.keycloak.common.Profile;
 import org.keycloak.events.Errors;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -39,6 +40,7 @@ import org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant;
 import org.keycloak.protocol.oid4vc.utils.CredentialScopeModelUtils;
 import org.keycloak.util.Strings;
 
+import static org.keycloak.OID4VCConstants.OID4VCI_ENABLED_ATTRIBUTE_KEY;
 import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
 import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
 
@@ -85,6 +87,11 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
         String targetUserId = Optional.ofNullable(targetUsername)
                 .map(tu -> validateTargetUser(session, realmModel, user, tu))
                 .map(UserModel::getId).orElse(null);
+
+        // Validate the target client
+        if (targetClientId != null) {
+            validateTargetClient(realmModel, targetClientId);
+        }
 
         // Create the CredentialsOffer
         //
@@ -148,6 +155,20 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
         }
 
         return targetUserModel;
+    }
+
+    private void validateTargetClient(RealmModel realm, String clientId) {
+        ClientModel client = session.clients().getClientByClientId(realm, clientId);
+        if (client == null) {
+            throw new CredentialOfferException(Errors.CLIENT_NOT_FOUND, "Client '" + clientId + "' not found");
+        }
+        if (!client.isEnabled()) {
+            throw new CredentialOfferException(Errors.CLIENT_DISABLED, "Client '" + clientId + "' disabled");
+        }
+        boolean oid4vciEnabled = Boolean.parseBoolean(client.getAttributes().get(OID4VCI_ENABLED_ATTRIBUTE_KEY));
+        if (!oid4vciEnabled) {
+            throw new CredentialOfferException(Errors.INVALID_CLIENT, "Client '" + clientId + "' is not enabled for OID4VCI features.");
+        }
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionTest.java
@@ -33,6 +33,8 @@ import static org.keycloak.events.Details.CREDENTIAL_TYPE;
 import static org.keycloak.events.Details.CUSTOM_REQUIRED_ACTION;
 import static org.keycloak.events.Details.GRANT_TYPE;
 import static org.keycloak.events.Details.REASON;
+import static org.keycloak.events.Errors.CLIENT_NOT_FOUND;
+import static org.keycloak.events.Errors.INVALID_CLIENT;
 import static org.keycloak.events.Errors.REJECTED_BY_USER;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_CREDENTIAL_OFFER_REQUEST;
 import static org.keycloak.protocol.oid4vc.model.ErrorType.MISSING_CREDENTIAL_CONFIG;
@@ -111,6 +113,11 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
         credentialOfferPage.assertCurrent();
         assertEquals(credentialOfferUri, credentialOfferPage.getCredentialOfferUri());
 
+        loginSuccessForAuthorizationCodeCredentialOffer(credentialOfferUri);
+    }
+
+
+    private void loginSuccessForAuthorizationCodeCredentialOffer(String credentialOfferUri) {
         String credentialOfferNonce = getNonceFromCredentialOfferUri(credentialOfferUri);
 
         // Obtain credential offer
@@ -172,6 +179,79 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
                 .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
 
         verifyVCActionCredentialResponse(credResponse);
+    }
+
+
+    // Test successful scenario with wallet using "authorization code" grant. Credential offer is not target to any specific client
+    @Test
+    public void testCredentialOfferAIASuccess_authorizationCodeFlow_noSpecificClient() throws Exception {
+        // Login as user. Check required-action displayed
+        oauth.client(client.getClientId(), "test-secret");
+        oauth.loginForm()
+                .kcAction(getKcActionParameter(null, minimalJwtTypeCredentialConfigurationIdName, false))
+                .open();
+        oauth.fillLoginForm(user.getUsername(), TEST_PASSWORD);
+
+        credentialOfferPage.assertCurrent();
+        String credentialOfferUri = credentialOfferPage.getCredentialOfferUri();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .details(Details.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED, String.valueOf(false))
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_USER_ID, user.getId())
+                .withoutDetails(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID)
+                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
+
+        loginSuccessForAuthorizationCodeCredentialOffer(credentialOfferUri);
+    }
+
+
+    // Test that credential-offer created for different client than actual client used later at login request with issuer_state from credential-offer
+    @Test
+    public void testCredentialOfferAIASuccess_authorizationCodeFlow_differentClient() throws Exception {
+        // Create credential offer for 'oid4vci-test-pub' client
+        oauth.client(client.getClientId(), "test-secret");
+        oauth.loginForm()
+                .kcAction(getKcActionParameter(OID4VCI_PUBLIC_CLIENT_ID, minimalJwtTypeCredentialConfigurationIdName, false))
+                .open();
+        oauth.fillLoginForm(user.getUsername(), TEST_PASSWORD);
+
+        credentialOfferPage.assertCurrent();
+        String credentialOfferUri = credentialOfferPage.getCredentialOfferUri();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .details(Details.CREDENTIAL_TYPE, minimalJwtTypeCredentialConfigurationIdName)
+                .details(Details.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED, String.valueOf(false))
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_USER_ID, user.getId())
+                .details(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID, OID4VCI_PUBLIC_CLIENT_ID)
+                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
+
+        // Obtain credential offer
+        String credentialOfferNonce = getNonceFromCredentialOfferUri(credentialOfferUri);
+        CredentialOfferResponse credentialOfferResponse = oauth.oid4vc().credentialOfferRequest(credentialOfferNonce)
+                .send();
+        assertEquals(HttpStatus.SC_OK, credentialOfferResponse.getStatusCode());
+        CredentialsOffer credOffer = credentialOfferResponse.getCredentialsOffer();
+        String issuerState = credOffer.getIssuerState();
+        assertNotNull(issuerState);
+
+        // Send AuthorizationRequest with 'oid4vci-test' client
+        //
+        AuthorizationEndpointResponse authResponse = wallet
+                .authorizationRequest()
+                .scope(ctx.getScope())
+                .issuerState(issuerState)
+                .send(user.getUsername(), TEST_PASSWORD);
+        String authCode = authResponse.getCode();
+        assertNotNull(authCode, "No authCode");
+
+        // Build and send AccessTokenRequest. Fails due the different client used for credential-offer than for the login
+        //
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode).send();
+        assertNull(tokenResponse.getAccessToken());
+        assertEquals("Credential offer target client 'oid4vci-test-pub' different from login client 'oid4vci-test'", tokenResponse.getErrorDescription());
     }
 
 
@@ -246,6 +326,45 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
                 .details(CREDENTIAL_TYPE, "unknown-config-id")
                 .details(REASON, "Client scope was not found for credential configuration ID: unknown-config-id")
                 .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER_ERROR);
+        events.clear();
+    }
+
+    @Test
+    public void testCredentialOfferClientErrors() {
+        // Test kc_action_parameter referencing non-existing client
+        oauth.client(client.getClientId(), client.getSecret());
+
+        oauth.loginForm()
+                .kcAction(getKcActionParameter("non-existing", minimalJwtTypeCredentialConfigurationIdName, false))
+                .open();
+        oauth.fillLoginForm(user.getUsername(), TEST_PASSWORD);
+
+        AuthorizationEndpointResponse authzCodeResponse = new AuthorizationEndpointResponse(oauth);
+        assertNotNull(authzCodeResponse.getCode());
+        assertEquals(RequiredActionContext.KcActionStatus.ERROR.name().toLowerCase(), authzCodeResponse.getKcActionStatus());
+
+        EventAssertion.assertError(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .error(CLIENT_NOT_FOUND)
+                .details(REASON, "Client 'non-existing' not found")
+                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER_ERROR);
+        events.poll();
+
+        // Test disabled OID4VCI client
+        oauth.loginForm()
+                .kcAction(getKcActionParameter("account", minimalJwtTypeCredentialConfigurationIdName, false))
+                .open();
+        authzCodeResponse = new AuthorizationEndpointResponse(oauth);
+        assertNotNull(authzCodeResponse.getCode());
+        assertEquals(RequiredActionContext.KcActionStatus.ERROR.name().toLowerCase(), authzCodeResponse.getKcActionStatus());
+        EventAssertion.assertError(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .error(INVALID_CLIENT)
+                .details(REASON, "Client 'account' is not enabled for OID4VCI features.")
+                .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER_ERROR);
+
         events.clear();
     }
 


### PR DESCRIPTION
…Handle scenarios for invalid or disabled clients

closes #48886

During increasing test coverage, I also fixed some issues like:
- Make sure that when credential-offer is created for target client, it is validated that client is valid (existing, enabled, oid4vci-enabled)
- Make sure that when different client used for login and for credential-offer, the error is thrown earlier in the token-request rather than later in the credential request (This may help to avoid some corner-case scenarios as the fact that token-request would be successful and tokens would be issued can be also problematic). 
