### PR TITLE
Align LDAP searchScope default value with intended backend default

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/LDAPStorageProviderFactory.java
@@ -164,7 +164,7 @@ public class LDAPStorageProviderFactory implements UserStorageProviderFactory<LD
                 .add()
                 .property().name(LDAPConstants.SEARCH_SCOPE)
                 .type(ProviderConfigProperty.STRING_TYPE)
-                .defaultValue("1")
+                .defaultValue("2")
                 .add()
                 .property().name(LDAPConstants.VALIDATE_PASSWORD_POLICY)
                 .type(ProviderConfigProperty.BOOLEAN_TYPE)

--- a/js/apps/admin-ui/src/clients/add/__tests__/mock-serverinfo.json
+++ b/js/apps/admin-ui/src/clients/add/__tests__/mock-serverinfo.json
@@ -4440,7 +4440,7 @@
               {
                  "name":"searchScope",
                  "type":"String",
-                 "defaultValue":"1",
+                 "defaultValue":"2",
                  "secret":false
               },
               {

--- a/js/apps/admin-ui/src/context/server-info/__tests__/mock.json
+++ b/js/apps/admin-ui/src/context/server-info/__tests__/mock.json
@@ -3545,7 +3545,7 @@
           {
             "name": "searchScope",
             "type": "String",
-            "defaultValue": "1",
+            "defaultValue": "2",
             "secret": false
           },
           {

--- a/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsSearching.tsx
+++ b/js/apps/admin-ui/src/user-federation/ldap/LdapSettingsSearching.tsx
@@ -115,7 +115,7 @@ export const LdapSettingsSearching = ({
           label={t("searchScope")}
           labelIcon={t("searchScopeHelp")}
           controller={{
-            defaultValue: "1",
+            defaultValue: "2",
           }}
           options={[
             { key: "1", value: t("oneLevel") },


### PR DESCRIPTION
### Changes
The Admin UI defaulted Search scope to One Level (`1`) when creating a new LDAP provider, but the backend has intended Subtree (`2`) as the default since v1.3. This caused one-level to be persisted silently for any provider created without explicitly changing the field. The update to `LdapSettingsSearching.tsx` ensures the new default Search scope is Subtree (`2`).

The `LdapSettingsSearching.tsx` change is the UI fix users will see. `LDAPStorageProviderFactory` is updated for consistency, as its declared `defaultValue` also contradicted the intended default and is the value serialized into the server-info response consumed by API clients. This change is not visible, but I happened to notice it while digging into this.

The two mock JSON fixtures are updated to match. No new test added, since the change is a single default value correction and the existing mocks are updated to reflect it.

### Testing
Run the JS unit tests to verify the mock fixture updates:
```
cd js/apps/admin-ui && pnpm test
```
Manual:
1. Navigate to User Federation → Add provider → ldap
2. Scroll to the "Search scope" field
3. Verify the default selection is Subtree (previously One Level)

Closes #48996