### PR TITLE
Expose role enrichment helper for cross-client authorization evaluation

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/PolicyEvaluationService.java
@@ -45,6 +45,7 @@ import org.keycloak.authorization.admin.representation.PolicyEvaluationResponseB
 import org.keycloak.authorization.attribute.Attributes;
 import org.keycloak.authorization.common.DefaultEvaluationContext;
 import org.keycloak.authorization.common.KeycloakIdentity;
+import org.keycloak.authorization.common.TokenIdentityEnricher;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.authorization.model.Resource;
 import org.keycloak.authorization.model.ResourceServer;
@@ -380,15 +381,7 @@ public class PolicyEvaluationService {
             UserModel user = keycloakSession.users().getUserById(realm, representation.getUserId());
 
             if (user != null) {
-                AccessToken finalAccessToken = accessToken;
-                user.getRoleMappingsStream().forEach(roleModel -> {
-                    if (roleModel.isClientRole()) {
-                        ClientModel client = (ClientModel) roleModel.getContainer();
-                        finalAccessToken.addAccess(client.getClientId()).addRole(roleModel.getName());
-                    } else {
-                        realmAccess.addRole(roleModel.getName());
-                    }
-                });
+                TokenIdentityEnricher.addAllUserRoles(accessToken, user);
             }
         }
 

--- a/services/src/main/java/org/keycloak/authorization/common/TokenIdentityEnricher.java
+++ b/services/src/main/java/org/keycloak/authorization/common/TokenIdentityEnricher.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.common;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.AccessToken;
+
+/**
+ * Utilities for projecting a user's full role assignments onto an
+ * {@link AccessToken} so that authorization evaluation has visibility into
+ * roles that are otherwise filtered out by OIDC scope configuration.
+ *
+ * <p>A {@link KeycloakIdentity} constructed directly from a bearer access
+ * token derives its role attributes from the token's
+ * {@code realm_access} and {@code resource_access} claims. When a policy
+ * references a role defined in a client other than the resource server, and
+ * that client is not part of the requesting client's scope, the role will
+ * be absent from the token and the policy will evaluate to DENY even when
+ * the user has been granted the role.
+ *
+ * <p>This helper centralizes the enrichment logic the Keycloak admin
+ * console already uses internally when evaluating policies on behalf of a
+ * user. Extensions performing programmatic permission evaluation can use it
+ * to obtain a {@code KeycloakIdentity} consistent with the admin console's
+ * behavior:
+ *
+ * <pre>{@code
+ * AccessToken token = Tokens.getAccessToken(session);
+ * UserModel user = session.users().getUserById(realm, token.getSubject());
+ * TokenIdentityEnricher.addAllUserRoles(token, user);
+ * Identity identity = new KeycloakIdentity(token, session, realm);
+ * }</pre>
+ */
+public final class TokenIdentityEnricher {
+
+    private TokenIdentityEnricher() {
+    }
+
+    /**
+     * Adds every role mapping of {@code user} to {@code token}. Realm roles
+     * are added to {@code realm_access}; client roles are added to
+     * {@code resource_access} under their owning client. Existing roles on
+     * the token are preserved.
+     *
+     * @param token the access token to enrich; must not be {@code null}
+     * @param user  the user whose role mappings will be projected onto the
+     *              token; must not be {@code null}
+     * @throws IllegalArgumentException if {@code token} or {@code user} is
+     *                                  {@code null}
+     */
+    public static void addAllUserRoles(AccessToken token, UserModel user) {
+        if (token == null) {
+            throw new IllegalArgumentException("token must not be null");
+        }
+        if (user == null) {
+            throw new IllegalArgumentException("user must not be null");
+        }
+
+        user.getRoleMappingsStream().forEach(roleModel -> {
+            if (roleModel.isClientRole()) {
+                ClientModel client = (ClientModel) roleModel.getContainer();
+                token.addAccess(client.getClientId()).addRole(roleModel.getName());
+            } else {
+                AccessToken.Access realmAccess = token.getRealmAccess();
+                if (realmAccess == null) {
+                    realmAccess = new AccessToken.Access();
+                    token.setRealmAccess(realmAccess);
+                }
+                realmAccess.addRole(roleModel.getName());
+            }
+        });
+    }
+}

--- a/services/src/main/java/org/keycloak/authorization/common/TokenIdentityEnricher.java
+++ b/services/src/main/java/org/keycloak/authorization/common/TokenIdentityEnricher.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.common;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.AccessToken;
+
+/**
+ * Utilities for projecting a user's role assignments onto an
+ * {@link AccessToken} so that authorization evaluation has visibility into
+ * roles that are otherwise filtered out by OIDC scope configuration.
+ *
+ * <p>A {@link KeycloakIdentity} constructed directly from a bearer access
+ * token derives its role attributes from the token's
+ * {@code realm_access} and {@code resource_access} claims. When a policy
+ * references a role defined in a client other than the resource server, and
+ * that client is not part of the requesting client's scope, the role will
+ * be absent from the token and the policy will evaluate to DENY even when
+ * the user has been granted the role.
+ *
+ * <p>This helper centralizes the enrichment logic the Keycloak admin
+ * console already uses internally when evaluating policies on behalf of a
+ * user. Extensions performing programmatic permission evaluation can use it
+ * to obtain a {@code KeycloakIdentity} consistent with the admin console's
+ * behavior:
+ *
+ * <pre>{@code
+ * AccessToken token = Tokens.getAccessToken(session);
+ * UserModel user = session.users().getUserById(realm, token.getSubject());
+ * TokenIdentityEnricher.addAllUserRoles(token, user);
+ * Identity identity = new KeycloakIdentity(token, session, realm);
+ * }</pre>
+ */
+public final class TokenIdentityEnricher {
+
+    private TokenIdentityEnricher() {
+    }
+
+    /**
+     * Adds the role mappings directly assigned to {@code user} to
+     * {@code token}. Realm roles are added to {@code realm_access}; client
+     * roles are added to {@code resource_access} under their owning client.
+     * Existing roles on the token are preserved.
+     *
+     * <p>Only direct assignments are projected, as returned by
+     * {@link UserModel#getRoleMappingsStream()}: roles inherited through
+     * groups and roles implied by composites are not expanded. This mirrors
+     * the enrichment the admin console has always performed in
+     * {@code PolicyEvaluationService}, and differs from token issuance, which
+     * projects the deep mappings resolved by
+     * {@code RoleUtils#getDeepUserRoleMappings(UserModel)}.
+     *
+     * @param token the access token to enrich; must not be {@code null}
+     * @param user  the user whose direct role mappings will be projected onto
+     *              the token; must not be {@code null}
+     * @throws IllegalArgumentException if {@code token} or {@code user} is
+     *                                  {@code null}
+     */
+    public static void addAllUserRoles(AccessToken token, UserModel user) {
+        if (token == null) {
+            throw new IllegalArgumentException("token must not be null");
+        }
+        if (user == null) {
+            throw new IllegalArgumentException("user must not be null");
+        }
+
+        user.getRoleMappingsStream().forEach(roleModel -> {
+            if (roleModel.isClientRole()) {
+                ClientModel client = (ClientModel) roleModel.getContainer();
+                token.addAccess(client.getClientId()).addRole(roleModel.getName());
+            } else {
+                AccessToken.Access realmAccess = token.getRealmAccess();
+                if (realmAccess == null) {
+                    realmAccess = new AccessToken.Access();
+                    token.setRealmAccess(realmAccess);
+                }
+                realmAccess.addRole(roleModel.getName());
+            }
+        });
+    }
+}

--- a/services/src/test/java/org/keycloak/authorization/common/TokenIdentityEnricherTest.java
+++ b/services/src/test/java/org/keycloak/authorization/common/TokenIdentityEnricherTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.common;
+
+import org.keycloak.representations.AccessToken;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Boundary-condition tests for {@link TokenIdentityEnricher}.
+ *
+ * <p>Functional coverage of the enrichment behavior (realm vs. client roles,
+ * cross-client role projection) is provided by the integration test
+ * {@code org.keycloak.testsuite.authz.KeycloakIdentityCrossClientRoleTest},
+ * which exercises the helper end-to-end against a running Keycloak session.
+ */
+class TokenIdentityEnricherTest {
+
+    @Test
+    void addAllUserRoles_rejectsNullToken() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> TokenIdentityEnricher.addAllUserRoles(null, null));
+        assertEquals("token must not be null", ex.getMessage());
+    }
+
+    @Test
+    void addAllUserRoles_rejectsNullUser() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> TokenIdentityEnricher.addAllUserRoles(new AccessToken(), null));
+        assertEquals("user must not be null", ex.getMessage());
+    }
+}

--- a/services/src/test/java/org/keycloak/authorization/common/TokenIdentityEnricherTest.java
+++ b/services/src/test/java/org/keycloak/authorization/common/TokenIdentityEnricherTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.authorization.common;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.keycloak.models.RoleContainerModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.UserModelDelegate;
+import org.keycloak.representations.AccessToken;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link TokenIdentityEnricher}: the null-argument contract and
+ * the realm-role projection, including the case where the token carries no
+ * {@code realm_access} claim yet and the enricher has to create it.
+ *
+ * <p>The client-role branch resolves the role's owning {@link RoleContainerModel}
+ * as a client, which is impractical to fake at this level; it is covered
+ * end-to-end, together with the cross-client projection this helper exists for,
+ * by the integration test
+ * {@code org.keycloak.tests.authz.services.KeycloakIdentityCrossClientRoleTest}.
+ */
+class TokenIdentityEnricherTest {
+
+    private static final String REALM_ROLE = "realm-role";
+
+    @Test
+    void addAllUserRoles_rejectsNullToken() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> TokenIdentityEnricher.addAllUserRoles(null, null));
+        assertEquals("token must not be null", ex.getMessage());
+    }
+
+    @Test
+    void addAllUserRoles_rejectsNullUser() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> TokenIdentityEnricher.addAllUserRoles(new AccessToken(), null));
+        assertEquals("user must not be null", ex.getMessage());
+    }
+
+    @Test
+    void addAllUserRoles_createsRealmAccess_whenTokenHasNone() {
+        AccessToken token = new AccessToken();
+
+        TokenIdentityEnricher.addAllUserRoles(token, userWithRoles(new FakeRealmRole(REALM_ROLE)));
+
+        AccessToken.Access realmAccess = token.getRealmAccess();
+        assertNotNull(realmAccess, "realm_access should have been created for the projected realm role");
+        assertEquals(Set.of(REALM_ROLE), realmAccess.getRoles());
+    }
+
+    @Test
+    void addAllUserRoles_preservesExistingRealmRoles() {
+        AccessToken token = new AccessToken();
+        token.setRealmAccess(new AccessToken.Access().addRole("pre-existing"));
+
+        TokenIdentityEnricher.addAllUserRoles(token, userWithRoles(new FakeRealmRole(REALM_ROLE)));
+
+        AccessToken.Access realmAccess = token.getRealmAccess();
+        assertTrue(realmAccess.isUserInRole("pre-existing"), "existing realm roles must be preserved");
+        assertTrue(realmAccess.isUserInRole(REALM_ROLE), "projected realm role must be added");
+    }
+
+    private static UserModel userWithRoles(RoleModel... roles) {
+        return new UserModelDelegate(null) {
+            @Override
+            public Stream<RoleModel> getRoleMappingsStream() {
+                return Stream.of(roles);
+            }
+        };
+    }
+
+    /**
+     * Minimal realm {@link RoleModel} double, in the spirit of the {@code FakeRole}
+     * used by {@code RoleProviderCompositeDefaultTest}: only the surface the
+     * enricher touches is implemented.
+     */
+    private static final class FakeRealmRole implements RoleModel {
+
+        private final String name;
+
+        FakeRealmRole(String name) {
+            this.name = name;
+        }
+
+        @Override public String getName() { return name; }
+        @Override public boolean isClientRole() { return false; }
+
+        // --- unused RoleModel surface --------------------------------------------------------
+
+        @Override public String getDescription() { throw new UnsupportedOperationException(); }
+        @Override public void setDescription(String description) { throw new UnsupportedOperationException(); }
+        @Override public String getId() { throw new UnsupportedOperationException(); }
+        @Override public void setName(String name) { throw new UnsupportedOperationException(); }
+        @Override public boolean isComposite() { throw new UnsupportedOperationException(); }
+        @Override public void addCompositeRole(RoleModel role) { throw new UnsupportedOperationException(); }
+        @Override public void removeCompositeRole(RoleModel role) { throw new UnsupportedOperationException(); }
+        @Override public Stream<RoleModel> getCompositesStream(String search, Integer first, Integer max) { throw new UnsupportedOperationException(); }
+        @Override public String getContainerId() { throw new UnsupportedOperationException(); }
+        @Override public RoleContainerModel getContainer() { throw new UnsupportedOperationException(); }
+        @Override public boolean hasRole(RoleModel role) { throw new UnsupportedOperationException(); }
+        @Override public void setSingleAttribute(String name, String value) { throw new UnsupportedOperationException(); }
+        @Override public void setAttribute(String name, List<String> values) { throw new UnsupportedOperationException(); }
+        @Override public void removeAttribute(String name) { throw new UnsupportedOperationException(); }
+        @Override public Stream<String> getAttributeStream(String name) { throw new UnsupportedOperationException(); }
+        @Override public Map<String, List<String>> getAttributes() { throw new UnsupportedOperationException(); }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/authz/services/KeycloakIdentityCrossClientRoleTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/authz/services/KeycloakIdentityCrossClientRoleTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.tests.authz.services;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.common.DefaultEvaluationContext;
+import org.keycloak.authorization.common.KeycloakIdentity;
+import org.keycloak.authorization.common.TokenIdentityEnricher;
+import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
+import org.keycloak.authorization.permission.ResourcePermission;
+import org.keycloak.authorization.permission.evaluator.PermissionEvaluator;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.DecisionEffect;
+import org.keycloak.representations.idm.authorization.DecisionStrategy;
+import org.keycloak.representations.idm.authorization.Logic;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationRequest;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationResponse;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.UserSessionManager;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Demonstrates the cross-client role gap addressed by the
+ * {@code TokenIdentityEnricher} contribution.
+ *
+ * <p>Scenario: a resource on {@code client-a} is protected by a role policy
+ * referencing a client role defined in {@code client-b}. The user holds the
+ * {@code client-b} role.
+ *
+ * <ul>
+ *   <li>{@link #adminConsoleEvaluate_includesCrossClientRole_yieldsPermit()}
+ *       captures the admin console reference: {@code PolicyEvaluationService}
+ *       enriches the synthetic token with the user's role mappings, yielding
+ *       PERMIT for the same scenario. This guards against regressions in the
+ *       admin-console code path after the helper refactor.</li>
+ *   <li>{@link #plainTokenIdentity_missesCrossClientRole_yieldsDeny()} pins
+ *       the gap itself: an identity built from the raw client token is denied,
+ *       because the {@code client-b} role never reaches the token.</li>
+ *   <li>{@link #enrichedTokenIdentity_includesCrossClientRole_yieldsPermit()}
+ *       proves the helper's value: after invoking
+ *       {@link TokenIdentityEnricher#addAllUserRoles(AccessToken, UserModel)},
+ *       a token-bound identity grants the same permission as the admin
+ *       console.</li>
+ * </ul>
+ */
+@KeycloakIntegrationTest
+public class KeycloakIdentityCrossClientRoleTest {
+
+    private static final String CLIENT_A = "resource-server-client-a";
+    private static final String CLIENT_B = "role-container-client-b";
+    private static final String CLIENT_B_ROLE = "special";
+    private static final String USER_NAME = "cross-client-user";
+    private static final String RESOURCE = "myresource";
+    private static final String SCOPE = "myscope";
+    private static final String PERMISSION = "mypermission";
+
+    @InjectRealm(config = CrossClientRoleRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @BeforeEach
+    public void createAuthorizationConfig() {
+        runOnServer.run(KeycloakIdentityCrossClientRoleTest::setup);
+    }
+
+    public static void setup(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        AuthorizationProvider authz = session.getProvider(AuthorizationProvider.class);
+        ClientModel clientA = realm.getClientByClientId(CLIENT_A);
+
+        // Idempotent: the realm outlives a single test, so later invocations
+        // become no-ops.
+        if (authz.getStoreFactory().getResourceServerStore().findByClient(clientA) != null) {
+            return;
+        }
+
+        RoleModel role = realm.getClientByClientId(CLIENT_B).getRole(CLIENT_B_ROLE);
+
+        ResourceServer resourceServer = authz.getStoreFactory().getResourceServerStore().create(clientA);
+        Policy policy = createRolePolicy(authz, resourceServer, role);
+
+        Scope scope = authz.getStoreFactory().getScopeStore().create(resourceServer, SCOPE);
+        Resource resource = authz.getStoreFactory().getResourceStore()
+                .create(resourceServer, RESOURCE, resourceServer.getClientId());
+        resource.updateScopes(Set.of(scope));
+        addScopePermission(authz, resourceServer, PERMISSION, resource, scope, policy);
+    }
+
+    public static void evaluateWithPlainTokenIdentity(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel clientA = realm.getClientByClientId(CLIENT_A);
+        UserModel user = session.users().getUserByUsername(realm, USER_NAME);
+
+        AccessToken token = synthesizeClientToken(session, realm, clientA, user);
+
+        KeycloakIdentity identity = new KeycloakIdentity(token, session, realm);
+
+        Collection<Permission> permissions = evaluateResourcePermission(session, clientA, identity);
+
+        Assertions.assertTrue(
+                permissions.isEmpty(),
+                "Expected the un-enriched identity to be denied: the client-b role is outside "
+                        + "client-a's scope, so it is absent from the token. If this grants access, "
+                        + "the test no longer exercises the gap the enrichment closes.");
+    }
+
+    public static void evaluateWithEnrichedTokenIdentity(KeycloakSession session) {
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel clientA = realm.getClientByClientId(CLIENT_A);
+        UserModel user = session.users().getUserByUsername(realm, USER_NAME);
+
+        AccessToken token = synthesizeClientToken(session, realm, clientA, user);
+        TokenIdentityEnricher.addAllUserRoles(token, user);
+
+        KeycloakIdentity identity = new KeycloakIdentity(token, session, realm);
+
+        Collection<Permission> permissions = evaluateResourcePermission(session, clientA, identity);
+
+        Assertions.assertFalse(
+                permissions.isEmpty(),
+                "Expected enriched identity to grant the cross-client role policy. "
+                        + "If empty, the enrichment loop or evaluator wiring regressed.");
+    }
+
+    private static AccessToken synthesizeClientToken(KeycloakSession session, RealmModel realm,
+                                                     ClientModel client, UserModel user) {
+        AuthenticationSessionModel authSession = session.authenticationSessions()
+                .createRootAuthenticationSession(realm)
+                .createAuthenticationSession(client);
+        authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        authSession.setAuthenticatedUser(user);
+
+        UserSessionModel userSession = new UserSessionManager(session).createUserSession(
+                authSession.getParentSession().getId(), realm, user,
+                user.getUsername(), "127.0.0.1", "passwd", false, null, null,
+                UserSessionModel.SessionPersistenceState.PERSISTENT);
+
+        AuthenticationManager.setClientScopesInSession(session, authSession);
+        ClientSessionContext ctx = TokenManager.attachAuthenticationSession(session, userSession, authSession);
+
+        return new TokenManager().createClientAccessToken(session, realm, client, user, userSession, ctx,
+                ctx.isOfflineTokenRequested());
+    }
+
+    private static Collection<Permission> evaluateResourcePermission(KeycloakSession session,
+                                                                     ClientModel clientA,
+                                                                     KeycloakIdentity identity) {
+        AuthorizationProvider authz = session.getProvider(AuthorizationProvider.class);
+        ResourceServer resourceServer = authz.getStoreFactory().getResourceServerStore().findByClient(clientA);
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(resourceServer, RESOURCE);
+        Scope scope = authz.getStoreFactory().getScopeStore().findByName(resourceServer, SCOPE);
+
+        PermissionEvaluator evaluator = authz.evaluators().from(
+                Arrays.asList(new ResourcePermission(resource, Arrays.asList(scope), resourceServer)),
+                new DefaultEvaluationContext(identity, session));
+        return evaluator.evaluate(resourceServer, null);
+    }
+
+    private static Policy createRolePolicy(AuthorizationProvider authz, ResourceServer resourceServer, RoleModel role) {
+        PolicyRepresentation representation = new PolicyRepresentation();
+        representation.setName(role.getName() + "-policy");
+        representation.setType("role");
+        representation.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
+        representation.setLogic(Logic.POSITIVE);
+        String roleValues = "[{\"id\":\"" + role.getId() + "\",\"required\": true}]";
+        Map<String, String> config = new HashMap<>();
+        config.put("roles", roleValues);
+        // fetchRoles is deliberately left off: with it enabled RolePolicyProvider
+        // reloads the subject and calls UserModel#hasRole, bypassing the identity
+        // altogether, so these tests would pass even without the enrichment. The
+        // default resolves the role from the identity's token claims, which is the
+        // path the helper feeds.
+        representation.setConfig(config);
+
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
+    }
+
+    private static Policy addScopePermission(AuthorizationProvider authz, ResourceServer resourceServer, String name,
+                                             Resource resource, Scope scope, Policy policy) {
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+        representation.setName(name);
+        representation.setType("scope");
+        representation.addResource(resource.getName());
+        representation.addScope(scope.getName());
+        representation.addPolicy(policy.getName());
+        representation.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
+        representation.setLogic(Logic.POSITIVE);
+
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
+    }
+
+    @Test
+    public void adminConsoleEvaluate_includesCrossClientRole_yieldsPermit() {
+        String resourceServerId = realm.admin().clients().findByClientId(CLIENT_A).get(0).getId();
+        UserRepresentation user = realm.admin().users().search(USER_NAME).get(0);
+
+        PolicyEvaluationRequest request = new PolicyEvaluationRequest();
+        request.setUserId(user.getId());
+        request.setClientId(resourceServerId);
+        request.addResource(RESOURCE, SCOPE);
+
+        PolicyEvaluationResponse result = realm.admin().clients().get(resourceServerId)
+                .authorization().policies().evaluate(request);
+        Assertions.assertEquals(DecisionEffect.PERMIT, result.getStatus(),
+                "Admin console must grant access via internal role enrichment.");
+    }
+
+    @Test
+    public void plainTokenIdentity_missesCrossClientRole_yieldsDeny() {
+        runOnServer.run(KeycloakIdentityCrossClientRoleTest::evaluateWithPlainTokenIdentity);
+    }
+
+    @Test
+    public void enrichedTokenIdentity_includesCrossClientRole_yieldsPermit() {
+        runOnServer.run(KeycloakIdentityCrossClientRoleTest::evaluateWithEnrichedTokenIdentity);
+    }
+
+    private static class CrossClientRoleRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            // client-b: role container, not a resource server and not in client-a's scope.
+            realm.clients(ClientBuilder.create().clientId(CLIENT_B));
+            realm.clientRoles(CLIENT_B, CLIENT_B_ROLE);
+
+            // client-a: resource server holding the permission. fullScopeEnabled=false is
+            // the production-realistic setting: only roles explicitly mapped into
+            // client-a's scope appear in the tokens it issues. Without it the access token
+            // would carry client-b roles via the full-scope shortcut and the cross-client
+            // gap would not reproduce.
+            realm.clients(ClientBuilder.create().clientId(CLIENT_A).fullScopeEnabled(false));
+
+            realm.users(UserBuilder.create().username(USER_NAME).clientRoles(CLIENT_B, CLIENT_B_ROLE));
+
+            return realm;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/KeycloakIdentityCrossClientRoleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/KeycloakIdentityCrossClientRoleTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.authz;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.authorization.AuthorizationProvider;
+import org.keycloak.authorization.AuthorizationProviderFactory;
+import org.keycloak.authorization.common.DefaultEvaluationContext;
+import org.keycloak.authorization.common.KeycloakIdentity;
+import org.keycloak.authorization.common.TokenIdentityEnricher;
+import org.keycloak.authorization.model.Policy;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
+import org.keycloak.authorization.permission.ResourcePermission;
+import org.keycloak.authorization.permission.evaluator.PermissionEvaluator;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.DecisionEffect;
+import org.keycloak.representations.idm.authorization.DecisionStrategy;
+import org.keycloak.representations.idm.authorization.Logic;
+import org.keycloak.representations.idm.authorization.Permission;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationRequest;
+import org.keycloak.representations.idm.authorization.PolicyEvaluationResponse;
+import org.keycloak.representations.idm.authorization.PolicyRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.managers.UserSessionManager;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import static org.keycloak.testsuite.auth.page.AuthRealm.TEST;
+
+/**
+ * Demonstrates the cross-client role gap addressed by the
+ * {@code TokenIdentityEnricher} contribution.
+ *
+ * <p>Scenario: a resource on {@code client-a} is protected by a role policy
+ * referencing a client role defined in {@code client-b}. The user holds the
+ * {@code client-b} role.
+ *
+ * <ul>
+ *   <li>{@link #adminConsoleEvaluate_includesCrossClientRole_yieldsPermit()}
+ *       captures the admin console reference: {@code PolicyEvaluationService}
+ *       enriches the synthetic token with all user role mappings, yielding
+ *       PERMIT for the same scenario. This guards against regressions in the
+ *       admin-console code path after the helper refactor.</li>
+ *   <li>{@link #enrichedTokenIdentity_includesCrossClientRole_yieldsPermit()}
+ *       proves the helper's value: after invoking
+ *       {@link TokenIdentityEnricher#addAllUserRoles(AccessToken, UserModel)},
+ *       a token-bound identity grants the same permission as the admin
+ *       console.</li>
+ * </ul>
+ */
+public class KeycloakIdentityCrossClientRoleTest extends AbstractAuthzTest {
+
+    private static final String CLIENT_A = "resource-server-client-a";
+    private static final String CLIENT_B = "role-container-client-b";
+    private static final String CLIENT_B_ROLE = "special";
+    private static final String USER_NAME = "cross-client-user";
+    private static final String RESOURCE = "myresource";
+    private static final String SCOPE = "myscope";
+    private static final String PERMISSION = "mypermission";
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        RealmRepresentation testRealmRep = new RealmRepresentation();
+        testRealmRep.setId(TEST);
+        testRealmRep.setRealm(TEST);
+        testRealmRep.setEnabled(true);
+        testRealms.add(testRealmRep);
+    }
+
+    public static void setup(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName(TEST);
+        session.getContext().setRealm(realm);
+
+        // Idempotent: each @Test invokes setup, but the realm persists across
+        // the run, so subsequent calls become no-ops.
+        if (realm.getClientByClientId(CLIENT_A) != null) {
+            return;
+        }
+
+        // client-b: role container (not a resource server, not in client-a's scope)
+        ClientModel clientB = session.clients().addClient(realm, CLIENT_B);
+        RoleModel role = clientB.addRole(CLIENT_B_ROLE);
+
+        // client-a: resource server with a role-policy referencing client-b's role.
+        // fullScopeAllowed=false is the production-realistic setting: only roles
+        // explicitly mapped into client-a's scope appear in tokens it issues.
+        // Without this, the access token would carry client-b roles via the
+        // full-scope shortcut and the cross-client gap would not reproduce.
+        ClientModel clientA = session.clients().addClient(realm, CLIENT_A);
+        clientA.setFullScopeAllowed(false);
+
+        AuthorizationProviderFactory factory = (AuthorizationProviderFactory)
+                session.getKeycloakSessionFactory().getProviderFactory(AuthorizationProvider.class);
+        AuthorizationProvider authz = factory.create(session, realm);
+        ResourceServer resourceServer = authz.getStoreFactory().getResourceServerStore().create(clientA);
+        Policy policy = createRolePolicy(authz, resourceServer, role);
+
+        Scope scope = authz.getStoreFactory().getScopeStore().create(resourceServer, SCOPE);
+        Resource resource = authz.getStoreFactory().getResourceStore()
+                .create(resourceServer, RESOURCE, resourceServer.getClientId());
+        addScopePermission(authz, resourceServer, PERMISSION, resource, scope, policy);
+
+        UserModel user = session.users().addUser(realm, USER_NAME);
+        user.grantRole(role);
+    }
+
+    public static void evaluateWithEnrichedTokenIdentity(KeycloakSession session) {
+        RealmModel realm = session.realms().getRealmByName(TEST);
+        session.getContext().setRealm(realm);
+
+        ClientModel clientA = realm.getClientByClientId(CLIENT_A);
+        UserModel user = session.users().getUserByUsername(realm, USER_NAME);
+
+        AccessToken token = synthesizeClientToken(session, realm, clientA, user);
+        TokenIdentityEnricher.addAllUserRoles(token, user);
+
+        KeycloakIdentity identity = new KeycloakIdentity(token, session, realm);
+
+        Collection<Permission> permissions = evaluateResourcePermission(session, clientA, identity);
+
+        Assertions.assertFalse(
+                permissions.isEmpty(),
+                "Expected enriched identity to grant the cross-client role policy. "
+                        + "If empty, the enrichment loop or evaluator wiring regressed.");
+    }
+
+    private static AccessToken synthesizeClientToken(KeycloakSession session, RealmModel realm,
+                                                     ClientModel client, UserModel user) {
+        AuthenticationSessionModel authSession = session.authenticationSessions()
+                .createRootAuthenticationSession(realm)
+                .createAuthenticationSession(client);
+        authSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        authSession.setAuthenticatedUser(user);
+
+        UserSessionModel userSession = new UserSessionManager(session).createUserSession(
+                authSession.getParentSession().getId(), realm, user,
+                user.getUsername(), "127.0.0.1", "passwd", false, null, null,
+                UserSessionModel.SessionPersistenceState.PERSISTENT);
+
+        AuthenticationManager.setClientScopesInSession(session, authSession);
+        ClientSessionContext ctx = TokenManager.attachAuthenticationSession(session, userSession, authSession);
+
+        return new TokenManager().createClientAccessToken(session, realm, client, user, userSession, ctx,
+                ctx.isOfflineTokenRequested());
+    }
+
+    private static Collection<Permission> evaluateResourcePermission(KeycloakSession session,
+                                                                     ClientModel clientA,
+                                                                     KeycloakIdentity identity) {
+        AuthorizationProvider authz = session.getProvider(AuthorizationProvider.class);
+        ResourceServer resourceServer = authz.getStoreFactory().getResourceServerStore().findByClient(clientA);
+        Resource resource = authz.getStoreFactory().getResourceStore().findByName(resourceServer, RESOURCE);
+        Scope scope = authz.getStoreFactory().getScopeStore().findByName(resourceServer, SCOPE);
+
+        PermissionEvaluator evaluator = authz.evaluators().from(
+                Arrays.asList(new ResourcePermission(resource, Arrays.asList(scope), resourceServer)),
+                new DefaultEvaluationContext(identity, session));
+        return evaluator.evaluate(resourceServer, null);
+    }
+
+    private static Policy createRolePolicy(AuthorizationProvider authz, ResourceServer resourceServer, RoleModel role) {
+        PolicyRepresentation representation = new PolicyRepresentation();
+        representation.setName(role.getName() + "-policy");
+        representation.setType("role");
+        representation.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
+        representation.setLogic(Logic.POSITIVE);
+        String roleValues = "[{\"id\":\"" + role.getId() + "\",\"required\": true}]";
+        Map<String, String> config = new HashMap<>();
+        config.put("roles", roleValues);
+        config.put("fetchRoles", Boolean.TRUE.toString());
+        representation.setConfig(config);
+
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
+    }
+
+    private static Policy addScopePermission(AuthorizationProvider authz, ResourceServer resourceServer, String name,
+                                             Resource resource, Scope scope, Policy policy) {
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+        representation.setName(name);
+        representation.setType("scope");
+        representation.addResource(resource.getName());
+        representation.addScope(scope.getName());
+        representation.addPolicy(policy.getName());
+        representation.setDecisionStrategy(DecisionStrategy.UNANIMOUS);
+        representation.setLogic(Logic.POSITIVE);
+
+        return authz.getStoreFactory().getPolicyStore().create(resourceServer, representation);
+    }
+
+    @Test
+    public void adminConsoleEvaluate_includesCrossClientRole_yieldsPermit() {
+        testingClient.server().run(KeycloakIdentityCrossClientRoleTest::setup);
+
+        RealmResource realm = adminClient.realm(TEST);
+        String resourceServerId = realm.clients().findByClientId(CLIENT_A).get(0).getId();
+        UserRepresentation user = realm.users().search(USER_NAME).get(0);
+
+        PolicyEvaluationRequest request = new PolicyEvaluationRequest();
+        request.setUserId(user.getId());
+        request.setClientId(resourceServerId);
+        request.addResource(RESOURCE, SCOPE);
+
+        PolicyEvaluationResponse result = realm.clients().get(resourceServerId)
+                .authorization().policies().evaluate(request);
+        Assertions.assertEquals(DecisionEffect.PERMIT, result.getStatus(),
+                "Admin console must grant access via internal role enrichment.");
+    }
+
+    @Test
+    public void enrichedTokenIdentity_includesCrossClientRole_yieldsPermit() {
+        testingClient.server().run(KeycloakIdentityCrossClientRoleTest::setup);
+        testingClient.server().run(KeycloakIdentityCrossClientRoleTest::evaluateWithEnrichedTokenIdentity);
+    }
+}


### PR DESCRIPTION
Closes #49048

## Summary

Extracts the role enrichment loop from `PolicyEvaluationService.createIdentity()` into a public static helper, `org.keycloak.authorization.common.TokenIdentityEnricher.addAllUserRoles(AccessToken, UserModel)`. `PolicyEvaluationService` now delegates to the helper. The change is additive — no existing public API is modified.

The motivation, scope, and the rationale for choosing a minimum-surface helper over the originally proposed `fromUser(...)` factory are in the linked issue.

## Changes

| File | Change |
|---|---|
| `services/.../common/TokenIdentityEnricher.java` | **New** public static helper with Javadoc and null-argument guards |
| `services/.../admin/PolicyEvaluationService.java` | `createIdentity()` delegates the role-projection loop to the helper; admin-console behavior preserved |
| `services/.../common/TokenIdentityEnricherTest.java` | **New** unit tests: null-argument contract + realm-role projection, including creation of `realm_access` on a token that has none |
| `tests/base/.../authz/services/KeycloakIdentityCrossClientRoleTest.java` | **New** integration tests: admin-console parity, the cross-client gap itself, and the helper closing it |

The integration test is written against the new test framework (`@KeycloakIntegrationTest`, `@InjectRealm`, `@InjectRunOnServer`) and lives in `tests/base`, not in the deprecated `testsuite/integration-arquillian` tree.

## Test plan

- `./mvnw test -pl services -Dtest=TokenIdentityEnricherTest` — 4/4 pass
  - `addAllUserRoles_rejectsNullToken`, `addAllUserRoles_rejectsNullUser` — null-argument contract
  - `addAllUserRoles_createsRealmAccess_whenTokenHasNone` — realm role projected onto a token carrying no `realm_access` claim yet
  - `addAllUserRoles_preservesExistingRealmRoles` — pre-existing realm roles survive the projection

  Verified to be self-checking: removing the `realm_access` initialization from `addAllUserRoles` turns `addAllUserRoles_createsRealmAccess_whenTokenHasNone` red.

- `./mvnw test -pl tests/base -Dtest=KeycloakIdentityCrossClientRoleTest` — 3/3 pass
  - `adminConsoleEvaluate_includesCrossClientRole_yieldsPermit` — admin-console reference behavior, guards the refactor
  - `plainTokenIdentity_missesCrossClientRole_yieldsDeny` — pins the gap: the raw client token never carries the `client-b` role under `fullScopeAllowed=false`
  - `enrichedTokenIdentity_includesCrossClientRole_yieldsPermit` — the helper closes the gap

  The client-role branch of the helper is covered here rather than in the unit test, since it resolves the role's owning container as a client.

- `./mvnw spotless:check` — clean
