### PR TITLE
Fix introspection error for invalid client authentication

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -20,11 +20,13 @@ import java.util.List;
 
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import org.keycloak.OAuthErrorException;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -37,6 +39,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.AccessTokenIntrospectionProviderFactory;
 import org.keycloak.protocol.oidc.TokenIntrospectionProvider;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenIntrospectContext;
@@ -136,9 +139,21 @@ public class TokenIntrospectionEndpoint {
 
         } catch (ErrorResponseException ere) {
             throw ere;
+        } catch (WebApplicationException wae) {
+            throw convertClientAuthenticationException(wae);
         } catch (Exception e) {
             throw throwErrorResponseException(Errors.INVALID_REQUEST, "Authentication failed.", Status.UNAUTHORIZED);
         }
+    }
+
+    private WebApplicationException convertClientAuthenticationException(WebApplicationException wae) {
+        Response response = wae.getResponse();
+        if (response != null && response.getStatus() == Status.UNAUTHORIZED.getStatusCode()
+                && response.getEntity() instanceof OAuth2ErrorRepresentation error
+                && OAuthErrorException.UNAUTHORIZED_CLIENT.equals(error.getError())) {
+            return throwErrorResponseException(OAuthErrorException.INVALID_CLIENT, "Client authentication failed.", Status.UNAUTHORIZED);
+        }
+        return wae;
     }
 
     private void checkSsl() {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExecutorTest.java
@@ -1815,7 +1815,7 @@ public class ClientPoliciesExecutorTest extends AbstractClientPoliciesTest {
         // Send a token introspection request with invalid 'aud' . Should fail
         signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.RS256, getRealmInfoUrl() + "/protocol/openid-connect/introspect");
         HttpResponse tokenIntrospectionResponse = doTokenIntrospectionWithSignedJWT("access_token", refreshedResponse.getAccessToken(), signedJwt);
-        assertEquals(401, tokenIntrospectionResponse.getStatusLine().getStatusCode());
+        assertEquals(400, tokenIntrospectionResponse.getStatusLine().getStatusCode());
 
         // Send a token introspection request with valid 'aud' . Should succeed
         signedJwt = createSignedRequestToken(clientId, privateKey, publicKey, Algorithm.RS256, getRealmInfoUrl());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/TokenIntrospectionTest.java
@@ -200,15 +200,27 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
     }
 
     @Test
-    public void testInvalidClientCredentials() throws Exception {
-        oauth.doLogin("test-user@localhost", "password");
-        String code = oauth.parseLoginResponse().getCode();
-        AccessTokenResponse accessTokenResponse = oauth.doAccessTokenRequest(code);
+    public void testInvalidClientCredentials() {
         oauth.client("confidential-cli", "bad_credential");
-        IntrospectionResponse tokenResponse = oauth.doIntrospectionAccessTokenRequest(accessTokenResponse.getAccessToken());
+        IntrospectionResponse tokenResponse = oauth.doIntrospectionAccessTokenRequest("any-token");
 
-        Assertions.assertEquals("Authentication failed.", tokenResponse.getErrorDescription());
-        Assertions.assertEquals(OAuthErrorException.INVALID_REQUEST, tokenResponse.getError());
+        Assertions.assertEquals(401, tokenResponse.getStatusCode());
+        Assertions.assertEquals(OAuthErrorException.INVALID_CLIENT, tokenResponse.getError());
+        Assertions.assertEquals("Client authentication failed.", tokenResponse.getErrorDescription());
+    }
+
+    @Test
+    public void testInvalidClientCredentialsPostAuthentication() throws Exception {
+        try (CloseableHttpResponse response = introspectAccessTokenWithClientSecretPost("confidential-cli", "bad_credential", "any-token")) {
+            Assertions.assertEquals(401, response.getStatusLine().getStatusCode());
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            response.getEntity().writeTo(out);
+            OAuth2ErrorRepresentation errorRep = JsonSerialization.readValue(
+                    new String(out.toByteArray(), StandardCharsets.UTF_8), OAuth2ErrorRepresentation.class);
+            Assertions.assertEquals(OAuthErrorException.INVALID_CLIENT, errorRep.getError());
+            Assertions.assertEquals("Client authentication failed.", errorRep.getErrorDescription());
+        }
     }
 
     @Test
@@ -706,6 +718,26 @@ public class TokenIntrospectionTest extends AbstractTestRealmKeycloakTest {
             return new String(out.toByteArray());
         } catch (Exception e) {
             throw new RuntimeException("Failed to retrieve access token", e);
+        }
+    }
+
+    private CloseableHttpResponse introspectAccessTokenWithClientSecretPost(String clientId, String clientSecret, String tokenToIntrospect) {
+        HttpPost post = new HttpPost(oauth.getEndpoints().getIntrospection());
+
+        List<NameValuePair> parameters = new LinkedList<>();
+
+        parameters.add(new BasicNameValuePair("client_id", clientId));
+        parameters.add(new BasicNameValuePair("client_secret", clientSecret));
+        parameters.add(new BasicNameValuePair("token", tokenToIntrospect));
+        parameters.add(new BasicNameValuePair("token_type_hint", "access_token"));
+
+        UrlEncodedFormEntity formEntity = new UrlEncodedFormEntity(parameters, StandardCharsets.UTF_8);
+        post.setEntity(formEntity);
+
+        try {
+            return HttpClientBuilder.create().build().execute(post);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to introspect access token", e);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the error returned by the OIDC token introspection endpoint when confidential client authentication fails.

Previously, invalid confidential-client credentials were reported as `invalid_request`. This change returns `invalid_client` with HTTP 401 for the introspection endpoint, matching the OAuth 2.0 client authentication error semantics referenced by RFC 7662.

Fixes #48721.

## Testing

- `./mvnw -pl services -am -DskipTests -DskipProtoLock=true install` - PASS
- `./mvnw -f testsuite/integration-arquillian/pom.xml -pl tests/base install -Dtest=ClientPoliciesExecutorTest -DskipProtoLock=true` - PASS
- `./mvnw -f testsuite/integration-arquillian/pom.xml -pl tests/base install -Dtest=TokenIntrospectionTest -DskipProtoLock=true` - PASS
- `./mvnw spotless:check` - PASS

## Risk

The change is scoped to the introspection endpoint's handling of failed confidential-client authentication.

Successful introspection, inactive-token responses, malformed requests with valid client authentication, public-client rejection, SAML-client rejection, CORS behavior, and shared client-authentication utilities are unchanged.