### PR TITLE
Enable Enter key to trigger search in SearchInputComponent

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/SearchInputComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/SearchInputComponent.tsx
@@ -35,6 +35,12 @@ export const SearchInputComponent = ({
           onChange={(event: React.FormEvent<HTMLInputElement>) =>
             onChange(event.currentTarget.value)
           }
+          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              onSearch(value);
+            }
+          }}
           placeholder={placeholder}
           aria-label={ariaLabel}
           data-testid="search-input"


### PR DESCRIPTION
Close: #49026 

- Add `onKeyDown` handler to `SearchInputComponent` so that pressing Enter triggers the search
- Fixes Organization Members, Organization Invitations, and User Organizations search inputs, which previously required clicking the arrow button to execute the search