### PR TITLE
Block account resource sharing when UMA is disabled 

### DIFF
--- a/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/permission/UMAPolicyProvider.java
+++ b/authz/policy/common/src/main/java/org/keycloak/authorization/policy/provider/permission/UMAPolicyProvider.java
@@ -32,7 +32,6 @@ public class UMAPolicyProvider extends AbstractPermissionProvider {
 
     @Override
     public void evaluate(Evaluation evaluation) {
-        logger.debugf("UMA policy %s evaluating using parent class", evaluation.getPolicy().getName());
         ResourcePermission permission = evaluation.getPermission();
         Resource resource = permission.getResource();
 
@@ -46,6 +45,13 @@ public class UMAPolicyProvider extends AbstractPermissionProvider {
                 return;
             }
         }
+
+        if (!evaluation.getAuthorizationProvider().getRealm().isUserManagedAccessAllowed()) {
+            logger.debugf("UMA policy %s skipped because user-managed access is disabled for the realm", evaluation.getPolicy().getName());
+            return;
+        }
+
+        logger.debugf("UMA policy %s evaluating using parent class", evaluation.getPolicy().getName());
 
         super.evaluate(evaluation);
     }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -222,6 +223,9 @@ public class AccountRestService {
     @Path("/resources")
     public ResourcesService resources() {
         checkAccountApiEnabled();
+        if (!realm.isUserManagedAccessAllowed()) {
+            throw new ForbiddenException();
+        }
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.VIEW_PROFILE);
         return new ResourcesService(session, user, auth, request);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
@@ -33,6 +33,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.Configuration;
 import org.keycloak.common.Profile;
@@ -46,6 +47,9 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
+import org.keycloak.representations.idm.authorization.AuthorizationResponse;
+import org.keycloak.representations.idm.authorization.PermissionRequest;
 import org.keycloak.representations.idm.authorization.PermissionTicketRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
@@ -500,6 +504,43 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
     }
 
     @Test
+    public void testResourcesApiBlockedWhenUserManagedAccessDisabled() throws Exception {
+        Resource resource = getMyResources().get(0);
+        final String resourcesUrl = getAccountUrl("resources");
+        final String resourceUrl = resourcesUrl + "/" + encodePathAsIs(resource.getId());
+        final String permissionsUrl = resourceUrl + "/permissions";
+
+        assertCanAuthorizeWithUmaGrant("alice", resource.getId(), "Scope A");
+        String permissionTicket = createPermissionTicket(resource.getId(), "Scope A");
+
+        setUserManagedAccessAllowed(false);
+        try {
+            for (String url : Arrays.asList(
+                    resourcesUrl,
+                    resourcesUrl + "/shared-with-me",
+                    resourcesUrl + "/shared-with-others",
+                    resourcesUrl + "/pending-requests",
+                    resourceUrl,
+                    permissionsUrl,
+                    permissionsUrl + "/requests",
+                    resourceUrl + "/user?value=alice")) {
+                assertEquals(Response.Status.FORBIDDEN.getStatusCode(),
+                        SimpleHttpDefault.doGet(url, httpClient).acceptJson().auth(tokenUtil.getToken()).asStatus(),
+                        "GET " + url);
+            }
+
+            assertEquals(Response.Status.FORBIDDEN.getStatusCode(),
+                    SimpleHttpDefault.doPut(permissionsUrl, httpClient).acceptJson().auth(tokenUtil.getToken())
+                            .json(Arrays.asList(new Permission("jdoe", "Scope A"))).asStatus(),
+                    "PUT " + permissionsUrl);
+
+            assertCannotAuthorizeWithUmaGrant("alice", permissionTicket);
+        } finally {
+            setUserManagedAccessAllowed(true);
+        }
+    }
+
+    @Test
     public void testRevokePermission() throws Exception {
         List<String> users = Arrays.asList("jdoe", "alice");
         List<Permission> permissions = new ArrayList<>();
@@ -759,6 +800,34 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
                 .create(new Configuration(suiteContext.getAuthServerInfo().getContextRoot().toString() + "/auth",
                         managedRealm.admin().toRepresentation().getRealm(), client.getClientId(),
                         credentials, httpClient));
+    }
+
+    private void setUserManagedAccessAllowed(boolean allowed) {
+        RealmRepresentation realm = managedRealm.admin().toRepresentation();
+        realm.setUserManagedAccessAllowed(allowed);
+        managedRealm.admin().update(realm);
+    }
+
+    private void assertCanAuthorizeWithUmaGrant(String userName, String resourceId, String scope) {
+        AuthorizationResponse response = authzClient.authorization(userName, "password")
+                .authorize(new AuthorizationRequest(createPermissionTicket(resourceId, scope)));
+
+        assertNotNull(response.getToken());
+    }
+
+    private void assertCannotAuthorizeWithUmaGrant(String userName, String permissionTicket) {
+        try {
+            authzClient.authorization(userName, "password")
+                    .authorize(new AuthorizationRequest(permissionTicket));
+            fail("User-managed access grant should not authorize the requester when UMA is disabled");
+        } catch (AuthorizationDeniedException expected) {
+            // expected
+        }
+    }
+
+    private String createPermissionTicket(String resourceId, String scope) {
+        return authzClient.protection("test-authz-user@localhost", "password").permission()
+                .create(new PermissionRequest(resourceId, scope)).getTicket();
     }
 
     private UserRepresentation createUser(String userName, String password, String firstName, String lastName, String email) {


### PR DESCRIPTION
Fixes: #48987

**Summary**

This PR enforces the `userManagedAccessAllowed` realm setting on Account API resource-sharing operations.

When user-managed access is disabled for a realm, the Account Console hides resource sharing, but the backend Account API resource endpoints could still be called directly. This change blocks access to `/realms/{realm}/account/resources` when UMA is disabled and prevents existing UMA user-managed sharing grants from being used for authorization while the setting is disabled.

**Changes**

- Return `403 Forbidden` from the Account API resources endpoint when `userManagedAccessAllowed=false`
- Skip UMA policy evaluation for user-managed grants when UMA is disabled
- Add regression coverage for blocked Account API resource operations and UMA authorization behavior

**Verification**

- `git diff --check`
- `./mvnw -pl services,authz/policy/common -am -DskipTests -DskipITs compile`