### PR TITLE
ReadOnlyAttributeUnchangedValidator should not reject omitted attributes

### DIFF
--- a/services/src/main/java/org/keycloak/userprofile/validator/ReadOnlyAttributeUnchangedValidator.java
+++ b/services/src/main/java/org/keycloak/userprofile/validator/ReadOnlyAttributeUnchangedValidator.java
@@ -96,6 +96,12 @@ public class ReadOnlyAttributeUnchangedValidator implements SimpleValidator {
             return true;
         }
 
+        if (existingValue != null && value == null) {
+            // if attribute exists on the user but was not provided in the request,
+            // treat as unchanged — the user is not attempting to modify it
+            return true;
+        }
+
         return ObjectUtil.isEqualOrBothNull(existingValue, value);
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserAttributesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserAttributesTest.java
@@ -274,6 +274,29 @@ public class UserAttributesTest extends AbstractUserTest {
     }
 
     @Test
+    public void updateUserOmittingReadOnlyAttributesShouldSucceed() {
+        // Create user with a read-only attribute (usercertificate is in DEFAULT_READ_ONLY_ATTRIBUTES)
+        UserRepresentation user1 = new UserRepresentation();
+        user1.setUsername("user1");
+        user1.singleAttribute("usercertificate", "cert-value");
+        String user1Id = createUser(user1);
+
+        // GET the user — read-only attribute should be present
+        user1 = managedRealm.admin().users().get(user1Id).toRepresentation();
+        assertAttributeValue("cert-value", user1.getAttributes().get("usercertificate"));
+
+        // PUT without the read-only attribute — should succeed (not treated as a change)
+        user1.getAttributes().remove("usercertificate");
+        user1.singleAttribute("someattr", "somevalue");
+        updateUser(managedRealm.admin().users().get(user1Id), user1);
+
+        // Verify the read-only attribute is preserved
+        user1 = managedRealm.admin().users().get(user1Id).toRepresentation();
+        assertAttributeValue("cert-value", user1.getAttributes().get("usercertificate"));
+        assertAttributeValue("somevalue", user1.getAttributes().get("someattr"));
+    }
+
+    @Test
     public void testImportUserWithNullAttribute() {
         RealmRepresentation rep = loadJson(UserAttributesTest.class.getResourceAsStream("testrealm-user-null-attr.json"), RealmRepresentation.class);
 


### PR DESCRIPTION
When updating a federated LDAP user via the Admin API, omitting read-only attributes (e.g. createTimestamp, modifyTimestamp) from the PUT body causes a 400 error with 'updateReadOnlyAttributesRejectedMessage'. The validator incorrectly treats the absence of a read-only attribute as an attempt to change it.

The fix adds a check in isUnchanged(): if the attribute exists on the user but the new value is null (not provided in the request), treat it as unchanged rather than rejecting it.

Closes #49272

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
