### PR TITLE
Override `org.postgresql:postgresql` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <cnpg.major-minor-version>1.29</cnpg.major-minor-version>
         <cnpg.patch-version>0</cnpg.patch-version>
         <cnpg.version>${cnpg.major-minor-version}.${cnpg.patch-version}</cnpg.version>
-        <postgresql-jdbc.version>42.7.10</postgresql-jdbc.version>
+        <postgresql-jdbc.version>42.7.11</postgresql-jdbc.version>
         <mariadb.version>11.8</mariadb.version>
         <mariadb.container>mirror.gcr.io/mariadb:${mariadb.version}</mariadb.container>
         <mariadb-jdbc.version>3.5.7</mariadb-jdbc.version>
@@ -340,6 +340,12 @@
                 <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Remove the override in https://github.com/keycloak/keycloak/issues/48990 -->
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql-jdbc.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.sundr</groupId>


### PR DESCRIPTION
Closes #48802

After version override:
```
===================================================================================================
Dependency tree for org.postgresql:postgresql
---------------------------------------------------------------------------------------------------
org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT
\- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
   \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-quarkus-server-deployment:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
      \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-quarkus-server-app:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
      \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-quarkus-dist:pom:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server-app:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
      \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
   \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
      \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-remote:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-junit5-config:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.tests:keycloak-tests-utils:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-admin-v2-tests:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-edb:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-mariadb:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-mssql:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-mysql:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-oracle:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-postgres:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-db-tidb:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-email-server:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-test-providers:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.testframework:keycloak-test-framework-ui:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-oauth:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-tests:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.testframework:keycloak-test-framework-infinispan-server:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testframework:keycloak-test-framework-clustering:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-test-containers:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.tests:keycloak-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.tests:keycloak-tests-clustering:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.tests:keycloak-tests-webauthn:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-quarkus-integration-tests:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-junit5:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.tests:keycloak-test-framework-scim-client:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.tests:keycloak-scim-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.tests:keycloak-test-framework-scim-client:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
            \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.tests:keycloak-ssf-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
         \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak.tests:keycloak-test-framework-authzen-client:jar:999.0.0-SNAPSHOT
\- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.tests:keycloak-authzen-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.tests:keycloak-test-framework-authzen-client:jar:999.0.0-SNAPSHOT:test
   \- org.keycloak.testframework:keycloak-test-framework-core:jar:999.0.0-SNAPSHOT:test
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:test
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:test
            \- org.postgresql:postgresql:jar:42.7.11:test
org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT
\- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testsuite:integration-arquillian-servers-auth-server-undertow:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT:compile
   \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testsuite:integration-arquillian-servers-auth-server-quarkus:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-dist:zip:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server-app:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testsuite:integration-arquillian-tests-base:jar:999.0.0-SNAPSHOT
\- org.keycloak.testsuite:integration-arquillian-servers-auth-server-undertow:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-testsuite-utils:jar:999.0.0-SNAPSHOT:compile
      \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak.testsuite:keycloak-model-test:jar:999.0.0-SNAPSHOT
\- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-guides-maven-plugin:maven-plugin:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-quarkus-server-deployment:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
      \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
         \- org.postgresql:postgresql:jar:42.7.11:compile
org.keycloak:keycloak-guides:jar:999.0.0-SNAPSHOT
\- org.keycloak:keycloak-guides-maven-plugin:jar:999.0.0-SNAPSHOT:compile
   \- org.keycloak:keycloak-quarkus-server-deployment:jar:999.0.0-SNAPSHOT:compile
      \- org.keycloak:keycloak-quarkus-server:jar:999.0.0-SNAPSHOT:compile
         \- io.quarkus:quarkus-jdbc-postgresql:jar:3.33.1.1:compile
            \- org.postgresql:postgresql:jar:42.7.11:compile
===================================================================================================
```