### PR TITLE
Use EventAssertion in some remaining tests and downgrade java to 21 for FIPS

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -x
 
+JAVA_VERSION=21
+
 rm -f /etc/system-fips
-dnf install -y java-25-openjdk-devel
+dnf install -y "java-${JAVA_VERSION}-openjdk-devel"
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --check | grep "FIPS mode is enabled."
 if [ $? -ne 0 ]; then
@@ -21,7 +23,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 echo "Tests: $TESTS"
-export JAVA_HOME=/etc/alternatives/java_sdk_25
+export JAVA_HOME="/etc/alternatives/java_sdk_${JAVA_VERSION}"
 set -o pipefail
 
 # Build adapter distributions
@@ -43,10 +45,10 @@ if [ $? -ne 0 ]; then
 fi
 
 # Profile app-server-wildfly needs to be explicitly set for FIPS tests
-./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dredhat.crypto-policies=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dcom.redhat.fips=false -Dredhat.crypto-policies=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
 # New Base Tests
-./mvnw package -nsu -B -Dredhat.crypto-policies=false -Dtest=$TESTSUITE_NAME -pl tests/base
+./mvnw package -nsu -B -Dcom.redhat.fips=false -Dredhat.crypto-policies=false -Dtest=$TESTSUITE_NAME -pl tests/base

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 
+JAVA_VERSION=21
+
 rm -f /etc/system-fips
-dnf install -y java-25-openjdk-devel crypto-policies-scripts
+dnf install -y "java-${JAVA_VERSION}-openjdk-devel"
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --check | grep "FIPS mode is enabled."
 if [ $? -ne 0 ]; then
   exit 1
 fi
-export JAVA_HOME=/etc/alternatives/java_sdk_25
+export JAVA_HOME="/etc/alternatives/java_sdk_${JAVA_VERSION}"
 
 # Build all dependent modules
 ./mvnw install -nsu -B -am -pl crypto/default,crypto/fips1402 -DskipTests
 
-./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dredhat.crypto-policies=true
+./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dcom.redhat.fips=true -Dredhat.crypto-policies=true
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
-./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dredhat.crypto-policies=true -Dorg.bouncycastle.fips.approved_only=true
+./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dcom.redhat.fips=true -Dredhat.crypto-policies=true -Dorg.bouncycastle.fips.approved_only=true

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/actions/AppInitiatedActionResetPasswordTest.java
@@ -45,7 +45,6 @@ import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testsuite.ActionURIUtils;
-import org.keycloak.testsuite.AssertEvents;
 import org.keycloak.testsuite.admin.AdminApiUtil;
 import org.keycloak.testsuite.pages.ErrorPage;
 import org.keycloak.testsuite.pages.LoginConfigTotpPage;
@@ -515,14 +514,14 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
                         + "auth_session_id=" + authSessionId))) {
                     Assert.assertEquals(302, response2.getStatusLine().getStatusCode());
                 }
-                events.expect(EventType.RESTART_AUTHENTICATION).user((String) null).assertEvent();
+                EventAssertion.assertSuccess(events.poll()).type(EventType.RESTART_AUTHENTICATION).userId(null);
 
                 // authenticate the user in the browser
                 oauth.openLoginForm();
                 loginPage.assertCurrent();
                 loginPage.login("test-user@localhost", "password");
                 appPage.assertCurrent();
-                events.expectLogin().user(AssertEvents.isUUID()).detail(Details.USERNAME, "test-user@localhost").assertEvent();
+                EventAssertion.expectLoginSuccess(events.poll()).hasUserId().details(Details.USERNAME, "test-user@localhost");
 
                 // navigate to the authenticate page with the other auth_session_id, tab_id and client_data
                 driver.navigate().to(oauth.getBaseUrl() + "/realms/" + oauth.getRealm()
@@ -531,8 +530,8 @@ public class AppInitiatedActionResetPasswordTest extends AbstractAppInitiatedAct
                         + "&tab_id=" + attrs.get("tab_id")
                         + "&client_data=" + attrs.get("client_data"));
                 errorPage.assertCurrent();
-                events.expect(EventType.LOGIN_ERROR).error(Errors.INVALID_CODE).user((String) null)
-                        .detail(Details.REASON, "cookie does not match auth_session query parameter").assertEvent();
+                EventAssertion.assertError(events.poll()).type(EventType.LOGIN_ERROR).error(Errors.INVALID_CODE).userId(null)
+                        .details(Details.REASON, "cookie does not match auth_session query parameter");
             }
         }
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/UserInfoTest.java
@@ -745,13 +745,12 @@ public class UserInfoTest extends AbstractKeycloakTest {
 
             assertEquals(Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
 
-            events.expect(EventType.USER_INFO_REQUEST_ERROR)
+            EventAssertion.assertError(events.poll()).type(EventType.USER_INFO_REQUEST_ERROR)
                     .error(Errors.INVALID_TOKEN)
-                    .user(Matchers.nullValue(String.class))
-                    .session(Matchers.nullValue(String.class))
-                    .detail(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN)
-                    .client((String) null)
-                    .assertEvent();
+                    .userId(null)
+                    .sessionId(null)
+                    .details(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN)
+                    .clientId(null);
 
             rep.setNotBefore(0);
             realm.update(rep);


### PR DESCRIPTION
Closes #49142
Closes #49151

Doing the EventAssertion changes for the remaining tests that were added simultaneously. The PR also fixes #49151 downgrading to java 21 until the devel package is re-added. It seems there is a bug or something in the ubi rhel9 repo.
