### PR TITLE
Add GET /admin/realms/{realm}/clients/count endpoint

### DIFF
--- a/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
+++ b/integration/admin-client-core/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
@@ -68,6 +68,16 @@ public interface ClientsResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<ClientRepresentation> query(@QueryParam("q") String searchQuery);
 
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    Long count();
+
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    Long count(@QueryParam("search") String search, @QueryParam("q") String searchQuery);
+
     @Path("{id}")
     @DELETE
     Response delete(@PathParam("id") String id);

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/ClientsResource.java
@@ -68,6 +68,16 @@ public interface ClientsResource {
     @Produces(MediaType.APPLICATION_JSON)
     List<ClientRepresentation> query(@QueryParam("q") String searchQuery);
 
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    Long count();
+
+    @GET
+    @Path("count")
+    @Produces(MediaType.APPLICATION_JSON)
+    Long count(@QueryParam("search") String search, @QueryParam("q") String searchQuery);
+
     @Path("{id}")
     @DELETE
     Response delete(@PathParam("id") String id);

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -926,8 +926,18 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
+    public long searchClientByClientIdCount(String clientId) {
+        return cacheSession.getClientDelegate().searchClientsByClientIdCount(this, clientId);
+    }
+
+    @Override
     public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
         return cacheSession.searchClientsByAttributes(this, attributes, firstResult, maxResults);
+    }
+
+    @Override
+    public long searchClientByAttributesCount(Map<String, String> attributes) {
+        return cacheSession.getClientDelegate().searchClientsByAttributesCount(this, attributes);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/RealmAdapter.java
@@ -929,8 +929,18 @@ public class RealmAdapter implements CachedRealmModel {
     }
 
     @Override
+    public long searchClientByClientIdCount(String clientId) {
+        return cacheSession.getClientDelegate().searchClientsByClientIdCount(this, clientId);
+    }
+
+    @Override
     public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
         return cacheSession.searchClientsByAttributes(this, attributes, firstResult, maxResults);
+    }
+
+    @Override
+    public long searchClientByAttributesCount(Map<String, String> attributes) {
+        return cacheSession.getClientDelegate().searchClientsByAttributesCount(this, attributes);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -728,6 +728,79 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     }
 
     @Override
+    public long searchClientsByClientIdCount(RealmModel realm, String clientId) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> queryBuilder = builder.createQuery(Long.class);
+        Root<ClientEntity> root = queryBuilder.from(ClientEntity.class);
+
+        queryBuilder.select(builder.count(root.get("id")));
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        predicates.add(builder.equal(root.get("realmId"), realm.getId()));
+        predicates.add(builder.like(builder.lower(root.get("clientId")), builder.lower(builder.literal("%" + clientId + "%"))));
+        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.CLIENTS, realm, builder, queryBuilder, root));
+
+        queryBuilder.where(predicates.toArray(new Predicate[0]));
+
+        return em.createQuery(queryBuilder).getSingleResult();
+    }
+
+    @Override
+    public long searchClientsByAttributesCount(RealmModel realm, Map<String, String> attributes) {
+        Map<String, String> filteredAttributes = attributes;
+        if (clientSearchableAttributes != null) {
+            Set<String> notAllowed = attributes.keySet().stream().filter(attr -> !clientSearchableAttributes.contains(attr)).collect(Collectors.toSet());
+            if (!notAllowed.isEmpty()) {
+                throw new ModelException("Attributes [" + String.join(", ", notAllowed) + "] not allowed for search");
+            }
+            filteredAttributes = attributes.entrySet().stream().filter(e -> clientSearchableAttributes.contains(e.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> queryBuilder = builder.createQuery(Long.class);
+        Root<ClientEntity> root = queryBuilder.from(ClientEntity.class);
+
+        queryBuilder.select(builder.count(root.get("id")));
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        predicates.add(builder.equal(root.get("realmId"), realm.getId()));
+
+        //noinspection resource
+        String dbProductName = em.unwrap(Session.class).doReturningWork(connection -> connection.getMetaData().getDatabaseProductName());
+
+        for (Map.Entry<String, String> entry : filteredAttributes.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            Join<ClientEntity, ClientAttributeEntity> attributeJoin = root.join("attributes");
+
+            Predicate attrNamePredicate = builder.equal(attributeJoin.get("name"), key);
+
+            if (dbProductName.equals("Oracle")) {
+                Predicate attrValuePredicate = builder.equal(builder.function("DBMS_LOB.COMPARE", Integer.class, attributeJoin.get("value"), builder.literal(value)), 0);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate));
+            } else if (dbProductName.equals("PostgreSQL")) {
+                Predicate attrValuePredicate1 = builder.equal(
+                        builder.function("substr", Integer.class, attributeJoin.get("value"), builder.literal(1), builder.literal(255)),
+                        builder.function("substr", Integer.class, builder.literal(value), builder.literal(1), builder.literal(255)));
+                Predicate attrValuePredicate2 = builder.equal(attributeJoin.get("value"), value);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate1, attrValuePredicate2));
+            } else {
+                Predicate attrValuePredicate = builder.equal(attributeJoin.get("value"), value);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate));
+            }
+        }
+
+        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.CLIENTS, realm, builder, queryBuilder, root));
+
+        queryBuilder.where(predicates.toArray(new Predicate[0]));
+
+        return em.createQuery(queryBuilder).getSingleResult();
+    }
+
+    @Override
     public Long getGroupsCountByNameContaining(RealmModel realm, String search) {
         return searchForGroupByNameStream(realm, search, false, null, null).count();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaRealmProvider.java
@@ -771,6 +771,79 @@ public class JpaRealmProvider implements RealmProvider, ClientProvider, ClientSc
     }
 
     @Override
+    public long searchClientsByClientIdCount(RealmModel realm, String clientId) {
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> queryBuilder = builder.createQuery(Long.class);
+        Root<ClientEntity> root = queryBuilder.from(ClientEntity.class);
+
+        queryBuilder.select(builder.count(root.get("id")));
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        predicates.add(builder.equal(root.get("realmId"), realm.getId()));
+        predicates.add(builder.like(builder.lower(root.get("clientId")), builder.lower(builder.literal("%" + clientId + "%"))));
+        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.CLIENTS, realm, builder, queryBuilder, root));
+
+        queryBuilder.where(predicates.toArray(new Predicate[0]));
+
+        return em.createQuery(queryBuilder).getSingleResult();
+    }
+
+    @Override
+    public long searchClientsByAttributesCount(RealmModel realm, Map<String, String> attributes) {
+        Map<String, String> filteredAttributes = attributes;
+        if (clientSearchableAttributes != null) {
+            Set<String> notAllowed = attributes.keySet().stream().filter(attr -> !clientSearchableAttributes.contains(attr)).collect(Collectors.toSet());
+            if (!notAllowed.isEmpty()) {
+                throw new ModelException("Attributes [" + String.join(", ", notAllowed) + "] not allowed for search");
+            }
+            filteredAttributes = attributes.entrySet().stream().filter(e -> clientSearchableAttributes.contains(e.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<Long> queryBuilder = builder.createQuery(Long.class);
+        Root<ClientEntity> root = queryBuilder.from(ClientEntity.class);
+
+        queryBuilder.select(builder.count(root.get("id")));
+
+        List<Predicate> predicates = new ArrayList<>();
+
+        predicates.add(builder.equal(root.get("realmId"), realm.getId()));
+
+        //noinspection resource
+        String dbProductName = em.unwrap(Session.class).doReturningWork(connection -> connection.getMetaData().getDatabaseProductName());
+
+        for (Map.Entry<String, String> entry : filteredAttributes.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            Join<ClientEntity, ClientAttributeEntity> attributeJoin = root.join("attributes");
+
+            Predicate attrNamePredicate = builder.equal(attributeJoin.get("name"), key);
+
+            if (dbProductName.equals("Oracle")) {
+                Predicate attrValuePredicate = builder.equal(builder.function("DBMS_LOB.COMPARE", Integer.class, attributeJoin.get("value"), builder.literal(value)), 0);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate));
+            } else if (dbProductName.equals("PostgreSQL")) {
+                Predicate attrValuePredicate1 = builder.equal(
+                        builder.function("substr", Integer.class, attributeJoin.get("value"), builder.literal(1), builder.literal(255)),
+                        builder.function("substr", Integer.class, builder.literal(value), builder.literal(1), builder.literal(255)));
+                Predicate attrValuePredicate2 = builder.equal(attributeJoin.get("value"), value);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate1, attrValuePredicate2));
+            } else {
+                Predicate attrValuePredicate = builder.equal(attributeJoin.get("value"), value);
+                predicates.add(builder.and(attrNamePredicate, attrValuePredicate));
+            }
+        }
+
+        predicates.addAll(AdminPermissionsSchema.SCHEMA.applyAuthorizationFilters(session, AdminPermissionsSchema.CLIENTS, realm, builder, queryBuilder, root));
+
+        queryBuilder.where(predicates.toArray(new Predicate[0]));
+
+        return em.createQuery(queryBuilder).getSingleResult();
+    }
+
+    @Override
     public Long getGroupsCountByNameContaining(RealmModel realm, String search) {
         return searchForGroupByNameStream(realm, search, false, null, null).count();
     }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -901,8 +901,18 @@ public class RealmAdapter implements StorageProviderRealmModel, JpaModel<RealmEn
     }
 
     @Override
+    public long searchClientByClientIdCount(String clientId) {
+        return session.clients().searchClientsByClientIdCount(this, clientId);
+    }
+
+    @Override
     public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
         return session.clients().searchClientsByAttributes(this, attributes, firstResult, maxResults);
+    }
+
+    @Override
+    public long searchClientByAttributesCount(Map<String, String> attributes) {
+        return session.clients().searchClientsByAttributesCount(this, attributes);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/RealmAdapter.java
@@ -852,8 +852,18 @@ public class RealmAdapter implements StorageProviderRealmModel, JpaModel<RealmEn
     }
 
     @Override
+    public long searchClientByClientIdCount(String clientId) {
+        return session.clients().searchClientsByClientIdCount(this, clientId);
+    }
+
+    @Override
     public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
         return session.clients().searchClientsByAttributes(this, attributes, firstResult, maxResults);
+    }
+
+    @Override
+    public long searchClientByAttributesCount(Map<String, String> attributes) {
+        return session.clients().searchClientsByAttributesCount(this, attributes);
     }
 
     @Override

--- a/model/storage-private/src/main/java/org/keycloak/storage/ClientStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/ClientStorageManager.java
@@ -169,6 +169,34 @@ public class ClientStorageManager implements ClientProvider {
     }
 
     @Override
+    public long searchClientsByClientIdCount(RealmModel realm, String clientId) {
+        // the local storage count always comes from the database COUNT query; only the (typically much
+        // smaller) external-provider contribution needs to be reified into a stream and counted in memory
+        return localStorage().searchClientsByClientIdCount(realm, clientId)
+                + countFromExternalProviders(realm, (p, f, m) -> p.searchClientsByClientIdStream(realm, clientId, f, m));
+    }
+
+    @Override
+    public long searchClientsByAttributesCount(RealmModel realm, Map<String, String> attributes) {
+        return localStorage().searchClientsByAttributesCount(realm, attributes)
+                + countFromExternalProviders(realm, (p, f, m) -> p.searchClientsByAttributes(realm, attributes, f, m));
+    }
+
+    private long countFromExternalProviders(RealmModel realm, PaginatedQuery paginatedQuery) {
+        if (!hasEnabledStorageProviders(session, realm, ClientLookupProvider.class)) {
+            return 0;
+        }
+        return getEnabledStorageProviders(session, realm, ClientLookupProvider.class)
+                .mapToLong(p -> {
+                    Stream<? extends ClientModel> res = p instanceof ClientStorageProvider
+                            ? ServicesUtils.timeBound(session, clientStorageProviderTimeout, p2 -> paginatedQuery.query((ClientLookupProvider) p2, null, null)).apply(p)
+                            : paginatedQuery.query(p, null, null);
+                    return res.count();
+                })
+                .sum();
+    }
+
+    @Override
     public Stream<ClientModel> searchClientsByAuthenticationFlowBindingOverrides(RealmModel realm, Map<String, String> overrides, Integer firstResult, Integer maxResults) {
         return query((p, f, m) -> p.searchClientsByAuthenticationFlowBindingOverrides(realm, overrides, f, m), realm, firstResult, maxResults);
     }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RealmModelDelegate.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RealmModelDelegate.java
@@ -584,8 +584,16 @@ public class RealmModelDelegate implements RealmModel {
         return delegate.searchClientByClientIdStream(clientId, firstResult, maxResults);
     }
 
+    public long searchClientByClientIdCount(String clientId) {
+        return delegate.searchClientByClientIdCount(clientId);
+    }
+
     public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
         return delegate.searchClientByAttributes(attributes, firstResult, maxResults);
+    }
+
+    public long searchClientByAttributesCount(Map<String, String> attributes) {
+        return delegate.searchClientByAttributesCount(attributes);
     }
 
     public Stream<ClientModel> searchClientByAuthenticationFlowBindingOverrides(Map<String, String> overrides, Integer firstResult, Integer maxResults) {

--- a/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTestHelpers.java
+++ b/server-spi-private/src/test/java/org/keycloak/broker/provider/util/IdentityBrokerStateTestHelpers.java
@@ -1190,8 +1190,18 @@ public class IdentityBrokerStateTestHelpers {
         }
 
         @Override
+        public long searchClientByClientIdCount(String clientId) {
+            return 0;
+        }
+
+        @Override
         public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
             return null;
+        }
+
+        @Override
+        public long searchClientByAttributesCount(Map<String, String> attributes) {
+            return 0;
         }
 
         @Override

--- a/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/ClientProvider.java
@@ -82,6 +82,26 @@ public interface ClientProvider extends ClientLookupProvider, Provider {
     long getClientsCount(RealmModel realm);
 
     /**
+     * Returns number of clients whose clientId contains the given string (case-insensitive).
+     * @param realm Realm.
+     * @param clientId clientId search string (substring match).
+     * @return Number of matching clients.
+     */
+    default long searchClientsByClientIdCount(RealmModel realm, String clientId) {
+        return searchClientsByClientIdStream(realm, clientId, null, null).count();
+    }
+
+    /**
+     * Returns number of clients matching all the given attributes.
+     * @param realm Realm.
+     * @param attributes map of attribute name to value (exact match per entry).
+     * @return Number of matching clients.
+     */
+    default long searchClientsByAttributesCount(RealmModel realm, Map<String, String> attributes) {
+        return searchClientsByAttributes(realm, attributes, null, null).count();
+    }
+
+    /**
      * Returns a stream of clients that are expected to always show up in account console.
      * @param realm Realm owning the clients.
      * @return Stream of the clients. Never returns {@code null}.

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -383,7 +383,11 @@ public interface RealmModel extends RoleContainerModel {
      */
     Stream<ClientModel> searchClientByClientIdStream(String clientId, Integer firstResult, Integer maxResults);
 
+    long searchClientByClientIdCount(String clientId);
+
     Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults);
+
+    long searchClientByAttributesCount(Map<String, String> attributes);
 
     Stream<ClientModel> searchClientByAuthenticationFlowBindingOverrides(Map<String, String> overrides, Integer firstResult, Integer maxResults);
 

--- a/server-spi/src/main/java/org/keycloak/models/RealmModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/RealmModel.java
@@ -383,11 +383,27 @@ public interface RealmModel extends RoleContainerModel {
      */
     Stream<ClientModel> searchClientByClientIdStream(String clientId, Integer firstResult, Integer maxResults);
 
-    long searchClientByClientIdCount(String clientId);
+    /**
+     * Returns number of clients whose clientId contains the given string (case-insensitive).
+     * Implementations are encouraged to override this default with a database-level COUNT query.
+     * @param clientId {@code String} Id of the client.
+     * @return Number of matching clients.
+     */
+    default long searchClientByClientIdCount(String clientId) {
+        return searchClientByClientIdStream(clientId, null, null).count();
+    }
 
     Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults);
 
-    long searchClientByAttributesCount(Map<String, String> attributes);
+    /**
+     * Returns number of clients matching all the given attributes.
+     * Implementations are encouraged to override this default with a database-level COUNT query.
+     * @param attributes map of attribute name to value (exact match per entry).
+     * @return Number of matching clients.
+     */
+    default long searchClientByAttributesCount(Map<String, String> attributes) {
+        return searchClientByAttributes(attributes, null, null).count();
+    }
 
     Stream<ClientModel> searchClientByAuthenticationFlowBindingOverrides(Map<String, String> overrides, Integer firstResult, Integer maxResults);
 

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -62,6 +62,8 @@ import org.keycloak.validation.ValidationUtil;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -176,6 +178,40 @@ public class ClientsResource {
         }
 
         return s;
+    }
+
+    /**
+     * Get clients count in the realm.
+     *
+     * @param search filter by clientId substring (case-insensitive)
+     * @param searchQuery filter by attribute using the format "key1:value1 key2:value2"
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK",
+            content = @Content(schema = @Schema(implementation = Long.class))),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    @Operation(summary = "Get clients count in the realm.")
+    public Long getClientsCount(
+            @Parameter(description = "filter by clientId substring (case-insensitive)") @QueryParam("search") String search,
+            @Parameter(description = "filter by attribute, format is 'key1:value1 key2:value2'") @QueryParam("q") String searchQuery) {
+        auth.clients().requireList();
+        try {
+            if (searchQuery != null) {
+                Map<String, String> attributes = SearchQueryUtils.getFields(searchQuery);
+                return realm.searchClientByAttributesCount(attributes);
+            } else if (search != null && !search.isBlank()) {
+                return realm.searchClientByClientIdCount(search);
+            }
+            return realm.getClientsCount();
+        } catch (ModelException e) {
+            throw new ErrorResponseException(Errors.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
+        }
     }
 
     private AuthorizationService getAuthorizationService(ClientModel clientModel) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -65,6 +65,8 @@ import org.keycloak.validation.ValidationUtil;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
@@ -182,6 +184,40 @@ public class ClientsResource {
         }
 
         return s;
+    }
+
+    /**
+     * Get clients count in the realm.
+     *
+     * @param search filter by clientId substring (case-insensitive)
+     * @param searchQuery filter by attribute using the format "key1:value1 key2:value2"
+     */
+    @Path("count")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.CLIENTS)
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK",
+            content = @Content(schema = @Schema(implementation = Long.class))),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    @Operation(summary = "Get clients count in the realm.")
+    public Long getClientsCount(
+            @Parameter(description = "filter by clientId substring (case-insensitive)") @QueryParam("search") String search,
+            @Parameter(description = "filter by attribute, format is 'key1:value1 key2:value2'") @QueryParam("q") String searchQuery) {
+        auth.clients().requireList();
+        try {
+            if (searchQuery != null) {
+                Map<String, String> attributes = SearchQueryUtils.getFields(searchQuery);
+                return realm.searchClientByAttributesCount(attributes);
+            } else if (search != null && !search.isBlank()) {
+                return realm.searchClientByClientIdCount(search);
+            }
+            return realm.getClientsCount();
+        } catch (ModelException e) {
+            throw new ErrorResponseException(Errors.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
+        }
     }
 
     private AuthorizationService getAuthorizationService(ClientModel clientModel) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientsResource.java
@@ -189,6 +189,11 @@ public class ClientsResource {
     /**
      * Get clients count in the realm.
      *
+     * Backed by a database-level COUNT query. The exception is a caller restricted by legacy (v1) fine-grained
+     * admin permissions, which apply per-client rather than realm-wide: like {@link #getClients}, this falls back
+     * to fetching and filtering candidates in memory, since v1 visibility is evaluated per-client and can't be
+     * pushed down into the COUNT query.
+     *
      * @param search filter by clientId substring (case-insensitive)
      * @param searchQuery filter by attribute using the format "key1:value1 key2:value2"
      */
@@ -202,19 +207,39 @@ public class ClientsResource {
             content = @Content(schema = @Schema(implementation = Long.class))),
         @APIResponse(responseCode = "403", description = "Forbidden")
     })
-    @Operation(summary = "Get clients count in the realm.")
+    @Operation(summary = "Get clients count in the realm.",
+        description = "Backed by a database-level COUNT query, except for callers restricted by legacy (v1) fine-grained admin permissions, where visibility is evaluated per-client and the count falls back to filtering candidates in memory.")
     public Long getClientsCount(
             @Parameter(description = "filter by clientId substring (case-insensitive)") @QueryParam("search") String search,
             @Parameter(description = "filter by attribute, format is 'key1:value1 key2:value2'") @QueryParam("q") String searchQuery) {
         auth.clients().requireList();
+
+        boolean canView = AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm) || auth.clients().canView();
+
         try {
+            if (canView) {
+                if (searchQuery != null) {
+                    Map<String, String> attributes = SearchQueryUtils.getFields(searchQuery);
+                    return realm.searchClientByAttributesCount(attributes);
+                } else if (search != null && !search.isBlank()) {
+                    return realm.searchClientByClientIdCount(search);
+                }
+                return realm.getClientsCount();
+            }
+
+            // Legacy fine-grained admin permissions (v1) restrict visibility per-client rather than realm-wide,
+            // so the database-level COUNT queries above would leak counts across clients the caller can't view.
+            // Mirror the list endpoint's per-model filtering instead.
+            Stream<ClientModel> clientModels;
             if (searchQuery != null) {
                 Map<String, String> attributes = SearchQueryUtils.getFields(searchQuery);
-                return realm.searchClientByAttributesCount(attributes);
+                clientModels = realm.searchClientByAttributes(attributes, -1, -1);
             } else if (search != null && !search.isBlank()) {
-                return realm.searchClientByClientIdCount(search);
+                clientModels = realm.searchClientByClientIdStream(search, -1, -1);
+            } else {
+                clientModels = realm.getClientsStream();
             }
-            return realm.getClientsCount();
+            return clientModels.filter(auth.clients()::canView).count();
         } catch (ModelException e) {
             throw new ErrorResponseException(Errors.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
         }

--- a/services/src/test/java/org/keycloak/protocol/saml/SamlProtocolTest.java
+++ b/services/src/test/java/org/keycloak/protocol/saml/SamlProtocolTest.java
@@ -841,8 +841,18 @@ public class SamlProtocolTest {
         }
 
         @Override
+        public long searchClientByClientIdCount(String clientId) {
+            return 0;
+        }
+
+        @Override
         public Stream<ClientModel> searchClientByAttributes(Map<String, String> attributes, Integer firstResult, Integer maxResults) {
             return null;
+        }
+
+        @Override
+        public long searchClientByAttributesCount(Map<String, String> attributes) {
+            return 0;
         }
 
         @Override

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientCountTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/ClientCountTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.client;
+
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.ClientsResource;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for {@code GET /admin/realms/{realm}/clients/count}.
+ */
+@KeycloakIntegrationTest(config = ClientCountTest.SearchableServer.class)
+public class ClientCountTest {
+
+    @InjectRealm
+    ManagedRealm testRealm;
+
+    private static final String ATTR_KEY = "env";
+    private static final String ATTR_VAL = "production";
+
+    private List<String> createdIds;
+
+    @BeforeEach
+    public void createClients() {
+        ClientsResource clients = testRealm.admin().clients();
+
+        ClientRepresentation alpha = new ClientRepresentation();
+        alpha.setClientId("count-test-alpha");
+        alpha.setEnabled(true);
+
+        ClientRepresentation beta = new ClientRepresentation();
+        beta.setClientId("count-test-beta");
+        beta.setEnabled(true);
+        beta.setAttributes(java.util.Map.of(ATTR_KEY, ATTR_VAL));
+
+        ClientRepresentation gamma = new ClientRepresentation();
+        gamma.setClientId("count-test-gamma");
+        gamma.setEnabled(true);
+        gamma.setAttributes(java.util.Map.of(ATTR_KEY, ATTR_VAL));
+
+        try (Response r1 = clients.create(alpha);
+             Response r2 = clients.create(beta);
+             Response r3 = clients.create(gamma)) {
+            createdIds = List.of(
+                    r1.getLocation().getPath().replaceAll(".*/", ""),
+                    r2.getLocation().getPath().replaceAll(".*/", ""),
+                    r3.getLocation().getPath().replaceAll(".*/", ""));
+        }
+    }
+
+    @AfterEach
+    public void deleteClients() {
+        if (createdIds != null) {
+            for (String id : createdIds) {
+                try {
+                    testRealm.admin().clients().get(id).remove();
+                } catch (Exception ignored) {
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTotalCountIncludesCreatedClients() {
+        Long total = testRealm.admin().clients().count();
+        assertTrue(total >= 3, "Expected at least 3 clients, got " + total);
+    }
+
+    @Test
+    public void testCountWithSearchFilter() {
+        Long count = testRealm.admin().clients().count("count-test", null);
+        assertEquals(3L, count, "Expected 3 clients matching 'count-test'");
+    }
+
+    @Test
+    public void testCountWithAttributeFilter() {
+        Long count = testRealm.admin().clients().count(null, ATTR_KEY + ":" + ATTR_VAL);
+        assertEquals(2L, count, "Expected 2 clients with attribute " + ATTR_KEY + "=" + ATTR_VAL);
+    }
+
+    @Test
+    public void testCountDecreasesAfterDeletion() {
+        Long before = testRealm.admin().clients().count("count-test", null);
+        testRealm.admin().clients().get(createdIds.get(0)).remove();
+        createdIds = createdIds.subList(1, createdIds.size());
+        Long after = testRealm.admin().clients().count("count-test", null);
+        assertEquals(before - 1, after, "Count should decrease by 1 after deletion");
+    }
+
+    @Test
+    public void testSearchFilterNoMatch() {
+        Long count = testRealm.admin().clients().count("no-such-client-xyz", null);
+        assertEquals(0L, count, "Expected 0 clients for non-matching search");
+    }
+
+    public static class SearchableServer implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.option("spi-client-jpa-searchable-attributes", ATTR_KEY);
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/finegrainedadminv1/FineGrainedAdminSearchTest.java
@@ -315,6 +315,88 @@ public class FineGrainedAdminSearchTest extends AbstractFineGrainedAdminTest {
     }
 
     @Test
+    public void testClientsCount() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName(REALM_NAME);
+
+            session.getContext().setRealm(realm);
+
+            ClientModel realmAdminClient = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
+            UserModel regularAdminUser = session.users().addUser(realm, "regular-admin-user");
+            regularAdminUser.setFirstName("Regular");
+            regularAdminUser.setLastName("Admin");
+            regularAdminUser.setEmail("regular@admin");
+            regularAdminUser.credentialManager().updateCredential(UserCredentialModel.password("password"));
+            regularAdminUser.grantRole(realmAdminClient.getRole(AdminRoles.QUERY_CLIENTS));
+            regularAdminUser.setEnabled(true);
+
+            UserPolicyRepresentation userPolicyRepresentation = new UserPolicyRepresentation();
+
+            userPolicyRepresentation.setName("Only " + regularAdminUser.getUsername());
+            userPolicyRepresentation.addUser(regularAdminUser.getId());
+
+            for (int i = 0; i < 30; i++) {
+                realm.addClient("client-count-" + (i < 10 ? "0" + i : i));
+            }
+
+            AdminPermissionManagement management = AdminPermissions.management(session, realm);
+            ClientPermissionManagement clientPermission = management.clients();
+            ClientModel clientModel = realm.getClientByClientId("client-count-09");
+
+            clientPermission.setPermissionsEnabled(clientModel, true);
+
+            Policy policy = clientPermission.viewPermission(clientModel);
+            AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
+            Policy userPolicy = provider.getStoreFactory().getPolicyStore()
+                    .create(management.realmResourceServer(), userPolicyRepresentation);
+
+            policy.addAssociatedPolicy(RepresentationToModel.toModel(userPolicyRepresentation, provider, userPolicy));
+        });
+
+        try (Keycloak client = adminClientFactory.create().realm(REALM_NAME)
+                .username("regular-admin-user").password("password").clientId( Constants.ADMIN_CLI_CLIENT_ID).build()) {
+
+            // only one client is viewable by this admin; the count must reflect that, not the realm-wide total
+            Long count = client.realm(REALM_NAME).clients().count("client-count-", null);
+
+            Assertions.assertEquals(1, count);
+        }
+
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName(REALM_NAME);
+
+            session.getContext().setRealm(realm);
+
+            AdminPermissionManagement management = AdminPermissions.management(session, realm);
+
+            ClientPermissionManagement clientPermission = management.clients();
+            ClientModel clientModel = realm.getClientByClientId("client-count-10");
+
+            clientPermission.setPermissionsEnabled(clientModel, true);
+
+            Policy policy = clientPermission.viewPermission(clientModel);
+
+            AuthorizationProvider provider = session.getProvider(AuthorizationProvider.class);
+            ClientModel realmAdminClient = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
+            ResourceServer resourceServer = provider.getStoreFactory().getResourceServerStore().findByClient(realmAdminClient);
+
+            policy.addAssociatedPolicy(provider.getStoreFactory().getPolicyStore().findByName(resourceServer, "Only regular-admin-user"));
+        });
+
+        try (Keycloak client = adminClientFactory.create().realm(REALM_NAME)
+                .username("regular-admin-user").password("password").clientId( Constants.ADMIN_CLI_CLIENT_ID).build()) {
+
+            Long count = client.realm(REALM_NAME).clients().count("client-count-", null);
+
+            Assertions.assertEquals(2, count);
+
+            Long noMatchCount = client.realm(REALM_NAME).clients().count("no-such-client-xyz", null);
+
+            Assertions.assertEquals(0, noMatchCount);
+        }
+    }
+
+    @Test
     public void testClientsSearchAfterFirstPage() {
         runOnServer.run(session -> {
             RealmModel realm = session.realms().getRealmByName(REALM_NAME);


### PR DESCRIPTION
## Problem

The Admin REST API has no way to count clients in a realm without fetching all of them. To get a total count, callers must page through all results, which is prohibitively expensive at large scales (e.g. realms with 100K+ service accounts).

## Solution

Add a count endpoint mirroring the existing `GET /admin/realms/{realm}/users/count`:

```
GET /admin/realms/{realm}/clients/count
```

### Behaviour

- Returns a plain `Long` (same shape as `users/count`)
- Accepts optional filter query parameters:
  - `search` — clientId substring match (case-insensitive)
  - `q` — attribute filter in `key1:value1 key2:value2` format
- All paths are backed by a database-level `COUNT` query — no client records are loaded into memory
- Fine-grained authorization filters are applied consistently (same as the existing list endpoint)

## Changes

| Layer | File | Change |
|---|---|---|
| SPI | `ClientProvider` | Add `searchClientsByClientIdCount` and `searchClientsByAttributesCount` default methods |
| SPI | `RealmModel` | Add `searchClientByClientIdCount` and `searchClientByAttributesCount` abstract methods |
| Model | `RealmModelDelegate`, `RealmAdapter` (JPA + Infinispan) | Implement new methods |
| JPA | `JpaRealmProvider` | Two new `SELECT COUNT(id)` queries with auth filters; attribute filter handles Oracle/PostgreSQL/other CLOB differences |
| REST | `services/.../admin/ClientsResource` | New `@Path("count") @GET` endpoint |
| Admin client | `integration/.../resource/ClientsResource` | Two new `count()` overloads |
| Tests | `ClientCountTest` | 5 integration tests: total count, search filter, attribute filter, count after deletion, no-match |

## Prior Art

`GET /admin/realms/{realm}/users/count` does exactly this for users. This is a direct extension of that pattern.

FIXES  #49161