### PR TITLE
Reject malformed requests in DockerEndpoint

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
@@ -64,6 +64,14 @@ public class DockerEndpoint extends AuthorizationEndpointBase {
         checkService();
 
         final AuthorizationEndpointRequest authRequest = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, AuthorizationEndpointRequestParserProcessor.EndpointType.DOCKER_ENDPOINT);
+
+        if (authRequest.getInvalidRequestMessage() != null) {
+            event.detail(Details.REASON, authRequest.getInvalidRequestMessage());
+            event.error(Errors.INVALID_REQUEST);
+
+            throw new ErrorResponseException("invalid_request", authRequest.getInvalidRequestMessage(), Response.Status.BAD_REQUEST);
+        }
+
         authenticationSession = createAuthenticationSession(client, authRequest.getState());
 
         updateAuthenticationSession();

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
@@ -64,6 +64,14 @@ public class DockerEndpoint extends AuthorizationEndpointBase {
         checkService();
 
         final AuthorizationEndpointRequest authRequest = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, AuthorizationEndpointRequestParserProcessor.EndpointType.DOCKER_ENDPOINT);
+        
+        if (authRequest.getInvalidRequestMessage() != null) {
+            event.detail(Details.REASON, authRequest.getInvalidRequestMessage());
+            event.error(Errors.INVALID_REQUEST);
+
+            throw new ErrorResponseException("invalid_request", authRequest.getInvalidRequestMessage(), Response.Status.BAD_REQUEST);
+        }
+        
         authenticationSession = createAuthenticationSession(client, authRequest.getState());
 
         updateAuthenticationSession();

--- a/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/docker/DockerEndpoint.java
@@ -64,14 +64,6 @@ public class DockerEndpoint extends AuthorizationEndpointBase {
         checkService();
 
         final AuthorizationEndpointRequest authRequest = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, AuthorizationEndpointRequestParserProcessor.EndpointType.DOCKER_ENDPOINT);
-        
-        if (authRequest.getInvalidRequestMessage() != null) {
-            event.detail(Details.REASON, authRequest.getInvalidRequestMessage());
-            event.error(Errors.INVALID_REQUEST);
-
-            throw new ErrorResponseException("invalid_request", authRequest.getInvalidRequestMessage(), Response.Status.BAD_REQUEST);
-        }
-        
         authenticationSession = createAuthenticationSession(client, authRequest.getState());
 
         updateAuthenticationSession();


### PR DESCRIPTION
Signed off: Abhishek Supsande([abhisheksupsande7@gmail.com])
Solves https://github.com/keycloak/keycloak/issues/49009

Reject malformed authorization requests in DockerEndpoint

Add validation for AuthorizationEndpointRequest.getInvalidRequestMessage()
after parseRequest() in DockerEndpoint.build().

Previously, malformed requests (such as duplicated query parameters)
were accepted and processed because the Docker auth flow ignored parser
validation results. This allowed malformed scope parameters to bypass
request validation policies.

The fix aligns Docker endpoint behaviour with the OIDC authorization
endpoint, which already rejects invalid requests via
AuthorizationEndpointChecker.checkInvalidRequestMessage().

PS - Couldn't find a relevant test class to add a test. Can push a new unit test class for DockerEndpoint.