### PR TITLE
Fix group membership management without user-level permission in FGAP V2

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/fgap/UserPermissionsV2.java
@@ -145,7 +145,7 @@ class UserPermissionsV2 extends UserPermissions {
             return true;
         }
 
-        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.MANAGE_GROUP_MEMBERSHIP);
+        return eval.hasPermission(new UserModelRecord(user), null, AdminPermissionsSchema.MANAGE_GROUP_MEMBERSHIP, () -> true);
     }
 
     @Override

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/GroupResourceTypeEvaluationTest.java
@@ -285,7 +285,7 @@ public class GroupResourceTypeEvaluationTest extends AbstractPermissionTest {
     public void testManageGroupMembership() {
         // myadmin shouldn't be able to manage group membership of the user just yet
         try {
-            realmAdminClient.realm(realm.getName()).users().get(userAlice.getId()).joinGroup("no-such");
+            realmAdminClient.realm(realm.getName()).users().get(userAlice.getId()).joinGroup(topGroup.getId());
             fail("Expected Exception wasn't thrown.");
         } catch (Exception ex) {
             assertThat(ex, instanceOf(ForbiddenException.class));
@@ -437,6 +437,75 @@ public class GroupResourceTypeEvaluationTest extends AbstractPermissionTest {
 
         realmAdminClient.realm(realm.getName()).users().get(userJdoe.getId()).impersonate();
         realmAdminClient.tokenManager().logout();
+    }
+
+    /**
+     * Tests that a limited admin with ONLY group-level manage-membership permission
+     * (no user-level manage-group-membership) should be able to add a user to the group.
+     * In FGAP V2, the group-level permission alone must be sufficient.
+     */
+    @Test
+    public void testJoinGroupWithOnlyGroupPermission() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowMyAdminPermission = createUserPolicy(realm, client, "Only My Admin Policy", myadmin.getId());
+        GroupRepresentation target = createGroup("target");
+        UserRepresentation userBob = createUser("bob");
+
+        // myadmin should not be able to add bob to the group without any permission
+        try {
+            realmAdminClient.realm(realm.getName()).users().get(userBob.getId()).joinGroup(target.getId());
+            fail("Expected ForbiddenException was not thrown.");
+        } catch (Exception ex) {
+            assertThat(ex, instanceOf(ForbiddenException.class));
+        }
+
+        // Grant ONLY group-level manage-membership permission — no user-level permission granted
+        createAllPermission(client, AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, allowMyAdminPermission, Set.of(MANAGE_MEMBERSHIP));
+
+        // myadmin should now be able to add bob to the group with only the group-level permission
+        realmAdminClient.realm(realm.getName()).users().get(userBob.getId()).joinGroup(target.getId());
+
+        // Verify bob is actually a member of the group
+        assertTrue(
+                realm.admin().users().get(userBob.getId()).groups().stream().anyMatch(g -> target.getId().equals(g.getId())),
+                "Expected bob to be a member of target group after joinGroup"
+        );
+    }
+
+    /**
+     * Tests that a limited admin with ONLY group-level manage-membership permission
+     * (no user-level manage-group-membership) should be able to remove a user from the group.
+     * In FGAP V2, the group-level permission alone must be sufficient.
+     */
+    @Test
+    public void testLeaveGroupWithOnlyGroupPermission() {
+        UserRepresentation myadmin = realm.admin().users().search("myadmin").get(0);
+        UserPolicyRepresentation allowMyAdminPermission = createUserPolicy(realm, client, "Only My Admin Policy", myadmin.getId());
+        GroupRepresentation target = createGroup("target");
+        UserRepresentation userBob = createUser("bob");
+
+        // Pre-condition: add bob to target using the super-admin
+        realm.admin().users().get(userBob.getId()).joinGroup(target.getId());
+
+        // myadmin should not be able to remove bob from the group without any permission
+        try {
+            realmAdminClient.realm(realm.getName()).users().get(userBob.getId()).leaveGroup(target.getId());
+            fail("Expected ForbiddenException was not thrown.");
+        } catch (Exception ex) {
+            assertThat(ex, instanceOf(ForbiddenException.class));
+        }
+
+        // Grant ONLY group-level manage-membership permission — no user-level permission granted
+        createAllPermission(client, AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, allowMyAdminPermission, Set.of(MANAGE_MEMBERSHIP));
+
+        // myadmin should now be able to remove bob from the group with only the group-level permission
+        realmAdminClient.realm(realm.getName()).users().get(userBob.getId()).leaveGroup(target.getId());
+
+        // Verify bob is no longer a member of the group
+        assertTrue(
+                realm.admin().users().get(userBob.getId()).groups().stream().noneMatch(g -> target.getId().equals(g.getId())),
+                "Expected bob to no longer be a member of target group after leaveGroup"
+        );
     }
 
     private ScopePermissionRepresentation createAllGroupsPermission(UserPolicyRepresentation policy, Set<String> scopes) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeEvaluationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/UserResourceTypeEvaluationTest.java
@@ -386,8 +386,9 @@ public class UserResourceTypeEvaluationTest extends AbstractPermissionTest {
         }
 
         // with manage permission it is NOT possible to manage group membership
+        GroupRepresentation testGroup = createGroup("test-no-transitive");
         try {
-            realmAdminClient.realm(realm.getName()).users().get(userAlice.getId()).joinGroup("no-such");
+            realmAdminClient.realm(realm.getName()).users().get(userAlice.getId()).joinGroup(testGroup.getId());
             fail("Expected Exception wasn't thrown.");
         } catch (Exception ex) {
             assertThat(ex, instanceOf(ForbiddenException.class));


### PR DESCRIPTION
UserPermissionsV2.canManageGroupMembership() had no fallback, causing
joinGroup/leaveGroup to return 403 when only a group-level
manage-membership permission was configured. Added a default supplier
(() -> true) to hasPermission() so evaluation falls through to
group-level checks when no user-level policy is configured.

**Tests added:**
- `testJoinGroupWithOnlyGroupPermission` — verifies join works with only group-level permission
- `testLeaveGroupWithOnlyGroupPermission` — verifies leave works with only group-level permission
- Fixed `testNoTransitiveUserPermissions` to use a real group ID

**AI disclosure:** 
Claude Code was used to assist with identifying, implementing and testing this fix.

Closes [#38889](https://github.com/keycloak/keycloak/issues/38889)
