### PR TITLE
fix: handle missing realm gracefully in UserStorageEventListener.java

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageEventListener.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageEventListener.java
@@ -39,6 +39,10 @@ public final class UserStorageEventListener implements ClusterListener, Provider
             RealmModel realm = session.realms().getRealm(realmId);
 
             if (realm == null) {
+                if (fedEvent.isRemoved()) {
+                    logger.debugf("Realm with id %s not found when handling user storage removal event, it may have been deleted already", realmId);
+                    return;
+                }
                 throw new RuntimeException("Failed to execute session task. Realm with id " + realmId + " not found.");
             }
 


### PR DESCRIPTION
## Summary
Fixes #48904

## Problem
When a realm is deleted via the REST API, Keycloak fires a cluster 
event for each of its User Storage providers (e.g. LDAP). The 
UserStorageEventListener receives this event asynchronously. By this 
time, the realm is already deleted from the database, so getRealm() 
returns null.

The current code unconditionally throws a RuntimeException when realm 
is null, which propagates as HTTP 500 on the DELETE response even 
though the deletion actually succeeded.

## Fix
Added an isRemoved() check before throwing. When the event is a 
removal event and realm is null, we log a debug message and return 
cleanly instead of throwing. This restores the behaviour of the 
original UserStorageSyncManager code before the regression introduced 
in commit 96aea99.

## Testing
1. Start Keycloak
2. Create a realm with an LDAP User Federation provider
3. Call DELETE /admin/realms/{realm} via REST API
4. Before fix: returns 500
5. After fix: returns 204 No Content