### PR TITLE
Allow custom protocol mappers to be recognized as organization-aware in OrganizationScope

### DIFF
--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationMembershipMapper.java
@@ -45,6 +45,7 @@ import org.keycloak.protocol.oidc.mappers.AbstractOIDCProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
+import org.keycloak.protocol.oidc.mappers.OrganizationAwareMapper;
 import org.keycloak.protocol.oidc.mappers.TokenIntrospectionTokenMapper;
 import org.keycloak.protocol.oidc.mappers.UserInfoTokenMapper;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
@@ -54,7 +55,7 @@ import org.keycloak.representations.IDToken;
 import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.JSON_TYPE;
 import static org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper.TOKEN_CLAIM_NAME;
 
-public class OrganizationMembershipMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper, TokenIntrospectionTokenMapper, EnvironmentDependentProviderFactory {
+public class OrganizationMembershipMapper extends AbstractOIDCProtocolMapper implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper, TokenIntrospectionTokenMapper, EnvironmentDependentProviderFactory, OrganizationAwareMapper {
 
     public static final String PROVIDER_ID = "oidc-organization-membership-mapper";
     public static final String ADD_ORGANIZATION_ATTRIBUTES = "addOrganizationAttributes";

--- a/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationScope.java
+++ b/services/src/main/java/org/keycloak/organization/protocol/mappers/oidc/OrganizationScope.java
@@ -39,9 +39,11 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.OrganizationModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.mappers.OrganizationAwareMapper;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.utils.StringUtil;
 
@@ -415,9 +417,11 @@ public enum OrganizationScope {
         ClientScopeModel clientScope = getClientScope(client, scope);
 
         if (clientScope != null) {
-            Stream<String> mappers = clientScope.getProtocolMappersStream().map(ProtocolMapperModel::getProtocolMapper);
-
-            if (mappers.noneMatch(OrganizationMembershipMapper.PROVIDER_ID::equals)) {
+            if (clientScope.getProtocolMappersStream()
+                    .map(ProtocolMapperModel::getProtocolMapper)
+                    .map(id -> session.getKeycloakSessionFactory().getProviderFactory(ProtocolMapper.class, id))
+                    .filter(Objects::nonNull)
+                    .noneMatch(OrganizationAwareMapper.class::isInstance)) {
                 Set<String> nonOrganizationScopes = session.getAttributeOrDefault(UNSUPPORTED_ORGANIZATION_SCOPES_ATTRIBUTE, Set.of());
 
                 if (nonOrganizationScopes.isEmpty()) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/OrganizationAwareMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/OrganizationAwareMapper.java
@@ -1,0 +1,16 @@
+package org.keycloak.protocol.oidc.mappers;
+
+/**
+ * Marker interface for protocol mappers that handle organization claims.
+ *
+ * <p>Mappers implementing this interface are recognized by
+ * {@link org.keycloak.organization.protocol.mappers.oidc.OrganizationScope OrganizationScope}
+ * as organization-aware, enabling scope-based organization resolution for the
+ * client scope containing the mapper.
+ *
+ * <p>This follows the same pattern as {@link OIDCAccessTokenMapper} and
+ * {@link UserInfoTokenMapper}, where mapper capabilities are declared
+ * through interface implementation and checked via {@code instanceof}.
+ */
+public interface OrganizationAwareMapper {
+}


### PR DESCRIPTION
Closes #49021 

`OrganizationScope.resolveClientScope()` determines whether a client scope supports organizations by checking for the hardcoded `oidc-organization-membership-mapper` provider ID.
Custom protocol mappers that handle organization claims are not recognized, causing scope-based organization resolution to be silently skipped. This means the SSO propagation fixes (#35949, #43339) do not apply when a custom mapper replaces the built-in `OrganizationMembershipMapper`.

This PR introduces an `OrganizationAwareMapper` marker interface that custom mappers can implement to declare organization support. The check in `OrganizationScope` is changed from a provider ID string match to an `instanceof` check, following the established pattern used by `OIDCAccessTokenMapper`, `UserInfoTokenMapper`, and `SAMLAttributeStatementMapper`.

## Changes
- Add `OrganizationAwareMapper` marker interface in `org.keycloak.protocol.oidc.mappers`
- `OrganizationMembershipMapper` implements `OrganizationAwareMapper` (backward compatible)
- `OrganizationScope.resolveClientScope()` uses `instanceof OrganizationAwareMapper`
  instead of hardcoded `OrganizationMembershipMapper.PROVIDER_ID`

---
AI-assisted development was used in this PR with Claude Code. All changes have been reviewed and are understood by the author.
