### PR TITLE
Fix multiselect chip removal adding label instead of removing value

### DIFF
--- a/js/libs/ui-shared/src/user-profile/SelectComponent.tsx
+++ b/js/libs/ui-shared/src/user-profile/SelectComponent.tsx
@@ -78,10 +78,14 @@ export const SelectComponent = (props: UserProfileFieldProps) => {
             onToggle={(b) => setOpen(b)}
             onClear={() => setValue("", field)}
             onSelect={(value) => {
-              const option = value.toString();
-              setValue(option, field);
-              if (!Array.isArray(field.value)) {
-                setOpen(false);
+              let option = value.toString()
+              // When a chip is removed in typeaheadMulti, the value passed is the label,
+              // not the raw option value. Reverse-map the label back to the original value.
+              if (isMultiValue && Array.isArray(field.value) && !field.value.includes(option)) {
+                const originalValue = field.value.find((v: string) => fetchLabel(v) === option)
+                if (originalValue) {
+                  option = originalValue
+                }
               }
             }}
             selections={


### PR DESCRIPTION
## Problem

When removing a selected option by clicking the X on a chip in a `typeaheadMulti` select (e.g., a multi select user profile attribute), the option's label is appended to the field value array instead of the corresponding raw value being removed.

This happens because `TypeaheadSelect` passes the displayed chip text (the label) to `onSelect` when a chip is clicked, but `SelectComponent.setValue()` checks `field.value.includes(value)` against the raw option values. When `inputOptionLabels` are configured and labels differ from values, the check always fails, causing the code to fall into the `else` branch and add the label string to the array.

## Root Cause

In `TypeaheadSelect`, the `selections` prop receives labels (`field.value.map(fetchLabel)`), and chip click handlers call `onSelect(selection)` with those labels. `SelectComponent`'s `onSelect` handler passes the label directly to `setValue`, which can't find it in `field.value` (which contains raw values), so it treats it as a new selection.

## Fix

Before calling `setValue`, if the received value isn't found in `field.value`, reverse-map it back to the original option value using `fetchLabel`. This ensures chip removal correctly identifies and removes the underlying value.

## How to Reproduce

1. Configure a user profile attribute as `multiselect` with `inputOptionLabels` (where labels differ from values)
2. Select one or more options
3. Click the X on a chip to remove a selection
4. Observe that the label string is added to the field value instead of the original value being removed