### PR TITLE
fix: refining the health check and exposing excluding the health check

### DIFF
--- a/docs/documentation/release_notes/topics/26_7_0.adoc
+++ b/docs/documentation/release_notes/topics/26_7_0.adoc
@@ -97,6 +97,10 @@ Parameterized scopes can now define a parameter type that validates the captured
 
 For more details, see the link:{upgradingguide_link}[{upgradingguide_name}].
 
+== Additional datasources may be excluded from health checks
+
+Read more about it in the link:https://www.keycloak.org/server/db#multiple-datasources[Configure multiple datasources] guide.
+
 = Configuring and Running
 
 == Deprecation of SHA1 hashing functions in {project_name} 27

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -708,7 +708,7 @@ In the example above, the `org.your.extension.UserEntity` JPA entity will be man
 ==== 2. Required properties
 
 Once you have set up your `persistence.xml`, the minimal configuration on the {project_name} side is the setup of the DB kind/vendor for the specified datasource.
-You need to specify the build time option `db-kind-<name>`, where the `<name>` is the name of your datasource and must be the **same** as specified in the `persistence.xml` file.
+You need to specify the build time option `db-kind-<datasource>`, where the `<datasource>` is the name of your datasource and must be the **same** as specified in the `persistence.xml` file.
 
 Therefore, you can enable the additional datasource `user-store` as follows (`postgres` as an example):
 
@@ -764,8 +764,8 @@ Therefore, use `quarkus.datasource.user-store.db-kind=h2`, instead of `quarkus.d
 
 === Health checks
 
-Additional datasources are included by default in the readiness heatlh check endpoint that is available when health and metrics are enabled. If the additional datasource is not critical to your usage, you may exclude it from
-the health check with `db-health-exclude-<name>` set to `true`. 
+Additional datasources are included by default in the readiness health check endpoint. If the additional datasource is not critical to your usage, you may exclude it from
+the health check with `db-health-exclude-<datasource>` set to `true`. 
 
 === Additional datasources options
 <@opts.includeOptions includedOptions="*-<datasource>"/>

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -762,6 +762,11 @@ Therefore, use `quarkus.datasource.user-store.db-kind=h2`, instead of `quarkus.d
 
 <@opts.printRelevantOptions includedOptions="db db-* transaction-xa-enabled transaction-default-timeout transaction-setup-timeout" excludedOptions="db-*-<datasource>">
 
+=== Health checks
+
+Additional datasources are included by default in the readiness heatlh check endpoint that is available when health and metrics are enabled. If the additional datasource is not critical to your usage, you may exclude it from
+the health check with `db-health-exclude-<name>` set to `true`. 
+
 === Additional datasources options
 <@opts.includeOptions includedOptions="*-<datasource>"/>
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -169,8 +169,8 @@ public class DatabaseOptions {
             .build();
     
     public static final Option<Boolean> DB_HEALTH_EXCLUDE = new OptionBuilder<>("db-health-exclude-<datasource>", Boolean.class)
-            .category(OptionCategory.DATABASE)
-            .description("If you have enabled heatlth endpoints, but want the given datasource excluded from the health check.")
+            .category(OptionCategory.DATABASE_DATASOURCES)
+            .description("If you have enabled health endpoints, but want the given datasource excluded from the health check.")
             .buildTime(true)
             .build();
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -167,6 +167,11 @@ public class DatabaseOptions {
             .category(OptionCategory.DATABASE)
             .description("The type of the keystore file. Common values include 'JKS' (Java KeyStore) and 'PKCS12'. If not specified, it uses the driver's default.")
             .build();
+    
+    public static final Option<Boolean> DB_HEALTH_EXCLUDE = new OptionBuilder<>("db-health-exclude-<datasource>", Boolean.class)
+            .category(OptionCategory.DATABASE)
+            .description("If you have enabled heatlth endpoints, but want the given datasource excluded from the health check.")
+            .build();
 
     public static class Datasources {
 

--- a/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
+++ b/quarkus/config-api/src/main/java/org/keycloak/config/DatabaseOptions.java
@@ -171,6 +171,7 @@ public class DatabaseOptions {
     public static final Option<Boolean> DB_HEALTH_EXCLUDE = new OptionBuilder<>("db-health-exclude-<datasource>", Boolean.class)
             .category(OptionCategory.DATABASE)
             .description("If you have enabled heatlth endpoints, but want the given datasource excluded from the health check.")
+            .buildTime(true)
             .build();
 
     public static class Datasources {

--- a/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakNegativeHealthCheckTest.java
+++ b/quarkus/deployment/src/test/java/test/org/keycloak/quarkus/services/health/KeycloakNegativeHealthCheckTest.java
@@ -54,8 +54,7 @@ public class KeycloakNegativeHealthCheckTest {
                 .statusCode(503)
                 .body(Matchers.allOf(Matchers.containsString("DOWN"), Matchers.containsString(KeycloakReadyHealthCheck.FAILING_SINCE)));
 
-        // now have an active connection, failing since should be cleared
-        Mockito.when(metrics.activeCount()).thenReturn(2L);
+        Mockito.when(dataSourceHealthCheck.call()).thenReturn(HealthCheckResponse.up("up"));
         given()
                 .when().get("/health/ready")
                 .then()

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -256,6 +256,10 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                         .transformer(DatabasePropertyMappers::toDatabaseKind)
                         .paramLabel("vendor")
                         .build(),
+                fromOption(DatabaseOptions.DB_HEALTH_EXCLUDE)
+                        .to("quarkus.datasource.\"<datasource>\".health-exclude")
+                        .paramLabel("exclude")
+                        .build(),
                 fromOption(DatabaseOptions.DB_POOL_MAX_LIFETIME)
                         .to("quarkus.datasource.jdbc.max-lifetime")
                         .mapFrom(DB, DatabasePropertyMappers::transformPoolMaxLifetime)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/DatabasePropertyMappers.java
@@ -258,7 +258,6 @@ public final class DatabasePropertyMappers implements PropertyMapperGrouping {
                         .build(),
                 fromOption(DatabaseOptions.DB_HEALTH_EXCLUDE)
                         .to("quarkus.datasource.\"<datasource>\".health-exclude")
-                        .paramLabel("exclude")
                         .build(),
                 fromOption(DatabaseOptions.DB_POOL_MAX_LIFETIME)
                         .to("quarkus.datasource.jdbc.max-lifetime")

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
@@ -38,7 +38,8 @@ import org.eclipse.microprofile.health.Readiness;
 /**
  * Keycloak Healthcheck Readiness Probe.
  * <p>
- * Converts the standard <code>DataSourceHealthCheck</code> that waits for a connection to be returned to the pool and checks if it's valid, to an async check.
+ * Converts the standard <code>DataSourceHealthCheck</code> that waits for a connection and checks if it's valid, to an async check with a
+ * dedicated pool to control load shedding.
  * <p>
  *
  * @see <a href="https://github.com/keycloak/keycloak-community/pull/55">Healthcheck API Design</a>

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
@@ -27,8 +27,10 @@ import jakarta.inject.Inject;
 
 import io.quarkus.agroal.runtime.health.DataSourceHealthCheck;
 import io.quarkus.smallrye.health.runtime.QuarkusAsyncHealthCheckFactory;
+import io.smallrye.context.api.ManagedExecutorConfig;
 import io.smallrye.health.api.AsyncHealthCheck;
 import io.smallrye.mutiny.Uni;
+import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
 import org.eclipse.microprofile.health.Readiness;
@@ -59,23 +61,29 @@ public class KeycloakReadyHealthCheck implements AsyncHealthCheck {
     @Inject
     DataSourceHealthCheck dataSourceHealthCheck;
 
+    @Inject
+    @ManagedExecutorConfig(maxAsync = 1, maxQueued = 20)
+    ManagedExecutor executor;
+
     private final AtomicReference<Instant> failingSince = new AtomicReference<>();
 
     @Override
     public Uni<HealthCheckResponse> call() {
+        Uni<HealthCheckResponse> uni = Uni.createFrom().item(this::syncCheck);
+        return uni.runSubscriptionOn(executor);
+    }
+
+    private HealthCheckResponse syncCheck() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Keycloak database connections async health check").up();
-        
-        return healthCheckFactory.callSync(() -> {
-            HealthCheckResponse activeCheckResult = dataSourceHealthCheck.call();
-            if (activeCheckResult.getStatus() == HealthCheckResponse.Status.DOWN) {
-                builder.down();
-                Instant failingTime = failingSince.updateAndGet(KeycloakReadyHealthCheck::createInstanceIfNeeded);
-                builder.withData(FAILING_SINCE, DATE_FORMATTER.format(failingTime));
-            } else {
-                failingSince.set(null);
-            }
-            return builder.build();
-        });
+        HealthCheckResponse activeCheckResult = dataSourceHealthCheck.call();
+        if (activeCheckResult.getStatus() == HealthCheckResponse.Status.DOWN) {
+            builder.down();
+            Instant failingTime = failingSince.updateAndGet(KeycloakReadyHealthCheck::createInstanceIfNeeded);
+            builder.withData(FAILING_SINCE, DATE_FORMATTER.format(failingTime));
+        } else {
+            failingSince.set(null);
+        }
+        return builder.build();
     }
 
     static Instant createInstanceIfNeeded(Instant instant) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
@@ -26,7 +26,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import io.quarkus.agroal.runtime.health.DataSourceHealthCheck;
-import io.quarkus.smallrye.health.runtime.QuarkusAsyncHealthCheckFactory;
 import io.smallrye.context.api.ManagedExecutorConfig;
 import io.smallrye.health.api.AsyncHealthCheck;
 import io.smallrye.mutiny.Uni;
@@ -55,9 +54,6 @@ public class KeycloakReadyHealthCheck implements AsyncHealthCheck {
      * by the probe with the logs.
      */
     static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS").withZone(ZoneId.systemDefault());
-
-    @Inject
-    QuarkusAsyncHealthCheckFactory healthCheckFactory;
 
     @Inject
     DataSourceHealthCheck dataSourceHealthCheck;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
@@ -16,14 +16,21 @@
  */
 package org.keycloak.quarkus.runtime.services.health;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
+import javax.sql.DataSource;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
 
 import io.agroal.api.AgroalDataSource;
 import io.agroal.api.AgroalDataSourceMetrics;
@@ -31,9 +38,9 @@ import io.quarkus.agroal.runtime.health.DataSourceHealthCheck;
 import io.quarkus.smallrye.health.runtime.QuarkusAsyncHealthCheckFactory;
 import io.smallrye.health.api.AsyncHealthCheck;
 import io.smallrye.mutiny.Uni;
-import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
-import org.eclipse.microprofile.health.Readiness;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Keycloak Healthcheck Readiness Probe.
@@ -57,8 +64,7 @@ public class KeycloakReadyHealthCheck implements AsyncHealthCheck {
      */
     static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS").withZone(ZoneId.systemDefault());
 
-    @Inject
-    AgroalDataSource agroalDataSource;
+    List<AgroalDataSource> agroalDataSources;
 
     @Inject
     QuarkusAsyncHealthCheckFactory healthCheckFactory;
@@ -67,14 +73,29 @@ public class KeycloakReadyHealthCheck implements AsyncHealthCheck {
     DataSourceHealthCheck dataSourceHealthCheck;
 
     private final AtomicReference<Instant> failingSince = new AtomicReference<>();
+    
+    @PostConstruct
+    protected void init() {
+        try {
+            Method getCheckedDataSources = dataSourceHealthCheck.getClass().getMethod("getCheckedDataSources");
+            getCheckedDataSources.setAccessible(true);
+            agroalDataSources = ((Map<String, DataSource>) getCheckedDataSources.invoke(dataSourceHealthCheck)).values().stream()
+                    .filter(AgroalDataSource.class::isInstance).map(AgroalDataSource.class::cast).toList();
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @Override
     public Uni<HealthCheckResponse> call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Keycloak database connections async health check").up();
-        AgroalDataSourceMetrics metrics = agroalDataSource.getMetrics();
-        long activeCount = metrics.activeCount();
-        long invalidCount = metrics.invalidCount();
-        if (activeCount < 1 || invalidCount > 0) {
+        
+        if (agroalDataSources.stream().anyMatch(agroalDataSource -> {
+            AgroalDataSourceMetrics metrics = agroalDataSource.getMetrics();
+            long activeCount = metrics.activeCount();
+            long invalidCount = metrics.invalidCount();
+            return activeCount < 1 || invalidCount > 0;
+        })) {
             return healthCheckFactory.callSync(() -> {
                 HealthCheckResponse activeCheckResult = dataSourceHealthCheck.call();
                 if (activeCheckResult.getStatus() == HealthCheckResponse.Status.DOWN) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/health/KeycloakReadyHealthCheck.java
@@ -16,39 +16,28 @@
  */
 package org.keycloak.quarkus.runtime.services.health;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.sql.DataSource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
-import org.eclipse.microprofile.health.HealthCheckResponse;
-import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
-import org.eclipse.microprofile.health.Readiness;
-
-import io.agroal.api.AgroalDataSource;
-import io.agroal.api.AgroalDataSourceMetrics;
 import io.quarkus.agroal.runtime.health.DataSourceHealthCheck;
 import io.quarkus.smallrye.health.runtime.QuarkusAsyncHealthCheckFactory;
 import io.smallrye.health.api.AsyncHealthCheck;
 import io.smallrye.mutiny.Uni;
-import jakarta.annotation.PostConstruct;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
 
 /**
  * Keycloak Healthcheck Readiness Probe.
  * <p>
- * Performs a hybrid between the passive and the active mode. If there are no healthy connections in the pool,
- * it invokes the standard <code>DataSourceHealthCheck</code> that creates a new connection and checks if it's valid.
+ * Converts the standard <code>DataSourceHealthCheck</code> that waits for a connection to be returned to the pool and checks if it's valid, to an async check.
  * <p>
- * While the check for healthy connections is non-blocking, the standard check is blocking, so it needs to be wrapped.
  *
  * @see <a href="https://github.com/keycloak/keycloak-community/pull/55">Healthcheck API Design</a>
  */
@@ -64,8 +53,6 @@ public class KeycloakReadyHealthCheck implements AsyncHealthCheck {
      */
     static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS").withZone(ZoneId.systemDefault());
 
-    List<AgroalDataSource> agroalDataSources;
-
     @Inject
     QuarkusAsyncHealthCheckFactory healthCheckFactory;
 
@@ -73,44 +60,22 @@ public class KeycloakReadyHealthCheck implements AsyncHealthCheck {
     DataSourceHealthCheck dataSourceHealthCheck;
 
     private final AtomicReference<Instant> failingSince = new AtomicReference<>();
-    
-    @PostConstruct
-    protected void init() {
-        try {
-            Method getCheckedDataSources = dataSourceHealthCheck.getClass().getMethod("getCheckedDataSources");
-            getCheckedDataSources.setAccessible(true);
-            agroalDataSources = ((Map<String, DataSource>) getCheckedDataSources.invoke(dataSourceHealthCheck)).values().stream()
-                    .filter(AgroalDataSource.class::isInstance).map(AgroalDataSource.class::cast).toList();
-        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     @Override
     public Uni<HealthCheckResponse> call() {
         HealthCheckResponseBuilder builder = HealthCheckResponse.named("Keycloak database connections async health check").up();
         
-        if (agroalDataSources.stream().anyMatch(agroalDataSource -> {
-            AgroalDataSourceMetrics metrics = agroalDataSource.getMetrics();
-            long activeCount = metrics.activeCount();
-            long invalidCount = metrics.invalidCount();
-            return activeCount < 1 || invalidCount > 0;
-        })) {
-            return healthCheckFactory.callSync(() -> {
-                HealthCheckResponse activeCheckResult = dataSourceHealthCheck.call();
-                if (activeCheckResult.getStatus() == HealthCheckResponse.Status.DOWN) {
-                    builder.down();
-                    Instant failingTime = failingSince.updateAndGet(KeycloakReadyHealthCheck::createInstanceIfNeeded);
-                    builder.withData(FAILING_SINCE, DATE_FORMATTER.format(failingTime));
-                } else {
-                    failingSince.set(null);
-                }
-                return builder.build();
-            });
-        } else {
-            failingSince.set(null);
-            return healthCheckFactory.callAsync(() -> Uni.createFrom().item(builder.build()));
-        }
+        return healthCheckFactory.callSync(() -> {
+            HealthCheckResponse activeCheckResult = dataSourceHealthCheck.call();
+            if (activeCheckResult.getStatus() == HealthCheckResponse.Status.DOWN) {
+                builder.down();
+                Instant failingTime = failingSince.updateAndGet(KeycloakReadyHealthCheck::createInstanceIfNeeded);
+                builder.withData(FAILING_SINCE, DATE_FORMATTER.format(failingTime));
+            } else {
+                failingSince.set(null);
+            }
+            return builder.build();
+        });
     }
 
     static Instant createInstanceIfNeeded(Instant instant) {

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/HealthDistTest.java
@@ -177,4 +177,18 @@ public class HealthDistTest {
             runner.stop();
         }
     }
+
+    @Test
+    @Launch({ "start-dev", "--metrics-enabled=true", "--health-enabled=true", "--db-kind-user=mariadb" })
+    void testHealthDownFailingDatasource(KeycloakRunner runner) {
+        when().get("/health/ready").then()
+                .statusCode(503);
+    }
+
+    @Test
+    @Launch({ "start-dev", "--db-health-exclude-user=true", "--metrics-enabled=true", "--health-enabled=true", "--db-kind-user=mariadb" })
+    void testHealthUpExcludingFailingDatasource(KeycloakRunner runner) {
+        when().get("/health/ready").then()
+                .statusCode(200);
+    }
 }

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -43,6 +43,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminService.approved.txt
@@ -43,9 +43,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -121,6 +118,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -45,6 +45,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBootstrapAdminUser.approved.txt
@@ -45,9 +45,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -123,6 +120,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testBuildHelp.approved.txt
@@ -32,6 +32,9 @@ Database - additional datasources:
                      Used for named <datasource>. The fully qualified class name of the JDBC
                        driver. If not set, a default driver is set accordingly to the chosen
                        database.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -38,9 +38,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -116,6 +113,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelp.approved.txt
@@ -38,6 +38,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -38,9 +38,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -116,6 +113,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testExportHelpAll.approved.txt
@@ -38,6 +38,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -38,9 +38,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -116,6 +113,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelp.approved.txt
@@ -38,6 +38,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -38,9 +38,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -116,6 +113,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testImportHelpAll.approved.txt
@@ -38,6 +38,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -86,9 +86,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -164,6 +161,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelp.approved.txt
@@ -86,6 +86,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -156,6 +156,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartDevHelpAll.approved.txt
@@ -156,9 +156,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -234,6 +231,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -134,6 +134,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelp.approved.txt
@@ -134,9 +134,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -212,6 +209,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -157,6 +157,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartHelpAll.approved.txt
@@ -157,9 +157,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -235,6 +232,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -128,9 +128,6 @@ Database:
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelp.approved.txt
@@ -128,6 +128,9 @@ Database:
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -151,9 +151,6 @@ Database:
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testStartOptimizedHelpAll.approved.txt
@@ -151,6 +151,9 @@ Database:
 --db-debug-jpql <true|false>
                      Add JPQL information as comments to SQL statements to debug JPA SQL statement
                        generation. Default: false.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -133,6 +133,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelp.approved.txt
@@ -133,9 +133,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -211,6 +208,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -156,6 +156,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityCheckHelpAll.approved.txt
@@ -156,9 +156,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -234,6 +231,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -131,9 +131,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -209,6 +206,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelp.approved.txt
@@ -131,6 +131,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -154,6 +154,9 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
+--db-health-exclude-<datasource> <exclude>
+                     If you have enabled heatlth endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.

--- a/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
+++ b/quarkus/tests/integration/src/test/resources/org/keycloak/it/cli/dist/approvals/cli/help/HelpCommandDistTest.testUpdateCompatibilityMetadataHelpAll.approved.txt
@@ -154,9 +154,6 @@ Database:
                        generation. Default: false.
 --db-driver <driver> The fully qualified class name of the JDBC driver. If not set, a default
                        driver is set accordingly to the chosen database.
---db-health-exclude-<datasource> <exclude>
-                     If you have enabled heatlth endpoints, but want the given datasource excluded
-                       from the health check. Default: false.
 --db-log-slow-queries-threshold <milliseconds>
                      Log SQL statements slower than the configured threshold with logger org.
                        hibernate.SQL_SLOW and log-level info. Default: 10000.
@@ -232,6 +229,9 @@ Database - additional datasources:
 --db-enabled-<datasource> <true|false>
                      If the named datasource <datasource> should be enabled at runtime. Default:
                        true.
+--db-health-exclude-<datasource> <true|false>
+                     If you have enabled health endpoints, but want the given datasource excluded
+                       from the health check. Default: false.
 --db-kind-<datasource> <vendor>
                      Used for named <datasource>. The database vendor. Possible values are:
                        dev-file, dev-mem, mariadb, mssql, mysql, oracle, postgres, tidb.


### PR DESCRIPTION
@vmuzikar this is essentially what you are describing in the issue. 

A potential problem with this is that the full check may be running much more frequently than before. In particular we may want to only consider the "no active" connections condition an issue only if we're dealing with the primary datasource. Alternatively to be less breaking we can flip the boolean on the health-exclude so that it is opt-in rather than opt-out.

This change also shows only allowing users to exclude the secondary datasources, which is more opinionated than Quarkus as it allows you to exclude the default datasource, or all datasources.

And of course we'll also want a quarkus upstream issue on exposing the datasources, rather than using reflection.

closes: #49248

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
