### PR TITLE
fix: restricting when the create user page is shown

### DIFF
--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HttpDistTest.java
@@ -28,16 +28,22 @@ import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
 import org.keycloak.it.junit5.extension.KeycloakRunner;
 import org.keycloak.it.junit5.extension.RawDistOnly;
+import org.keycloak.it.junit5.extension.StopServer;
 import org.keycloak.it.junit5.extension.StopServer.Mode;
 import org.keycloak.it.junit5.extension.TestProvider;
 import org.keycloak.it.resource.realm.TestRealmResourceTestProvider;
 import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import io.quarkus.test.junit.main.Launch;
+import io.restassured.RestAssured;
+import io.restassured.config.RedirectConfig;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,6 +54,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @DistributionTest(stopServer = Mode.MANUAL, enableTls = true)
 @RawDistOnly(reason = "Containers are immutable")
 public class HttpDistTest {
+
+    @BeforeEach
+    public void setRestAssuredHttps() {
+        RestAssured.useRelaxedHTTPSValidation();
+        RestAssured.config = RestAssured.config.redirect(RedirectConfig.redirectConfig().followRedirects(false));
+    }
+    
     @Test
     @TestProvider(TestRealmResourceTestProvider.class)
     public void maxQueuedRequestsTest(KeycloakRunner runner) {
@@ -114,6 +127,26 @@ public class HttpDistTest {
         result = runner.run("start", "--https-trust-store-file=" + truststorePath, "--hostname-strict=false");
         result.assertExitCode(-1);
         result.assertMessage("ERROR: No trust store password provided");
+    }
+    
+    @StopServer(Mode.MANUAL)
+    @Test
+    @Launch({"start", "--db=dev-file", "--hostname-strict=false", "--http-enabled=true"})
+    void testStartNonLocalHttps(CLIResult cliResult) {
+        cliResult.assertStarted();
+        
+        // should not be directed to create an admin user - we can't be sure if a local proxy is being used
+        when().get("https://localhost:8443/").then().statusCode(200).body(containsString("You will need local access"));
+    }
+    
+    @StopServer(Mode.MANUAL)
+    @Test
+    @Launch({"start", "--db=dev-file", "--proxy-headers=forwarded", "--hostname-strict=false", "--http-enabled=true"})
+    void testStartLocalHttps(CLIResult cliResult) {
+        cliResult.assertStarted();
+        
+        // should be directed to create an admin user, as the request is not setting the proxy header
+        when().get("https://localhost:8443/").then().statusCode(200).body(Matchers.not(containsString("You will need local access")));
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -34,6 +34,7 @@ import org.keycloak.it.utils.RawKeycloakDistribution;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.main.Launch;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 import static org.keycloak.quarkus.runtime.cli.command.Main.CONFIG_FILE_LONG_NAME;
 
+import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -155,6 +157,26 @@ public class StartCommandDistTest {
     @Order(2)
     void failIfOptimizedUsedForFirstStartup(CLIResult cliResult) {
         cliResult.assertError("The '--optimized' flag was used for first ever server start.");
+    }
+    
+    @StopServer(Mode.MANUAL)
+    @Test
+    @Launch({"start", "--db=dev-file", "--hostname-strict=false", "--http-enabled=true"})
+    void testStartNonLocal(CLIResult cliResult) {
+        cliResult.assertStarted();
+        
+        // should not be directed to create an admin user
+        when().get("/").then().statusCode(200).body(containsString("You will need local access"));
+    }
+    
+    @StopServer(Mode.MANUAL)
+    @Test
+    @Launch({"start", "--db=dev-file", "--proxy-headers=forwarded", "--hostname-strict=false", "--http-enabled=true"})
+    void testStartLocal(CLIResult cliResult) {
+        cliResult.assertStarted();
+        
+        // should not be directed to create an admin user
+        when().get("/").then().statusCode(200).body(Matchers.not(containsString("You will need local access")));
     }
 
     @Test

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/StartCommandDistTest.java
@@ -165,20 +165,10 @@ public class StartCommandDistTest {
     void testStartNonLocal(CLIResult cliResult) {
         cliResult.assertStarted();
         
-        // should not be directed to create an admin user
-        when().get("/").then().statusCode(200).body(containsString("You will need local access"));
-    }
-    
-    @StopServer(Mode.MANUAL)
-    @Test
-    @Launch({"start", "--db=dev-file", "--proxy-headers=forwarded", "--hostname-strict=false", "--http-enabled=true"})
-    void testStartLocal(CLIResult cliResult) {
-        cliResult.assertStarted();
-        
-        // should not be directed to create an admin user
+        // should be directed to create an admin user over http
         when().get("/").then().statusCode(200).body(Matchers.not(containsString("You will need local access")));
     }
-
+    
     @Test
     @Launch({ "start", "--db=dev-file", "--http-enabled=true" })
     void failNoHostnameNotSet(CLIResult cliResult) {

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -41,12 +41,16 @@ import jakarta.ws.rs.core.Response.ResponseBuilder;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.ext.Provider;
 
+import org.keycloak.Config;
+import org.keycloak.Config.Scope;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
 import org.keycloak.common.Version;
 import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.Environment;
 import org.keycloak.common.util.MimeTypeUtil;
 import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.config.ProxyOptions;
 import org.keycloak.cookie.CookieProvider;
 import org.keycloak.cookie.CookieType;
 import org.keycloak.http.HttpRequest;
@@ -283,6 +287,15 @@ public class WelcomeResource {
     }
 
     public static boolean isLocal(KeycloakSession session) {
+        // if proxy-headers and proxy-protocol aren't set, then we can't properly tell if we're behind a local proxy, so don't consider this local
+        Scope rootConfig = Config.scope().root();
+        if (rootConfig.get(ProxyOptions.PROXY_HEADERS.getKey()) == null
+                && !rootConfig.getBoolean(ProxyOptions.PROXY_PROTOCOL_ENABLED.getKey())
+                && !Environment.isDevMode()) {
+            logger.debugf("proxy-headers, nor proxy-protocol enabled, won't consider the access local for non-dev mode");
+            return false;
+        }
+
         ClientConnection clientConnection = session.getContext().getConnection();
         String remoteAddress = clientConnection.getRemoteAddr();
         String localAddress = clientConnection.getLocalAddr();

--- a/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/WelcomeResource.java
@@ -291,8 +291,9 @@ public class WelcomeResource {
         Scope rootConfig = Config.scope().root();
         if (rootConfig.get(ProxyOptions.PROXY_HEADERS.getKey()) == null
                 && !rootConfig.getBoolean(ProxyOptions.PROXY_PROTOCOL_ENABLED.getKey())
+                && "https".equals(session.getContext().getHttpRequest().getUri().getRequestUri().getScheme())
                 && !Environment.isDevMode()) {
-            logger.debugf("proxy-headers, nor proxy-protocol enabled, won't consider the access local for non-dev mode");
+            logger.debugf("proxy-headers, nor proxy-protocol enabled, won't consider the https access local for non-dev mode");
             return false;
         }
 


### PR DESCRIPTION
closes: #49137

@vmuzikar @sschu there are three approaches we can take here. This commit shows the narrow approach - for which I don't think additional documentation changes are needed as things will continue to work as it did before for all but a small amount of keycloak installs.

The possible wider changes are:

- don't allow the isLocal check to ever return true in prod mode. Would this need highlighted more in the docs in some way, or are the instructions already on the welcome page sufficient?

- If we don't want to trust how the user has configured the proxy at all, then we could replace the isLocal check entirely with isDev. This however would prevent some of the admin redirects from happening, and more importantly if you did have a dev instance behind a proxy, you would be allowed to create the user via the proxy.

WDYT?

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
