### PR TITLE
Make Roles optional on client Authorization Evaluate tab

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx
@@ -219,9 +219,6 @@ const AuthorizationEvaluateContent = ({ client }: Props) => {
                 placeholderText={t("selectARole")}
                 controller={{
                   defaultValue: [],
-                  rules: {
-                    required: true,
-                  },
                 }}
                 options={clientRoles.map((role) => role.name!)}
               />


### PR DESCRIPTION
## Description
On a client's **Authorization > Evaluate** tab, the form requires both a User and at least one Role before the "Evaluate" button is enabled.

The REST endpoint
`POST /admin/realms/{realm}/clients/{id}/authz/resource-server/policy/evaluate`
does not require `roleIds`. When roles are omitted, the server uses the selected user's effective role mappings (`PolicyEvaluationService#createIdentity`).

The roles field's own help text reads "Select the roles you want to associate with the selected user." That already describes roles as an adjunct to the selected user, not as an independent required input. So the UI is stricter than both the API and its own copy.

This PR drops the `required` rule on `roleIds` so the form mirrors the REST contract.

## Change
Single one-file change in `js/apps/admin-ui/src/clients/authorization/AuthorizationEvaluate.tsx`: remove `rules: { required: true }` from the `roleIds` `SelectControl`. The submit payload already handles the empty case (`roleIds: formValues.roleIds ?? []`).

## Out of scope
- The User field at the REST layer is also technically optional (anonymous evaluation). Not changed here; can be a follow-up if anyone wants it.

## How to verify
1. Open a client with Authorization enabled.
2. Go to **Authorization > Evaluate**.
3. Select a User, leave Roles empty.
4. The Evaluate button is enabled; clicking it returns an evaluation based on the user's effective roles.

## Video Result

[role-select-optional.webm](https://github.com/user-attachments/assets/1164bdb3-2a9a-4a87-adfd-d285e1d6c9ba)


Closes #49056
