### PR TITLE
fix: normalizing logic when context is not available

### DIFF
--- a/common/src/main/java/org/keycloak/common/ClientConnection.java
+++ b/common/src/main/java/org/keycloak/common/ClientConnection.java
@@ -32,7 +32,7 @@ public interface ClientConnection {
         return null;
     }
     /**
-     * @return the remote host, which will be an IP address or whatever is provided via proxy headers, if 
+     * @return the remote host, which will be an IP address or whatever is provided via proxy headers, if
      * available, otherwise null
      */
     default String getRemoteHost() {
@@ -40,7 +40,7 @@ public interface ClientConnection {
     }
     
     /**
-     * @return the remote port if it available, otherwise 0
+     * @return the remote port if it is available, otherwise 0
      */
     default int getRemotePort() {
         return 0;
@@ -54,7 +54,7 @@ public interface ClientConnection {
     }
     
     /**
-     * @return the local port if it available, otherwise 0
+     * @return the local port if it is available, otherwise 0
      */
     default int getLocalPort() {
         return 0;

--- a/common/src/main/java/org/keycloak/common/ClientConnection.java
+++ b/common/src/main/java/org/keycloak/common/ClientConnection.java
@@ -28,13 +28,35 @@ public interface ClientConnection {
     /**
      * @return the IP address as a string if it is available, otherwise null
      */
-    String getRemoteAddr();
+    default String getRemoteAddr() {
+        return null;
+    }
     /**
-     * @return the remote host, which will be an IP address or whatever is provided via proxy headers
+     * @return the remote host, which will be an IP address or whatever is provided via proxy headers, if 
+     * available, otherwise null
      */
-    String getRemoteHost();
-    int getRemotePort();
+    default String getRemoteHost() {
+        return null;
+    }
+    
+    /**
+     * @return the remote port if it available, otherwise 0
+     */
+    default int getRemotePort() {
+        return 0;
+    }
 
-    String getLocalAddr();
-    int getLocalPort();
+    /**
+     * @return the local IP address as a string if it is available, otherwise null
+     */
+    default String getLocalAddr() {
+        return null;
+    }
+    
+    /**
+     * @return the local port if it available, otherwise 0
+     */
+    default int getLocalPort() {
+        return 0;
+    }
 }

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -188,6 +188,12 @@ See the link:{client_certificate_lookup_link}[Reverse Proxy guide] for more deta
 
 Async custom REST endpoints using `AsyncResponse` or returning an async type such as `CompletableFuture` or `CompletionState` should not be used. If you are using them, be aware that the `KeycloakSession` used to initial the request will be immediately closed - it will not remain open for the entire lifespan of the request - and that you are fully responsible for transaction management in the async work.
 
+=== `KeycloakContext` refinements when no request is active
+
+The `KeycloakContext` provided by `KeycloakSession` for async work will typically not have an active request. The JavaDocs for methods now describe when a
+`ContextNotActiveException` is thrown, and some of the logic is now tolerant to returning values even if no request is active. Please review places where you are
+catching `ContextNotActiveException` in your extension logic against the new JavaDocs.
+
 === Validation of client_session_host parameter
 The `client_session_host` parameter is now validated against the client's registered nodes and management URL.
 This parameter is sent by clients during token refresh and is used when the `${application.session.host}` placeholder is present in a client's backchannel logout URL configuration.

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusClientConnection.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusClientConnection.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.quarkus.runtime.integration.resteasy;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.keycloak.common.ClientConnection;
@@ -29,7 +30,7 @@ public final class QuarkusClientConnection implements ClientConnection {
     private final HttpServerRequest request;
 
     public QuarkusClientConnection(HttpServerRequest request) {
-        this.request = request;
+        this.request = Objects.requireNonNull(request);
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusClientConnection.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusClientConnection.java
@@ -17,9 +17,12 @@
 
 package org.keycloak.quarkus.runtime.integration.resteasy;
 
+import java.util.Optional;
+
 import org.keycloak.common.ClientConnection;
 
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
 
 public final class QuarkusClientConnection implements ClientConnection {
 
@@ -31,26 +34,26 @@ public final class QuarkusClientConnection implements ClientConnection {
 
     @Override
     public String getRemoteAddr() {
-        return request.remoteAddress().hostAddress();
+        return Optional.ofNullable(request.remoteAddress()).map(SocketAddress::hostAddress).orElse(null);
     }
 
     @Override
     public String getRemoteHost() {
-        return request.remoteAddress().host();
+        return Optional.ofNullable(request.remoteAddress()).map(SocketAddress::host).orElse(null);
     }
 
     @Override
     public int getRemotePort() {
-        return request.remoteAddress().port();
+        return Optional.ofNullable(request.remoteAddress()).map(SocketAddress::port).orElse(0);
     }
 
     @Override
     public String getLocalAddr() {
-        return request.localAddress().hostAddress();
+        return Optional.ofNullable(request.localAddress()).map(SocketAddress::hostAddress).orElse(null);
     }
 
     @Override
     public int getLocalPort() {
-        return request.localAddress().port();
+        return Optional.ofNullable(request.localAddress()).map(SocketAddress::port).orElse(0);
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusHttpRequest.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusHttpRequest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.security.cert.X509Certificate;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.Objects;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 
@@ -53,23 +54,16 @@ public final class QuarkusHttpRequest implements HttpRequest {
     private MultivaluedMap<String, String> decodedFormParameters;
 
     public <R> QuarkusHttpRequest(ResteasyReactiveRequestContext context) {
-        this.context = context;
+        this.context = Objects.requireNonNull(context);
     }
 
     @Override
     public String getHttpMethod() {
-        if (context == null) {
-            return null;
-        }
         return context.getMethod();
     }
 
     @Override
     public MultivaluedMap<String, String> getDecodedFormParameters() {
-        if (context == null) {
-            return null;
-        }
-
         if (decodedFormParameters == null) {
             FormData parameters = context.getFormData();
 
@@ -97,9 +91,6 @@ public final class QuarkusHttpRequest implements HttpRequest {
 
     @Override
     public MultivaluedMap<String, FormPartValue> getMultiPartFormParameters() {
-        if (context == null) {
-            return null;
-        }
         FormData formData = context.getFormData();
 
         if (formData == null) {
@@ -135,9 +126,6 @@ public final class QuarkusHttpRequest implements HttpRequest {
 
     @Override
     public HttpHeaders getHttpHeaders() {
-        if (context == null) {
-            return null;
-        }
         return context.getHttpHeaders();
     }
 
@@ -166,9 +154,6 @@ public final class QuarkusHttpRequest implements HttpRequest {
 
     @Override
     public UriInfo getUri() {
-        if (context == null) {
-            return null;
-        }
         return context.getUriInfo();
     }
 

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusHttpResponse.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusHttpResponse.java
@@ -18,6 +18,7 @@
 package org.keycloak.quarkus.runtime.integration.resteasy;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import jakarta.ws.rs.core.HttpHeaders;
@@ -38,7 +39,7 @@ public final class QuarkusHttpResponse implements HttpResponse {
     private Set<NewCookie> newCookies;
 
     public QuarkusHttpResponse(ResteasyReactiveRequestContext requestContext) {
-        this.requestContext = requestContext;
+        this.requestContext = Objects.requireNonNull(requestContext);
     }
 
     @Override

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusKeycloakContext.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusKeycloakContext.java
@@ -19,6 +19,8 @@ package org.keycloak.quarkus.runtime.integration.resteasy;
 
 import java.util.Optional;
 
+import jakarta.enterprise.context.ContextNotActiveException;
+
 import org.keycloak.common.ClientConnection;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
@@ -51,6 +53,10 @@ public final class QuarkusKeycloakContext extends DefaultKeycloakContext {
     }
 
     private Optional<ResteasyReactiveRequestContext> getResteasyReactiveRequestContext() {
-        return Optional.ofNullable(CurrentRequestManager.get());
+        try {
+            return Optional.ofNullable(CurrentRequestManager.get());
+        } catch (ContextNotActiveException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusKeycloakContext.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/integration/resteasy/QuarkusKeycloakContext.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.quarkus.runtime.integration.resteasy;
 
+import java.util.Optional;
+
 import org.keycloak.common.ClientConnection;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
@@ -34,23 +36,21 @@ public final class QuarkusKeycloakContext extends DefaultKeycloakContext {
     }
 
     @Override
-    protected HttpRequest createHttpRequest() {
-        return new QuarkusHttpRequest(getResteasyReactiveRequestContext());
+    protected Optional<HttpRequest> createHttpRequest() {
+        return getResteasyReactiveRequestContext().map(QuarkusHttpRequest::new);
     }
 
     @Override
-    protected HttpResponse createHttpResponse() {
-        return new QuarkusHttpResponse(getResteasyReactiveRequestContext());
+    protected Optional<HttpResponse> createHttpResponse() {
+        return getResteasyReactiveRequestContext().map(QuarkusHttpResponse::new);
     }
 
     @Override
-    protected ClientConnection createClientConnection() {
-        ResteasyReactiveRequestContext requestContext = getResteasyReactiveRequestContext();
-        HttpServerRequest serverRequest = requestContext.unwrap(HttpServerRequest.class);
-        return new QuarkusClientConnection(serverRequest);
+    protected Optional<ClientConnection> createClientConnection() {
+        return getResteasyReactiveRequestContext().map(c -> new QuarkusClientConnection(c.unwrap(HttpServerRequest.class)));
     }
 
-    private ResteasyReactiveRequestContext getResteasyReactiveRequestContext() {
-        return CurrentRequestManager.get();
+    private Optional<ResteasyReactiveRequestContext> getResteasyReactiveRequestContext() {
+        return Optional.ofNullable(CurrentRequestManager.get());
     }
 }

--- a/server-spi-private/src/main/java/org/keycloak/transaction/RequestContextHelper.java
+++ b/server-spi-private/src/main/java/org/keycloak/transaction/RequestContextHelper.java
@@ -22,6 +22,7 @@ package org.keycloak.transaction;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.MultivaluedMap;
 
 import org.keycloak.OAuth2Constants;
@@ -82,6 +83,8 @@ public class RequestContextHelper {
                         .append(httpRequest.getUri().getPath())
                         .toString();
             }
+        } catch (ContextNotActiveException e) {
+            // non-http context
         } catch (Exception e) {
             return "Unknown context";
         }

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -48,7 +48,7 @@ public interface KeycloakContext {
 
      /**
      * @deprecated Use {@link #getHttpRequest()} to obtain the request headers.
-     * @throws {@link ContextNotActiveException} when a request is active
+     * @throws {@link ContextNotActiveException} when no request is active
      */
     @Deprecated
     HttpHeaders getRequestHeaders();

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -37,18 +37,18 @@ import org.keycloak.urls.UrlType;
 public interface KeycloakContext {
 
     /**
-     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     * @throws ContextNotActiveException if no request is active and a non-full URL hostname is configured
      */
     URI getAuthServerUrl();
 
     /**
-     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     * @throws ContextNotActiveException if no request is active and a non-full URL hostname is configured
      */
     String getContextPath();
 
      /**
      * @deprecated Use {@link #getHttpRequest()} to obtain the request headers.
-     * @throws {@link ContextNotActiveException} when no request is active
+     * @throws ContextNotActiveException when no request is active
      */
     @Deprecated
     HttpHeaders getRequestHeaders();
@@ -57,7 +57,7 @@ public interface KeycloakContext {
     /**
      * Returns the URI assuming it is a frontend request. To resolve URI for a backend request use {@link #getUri(UrlType)}
      *
-     * method calls on the returned {@link KeycloakUriInfo} will throw a {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     * method calls on the returned {@link KeycloakUriInfo} may throw a {@link ContextNotActiveException} if no request is active
      */
     KeycloakUriInfo getUri();
 
@@ -66,10 +66,11 @@ public interface KeycloakContext {
      * request (request from a client) should be set to false. Depending on the configure hostname provider it may
      * return a hard-coded base URL for frontend request (for example https://auth.mycompany.com) and use the
      * request URL for backend requests. Frontend URI should also be used for realm issuer fields in tokens.
+     * <p>
+     * Method calls on the returned {@link KeycloakUriInfo} may throw a {@link ContextNotActiveException} if no request is active.
      *
      * @param type the type of the request
-     *
-     * method calls on the returned {@link KeycloakUriInfo} will throw a {@link ContextNotActiveException} if no request is active and any information needs resolved from a request URI.
+     * @throws ContextNotActiveException if no request is active and information from a current request is needed to determine the base URI.
      */
     KeycloakUriInfo getUri(UrlType type);
 

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -20,6 +20,7 @@ package org.keycloak.models;
 import java.net.URI;
 import java.util.Locale;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import org.keycloak.Token;
@@ -35,12 +36,19 @@ import org.keycloak.urls.UrlType;
  */
 public interface KeycloakContext {
 
+    /**
+     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     */
     URI getAuthServerUrl();
 
+    /**
+     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     */
     String getContextPath();
     
      /**
      * @deprecated Use {@link #getHttpRequest()} to obtain the request headers.
+     * @throws {@link ContextNotActiveException} when a request is active
      */
     @Deprecated
     HttpHeaders getRequestHeaders();
@@ -48,7 +56,8 @@ public interface KeycloakContext {
 
     /**
      * Returns the URI assuming it is a frontend request. To resolve URI for a backend request use {@link #getUri(UrlType)}
-     * @return
+     *
+     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
      */
     KeycloakUriInfo getUri();
 
@@ -59,7 +68,8 @@ public interface KeycloakContext {
      * request URL for backend requests. Frontend URI should also be used for realm issuer fields in tokens.
      *
      * @param type the type of the request
-     * @return
+     *
+     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
      */
     KeycloakUriInfo getUri(UrlType type);
 
@@ -85,6 +95,9 @@ public interface KeycloakContext {
 
     void setOrganization(OrganizationModel organization);
 
+    /**
+     * If there is no active request, a {@link ClientConnection} will still be returned
+     */
     ClientConnection getConnection();
 
     Locale resolveLocale(UserModel user);
@@ -106,8 +119,14 @@ public interface KeycloakContext {
 
     void setAuthenticationSession(AuthenticationSessionModel authenticationSession);
 
+    /**
+     * If there is no active request, a {@link ContextNotActiveException} will be thrown
+     */
     HttpRequest getHttpRequest();
 
+    /**
+     * If there is no active request, a {@link ContextNotActiveException} will be thrown
+     */
     HttpResponse getHttpResponse();
 
     void setConnection(ClientConnection clientConnection);

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -45,19 +45,19 @@ public interface KeycloakContext {
      * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
      */
     String getContextPath();
-    
+
      /**
      * @deprecated Use {@link #getHttpRequest()} to obtain the request headers.
      * @throws {@link ContextNotActiveException} when a request is active
      */
     @Deprecated
     HttpHeaders getRequestHeaders();
-    
+
 
     /**
      * Returns the URI assuming it is a frontend request. To resolve URI for a backend request use {@link #getUri(UrlType)}
      *
-     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     * method calls on the returned {@link KeycloakUriInfo} will throw a {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
      */
     KeycloakUriInfo getUri();
 
@@ -69,7 +69,7 @@ public interface KeycloakContext {
      *
      * @param type the type of the request
      *
-     * @throws {@link ContextNotActiveException} if no request is active and a non-full URL hostname is configured
+     * method calls on the returned {@link KeycloakUriInfo} will throw a {@link ContextNotActiveException} if no request is active and any information needs resolved from a request URI.
      */
     KeycloakUriInfo getUri(UrlType type);
 

--- a/server-spi/src/main/java/org/keycloak/models/KeycloakUriInfo.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakUriInfo.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
@@ -33,6 +34,9 @@ import org.jboss.resteasy.reactive.common.jaxrs.UriBuilderImpl;
 
 import static org.keycloak.common.util.UriUtils.parseQueryParameters;
 
+/**
+ * Contrary to the {@link UriInfo} javadocs, most methods throw {@link ContextNotActiveException}, not {@link IllegalStateException}, if there is no active request.
+ */
 public class KeycloakUriInfo implements UriInfo {
 
     private final UriInfo delegate;

--- a/server-spi/src/main/java/org/keycloak/urls/HostnameProvider.java
+++ b/server-spi/src/main/java/org/keycloak/urls/HostnameProvider.java
@@ -18,6 +18,7 @@ package org.keycloak.urls;
 
 import java.net.URI;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.models.KeycloakContext;
@@ -27,8 +28,10 @@ import org.keycloak.provider.Provider;
  * The Hostname provider is used by Keycloak to decide URLs for frontend and backend requests. A provider can either
  * base the URL on the request (Host header for example) or based on hard-coded URLs. Further, it is possible to have
  * different URLs on frontend requests and backend requests.
- *
+ * <p>
  * Note: Do NOT use {@link KeycloakContext#getUri()} within a Hostname provider. It will result in an infinite loop.
+ * <p>
+ * Note: the {@link UriInfo} provided to these methods will throw {@link ContextNotActiveException} rather than {@link IllegalStateException} as described in the javadoc.
  */
 public interface HostnameProvider extends Provider {
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -151,6 +151,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
             <artifactId>owasp-java-html-sanitizer</artifactId>
         </dependency>

--- a/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
+++ b/services/src/main/java/org/keycloak/email/freemarker/FreeMarkerEmailTemplateProvider.java
@@ -253,7 +253,6 @@ public class FreeMarkerEmailTemplateProvider implements EmailTemplateProvider {
             } catch (ContextNotActiveException e) {
                 log.debug("No active request, can't make url attribute available to the template");
                 // ignore when running without an active request context such as sending emails from an scheduled task
-                // TODO: make it possible to make the URL available to email templates based on the hostname configured in the realm or at the server level
             }
 
             String subject = new MessageFormat(messages.getProperty(subjectKey, subjectKey), locale).format(subjectAttributes.toArray());

--- a/services/src/main/java/org/keycloak/events/log/JBossLoggingEventListenerProvider.java
+++ b/services/src/main/java/org/keycloak/events/log/JBossLoggingEventListenerProvider.java
@@ -19,6 +19,7 @@ package org.keycloak.events.log;
 
 import java.util.Map;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.UriInfo;
@@ -198,27 +199,30 @@ public class JBossLoggingEventListenerProvider implements EventListenerProvider 
 
     private void setKeycloakContext(StringBuilder sb) {
         KeycloakContext context = session.getContext();
-        UriInfo uriInfo = context.getUri();
-        HttpHeaders headers = context.getRequestHeaders();
-        if (uriInfo != null) {
-            sb.append(", requestUri=");
-            sanitize(sb, uriInfo.getRequestUri().toString());
-        }
-
-        if (headers != null) {
-            sb.append(", cookies=[");
-            boolean f = true;
-            for (Map.Entry<String, Cookie> e : headers.getCookies().entrySet()) {
-                if (f) {
-                    f = false;
-                } else {
-                    sb.append(", ");
-                }
-                sb.append(StringUtil.sanitizeSpacesAndQuotes(e.getValue().toString(), null));
+        try {
+            UriInfo uriInfo = context.getUri();
+            HttpHeaders headers = context.getRequestHeaders();
+            if (uriInfo != null) {
+                sb.append(", requestUri=");
+                sanitize(sb, uriInfo.getRequestUri().toString());
             }
-            sb.append("]");
-        }
 
+            if (headers != null) {
+                sb.append(", cookies=[");
+                boolean f = true;
+                for (Map.Entry<String, Cookie> e : headers.getCookies().entrySet()) {
+                    if (f) {
+                        f = false;
+                    } else {
+                        sb.append(", ");
+                    }
+                    sb.append(StringUtil.sanitizeSpacesAndQuotes(e.getValue().toString(), null));
+                }
+                sb.append("]");
+            }
+        } catch (ContextNotActiveException e) {
+            // no context information to add
+        }
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import org.keycloak.Token;
@@ -153,7 +154,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public ClientConnection getConnection() {
         if (clientConnection == null) {
-            clientConnection = createClientConnection();
+            clientConnection = createClientConnection().orElseThrow(ContextNotActiveException::new);
         }
 
         return clientConnection;
@@ -184,7 +185,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public HttpRequest getHttpRequest() {
         if (request == null) {
-            request = createHttpRequest();
+            request = createHttpRequest().orElseThrow(ContextNotActiveException::new);
         }
 
         return request;
@@ -193,19 +194,19 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public HttpResponse getHttpResponse() {
         if (response == null) {
-            response = createHttpResponse();
+            response = createHttpResponse().orElseThrow(ContextNotActiveException::new);
         }
 
         return response;
     }
 
-    protected ClientConnection createClientConnection() {
+    protected Optional<ClientConnection> createClientConnection() {
         return null;
     }
 
-    protected abstract HttpRequest createHttpRequest();
+    protected abstract Optional<HttpRequest> createHttpRequest();
 
-    protected abstract HttpResponse createHttpResponse();
+    protected abstract Optional<HttpResponse> createHttpResponse();
 
     protected KeycloakSession getSession() {
         return session;

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services;
 
+import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Locale;
@@ -25,6 +26,7 @@ import java.util.Optional;
 
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.Token;
 import org.keycloak.common.ClientConnection;
@@ -93,8 +95,15 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
             if (uriInfo == null) {
                 uriInfo = new HashMap<>();
             }
-
-            uriInfo.put(type, new KeycloakUriInfo(session, type, getHttpRequest().getUri()));
+            UriInfo info = null;
+            try {
+                info = getHttpRequest().getUri();
+            } catch (ContextNotActiveException e) {
+                info = (UriInfo) Proxy.newProxyInstance(UriInfo.class.getClassLoader(), new Class[] { UriInfo.class }, (proxy, method, args) -> {
+                    throw new ContextNotActiveException();
+                });
+            }
+            uriInfo.put(type, new KeycloakUriInfo(session, type, info));
         }
         return uriInfo.get(type);
     }
@@ -104,7 +113,6 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
         return getUri(UrlType.FRONTEND);
     }
 
-  
     @Override
     public HttpHeaders getRequestHeaders() {
         return getHttpRequest().getHttpHeaders();
@@ -154,7 +162,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     @Override
     public ClientConnection getConnection() {
         if (clientConnection == null) {
-            clientConnection = createClientConnection().orElseThrow(ContextNotActiveException::new);
+            clientConnection = createClientConnection().orElseGet(() -> new ClientConnection() {});
         }
 
         return clientConnection;
@@ -201,7 +209,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
     }
 
     protected Optional<ClientConnection> createClientConnection() {
-        return null;
+        return Optional.empty();
     }
 
     protected abstract Optional<HttpRequest> createHttpRequest();

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -100,7 +100,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
                 info = getHttpRequest().getUri();
             } catch (ContextNotActiveException e) {
                 info = (UriInfo) Proxy.newProxyInstance(UriInfo.class.getClassLoader(), new Class[] { UriInfo.class }, (proxy, method, args) -> {
-                    throw new ContextNotActiveException();
+                    throw new ContextNotActiveException(e); // see the javadoc on UriInfo / KeycloakUriInfo, but we are throwing ContextNotActiveException, rather than IllegalStateException.
                 });
             }
             uriInfo.put(type, new KeycloakUriInfo(session, type, info));

--- a/services/src/test/java/org/keycloak/services/DefaultKeycloakContextTest.java
+++ b/services/src/test/java/org/keycloak/services/DefaultKeycloakContextTest.java
@@ -16,9 +16,9 @@ import org.keycloak.urls.HostnameProvider;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DefaultKeycloakContextTest {
 

--- a/services/src/test/java/org/keycloak/services/DefaultKeycloakContextTest.java
+++ b/services/src/test/java/org/keycloak/services/DefaultKeycloakContextTest.java
@@ -56,14 +56,18 @@ public class DefaultKeycloakContextTest {
         factory.factoriesMap.put(HostnameProvider.class, map);
 
         // the following can be inferred from the full hostname, so an exception is not expected
-        KeycloakContext context = factory.create().getContext();
-        assertNotNull(context.getUri());
-        assertEquals("https://full.host.name/path/", context.getAuthServerUrl().toString());
-        assertEquals("/path/", context.getContextPath());
+        try (KeycloakSession keycloakSession = factory.create()) {
+            KeycloakContext context = keycloakSession.getContext();
+            assertNotNull(context.getUri());
+            assertEquals("https://full.host.name/path/", context.getAuthServerUrl().toString());
+            assertEquals("/path/", context.getContextPath());
 
-        assertEquals(0, context.getConnection().getLocalPort());
+            assertEquals(0, context.getConnection().getLocalPort());
 
-        assertThrows(ContextNotActiveException.class, () -> context.getHttpRequest());
+            assertThrows(ContextNotActiveException.class, () -> context.getHttpRequest());
+        } finally {
+            factory.close();
+        }
     }
 
 }

--- a/services/src/test/java/org/keycloak/services/DefaultKeycloakContextTest.java
+++ b/services/src/test/java/org/keycloak/services/DefaultKeycloakContextTest.java
@@ -1,0 +1,69 @@
+package org.keycloak.services;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ContextNotActiveException;
+
+import org.keycloak.http.HttpRequest;
+import org.keycloak.http.HttpResponse;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.url.HostnameV2ProviderFactory;
+import org.keycloak.url.HostnameV2ProviderFactoryTest;
+import org.keycloak.urls.HostnameProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DefaultKeycloakContextTest {
+
+    @Test
+    public void testNonActiveWithFullUrlHostname() {
+        DefaultKeycloakSessionFactory factory = new DefaultKeycloakSessionFactory() {
+
+            @Override
+            public KeycloakSession create() {
+                return new DefaultKeycloakSession(this) {
+
+                    @Override
+                    protected DefaultKeycloakContext createKeycloakContext(KeycloakSession session) {
+                        return new DefaultKeycloakContext(session) {
+
+                            @Override
+                            protected Optional<HttpResponse> createHttpResponse() {
+                                return Optional.empty();
+                            }
+
+                            @Override
+                            protected Optional<HttpRequest> createHttpRequest() {
+                                return Optional.empty();
+                            }
+                        };
+                    }
+                };
+            }
+        };
+
+        HostnameV2ProviderFactory v2Factory = HostnameV2ProviderFactoryTest.init("https://full.host.name/path");
+        HashMap<String, ProviderFactory> map = new HashMap<>();
+        map.put(null, v2Factory);
+
+        factory.factoriesMap.put(HostnameProvider.class, map);
+
+        // the following can be inferred from the full hostname, so an exception is not expected
+        KeycloakContext context = factory.create().getContext();
+        assertNotNull(context.getUri());
+        assertEquals("https://full.host.name/path/", context.getAuthServerUrl().toString());
+        assertEquals("/path/", context.getContextPath());
+
+        assertEquals(0, context.getConnection().getLocalPort());
+
+        assertThrows(ContextNotActiveException.class, () -> context.getHttpRequest());
+    }
+
+}

--- a/services/src/test/java/org/keycloak/services/resteasy/ClientConnectionImpl.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ClientConnectionImpl.java
@@ -1,0 +1,46 @@
+package org.keycloak.services.resteasy;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.keycloak.common.ClientConnection;
+
+public class ClientConnectionImpl implements ClientConnection {
+
+    private HttpServletRequest request;
+
+    public ClientConnectionImpl(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+
+        if (forwardedFor != null) {
+            return forwardedFor;
+        }
+
+        return request.getRemoteAddr();
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return request.getRemoteHost();
+    }
+
+    @Override
+    public int getRemotePort() {
+        return request.getRemotePort();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return request.getLocalAddr();
+    }
+
+    @Override
+    public int getLocalPort() {
+        return request.getLocalPort();
+    }
+
+}

--- a/services/src/test/java/org/keycloak/services/resteasy/HttpRequestImpl.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/HttpRequestImpl.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -45,22 +46,16 @@ public class HttpRequestImpl implements HttpRequest {
     private org.jboss.resteasy.spi.HttpRequest delegate;
 
     public HttpRequestImpl(org.jboss.resteasy.spi.HttpRequest delegate) {
-        this.delegate = delegate;
+        this.delegate = Objects.requireNonNull(delegate);
     }
 
     @Override
     public String getHttpMethod() {
-        if (delegate == null) {
-            return null;
-        }
         return delegate.getHttpMethod();
     }
 
     @Override
     public MultivaluedMap<String, String> getDecodedFormParameters() {
-        if (delegate == null) {
-            return null;
-        }
         MediaType mediaType = getHttpHeaders().getMediaType();
         if (mediaType == null || !mediaType.isCompatible(MediaType.valueOf("application/x-www-form-urlencoded"))) {
             return new MultivaluedHashMap<>();
@@ -103,25 +98,16 @@ public class HttpRequestImpl implements HttpRequest {
 
     @Override
     public HttpHeaders getHttpHeaders() {
-        if (delegate == null) {
-            return null;
-        }
         return delegate.getHttpHeaders();
     }
 
     @Override
     public X509Certificate[] getClientCertificateChain() {
-        if (delegate == null) {
-            return null;
-        }
         return (X509Certificate[]) delegate.getAttribute("jakarta.servlet.request.X509Certificate");
     }
 
     @Override
     public UriInfo getUri() {
-        if (delegate == null) {
-            return null;
-        }
         return delegate.getUri();
     }
 

--- a/services/src/test/java/org/keycloak/services/resteasy/HttpResponseImpl.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/HttpResponseImpl.java
@@ -18,6 +18,7 @@
 package org.keycloak.services.resteasy;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import jakarta.ws.rs.core.NewCookie;
@@ -30,7 +31,7 @@ public class HttpResponseImpl implements HttpResponse {
     private Set<NewCookie> newCookies;
 
     public HttpResponseImpl(org.jboss.resteasy.spi.HttpResponse delegate) {
-        this.delegate = delegate;
+        this.delegate = Objects.requireNonNull(delegate);
     }
 
     @Override

--- a/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakContext.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakContext.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.services.resteasy;
 
+import java.util.Optional;
+
+import org.keycloak.common.ClientConnection;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
 import org.keycloak.models.KeycloakSession;
@@ -31,13 +34,18 @@ public class ResteasyKeycloakContext extends DefaultKeycloakContext {
     }
 
     @Override
-    protected HttpRequest createHttpRequest() {
-        return new HttpRequestImpl(ResteasyContext.getContextData(org.jboss.resteasy.spi.HttpRequest.class));
+    protected Optional<HttpRequest> createHttpRequest() {
+        return Optional.ofNullable(ResteasyContext.getContextData(org.jboss.resteasy.spi.HttpRequest.class)).map(HttpRequestImpl::new);
     }
 
     @Override
-    protected HttpResponse createHttpResponse() {
-        return new HttpResponseImpl(ResteasyContext.getContextData(org.jboss.resteasy.spi.HttpResponse.class));
+    protected Optional<HttpResponse> createHttpResponse() {
+        return Optional.ofNullable(ResteasyContext.getContextData(org.jboss.resteasy.spi.HttpResponse.class)).map(HttpResponseImpl::new);
+    }
+
+    @Override
+    public ClientConnection getConnection() {
+        throw new UnsupportedOperationException();
     }
 
 }

--- a/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakContext.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakContext.java
@@ -19,6 +19,8 @@ package org.keycloak.services.resteasy;
 
 import java.util.Optional;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 import org.keycloak.common.ClientConnection;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.http.HttpResponse;
@@ -44,8 +46,8 @@ public class ResteasyKeycloakContext extends DefaultKeycloakContext {
     }
 
     @Override
-    public ClientConnection getConnection() {
-        throw new UnsupportedOperationException();
+    protected Optional<ClientConnection> createClientConnection() {
+        return Optional.ofNullable(ResteasyContext.getContextData(HttpServletRequest.class)).map(ClientConnectionImpl::new);
     }
 
 }

--- a/services/src/test/java/org/keycloak/url/HostnameV2ProviderFactoryTest.java
+++ b/services/src/test/java/org/keycloak/url/HostnameV2ProviderFactoryTest.java
@@ -77,15 +77,20 @@ public class HostnameV2ProviderFactoryTest {
     }
 
     private void assertHostname(String hostname, boolean valid) {
-        Map<String, String> values = new HashMap<>();
-        values.put("hostname", hostname);
-        HostnameV2ProviderFactory factory = new HostnameV2ProviderFactory();
         try {
-            factory.init(ScopeUtil.createScope(values));
+            init(hostname);
             assertTrue(valid);
         } catch (IllegalArgumentException e) {
             assertFalse(valid);
         }
+    }
+
+    public static HostnameV2ProviderFactory init(String hostname) {
+        Map<String, String> values = new HashMap<>();
+        values.put("hostname", hostname);
+        HostnameV2ProviderFactory factory = new HostnameV2ProviderFactory();
+        factory.init(ScopeUtil.createScope(values));
+        return factory;
     }
 
 }

--- a/testsuite/utils/src/main/java/org/keycloak/testsuite/UndertowRequestFilter.java
+++ b/testsuite/utils/src/main/java/org/keycloak/testsuite/UndertowRequestFilter.java
@@ -26,7 +26,6 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.keycloak.common.ClientConnection;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -47,51 +46,15 @@ public class UndertowRequestFilter implements Filter {
         servletRequest.setCharacterEncoding("UTF-8");
         final HttpServletRequest request = (HttpServletRequest) servletRequest;
 
-        ClientConnection connection = createClientConnection(request);
         KeycloakModelUtils.runJobInTransaction(factory, session -> {
             try {
                 ResteasyContext.pushContext(KeycloakSession.class, session);
-                session.getContext().setConnection(connection);
+                ResteasyContext.pushContext(HttpServletRequest.class, request);
                 filterChain.doFilter(servletRequest, servletResponse);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         });
-    }
-
-    private ClientConnection createClientConnection(HttpServletRequest request) {
-        return new ClientConnection() {
-            @Override
-            public String getRemoteAddr() {
-                String forwardedFor = request.getHeader("X-Forwarded-For");
-
-                if (forwardedFor != null) {
-                    return forwardedFor;
-                }
-
-                return request.getRemoteAddr();
-            }
-
-            @Override
-            public String getRemoteHost() {
-                return request.getRemoteHost();
-            }
-
-            @Override
-            public int getRemotePort() {
-                return request.getRemotePort();
-            }
-
-            @Override
-            public String getLocalAddr() {
-                return request.getLocalAddr();
-            }
-
-            @Override
-            public int getLocalPort() {
-                return request.getLocalPort();
-            }
-        };
     }
 
     @Override


### PR DESCRIPTION
closes: #49083

@pruivo @ahus1 @pedroigor @vmuzikar @michalvavrik handling a ContextNotActiveException from async work keeps coming up. There are a couple of places we're catching ContextNotActiveException already, and now it looks like it's needed for session expiration logic.

The changes in this initial commit were to see what in our existing tests fail if we more comprehensively throw exceptions from our connection, request, and response methods. We currently have a mixture of behaviors depending upon whether quarkus or resteasy is being used. Even for quarkus there are times when the request context will be active, but the ResteasyReactiveRequestContext is not available (for example if you simply manually activate the context via Arc.container().requestContext().activate())

What I'm wondering is:
- should we just continue the pattern of catching the ContextNotActiveException as we hit this problem, and probably add more javadocs about this possibility
- begin the process of migrating the api to methods that return Optional - if we do this completely interally, it would also eventually address things like HostnameProvider logic #42450 
- or should the methods acutally return dummy connection, request, and response values (which the logic in QuarkusHttpResponse already allows for). This could be taken further so that we're also returning a dummy UriInfo.

WDYT?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloa
-->
