### PR TITLE
[26.2] Exclude transitive Quarkus deployment module dependency kotlinx-metadata-jvm

### DIFF
--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -243,6 +243,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-openapi-deployment</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlinx</groupId>
+                    <artifactId>kotlinx-metadata-jvm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
@@ -35,7 +35,6 @@ import org.keycloak.testframework.util.TmpDir;
 
 import io.quarkus.fs.util.ZipUtils;
 import org.jboss.logging.Logger;
-import org.jetbrains.annotations.NotNull;
 
 public class DistributionKeycloakServer implements KeycloakServer {
 
@@ -136,7 +135,7 @@ public class DistributionKeycloakServer implements KeycloakServer {
         }
     }
 
-    private @NotNull DistributionKeycloakServer.OutputHandler startKeycloak(List<String> args) {
+    private DistributionKeycloakServer.OutputHandler startKeycloak(List<String> args) {
         log.trace("Starting Keycloak");
         List<String> cmd = new LinkedList<>();
         if (Environment.isWindows()) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
@@ -95,10 +95,10 @@ import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvide
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.AssertionsKt.assertNotNull;
 
 
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)


### PR DESCRIPTION
Backports https://github.com/keycloak/keycloak/pull/48953 based on https://github.com/keycloak/keycloak/pull/48953#pullrequestreview-4283994491 request in order to resolve https://github.com/keycloak/keycloak/issues/48952 for 2.26 release.