### PR TITLE
Reorder X509 validation to check revocation after trust

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/ValidateX509CertificateUsername.java
@@ -75,12 +75,12 @@ public class ValidateX509CertificateUsername extends AbstractX509ClientCertifica
         try {
             CertificateValidator.CertificateValidatorBuilder builder = certificateValidationParameters(context.getSession(), config);
             CertificateValidator validator = builder.build(certs);
-            validator.checkRevocationStatus()
-                    .validateTrust()
+            validator.validateTrust()
+                    .validateTimestamps()
                     .validateKeyUsage()
                     .validateExtendedKeyUsage()
-                    .validateTimestamps()
-                    .validatePolicy();
+                    .validatePolicy()
+                    .checkRevocationStatus();
         } catch(Exception e) {
             logger.error(e.getMessage(), e);
             // TODO use specific locale to load error messages

--- a/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/x509/X509ClientCertificateAuthenticator.java
@@ -90,12 +90,12 @@ public class X509ClientCertificateAuthenticator extends AbstractX509ClientCertif
             try {
                 CertificateValidator.CertificateValidatorBuilder builder = certificateValidationParameters(context.getSession(), config);
                 CertificateValidator validator = builder.build(certs);
-                validator.checkRevocationStatus()
-                         .validateTrust()
+                validator.validateTrust()
+                         .validateTimestamps()
                          .validateKeyUsage()
                          .validateExtendedKeyUsage()
                          .validatePolicy()
-                         .validateTimestamps();
+                         .checkRevocationStatus();
             } catch(Exception e) {
                 logger.error(e.getMessage(), e);
                 // TODO use specific locale to load error messages


### PR DESCRIPTION
Close #46742

Just reordering the X509 validation to do the revocation checks after the trust. This way we ensure the revocation is only done if the certificate is valid based on the other checks. As commented in the issue, mTLS already approved the certificate, so this is only done if configured to re-validate.
