### PR TITLE
Revert back to use Java 25 in FIPS CI scripts

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
-JAVA_VERSION=21
+JAVA_VERSION=25
 
 rm -f /etc/system-fips
 dnf install -y "java-${JAVA_VERSION}-openjdk-devel"

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-JAVA_VERSION=21
+JAVA_VERSION=25
 
 rm -f /etc/system-fips
 dnf install -y "java-${JAVA_VERSION}-openjdk-devel"


### PR DESCRIPTION
Closes #49194

Revert back to Java 25 for FIPS jobs. Just updating the new variable.
