### PR TITLE
Fix prompt create handling with PAR

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -223,7 +223,7 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
 
         // Add support for Initiating User Registration via OpenID Connect 1.0 via prompt=create
         // see: https://openid.net/specs/openid-connect-prompt-create-1_0.html#section-4.1
-        if (OIDCLoginProtocol.PROMPT_VALUE_CREATE.equals(params.getFirst(OAuth2Constants.PROMPT))) {
+        if (OIDCLoginProtocol.PROMPT_VALUE_CREATE.equals(request.getPrompt())) {
             if (!Organizations.isRegistrationAllowed(session, realm)) {
                 throw new ErrorPageException(session, authenticationSession, Response.Status.BAD_REQUEST, Messages.REGISTRATION_NOT_ALLOWED);
             }

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -95,6 +95,14 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
     }
 
     @Override
+    protected <T> T replaceIfNotNull(T previousVal, T newVal) {
+        // When PAR is used, the values from the pushed request must be used.
+        // Values added later to the browser redirect URL must not override
+        // or complete the pushed request.
+        return newVal;
+    }
+
+    @Override
     protected String getParameter(String paramName) {
         return requestParams.get(paramName);
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/par/ParTest.java
@@ -70,6 +70,7 @@ import org.keycloak.testsuite.util.oauth.OAuthClient;
 import org.keycloak.testsuite.util.oauth.ParRequest;
 import org.keycloak.testsuite.util.oauth.ParResponse;
 import org.keycloak.util.JsonSerialization;
+import org.keycloak.OAuth2Constants;
 
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -1275,6 +1276,98 @@ public class ParTest extends AbstractClientPoliciesTest {
         assertEquals(400, response.getStatusCode());
         assertEquals(ClientPolicyEvent.PUSHED_AUTHORIZATION_REQUEST.toString(), response.getError());
         assertEquals("Exception thrown intentionally", response.getErrorDescription());
+    }
+
+    // Verifies that prompt=create must come from the pushed authorization request when PAR is used.
+    @Test
+    public void testPromptCreateInParRequestOpensRegistration() throws Exception {
+        try {
+            // setup PAR realm settings
+            int requestUriLifespan = 45;
+            setParRealmSettings(requestUriLifespan);
+
+            // create client dynamically
+            String clientId = createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+                clientRep.setRequirePushedAuthorizationRequests(Boolean.TRUE);
+                clientRep.setRedirectUris(new ArrayList<String>(Arrays.asList(CLIENT_REDIRECT_URI)));
+            });
+            OIDCClientRepresentation oidcCRep = getClientDynamically(clientId);
+            String clientSecret = oidcCRep.getClientSecret();
+            assertEquals(Boolean.TRUE, oidcCRep.getRequirePushedAuthorizationRequests());
+            assertTrue(oidcCRep.getRedirectUris().contains(CLIENT_REDIRECT_URI));
+            assertEquals(OIDCLoginProtocol.CLIENT_SECRET_BASIC, oidcCRep.getTokenEndpointAuthMethod());
+
+            // Pushed Authorization Request with prompt=create
+            oauth.client(clientId, clientSecret);
+            oauth.redirectUri(CLIENT_REDIRECT_URI);
+            ParResponse pResp = new ParRequest(oauth) {
+                @Override
+                protected void initRequest() {
+                    super.initRequest();
+                    parameter(OAuth2Constants.PROMPT, OIDCLoginProtocol.PROMPT_VALUE_CREATE);
+                }
+            }.send();
+
+            assertEquals(201, pResp.getStatusCode());
+            String requestUri = pResp.getRequestUri();
+            assertEquals(requestUriLifespan, pResp.getExpiresIn());
+
+            // Authorization Request with request_uri of PAR
+            // remove parameters as query strings of uri
+            oauth.redirectUri(null);
+            oauth.scope(null);
+            oauth.responseType(null);
+            oauth.loginForm().requestUri(requestUri).open();
+
+            assertThat(driver.getCurrentUrl(), startsWith(OAuthClient.AUTH_SERVER_ROOT + "/realms/" + oauth.getRealm() + "/login-actions/registration"));
+        } finally {
+            restoreParRealmSettings();
+        }
+    }
+
+    // Verifies that prompt=create appended to the final authorization URL does not complete the PAR request.
+    @Test
+    public void testPromptCreateOnAuthorizationUrlDoesNotCompleteParRequest() throws Exception {
+        try {
+            // setup PAR realm settings
+            int requestUriLifespan = 45;
+            setParRealmSettings(requestUriLifespan);
+
+            // create client dynamically
+            String clientId = createClientDynamically(generateSuffixedName(CLIENT_NAME), (OIDCClientRepresentation clientRep) -> {
+                clientRep.setRequirePushedAuthorizationRequests(Boolean.TRUE);
+                clientRep.setRedirectUris(new ArrayList<String>(Arrays.asList(CLIENT_REDIRECT_URI)));
+            });
+            OIDCClientRepresentation oidcCRep = getClientDynamically(clientId);
+            String clientSecret = oidcCRep.getClientSecret();
+            assertEquals(Boolean.TRUE, oidcCRep.getRequirePushedAuthorizationRequests());
+            assertTrue(oidcCRep.getRedirectUris().contains(CLIENT_REDIRECT_URI));
+            assertEquals(OIDCLoginProtocol.CLIENT_SECRET_BASIC, oidcCRep.getTokenEndpointAuthMethod());
+
+            // Pushed Authorization Request without prompt=create
+            oauth.client(clientId, clientSecret);
+            oauth.redirectUri(CLIENT_REDIRECT_URI);
+            ParResponse pResp = oauth.doPushedAuthorizationRequest();
+
+            assertEquals(201, pResp.getStatusCode());
+            String requestUri = pResp.getRequestUri();
+            assertEquals(requestUriLifespan, pResp.getExpiresIn());
+
+            // Authorization Request with request_uri of PAR.
+            // prompt=create is added only to the final browser authorization request
+            // and must not complete or override the pushed authorization request.
+            oauth.redirectUri(null);
+            oauth.scope(null);
+            oauth.responseType(null);
+            oauth.loginForm()
+                    .requestUri(requestUri)
+                    .prompt(OIDCLoginProtocol.PROMPT_VALUE_CREATE)
+                    .open();
+
+            assertThat(driver.getCurrentUrl(), startsWith(OAuthClient.AUTH_SERVER_ROOT + "/realms/" + oauth.getRealm() + "/login-actions/authenticate"));
+        } finally {
+            restoreParRealmSettings();
+        }
     }
 
     // Successful redirection to identity provider when including kc_idp_hint in the PAR request.


### PR DESCRIPTION
### Summary

This fixes `prompt=create` handling when Pushed Authorization Requests (PAR) are used.

Before this change, `prompt=create` was checked directly from the final authorization request query parameters. This meant that `prompt=create` sent in the pushed authorization request was not considered for the registration flow.

The fix changes the registration check to use the parsed `AuthorizationEndpointRequest`.

In addition, PAR parsing now treats the pushed request as authoritative. Parameters appended later to the final browser authorization URL must not complete or override the pushed authorization request.

### Security behavior

When PAR is used, `prompt=create` must only trigger registration if it is part of the pushed authorization request.

For example:

- PAR request contains `prompt=create`  
  → registration page opens

- PAR request does not contain `prompt=create`, but the final `/auth?...&request_uri=...` URL is manually appended with `&prompt=create`  
  → login page opens, not registration

This prevents the final browser authorization URL from changing the effective PAR request.

### Tests

Added tests in `ParTest` for:

- `prompt=create` in the pushed authorization request opens registration
- `prompt=create` appended only to the final authorization URL does not complete the PAR request

Manual tests performed:

- normal login opens login page
- PAR with `prompt=create` opens registration page
- PAR without `prompt=create` plus final URL `&prompt=create` opens login page
- registration disabled blocks `prompt=create`
- invalid redirect URI is rejected
- PKCE required with missing PKCE parameters is rejected
- `prompt=create123` does not open registration
- `prompt=<script>alert(1)</script>` does not open registration and no script is executed
- `prompt=login` opens login page
- `prompt=none` redirects with `login_required` and does not open registration

Build verification:

```bash
mvn -pl testsuite/integration-arquillian/tests/base -am -DskipTests package

The build completed successfully.