### PR TITLE
fix: initial implementation of memory-safe streaming

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/Managed.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/Managed.java
@@ -1,0 +1,26 @@
+package org.keycloak.models.cache.infinispan;
+
+import java.util.HashMap;
+
+import org.keycloak.connections.jpa.support.EntityManagers;
+
+public class Managed<T> {
+
+    HashMap<String, T> map = new HashMap<>();
+
+    public T get(String key) {
+        return map.get(key);
+    }
+
+    public boolean containsKey(String key) {
+        return map.containsKey(key);
+    }
+
+    public void put(String id, T value) {
+        if (EntityManagers.isBatchMode()) {
+            return;
+        }
+        map.put(id, value);
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmCacheSession.java
@@ -161,9 +161,9 @@ public class RealmCacheSession implements CacheRealmProvider {
     protected boolean setRollbackOnly;
 
     protected Map<String, RealmAdapter> managedRealms = new HashMap<>();
-    protected Map<String, ClientModel> managedApplications = new HashMap<>();
+    protected Managed<ClientModel> managedApplications = new Managed<>();
     protected Map<String, ClientScopeAdapter> managedClientScopes = new HashMap<>();
-    protected Map<String, RoleAdapter> managedRoles = new HashMap<>();
+    protected Managed<RoleAdapter> managedRoles = new Managed<>();
     protected Map<String, GroupAdapter> managedGroups = new HashMap<>();
     protected Set<String> listInvalidations = new HashSet<>();
     protected Set<String> invalidations = new HashSet<>();

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.cache.infinispan;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.stream.Stream;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.constants.ServiceAccountConstants;
 import org.keycloak.component.ComponentModel;
-import org.keycloak.connections.jpa.support.EntityManagers;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
@@ -106,7 +104,7 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     protected Set<String> invalidations = new HashSet<>();
     protected Set<String> realmInvalidations = new HashSet<>();
     protected Set<InvalidationEvent> invalidationEvents = new HashSet<>(); // Events to be sent across cluster
-    protected Map<String, UserModel> managedUsers = new HashMap<>();
+    protected Managed<UserModel> managedUsers = new Managed<>();
     private StoreManagers datastoreProvider;
 
     public UserCacheSession(UserCacheManager cache, KeycloakSession session) {
@@ -928,9 +926,6 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     private void addManagedUser(String id, UserModel user) {
-        if (EntityManagers.isBatchMode()) {
-            return;
-        }
         managedUsers.put(id, user);
     }
 

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -17,6 +17,7 @@ import jakarta.validation.groups.Default;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.connections.jpa.support.EntityManagers;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.events.admin.v2.AdminEventV2Builder;
@@ -134,11 +135,12 @@ public class DefaultClientService implements ClientService {
         // When disabled, we fall back to in-memory filtering by VIEW_CLIENTS role.
         boolean canView = AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm) || permissions.clients().canView();
         try {
-            return realm.getClientsStream()
+            Supplier<Stream<BaseClientRepresentation>> supplier = () -> realm.getClientsStream()
                     .filter(client -> canView || permissions.clients().canView(client))
                     .filter(client -> client.getProtocol() != null)
                     .map(client -> getMapper(client.getProtocol()).fromModel(client, projectionOptions.getFields()))
                     .filter(java.util.Objects::nonNull);
+            return EntityManagers.streamInBatch(session, supplier, 100);
         } catch (ModelException e) {
             throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);
         }

--- a/server-spi-private/src/main/java/org/keycloak/connections/jpa/support/EntityManagers.java
+++ b/server-spi-private/src/main/java/org/keycloak/connections/jpa/support/EntityManagers.java
@@ -21,7 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
@@ -131,6 +133,44 @@ public class EntityManagers {
                         p.setEntityManager(old);
                     } // else - created during the batch run, so it's enough that it was flushed / cleared
                 });
+            }
+        }
+    }
+
+    /**
+     * For read-only operations.
+     *
+     * The presumed usage is for top-level jax-rs methods, so there's no nesting logic
+     */
+    public static <T> Stream<T> streamInBatch(KeycloakSession session, Supplier<Stream<T>> streamSupplier, int clearInterval) {
+        // TODO: not necessary if read-only
+        flush(session, false); // make sure the state entering the batch processing is committed
+
+        // TODO: hibnerate does support a read-only SessionImpl. it's not easily accessible to control that, but can be done with a nested entity manager
+        // so perhaps underneath the overall Session txn we could consider nesting a read-only Session to enforce that the business logic of endpoints are read-only
+
+        boolean isBatched = isBatchMode();
+        batchMode.set(true);
+        Runnable done = () -> {
+            if (!isBatched) {
+                batchMode.remove();
+            }
+        };
+        boolean success = false;
+        try {
+            Stream<T> result = streamSupplier.get();
+            AtomicInteger counter = new AtomicInteger();
+            result = result.map(value -> {
+                if (counter.incrementAndGet() % clearInterval == 0) {
+                    forEachEntityManager(session, EntityManager::clear);
+                }
+                return value;
+            }).onClose(done);
+            success = true;
+            return result;
+        } finally {
+            if (!success) {
+                done.run();
             }
         }
     }


### PR DESCRIPTION
closes: #48651

What we're doing here:
 - running the streaming operation in "batch" mode
 - inhibiting the creation of managedentities
 - periodically clearing the persistence context

This should allow us greater lattitude in setting reasonable maximums for the number of resources that can be retrieved via admin api endpoints.

relates to #47611 - the logic on either end is still based upon an array in the payload, so clients that lack a streaming parser will still have a problem with large results. This same logic though is applicable to NDJSON or other streaming schemes.

Assumptions:
- that the operation is read-only and there's no need to create nested entitymanagers
- that not much, if anything, will be shared across the resources such that periodically clearing persistence context while not having the managed entities won't result in a lot of re-fetching. I believe this is the case with what we're doing with clients currently.

Next steps:
- something like streamInBatch could be added to existing endpoints that return a stream. Not sure if it's general enough of a concern, or if it could / should be done in a request filter.
- if we do expand usage, then we'll need to more pervasively inhibit adding managed entities, the changes here only account for what v2 Clients is accessing

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
