### PR TITLE
[OID4VCI-HAIP] Revisit ABCA in connection with fapi-2-dpop-security-profile

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureClientUrisExecutor.java
@@ -41,19 +41,32 @@ import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
 import org.keycloak.services.clientpolicy.context.DynamicClientRegisterContext;
 import org.keycloak.services.clientpolicy.context.DynamicClientUpdateContext;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jboss.logging.Logger;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class SecureClientUrisExecutor implements ClientPolicyExecutorProvider<ClientPolicyExecutorConfigurationRepresentation> {
+public class SecureClientUrisExecutor implements ClientPolicyExecutorProvider<SecureClientUrisExecutor.Configuration> {
 
     private static final Logger logger = Logger.getLogger(SecureClientUrisExecutor.class);
 
     private final KeycloakSession session;
+    private Configuration configuration;
+
 
     public SecureClientUrisExecutor(KeycloakSession session) {
         this.session = session;
+    }
+
+    @Override
+    public void setupConfiguration(Configuration config) {
+        this.configuration = config;
+    }
+
+    @Override
+    public Class<Configuration> getExecutorConfigurationClass() {
+        return Configuration.class;
     }
 
     @Override
@@ -180,8 +193,14 @@ public class SecureClientUrisExecutor implements ClientPolicyExecutorProvider<Cl
         }
 
         logger.tracev("Redirect URI = {0}", redirectUri);
-        if (!redirectUri.startsWith("https://") || redirectUri.contains("*")) {
+        if (redirectUri.contains("*")) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Invalid redirect_uri");
+        }
+        if (!redirectUri.startsWith("https://")) {
+            boolean isRedirectToLocalhost = redirectUri.startsWith("http://localhost") || redirectUri.startsWith("http://127.0.0.1");
+            if (!configuration.allowHttpOnLocalhost || !isRedirectToLocalhost) {
+                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "Invalid redirect_uri");
+            }
         }
     }
 
@@ -192,5 +211,19 @@ public class SecureClientUrisExecutor implements ClientPolicyExecutorProvider<Cl
         }
         Set<String> resolvedUrls = RedirectUtils.resolveUrlsWithRedirects(session, originalUrls, rootUrl, redirectUris, returnAsOrigins);
         return new ArrayList<>(resolvedUrls);
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+
+        @JsonProperty("allow-http-on-localhost")
+        protected boolean allowHttpOnLocalhost;
+
+        public boolean getAllowHttpOnLocalhost() {
+            return allowHttpOnLocalhost;
+        }
+
+        public void setAllowHttpOnLocalhost(boolean allowHttpOnLocalhost) {
+            this.allowHttpOnLocalhost = allowHttpOnLocalhost;
+        }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -61,6 +61,7 @@ import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcNonceRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.PreAuthorizedCodeGrantRequest;
 import org.keycloak.util.DPoPGenerator;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.util.TokenUtil;
 
 import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
@@ -363,7 +364,7 @@ public class OID4VCBasicWallet {
         return request;
     }
 
-    public Oid4vcCredentialRequest credentialRequest(OID4VCTestContext ctx, String accessToken) {
+    public Oid4vcCredentialRequest credentialRequest(OID4VCTestContext ctx, String tokenType, String accessToken) {
         Oid4vcCredentialRequest request = new Oid4vcCredentialRequest(oauth, new CredentialRequest()) {
             public Oid4vcCredentialResponse send() {
                 Oid4vcCredentialResponse response = super.send();
@@ -371,8 +372,12 @@ public class OID4VCBasicWallet {
                 return response;
             }
         };
-        request.bearerToken(accessToken);
+        request.authToken(tokenType, accessToken);
         return request;
+    }
+
+    public Oid4vcCredentialRequest credentialRequest(OID4VCTestContext ctx, String accessToken) {
+        return credentialRequest(ctx, TokenUtil.TOKEN_TYPE_BEARER, accessToken);
     }
 
     public Oid4vcCredentialResponse fetchCredentialByOffer(OID4VCTestContext ctx, CredentialsOffer offer) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -71,6 +71,17 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.services.clientpolicy.executor.ConfidentialClientAcceptExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.DPoPBindEnforcerExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.PKCEEnforcerExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.RejectImplicitGrantExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticationAssertionExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientAuthenticatorExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureClientUrisExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureParContentsExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmExecutorFactory;
+import org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtExecutorFactory;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectEvents;
@@ -156,6 +167,7 @@ public abstract class OID4VCIssuerTestBase {
             .truncatedTo(ChronoUnit.SECONDS);
     public static final Instant TEST_ISSUANCE_DATE = Instant.ofEpochSecond(1000);
 
+    public static final String VCI_CLIENT_POLICY_HAIP = "oid4vc-haip-policy";
     public static final String VCI_CLIENT_POLICY_OFFER_REQUIRED = "oid4vci-offer-required";
 
     @InjectRealm(config = VCTestRealmConfig.class)
@@ -605,10 +617,14 @@ public abstract class OID4VCIssuerTestBase {
             // Add Client Policies
             //
             ClientProfileRepresentation credentialIssuanceProfile = createClientProfileCredentialIssuance();
+            ClientProfileRepresentation haipConformanceProfile = createClientProfileHaipConformance();
             realm.clientProfile(credentialIssuanceProfile);
+            realm.clientProfile(haipConformanceProfile);
 
             ClientPolicyRepresentation offerRequiredPolicy = createClientPolicyOfferRequired(credentialIssuanceProfile);
+            ClientPolicyRepresentation haipConformancePolicy = createClientPolicyHaipConformance(haipConformanceProfile);
             realm.clientPolicy(offerRequiredPolicy);
+            realm.clientPolicy(haipConformancePolicy);
 
             return realm;
         }
@@ -624,6 +640,133 @@ public abstract class OID4VCIssuerTestBase {
             profile.setExecutors(List.of(executor));
 
             return profile;
+        }
+
+        private ClientProfileRepresentation createClientProfileHaipConformance() {
+
+            ClientProfileRepresentation profile = new ClientProfileRepresentation();
+            profile.setName("oid4vc-haip-profile"); // Modelled on fapi-2-dpop-security-profile
+            profile.setDescription("Client profile, which enforces clients to conform to the OpenID4VC High Assurance Interoperability Profile 1.0");
+
+            // confidential-client
+            //
+            ClientPolicyExecutorRepresentation confidentialClientEnforcer = new ClientPolicyExecutorRepresentation();
+            confidentialClientEnforcer.setExecutorProviderId(ConfidentialClientAcceptExecutorFactory.PROVIDER_ID);
+            confidentialClientEnforcer.setConfiguration(JsonNodeFactory.instance.objectNode());
+
+            // secure-client-authenticator
+            //
+            ClientPolicyExecutorRepresentation secureClientAuthenticator = new ClientPolicyExecutorRepresentation();
+            secureClientAuthenticator.setExecutorProviderId(SecureClientAuthenticatorExecutorFactory.PROVIDER_ID);
+            ObjectNode secureClientAuthenticatorConfig = JsonNodeFactory.instance.objectNode();
+            secureClientAuthenticatorConfig.putArray("allowed-client-authenticators")
+                    .add("client-jwt")
+                    .add("client-x509")
+                    .add("attestation-based"); // added for Attestation-Based Client Authentication (ABCA)
+            secureClientAuthenticatorConfig.put("default-client-authenticator", "attestation-based");
+            secureClientAuthenticator.setConfiguration(secureClientAuthenticatorConfig);
+
+            // secure-client-uris
+            //
+            ClientPolicyExecutorRepresentation secureClientUris = new ClientPolicyExecutorRepresentation();
+            secureClientUris.setExecutorProviderId(SecureClientUrisExecutorFactory.PROVIDER_ID);
+            secureClientUris.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("allow-http-on-localhost", true));
+
+            // secure-signature-algorithm
+            //
+            ClientPolicyExecutorRepresentation secureSigningAlgorithm = new ClientPolicyExecutorRepresentation();
+            secureSigningAlgorithm.setExecutorProviderId(SecureSigningAlgorithmExecutorFactory.PROVIDER_ID);
+            secureSigningAlgorithm.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("default-algorithm", "PS256"));
+
+            // consent-required (not used)
+            //
+
+            // secure-signature-algorithm-signed-jwt
+            //
+            ClientPolicyExecutorRepresentation secureSigningAlgorithmForSignedJwt = new ClientPolicyExecutorRepresentation();
+            secureSigningAlgorithmForSignedJwt.setExecutorProviderId(SecureSigningAlgorithmForSignedJwtExecutorFactory.PROVIDER_ID);
+            secureSigningAlgorithmForSignedJwt.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("require-client-assertion", false));
+
+            // full-scope-disabled
+            //
+            ClientPolicyExecutorRepresentation fullScopeDisabled = new ClientPolicyExecutorRepresentation();
+            fullScopeDisabled.setExecutorProviderId(FullScopeDisabledExecutorFactory.PROVIDER_ID);
+            fullScopeDisabled.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            // reject-implicit-grant
+            //
+            ClientPolicyExecutorRepresentation rejectImplicitGrant = new ClientPolicyExecutorRepresentation();
+            rejectImplicitGrant.setExecutorProviderId(RejectImplicitGrantExecutorFactory.PROVIDER_ID);
+            rejectImplicitGrant.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            // pkce-enforcer
+            //
+            ClientPolicyExecutorRepresentation pkceEnforcer = new ClientPolicyExecutorRepresentation();
+            pkceEnforcer.setExecutorProviderId(PKCEEnforcerExecutorFactory.PROVIDER_ID);
+            pkceEnforcer.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false));
+
+            // secure-client-authentication-assertion
+            //
+            ClientPolicyExecutorRepresentation secureClientAuthenticationAssertion = new ClientPolicyExecutorRepresentation();
+            secureClientAuthenticationAssertion.setExecutorProviderId(SecureClientAuthenticationAssertionExecutorFactory.PROVIDER_ID);
+            secureClientAuthenticationAssertion.setConfiguration(JsonNodeFactory.instance.objectNode());
+
+            // secure-par-content
+            //
+            ClientPolicyExecutorRepresentation secureParContents = new ClientPolicyExecutorRepresentation();
+            secureParContents.setExecutorProviderId(SecureParContentsExecutorFactory.PROVIDER_ID);
+            secureParContents.setConfiguration(JsonNodeFactory.instance.objectNode());
+
+            ClientPolicyExecutorRepresentation dpopBindEnforcerExecutor = new ClientPolicyExecutorRepresentation();
+            dpopBindEnforcerExecutor.setExecutorProviderId(DPoPBindEnforcerExecutorFactory.PROVIDER_ID);
+            dpopBindEnforcerExecutor.setConfiguration(JsonNodeFactory.instance.objectNode()
+                    .put("auto-configure", false)
+                    .put("enforce-authorization-code-binding-to-dpop", false)
+                    .put("allow-only-refresh-token-binding", false));
+
+            profile.setExecutors(List.of(
+                    confidentialClientEnforcer,
+                    secureClientAuthenticator,
+                    secureClientUris,
+                    secureSigningAlgorithm,
+                    secureSigningAlgorithmForSignedJwt,
+                    fullScopeDisabled,
+                    rejectImplicitGrant,
+                    pkceEnforcer,
+                    secureClientAuthenticationAssertion,
+                    secureParContents,
+                    dpopBindEnforcerExecutor
+            ));
+
+            return profile;
+        }
+
+        private ClientPolicyRepresentation createClientPolicyHaipConformance(ClientProfileRepresentation profile) {
+
+            ClientPolicyRepresentation policy = new ClientPolicyRepresentation();
+            policy.setName(VCI_CLIENT_POLICY_HAIP);
+            policy.setDescription("Client policy that enables the oid4vc-haip-profile");
+            policy.setEnabled(false);
+
+            ClientPolicyConditionRepresentation condition = new ClientPolicyConditionRepresentation();
+            condition.setConditionProviderId("client-attributes");
+            ObjectNode config = JsonNodeFactory.instance.objectNode();
+            config.put("attributes", JsonSerialization.valueAsString(List.of(Map.of(
+                    "key", OID4VCI_ENABLED_ATTRIBUTE_KEY,
+                    "value", String.valueOf(true)
+            ))));
+            condition.setConfiguration(config);
+
+            policy.setConditions(List.of(condition));
+            policy.setProfiles(List.of(profile.getName()));
+
+            return policy;
         }
 
         private ClientPolicyRepresentation createClientPolicyOfferRequired(ClientProfileRepresentation profile) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
@@ -40,6 +40,8 @@ import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.testsuite.util.oauth.ParResponse;
+import org.keycloak.testsuite.util.oauth.PkceGenerator;
 import org.keycloak.util.JsonSerialization;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -143,6 +145,10 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
         String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw);
 
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+
+        // Send Authorization Request
+        //
         AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
                 .scope(ctx.getScope())
                 .send(ctx.getHolder(), TEST_PASSWORD);
@@ -153,6 +159,8 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         String authCode = authResponse.getCode();
         assertNotNull(authCode, "No auth code");
 
+        // Send Token Request
+        //
         AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
                 .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
                 .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
@@ -170,15 +178,106 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         String credIdentifier = ctx.getAuthorizedCredentialIdentifier();
         assertNotNull(credIdentifier, "No credential identifier");
 
-        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        // Send Nonce Request
+        //
         String nonce = wallet.nonceRequest().send().getNonce();
         Proofs jwtProof = wallet.generateJwtProof(ctx, ecKey, nonce);
 
+        // Send Credential Request
+        //
         CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
                 .credentialIdentifier(credIdentifier)
                 .proofs(jwtProof)
                 .send().getCredentialResponse();
 
         assertFalse(credResponse.getCredentials().isEmpty(), "No credential");
+    }
+
+    @Test
+    public void testClientAttestationHappyFlow_HaipProfileEnabled() {
+
+        Boolean wasEnabled = getClientPolicy(VCI_CLIENT_POLICY_HAIP).isEnabled();
+        try {
+            setClientPolicyEnabled(VCI_CLIENT_POLICY_HAIP, true);
+
+            var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+            ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+            var kw = wallet.getRSAKeyPair(ctx);
+            String attestationJwt = wallet.buildClientAttestationJWT(ctx, kw);
+            String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, kw);
+
+            PkceGenerator pkce = PkceGenerator.s256();
+            KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+
+            // Send PAR Request
+            //
+            ParResponse parResponse = oauth.pushedAuthorizationRequest()
+                    .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                    .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                    .scopeParam(ctx.getScope())
+                    .codeChallenge(pkce)
+                    .send();
+
+            String errorDescription = parResponse.getErrorDescription();
+            assertNull(errorDescription, "PAR request error: " + errorDescription);
+
+            String requestUri = parResponse.getRequestUri();
+            assertNotNull(requestUri, "No requestUri");
+
+            // Send Authorization Request
+            //
+            AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                    .scope(ctx.getScope())
+                    .codeChallenge(pkce)
+                    .requestUri(requestUri)
+                    .send(ctx.getHolder(), TEST_PASSWORD);
+
+            errorDescription = authResponse.getErrorDescription();
+            assertNull(errorDescription, "Authorization error: " + errorDescription);
+
+            String authCode = authResponse.getCode();
+            assertNotNull(authCode, "No auth code");
+
+            // Send Token Request
+            //
+            String tokenEndpoint = oauth.getEndpoints().getToken();
+            AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
+                    .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                    .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                    .dpopProof(wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null))
+                    .codeVerifier(pkce)
+                    .send();
+
+            errorDescription = tokenResponse.getErrorDescription();
+            assertNull(errorDescription, "Token request error: " + errorDescription);
+
+            String tokenType = tokenResponse.getTokenType();
+            assertNotNull(tokenType, "No token type");
+
+            String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+            assertNotNull(accessToken, "No access token");
+
+            String credIdentifier = ctx.getAuthorizedCredentialIdentifier();
+            assertNotNull(credIdentifier, "No credential identifier");
+
+            // Send Nonce Request
+            //
+            String nonce = wallet.nonceRequest().send().getNonce();
+
+            // Send Credential Request
+            //
+            String credentialEndpoint = oauth.getEndpoints().getOid4vcCredential();
+            CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenType, accessToken)
+                    .credentialIdentifier(credIdentifier)
+                    .dpopProof(wallet.generateSignedDPoPProof(credentialEndpoint, ecKey, accessToken))
+                    .proofs(wallet.generateJwtProof(ctx, ecKey, nonce))
+                    .send().getCredentialResponse();
+
+            assertFalse(credResponse.getCredentials().isEmpty(), "No credential");
+
+        } finally {
+            setClientPolicyEnabled(VCI_CLIENT_POLICY_HAIP, wasEnabled);
+        }
     }
 }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractHttpPostRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractHttpPostRequest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.util.BasicAuthHelper;
+import org.keycloak.util.TokenUtil;
 import org.keycloak.utils.MediaType;
 
 import org.apache.http.HttpEntity;
@@ -28,7 +29,8 @@ public abstract class AbstractHttpPostRequest<T, R> {
     protected String clientAssertion;
     protected String clientAssertionType;
 
-    protected String bearerToken;
+    protected String tokenType;
+    protected String tokenValue;
 
     protected HttpPost post;
 
@@ -89,7 +91,16 @@ public abstract class AbstractHttpPostRequest<T, R> {
     }
 
     public T bearerToken(String token) {
-        this.bearerToken = token;
+        return authToken(TokenUtil.TOKEN_TYPE_BEARER, token);
+    }
+
+    public T dpopToken(String token) {
+        return authToken(TokenUtil.TOKEN_TYPE_DPOP, token);
+    }
+
+    public T authToken(String type, String token) {
+        this.tokenType = type;
+        this.tokenValue = token;
         return request();
     }
 
@@ -137,8 +148,8 @@ public abstract class AbstractHttpPostRequest<T, R> {
         if (clientAssertion != null && clientAssertionType != null) {
             parameter("client_assertion_type", clientAssertionType);
             parameter("client_assertion", clientAssertion);
-        } else if (bearerToken != null) {
-            header("Authorization", "Bearer " + bearerToken);
+        } else if (tokenType != null && tokenValue != null) {
+            header("Authorization", tokenType + " " + tokenValue);
         } else if (clientSecret != null) {
             String authorization = BasicAuthHelper.RFC6749.createHeader(clientId, clientSecret);
             header("Authorization", authorization);


### PR DESCRIPTION
closes #49123

-- Allow http (instead of https) requests to localhost
-- Add oid4vc-haip-profile based on fapi-2-dpop-security-profile to test base
