### PR TITLE
fix: Promote Dynamic Client scopes feature to preview

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -92,7 +92,7 @@ public class Profile {
 
         PAR("OAuth 2.0 Pushed Authorization Requests (PAR)", Type.DEFAULT),
 
-        DYNAMIC_SCOPES("Dynamic OAuth 2.0 scopes", Type.EXPERIMENTAL),
+        DYNAMIC_SCOPES("Dynamic OAuth 2.0 scopes", Type.PREVIEW),
 
         CLIENT_SECRET_ROTATION("Client Secret Rotation", Type.PREVIEW),
 

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -32,7 +32,8 @@ public class ProfileTest {
     private static final Profile.Feature DEFAULT_FEATURE = Profile.Feature.CLIENT_POLICIES;
     private static final Profile.Feature DISABLED_BY_DEFAULT_FEATURE = Profile.Feature.DOCKER;
     private static final Profile.Feature PREVIEW_FEATURE = Profile.Feature.TOKEN_EXCHANGE;
-    private static final Profile.Feature EXPERIMENTAL_FEATURE = Profile.Feature.DYNAMIC_SCOPES;
+    private static final Profile.Feature DYNAMIC_SCOPES_FEATURE = Profile.Feature.DYNAMIC_SCOPES;
+    private static final Profile.Feature EXPERIMENTAL_FEATURE = Profile.Feature.CLIENT_TYPES;
     private static Profile.Feature DEPRECATED_FEATURE = Profile.Feature.LOGIN_V1;
 
     @TempDir
@@ -43,6 +44,7 @@ public class ProfileTest {
         Assertions.assertEquals(Profile.Feature.Type.DEFAULT, DEFAULT_FEATURE.getType());
         Assertions.assertEquals(Profile.Feature.Type.DISABLED_BY_DEFAULT, DISABLED_BY_DEFAULT_FEATURE.getType());
         Assertions.assertEquals(Profile.Feature.Type.PREVIEW, PREVIEW_FEATURE.getType());
+        Assertions.assertEquals(Profile.Feature.Type.PREVIEW, DYNAMIC_SCOPES_FEATURE.getType());
         Assertions.assertEquals(Profile.Feature.Type.EXPERIMENTAL, EXPERIMENTAL_FEATURE.getType());
 
         for (Profile.Feature feature : Profile.Feature.values()) {
@@ -73,6 +75,9 @@ public class ProfileTest {
         Assertions.assertFalse(DISABLED_BY_DEFAULT_FEATURE.isDeprecated());
         assertThat(profile.getPreviewFeatures(), Matchers.not(Matchers.hasItem(DISABLED_BY_DEFAULT_FEATURE)));
         Assertions.assertFalse(Profile.isFeatureEnabled(PREVIEW_FEATURE));
+        Assertions.assertFalse(Profile.isFeatureEnabled(DYNAMIC_SCOPES_FEATURE));
+        Assertions.assertFalse(DYNAMIC_SCOPES_FEATURE.isDeprecated());
+        assertThat(profile.getPreviewFeatures(), Matchers.hasItem(DYNAMIC_SCOPES_FEATURE));
         Assertions.assertFalse(Profile.isFeatureEnabled(EXPERIMENTAL_FEATURE));
         Assertions.assertFalse(EXPERIMENTAL_FEATURE.isDeprecated());
         assertThat(profile.getPreviewFeatures(), Matchers.not(Matchers.hasItem(EXPERIMENTAL_FEATURE)));
@@ -140,6 +145,15 @@ public class ProfileTest {
 
         Assertions.assertEquals(Profile.ProfileName.PREVIEW, Profile.getInstance().getName());
         Assertions.assertTrue(Profile.isFeatureEnabled(PREVIEW_FEATURE));
+    }
+
+    @Test
+    public void enablePreviewEnablesDynamicScopes() {
+        Properties properties = new Properties();
+        properties.setProperty("keycloak.profile", "preview");
+        Profile.configure(new PropertiesProfileConfigResolver(properties));
+
+        Assertions.assertTrue(Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Promote dynamic client scopes feature to preview.

## Root cause

The targeted test failed with `AssertionFailedError: expected: <true> but was: <false>` at `ProfileTest.enablePreviewEnablesDynamicScopes`. The surefire output showed `BUILD FAILURE` and the assertion stack trace, demonstrating that preview profile did not activate dynamic scopes. This confirms the feature had not yet been promoted from experimental to preview.

## Steps to reproduce

1. From the repository root, run `mvn -pl common -Dtest=ProfileTest#enablePreviewEnablesDynamicScopes test -DskipITs -DskipExamples`.
2. This test configures `keycloak.profile=preview` and checks whether `Profile.Feature.DYNAMIC_SCOPES` is enabled.
3. Before the fix, dynamic scopes were still classified as `Type.EXPERIMENTAL`, so preview mode did not enable them.

## Fix

Files changed (2):

- `common/src/main/java/org/keycloak/common/Profile.java`
- `common/src/test/java/org/keycloak/common/ProfileTest.java`

## Verification

Test file changed: `common/src/test/java/org/keycloak/common/ProfileTest.java`.

Fixes #46523
