### PR TITLE
[OID4VCI-HAIP] Pass oid4vci-1_0-issuer-happy-flow

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -135,6 +135,8 @@ public class Profile {
         OID4VC_VCI_PREAUTH_CODE("Support for credential offers with `pre-authorized_code` grant.", Type.EXPERIMENTAL, OID4VC_VCI),
         OID4VC_VCI_REST_CREDENTIAL_OFFER("Support for the REST endpoint to create credential offers.", Type.EXPERIMENTAL, OID4VC_VCI),
 
+        OID4VC_HAIP("OpenID4VC High Assurance Interoperability Profile 1.0", Type.EXPERIMENTAL, OID4VC_VCI),
+
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),
         OPENTELEMETRY_METRICS("Micrometer to OpenTelemetry bridge support for metrics", Type.EXPERIMENTAL, 1, false, true,

--- a/core/src/main/java/org/keycloak/util/DPoPGenerator.java
+++ b/core/src/main/java/org/keycloak/util/DPoPGenerator.java
@@ -20,13 +20,17 @@ package org.keycloak.util;
 import java.security.Key;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.interfaces.ECPublicKey;
 
 import org.keycloak.OAuth2Constants;
+import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
+import org.keycloak.crypto.KeyType;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.jose.jwk.ECPublicJWK;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.jose.jws.JWSBuilder;
@@ -36,6 +40,7 @@ import org.keycloak.representations.dpop.DPoP;
 
 import static org.keycloak.OAuth2Constants.DPOP_DEFAULT_ALGORITHM;
 import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
+import static org.keycloak.jose.jwk.JWKUtil.toIntegerBytes;
 
 /**
  * Utility for generating signed DPoP proofs
@@ -55,19 +60,33 @@ public class DPoPGenerator {
     }
 
 
-    private static JWK createRsaJwk(Key publicKey) {
+    public static JWK createRsaJwk(Key publicKey) {
         return JWKBuilder.create()
                 .rsa(publicKey, KeyUse.SIG);
     }
 
+    public static JWK createEcJwk(Key publicKey) {
+        ECPublicKey ecKey = (ECPublicKey) publicKey;
+        int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+        ECPublicJWK k = new ECPublicJWK();
+        k.setKeyType(KeyType.EC);
+        k.setCrv("P-" + fieldSize);
+        k.setX(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineX(), fieldSize)));
+        k.setY(Base64Url.encode(toIntegerBytes(ecKey.getW().getAffineY(), fieldSize)));
+        return k;
+    }
 
-    public String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken) {
+    public static String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, JWSHeader jwsHeader, KeyWrapper keyWrapper, String accessToken) {
         DPoP dpop = generateDPoP(jti, htm, htu, iat, accessToken);
-        KeyWrapper keyWrapper = getKeyWrapper(jwsHeader, privateKey);
         return sign(jwsHeader, dpop, keyWrapper);
     }
 
-    private DPoP generateDPoP(String jti, String htm, String htu, Long iat, String accessToken) {
+    public String generateSignedDPoPProof(String jti, String htm, String htu, Long iat, JWSHeader jwsHeader, PrivateKey privateKey, String accessToken) {
+        KeyWrapper keyWrapper = getKeyWrapper(jwsHeader, privateKey);
+        return generateSignedDPoPProof(jti, htm, htu, iat, jwsHeader, keyWrapper, accessToken);
+    }
+
+    private static DPoP generateDPoP(String jti, String htm, String htu, Long iat, String accessToken) {
         DPoP dpop = new DPoP();
         dpop.id(jti);
         dpop.setHttpMethod(htm);
@@ -89,9 +108,8 @@ public class DPoPGenerator {
         return keyWrapper;
     }
 
-    private String sign(JWSHeader jwsHeader, DPoP dpop, KeyWrapper keyWrapper) {
+    private static String sign(JWSHeader jwsHeader, DPoP dpop, KeyWrapper keyWrapper) {
         SignatureSignerContext sigCtx = KeyWrapperUtil.createSignatureSignerContext(keyWrapper);
-
         return new JWSBuilder()
                 .header(jwsHeader)
                 .jsonContent(dpop)

--- a/server-spi-private/src/main/java/org/keycloak/events/Details.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/Details.java
@@ -33,6 +33,7 @@ public interface Details {
     String ACTION = "action";
     String CODE_ID = "code_id";
     String REDIRECT_URI = "redirect_uri";
+    String REQUEST_URI = "request_uri";
     String RESPONSE_TYPE = "response_type";
     String RESPONSE_MODE = "response_mode";
     String GRANT_TYPE = "grant_type";

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -59,6 +60,9 @@ import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.LoginProtocol.Error;
 import org.keycloak.protocol.RestartLoginCookie;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
+import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
+import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.services.ErrorPage;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
@@ -1239,10 +1243,23 @@ public class AuthenticationProcessor {
 
         String nextRequiredAction = nextRequiredAction();
         if (nextRequiredAction != null) {
-            return AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
+            Response response = AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
+            return response;
         } else {
             event.detail(Details.CODE_ID, authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
-            return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+            Response response = AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+
+            // Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+            // not at the point of visiting the authorization endpoint
+            String requestUri = authenticationSession.getAuthNote(Details.REQUEST_URI);
+            RequestUriType requestUriType = Optional.ofNullable(requestUri)
+                    .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
+                    .orElse(null);
+            if (requestUriType == RequestUriType.PAR) {
+                AuthzEndpointParParser.removeRequestObject(session, requestUri);
+            }
+
+            return response;
         }
     }
 

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
@@ -20,6 +20,7 @@ package org.keycloak.authentication.authenticators.client;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +51,8 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.OIDCWellKnownProviderFactory;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.JsonWebToken;
@@ -57,6 +60,7 @@ import org.keycloak.saml.RandomSecret;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.Strings;
+import org.keycloak.wellknown.WellKnownProvider;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -110,6 +114,7 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
     @Override
     public void authenticateClient(ClientAuthenticationFlowContext context) {
 
+        KeycloakSession session = context.getSession();
         HttpHeaders headers = context.getHttpRequest().getHttpHeaders();
         String attestationValue = headers.getHeaderString(OAUTH_CLIENT_ATTESTATION_HEADER);
         String attestationPoPValue = headers.getHeaderString(OAUTH_CLIENT_ATTESTATION_POP_HEADER);
@@ -126,16 +131,27 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         context.attempted();
 
         try {
-            ClientAttestationJwt attesterJwt = validateClientAttestationJwt(context);
-            validateClientAttestationPoPJwt(context, attesterJwt);
+            ABCAResult abcaResult = new ABCAResult();
+            session.setAttribute(ABCAResult.ABCA_RESULT, abcaResult);
+
+            validateClientAttestationJwt(context, abcaResult);
+            validateClientAttestationPoPJwt(context, abcaResult);
 
             context.success();
+
+            ClientModel clientModel = context.getClient();
+            abcaResult.setAttestedClient(clientModel);
 
         } catch (Exception ex) {
             ServicesLogger.LOGGER.errorValidatingAssertion(ex);
             Response response = ClientAuthUtil.errorResponse(BAD_REQUEST.getStatusCode(), INVALID_CLIENT_ATTESTATION, ex.getMessage());
             context.failure(AuthenticationFlowError.INVALID_CLIENT_ATTESTATION, response);
         }
+
+        // Error Message specifically related to the use of client attestations
+        // [TODO] use_attestation_challenge MUST be used when the Client Attestation PoP JWT is not using an expected server-provided challenge.
+        // [TODO] use_fresh_attestation MUST be used when the Client Attestation JWT is deemed to be not fresh enough to be acceptable by the server.
+        // [TODO] invalid_client_attestation MAY be used in addition to the more general invalid_client error code as defined in [RFC6749] if the attestation or its proof of possession could not be successfully verified
     }
 
     @Override
@@ -331,7 +347,7 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
 
     // Validate the Client Attestation JWT
     // https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html#section-5.1
-    private ClientAttestationJwt validateClientAttestationJwt(ClientAuthenticationFlowContext context) throws Exception {
+    private void validateClientAttestationJwt(ClientAuthenticationFlowContext context, ABCAResult abcaResult) throws Exception {
 
         KeycloakSession session = context.getSession();
         RealmModel realmModel = session.getContext().getRealm();
@@ -341,17 +357,20 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
                 .orElseThrow(() -> new IllegalArgumentException("Required header " + OAUTH_CLIENT_ATTESTATION_HEADER + " is missing"));
 
         MultivaluedMap<String, String> formParams = context.getHttpRequest().getDecodedFormParameters();
+        String clientIdParam = formParams.getFirst(CLIENT_ID);
 
         JWSInput jws = new JWSInput(headerValue);
         String jwsType = jws.getHeader().getType();
         if (!OAUTH_CLIENT_ATTESTATION_JWT_TYPE.equals(jwsType))
             throw new IllegalArgumentException("The JWS type MUST be " + OAUTH_CLIENT_ATTESTATION_JWT_TYPE + " instead of " + jwsType);
 
-        // Get the client model from the JWT subject
         ClientAttestationJwt attestationJwt = jws.readJsonContent(ClientAttestationJwt.class);
-        ClientModel clientModel = Optional.ofNullable(attestationJwt.getSubject())
+        String clientId = Optional.ofNullable(clientIdParam).orElse(attestationJwt.getSubject());
+
+        // Get the client model from the given client_id
+        ClientModel clientModel = Optional.ofNullable(clientId)
                 .map(realmModel::getClientByClientId)
-                .orElseThrow(() -> new TokenVerificationException(attestationJwt, "The sub (subject) claim MUST identify a known client_id"));
+                .orElseThrow(() -> new TokenVerificationException(attestationJwt, "No such client: " + clientId));
 
         // Set the target client in the context before we attempt signature verification
         context.setClient(clientModel);
@@ -360,7 +379,6 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         //
 
         TokenVerifier.Predicate<JsonWebToken> subCheck = (t) -> {
-            String clientIdParam = formParams.getFirst(CLIENT_ID);
             if (clientIdParam != null && !clientIdParam.equals(t.getSubject()))
                 throw new TokenVerificationException(t, "The sub claim (subject) MUST match the client_id parameter");
             return true;
@@ -401,17 +419,18 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
             throw new TokenSignatureInvalidException(attestationJwt, "Invalid token signature");
         }
 
+        abcaResult.setAttestationJwt(attestationJwt);
+
         // [TODO] The alg JOSE Header Parameter for both JWTs indicates a registered asymmetric digital signature algorithm
         // [TODO] The key contained in the cnf claim of the Client Attestation JWT is not a private key
-
-        return attestationJwt;
     }
 
     // Validate the Client Attestation PoP JWT
     // https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html#section-5.2
-    private ClientAttestationPoPJwt validateClientAttestationPoPJwt(ClientAuthenticationFlowContext context, ClientAttestationJwt attesterJwt) throws Exception {
+    private void validateClientAttestationPoPJwt(ClientAuthenticationFlowContext context, ABCAResult abcaResult) throws Exception {
 
         KeycloakSession session = context.getSession();
+        ClientAttestationJwt attestationJwt = abcaResult.getAttestationJwt();
 
         HttpHeaders headers = context.getHttpRequest().getHttpHeaders();
         String headerValue = Optional.ofNullable(headers.getHeaderString(OAUTH_CLIENT_ATTESTATION_POP_HEADER))
@@ -440,20 +459,23 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         };
 
         TokenVerifier.Predicate<JsonWebToken> issCheck = (t) -> {
-            if (Strings.isEmpty(t.getIssuer()) || !t.getIssuer().equals(attesterJwt.getSubject()))
+            if (Strings.isEmpty(t.getIssuer()) || !t.getIssuer().equals(attestationJwt.getSubject()))
                 throw new TokenVerificationException(t, "The value of the iss (issuer) claim, representing the client_id MUST match the value of the sub (subject) claim in the Client Attestation");
             return true;
         };
 
         TokenVerifier.Predicate<JsonWebToken> audCheck = (t) -> {
-            if (t.getAudience() == null || t.getAudience().length == 0)
+            WellKnownProvider oidcProvider = session.getProvider(WellKnownProvider.class, OIDCWellKnownProviderFactory.PROVIDER_ID);
+            OIDCConfigurationRepresentation oidcConfig = (OIDCConfigurationRepresentation) oidcProvider.getConfig();
+            List<String> audiences = Optional.ofNullable(t.getAudience()).map(Arrays::asList).orElse(List.of());
+            if (!audiences.contains(oidcConfig.getIssuer()))
                 throw new TokenVerificationException(t, "The aud (audience) claim MUST specify a value that identifies the authorization server as an intended audience.");
             return true;
         };
 
         // The public key used to verify the ClientAttestationPoP JWT MUST be the key located in the "cnf" claim of the corresponding ClientAttestation JWT
         //
-        JWK jwk = attesterJwt.getConfirmation().getJwk();
+        JWK jwk = attestationJwt.getConfirmation().getJwk();
         KeyWrapper clientKey = toPublicKeyWrapper(jwk);
 
         // Client Attestation PoP JWT verification without signature check
@@ -474,20 +496,14 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
             throw new TokenSignatureInvalidException(attestationPoPJwt, "Invalid token signature");
         }
 
-        // [TODO] The aud (audience) claim MUST specify a value that identifies the authorization server as an intended audience
+        abcaResult.setAttestationPoPJwt(attestationPoPJwt);
+
         // [TODO] The authorization server can utilize the jti value for replay attack detection
         // [TODO] The authorization server may reject JWTs with an "iat" claim value that is unreasonably far in the past
 
         // [TODO] If the server provided a challenge value to the client, the challenge claim is present in the Client Attestation PoP JWT and matches the server-provided challenge value.
         // [TODO] Additional checks to guarantee replay protection for the Client Attestation PoP JWT might need to be applied
-
-        return attestationPoPJwt;
     }
-
-    // Error Message specifically related to the use of client attestations
-    // [TODO] use_attestation_challenge MUST be used when the Client Attestation PoP JWT is not using an expected server-provided challenge.
-    // [TODO] use_fresh_attestation MUST be used when the Client Attestation JWT is deemed to be not fresh enough to be acceptable by the server.
-    // [TODO] invalid_client_attestation MAY be used in addition to the more general invalid_client error code as defined in [RFC6749] if the attestation or its proof of possession could not be successfully verified
 
     /**
      * The AttestationBasedClientAuthenticator config
@@ -504,6 +520,46 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
         public ABCAConfig setKeys(List<JWK> keys) {
             this.keys = keys;
             return this;
+        }
+    }
+
+    public static class ABCAResult {
+
+        /**
+         *  A key to a KeycloakSession attribute that contains the ABCA validation result
+         */
+        public static final String ABCA_RESULT = "ABCAResult";
+
+        private ClientAttestationJwt attestationJwt;
+        private ClientAttestationPoPJwt attestationPoPJwt;
+        private ClientModel attestedClient;
+
+        public ClientAttestationJwt getAttestationJwt() {
+            return attestationJwt;
+        }
+
+        public void setAttestationJwt(ClientAttestationJwt attestationJwt) {
+            this.attestationJwt = attestationJwt;
+        }
+
+        public ClientAttestationPoPJwt getAttestationPoPJwt() {
+            return attestationPoPJwt;
+        }
+
+        public void setAttestationPoPJwt(ClientAttestationPoPJwt attestationPoPJwt) {
+            this.attestationPoPJwt = attestationPoPJwt;
+        }
+
+        public ClientModel getAttestedClient() {
+            return attestedClient;
+        }
+
+        public void setAttestedClient(ClientModel client) {
+            this.attestedClient = client;
+        }
+
+        public boolean hasAttestedClient() {
+            return attestedClient != null;
         }
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/SdJwtCredentialSigner.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/signing/SdJwtCredentialSigner.java
@@ -22,7 +22,7 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
+import javax.security.auth.x500.X500Principal;
 
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.models.KeycloakSession;
@@ -84,6 +84,7 @@ public class SdJwtCredentialSigner extends AbstractCredentialSigner<String> {
         if (certificateChain != null && !certificateChain.isEmpty()) {
             List<String> x5cList = certificateChain.stream()
                     .filter(Objects::nonNull)
+                    .filter(cert -> !isTrustAnchor(cert))
                     .map(cert -> {
                         try {
                             return Base64.getEncoder().encodeToString(cert.getEncoded());
@@ -91,7 +92,7 @@ public class SdJwtCredentialSigner extends AbstractCredentialSigner<String> {
                             throw new RuntimeException(e);
                         }
                     })
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (!x5cList.isEmpty()) {
                 sdJwtCredentialBody.getIssuerSignedJWT().getJwsHeader().setX5c(x5cList);
@@ -101,5 +102,18 @@ public class SdJwtCredentialSigner extends AbstractCredentialSigner<String> {
         } else {
             LOGGER.debugf("No certificate or certificate chain available for x5c header in SD-JWT credential.");
         }
+    }
+
+    private boolean isTrustAnchor(X509Certificate cert) {
+        boolean isTrustAnchor = false;
+        try {
+            int basicConstraints = cert.getBasicConstraints();
+            X500Principal issuerPrincipal = cert.getIssuerX500Principal();
+            X500Principal subjectPrincipal = cert.getSubjectX500Principal();
+            isTrustAnchor = subjectPrincipal.equals(issuerPrincipal) && basicConstraints >= 0;
+        } catch (Exception e) {
+            // ignore
+        }
+        return isTrustAnchor;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oidc.endpoints;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import jakarta.ws.rs.Consumes;
@@ -396,16 +397,22 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
     }
 
-    private Response buildAuthorizationCodeAuthorizationResponse(String requestUriParam) {
+    private Response buildAuthorizationCodeAuthorizationResponse(String requestUri) {
         this.event.event(EventType.LOGIN);
         authenticationSession.setAuthNote(Details.AUTH_TYPE, CODE_AUTH_TYPE);
+        authenticationSession.setAuthNote(Details.REQUEST_URI, requestUri);
 
-        // redirect if it is a PAR request because authentication can need a refresh (kerberos) and the single object is consumed now
-        final boolean redirectToAuthenticationIfParRequest = requestUriParam != null
-                && RequestUriType.PAR == AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUriParam);
+        RequestUriType requestUriType = Optional.ofNullable(requestUri)
+                .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
+                .orElse(null);
 
-        return handleBrowserAuthenticationRequest(authenticationSession, new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event),
-                TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE), redirectToAuthenticationIfParRequest);
+        // Redirect if it is a PAR request because authentication may need a refresh (kerberos) and the single object is consumed now
+        boolean redirectToAuthFlow = requestUriType == RequestUriType.PAR;
+
+        OIDCLoginProtocol loginProtocol = new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event);
+        boolean isPassive = TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE);
+        Response response = handleBrowserAuthenticationRequest(authenticationSession, loginProtocol, isPassive, redirectToAuthFlow);
+        return response;
     }
 
     private Response buildRegister() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -19,8 +19,10 @@
 package org.keycloak.protocol.oidc.par.endpoints.request;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -53,29 +55,18 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         super(session);
         this.session = session;
         this.client = client;
-        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        String key;
-        try {
-            key = requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
-        } catch (RuntimeException re) {
-            logger.warnf(re,"Unable to parse request_uri: %s", requestUri);
-            throw new RuntimeException("Unable to parse request_uri");
-        }
-        Map<String, String> retrievedRequest = singleUseStore.remove(CACHE_KEY_PREFIX + key);
-        if (retrievedRequest == null) {
-            throw new RuntimeException("PAR not found. not issued or used multiple times.");
-        }
-
         RealmModel realm = session.getContext().getRealm();
+        Map<String, String> parRequestParams = Optional.ofNullable(getRequestObject(session, requestUri))
+                .orElseThrow(() -> new RuntimeException("PAR not found, not issued or used multiple times."));
+        long created = Long.parseLong(parRequestParams.get(PAR_CREATED_TIME));
         int expiresIn = realm.getParPolicy().getRequestUriLifespan();
-        long created = Long.parseLong(retrievedRequest.get(PAR_CREATED_TIME));
-        if (System.currentTimeMillis() - created < (expiresIn * 1000)) {
-            requestParams = retrievedRequest;
+        if (System.currentTimeMillis() - created < expiresIn * 1000L) {
+            requestParams = parRequestParams;
         } else {
             throw new RuntimeException("PAR expired.");
         }
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
-        String dpopJkt = retrievedRequest.get(PAR_DPOP_PROOF_JKT);
+        String dpopJkt = parRequestParams.get(PAR_DPOP_PROOF_JKT);
         if (dpopJkt != null) {
             session.setAttribute(PAR_DPOP_PROOF_JKT, dpopJkt);
         }
@@ -87,7 +78,7 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
 
         if (requestParam != null) {
             // parses the request object if PAR was registered using JAR
-            // parameters from requets object have precedence over those sent directly in the request
+            // parameters from the request object have precedence over those sent directly in the request
             new ParEndpointRequestObjectParser(session, requestParam, client).parseRequest(request);
         } else {
             super.parseRequest(request);
@@ -114,4 +105,39 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         return requestParams.keySet();
     }
 
+    protected <T> T replaceIfNotNull(T previousVal, T newVal) {
+        // FAPI says only parameters inside the request object should be used
+        // https://github.com/keycloak/keycloak/issues/48047
+        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_HAIP)) {
+            return newVal;
+        } else {
+            return super.replaceIfNotNull(previousVal, newVal);
+        }
+    }
+
+    public static Map<String, String> getRequestObject(KeycloakSession session, String requestUri) {
+        String key = getRequestObjectKey(requestUri);
+        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
+        Map<String, String> retrievedRequest = singleUseStore.get(CACHE_KEY_PREFIX + key);
+        return retrievedRequest;
+    }
+
+    /**
+     * Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+     * not at the point of visiting the authorization endpoint
+     * OpenID CT: fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds
+     */
+    public static void removeRequestObject(KeycloakSession session, String requestUri) {
+        String key = getRequestObjectKey(requestUri);
+        session.singleUseObjects().remove(CACHE_KEY_PREFIX + key);
+    }
+
+    private static String getRequestObjectKey(String requestUri) {
+        try {
+            return requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
+        } catch (RuntimeException re) {
+            logger.warnf(re,"Unable to parse request_uri: %s", requestUri);
+            throw new RuntimeException("Unable to parse request_uri");
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/HolderOfKeyEnforcerExecutor.java
@@ -22,12 +22,14 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ABCAResult;
 import org.keycloak.events.Errors;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.RefreshToken;
+import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
@@ -37,9 +39,12 @@ import org.keycloak.services.clientpolicy.context.LogoutRequestContext;
 import org.keycloak.services.clientpolicy.context.TokenRefreshContext;
 import org.keycloak.services.clientpolicy.context.TokenRevokeContext;
 import org.keycloak.services.clientpolicy.context.UserInfoRequestContext;
+import org.keycloak.services.util.DPoPUtil;
 import org.keycloak.services.util.MtlsHoKTokenUtil;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ABCAResult.ABCA_RESULT;
 
 public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider<HolderOfKeyEnforcerExecutor.Configuration> {
 
@@ -91,9 +96,10 @@ public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider
             case TOKEN_REQUEST:
             case SERVICE_ACCOUNT_TOKEN_REQUEST:
             case BACKCHANNEL_TOKEN_REQUEST:
+                DPoP dpop = session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE, DPoP.class);
                 AccessToken.Confirmation certConf = MtlsHoKTokenUtil.bindTokenWithClientCertificate(request, session);
-                if (certConf == null) {
-                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Client Certification missing for MTLS HoK Token Binding");
+                if (dpop == null && certConf == null) {
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Holder of Key Proof required (e.g. mTLS, DPoP)");
                 }
                 break;
             case TOKEN_REFRESH:
@@ -136,7 +142,7 @@ public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider
             return;
         }
 
-        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
+        if (!verifyHolderOfKeyBinding(request, refreshToken)) {
             throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
         }
     }
@@ -165,7 +171,7 @@ public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider
             return;
         }
 
-        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
+        if (!verifyHolderOfKeyBinding(request, refreshToken)) {
             throw new ClientPolicyException(Errors.NOT_ALLOWED, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.UNAUTHORIZED);
         }
     }
@@ -180,9 +186,14 @@ public class HolderOfKeyEnforcerExecutor implements ClientPolicyExecutorProvider
             return;
         }
 
-        if (!MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session)) {
+        if (!verifyHolderOfKeyBinding(request, refreshToken)) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_GRANT, MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC, Response.Status.BAD_REQUEST);
         }
     }
 
+    private boolean verifyHolderOfKeyBinding(HttpRequest request, RefreshToken refreshToken) {
+        ABCAResult abcaResult = session.getAttribute(ABCA_RESULT, ABCAResult.class);
+        boolean clientCertVerified = MtlsHoKTokenUtil.verifyTokenBindingWithClientCertificate(refreshToken, request, session);
+        return clientCertVerified || abcaResult != null && abcaResult.hasAttestedClient();
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisExecutor.java
@@ -180,7 +180,8 @@ public class SecureClientUrisExecutor implements ClientPolicyExecutorProvider<Cl
         }
 
         logger.tracev("Redirect URI = {0}", redirectUri);
-        if (!redirectUri.startsWith("https://") || redirectUri.contains("*")) {
+        boolean isRedirectToLocalhost = redirectUri.startsWith("http://localhost") || redirectUri.startsWith("http://127.0.0.1");
+        if (!redirectUri.startsWith("https://") && !isRedirectToLocalhost || redirectUri.contains("*")) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Invalid redirect_uri");
         }
     }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
@@ -18,6 +18,7 @@
 package org.keycloak.services.clientpolicy.executor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,10 +26,10 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
@@ -36,7 +37,7 @@ import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestObjectParser;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
-import org.keycloak.protocol.oidc.par.endpoints.ParEndpoint;
+import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -76,18 +77,13 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
     private void checkValidParContents(PreAuthorizationRequestContext preAuthorizationRequestContext) throws ClientPolicyException {
         MultivaluedMap<String, String> requestParametersFromQuery = preAuthorizationRequestContext.getRequestParameters();
         String requestUri = requestParametersFromQuery.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
-        if (requestUri == null) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "request_uri not included.");
-        }
-        if (requestUri != null && AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUri) != RequestUriType.PAR) {
+        if (requestUri == null || AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUri) != RequestUriType.PAR) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request_uri not included.");
         }
 
-        String key = requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
-        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        Map<String, String> requestParametersFromPAR = singleUseStore.get(ParEndpoint.CACHE_KEY_PREFIX + key);
+        Map<String, String> requestParametersFromPAR = AuthzEndpointParParser.getRequestObject(session, requestUri);
         if (requestParametersFromPAR == null) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR not found. not issued or used multiple times.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_URI, "PAR not found, not issued or used multiple times.");
         }
 
         Set<String> requestParametersNameFromPAR = new HashSet<>();
@@ -98,10 +94,18 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
             requestParametersNameFromPAR = requestParametersFromPAR.keySet();
         }
 
-        for (String queryParamName : requestParametersFromQuery.keySet()) {
-            if (!requestParametersNameFromPAR.contains(queryParamName) && !OIDCLoginProtocol.REQUEST_URI_PARAM.equals(queryParamName)) {
-                singleUseStore.remove(ParEndpoint.CACHE_KEY_PREFIX + key);
-                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request did not include necessary parameters");
+        List<String> queryKeys = requestParametersFromQuery.keySet().stream()
+                .filter(it -> !it.equals(OIDCLoginProtocol.REQUEST_URI_PARAM))
+                .toList();
+
+        // FAPI says only parameters inside the request object should be used
+        // https://github.com/keycloak/keycloak/issues/48047
+        if (!Profile.isFeatureEnabled(Profile.Feature.OID4VC_HAIP)) {
+            for (String queryParam : queryKeys) {
+                if (!requestParametersNameFromPAR.contains(queryParam)) {
+                    AuthzEndpointParParser.removeRequestObject(session, requestUri);
+                    throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_OBJECT, "PAR request did not include query parameter: " + queryParam);
+                }
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRequestObjectExecutor.java
@@ -28,6 +28,7 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
+import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
@@ -39,6 +40,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.OAuthErrorException.INVALID_REQUEST_OBJECT;
+import static org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor.getRequestUriType;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
@@ -48,7 +50,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
     private static final Logger logger = Logger.getLogger(SecureRequestObjectExecutor.class);
 
     public static final Integer DEFAULT_AVAILABLE_PERIOD = Integer.valueOf(3600); // (sec) from FAPI 1.0 Advanced requirement
-    public static final Integer DEAULT_ALLOWED_CLOCK_SKEW = Integer.valueOf(15); // (sec) from FAPI 2.0 requirement
+    public static final Integer DEFAULT_ALLOWED_CLOCK_SKEW = Integer.valueOf(15); // (sec) from FAPI 2.0 requirement
 
     private final KeycloakSession session;
     private Configuration configuration;
@@ -64,7 +66,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
             configuration.setVerifyNbf(Boolean.TRUE);
             configuration.setAvailablePeriod(DEFAULT_AVAILABLE_PERIOD);
             configuration.setEncryptionRequired(Boolean.FALSE);
-            configuration.setAllowedClockSkew(DEAULT_ALLOWED_CLOCK_SKEW);
+            configuration.setAllowedClockSkew(DEFAULT_ALLOWED_CLOCK_SKEW);
         } else {
             configuration = config;
             if (config.isVerifyNbf() == null) {
@@ -77,7 +79,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
                 configuration.setEncryptionRequired(Boolean.FALSE);
             }
             if (config.getAllowedClockSkew() == null) {
-                configuration.setAllowedClockSkew(DEAULT_ALLOWED_CLOCK_SKEW);
+                configuration.setAllowedClockSkew(DEFAULT_ALLOWED_CLOCK_SKEW);
             }
         }
     }
@@ -160,7 +162,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
         String requestParam = params.getFirst(OIDCLoginProtocol.REQUEST_PARAM);
         String requestUriParam = params.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
 
-        // check whether whether request object exists
+        // check whether the request object exists
         if (requestParam == null && requestUriParam == null) {
             logger.trace("request object not exist.");
             throwClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Missing parameter: 'request' or 'request_uri'",
@@ -171,9 +173,13 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
 
         // check whether request object exists
         if (requestObject == null || requestObject.isEmpty()) {
+            RequestUriType requestUriType = getRequestUriType(requestUriParam);
+            if (requestUriType == RequestUriType.PAR) {
+                logger.trace("Nothing to do for 'request_uri' type PAR");
+                return;
+            }
             logger.trace("request object not exist.");
-            throwClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: : 'request' or 'request_uri'",
-                    context);
+            throwClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Empty parameter: 'request'", context);
         }
 
         // check whether scope exists in both query parameter and request object
@@ -185,7 +191,7 @@ public class SecureRequestObjectExecutor implements ClientPolicyExecutorProvider
 
         // check whether "exp" claim exists
         if (requestObject.get("exp") == null) {
-            logger.trace("exp claim not incuded.");
+            logger.trace("exp claim not included.");
             throwClientPolicyException(INVALID_REQUEST_OBJECT, "Missing parameter in the 'request' object: exp", context);
         }
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtExecutorFactory.java
@@ -17,8 +17,6 @@
 
 package org.keycloak.services.clientpolicy.executor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.keycloak.Config.Scope;
@@ -66,7 +64,7 @@ public class SecureSigningAlgorithmForSignedJwtExecutorFactory implements Client
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return new ArrayList<>(Arrays.asList(REQUIRE_CLIENT_ASSERTION_PROPERTY));
+        return List.of(REQUIRE_CLIENT_ASSERTION_PROPERTY);
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -8,18 +8,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Consumer;
+
+import jakarta.ws.rs.HttpMethod;
 
 import org.keycloak.OID4VCConstants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ClientAttestationPoPJwt;
+import org.keycloak.common.util.Time;
 import org.keycloak.crypto.AsymmetricSignatureSignerContext;
 import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwk.ECPublicJWK;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jwk.RSAPublicJWK;
+import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
@@ -49,10 +57,14 @@ import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcNonceRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.PreAuthorizedCodeGrantRequest;
+import org.keycloak.util.DPoPGenerator;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.TokenUtil;
 
 import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
+import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_JWT_TYPE;
 import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
 import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.TEST_PASSWORD;
@@ -72,6 +84,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+
 
 /**
  * A specialized Wallet facade for OID4VCI integration tests.
@@ -231,10 +244,14 @@ public class OID4VCBasicWallet {
     }
 
     public Proofs generateJwtProof(OID4VCTestContext ctx) {
+        String nonce = nonceRequest().send().getNonce();
+        KeyWrapper ecKey = getECKeyPair(ctx, null);
+        return generateJwtProof(ctx, ecKey, nonce);
+    }
+
+    public Proofs generateJwtProof(OID4VCTestContext ctx, KeyWrapper ecKey, String nonce) {
         String aud = getIssuerMetadata(ctx).getCredentialIssuer();
-        String nonce = oauth.oid4vc().doNonceRequest().getNonce();
-        KeyWrapper kw = getECKeyPair(ctx, null);
-        return Proofs.create(ProofType.JWT, OID4VCProofTestUtils.generateJwtProof(aud, kw, nonce));
+        return Proofs.create(ProofType.JWT, OID4VCProofTestUtils.generateJwtProof(aud, ecKey, nonce));
     }
 
     public KeyWrapper getECKeyPair(OID4VCTestContext ctx) {
@@ -252,6 +269,14 @@ public class OID4VCBasicWallet {
         return kw;
     }
 
+    public JWK getECJwk(KeyWrapper ecKey) {
+        JWK jwkEc = DPoPGenerator.createEcJwk(ecKey.getPublicKey());
+        jwkEc.getOtherClaims().put(ECPublicJWK.CRV, ((ECPublicJWK) jwkEc).getCrv());
+        jwkEc.getOtherClaims().put(ECPublicJWK.X, ((ECPublicJWK) jwkEc).getX());
+        jwkEc.getOtherClaims().put(ECPublicJWK.Y, ((ECPublicJWK) jwkEc).getY());
+        return jwkEc;
+    }
+
     public KeyWrapper getRSAKeyPair(OID4VCTestContext ctx) {
         return getRSAKeyPair(ctx, null);
     }
@@ -265,6 +290,24 @@ public class OID4VCBasicWallet {
             ctx.putAttachment(attachmentKey, kw);
         }
         return kw;
+    }
+
+    public JWK getRSAJwk(KeyWrapper rsaKey) {
+        JWK jwkRsa = DPoPGenerator.createRsaJwk(rsaKey.getPublicKey());
+        jwkRsa.getOtherClaims().put(RSAPublicJWK.MODULUS, ((RSAPublicJWK) jwkRsa).getModulus());
+        jwkRsa.getOtherClaims().put(RSAPublicJWK.PUBLIC_EXPONENT, ((RSAPublicJWK) jwkRsa).getPublicExponent());
+        return jwkRsa;
+    }
+
+    public String generateSignedDPoPProof(String htu, KeyWrapper ecKey, String accessToken) {
+        JWK jwkEc = getECJwk(ecKey);
+        JWSHeader jwsEcHeader = new JWSHeader(Algorithm.ES256, DPOP_JWT_HEADER_TYPE, jwkEc.getKeyId(), jwkEc);
+        return DPoPGenerator.generateSignedDPoPProof(
+                UUID.randomUUID().toString(),
+                HttpMethod.POST,
+                htu,
+                (long) Time.currentTime(),
+                jwsEcHeader, ecKey, accessToken);
     }
 
     public AuthorizationEndpointRequest authorizationRequest() {
@@ -321,16 +364,22 @@ public class OID4VCBasicWallet {
         return request;
     }
 
-    public Oid4vcCredentialRequest credentialRequest(OID4VCTestContext ctx, String accessToken) {
+    public Oid4vcCredentialRequest credentialRequest(OID4VCTestContext ctx, String tokenType, String accessToken) {
         Oid4vcCredentialRequest request = new Oid4vcCredentialRequest(oauth, new CredentialRequest()) {
             public Oid4vcCredentialResponse send() {
+                if (bearerToken == null) {
+                    header("Authorization", tokenType + " " + accessToken);
+                }
                 Oid4vcCredentialResponse response = super.send();
                 ctx.putAttachment(CREDENTIALS_RESPONSE_ATTACHMENT_KEY, response);
                 return response;
             }
         };
-        request.bearerToken(accessToken);
         return request;
+    }
+
+    public Oid4vcCredentialRequest credentialRequest(OID4VCTestContext ctx, String accessToken) {
+        return credentialRequest(ctx, TokenUtil.TOKEN_TYPE_BEARER, accessToken);
     }
 
     public Oid4vcCredentialResponse fetchCredentialByOffer(OID4VCTestContext ctx, CredentialsOffer offer) {
@@ -398,6 +447,11 @@ public class OID4VCBasicWallet {
         UserResource userResource = realm.users().get(userRep.getId());
         userResource.logout();
     }
+
+    public Oid4vcNonceRequest nonceRequest() {
+        return new Oid4vcNonceRequest(oauth);
+    }
+
 
     // State Validation ------------------------------------------------------------------------------------------------
 
@@ -533,6 +587,11 @@ public class OID4VCBasicWallet {
             return this;
         }
 
+        public AuthorizationEndpointRequest dpopJkt(String dpopJkt) {
+            loginForm.dpopJkt(dpopJkt);
+            return this;
+        }
+
         public AuthorizationEndpointRequest issuerState(String issuerState) {
             loginForm.issuerState(issuerState);
             return this;
@@ -540,6 +599,11 @@ public class OID4VCBasicWallet {
 
         public AuthorizationEndpointRequest request(String request) {
             loginForm.request(request);
+            return this;
+        }
+
+        public AuthorizationEndpointRequest requestUri(String requestUri) {
+            loginForm.requestUri(requestUri);
             return this;
         }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIRestCredentialOfferFeatureEnabledTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIRestCredentialOfferFeatureEnabledTest.java
@@ -34,7 +34,7 @@ import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfigRestCredentialOffer.class)
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithRestCredentialOfferEnabled.class)
 public class OID4VCIRestCredentialOfferFeatureEnabledTest extends OID4VCIssuerEndpointTest {
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.keycloak.OID4VCConstants;
 import org.keycloak.VCFormat;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientPoliciesPoliciesResource;
 import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -56,6 +57,7 @@ import org.keycloak.protocol.oid4vc.model.CredentialSubject;
 import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.representations.idm.ClientPoliciesRepresentation;
 import org.keycloak.representations.idm.ClientPolicyConditionRepresentation;
 import org.keycloak.representations.idm.ClientPolicyExecutorRepresentation;
 import org.keycloak.representations.idm.ClientPolicyRepresentation;
@@ -69,6 +71,18 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.services.clientpolicy.executor.DPoPBindEnforcerExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.RejectImplicitGrantExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticationAssertionExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientUrisExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureParContentsExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureRequestObjectExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtExecutorFactory;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectEvents;
@@ -116,7 +130,6 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BINDING_REQUIR
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BINDING_REQUIRED_PROOF_TYPES;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CRYPTOGRAPHIC_BINDING_METHODS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_FORMAT_DEFAULT;
-import static org.keycloak.protocol.oid4vc.clientpolicy.CredentialClientPolicies.VC_POLICY_CREDENTIAL_OFFER_REQUIRED;
 
 /**
  * Abstract base class for OID4VCI Testing
@@ -149,10 +162,13 @@ public abstract class OID4VCIssuerTestBase {
 
     public static final String CONTEXT_URL = "https://www.w3.org/2018/credentials/v1";
     protected static final List<String> TEST_TYPES = List.of("VerifiableCredential");
-    protected static final Instant TEST_EXPIRATION_DATE = Instant.ofEpochMilli(Time.currentTimeMillis())
+    public static final Instant TEST_EXPIRATION_DATE = Instant.ofEpochMilli(Time.currentTimeMillis())
             .plus(365, ChronoUnit.DAYS)
             .truncatedTo(ChronoUnit.SECONDS);
-    protected static final Instant TEST_ISSUANCE_DATE = Instant.ofEpochSecond(1000);
+    public static final Instant TEST_ISSUANCE_DATE = Instant.ofEpochSecond(1000);
+
+    public static final String VCI_CLIENT_POLICY_HAIP = "oid4vc-haip-policy";
+    public static final String VCI_CLIENT_POLICY_OFFER_REQUIRED = "oid4vci-offer-required";
 
     @InjectRealm(config = VCTestRealmConfig.class)
     protected ManagedRealm testRealm;
@@ -207,7 +223,7 @@ public abstract class OID4VCIssuerTestBase {
         boolean isRestCredentialEnabled = runOnServer.fetch(session -> Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_REST_CREDENTIAL_OFFER), Boolean.class);
 
         if (isRestCredentialEnabled) {
-            UserRepresentation testUser = getExistingUser(TEST_USER);
+            UserRepresentation testUser = requireUserByUsername(TEST_USER);
             RoleRepresentation credentialOfferRole = realmResource.roles().get(CREDENTIAL_OFFER_CREATE.getName()).toRepresentation();
             testUser.setRealmRoles(List.of(CREDENTIAL_OFFER_CREATE.getName()));
             realmResource.users().get(testUser.getId()).roles().realmLevel().add(List.of(credentialOfferRole));
@@ -221,14 +237,14 @@ public abstract class OID4VCIssuerTestBase {
         client = managedClient.admin().toRepresentation();
         pubClient = managedPublicClient.admin().toRepresentation();
 
-        jwtTypeCredentialScope = requireExistingCredentialScope(jwtTypeCredentialScopeName);
-        sdJwtTypeCredentialScope = requireExistingCredentialScope(sdJwtTypeCredentialScopeName);
-        minimalJwtTypeCredentialScope = requireExistingCredentialScope(minimalJwtTypeCredentialScopeName);
-        jwtNaturalPersonCredentialScope = requireExistingCredentialScope(jwtTypeNaturalPersonScopeName);
-        sdJwtNaturalPersonCredentialScope = requireExistingCredentialScope(sdJwtTypeNaturalPersonScopeName);
+        jwtTypeCredentialScope = requireCredentialScope(jwtTypeCredentialScopeName);
+        sdJwtTypeCredentialScope = requireCredentialScope(sdJwtTypeCredentialScopeName);
+        minimalJwtTypeCredentialScope = requireCredentialScope(minimalJwtTypeCredentialScopeName);
+        jwtNaturalPersonCredentialScope = requireCredentialScope(jwtTypeNaturalPersonScopeName);
+        sdJwtNaturalPersonCredentialScope = requireCredentialScope(sdJwtTypeNaturalPersonScopeName);
 
         oauth.client(client.getClientId(), client.getSecret());
-        enableVerifiableCredentialEvents(testRealm);
+        enableVerifiableCredentialEvents();
 
         wallet = new OID4VCBasicWallet(keycloak, oauth);
     }
@@ -288,14 +304,18 @@ public abstract class OID4VCIssuerTestBase {
                 .orElse(null);
     }
 
-    protected CredentialScopeRepresentation requireExistingCredentialScope(String scopeName) {
+    protected CredentialScopeRepresentation requireCredentialScope(String scopeName) {
         return Optional.ofNullable(getCredentialScope(scopeName))
                 .orElseThrow(() -> new IllegalStateException("No such credential scope: " + scopeName));
     }
 
-    protected UserRepresentation getExistingUser(String username) {
+    protected UserRepresentation getUserByUsername(String username) {
         return testRealm.admin().users().search(username).stream()
                 .findFirst()
+                .orElse(null);
+    }
+    protected UserRepresentation requireUserByUsername(String username) {
+        return Optional.ofNullable(getUserByUsername(username))
                 .orElseThrow(() -> new IllegalStateException("No such user: " + username));
     }
 
@@ -443,6 +463,25 @@ public abstract class OID4VCIssuerTestBase {
         clientScopeResource.update(clientScope);
     }
 
+    protected ClientPolicyRepresentation getClientPolicy(String policyName) {
+        ClientPoliciesPoliciesResource clientPoliciesResource = testRealm.admin().clientPoliciesPoliciesResource();
+        ClientPoliciesRepresentation policies = clientPoliciesResource.getPolicies();
+        ClientPolicyRepresentation clientPolicy = policies.getPolicies().stream()
+                .filter(cp -> cp.getName().equals(policyName))
+                .findFirst().orElse(null);
+        return clientPolicy;
+    }
+
+    protected void setClientPolicyEnabled(String policyName, boolean enabled) {
+        ClientPoliciesPoliciesResource clientPoliciesResource = testRealm.admin().clientPoliciesPoliciesResource();
+        ClientPoliciesRepresentation policies = clientPoliciesResource.getPolicies();
+        ClientPolicyRepresentation clientPolicy = policies.getPolicies().stream()
+                .filter(cp -> cp.getName().equals(policyName))
+                .findFirst().orElseThrow(() -> new IllegalStateException("No such client policy: " + policyName));
+        clientPolicy.setEnabled(enabled);
+        clientPoliciesResource.updatePolicies(policies);
+    }
+
     // Private ---------------------------------------------------------------------------------------------------------
 
     private ComponentRepresentation createRsaKeyProviderComponent(KeyWrapper keyWrapper, String name, int priority) {
@@ -468,12 +507,12 @@ public abstract class OID4VCIssuerTestBase {
         return component;
     }
 
-    private void enableVerifiableCredentialEvents(ManagedRealm realm) {
-        RealmEventsConfigRepresentation realmEventsConfig = realm.admin().getRealmEventsConfig();
+    private void enableVerifiableCredentialEvents() {
+        RealmEventsConfigRepresentation realmEventsConfig = testRealm.admin().getRealmEventsConfig();
         List<String> enabledEventTypes = realmEventsConfig.getEnabledEventTypes();
         if (!enabledEventTypes.contains(EventType.VERIFIABLE_CREDENTIAL_NONCE_REQUEST.name())) {
             enabledEventTypes.add(EventType.VERIFIABLE_CREDENTIAL_NONCE_REQUEST.name());
-            realm.admin().updateRealmEventsConfig(realmEventsConfig);
+            testRealm.admin().updateRealmEventsConfig(realmEventsConfig);
         }
     }
 
@@ -486,10 +525,17 @@ public abstract class OID4VCIssuerTestBase {
         }
     }
 
-    public static class VCTestServerConfigRestCredentialOffer implements KeycloakServerConfig {
+    public static class VCTestServerWithABCAEnabled implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_VCI_REST_CREDENTIAL_OFFER);
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.CLIENT_AUTH_ABCA);
+        }
+    }
+
+    public static class VCTestServerWithHAIPEnabled implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_HAIP);
         }
     }
 
@@ -500,10 +546,10 @@ public abstract class OID4VCIssuerTestBase {
         }
     }
 
-    public static class VCTestServerWithABCAEnabled implements KeycloakServerConfig {
+    public static class VCTestServerWithRestCredentialOfferEnabled implements KeycloakServerConfig {
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.CLIENT_AUTH_ABCA);
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.OID4VC_VCI_REST_CREDENTIAL_OFFER);
         }
     }
 
@@ -571,22 +617,113 @@ public abstract class OID4VCIssuerTestBase {
                     null
             ));
 
-            realm.users(getUserRepresentation("John Doe", Map.of("did", "did:key:1234"), List.of(), Collections.emptyMap()));
-            realm.users(getUserRepresentation("Alice Wonderland", Map.of("did", "did:key:5678"), List.of(), Map.of()));
+            realm.users(createUser("John Doe", Map.of("did", "did:key:1234"), List.of(), Collections.emptyMap()));
+            realm.users(createUser("Alice Wonderland", Map.of("did", "did:key:5678"), List.of(), Map.of()));
 
             // Add Client Policies
             //
-            ClientProfileRepresentation profile = createClientPolicyProfile();
-            realm.clientPolicy(createClientPolicyOfferRequired(profile));
-            realm.clientProfile(profile);
+            ClientProfileRepresentation haipProfile = createClientProfileHaip();
+            ClientProfileRepresentation offerPoliciesProfile = createClientProfileOfferPolicies();
+            realm.clientProfile(haipProfile);
+            realm.clientProfile(offerPoliciesProfile);
+
+            realm.clientPolicy(createClientPolicyHaip(haipProfile));
+            realm.clientPolicy(createClientPolicyOfferRequired(offerPoliciesProfile));
 
             return realm;
         }
 
-        private ClientProfileRepresentation createClientPolicyProfile() {
+        private ClientProfileRepresentation createClientProfileHaip() {
 
             ClientProfileRepresentation profile = new ClientProfileRepresentation();
-            profile.setName("oid4vci-client-profile");
+            profile.setName("oid4vc-haip-profile");
+            profile.setDescription("Client profile, which enforces clients to conform to the OpenID4VC High Assurance Interoperability Profile 1.0");
+
+            ClientPolicyExecutorRepresentation dpopBindEnforcer = new ClientPolicyExecutorRepresentation();
+            dpopBindEnforcer.setExecutorProviderId(DPoPBindEnforcerExecutorFactory.PROVIDER_ID);
+            dpopBindEnforcer.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false)
+                    .put("enforce-authorization-code-binding-to-dpop", false)
+                    .put("allow-only-refresh-token-binding", false));
+
+            ClientPolicyExecutorRepresentation fullScopeDisabled = new ClientPolicyExecutorRepresentation();
+            fullScopeDisabled.setExecutorProviderId(FullScopeDisabledExecutorFactory.PROVIDER_ID);
+            fullScopeDisabled.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            ClientPolicyExecutorRepresentation holderOfKeyEnforcer = new ClientPolicyExecutorRepresentation();
+            holderOfKeyEnforcer.setExecutorProviderId(HolderOfKeyEnforcerExecutorFactory.PROVIDER_ID);
+            holderOfKeyEnforcer.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            ClientPolicyExecutorRepresentation pkceEnforcer = new ClientPolicyExecutorRepresentation();
+            pkceEnforcer.setExecutorProviderId(PKCEEnforcerExecutorFactory.PROVIDER_ID);
+            pkceEnforcer.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            ClientPolicyExecutorRepresentation rejectImplicitGrant = new ClientPolicyExecutorRepresentation();
+            rejectImplicitGrant.setExecutorProviderId(RejectImplicitGrantExecutorFactory.PROVIDER_ID);
+            rejectImplicitGrant.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            ClientPolicyExecutorRepresentation secureClientAuthenticationAssertion = new ClientPolicyExecutorRepresentation();
+            secureClientAuthenticationAssertion.setExecutorProviderId(SecureClientAuthenticationAssertionExecutorFactory.PROVIDER_ID);
+            secureClientAuthenticationAssertion.setConfiguration(JsonNodeFactory.instance.objectNode());
+
+            ClientPolicyExecutorRepresentation secureClientAuthenticator = new ClientPolicyExecutorRepresentation();
+            secureClientAuthenticator.setExecutorProviderId(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID);
+            ObjectNode secureClientAuthenticatorConfig = JsonNodeFactory.instance.objectNode();
+            secureClientAuthenticatorConfig.putArray("allowed-client-authenticators").add("client-jwt").add("client-x509");
+            secureClientAuthenticatorConfig.put("default-client-authenticator", "client-jwt");
+            secureClientAuthenticator.setConfiguration(secureClientAuthenticatorConfig);
+
+            ClientPolicyExecutorRepresentation secureClientUris = new ClientPolicyExecutorRepresentation();
+            secureClientUris.setExecutorProviderId(SecureClientUrisExecutorFactory.PROVIDER_ID);
+            secureClientUris.setConfiguration(JsonNodeFactory.instance.objectNode());
+
+            ClientPolicyExecutorRepresentation secureParContents = new ClientPolicyExecutorRepresentation();
+            secureParContents.setExecutorProviderId(SecureParContentsExecutorFactory.PROVIDER_ID);
+            secureParContents.setConfiguration(JsonNodeFactory.instance.objectNode());
+
+            ClientPolicyExecutorRepresentation secureRequestObject = new ClientPolicyExecutorRepresentation();
+            secureRequestObject.setExecutorProviderId(SecureRequestObjectExecutorFactory.PROVIDER_ID);
+            secureRequestObject.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("available-period", 3600)
+                    .put("encryption-required", false)
+                    .put("verify-nbf", true));
+
+            ClientPolicyExecutorRepresentation secureSigningAlgorithm = new ClientPolicyExecutorRepresentation();
+            secureSigningAlgorithm.setExecutorProviderId(SecureSigningAlgorithmExecutorFactory.PROVIDER_ID);
+            secureSigningAlgorithm.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("default-algorithm", "PS256"));
+
+            ClientPolicyExecutorRepresentation secureSigningAlgorithmForSignedJwt = new ClientPolicyExecutorRepresentation();
+            secureSigningAlgorithmForSignedJwt.setExecutorProviderId(SecureSigningAlgorithmForSignedJwtExecutorFactory.PROVIDER_ID);
+            secureSigningAlgorithmForSignedJwt.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("require-client-assertion", false));
+
+            profile.setExecutors(List.of(
+                    dpopBindEnforcer,
+                    fullScopeDisabled,
+                    holderOfKeyEnforcer,
+                    pkceEnforcer,
+                    rejectImplicitGrant,
+                    secureClientAuthenticationAssertion,
+                    secureClientAuthenticator,
+                    secureClientUris,
+                    secureParContents,
+                    secureRequestObject,
+                    secureSigningAlgorithm,
+                    secureSigningAlgorithmForSignedJwt
+            ));
+
+            return profile;
+        }
+
+        private ClientProfileRepresentation createClientProfileOfferPolicies() {
+
+            ClientProfileRepresentation profile = new ClientProfileRepresentation();
+            profile.setName("oid4vc-credential-offer-profile");
 
             ClientPolicyExecutorRepresentation executor = new ClientPolicyExecutorRepresentation();
             executor.setExecutorProviderId(CredentialClientPolicyExecutorFactory.PROVIDER_ID);
@@ -596,10 +733,32 @@ public abstract class OID4VCIssuerTestBase {
             return profile;
         }
 
+        private ClientPolicyRepresentation createClientPolicyHaip(ClientProfileRepresentation profile) {
+
+            ClientPolicyRepresentation policy = new ClientPolicyRepresentation();
+            policy.setName(VCI_CLIENT_POLICY_HAIP);
+            policy.setDescription("Client policy that enables the oid4vc-haip-profile");
+            policy.setEnabled(false);
+
+            ClientPolicyConditionRepresentation condition = new ClientPolicyConditionRepresentation();
+            condition.setConditionProviderId("client-attributes");
+            ObjectNode config = JsonNodeFactory.instance.objectNode();
+            config.put("attributes", JsonSerialization.valueAsString(List.of(Map.of(
+                    "key", OID4VCI_ENABLED_ATTRIBUTE_KEY,
+                    "value", String.valueOf(true)
+            ))));
+            condition.setConfiguration(config);
+
+            policy.setConditions(List.of(condition));
+            policy.setProfiles(List.of(profile.getName()));
+
+            return policy;
+        }
+
         private ClientPolicyRepresentation createClientPolicyOfferRequired(ClientProfileRepresentation profile) {
 
             ClientPolicyRepresentation policy = new ClientPolicyRepresentation();
-            policy.setName(VC_POLICY_CREDENTIAL_OFFER_REQUIRED.getName());
+            policy.setName(VCI_CLIENT_POLICY_OFFER_REQUIRED);
             policy.setDescription("Client policy to determine whether a credential offers is required");
             policy.setEnabled(false);
 
@@ -664,7 +823,7 @@ public abstract class OID4VCIssuerTestBase {
             return cs;
         }
 
-        private UserRepresentation getUserRepresentation(
+        private UserRepresentation createUser(
                 String fullName,
                 Map<String, String> attributes,
                 List<String> realmRoles,

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -108,7 +108,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfigRestCredentialOffer.class)
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithRestCredentialOfferEnabled.class)
 public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
 
     @InjectRunOnServer

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialByScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialByScopeTest.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.function.Function;
 
 import org.keycloak.TokenVerifier;
-import org.keycloak.admin.client.resource.ClientPoliciesPoliciesResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.protocol.oid4vc.clientpolicy.PredicateCredentialClientPolicy;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
@@ -14,8 +13,6 @@ import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.keycloak.representations.JsonWebToken;
-import org.keycloak.representations.idm.ClientPoliciesRepresentation;
-import org.keycloak.representations.idm.ClientPolicyRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.tests.oid4vc.OID4VCBasicWallet.AuthorizationEndpointRequest;
@@ -34,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfigRestCredentialOffer.class)
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithRestCredentialOfferEnabled.class)
 public class OID4VCredentialByScopeTest extends OID4VCIssuerTestBase {
 
     @TestSetup
@@ -111,14 +108,8 @@ public class OID4VCredentialByScopeTest extends OID4VCIssuerTestBase {
 
             // Set client policy 'oid4vci-offer-required'
             //
-            ClientPoliciesPoliciesResource clientPoliciesResource = testRealm.admin().clientPoliciesPoliciesResource();
-            ClientPoliciesRepresentation policies = clientPoliciesResource.getPolicies();
-            ClientPolicyRepresentation clientPolicy = policies.getPolicies().stream()
-                    .filter(cp -> cp.getName().equals(offerRequiredPolicy.getName()))
-                    .findFirst().orElseThrow();
-            Boolean wasPolicyEnabled = clientPolicy.isEnabled();
-            clientPolicy.setEnabled(policyEnabled);
-            clientPoliciesResource.updatePolicies(policies);
+            Boolean wasPolicyEnabled = getClientPolicy(offerRequiredPolicy.getName()).isEnabled();
+            setClientPolicyEnabled(offerRequiredPolicy.getName(), policyEnabled);
 
             // Set client scope attribute 'vc.policy.offer.required'
             //
@@ -179,8 +170,7 @@ public class OID4VCredentialByScopeTest extends OID4VCIssuerTestBase {
                 assertFalse(credentialResponse.getCredentials().isEmpty(), "Credentials expected");
                 return true;
             } finally {
-                clientPolicy.setEnabled(wasPolicyEnabled);
-                clientPoliciesResource.updatePolicies(policies);
+                setClientPolicyEnabled(offerRequiredPolicy.getName(), wasPolicyEnabled);
 
                 credScope.setCredentialPolicyValue(offerRequiredPolicy, wasScopeEnabled);
                 updateCredentialScope(credScope);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * | yes      | yes      | yes     | Pre-auth for a specific target user.                 |
  * +----------+----------+---------+------------------------------------------------------+
  */
-@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfigRestCredentialOffer.class)
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithRestCredentialOfferEnabled.class)
 public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/haip/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/haip/HAIPIssuerConformanceTest.java
@@ -1,0 +1,144 @@
+package org.keycloak.tests.oid4vc.haip;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.keycloak.TokenVerifier;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.tests.oid4vc.OID4VCTestContext;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.PkceGenerator;
+import org.keycloak.util.JWKSUtils;
+import org.keycloak.util.TokenUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_HEADER;
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_HEADER;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Mirrors oid4vci-1_0-issuer-haip-test-plan:oid4vci-1_0-issuer-happy-flow
+ */
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithHAIPEnabled.class)
+public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
+
+    @BeforeEach
+    void beforeEach() {
+        oauth.client(pubClient.getClientId());
+        setClientPolicyEnabled(VCI_CLIENT_POLICY_HAIP, true);
+    }
+
+    @Test
+    public void testIssuerHappyFlow() throws Exception {
+
+        var ctx = new OID4VCTestContext(pubClient, sdJwtTypeCredentialScope);
+
+        var pkce = PkceGenerator.s256();
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper rsaKey = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, rsaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, rsaKey);
+
+        // Send PAR Request
+        //
+        String requestUri = oauth.pushedAuthorizationRequest()
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .scopeParam(ctx.getScope())
+                .codeChallenge(pkce)
+                .send().getRequestUri();
+        assertNotNull(requestUri, "No requestUri");
+
+        // Send Authorization Request
+        //
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        JWK jwkEc = wallet.getECJwk(ecKey);
+
+        String authCode = wallet.authorizationRequest()
+                .requestUri(requestUri)
+                .codeChallenge(pkce)
+                .dpopJkt(JWKSUtils.computeThumbprint(jwkEc))
+                .send(ctx.getHolder(), TEST_PASSWORD)
+                .getCode();
+        assertNotNull(authCode, "No auth code");
+
+        // Send Token Request
+        //
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+        String dpopProof = wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null);
+
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .codeVerifier(pkce)
+                .dpopProof(dpopProof)
+                .send();
+        String tokenType = tokenResponse.getTokenType();
+        String accessToken = tokenResponse.getAccessToken();
+        assertEquals(TokenUtil.TOKEN_TYPE_DPOP, tokenType);
+        assertNotNull(accessToken, "No access token");
+
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(credentialIdentifier, "No authorized credential identifier");
+
+        // Send Nonce Request
+        //
+        String nonce = wallet.nonceRequest().send().getNonce();
+        Proofs jwtProof = wallet.generateJwtProof(ctx, ecKey, nonce);
+
+        // Send Credential Request
+        // Note, we use the same EC key for DPoP and Holder identity
+        //
+        String credentialEndpoint = oauth.getEndpoints().getOid4vcCredential();
+        dpopProof = wallet.generateSignedDPoPProof(credentialEndpoint, ecKey, accessToken);
+
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenType, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .dpopProof(dpopProof)
+                .proofs(jwtProof)
+                .send().getCredentialResponse();
+
+        // Verify Credential Response
+        //
+        verifyCredentialResponse(ctx, credResponse);
+    }
+
+    private void verifyCredentialResponse(OID4VCTestContext ctx, CredentialResponse credResponse) throws Exception {
+
+        CredentialScopeRepresentation credScope = ctx.getCredentialScope();
+        String issuer = wallet.getIssuerMetadata(ctx).getCredentialIssuer();
+        CredentialResponse.Credential credObj = credResponse.getCredentials().get(0);
+        assertNotNull(credObj, "The first credential in the array should not be null");
+
+        SdJwtVP sdJwtVP = SdJwtVP.of(credObj.getCredential().toString());
+        IssuerSignedJWT issuerSignedJWT = sdJwtVP.getIssuerSignedJWT();
+        JsonWebToken vcSdJwt = TokenVerifier.create(issuerSignedJWT.getJws(), JsonWebToken.class).getToken();
+        Map<String, Object> otherClaims = vcSdJwt.getOtherClaims();
+        assertEquals(issuer, vcSdJwt.getIssuer());
+        assertEquals(credScope.getVct(), otherClaims.get(CLAIM_NAME_VCT));
+
+        Map<String, String> claims = sdJwtVP.getClaims().values().stream().collect(Collectors.toMap(
+                arrayNode -> arrayNode.get(1).asText(),
+                arrayNode -> arrayNode.get(2).asText()
+        ));
+        assertEquals("Alice", claims.get("firstName"));
+        assertEquals("Wonderland", claims.get("lastName"));
+        assertEquals("alice@email.cz", claims.get("email"));
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCSdJwtPreInstalledNaturalPersonTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCSdJwtPreInstalledNaturalPersonTest.java
@@ -54,7 +54,7 @@ public class OID4VCSdJwtPreInstalledNaturalPersonTest extends OID4VCIssuerEndpoi
     @Test
     public void testGetSdJwtConfigFromMetadata() {
         String scopeName = sdJwtTypeNaturalPersonScopeName;
-        CredentialScopeRepresentation clientScope = requireExistingCredentialScope(scopeName);
+        CredentialScopeRepresentation clientScope = requireCredentialScope(scopeName);
         String credentialConfigurationId = clientScope.getAttributes().get(VC_CONFIGURATION_ID);
         String expectedIssuer = testRealm.getBaseUrl();
         runOnServer

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/JwtPreAuthCodeHandlerTest.java
@@ -200,7 +200,7 @@ public class JwtPreAuthCodeHandlerTest extends OID4VCIssuerTestBase {
 
     private void assertPreAuthCodeCtx(PreAuthCodeCtx preAuthCodeCtx) {
         assertEquals(client.getClientId(), preAuthCodeCtx.getTargetClientId());
-        assertEquals(getExistingUser(ctx.getHolder()).getId(), preAuthCodeCtx.getTargetUserId());
+        assertEquals(requireUserByUsername(ctx.getHolder()).getId(), preAuthCodeCtx.getTargetUserId());
         assertEquals(List.of(ctx.getCredentialScope().getCredentialConfigurationId()),
                 preAuthCodeCtx.getCredentialConfigurationIds());
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCSdJwtAuthorizationDetailsFlowPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCSdJwtAuthorizationDetailsFlowPreAuthTest.java
@@ -24,6 +24,7 @@ import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import static org.keycloak.OID4VCConstants.SDJWT_DELIMITER;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,7 +54,7 @@ public class OID4VCSdJwtAuthorizationDetailsFlowPreAuthTest extends OID4VCAuthor
         assertNotNull(credentialObj, "Credential object should not be null");
 
         // For SD-JWT VC, the credential should be a string
-        assertTrue(credentialObj instanceof String, "SD-JWT credential should be a string");
+        assertInstanceOf(String.class, credentialObj, "SD-JWT credential should be a string");
         String sdJwtString = (String) credentialObj;
         assertFalse(sdJwtString.isEmpty(), "SD-JWT credential should not be empty");
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractHttpPostRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractHttpPostRequest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.util.BasicAuthHelper;
+import org.keycloak.util.TokenUtil;
 import org.keycloak.utils.MediaType;
 
 import org.apache.http.HttpEntity;
@@ -133,15 +134,16 @@ public abstract class AbstractHttpPostRequest<T, R> {
     protected void authorization() {
         String clientId = this.clientId != null ? this.clientId : client.config().getClientId();
         String clientSecret = this.clientId != null ? this.clientSecret : client.config().getClientSecret();
+        String authHeader = headers.get("Authorization");
 
         if (clientAssertion != null && clientAssertionType != null) {
             parameter("client_assertion_type", clientAssertionType);
             parameter("client_assertion", clientAssertion);
-        } else if (bearerToken != null) {
-            header("Authorization", "Bearer " + bearerToken);
-        } else if (clientSecret != null) {
-            String authorization = BasicAuthHelper.RFC6749.createHeader(clientId, clientSecret);
-            header("Authorization", authorization);
+        } else if (bearerToken != null && authHeader == null) {
+            header("Authorization", TokenUtil.TOKEN_TYPE_BEARER + " " + bearerToken);
+        } else if (clientSecret != null && authHeader == null) {
+            String basicEncoded = BasicAuthHelper.RFC6749.createHeader(clientId, clientSecret);
+            header("Authorization", basicEncoded);
         } else if (clientId != null) {
             parameter("client_id", clientId);
         }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vcCredentialRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vcCredentialRequest.java
@@ -16,6 +16,7 @@ import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.testsuite.util.oauth.AbstractHttpPostRequest;
 import org.keycloak.testsuite.util.oauth.AbstractOAuthClient;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.TokenUtil;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.ContentType;
@@ -39,6 +40,11 @@ public class Oid4vcCredentialRequest extends AbstractHttpPostRequest<Oid4vcCrede
 
     public Oid4vcCredentialRequest credentialIdentifier(String credentialIdentifier) {
         credRequest.setCredentialIdentifier(credentialIdentifier);
+        return this;
+    }
+
+    public Oid4vcCredentialRequest dpopProof(String dpopProof) {
+        header(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
         return this;
     }
 

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vcNonceRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/Oid4vcNonceRequest.java
@@ -9,7 +9,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 
 public class Oid4vcNonceRequest extends AbstractHttpPostRequest<Oid4vcNonceRequest, Oid4vcNonceResponse> {
 
-    Oid4vcNonceRequest(AbstractOAuthClient<?> client) {
+    public Oid4vcNonceRequest(AbstractOAuthClient<?> client) {
         super(client);
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -2268,7 +2268,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             AccessTokenResponse tokenRes = oauth.ciba().doBackchannelAuthenticationTokenRequest(response.getAuthReqId());
             assertThat(tokenRes.getStatusCode(), is(equalTo(400)));
             assertThat(tokenRes.getError(), is(equalTo(OAuthErrorException.INVALID_GRANT)));
-            assertThat(tokenRes.getErrorDescription(), is(equalTo("Client Certification missing for MTLS HoK Token Binding")));
+            assertThat(tokenRes.getErrorDescription(), is(equalTo("Holder of Key Proof required (e.g. mTLS, DPoP)")));
             events.expect(EventType.AUTHREQID_TO_TOKEN_ERROR).clearDetails().user((String)null).client(TEST_CLIENT_NAME).error(OAuthErrorException.INVALID_REQUEST).assertEvent();
             oauth.httpClient().reset();
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI1Test.java
@@ -466,7 +466,7 @@ public class FAPI1Test extends AbstractFAPITest {
         String signedJwt = createSignedRequestToken("foo", privateKey, publicKey, org.keycloak.crypto.Algorithm.PS256);
         AccessTokenResponse tokenResponse = doAccessTokenRequestWithClientSignedJWT(code, signedJwt, DefaultHttpClient::new);
         Assertions.assertEquals(OAuthErrorException.INVALID_GRANT,tokenResponse.getError());
-        Assertions.assertEquals("Client Certification missing for MTLS HoK Token Binding", tokenResponse.getErrorDescription());
+        Assertions.assertEquals("Holder of Key Proof required (e.g. mTLS, DPoP)", tokenResponse.getErrorDescription());
 
         // Login with private-key-jwt client authentication and MTLS added to HttpClient. TokenRequest should be successful now
         oauth.loginForm().requestUri(requestUri).open();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2DPoPTest.java
@@ -223,7 +223,7 @@ public class FAPI2DPoPTest extends AbstractFAPI2Test {
 
         // without PAR request - should fail
         oauth.openLoginForm();
-        assertBrowserWithError("request_uri not included.");
+        assertBrowserWithError("PAR request_uri not included.");
 
         pkceGenerator = PkceGenerator.s256();
 
@@ -252,11 +252,11 @@ public class FAPI2DPoPTest extends AbstractFAPI2Test {
                 .send();
         assertEquals(201, pResp.getStatusCode());
         oauth.loginForm().requestUri(pResp.getRequestUri()).param("custom", "value").open();
-        assertBrowserWithError("PAR request did not include necessary parameters");
+        assertBrowserWithError("PAR request did not include query parameter: custom");
 
         // duplicated usage of a PAR request - should fail
         oauth.loginForm().requestUri(pResp.getRequestUri()).open();
-        assertBrowserWithError("PAR not found. not issued or used multiple times.");
+        assertBrowserWithError("PAR not found, not issued or used multiple times.");
 
         // send a pushed authorization request
         // use RSA key for DPoP proof but not send dpop_jkt

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
@@ -161,7 +161,7 @@ public class FAPI2Test extends AbstractFAPI2Test {
 
         // without PAR request - should fail
         oauth.openLoginForm();
-        assertBrowserWithError("request_uri not included.");
+        assertBrowserWithError("PAR request_uri not included.");
 
         pkceGenerator = PkceGenerator.s256();
 
@@ -189,11 +189,11 @@ public class FAPI2Test extends AbstractFAPI2Test {
         assertEquals(201, pResp.getStatusCode());
         requestUri = pResp.getRequestUri();
         oauth.loginForm().requestUri(requestUri).state("testFAPI2SecurityProfileLoginWithMTLS").open();
-        assertBrowserWithError("PAR request did not include necessary parameters");
+        assertBrowserWithError("PAR request did not include query parameter: state");
 
         // duplicated usage of a PAR request - should fail
         oauth.loginForm().requestUri(requestUri).state("testFAPI2SecurityProfileLoginWithMTLS").codeChallenge(pkceGenerator).open();
-        assertBrowserWithError("PAR not found. not issued or used multiple times.");
+        assertBrowserWithError("PAR not found, not issued or used multiple times.");
 
         // send a pushed authorization request
         pResp = oauth.pushedAuthorizationRequest().nonce("123456").codeChallenge(pkceGenerator).send();

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesExecutorTest.java
@@ -484,7 +484,7 @@ public class ClientPoliciesExecutorTest extends AbstractClientPoliciesTest {
     @Test
     public void testSecureRequestObjectExecutor() throws Exception {
         Integer availablePeriod = SecureRequestObjectExecutor.DEFAULT_AVAILABLE_PERIOD + 400;
-        Integer allowedClockSkew = SecureRequestObjectExecutor.DEAULT_ALLOWED_CLOCK_SKEW + 15; // 30 sec
+        Integer allowedClockSkew = SecureRequestObjectExecutor.DEFAULT_ALLOWED_CLOCK_SKEW + 15; // 30 sec
 
         // register profiles
         String json = (new ClientProfilesBuilder()).addProfile(
@@ -1650,10 +1650,10 @@ public class ClientPoliciesExecutorTest extends AbstractClientPoliciesTest {
         oauth.client(clientBetaId);
         oauth.loginForm().state("randomstatesomething").requestUri(requestUri).open();
         assertTrue(errorPage.isCurrent());
-        assertEquals("PAR request did not include necessary parameters", errorPage.getError());
-        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        "PAR request did not include necessary parameters").client((String) null)
+        assertEquals("PAR request did not include query parameter: state", errorPage.getError());
+        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        "PAR request did not include query parameter: state").client((String) null)
                 .user((String) null).assertEvent();
 
         oauth.client(clientBetaId, "secretBeta");
@@ -1699,10 +1699,10 @@ public class ClientPoliciesExecutorTest extends AbstractClientPoliciesTest {
         // only query parameters include state parameter
         oauth.loginForm().requestUri(requestUri).state("mystate2").open();
         assertTrue(errorPage.isCurrent());
-        assertEquals("PAR request did not include necessary parameters", errorPage.getError());
-        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST,
-                        "PAR request did not include necessary parameters").client((String) null)
+        assertEquals("PAR request did not include query parameter: state", errorPage.getError());
+        events.expectClientPolicyError(EventType.LOGIN_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        Details.CLIENT_POLICY_ERROR, OAuthErrorException.INVALID_REQUEST_OBJECT,
+                        "PAR request did not include query parameter: state").client((String) null)
                 .user((String) null).assertEvent();
 
         // Pushed Authorization Request with state parameter

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/hok/HoKTest.java
@@ -70,6 +70,7 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.openqa.selenium.WebDriver;
 
+import static org.keycloak.services.util.MtlsHoKTokenUtil.CERT_VERIFY_ERROR_DESC;
 import static org.keycloak.testsuite.admin.AdminApiUtil.findUserByUsername;
 import static org.keycloak.testsuite.util.ServerURLs.AUTH_SERVER_SSL_REQUIRED;
 
@@ -321,7 +322,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         // Error Pattern
         assertEquals(401, response.getStatusCode());
         assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, response.getError());
-        assertEquals("Client certificate missing, or its thumbprint and one in the token did NOT match", response.getErrorDescription());
+        assertEquals(CERT_VERIFY_ERROR_DESC, response.getErrorDescription());
     }
 
     @Test
@@ -413,7 +414,7 @@ public class HoKTest extends AbstractTestRealmKeycloakTest {
         // Error Pattern
         assertEquals(401, response.getStatusCode());
         assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, response.getError());
-        assertEquals("Client certificate missing, or its thumbprint and one in the token did NOT match", response.getErrorDescription());
+        assertEquals(CERT_VERIFY_ERROR_DESC, response.getErrorDescription());
     }
 
     private void expectSuccessfulResponseFromTokenEndpoint(AccessTokenResponse response, String sessionId, AccessToken token, RefreshToken refreshToken, EventRepresentation tokenEvent) {


### PR DESCRIPTION
closes #47316

-- add experimental feature oid4vc-haip
-- add Attestation-Based Client Authorization result to session context
-- enforce one-time use of request_uri value at the point of authorization (not of first access)
-- add x5c certificates to header except for trust anchor
-- only params inside the PAR request object should be used
-- enforce holder of key also accepts DPoP (not just mTLS)
-- add DPoP to token and credential request
-- add DPoP support to basic wallet
-- explicit usage of nonce in credential proof

