### PR TITLE
SSF: Move push timeout settings to the SSF Receiver tab

### DIFF
--- a/js/apps/admin-ui/src/clients/ssf/SsfTab.tsx
+++ b/js/apps/admin-ui/src/clients/ssf/SsfTab.tsx
@@ -269,6 +269,8 @@ export const SsfTab = ({ save, client, activeTab }: SsfTabProps) => {
           availableSupportedEvents={availableSupportedEvents}
           nativelyEmittedEvents={nativelyEmittedEvents}
           defaultUserSubjectFormat={defaultUserSubjectFormat}
+          defaultPushConnectTimeoutMillis={defaultPushConnectTimeoutMillis}
+          defaultPushSocketTimeoutMillis={defaultPushSocketTimeoutMillis}
           save={save}
           reset={reset}
         />
@@ -280,8 +282,6 @@ export const SsfTab = ({ save, client, activeTab }: SsfTabProps) => {
           setClientStream={setClientStream}
           defaultSupportedEvents={defaultSupportedEvents}
           nativelyEmittedEvents={nativelyEmittedEvents}
-          defaultPushConnectTimeoutMillis={defaultPushConnectTimeoutMillis}
-          defaultPushSocketTimeoutMillis={defaultPushSocketTimeoutMillis}
           save={save}
           reset={reset}
           refresh={refresh}

--- a/js/apps/admin-ui/src/clients/ssf/tabs/ReceiverTab.tsx
+++ b/js/apps/admin-ui/src/clients/ssf/tabs/ReceiverTab.tsx
@@ -87,6 +87,8 @@ export type ReceiverTabProps = {
   availableSupportedEvents: string[];
   nativelyEmittedEvents: string[];
   defaultUserSubjectFormat: string;
+  defaultPushConnectTimeoutMillis: number;
+  defaultPushSocketTimeoutMillis: number;
   save: (options?: SaveOptions) => void;
   reset: () => void;
 };
@@ -98,6 +100,8 @@ export const ReceiverTab = ({
   availableSupportedEvents,
   nativelyEmittedEvents,
   defaultUserSubjectFormat,
+  defaultPushConnectTimeoutMillis,
+  defaultPushSocketTimeoutMillis,
   save,
   reset,
 }: ReceiverTabProps) => {
@@ -674,6 +678,36 @@ export const ReceiverTab = ({
                           stringify
                         />
                       </FormGroup>
+                    )}
+                    {pushDeliveryAllowed && (
+                      <>
+                        <NumberControl
+                          name={convertAttributeNameToForm<FormFields>(
+                            "attributes.ssf.pushEndpointConnectTimeoutMillis",
+                          )}
+                          label={t("ssfPushEndpointConnectTimeout")}
+                          labelIcon={t("ssfPushEndpointConnectTimeoutHelp")}
+                          controller={{
+                            defaultValue: defaultPushConnectTimeoutMillis,
+                            rules: {
+                              min: 0,
+                            },
+                          }}
+                        />
+                        <NumberControl
+                          name={convertAttributeNameToForm<FormFields>(
+                            "attributes.ssf.pushEndpointSocketTimeoutMillis",
+                          )}
+                          label={t("ssfPushEndpointSocketTimeout")}
+                          labelIcon={t("ssfPushEndpointSocketTimeoutHelp")}
+                          controller={{
+                            defaultValue: defaultPushSocketTimeoutMillis,
+                            rules: {
+                              min: 0,
+                            },
+                          }}
+                        />
+                      </>
                     )}
                   </div>
                 ),

--- a/js/apps/admin-ui/src/clients/ssf/tabs/StreamTab.tsx
+++ b/js/apps/admin-ui/src/clients/ssf/tabs/StreamTab.tsx
@@ -3,7 +3,6 @@ import {
   HelpItem,
   KeycloakSelect,
   ListEmptyState,
-  NumberControl,
   PasswordInput,
   SelectVariant,
   useAlerts,
@@ -108,8 +107,6 @@ export type StreamTabProps = {
   setClientStream: (stream: SsfClientStream | null) => void;
   defaultSupportedEvents: string;
   nativelyEmittedEvents: string[];
-  defaultPushConnectTimeoutMillis: number;
-  defaultPushSocketTimeoutMillis: number;
   save: (options?: SaveOptions) => void;
   reset: () => void;
   refresh: () => void;
@@ -121,8 +118,6 @@ export const StreamTab = ({
   setClientStream,
   defaultSupportedEvents,
   nativelyEmittedEvents,
-  defaultPushConnectTimeoutMillis,
-  defaultPushSocketTimeoutMillis,
   save,
   reset,
   refresh,
@@ -133,15 +128,6 @@ export const StreamTab = ({
   const { control, setValue } = useFormContext<FormFields>();
   const { addAlert, addError } = useAlerts();
   const formatDate = useFormatDate();
-
-  // Watch the delivery method via useWatch so the controlled context
-  // hook plays nicely with this child component.
-  const ssfDelivery = useWatch({
-    control,
-    name: convertAttributeNameToForm<FormFields>(
-      "attributes.ssf.delivery",
-    ) as never,
-  }) as string | undefined;
 
   // The Events Requested dropdown on the create-stream form should
   // surface only events the receiver has marked as Supported, not the
@@ -1135,41 +1121,6 @@ export const StreamTab = ({
                   />
                 )}
               </FormGroup>
-              {/* Push timeouts only apply when Keycloak makes outbound
-                HTTP push requests. POLL is inbound (receivers call
-                the transmitter), so the timeout knobs have no effect
-                and we hide them to avoid suggesting otherwise. */}
-              {(ssfDelivery === "PUSH" || !ssfDelivery) &&
-                !isPollDeliveryMethod(clientStream.delivery?.method) && (
-                  <>
-                    <NumberControl
-                      name={convertAttributeNameToForm<FormFields>(
-                        "attributes.ssf.pushEndpointConnectTimeoutMillis",
-                      )}
-                      label={t("ssfPushEndpointConnectTimeout")}
-                      labelIcon={t("ssfPushEndpointConnectTimeoutHelp")}
-                      controller={{
-                        defaultValue: defaultPushConnectTimeoutMillis,
-                        rules: {
-                          min: 0,
-                        },
-                      }}
-                    />
-                    <NumberControl
-                      name={convertAttributeNameToForm<FormFields>(
-                        "attributes.ssf.pushEndpointSocketTimeoutMillis",
-                      )}
-                      label={t("ssfPushEndpointSocketTimeout")}
-                      labelIcon={t("ssfPushEndpointSocketTimeoutHelp")}
-                      controller={{
-                        defaultValue: defaultPushSocketTimeoutMillis,
-                        rules: {
-                          min: 0,
-                        },
-                      }}
-                    />
-                  </>
-                )}
               <ActionGroup>
                 <Button
                   variant="secondary"


### PR DESCRIPTION
Push Connect/Socket Timeout were only rendered on the Stream tab inside the "stream exists" branch, so admins could not configure them before a stream was created. Move both controls to the Receiver tab's Delivery section, shown only when push delivery is allowed for the receiver.

The timeouts are already stored as receiver client attributes (ssf.pushEndpointConnectTimeoutMillis / ssf.pushEndpointSocketTimeoutMillis), so this is a UI-only relocation — no backend, representation, or save-path change.

Fixes #49235

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
