### PR TITLE
Add bottom padding on Authorization Evaluate results page

### DIFF
--- a/js/apps/admin-ui/src/clients/authorization/evaluate/Results.tsx
+++ b/js/apps/admin-ui/src/clients/authorization/evaluate/Results.tsx
@@ -85,7 +85,7 @@ export const Results = ({ evaluateResult, refresh, back }: ResultProps) => {
   const noFilteredData = filteredResources.length === 0;
 
   return (
-    <PageSection>
+    <PageSection style={{ paddingBottom: "var(--pf-v5-global--spacer--4xl)" }}>
       <Toolbar>
         <ToolbarGroup className="providers-toolbar">
           <ToolbarItem>


### PR DESCRIPTION
## Body
On Clients > Authorization > Evaluate, the last resource row in the results list is hidden behind the fixed action bar at the bottom of the screen. This adds bottom padding to the results page so the last row stays visible above the bar.

AI usage: used Claude / OpenCode to investigate the layout and draft this text. Reviewed and understood the one-line change.

## Video Result
[evaluate-resource-list-padding-fixed.webm](https://github.com/user-attachments/assets/9c9a8f9d-1756-4f5f-9659-f2fa57f85863)

## Closes
Closes #49063

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
