### PR TITLE
[OAuth] Prefer authorization error on redirect_uri

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -137,6 +137,8 @@ public class Profile {
         OID4VC_VCI_PREAUTH_CODE("Support for credential offers with `pre-authorized_code` grant.", Type.EXPERIMENTAL, OID4VC_VCI),
         OID4VC_VCI_REST_CREDENTIAL_OFFER("Support for the REST endpoint to create credential offers.", Type.EXPERIMENTAL, OID4VC_VCI),
 
+        OID4VC_HAIP("OpenID4VC High Assurance Interoperability Profile 1.0", Type.EXPERIMENTAL, OID4VC_VCI),
+
         OPENTELEMETRY("OpenTelemetry support", Type.DEFAULT),
         OPENTELEMETRY_LOGS("OpenTelemetry Logs support", Type.PREVIEW, OPENTELEMETRY),
         OPENTELEMETRY_METRICS("Micrometer to OpenTelemetry bridge support for metrics", Type.EXPERIMENTAL, OPENTELEMETRY),

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
@@ -95,6 +95,7 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
      * Comma-separated aliases of trust-material identity providers that expose the trusted attester keys.
      */
     public static final String OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS = "attester_trust_idps";
+    public static final String OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS = "abca-attester-default-trust";
 
     @Override
     public String getId() {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationCheckProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationCheckProvider.java
@@ -16,9 +16,9 @@ import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
 import org.keycloak.protocol.oid4vc.model.IssuerState;
 import org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointCheckProvider;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
-import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 
 import static org.keycloak.OAuth2Constants.ISSUER_STATE;

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -46,6 +46,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.ClientData;
 import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.utils.LogoutUtil;
@@ -57,6 +58,7 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.adapters.action.PushNotBeforeAction;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -436,8 +438,8 @@ public class OIDCLoginProtocol implements LoginProtocol {
         try {
             checker.checkResponseType();
             checker.checkRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            checker.throwAsErrorPageException(null, ex);
+        } catch (AuthorizationCheckException ex) {
+            throw new ErrorPageException(session, ex.getError(), ex.getStatus(), ex.getErrorMessage(), ex.getParameters());
         }
 
         setupResponseTypeAndMode(clientData.getResponseType(), clientData.getResponseMode());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationCheckException.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationCheckException.java
@@ -1,0 +1,49 @@
+package org.keycloak.protocol.oidc.endpoints;
+
+import java.text.MessageFormat;
+
+import jakarta.ws.rs.core.Response;
+
+// Exception propagated to the caller, which will allow caller to send proper error response based on the context (Browser OIDC Authorization Endpoint, PAR etc)
+public class AuthorizationCheckException extends Exception {
+
+    private final Response.Status status;
+    private final String error;
+    private final String errorMessage;
+    private final Object[] parameters;
+
+    public AuthorizationCheckException(Response.Status status, String error, String errorDescription) {
+        this(error, status, errorDescription);
+    }
+
+    public AuthorizationCheckException(String error, Response.Status status, String errorMessage, Object... params) {
+        this.status = status;
+        this.error = error;
+        this.errorMessage = errorMessage;
+        this.parameters = params;
+    }
+
+    public Response.Status getStatus() {
+        return status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorDescription() {
+        String errorDescription = errorMessage;
+        if (parameters.length > 0) {
+            errorDescription = MessageFormat.format(errorMessage, parameters);
+        }
+        return errorDescription;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Object[] getParameters() {
+        return parameters;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -17,8 +17,12 @@
 
 package org.keycloak.protocol.oidc.endpoints;
 
+import java.io.IOException;
+import java.text.MessageFormat;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.function.BiConsumer;
 
 import jakarta.ws.rs.Consumes;
@@ -48,12 +52,14 @@ import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor.EndpointType;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
 import org.keycloak.protocol.oidc.grants.device.endpoints.DeviceEndpoint;
 import org.keycloak.protocol.oidc.utils.AcrUtils;
 import org.keycloak.protocol.oidc.utils.OIDCRedirectUriBuilder;
 import org.keycloak.protocol.oidc.utils.OIDCResponseMode;
 import org.keycloak.protocol.oidc.utils.OIDCResponseType;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.Urls;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -65,6 +71,7 @@ import org.keycloak.services.resources.LoginActionsService;
 import org.keycloak.services.util.CacheControlUtil;
 import org.keycloak.services.util.LocaleUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.theme.Theme;
 import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
@@ -80,6 +87,9 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
     public static final String CODE_AUTH_TYPE = "code";
 
+    // Prefer error delivery on `redirect_uri` - rather than as HTML error page
+    public static final String AUTHORIZATION_PREFER_ERROR_ON_REDIRECT = "authorization.preferErrorOnRedirect";
+
     /**
      * Prefix used to store additional HTTP GET params from original client request into {@link AuthenticationSessionModel} note to be available later in Authenticators, RequiredActions etc. Prefix is used to
      * prevent collisions with internally used notes.
@@ -93,6 +103,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private ClientModel client;
+    private AuthorizationEndpointChecker checker;
     private AuthenticationSessionModel authenticationSession;
 
     private Action action;
@@ -100,7 +111,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     private OIDCResponseMode parsedResponseMode;
 
     private AuthorizationEndpointRequest request;
-    private String redirectUri;
+    private String parsedRedirectUri;
 
     public AuthorizationEndpoint(KeycloakSession session, EventBuilder event) {
         super(session, event);
@@ -132,52 +143,58 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
     }
 
     private Response process(final MultivaluedMap<String, String> params) {
-        String clientId = AuthorizationEndpointRequestParserProcessor.getClientId(event, session, params);
-
-        checkSsl();
-        checkRealm();
 
         try {
-            session.clientPolicy().triggerOnEvent(new PreAuthorizationRequestContext(clientId, params));
-        } catch (ClientPolicyException cpe) {
-            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
-            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
-            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
-            event.error(cpe.getError());
-            throw new ErrorPageException(session, authenticationSession, cpe.getErrorStatus(), cpe.getErrorDetail());
+            String clientId = AuthorizationEndpointRequestParserProcessor.getClientId(event, session, params);
+
+            checkSsl();
+            checkRealm();
+
+            try {
+                session.clientPolicy().triggerOnEvent(new PreAuthorizationRequestContext(clientId, params));
+            } catch (ClientPolicyException cpe) {
+                event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
+                event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
+                event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+                event.error(cpe.getError());
+                throw new ErrorPageException(session, cpe.getError(), cpe.getErrorStatus(), cpe.getErrorDetail());
+            }
+            checkClient(clientId);
+
+            request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, EndpointType.OIDC_AUTH_ENDPOINT);
+
+        } catch (ErrorPageException ex) {
+            buildAuthorizationEndpointChecker(params);
+            return handleErrorPageException(ex);
         }
-        checkClient(clientId);
 
-        request = AuthorizationEndpointRequestParserProcessor.parseRequest(event, session, client, params, AuthorizationEndpointRequestParserProcessor.EndpointType.OIDC_AUTH_ENDPOINT);
-
-        AuthorizationEndpointChecker checker = new AuthorizationEndpointChecker()
-                .event(event)
-                .client(client)
-                .realm(realm)
-                .request(request)
-                .session(session)
-                .params(params);
+        buildAuthorizationEndpointChecker(params);
 
         try {
             checker.checkRedirectUri();
-            this.redirectUri = checker.getRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            checker.throwAsErrorPageException(authenticationSession, ex);
+            parsedRedirectUri = checker.getRedirectUri();
+        } catch (AuthorizationCheckException ex) {
+            ErrorPageException epex = new ErrorPageException(session, ex.getError(), ex.getStatus(), ex.getErrorMessage(), ex.getParameters());
+            return handleErrorPageException(epex);
         }
 
         try {
             checker.checkResponseType();
-            this.parsedResponseType = checker.getParsedResponseType();
-            this.parsedResponseMode = checker.getParsedResponseMode();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            OIDCResponseMode responseMode;
+            parsedResponseType = checker.getParsedResponseType();
+            parsedResponseMode = checker.getParsedResponseMode();
+        } catch (AuthorizationCheckException ex) {
             if (checker.isInvalidResponseType(ex)) {
-                responseMode = OIDCResponseMode.parseWhenInvalidResponseType(request.getResponseMode());
-            } else {
-                responseMode = checker.getParsedResponseMode() != null ? checker.getParsedResponseMode() : OIDCResponseMode.QUERY;
+                parsedResponseMode = OIDCResponseMode.parseWhenInvalidResponseType(request.getResponseMode());
             }
-            return redirectErrorToClient(responseMode, ex.getError(), ex.getErrorDescription());
+            if (parsedResponseMode == null) {
+                parsedResponseMode = checker.getParsedResponseMode();
+            }
+            if (parsedResponseMode == null) {
+                parsedResponseMode = OIDCResponseMode.QUERY;
+            }
+            return handleRedirectErrorToClient(ex.getError(), ex.getErrorDescription());
         }
+
         if (action == null) {
             action = AuthorizationEndpoint.Action.CODE;
         }
@@ -192,8 +209,8 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
             checker.checkOIDCParams();
             checker.checkPKCEParams();
             checker.checkProviderAddOns();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            return redirectErrorToClient(parsedResponseMode, ex.getError(), ex.getErrorDescription());
+        } catch (AuthorizationCheckException ex) {
+            return handleRedirectErrorToClient(ex.getError(), ex.getErrorDescription());
         }
 
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
@@ -206,14 +223,14 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         authenticationSession = createAuthenticationSession(client, request.getState());
 
         try {
-            session.clientPolicy().triggerOnEvent(new AuthorizationRequestContext(parsedResponseType, request, redirectUri, params, authenticationSession));
+            session.clientPolicy().triggerOnEvent(new AuthorizationRequestContext(parsedResponseType, request, parsedRedirectUri, params, authenticationSession));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
             event.error(cpe.getError());
             new AuthenticationSessionManager(session).removeAuthenticationSession(realm, authenticationSession, false);
-            return redirectErrorToClient(parsedResponseMode, cpe.getError(), cpe.getErrorDetail());
+            return handleRedirectErrorToClient(cpe.getError(), cpe.getErrorDetail());
         }
 
         updateAuthenticationSession();
@@ -240,6 +257,19 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
 
         throw new RuntimeException("Unknown action " + action);
+    }
+
+    private AuthorizationEndpointChecker buildAuthorizationEndpointChecker(MultivaluedMap<String, String> params) {
+        if (checker == null) {
+            checker = new AuthorizationEndpointChecker()
+                    .event(event)
+                    .client(client)
+                    .realm(realm)
+                    .request(request)
+                    .session(session)
+                    .params(params);
+        }
+        return checker;
     }
 
     public AuthorizationEndpoint register(String tokenString) {
@@ -272,7 +302,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         return this;
     }
 
-    private void checkClient(String clientId) {
+    private ClientModel checkClient(String clientId) {
         if (clientId == null) {
             event.detail(Details.REASON, "Missing parameter: " + OIDCLoginProtocol.CLIENT_ID_PARAM);
             event.error(Errors.INVALID_REQUEST);
@@ -310,24 +340,84 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
 
         session.getContext().setClient(client);
+        return client;
     }
 
-    private Response redirectErrorToClient(OIDCResponseMode responseMode, String error, String errorDescription) {
+    private Response handleErrorPageException(ErrorPageException epex) {
+
+        // Do a second pass trying to obtain the required parameters for a valid redirect
+        //
+        try {
+            MultivaluedMap<String, String> params = checker.getRequestParams();
+            AuthorizationEndpointRequest request = checker.getAuthorizationEndpointRequest();
+            if (client == null) {
+                String clientId = request != null ? request.getClientId() : params.getFirst(OIDCLoginProtocol.CLIENT_ID_PARAM);
+                client = checkClient(clientId);
+                checker.client(client);
+            }
+            if (parsedRedirectUri == null) {
+                checker.checkRedirectUri();
+                parsedRedirectUri = checker.getRedirectUri();
+            }
+            if (parsedResponseType == null || parsedResponseMode == null) {
+                checker.checkResponseType();
+                parsedResponseType = checker.getParsedResponseType();
+                parsedResponseMode = checker.getParsedResponseMode();
+            }
+        } catch (Exception aux) {
+            // ignore
+        }
+
+        // Prefer authorization error on redirect_uri
+        // https://github.com/keycloak/keycloak/issues/48542
+        boolean preferErrorOnRedirect = false;
+        if (client != null) {
+            preferErrorOnRedirect = Boolean.parseBoolean(client.getAttribute(AUTHORIZATION_PREFER_ERROR_ON_REDIRECT));
+        }
+        if (!preferErrorOnRedirect)
+            throw epex;
+
+        // Get the localized error message (english)
+        //
+        String errorMessage = epex.getErrorMessage();
+        try {
+            Theme theme = session.theme().getTheme(Theme.Type.LOGIN);
+            Properties localizedMessages = theme.getEnhancedMessages(realm, Locale.ENGLISH);
+            if (localizedMessages.containsKey(errorMessage)) {
+                errorMessage = localizedMessages.getProperty(errorMessage);
+                Object[] params = epex.getParameters();
+                if (params.length > 0) {
+                    errorMessage = MessageFormat.format(errorMessage, params);
+                }
+            }
+        } catch (IOException ioe) {
+            // ignore
+        }
+
+        if (client != null && parsedRedirectUri != null && parsedResponseType != null && parsedResponseMode != null) {
+            return handleRedirectErrorToClient(epex.getError(), errorMessage);
+        }
+
+        Response.Status status = epex.getStatus();
+        var errRep = new OAuth2ErrorRepresentation(epex.getError(), errorMessage);
+        return Response.status(status).entity(errRep).type(MediaType.APPLICATION_JSON_TYPE).build();
+    }
+
+    private Response handleRedirectErrorToClient(String error, String errorDescription) {
         CacheControlUtil.noBackButtonCacheControlHeader(session);
 
-        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(redirectUri, responseMode, session, null)
+        OIDCRedirectUriBuilder errorResponseBuilder = OIDCRedirectUriBuilder.fromUri(parsedRedirectUri, parsedResponseMode, session, null)
                 .addParam(OAuth2Constants.ERROR, error);
 
         if (errorDescription != null) {
             errorResponseBuilder.addParam(OAuth2Constants.ERROR_DESCRIPTION, errorDescription);
         }
 
-        if (request.getState() != null) {
+        if (request != null && request.getState() != null) {
             errorResponseBuilder.addParam(OAuth2Constants.STATE, request.getState());
         }
 
-        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
-        if (!clientConfig.isExcludeIssuerFromAuthResponse()) {
+        if (client != null && !OIDCAdvancedConfigWrapper.fromClientModel(client).isExcludeIssuerFromAuthResponse()) {
             errorResponseBuilder.addParam(OAuth2Constants.ISSUER, Urls.realmIssuer(session.getContext().getUri().getBaseUri(), realm.getName()));
         }
 
@@ -336,7 +426,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
     private void updateAuthenticationSession() {
         authenticationSession.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
-        authenticationSession.setRedirectUri(redirectUri);
+        authenticationSession.setRedirectUri(parsedRedirectUri);
         authenticationSession.setAction(AuthenticationSessionModel.Action.AUTHENTICATE.name());
         authenticationSession.setClientNote(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, request.getResponseType());
         authenticationSession.setClientNote(OIDCLoginProtocol.REDIRECT_URI_PARAM, request.getRedirectUri());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointCheckProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointCheckProvider.java
@@ -1,6 +1,5 @@
 package org.keycloak.protocol.oidc.endpoints;
 
-import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker.AuthorizationCheckException;
 import org.keycloak.provider.Provider;
 
 public interface AuthorizationEndpointCheckProvider extends Provider {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -58,12 +58,10 @@ import org.keycloak.protocol.oidc.utils.OIDCResponseType;
 import org.keycloak.protocol.oidc.utils.RedirectUtils;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.services.CorsErrorResponseException;
-import org.keycloak.services.ErrorPageException;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.cors.Cors;
 import org.keycloak.services.messages.Messages;
 import org.keycloak.services.util.DPoPUtil;
-import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
 import org.keycloak.utils.StringUtil;
 
@@ -159,25 +157,32 @@ public class AuthorizationEndpointChecker {
         return parsedResponseMode;
     }
 
+    public MultivaluedMap<String, String> getRequestParams() {
+        return params;
+    }
+
     public void checkRedirectUri() throws AuthorizationCheckException {
-        String redirectUriParam = request.getRedirectUri();
-        boolean isOIDCRequest = TokenUtil.isOIDCRequest(request.getScope());
+
+        String redirectUriParam = request != null ? request.getRedirectUri() : params.getFirst(OIDCLoginProtocol.REDIRECT_URI_PARAM);
+        String scope = request != null ? request.getScope() : params.getFirst(OIDCLoginProtocol.SCOPE_PARAM);
+
+        // The redirect_uri parameter is required for OIDC, but optional for OAuth2
+        boolean isOIDCRequest = TokenUtil.isOIDCRequest(scope);
 
         event.detail(Details.REDIRECT_URI, redirectUriParam);
 
-        // redirect_uri parameter is required per OpenID Connect, but optional per OAuth2
         this.redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client, isOIDCRequest);
         if (redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+            throw new AuthorizationCheckException(OAuthErrorException.INVALID_REDIRECT_URI, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
         }
     }
 
-
     public void checkResponseType() throws AuthorizationCheckException {
-        String responseType = request.getResponseType();
+        String responseTypeParam = request != null ? request.getResponseType() : params.getFirst(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+        String responseModeParam = request != null ? request.getResponseMode() : params.getFirst(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
 
-        if (responseType == null) {
+        if (responseTypeParam == null) {
             ServicesLogger.LOGGER.missingParameter(OAuth2Constants.RESPONSE_TYPE);
             String errorMessage = "Missing parameter: response_type";
             event.detail(Details.REASON, errorMessage);
@@ -185,19 +190,21 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        event.detail(Details.RESPONSE_TYPE, responseType);
+        event.detail(Details.RESPONSE_TYPE, responseTypeParam);
 
         try {
-            this.parsedResponseType = OIDCResponseType.parse(responseType);
+            parsedResponseType = OIDCResponseType.parse(responseTypeParam);
         } catch (IllegalArgumentException iae) {
-            event.detail(Details.REASON, iae.getMessage());
+            ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_TYPE_PARAM);
+            String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_TYPE_PARAM;
+            event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, null);
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, errorMessage);
         }
 
-        OIDCResponseMode parsedResponseMode = null;
+        OIDCResponseMode responseMode;
         try {
-            parsedResponseMode = OIDCResponseMode.parse(request.getResponseMode(), parsedResponseType);
+            responseMode = OIDCResponseMode.parse(responseModeParam, parsedResponseType);
         } catch (IllegalArgumentException iae) {
             ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
             String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_MODE_PARAM;
@@ -206,10 +213,10 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        event.detail(Details.RESPONSE_MODE, parsedResponseMode.toString().toLowerCase());
+        event.detail(Details.RESPONSE_MODE, responseMode.toString().toLowerCase());
 
         // Disallowed by OIDC specs
-        if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY) {
+        if (parsedResponseType.isImplicitOrHybridFlow() && responseMode == OIDCResponseMode.QUERY) {
             ServicesLogger.LOGGER.responseModeQueryNotAllowed();
             String errorMessage = "Response_mode 'query' not allowed for implicit or hybrid flow";
             event.detail(Details.REASON, errorMessage);
@@ -217,9 +224,9 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        this.parsedResponseMode = parsedResponseMode;
+        parsedResponseMode = responseMode;
 
-        if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY_JWT &&
+        if (parsedResponseType.isImplicitOrHybridFlow() && responseMode == OIDCResponseMode.QUERY_JWT &&
                 (!StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ALG)) ||
                 !StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ENC)))) {
             ServicesLogger.LOGGER.responseModeQueryJwtNotAllowed();
@@ -256,14 +263,14 @@ public class AuthorizationEndpointChecker {
         }
     }
 
-    public boolean isInvalidResponseType(AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+    public boolean isInvalidResponseType(AuthorizationCheckException ex) {
         return "Missing parameter: response_type".equals(ex.getErrorDescription()) || OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE.equals(ex.getError());
     }
 
     public void checkInvalidRequestMessage() throws AuthorizationCheckException {
         if (request.getInvalidRequestMessage() != null) {
             event.error(Errors.INVALID_REQUEST);
-            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Errors.INVALID_REQUEST, request.getInvalidRequestMessage());
+            throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, request.getInvalidRequestMessage());
         }
     }
 
@@ -280,7 +287,7 @@ public class AuthorizationEndpointChecker {
                 new AuthorizationDetailsProcessorManager(session).validateAuthorizationDetail(authDetailsParam);
             } catch (Exception e) {
                 event.error(Errors.INVALID_REQUEST);
-                throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Errors.INVALID_REQUEST, e.getMessage());
+                throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, e.getMessage());
             }
         }
     }
@@ -511,35 +518,8 @@ public class AuthorizationEndpointChecker {
         }
     }
 
-    public void throwAsErrorPageException(AuthenticationSessionModel authenticationSession, AuthorizationCheckException ex) {
-        throw new ErrorPageException(session, authenticationSession, ex.status, ex.error, ex.errorDescription);
-    }
-
     public void throwAsCorsErrorResponseException(Cors cors, AuthorizationCheckException ex) {
-        event.detail("detail", ex.errorDescription).error(ex.error);
-        throw new CorsErrorResponseException(cors, ex.error, ex.errorDescription, ex.status);
-    }
-
-
-    // Exception propagated to the caller, which will allow caller to send proper error response based on the context (Browser OIDC Authorization Endpoint, PAR etc)
-    public static class AuthorizationCheckException extends Exception {
-
-        private final Response.Status status;
-        private final String error;
-        private final String errorDescription;
-
-        public AuthorizationCheckException(Response.Status status, String error, String errorDescription) {
-            this.status = status;
-            this.error = error;
-            this.errorDescription = errorDescription;
-        }
-
-        public String getError() {
-            return error;
-        }
-
-        public String getErrorDescription() {
-            return errorDescription;
-        }
+        event.detail("detail", ex.getErrorDescription()).error(ex.getError());
+        throw new CorsErrorResponseException(cors, ex.getError(), ex.getErrorDescription(), ex.getStatus());
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/endpoints/DeviceEndpoint.java
@@ -50,6 +50,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.AuthorizationEndpointBase;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
@@ -145,7 +146,7 @@ public class DeviceEndpoint extends AuthorizationEndpointBase implements RealmRe
 
         try {
             checker.checkPKCEParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             throw new ErrorResponseException(ex.getError(), ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -42,6 +42,7 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
+import org.keycloak.protocol.oidc.endpoints.AuthorizationCheckException;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.protocol.oidc.par.ParResponse;
@@ -123,13 +124,13 @@ public class ParEndpoint extends AbstractParEndpoint {
 
         try {
             checker.checkRedirectUri();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: redirect_uri", Response.Status.BAD_REQUEST);
         }
 
         try {
             checker.checkResponseType();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             if (ex.getError().equals(OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE)) {
                 throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Unsupported response type", Response.Status.BAD_REQUEST);
             } else {
@@ -139,7 +140,7 @@ public class ParEndpoint extends AbstractParEndpoint {
 
         try {
             checker.checkValidScope();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             // PAR throws this as "invalid_request" error
             throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
@@ -150,7 +151,7 @@ public class ParEndpoint extends AbstractParEndpoint {
             checker.checkOIDCParams();
             checker.checkPKCEParams();
             checker.checkParDPoPParams();
-        } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
+        } catch (AuthorizationCheckException ex) {
             checker.throwAsCorsErrorResponseException(cors, ex);
         }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -19,8 +19,10 @@
 package org.keycloak.protocol.oidc.par.endpoints.request;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
+import org.keycloak.common.Profile;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -53,29 +55,18 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         super(session);
         this.session = session;
         this.client = client;
-        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        String key;
-        try {
-            key = requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
-        } catch (RuntimeException re) {
-            logger.warnf(re,"Unable to parse request_uri: %s", requestUri);
-            throw new RuntimeException("Unable to parse request_uri");
-        }
-        Map<String, String> retrievedRequest = singleUseStore.remove(CACHE_KEY_PREFIX + key);
-        if (retrievedRequest == null) {
-            throw new RuntimeException("PAR not found. not issued or used multiple times.");
-        }
-
         RealmModel realm = session.getContext().getRealm();
+        Map<String, String> parRequestParams = Optional.ofNullable(getRequestObject(session, requestUri))
+                .orElseThrow(() -> new RuntimeException("PAR not found, not issued or used multiple times."));
+        long created = Long.parseLong(parRequestParams.get(PAR_CREATED_TIME));
         int expiresIn = realm.getParPolicy().getRequestUriLifespan();
-        long created = Long.parseLong(retrievedRequest.get(PAR_CREATED_TIME));
-        if (System.currentTimeMillis() - created < (expiresIn * 1000)) {
-            requestParams = retrievedRequest;
+        if (System.currentTimeMillis() - created < expiresIn * 1000L) {
+            requestParams = parRequestParams;
         } else {
             throw new RuntimeException("PAR expired.");
         }
         // If DPoP Proof existed with PAR request, its public key needs to be matched with the one with Token Request afterward
-        String dpopJkt = retrievedRequest.get(PAR_DPOP_PROOF_JKT);
+        String dpopJkt = parRequestParams.get(PAR_DPOP_PROOF_JKT);
         if (dpopJkt != null) {
             session.setAttribute(PAR_DPOP_PROOF_JKT, dpopJkt);
         }
@@ -87,7 +78,7 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
 
         if (requestParam != null) {
             // parses the request object if PAR was registered using JAR
-            // parameters from requets object have precedence over those sent directly in the request
+            // parameters from the request object have precedence over those sent directly in the request
             new ParEndpointRequestObjectParser(session, requestParam, client).parseRequest(request);
         } else {
             super.parseRequest(request);
@@ -114,4 +105,39 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         return requestParams.keySet();
     }
 
+    protected <T> T replaceIfNotNull(T previousVal, T newVal) {
+        // FAPI says only parameters inside the request object should be used
+        // https://github.com/keycloak/keycloak/issues/48047
+        if (Profile.isFeatureEnabled(Profile.Feature.OID4VC_HAIP)) {
+            return newVal;
+        } else {
+            return super.replaceIfNotNull(previousVal, newVal);
+        }
+    }
+
+    public static Map<String, String> getRequestObject(KeycloakSession session, String requestUri) {
+        String key = getRequestObjectKey(requestUri);
+        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
+        Map<String, String> retrievedRequest = singleUseStore.get(CACHE_KEY_PREFIX + key);
+        return retrievedRequest;
+    }
+
+    /**
+     * Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+     * not at the point of visiting the authorization endpoint
+     * OpenID CT: fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds
+     */
+    public static void removeRequestObject(KeycloakSession session, String requestUri) {
+        String key = getRequestObjectKey(requestUri);
+        session.singleUseObjects().remove(CACHE_KEY_PREFIX + key);
+    }
+
+    private static String getRequestObjectKey(String requestUri) {
+        try {
+            return requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
+        } catch (RuntimeException re) {
+            logger.warnf(re,"Unable to parse request_uri: %s", requestUri);
+            throw new RuntimeException("Unable to parse request_uri");
+        }
+    }
 }

--- a/services/src/main/java/org/keycloak/services/ErrorPageException.java
+++ b/services/src/main/java/org/keycloak/services/ErrorPageException.java
@@ -23,20 +23,53 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
+import static org.keycloak.OAuthErrorException.INVALID_REQUEST;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 public class ErrorPageException extends WebApplicationException {
 
+    private String error;
+    private String errorMessage;
+    private Object[] parameters;
+
     public ErrorPageException(KeycloakSession session, Response.Status status, String errorMessage, Object... parameters) {
-        super(errorMessage, ErrorPage.error(session, null, status, errorMessage, parameters));
+        this(session, INVALID_REQUEST, status, errorMessage, parameters);
+    }
+
+    public ErrorPageException(KeycloakSession session, String error, Response.Status status, String errorMessage, Object... parameters) {
+        this(session, null, error, status, errorMessage, parameters);
     }
 
     public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, Response.Status status, String errorMessage, Object... parameters) {
+        this(session, authSession, INVALID_REQUEST, status, errorMessage, parameters);
+    }
+
+    public ErrorPageException(KeycloakSession session, AuthenticationSessionModel authSession, String error, Response.Status status, String errorMessage, Object... parameters) {
         super(errorMessage, ErrorPage.error(session, authSession, status, errorMessage, parameters));
+        this.error = error;
+        this.errorMessage = errorMessage;
+        this.parameters = parameters;
     }
 
     public ErrorPageException(Response response) {
         super((Throwable) null, response);
+    }
+
+    public Response.Status getStatus() {
+        return Response.Status.fromStatusCode(getResponse().getStatus());
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public Object[] getParameters() {
+        return parameters;
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
@@ -18,6 +18,7 @@
 package org.keycloak.services.clientpolicy.executor;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,7 +29,6 @@ import org.keycloak.OAuthErrorException;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
@@ -36,7 +36,7 @@ import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestObjectParser;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
-import org.keycloak.protocol.oidc.par.endpoints.ParEndpoint;
+import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -76,21 +76,16 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
     private void checkValidParContents(PreAuthorizationRequestContext preAuthorizationRequestContext) throws ClientPolicyException {
         MultivaluedMap<String, String> requestParametersFromQuery = preAuthorizationRequestContext.getRequestParameters();
         String requestUri = requestParametersFromQuery.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
-        if (requestUri == null) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "request_uri not included.");
-        }
-        if (requestUri != null && AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUri) != RequestUriType.PAR) {
+        if (requestUri == null || AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUri) != RequestUriType.PAR) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request_uri not included.");
         }
 
-        String key = requestUri.substring(ParEndpoint.REQUEST_URI_PREFIX_LENGTH);
-        SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        Map<String, String> requestParametersFromPAR = singleUseStore.get(ParEndpoint.CACHE_KEY_PREFIX + key);
+        Map<String, String> requestParametersFromPAR = AuthzEndpointParParser.getRequestObject(session, requestUri);
         if (requestParametersFromPAR == null) {
-            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR not found. not issued or used multiple times.");
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_URI, "PAR not found, not issued or used multiple times.");
         }
 
-        Set<String> requestParametersNameFromPAR = new HashSet<>();
+        Set<String> requestParametersNameFromPAR;
         if (requestParametersFromPAR.containsKey(OIDCLoginProtocol.REQUEST_PARAM)) {
             // if PAR request includes request object (JAR), parsing the request is needed.
             requestParametersNameFromPAR = getParRetrievedRequestParameters(requestParametersFromPAR, preAuthorizationRequestContext.getClientId());
@@ -98,10 +93,16 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
             requestParametersNameFromPAR = requestParametersFromPAR.keySet();
         }
 
-        for (String queryParamName : requestParametersFromQuery.keySet()) {
-            if (!requestParametersNameFromPAR.contains(queryParamName) && !OIDCLoginProtocol.REQUEST_URI_PARAM.equals(queryParamName)) {
-                singleUseStore.remove(ParEndpoint.CACHE_KEY_PREFIX + key);
-                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request did not include necessary parameters");
+        List<String> queryKeys = requestParametersFromQuery.keySet().stream()
+                .filter(it -> !it.equals(OIDCLoginProtocol.REQUEST_URI_PARAM))
+                .toList();
+
+        // FAPI says only parameters inside the request object should be used
+        //
+        for (String queryParam : queryKeys) {
+            if (!requestParametersNameFromPAR.contains(queryParam)) {
+                AuthzEndpointParParser.removeRequestObject(session, requestUri);
+                throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_OBJECT, "PAR request did not include query parameter: " + queryParam);
             }
         }
     }

--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -474,22 +474,22 @@ public class LoginActionsService {
         if (clientID == null) {
             if (redirectUriParam != null) {
                 logger.warn("Unsupported to send 'redirect_uri' parameter without providing 'client_id' parameter.");
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, OIDCLoginProtocol.CLIENT_ID_PARAM);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.MISSING_PARAMETER, OIDCLoginProtocol.CLIENT_ID_PARAM);
             }
             client = SystemClientUtil.getSystemClient(realm);
             redirectUri = Urls.accountBase(session.getContext().getUri().getBaseUri()).path("/").build(realm.getName()).toString();
         } else {
             client = session.clients().getClientByClientId(realm, clientID);
             if (client == null) {
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_NOT_FOUND);
             }
             if (!client.isEnabled()) {
-                throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
+                throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.CLIENT_DISABLED);
             }
             if (redirectUriParam != null) {
                 redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client);
                 if (redirectUri == null) {
-                    throw new ErrorPageException(session, null, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
+                    throw new ErrorPageException(session, Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
                 }
             }
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -638,6 +638,11 @@ public class OID4VCBasicWallet {
             return this;
         }
 
+        public AuthorizationEndpointRequest state(String state) {
+            loginForm.state(state);
+            return this;
+        }
+
         public boolean openLoginForm() {
             loginForm.open();
             String currUrl = oauth.getDriver().getCurrentUrl();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -470,7 +470,7 @@ public abstract class OID4VCIssuerTestBase {
         realmResource.update(realm);
     }
 
-    protected void setVerifiableCredentialsEnabled(boolean enabled) {
+    protected void setRealmVerifiableCredentialsEnabled(boolean enabled) {
         RealmResource realmResource = testRealm.admin();
         RealmRepresentation realm = realmResource.toRepresentation();
         realm.setVerifiableCredentialsEnabled(enabled);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -26,6 +26,7 @@ import org.keycloak.OID4VCConstants;
 import org.keycloak.VCFormat;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientPoliciesPoliciesResource;
+import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.ClientScopeResource;
 import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.admin.client.resource.RealmResource;
@@ -125,6 +126,7 @@ import static org.keycloak.OID4VCConstants.CLAIM_NAME_SUBJECT_ID;
 import static org.keycloak.OID4VCConstants.OID4VCI_ENABLED_ATTRIBUTE_KEY;
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS;
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS;
 import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
 import static org.keycloak.models.Constants.CREATE_DEFAULT_CLIENT_SCOPES;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT;
@@ -185,10 +187,10 @@ public abstract class OID4VCIssuerTestBase {
     protected ManagedClient managedClient;
 
     @InjectClient(ref = OID4VCI_ABCA_CLIENT_ID, config = OID4VCAttestationBasedClient.class)
-    ManagedClient managedAttestationBasedClient;
+    protected ManagedClient managedAttestationBasedClient;
 
     @InjectClient(ref = OID4VCI_PUBLIC_CLIENT_ID, config = OID4VCPublicClient.class)
-    ManagedClient managedPublicClient;
+    protected ManagedClient managedPublicClient;
 
     @InjectOAuthClient
     protected OAuthClient oauth;
@@ -240,7 +242,6 @@ public abstract class OID4VCIssuerTestBase {
             testUser.setRealmRoles(List.of(CREDENTIAL_OFFER_CREATE.getName()));
             realmResource.users().get(testUser.getId()).roles().realmLevel().add(List.of(credentialOfferRole));
         }
-
     }
 
     @BeforeEach
@@ -284,14 +285,6 @@ public abstract class OID4VCIssuerTestBase {
             trustIdp.setConfig(config);
             realm.updateIdentityProvider(trustIdp);
         }
-    }
-
-    protected void setClientTrustSource(String alias) {
-        Map<String, String> attributes = new HashMap<>(Optional.ofNullable(abcaClient.getAttributes()).orElse(Map.of()));
-        attributes.put(OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS, alias);
-        abcaClient.setAttributes(attributes);
-        testRealm.admin().clients().get(abcaClient.getId()).update(abcaClient);
-        abcaClient = testRealm.admin().clients().get(abcaClient.getId()).toRepresentation();
     }
 
     protected static KeyWrapper getKeyFromSession(KeycloakSession keycloakSession) {
@@ -482,6 +475,25 @@ public abstract class OID4VCIssuerTestBase {
         RealmRepresentation realm = realmResource.toRepresentation();
         realm.setVerifiableCredentialsEnabled(enabled);
         realmResource.update(realm);
+    }
+
+    protected void setClientAttribute(ClientRepresentation client, String attrKey, String attrValue) {
+        setClientAttributes(client, Map.of(attrKey, attrValue));
+    }
+
+    protected void setClientAttributes(ClientRepresentation client, Map<String, String> attrUpdate) {
+        Map<String, String> attrs = client.getAttributes();
+        boolean updateNeeded = attrUpdate.entrySet().stream()
+                .anyMatch(e -> !e.getValue().equals(attrs.get(e.getKey())));
+        if (updateNeeded) {
+            ClientResource clientResource = testRealm.admin().clients().get(client.getId());
+            client.getAttributes().putAll(attrUpdate);
+            clientResource.update(client);
+        }
+    }
+
+    protected void setCredentialScopeAttribute(ClientScopeRepresentation credScope, String attrKey, String attrValue) {
+        setCredentialScopeAttributes(credScope, Map.of(attrKey, attrValue));
     }
 
     protected void setCredentialScopeAttributes(ClientScopeRepresentation credScope, Map<String, String> attrUpdate) {
@@ -941,6 +953,7 @@ public abstract class OID4VCIssuerTestBase {
                     .defaultClientScopes("basic", "profile", "roles")
                     .optionalClientScopes(optionalClientScopes)
                     .attribute(OID4VCI_ENABLED_ATTRIBUTE_KEY, "true")
+                    .attribute(OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS, OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS)
                     .redirectUris("*");
             return client;
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerWellKnownProviderTest.java
@@ -524,7 +524,7 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerTestBase {
     @Test
     public void testWellKnownEndpointDisabledWhenVerifiableCredentialsOff() {
 
-        setVerifiableCredentialsEnabled(false);
+        setRealmVerifiableCredentialsEnabled(false);
         try {
             CredentialIssuerMetadataResponse response = oauth.oid4vc()
                     .issuerMetadataRequest()
@@ -537,7 +537,7 @@ public class OID4VCIssuerWellKnownProviderTest extends OID4VCIssuerTestBase {
             assertEquals("OID4VCI functionality is disabled for this realm", error.getMessage());
 
         } finally {
-            setVerifiableCredentialsEnabled(true);
+            setRealmVerifiableCredentialsEnabled(true);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMetadataDiscoveryTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCMetadataDiscoveryTest.java
@@ -54,7 +54,7 @@ public class OID4VCMetadataDiscoveryTest extends OID4VCIssuerTestBase {
     @Test
     public void testMetadataAbsentWhenOID4VCDisabled() {
         try {
-            setVerifiableCredentialsEnabled(false);
+            setRealmVerifiableCredentialsEnabled(false);
 
             OIDCConfigurationRepresentation metadata = oauth.wellknownRequest()
                     .endpoint(oauth.getBaseUrl() + "/" + oauthServerLegacyWellKnownPath())
@@ -67,7 +67,7 @@ public class OID4VCMetadataDiscoveryTest extends OID4VCIssuerTestBase {
                 assertFalse(authDetailsTypes.contains(OPENID_CREDENTIAL));
             }
         } finally {
-            setVerifiableCredentialsEnabled(true);
+            setRealmVerifiableCredentialsEnabled(true);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
@@ -47,6 +47,7 @@ import org.keycloak.util.JsonSerialization;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_HEADER;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_HEADER;
 import static org.keycloak.protocol.oidc.OIDCLoginProtocol.ATTEST_JWT_CLIENT_AUTH;
@@ -61,8 +62,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithABCAEnabled.class)
 public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTestBase {
-
-    private static final String ATTESTER_DEFAULT_TRUST_IDP_ALIAS = "abca-attester-default-trust";
 
     private static OIDCClientAttester attester;
     private static String attesterJwks;
@@ -85,11 +84,10 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         String jwks = attesterJwks;
         runOnServer.run(session -> {
             RealmModel realm = session.getContext().getRealm();
-            configureTrustIdentityProvider(realm, ATTESTER_DEFAULT_TRUST_IDP_ALIAS,
+            configureTrustIdentityProvider(realm, OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS,
                     DefaultTrustIdentityProviderFactory.PROVIDER_ID,
                     Map.of(DefaultTrustIdentityProviderConfig.TRUSTED_JWKS, jwks));
         });
-        setClientTrustSource(ATTESTER_DEFAULT_TRUST_IDP_ALIAS);
         oauth.client(abcaClient.getClientId(), null);
     }
 
@@ -140,7 +138,6 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
 
     @Test
     public void testClientAttestationHappyFlow() {
-        setClientTrustSource(ATTESTER_DEFAULT_TRUST_IDP_ALIAS);
 
         var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
         ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/haip/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/haip/HAIPIssuerConformanceTest.java
@@ -20,11 +20,13 @@ import org.keycloak.sdjwt.IssuerSignedJWT;
 import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.tests.oid4vc.OID4VCBasicWallet.AuthorizationEndpointRequest;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.tests.oid4vc.abca.OIDCClientAttester;
 import org.keycloak.tests.oid4vc.abca.OIDCMockClientAttester;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.oauth.PkceGenerator;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
@@ -33,21 +35,22 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_HEADER;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_HEADER;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
- * Mirrors oid4vci-1_0-issuer-haip-test-plan:oid4vci-1_0-issuer-happy-flow
+ * Replicates various tests in oid4vci-1_0-issuer-haip-test-plan
  */
 @KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithABCAEnabled.class)
 public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
-
-    private static final String ATTESTER_DEFAULT_TRUST_IDP_ALIAS = "abca-attester-default-trust";
 
     private static OIDCClientAttester attester;
     private static String attesterJwks;
@@ -70,16 +73,19 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         String jwks = attesterJwks;
         runOnServer.run(session -> {
             RealmModel realm = session.getContext().getRealm();
-
-            configureTrustIdentityProvider(realm, ATTESTER_DEFAULT_TRUST_IDP_ALIAS,
+            configureTrustIdentityProvider(realm, OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS,
                     DefaultTrustIdentityProviderFactory.PROVIDER_ID,
                     Map.of(DefaultTrustIdentityProviderConfig.TRUSTED_JWKS, jwks));
         });
-        setClientTrustSource(ATTESTER_DEFAULT_TRUST_IDP_ALIAS);
         setClientPolicyEnabled(VCI_CLIENT_POLICY_HAIP, true);
         oauth.client(abcaClient.getClientId(), null);
     }
 
+    /**
+     * oid4vci-1_0-issuer-happy-flow
+     *
+     * Validates the standard credential issuance flow using an emulated wallet, as defined by OpenID4VCI.
+     */
     @Test
     public void testIssuerHappyFlow() throws Exception {
 
@@ -154,6 +160,55 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         //
         verifyCredentialResponse(ctx, credResponse);
     }
+
+    /**
+     * fapi2-security-profile-final-state-only-outside-request-object-not-used
+     *
+     * Uses a request object that does not contain state, but state is passed in the url parameters to the authorization endpoint
+     * (hence state should be ignored, as FAPI says only parameters inside the request object should be used).
+     * The expected result is a successful authentication that returns neither state nor s_hash.
+     *
+     * It is also permissible to return an error message: invalid_request, invalid_request_object or access_denied.
+     */
+    @Test
+    public void testOnlyParametersInsideRequestObjectAreUsed() throws Exception {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var pkce = PkceGenerator.s256();
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper rsaKey = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, rsaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, rsaKey);
+
+        // Send PAR Request
+        //
+        String requestUri = oauth.pushedAuthorizationRequest()
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .scopeParam(ctx.getScope())
+                .codeChallenge(pkce)
+                .send().getRequestUri();
+        assertNotNull(requestUri, "No requestUri");
+
+        // Send Authorization Request
+        //
+        AuthorizationEndpointRequest authRequest = wallet.authorizationRequest()
+                .requestUri(requestUri)
+                .codeChallenge(pkce)
+                .state("123456");
+        assertFalse(authRequest.openLoginForm(), "Error expected");
+        AuthorizationEndpointResponse authResponse = authRequest.parseLoginResponse();
+
+        assertNull(authResponse.getCode(), "Expected no auth code");
+        assertEquals("invalid_request", authResponse.getError());
+        assertEquals("PAR request did not include necessary parameters", authResponse.getErrorDescription());
+    }
+
+    // Private ---------------------------------------------------------------------------------------------------------
 
     private void verifyCredentialResponse(OID4VCTestContext ctx, CredentialResponse credResponse) throws Exception {
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/haip/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/haip/HAIPIssuerConformanceTest.java
@@ -38,6 +38,7 @@ import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_DEFAULT_TRUST_IDP_ALIAS;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_HEADER;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_HEADER;
+import static org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint.AUTHORIZATION_PREFER_ERROR_ON_REDIRECT;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 
@@ -77,6 +78,7 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
                     DefaultTrustIdentityProviderFactory.PROVIDER_ID,
                     Map.of(DefaultTrustIdentityProviderConfig.TRUSTED_JWKS, jwks));
         });
+        setClientAttribute(abcaClient, AUTHORIZATION_PREFER_ERROR_ON_REDIRECT, String.valueOf(true));
         setClientPolicyEnabled(VCI_CLIENT_POLICY_HAIP, true);
         oauth.client(abcaClient.getClientId(), null);
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCAuthorizationDetailsFlowTestBase.java
@@ -1,7 +1,6 @@
 package org.keycloak.tests.oid4vc.issuance.signing;
 
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -187,7 +186,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
         //
         String wasCredentialIdentifier = ctx.getCredentialScope().getCredentialIdentifier();
         if (!wasCredentialIdentifier.equals(credIdentifier)) {
-            setCredentialScopeAttributes(ctx.getCredentialScope(), Map.of(VC_IDENTIFIER, credIdentifier));
+            setCredentialScopeAttribute(ctx.getCredentialScope(), VC_IDENTIFIER, credIdentifier);
         }
 
         try {
@@ -244,7 +243,7 @@ public abstract class OID4VCAuthorizationDetailsFlowTestBase extends OID4VCIssue
 
             // Restore the vc.credential_identifier attribute value
             if (!wasCredentialIdentifier.equals(credIdentifier)) {
-                setCredentialScopeAttributes(ctx.getCredentialScope(), Map.of(VC_IDENTIFIER, wasCredentialIdentifier));
+                setCredentialScopeAttribute(ctx.getCredentialScope(), VC_IDENTIFIER, wasCredentialIdentifier);
             }
         }
     }


### PR DESCRIPTION
closes #48542

While processing an authorization request there are potential errors coming from 

1. checks in client policies
2. various request parsers (e.g. url query, request object, request_uri)
3. checks on request_uri, response_type, response_mode

most of these errors map to an unchecked ErrorPageException, which then displays an html error page.

When the request passes the above, errors tend to be reported back to the caller via redirect_uri already.

This PR proposes to first catch these ErrorPageExceptions and then (when configured to do so) make a "best effort" to use the redirect_uri path - otherwise, the error is returned to the caller as json object.

Without the `authorization.preferErrorOnRedirect` attribute on the client, this PR changes nothing. As a result, no test cases needed to be touched.

Automated conformance tests are headless - they prefer errors to be delivered on the redirect_uri when possible.

depends on

* https://github.com/keycloak/keycloak/pull/49221
