### PR TITLE
Make JWT client validator hooks protected

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AbstractJWTClientValidator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AbstractJWTClientValidator.java
@@ -72,7 +72,7 @@ public abstract class AbstractJWTClientValidator extends AbstractBaseJWTValidato
                 validateTokenActive(getAllowedClockSkew(), getMaximumExpirationTime(), isReusePermitted());
     }
 
-    private boolean validateClientAssertionParameters() {
+    protected boolean validateClientAssertionParameters() {
         String clientAssertionType = clientAssertionState.getClientAssertionType();
         String clientAssertion = clientAssertionState.getClientAssertion();
 
@@ -92,7 +92,7 @@ public abstract class AbstractJWTClientValidator extends AbstractBaseJWTValidato
         return true;
     }
 
-    private boolean validateClient() {
+    protected boolean validateClient() {
         JsonWebToken token = clientAssertionState.getToken();
 
         String clientId = token.getSubject();
@@ -133,7 +133,7 @@ public abstract class AbstractJWTClientValidator extends AbstractBaseJWTValidato
         return true;
     }
 
-    private boolean validateSignature() {
+    protected boolean validateSignature() {
         return signatureValidator.verifySignature(this);
     }
 
@@ -150,11 +150,11 @@ public abstract class AbstractJWTClientValidator extends AbstractBaseJWTValidato
         return failure(AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS, challengeResponse);
     }
 
-    private boolean failure(AuthenticationFlowError error) {
+    protected boolean failure(AuthenticationFlowError error) {
         return failure(error, null);
     }
 
-    private boolean failure(AuthenticationFlowError error, Response response) {
+    protected boolean failure(AuthenticationFlowError error, Response response) {
         context.failure(error, response);
         return false;
     }

--- a/services/src/test/java/org/keycloak/authentication/authenticators/client/extensibility/ClientValidatorExtensibilityTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/client/extensibility/ClientValidatorExtensibilityTest.java
@@ -1,0 +1,96 @@
+package org.keycloak.authentication.authenticators.client.extensibility;
+
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.authenticators.client.AbstractJWTClientValidator;
+import org.keycloak.authentication.authenticators.client.FederatedJWTClientValidator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ClientValidatorExtensibilityTest {
+
+    @Test
+    void validatorsExposeProtectedHooksForSubclassCustomization() {
+        assertNotNull(CustomJWTClientValidator.class);
+        assertNotNull(CustomFederatedJWTClientValidator.class);
+    }
+
+    private abstract static class CustomJWTClientValidator extends AbstractJWTClientValidator {
+
+        private CustomJWTClientValidator() throws Exception {
+            super(null, null, null);
+        }
+
+        @Override
+        protected boolean validateClientAssertionParameters() {
+            return true;
+        }
+
+        @Override
+        protected boolean validateClient() {
+            return failure(AuthenticationFlowError.CLIENT_NOT_FOUND);
+        }
+
+        @Override
+        protected boolean validateSignature() {
+            return failure(AuthenticationFlowError.INVALID_CLIENT_CREDENTIALS, Response.status(Response.Status.UNAUTHORIZED).build());
+        }
+
+        @Override
+        protected String getExpectedTokenIssuer() {
+            return "custom-issuer";
+        }
+
+        @Override
+        protected List<String> getExpectedAudiences() {
+            return List.of("custom-audience");
+        }
+
+        @Override
+        protected boolean isMultipleAudienceAllowed() {
+            return false;
+        }
+
+        @Override
+        protected int getAllowedClockSkew() {
+            return 0;
+        }
+
+        @Override
+        protected int getMaximumExpirationTime() {
+            return 300;
+        }
+
+        @Override
+        protected boolean isReusePermitted() {
+            return false;
+        }
+
+        @Override
+        protected String getExpectedSignatureAlgorithm() {
+            return "RS256";
+        }
+    }
+
+    private abstract static class CustomFederatedJWTClientValidator extends FederatedJWTClientValidator {
+
+        private CustomFederatedJWTClientValidator() throws Exception {
+            super(null, null, "custom-issuer", 0, true);
+        }
+
+        @Override
+        protected boolean validateClient() {
+            return true;
+        }
+
+        @Override
+        protected List<String> getExpectedAudiences() {
+            return List.of("custom-audience");
+        }
+    }
+}


### PR DESCRIPTION
Closes #49040

Superseded by #49046, which has the active maintainer discussion.

## Summary
- Change selected `AbstractJWTClientValidator` helper methods from `private` to `protected`.
- Allow downstream subclasses to customize individual JWT client validation steps without copying the full validator implementation.
- Add a compile-time services test covering subclass overrides for `AbstractJWTClientValidator`.

## Testing
- Superseded by #49046.