### PR TITLE
docs(workflows): fix offboarding example revoke-role role list format

### DIFF
--- a/docs/documentation/server_admin/topics/workflows/understanding-common-use-cases.adoc
+++ b/docs/documentation/server_admin/topics/workflows/understanding-common-use-cases.adoc
@@ -33,7 +33,10 @@ on: user-group-membership-removed(/Sales)
 steps:
   - uses: revoke-role
     with:
-      role: "manager,sales-rep,sales-intern"
+      role:
+        - sales-rep
+        - manager
+        - sales-intern
 ```
 
 == Tracking user activity and taking actions on inactivity


### PR DESCRIPTION
Closes #49140

The revoke-role step expects multivalued role names, not a comma-separated string.


(cherry picked from commit a988875ac4e57dabbcfdfaab23b6638a6d8cb7b7)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
