### PR TITLE
[26.6] Show OpenTelemetry Metrics feature in community build, but allow downstream projects to hide it

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -133,7 +133,9 @@ public class Profile {
 
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),
-        OPENTELEMETRY_METRICS("Micrometer to OpenTelemetry bridge support for metrics", Type.EXPERIMENTAL, OPENTELEMETRY),
+        OPENTELEMETRY_METRICS("Micrometer to OpenTelemetry bridge support for metrics", Type.EXPERIMENTAL, 1, false, true,
+                () -> isClassAvailable("io.quarkus.micrometer.opentelemetry.runtime.MicrometerOtelBridgeRecorder"),
+                null, OPENTELEMETRY),
 
         DECLARATIVE_UI("declarative ui spi", Type.EXPERIMENTAL),
 
@@ -181,6 +183,7 @@ public class Profile {
         private final String unversionedKey;
         private final String key;
         private final BooleanSupplier isAvailable;
+        private final boolean hideWhenUnavailable;
         private final FeatureUpdatePolicy updatePolicy;
         private final Set<Feature> dependencies;
         private final boolean deprecated;
@@ -207,11 +210,16 @@ public class Profile {
         }
 
         Feature(String label, Type type, int version, boolean deprecated, BooleanSupplier isAvailable, FeatureUpdatePolicy updatePolicy, Feature... dependencies) {
+            this(label, type, version, deprecated, false, isAvailable, updatePolicy, dependencies);
+        }
+
+        Feature(String label, Type type, int version, boolean deprecated, boolean hideWhenUnavailable, BooleanSupplier isAvailable, FeatureUpdatePolicy updatePolicy, Feature... dependencies) {
             this.label = label;
             this.type = type;
             this.version = version;
             this.deprecated = type == Type.DEPRECATED || deprecated;
             this.isAvailable = isAvailable;
+            this.hideWhenUnavailable = hideWhenUnavailable;
             this.updatePolicy = updatePolicy == null ? FeatureUpdatePolicy.ROLLING : updatePolicy;
             this.key = name().toLowerCase().replaceAll("_", "-");
             if (this.name().endsWith("_V" + version)) {
@@ -275,6 +283,10 @@ public class Profile {
 
         public FeatureUpdatePolicy getUpdatePolicy() {
             return updatePolicy;
+        }
+
+        private boolean isVisible() {
+            return isAvailable() || !hideWhenUnavailable;
         }
 
         public enum Type {
@@ -453,11 +465,18 @@ public class Profile {
     }
 
     public static Set<String> getAllUnversionedFeatureNames() {
-        return Collections.unmodifiableSet(getOrderedFeatures().keySet());
+        return Collections.unmodifiableSet(getOrderedFeatures().entrySet().stream()
+                .filter(e -> e.getValue().stream().anyMatch(Feature::isVisible))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet()));
     }
 
     public static Set<String> getDisableableUnversionedFeatureNames() {
-        return getOrderedFeatures().keySet().stream().filter(f -> !ESSENTIAL_FEATURES.contains(f)).collect(Collectors.toSet());
+        return getOrderedFeatures().entrySet().stream()
+                .filter(e -> !ESSENTIAL_FEATURES.contains(e.getKey()))
+                .filter(e -> e.getValue().stream().anyMatch(Feature::isVisible))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -573,6 +592,15 @@ public class Profile {
 
         if (!enabledFeaturesOfType.isEmpty()) {
             logger.logv(level, "{0} features enabled: {1}", type.getLabel(), enabledFeaturesOfType);
+        }
+    }
+
+    private static boolean isClassAvailable(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
 

--- a/docs/guides/observability/telemetry.adoc
+++ b/docs/guides/observability/telemetry.adoc
@@ -152,6 +152,8 @@ As stated for the general configuration of headers, you can configure custom req
 
 <@kc.start parameters="--telemetry-logs-header-Authorization='Bearer logs-token'"/>
 
+<@profile.ifCommunity>
+
 == Metrics
 
 WARNING: The OpenTelemetry Metrics feature is currently experimental, and it is not recommended for use in production.
@@ -177,8 +179,6 @@ For more information on how to set up metrics, see the configuration options bel
 As stated for the general configuration of headers, you can configure custom request headers that will be used when exporting metrics.
 
 <@kc.start parameters="--telemetry-metrics-header-Authorization='Bearer metrics-token'"/>
-
-<@profile.ifCommunity>
 
 == Development setup
 
@@ -206,8 +206,10 @@ Then, you can navigate to Grafana UI by accessing `+localhost:3000+` and then yo
 === Logs
 <@opts.includeOptions includedOptions="telemetry-logs-*"/>
 
+<@profile.ifCommunity>
 === Metrics
 <@opts.includeOptions includedOptions="metrics-enabled telemetry-metrics-*"/>
+</@profile.ifCommunity>
 
 </@opts.printRelevantOptions>
 

--- a/quarkus/deployment/pom.xml
+++ b/quarkus/deployment/pom.xml
@@ -272,11 +272,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
             <exclusions>
@@ -331,5 +326,22 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>community</id>
+            <activation>
+                <property>
+                    <name>!product</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-micrometer-opentelemetry-deployment</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -126,11 +126,6 @@
             <artifactId>opentelemetry-apache-httpclient-4.3</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.apicatalog</groupId>
             <artifactId>titanium-json-ld</artifactId>
         </dependency>
@@ -820,6 +815,20 @@
                             <artifactId>mssql-jdbc</artifactId>
                         </exclusion>
                     </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>community</id>
+            <activation>
+                <property>
+                    <name>!product</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-micrometer-opentelemetry</artifactId>
                 </dependency>
             </dependencies>
         </profile>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifacts.java
@@ -28,6 +28,7 @@ import org.keycloak.config.MetricsOptions;
 import org.keycloak.config.OpenApiOptions;
 import org.keycloak.config.TelemetryOptions;
 import org.keycloak.config.database.Database;
+import org.keycloak.quarkus.runtime.cli.PropertyException;
 
 import static java.util.Collections.emptySet;
 
@@ -187,6 +188,9 @@ public class IgnoredArtifacts {
 
     private static Set<String> otelMetrics() {
         boolean isOtelMetricsEnabled = Configuration.isTrue(TelemetryOptions.TELEMETRY_METRICS_ENABLED);
+        if (isOtelMetricsEnabled && !Profile.Feature.OPENTELEMETRY_METRICS.isAvailable()) {
+            throw new PropertyException("The OpenTelemetry Metrics feature is not available in this distribution.");
+        }
         return !isOtelMetricsEnabled ? OTEL_METRICS : emptySet();
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TelemetryPropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/TelemetryPropertyMappers.java
@@ -59,6 +59,7 @@ public class TelemetryPropertyMappers implements PropertyMapperGrouping{
     @Override
     public List<? extends PropertyMapper<?>> getPropertyMappers() {
         TELEMETRY_HEADERS_CACHE = null;
+        boolean metricsAvailable = Profile.Feature.OPENTELEMETRY_METRICS.isAvailable();
         return List.of(
                 fromOption(TELEMETRY_ENABLED)
                         .isEnabled(TelemetryPropertyMappers::isOtelFeatureEnabled, OTEL_FEATURE_ENABLED_MSG)
@@ -129,41 +130,45 @@ public class TelemetryPropertyMappers implements PropertyMapperGrouping{
                         .isMasked(true) // it may contain sensitive information
                         .build(),
                 // Telemetry Metrics
-                fromOption(TELEMETRY_METRICS_ENABLED)
+                fromOption(metricsAvailable ? TELEMETRY_METRICS_ENABLED : toHidden(TELEMETRY_METRICS_ENABLED))
                         .isEnabled(TelemetryPropertyMappers::isOtelMetricsFeatureEnabled, OTEL_METRICS_FEATURE_ENABLED_MSG)
                         .to("quarkus.otel.metrics.enabled")
                         .build(),
-                fromOption(TELEMETRY_METRICS_ENDPOINT)
+                fromOption(metricsAvailable ? TELEMETRY_METRICS_ENDPOINT : toHidden(TELEMETRY_METRICS_ENDPOINT))
                         .isEnabled(TelemetryPropertyMappers::isTelemetryMetricsEnabled, OTEL_METRICS_ENABLED_MSG)
                         .mapFrom(TelemetryOptions.TELEMETRY_ENDPOINT)
                         .to("quarkus.otel.exporter.otlp.metrics.endpoint")
                         .paramLabel("url")
                         .validator(TelemetryPropertyMappers::validateEndpoint)
                         .build(),
-                fromOption(TELEMETRY_METRICS_PROTOCOL)
+                fromOption(metricsAvailable ? TELEMETRY_METRICS_PROTOCOL : toHidden(TELEMETRY_METRICS_PROTOCOL))
                         .isEnabled(TelemetryPropertyMappers::isTelemetryMetricsEnabled, OTEL_METRICS_ENABLED_MSG)
                         .mapFrom(TelemetryOptions.TELEMETRY_PROTOCOL)
                         .to("quarkus.otel.exporter.otlp.metrics.protocol")
                         .paramLabel("protocol")
                         .build(),
-                fromOption(TELEMETRY_METRICS_INTERVAL)
+                fromOption(metricsAvailable ? TELEMETRY_METRICS_INTERVAL : toHidden(TELEMETRY_METRICS_INTERVAL))
                         .isEnabled(TelemetryPropertyMappers::isTelemetryMetricsEnabled, OTEL_METRICS_ENABLED_MSG)
                         .to("quarkus.otel.metric.export.interval")
                         .paramLabel("duration")
                         .validator(TelemetryPropertyMappers::validateDuration)
                         .build(),
-                fromOption(TELEMETRY_METRICS_HEADERS)
+                fromOption(metricsAvailable ? TELEMETRY_METRICS_HEADERS : toHidden(TELEMETRY_METRICS_HEADERS))
                         .isEnabled(TelemetryPropertyMappers::isTelemetryMetricsEnabled, OTEL_METRICS_ENABLED_MSG)
                         .to("quarkus.otel.exporter.otlp.metrics.headers")
                         .transformer((value, context) -> transformTelemetryHeaders(TELEMETRY_METRICS_HEADER, value))
                         .isMasked(true)
                         .build(),
-                fromOption(TELEMETRY_METRICS_HEADER)
+                fromOption(metricsAvailable ? TELEMETRY_METRICS_HEADER : toHidden(TELEMETRY_METRICS_HEADER))
                         .isEnabled(TelemetryPropertyMappers::isTelemetryMetricsEnabled, OTEL_METRICS_ENABLED_MSG)
                         .paramLabel("<value>")
                         .isMasked(true) // it may contain sensitive information
                         .build()
         );
+    }
+
+    private static <T> Option<T> toHidden(Option<T> option) {
+        return option.toBuilder().hidden().build();
     }
 
     private static String checkIfDependantsAreEnabled(String value, ConfigSourceInterceptorContext context) {

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/cli/PicocliTest.java
@@ -43,6 +43,7 @@ import org.keycloak.quarkus.runtime.configuration.PersistedConfigSource;
 
 import io.smallrye.config.SmallRyeConfig;
 import org.apache.commons.io.FileUtils;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 import picocli.CommandLine;
@@ -1142,6 +1143,7 @@ public class PicocliTest extends AbstractConfigurationTest {
 
     @Test
     public void telemetryParentHeaders() {
+        Assume.assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         // tracing enabled
         var nonRunningPicocli = pseudoLaunch("start-dev", "--tracing-enabled=true", "--telemetry-header-Authorization=Bearer asdlkfjadsflkj");
         assertNoError(nonRunningPicocli);
@@ -1236,6 +1238,7 @@ public class PicocliTest extends AbstractConfigurationTest {
 
     @Test
     public void otelMetricsHeaders() {
+        Assume.assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         // Otel Metrics is disabled
         var nonRunningPicocli = pseudoLaunch("start-dev", "--features=opentelemetry-metrics", "--metrics-enabled=true", "--telemetry-metrics-enabled=false", "--telemetry-metrics-header-Authorization=Bearer");
         assertError(nonRunningPicocli, "Unknown option:"); //for some reason, the wildcard options does not respect the isEnabled() when disabled
@@ -1731,6 +1734,7 @@ public class PicocliTest extends AbstractConfigurationTest {
 
     @Test
     public void otelMetrics() {
+        Assume.assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         // parent feature disabled
         NonRunningPicocli nonRunningPicocli = pseudoLaunch("start-dev", "--feature-opentelemetry=disabled", "--feature-opentelemetry-metrics=enabled");
         assertEquals(CommandLine.ExitCode.USAGE, nonRunningPicocli.exitCode);
@@ -1884,6 +1888,7 @@ public class PicocliTest extends AbstractConfigurationTest {
 
     @Test
     public void otelAll() {
+        Assume.assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         // tracing
         pseudoLaunch("start-dev", "--tracing-enabled=true");
         assertConfig("tracing-enabled", "true");

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifactsTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/IgnoredArtifactsTest.java
@@ -50,6 +50,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.in;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 public class IgnoredArtifactsTest extends AbstractConfigurationTest {
 
@@ -159,6 +160,7 @@ public class IgnoredArtifactsTest extends AbstractConfigurationTest {
 
     @Test
     public void otelMetrics(){
+        assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         assertIgnoredArtifacts(IgnoredArtifacts.OTEL_METRICS, TelemetryOptions.TELEMETRY_METRICS_ENABLED);
     }
 

--- a/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TelemetryConfigurationTest.java
+++ b/quarkus/runtime/src/test/java/org/keycloak/quarkus/runtime/configuration/TelemetryConfigurationTest.java
@@ -2,6 +2,9 @@ package org.keycloak.quarkus.runtime.configuration;
 
 import java.util.Map;
 
+import org.keycloak.common.Profile;
+
+import org.junit.Assume;
 import org.junit.Test;
 
 public class TelemetryConfigurationTest extends AbstractConfigurationTest {
@@ -127,6 +130,7 @@ public class TelemetryConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void metricsDefaults() {
+        Assume.assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         initConfig();
 
         assertConfig(Map.of(
@@ -147,6 +151,7 @@ public class TelemetryConfigurationTest extends AbstractConfigurationTest {
 
     @Test
     public void metricsPriorities() {
+        Assume.assumeTrue(Profile.Feature.OPENTELEMETRY_METRICS.isAvailable());
         ConfigArgsConfigSource.setCliArgs("--features=opentelemetry-metrics", "--metrics-enabled=true", "--telemetry-metrics-enabled=true", "--telemetry-metrics-endpoint=localhost:2000", "--telemetry-metrics-protocol=http/protobuf");
         initConfig();
         assertConfig(Map.of(

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -128,6 +128,12 @@
             	</exclusion>
             </exclusions>
         </dependency>
+        <!-- needed for FeatureCompatibilityMetadataProviderTest to detect OPENTELEMETRY_METRICS as available -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>


### PR DESCRIPTION
* Backports https://github.com/keycloak/keycloak/pull/49002 in order to resolve https://github.com/keycloak/keycloak/issues/48997 in 26.6 release
* Based on how https://github.com/keycloak/keycloak/pull/48984 review went I guess this should **not** be blocked, however I still need the PR CI to run against the `release/26.6` branch