### PR TITLE
Downgrade java version to 21 for the FIPS jobs (26.6)

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -x
 
+JAVA_VERSION=21
+
 rm -f /etc/system-fips
-dnf install -y java-25-openjdk-devel
+dnf install -y "java-${JAVA_VERSION}-openjdk-devel"
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --check | grep "FIPS mode is enabled."
 if [ $? -ne 0 ]; then
@@ -21,7 +23,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 echo "Tests: $TESTS"
-export JAVA_HOME=/etc/alternatives/java_sdk_25
+export JAVA_HOME="/etc/alternatives/java_sdk_${JAVA_VERSION}"
 set -o pipefail
 
 # Build adapter distributions
@@ -43,10 +45,10 @@ if [ $? -ne 0 ]; then
 fi
 
 # Profile app-server-wildfly needs to be explicitly set for FIPS tests
-./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dredhat.crypto-policies=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
+./mvnw test -Dsurefire.rerunFailingTestsCount=$SUREFIRE_RERUN_FAILING_COUNT -nsu -B -Pauth-server-quarkus,auth-server-fips140-2,app-server-wildfly -Dcom.redhat.fips=false -Dredhat.crypto-policies=false $STRICT_OPTIONS -Dtest=$TESTS -pl testsuite/integration-arquillian/tests/base 2>&1 | misc/log/trimmer.sh
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
 # New Base Tests
-./mvnw package -nsu -B -Dredhat.crypto-policies=false -Dtest=$TESTSUITE_NAME -pl tests/base
+./mvnw package -nsu -B -Dcom.redhat.fips=false -Dredhat.crypto-policies=false -Dtest=$TESTSUITE_NAME -pl tests/base

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 
+JAVA_VERSION=21
+
 rm -f /etc/system-fips
-dnf install -y java-25-openjdk-devel crypto-policies-scripts
+dnf install -y "java-${JAVA_VERSION}-openjdk-devel"
 fips-mode-setup --enable --no-bootcfg
 fips-mode-setup --check | grep "FIPS mode is enabled."
 if [ $? -ne 0 ]; then
   exit 1
 fi
-export JAVA_HOME=/etc/alternatives/java_sdk_25
+export JAVA_HOME="/etc/alternatives/java_sdk_${JAVA_VERSION}"
 
 # Build all dependent modules
 ./mvnw install -nsu -B -am -pl crypto/default,crypto/fips1402 -DskipTests
 
-./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dredhat.crypto-policies=true
+./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dcom.redhat.fips=true -Dredhat.crypto-policies=true
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
-./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dredhat.crypto-policies=true -Dorg.bouncycastle.fips.approved_only=true
+./mvnw test -nsu -B -pl crypto/default,crypto/fips1402 -Dcom.redhat.fips=true -Dredhat.crypto-policies=true -Dorg.bouncycastle.fips.approved_only=true


### PR DESCRIPTION
Closes #49151

Backport to 26.6 until the java 25 devel package comes back to rhel 9.
One commit of PR https://github.com/keycloak/keycloak/pull/49143.
