### PR TITLE
[OID4VCI]: Delegate private JWK claim validation to signature provider factories

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProviderFactory.java
@@ -16,11 +16,19 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.keycloak.Config;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.ProviderFactory;
 
 public interface SignatureProviderFactory extends ProviderFactory<SignatureProvider> {
+
+    Set<String> RSA_PRIVATE_JWK_CLAIMS = Set.of("d", "p", "q", "dp", "dq", "qi", "oth");
+    Set<String> EC_PRIVATE_JWK_CLAIMS = Set.of("d");
+    Set<String> OKP_PRIVATE_JWK_CLAIMS = Set.of("d");
+    Set<String> OCT_PRIVATE_JWK_CLAIMS = Set.of("k");
 
     @Override
     default void init(Config.Scope config) {
@@ -32,6 +40,23 @@ public interface SignatureProviderFactory extends ProviderFactory<SignatureProvi
 
     @Override
     default void close() {
+    }
+
+    /**
+     * @return a set of JWK claims that indicate the presence of private key material for the algorithm supported by this provider.
+     * An empty set indicates that the provider factory does not explicitly define private claims,
+     * allowing callers to apply a secure global default.
+     */
+    default Set<String> getJwkPrivateKeyClaims() {
+        return Collections.emptySet();
+    }
+
+    /**
+     * @return a unified set of all known JWK private key claims across all supported algorithms.
+     * This serves as a secure fallback when a specific signature provider factory cannot be resolved or doesn't define its own claims.
+     */
+    static Set<String> getDefaultJwkPrivateKeyClaims() {
+        return Set.of("d", "p", "q", "dp", "dq", "qi", "oth", "k");
     }
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/crypto/SignatureProviderFactory.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.crypto;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.keycloak.Config;
@@ -43,20 +42,9 @@ public interface SignatureProviderFactory extends ProviderFactory<SignatureProvi
     }
 
     /**
-     * @return a set of JWK claims that indicate the presence of private key material for the algorithm supported by this provider.
-     * An empty set indicates that the provider factory does not explicitly define private claims,
-     * allowing callers to apply a secure global default.
+     * Returns the JWK claim names that represent private key material for the algorithm
+     * supported by this provider implementation.
      */
-    default Set<String> getJwkPrivateKeyClaims() {
-        return Collections.emptySet();
-    }
-
-    /**
-     * @return a unified set of all known JWK private key claims across all supported algorithms.
-     * This serves as a secure fallback when a specific signature provider factory cannot be resolved or doesn't define its own claims.
-     */
-    static Set<String> getDefaultJwkPrivateKeyClaims() {
-        return Set.of("d", "p", "q", "dp", "dq", "qi", "oth", "k");
-    }
+    Set<String> getJwkPrivateKeyClaims();
 
 }

--- a/services/src/main/java/org/keycloak/crypto/ES256SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/ES256SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class ES256SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class ES256SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new ECDSASignatureProvider(session, Algorithm.ES256);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return EC_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/ES384SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/ES384SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class ES384SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class ES384SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new ECDSASignatureProvider(session, Algorithm.ES384);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return EC_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/ES512SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/ES512SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class ES512SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class ES512SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new ECDSASignatureProvider(session, Algorithm.ES512);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return EC_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/EdDSASignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/EdDSASignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 /**
@@ -33,6 +35,11 @@ public class EdDSASignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new EdDSASignatureProvider(session);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return OKP_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/HS256SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/HS256SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class HS256SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,14 @@ public class HS256SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new MacSecretSignatureProvider(session, Algorithm.HS256);
+    }
+
+    /**
+     * Returns the "k" claim which represents the secret key material for symmetric algorithms (oct JWKs).
+     */
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return OCT_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/HS384SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/HS384SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class HS384SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,14 @@ public class HS384SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new MacSecretSignatureProvider(session, Algorithm.HS384);
+    }
+
+    /**
+     * Returns the "k" claim which represents the secret key material for symmetric algorithms (oct JWKs).
+     */
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return OCT_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/HS512SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/HS512SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class HS512SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,14 @@ public class HS512SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new MacSecretSignatureProvider(session, Algorithm.HS512);
+    }
+
+    /**
+     * Returns the "k" claim which represents the secret key material for symmetric algorithms (oct JWKs).
+     */
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return OCT_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/PS256SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/PS256SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class PS256SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class PS256SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new AsymmetricSignatureProvider(session, Algorithm.PS256);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return RSA_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/PS384SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/PS384SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class PS384SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class PS384SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new AsymmetricSignatureProvider(session, Algorithm.PS384);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return RSA_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/PS512SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/PS512SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class PS512SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class PS512SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new AsymmetricSignatureProvider(session, Algorithm.PS512);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return RSA_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/RS256SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/RS256SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class RS256SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class RS256SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new AsymmetricSignatureProvider(session, Algorithm.RS256);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return RSA_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/RS384SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/RS384SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class RS384SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class RS384SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new AsymmetricSignatureProvider(session, Algorithm.RS384);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return RSA_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/crypto/RS512SignatureProviderFactory.java
+++ b/services/src/main/java/org/keycloak/crypto/RS512SignatureProviderFactory.java
@@ -16,6 +16,8 @@
  */
 package org.keycloak.crypto;
 
+import java.util.Set;
+
 import org.keycloak.models.KeycloakSession;
 
 public class RS512SignatureProviderFactory implements SignatureProviderFactory {
@@ -30,6 +32,11 @@ public class RS512SignatureProviderFactory implements SignatureProviderFactory {
     @Override
     public SignatureProvider create(KeycloakSession session) {
         return new AsymmetricSignatureProvider(session, Algorithm.RS512);
+    }
+
+    @Override
+    public Set<String> getJwkPrivateKeyClaims() {
+        return RSA_PRIVATE_JWK_CLAIMS;
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -381,18 +380,7 @@ public class JwtProofValidator extends AbstractProofValidator {
         Object factory = keycloakSession.getKeycloakSessionFactory()
                 .getProviderFactory(SignatureProvider.class, algorithm);
 
-        Set<String> privateClaimNames;
-        if (factory instanceof SignatureProviderFactory signatureProviderFactory) {
-            privateClaimNames = signatureProviderFactory.getJwkPrivateKeyClaims();
-        } else {
-            privateClaimNames = Collections.emptySet();
-        }
-
-        if (privateClaimNames.isEmpty()) {
-            // Fallback to the global set of claims if no provider is found, or it doesn't define any.
-            // This ensures we keep the same level of security for unknown or legacy providers.
-            privateClaimNames = SignatureProviderFactory.getDefaultJwkPrivateKeyClaims();
-        }
+        Set<String> privateClaimNames = getPrivateClaimNames(algorithm, factory);
 
         for (String privateClaim : privateClaimNames) {
             if (jwkMap.containsKey(privateClaim)) {
@@ -402,10 +390,25 @@ public class JwtProofValidator extends AbstractProofValidator {
         }
     }
 
+    private static Set<String> getPrivateClaimNames(String algorithm, Object factory) {
+        if (!(factory instanceof SignatureProviderFactory signatureProviderFactory)) {
+            throw new VCIssuerException(ErrorType.INVALID_PROOF,
+                    "No SignatureProviderFactory found for algorithm: " + algorithm);
+        }
+
+        Set<String> privateClaimNames = signatureProviderFactory.getJwkPrivateKeyClaims();
+
+        if (privateClaimNames.isEmpty()) {
+            throw new VCIssuerException(ErrorType.INVALID_PROOF,
+                    "SignatureProviderFactory for algorithm " + algorithm + " does not define private JWK claims");
+        }
+        return privateClaimNames;
+    }
+
     private void validateProofPayload(VCIssuanceContext vcIssuanceContext, AccessToken proofPayload)
             throws VCIssuerException, VerificationException {
         AuthenticationManager.AuthResult authResult = vcIssuanceContext.getAuthResult();
-        AccessToken requestToken = authResult != null ? authResult.getToken() : null;
+        AccessToken requestToken = authResult != null ? authResult.token() : null;
         String expectedClientId = requestToken != null ? requestToken.getIssuedFor() : null;
         String proofIssuer = proofPayload.getIssuer();
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -31,6 +32,8 @@ import java.util.Set;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.CryptoUtils;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureProviderFactory;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKParser;
@@ -68,8 +71,7 @@ public class JwtProofValidator extends AbstractProofValidator {
     public static final String PROOF_JWT_TYP = "openid4vci-proof+jwt";
     private static final String CRYPTOGRAPHIC_BINDING_METHOD_JWK = "jwk";
     private static final String KEY_ATTESTATION_CLAIM = "key_attestation";
-    // JOSE private JWK parameters across RSA/EC/OKP/oct key types. TODO: This is not very reliable and should be either removed or improved to cover the cases when other algorithms are introduced in the future
-    private static final Set<String> JWK_PRIVATE_KEY_CLAIMS = Set.of("d", "p", "q", "dp", "dq", "qi", "oth", "k");
+    
     private static final int PROOF_MAX_AGE_SECONDS = 30;
     private static final int PROOF_FUTURE_SKEW_SECONDS = 10;
     private final AttestationKeyResolver keyResolver;
@@ -148,7 +150,8 @@ public class JwtProofValidator extends AbstractProofValidator {
         Map<String, Object> headerClaims = JsonSerialization.mapper.convertValue(jwsHeader,
                 new TypeReference<>() {
                 });
-        validateNoPrivateKeyInHeaderClaims(headerClaims);
+        String algorithm = jwsHeader.getAlgorithm().name();
+        validateNoPrivateKeyInHeaderClaims(algorithm, headerClaims);
         KeyAttestationInfo attestationInfo = resolveHeaderAttestation(vcIssuanceContext, headerClaims);
 
         // Handle both JWK and kid cases for the proof key
@@ -230,7 +233,7 @@ public class JwtProofValidator extends AbstractProofValidator {
         Proofs proofs = credentialRequest != null ? credentialRequest.getProofs() : null;
 
         // If no proof types are configured for this credential configuration, cryptographic binding is
-        // not required and we must not enforce presence of proofs. However, if a JWT proof is supplied,
+        // not required, and we must not enforce presence of proofs. However, if a JWT proof is supplied,
         // reject it explicitly rather than silently ignoring an unconfigured proof input.
         // Note: do not use Optional.map(getProofTypesSupported): a null ProofTypesSupported must still run this logic.
         if (proofTypesSupported == null
@@ -271,7 +274,7 @@ public class JwtProofValidator extends AbstractProofValidator {
      */
     private void validateJwsHeader(VCIssuanceContext vcIssuanceContext, JWSHeader jwsHeader) throws VCIssuerException {
         String alg = Optional.ofNullable(jwsHeader.getAlgorithm())
-                .map(algorithm -> algorithm.name())
+                .map(Enum::name)
                 .orElseThrow(() -> new VCIssuerException(ErrorType.INVALID_PROOF, "Missing jwsHeader claim alg"));
         if (!CryptoUtils.getSupportedAsymmetricSignatureAlgorithms(keycloakSession).contains(alg)) {
             throw new VCIssuerException(ErrorType.INVALID_PROOF, "Proof signature algorithm not supported: " + alg);
@@ -366,12 +369,32 @@ public class JwtProofValidator extends AbstractProofValidator {
         }
     }
 
-    private void validateNoPrivateKeyInHeaderClaims(Map<String, Object> headerClaims) {
+    /**
+     * Rejects proofs containing private key material in their JWK header claim.
+     */
+    void validateNoPrivateKeyInHeaderClaims(String algorithm, Map<String, Object> headerClaims) {
         Object jwkClaim = headerClaims.get("jwk");
         if (!(jwkClaim instanceof Map<?, ?> jwkMap)) {
             return;
         }
-        for (String privateClaim : JWK_PRIVATE_KEY_CLAIMS) {
+
+        Object factory = keycloakSession.getKeycloakSessionFactory()
+                .getProviderFactory(SignatureProvider.class, algorithm);
+
+        Set<String> privateClaimNames;
+        if (factory instanceof SignatureProviderFactory signatureProviderFactory) {
+            privateClaimNames = signatureProviderFactory.getJwkPrivateKeyClaims();
+        } else {
+            privateClaimNames = Collections.emptySet();
+        }
+
+        if (privateClaimNames.isEmpty()) {
+            // Fallback to the global set of claims if no provider is found, or it doesn't define any.
+            // This ensures we keep the same level of security for unknown or legacy providers.
+            privateClaimNames = SignatureProviderFactory.getDefaultJwkPrivateKeyClaims();
+        }
+
+        for (String privateClaim : privateClaimNames) {
             if (jwkMap.containsKey(privateClaim)) {
                 throw new VCIssuerException(ErrorType.INVALID_PROOF,
                         "JWK header must not contain private key material claim: " + privateClaim);

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
@@ -58,8 +58,8 @@ public class JwtProofValidatorTest extends AbstractUtilSessionTest {
     }
 
     @Test
-    public void testValidateNoPrivateKeyInHeaderClaims_UnknownAlgorithm_FallbackBlocked() {
-        // FAKE256 should trigger the fallback which includes "d"
+    public void testValidateNoPrivateKeyInHeaderClaims_UnknownAlgorithm_Blocked() {
+        // FAKE256 has no registered provider, should throw
         assertBlocked("FAKE256", "RSA", "d", "secret");
     }
 

--- a/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidatorTest.java
@@ -1,0 +1,84 @@
+package org.keycloak.protocol.oid4vc.issuance.keybinding;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
+import org.keycloak.utils.AbstractUtilSessionTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JwtProofValidatorTest extends AbstractUtilSessionTest {
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_RS256_Blocked() {
+        assertBlocked("RS256", "RSA", "d", "secret");
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_RS256_BlockedBy_P_Claim() {
+        // Test that RSA rejects other private claims like 'p' even if 'd' is absent
+        assertBlocked("RS256", "RSA", "p", "secret-p");
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_RS256_Allowed() {
+        Map<String, Object> jwk = new HashMap<>();
+        jwk.put("kty", "RSA");
+        jwk.put("n", "modulus");
+        jwk.put("e", "exponent");
+        assertAllowed("RS256", jwk);
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_PS256_Blocked() {
+        assertBlocked("PS256", "RSA", "d", "secret");
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_ES256_Blocked() {
+        assertBlocked("ES256", "EC", "d", "secret");
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_ES256_Allowed() {
+        Map<String, Object> jwk = new HashMap<>();
+        jwk.put("kty", "EC");
+        jwk.put("x", "coord-x");
+        jwk.put("y", "coord-y");
+        assertAllowed("ES256", jwk);
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_EdDSA_Blocked() {
+        assertBlocked("EdDSA", "OKP", "d", "secret");
+    }
+
+    @Test
+    public void testValidateNoPrivateKeyInHeaderClaims_UnknownAlgorithm_FallbackBlocked() {
+        // FAKE256 should trigger the fallback which includes "d"
+        assertBlocked("FAKE256", "RSA", "d", "secret");
+    }
+
+    private void assertBlocked(String alg, String kty, String claim, Object value) {
+        JwtProofValidator validator = new JwtProofValidator(session, null);
+        Map<String, Object> headerClaims = new HashMap<>();
+        Map<String, Object> jwk = new HashMap<>();
+        jwk.put("kty", kty);
+        jwk.put(claim, value);
+        headerClaims.put("jwk", jwk);
+
+        assertThrows(VCIssuerException.class, () -> validator.validateNoPrivateKeyInHeaderClaims(alg, headerClaims));
+    }
+
+    private void assertAllowed(String alg, Map<String, Object> jwk) {
+        JwtProofValidator validator = new JwtProofValidator(session, null);
+        Map<String, Object> headerClaims = new HashMap<>();
+        headerClaims.put("jwk", jwk);
+
+        assertDoesNotThrow(() -> validator.validateNoPrivateKeyInHeaderClaims(alg, headerClaims));
+    }
+}


### PR DESCRIPTION
This PR replaces the hardcoded `JWK_PRIVATE_KEY_CLAIMS` constant in the OID4VCI `JwtProofValidator` with a dynamic, SPI-driven approach. Instead of guessing private claims, the validator now dynamically resolves the `SignatureProviderFactory` for the requested algorithm and queries it for its specific private key claims. 

**Key changes:**

- Replaced hardcoded JWK_PRIVATE_KEY_CLAIMS in JwtProofValidator with a pluggable SPI mechanism
- Extended SignatureProviderFactory with getJwkPrivateKeyClaims() to allow providers to declare their own private claims
- Implemented specific private claim metadata across RSA, EC, EdDSA, and HMAC signature providers
- Added JwtProofValidatorTest to unit test the dynamic claim detection and validation fallback
- Ensured existing OID4VCI integration tests correctly validate end-to-end flow using EC proofs

Closes #48415