### PR TITLE
Account resource sharing resolves recipient by username before email,…

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/resources/ResourceService.java
@@ -244,11 +244,15 @@ public class ResourceService extends AbstractResourceService {
 
     private UserModel getUser(String requester) {
         UserProvider users = provider.getKeycloakSession().users();
-        UserModel user = users.getUserByUsername(provider.getRealm(), requester);
+        UserModel userByUsername = users.getUserByUsername(provider.getRealm(), requester);
+        UserModel userByEmail = users.getUserByEmail(provider.getRealm(), requester);
 
-        if (user == null) {
-            user = users.getUserByEmail(provider.getRealm(), requester);
+        if (userByUsername != null && userByEmail != null
+                && !userByUsername.getId().equals(userByEmail.getId())) {
+            throw new BadRequestException("ambiguous_user");
         }
+
+        UserModel user = userByUsername != null ? userByUsername : userByEmail;
 
         if (user == null) {
             throw new NotFoundException(requester);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/account/ResourcesRestServiceTest.java
@@ -449,6 +449,42 @@ public class ResourcesRestServiceTest extends AbstractRestServiceTest {
     }
 
     @Test
+    public void testShareResourceRejectsAmbiguousUsernameEmail() throws Exception {
+        RealmRepresentation realm = adminClient.realm("test").toRepresentation();
+        realm.setLoginWithEmailAllowed(false);
+        adminClient.realm("test").update(realm);
+
+        UserRepresentation alice = findUser("alice");
+
+        // Create an attacker user whose username matches the email of a legitimate user.
+        UserRepresentation attacker = UserBuilder.create()
+                .username("alice@test.com")
+                .enabled(true)
+                .password("password")
+                .firstName("Attacker")
+                .lastName("X")
+                .email("attacker@test.com")
+                .build();
+        adminClient.realm("test").users().create(attacker);
+
+        alice.setEmail("alice@test.com");
+        adminClient.realm("test").users().get(alice.getId()).update(alice);
+
+        // The resource owner shares with "alice@test.com" intending alice (by email) but there is a clash as "alice@test.com" 
+        // is also the attacker's username -> reject the request due to unambiguity
+        List<Permission> permissions = new ArrayList<>();
+        permissions.add(new Permission("alice@test.com", "Scope A"));
+
+        String resourceId = getMyResources().get(0).getId();
+        SimpleHttpResponse response = SimpleHttpDefault.doPut(
+                getAccountUrl("resources/" + encodePathAsIs(resourceId) + "/permissions"), httpClient)
+                .auth(tokenUtil.getToken())
+                .json(permissions).asResponse();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
     public void failShareResourceInvalidPermissions() throws Exception {
         List<Permission> permissions = new ArrayList<>();
 


### PR DESCRIPTION
… granting access to wrong user

Closes #49086


(cherry picked from commit ba5d4bf165cea12afc37977c39d963889a200652)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
