### PR TITLE
upgrade pnpm version

### DIFF
--- a/.github/actions/pnpm-store-cache/action.yml
+++ b/.github/actions/pnpm-store-cache/action.yml
@@ -12,7 +12,6 @@ runs:
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       name: Cache PNPM store
       with:
-        # See: https://pnpm.io/npmrc#store-dir
         path: |
           ~/.local/share/pnpm/store
           ~/AppData/Local/pnpm/store

--- a/js/package.json
+++ b/js/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.1.3",
+  "packageManager": "pnpm@11.1.1",
   "scripts": {
     "prepare": "cd .. && husky js/.husky",
     "build": "wireit"

--- a/js/package.json
+++ b/js/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "prepare": "cd .. && husky js/.husky",
     "build": "wireit"
@@ -52,17 +52,5 @@
     "url": "https://github.com/keycloak/keycloak.git",
     "directory": "js/"
   },
-  "homepage": "https://www.keycloak.org/",
-  "pnpm": {
-    "overrides": {
-      "picomatch@^2": "^2.3.2",
-      "flatted": "^3.4.2",
-      "minimatch@~3": "^3.1.4",
-      "minimatch@~9": "^9.0.7",
-      "@isaacs/brace-expansion@^5": "^5.0.1",
-      "serialize-javascript": "^7.0.3",
-      "diff@^4": "^4.0.4",
-      "diff@^7": "^8.0.3"
-    }
-  }
+  "homepage": "https://www.keycloak.org/"
 }

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -3,10 +3,6 @@ packages:
   - libs/*
   - themes-vendor
 
-onlyBuiltDependencies:
-  - '@swc/core'
-  - esbuild
-
 ignoredOptionalDependencies:
   - '@types/c3'
   - bootstrap-datepicker
@@ -30,3 +26,15 @@ ignoredOptionalDependencies:
   - moment-timezone
   - patternfly-bootstrap-combobox
   - patternfly-bootstrap-treeview
+overrides:
+  picomatch@^2: ^2.3.2
+  flatted: ^3.4.2
+  minimatch@~3: ^3.1.4
+  minimatch@~9: ^9.0.7
+  '@isaacs/brace-expansion@^5': ^5.0.1
+  serialize-javascript: ^7.0.3
+  diff@^4: ^4.0.4
+  diff@^7: ^8.0.3
+allowBuilds:
+  '@swc/core': true
+  esbuild: true

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <node.version>v24.9.0</node.version>
-        <pnpm.version>10.14.0</pnpm.version>
+        <pnpm.version>11.1.3</pnpm.version>
         <!-- The JavaScript projects use non-standard folders for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>
         <maven.build.cache.input.2>public</maven.build.cache.input.2>
@@ -98,13 +98,13 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>${frontend.plugin.version}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
                         <goals>
                             <goal>install-node-and-pnpm</goal>
                         </goals>
+                        <phase>initialize</phase>
                     </execution>
                     <execution>
                         <id>pnpm-install</id>
@@ -112,7 +112,7 @@
                             <goal>pnpm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install --prefer-offline --frozen-lockfile --ignore-scripts</arguments>
+                            <arguments>install --prefer-offline --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false</arguments>
                         </configuration>
                     </execution>
                     <execution>
@@ -123,6 +123,23 @@
                         <configuration>
                             <arguments>build</arguments>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- newer versions of pnpm do not have an executable cjs file, see https://github.com/eirslett/frontend-maven-plugin/issues/1224 -->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <target>
+                                <chmod file="${maven.multiModuleProjectDirectory}/js/node/node_modules/pnpm/bin/pnpm.cjs" perm="755"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/js/pom.xml
+++ b/js/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <node.version>v24.9.0</node.version>
-        <pnpm.version>11.1.3</pnpm.version>
+        <pnpm.version>11.1.1</pnpm.version>
         <!-- The JavaScript projects use non-standard folders for their sources, therefore, name it here explicitly -->
         <maven.build.cache.input.1>src</maven.build.cache.input.1>
         <maven.build.cache.input.2>public</maven.build.cache.input.2>


### PR DESCRIPTION
closes: #49164

@edewit not sure if this helps anything with the build, but in trying to understand our pnpm build issue it looked vaguely related to https://github.com/pnpm/action-setup/issues/178 which several user link prs to that have upgrades of the pnpm version.

This was my best guess at aligning to latest. It doesn't seem great that the maven plugin doesn't understand version 11+ as it should be using the .mjs file, not the .cjs. Captured https://github.com/eirslett/frontend-maven-plugin/issues/1224 to track that issue.


