### PR TITLE
Export custom provider changesets in manual migration-strategy

### DIFF
--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusJpaUpdaterProvider.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/liquibase/QuarkusJpaUpdaterProvider.java
@@ -96,12 +96,13 @@ public class QuarkusJpaUpdaterProvider implements JpaUpdaterProvider {
 
         Writer exportWriter = null;
         try {
+            if (file != null) {
+                exportWriter = new FileWriter(file);
+            }
+
             if (needVerifyMasterChangelog()) {
                 // Run update with keycloak master changelog first
                 KeycloakLiquibase liquibase = getLiquibaseForKeycloakUpdate(connection, defaultSchema);
-                if (file != null) {
-                    exportWriter = new FileWriter(file);
-                }
                 updateChangeSet(liquibase, exportWriter);
             }
 

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestEntity.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestEntity.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.jpa.migration;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "MIGRATION_TEST_ENTITY")
+public class MigrationTestEntity {
+
+    @Id
+    @Column(name = "ID")
+    private String id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestJpaEntityProvider.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestJpaEntityProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.jpa.migration;
+
+import java.util.List;
+
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
+
+public class MigrationTestJpaEntityProvider implements JpaEntityProvider {
+
+    @Override
+    public List<Class<?>> getEntities() {
+        return List.of(MigrationTestEntity.class);
+    }
+
+    @Override
+    public String getChangelogLocation() {
+        return "META-INF/migration-test-changelog.xml";
+    }
+
+    @Override
+    public String getFactoryId() {
+        return MigrationTestJpaEntityProviderFactory.ID;
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestJpaEntityProviderFactory.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestJpaEntityProviderFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.jpa.migration;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProvider;
+import org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class MigrationTestJpaEntityProviderFactory implements JpaEntityProviderFactory {
+
+    static final String ID = "migration-test-entity-provider";
+
+    @Override
+    public JpaEntityProvider create(KeycloakSession session) {
+        return new MigrationTestJpaEntityProvider();
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestProvider.java
+++ b/quarkus/tests/integration/src/test-providers/java/org/keycloak/it/jpa/migration/MigrationTestProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.jpa.migration;
+
+import java.util.Map;
+
+import org.keycloak.it.TestProvider;
+
+public class MigrationTestProvider implements TestProvider {
+
+    @Override
+    public Class[] getClasses() {
+        return new Class[] {
+                MigrationTestEntity.class,
+                MigrationTestJpaEntityProvider.class,
+                MigrationTestJpaEntityProviderFactory.class
+        };
+    }
+
+    @Override
+    public Map<String, String> getManifestResources() {
+        return Map.of(
+                "migration-test-changelog.xml", "migration-test-changelog.xml",
+                "services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory",
+                "services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory"
+        );
+    }
+}

--- a/quarkus/tests/integration/src/test-providers/resources/org/keycloak/it/jpa/migration/migration-test-changelog.xml
+++ b/quarkus/tests/integration/src/test-providers/resources/org/keycloak/it/jpa/migration/migration-test-changelog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet author="keycloak" id="migration-test-1.0">
+        <createTable tableName="MIGRATION_TEST_ENTITY">
+            <column name="ID" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="NAME" type="VARCHAR(255)"/>
+        </createTable>
+        <addPrimaryKey constraintName="PK_MIGRATION_TEST_ENTITY"
+                       tableName="MIGRATION_TEST_ENTITY"
+                       columnNames="ID"/>
+    </changeSet>
+</databaseChangeLog>

--- a/quarkus/tests/integration/src/test-providers/resources/org/keycloak/it/jpa/migration/services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory
+++ b/quarkus/tests/integration/src/test-providers/resources/org/keycloak/it/jpa/migration/services/org.keycloak.connections.jpa.entityprovider.JpaEntityProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.it.jpa.migration.MigrationTestJpaEntityProviderFactory

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManualMigrationCustomProviderDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ManualMigrationCustomProviderDistTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.it.cli.dist;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.keycloak.it.jpa.migration.MigrationTestProvider;
+import org.keycloak.it.junit5.extension.CLIResult;
+import org.keycloak.it.junit5.extension.DistributionTest;
+import org.keycloak.it.junit5.extension.KeycloakRunner;
+import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.TestProvider;
+import org.keycloak.it.utils.RawDistRootPath;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DistributionTest
+@RawDistOnly(reason = "Containers are immutable")
+@TestProvider(MigrationTestProvider.class)
+public class ManualMigrationCustomProviderDistTest {
+
+    @Test
+    void testCustomProviderChangesetExportedInManualMode(KeycloakRunner runner, RawDistRootPath rawDistRootPath) {
+        // The framework preinitializes the raw H2 distribution with the master changelog applied,
+        // so we only need to rebuild (to include the custom provider) and start in manual mode.
+        // Master is VALID, custom is OUTDATED → triggers the custom-only export path the fix addresses.
+        runner.run("build").assertBuild();
+
+        CLIResult startResult = runner.run("start", "--optimized",
+                "--spi-connections-jpa-quarkus-migration-strategy=manual",
+                "--spi-connections-jpa-quarkus-initialize-empty=false",
+                "--http-enabled=true", "--hostname-strict=false");
+
+        startResult.assertMessage("Database not up-to-date, please migrate database with");
+
+        File script = rawDistRootPath.getDistRootPath().resolve("bin").resolve("keycloak-database-update.sql").toFile();
+        assertTrue(script.isFile(), "Export file must exist when migration-strategy=manual");
+
+        String output;
+        try {
+            output = FileUtils.readFileToString(script, Charset.defaultCharset());
+        } catch (IOException e) {
+            throw new AssertionError("Failed to read keycloak-database-update.sql", e);
+        }
+
+        assertThat(output, containsString("MIGRATION_TEST_ENTITY"));
+    }
+}


### PR DESCRIPTION
## What this PR does

`Writer exportWriter` in `QuarkusJpaUpdaterProvider.update(Connection, File, String)` is now initialized once at the top of the method, instead of inside the `if (needVerifyMasterChangelog())` branch. The same writer is used for both the master changelog and the custom `JpaEntityProvider` loop, so `migration-strategy=manual` correctly writes the export file (and avoids applying DDL directly) when only custom-provider changesets are pending and the master is skipped.

Resource handling is unchanged. The writer is still closed in the existing `finally` block.

## Why

See #49057 for the full root-cause walkthrough. Short version: when `MIGRATION_MODEL.version` equals `Version.VERSION`, the master branch is skipped, so the writer never gets initialized. The custom-provider loop then calls `updateChangeSet(liquibase, null)` and Liquibase applies the DDL directly, which silently breaks the DBA workflow that `manual` mode is supposed to guarantee.

## How it was tested

I built the patched class, swapped it into a Keycloak 26.6.1 image, and ran the matrix from the issue against PostgreSQL 15 with one custom `JpaEntityProvider` contributing its own changelog. The only row that changes versus the unpatched image is the bug case:

| `MIGRATION_MODEL.version` | Pending             | Strategy   | Before              | After                  |
| ------------------------- | ------------------- | ---------- | ------------------- | ---------------------- |
| mismatch                  | master              | manual     | export OK           | export OK              |
| mismatch                  | master + custom     | manual     | export OK           | export OK              |
| match                     | custom-only         | **manual** | **DDL applied 🐛**  | **export OK, no DDL**  |
| match                     | custom-only         | validate   | error thrown        | error thrown           |
| match                     | custom-only         | update     | DDL applied         | DDL applied            |

To make the export file easy to inspect without `kubectl cp`, I used a small entrypoint wrapper that `cat`s `KC_SPI_CONNECTIONS_JPA__QUARKUS__MIGRATION_EXPORT` to stdout when the server exits. That wrapper is not part of this PR, it is just how I read the file during verification. With the fix in place the file contains the expected `ALTER TABLE` / `CREATE INDEX` / `INSERT INTO databasechangelog_<provider>` statements. Without the fix the file is empty or missing and the schema is mutated.

## Notes on the contribution checklist

* **Automated test.** There is no existing test that exercises `QuarkusJpaUpdaterProvider` with `migration-strategy=manual` against a custom `JpaEntityProvider`, so a regression test needs new fixtures (a custom provider plus a separate changelog). Happy to add one in a follow-up if you want, just tell me which style you prefer (a unit test on `update(...)` with mocked Liquibase, or an integration test under `testsuite/`). The matrix above covers the four behavioural paths of `update(...)` end-to-end.
* **Spotless.** `./mvnw spotless:check` is clean on the change.
* **Documentation.** No docs update is included. `migration-strategy=manual` already documents the intended behaviour, this PR closes an implementation gap rather than changing the contract.

## AI disclosure

I used an AI assistant (Anthropic Claude) to help read through `QuarkusJpaUpdaterProvider` and `QuarkusJpaConnectionProviderFactory`, pinpoint the `exportWriter` scope issue, draft the issue/PR text, and run the empirical matrix above. The four-line code change itself I reviewed and understand, and I can answer follow-up questions or revise it independently.

## Closes

Closes #49057
