### PR TITLE
Fix/issue 47681 fix log injection vulnerability in OIDC endpoints

### DIFF
--- a/server-spi/src/main/java/org/keycloak/utils/StringUtil.java
+++ b/server-spi/src/main/java/org/keycloak/utils/StringUtil.java
@@ -66,6 +66,33 @@ public class StringUtil {
     }
 
     /**
+     * Removes ANSI escape codes and control characters from a string to prevent log injection attacks.
+     * This method:
+     * 1. Removes URL-encoded ANSI escape sequences (e.g., %1B[31m)
+     * 2. Removes literal ANSI escape sequences (e.g., \u001b[31m)
+     * 3. Removes URL-encoded control characters (e.g., %0D, %0A, %7F)
+     * 4. Removes any remaining literal control characters
+     *
+     * Note: This method does NOT decode legitimate URL-encoded characters (e.g., %20, %2F)
+     * to preserve the original encoding for use cases like redirect URI validation.
+     *
+     * @param str The string to sanitize
+     * @return The sanitized string without ANSI codes and control characters
+     */
+    public static String removeControlCharacters(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        str = str.replaceAll("\u001B\\[([0-9;]*)[a-zA-Z]", "");
+        str = str.replaceAll("(?i)%1B\\[([0-9;]*)[a-zA-Z]", "");
+        str = str.replaceAll("(?i)%0[0-9A-F]|(?i)%1[0-9A-F]|(?i)%7F", "");
+        str = str.replaceAll("[\u0000-\u001F\u007F]+", "");
+        str = str.replaceAll("\\[([0-9;]*)m", "");
+        return str;
+    }
+
+
+    /**
      * Utility method that substitutes any isWhitespace char to common space ' ' or character 20.
      * The idea is removing any weird space character in the string like \t, \n, \r.
      * If quotes character is passed the quotes char is escaped to mark is not the end

--- a/server-spi/src/test/java/org/keycloak/utils/StringUtilTest.java
+++ b/server-spi/src/test/java/org/keycloak/utils/StringUtilTest.java
@@ -16,8 +16,10 @@
  */
 package org.keycloak.utils;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  *
@@ -27,12 +29,35 @@ public class StringUtilTest {
 
     @Test
     public void testSanitize() {
-        Assert.assertEquals("test1 test2 test3", StringUtil.sanitizeSpacesAndQuotes("test1 test2 test3", null));
-        Assert.assertEquals("test1 test2 test3", StringUtil.sanitizeSpacesAndQuotes("test1\ntest2\ttest3", null));
-        Assert.assertEquals("test1 test2 test3 \"test4\"", StringUtil.sanitizeSpacesAndQuotes("test1\ntest2\ttest3\r\"test4\"", null));
-        Assert.assertEquals("teswith\\\"quotes", StringUtil.sanitizeSpacesAndQuotes("teswith\"quotes", '"'));
-        Assert.assertEquals("test1 test2 test3 \\\"test4\\\"", StringUtil.sanitizeSpacesAndQuotes("test1\ntest2\ttest3\r\"test4\"", '"'));
-        Assert.assertEquals(" \\\"test", StringUtil.sanitizeSpacesAndQuotes("\n\"test", '"'));
-        Assert.assertEquals("\\\" test", StringUtil.sanitizeSpacesAndQuotes("\"\rtest", '"'));
+        assertEquals("test1 test2 test3", StringUtil.sanitizeSpacesAndQuotes("test1 test2 test3", null));
+        assertEquals("test1 test2 test3", StringUtil.sanitizeSpacesAndQuotes("test1\ntest2\ttest3", null));
+        assertEquals("test1 test2 test3 \"test4\"", StringUtil.sanitizeSpacesAndQuotes("test1\ntest2\ttest3\r\"test4\"", null));
+        assertEquals("teswith\\\"quotes", StringUtil.sanitizeSpacesAndQuotes("teswith\"quotes", '"'));
+        assertEquals("test1 test2 test3 \\\"test4\\\"", StringUtil.sanitizeSpacesAndQuotes("test1\ntest2\ttest3\r\"test4\"", '"'));
+        assertEquals(" \\\"test", StringUtil.sanitizeSpacesAndQuotes("\n\"test", '"'));
+        assertEquals("\\\" test", StringUtil.sanitizeSpacesAndQuotes("\"\rtest", '"'));
+    }
+
+    @Test
+    public void testRemoveControlCharacters() {
+        assertEquals("THIS_IS_RED", StringUtil.removeControlCharacters("%1B[31mTHIS_IS_RED%1B[0m"));
+        // URL-encoded characters are NOT decoded, only control chars are removed
+        assertEquals("fake_client[FORGED+INFO]+User+admin+logged+in+successfully",
+                StringUtil.removeControlCharacters("fake_client%0D%0A%1b[32m[FORGED+INFO]+User+admin+logged+in+successfully%1b[0m"));
+
+        assertEquals("fake_client[FORGED INFO]",
+                StringUtil.removeControlCharacters("fake_client\r\n\u001b[32m[FORGED INFO]\u001b[0m"));
+
+        assertEquals("test", StringUtil.removeControlCharacters("te\u0001st"));
+        assertEquals("test", StringUtil.removeControlCharacters("te\u007Fst"));
+
+        assertNull(StringUtil.removeControlCharacters(null));
+        assertEquals("", StringUtil.removeControlCharacters(""));
+
+        assertEquals("normal text", StringUtil.removeControlCharacters("normal text"));
+        
+        assertEquals("foo%20bar", StringUtil.removeControlCharacters("foo%20bar"));
+        assertEquals("foo%2Fbar", StringUtil.removeControlCharacters("foo%2Fbar"));
+        assertEquals("test%2092", StringUtil.removeControlCharacters("test%2092"));
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -65,6 +65,7 @@ import org.keycloak.saml.common.util.DocumentUtil;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.cors.Cors;
 import org.keycloak.services.util.DPoPUtil;
+import org.keycloak.utils.StringUtil;
 
 import org.jboss.logging.Logger;
 import org.w3c.dom.Document;
@@ -125,6 +126,7 @@ public class TokenEndpoint {
         }
 
         formParams = formParameters;
+        sanitizeFormParameters();
         grantType = formParams.getFirst(OIDCLoginProtocol.GRANT_TYPE_PARAM);
 
         // https://tools.ietf.org/html/rfc6749#section-5.1
@@ -232,6 +234,17 @@ public class TokenEndpoint {
             }
         }
     }
+
+    private void sanitizeFormParameters() {
+        MultivaluedMap<String, String> sanitized = new MultivaluedHashMap<>();
+        for (Map.Entry<String, List<String>> entry : formParams.entrySet()) {
+            for (String value : entry.getValue()) {
+                sanitized.add(entry.getKey(), StringUtil.removeControlCharacters(value));
+            }
+        }
+        formParams = sanitized;
+    }
+
 
     protected void checkParameters() {
         OIDCLoginProtocol loginProtocol = (OIDCLoginProtocol) session.getProvider(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
@@ -32,6 +32,7 @@ import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.OIDCProviderConfig;
 import org.keycloak.services.ErrorResponseException;
+import org.keycloak.utils.StringUtil;
 
 import org.jboss.logging.Logger;
 
@@ -177,6 +178,8 @@ public abstract class AuthzEndpointRequestParser {
             continue;
           }
 
+          final String sanitizedValue = StringUtil.removeControlCharacters(value);
+
           // Compare with ">=", as the currently processed parameter will be added at the END of this method.
           if (additionalReqParams.size() >= additionalReqParamsMaxNumber) {
 
@@ -190,33 +193,33 @@ public abstract class AuthzEndpointRequestParser {
 
           }
 
-          if (value.length() + currentAdditionalReqParamMaxOverallSize > additionalReqParamsMaxOverallSize) {
+          if (sanitizedValue.length() + currentAdditionalReqParamMaxOverallSize > additionalReqParamsMaxOverallSize) {
 
             if (additionalReqParamsFailFast) {
-              logger.debugv("The OIDC additional parameter '{0}''s size ({1}) exceeds the maximum allowed size of all parameters ({2}).", paramName, value.length(), additionalReqParamsMaxOverallSize);
-              throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "The OIDC additional parameter '" + paramName + "'s size (" + value.length() + ") exceeds the maximum allowed size of all parameters (" + additionalReqParamsMaxOverallSize + ").", Response.Status.BAD_REQUEST);
+              logger.debugv("The OIDC additional parameter '{0}''s size ({1}) exceeds the maximum allowed size of all parameters ({2}).", paramName, sanitizedValue.length(), additionalReqParamsMaxOverallSize);
+              throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "The OIDC additional parameter '" + paramName + "'s size (" + sanitizedValue.length() + ") exceeds the maximum allowed size of all parameters (" + additionalReqParamsMaxOverallSize + ").", Response.Status.BAD_REQUEST);
             } else {
-              logger.debugv("The OIDC additional parameter '{0}''s size exceeds ({1}) the maximum allowed size of all parameters ({2}).", paramName, value.length(), additionalReqParamsMaxOverallSize);
+              logger.debugv("The OIDC additional parameter '{0}''s size exceeds ({1}) the maximum allowed size of all parameters ({2}).", paramName, sanitizedValue.length(), additionalReqParamsMaxOverallSize);
               break;
             }
 
           }
 
-          if (value.length() > additionalReqParamsMaxSize) {
+          if (sanitizedValue.length() > additionalReqParamsMaxSize) {
 
             if (additionalReqParamsFailFast) {
-              logger.debugv("The OIDC additional parameter '{0}''s size is longer ({1}) than allowed ({2}).", paramName, value.length(), additionalReqParamsMaxSize);
-              throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "The OIDC additional parameter '" + paramName + "'s size is longer (" + value.length() + ") than allowed (" + additionalReqParamsMaxSize + ").", Response.Status.BAD_REQUEST);
+              logger.debugv("The OIDC additional parameter '{0}''s size is longer ({1}) than allowed ({2}).", paramName, sanitizedValue.length(), additionalReqParamsMaxSize);
+              throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "The OIDC additional parameter '" + paramName + "'s size is longer (" + sanitizedValue.length() + ") than allowed (" + additionalReqParamsMaxSize + ").", Response.Status.BAD_REQUEST);
             } else {
-              logger.debugv("The OIDC additional parameter '{0}''s size is longer ({1}) than allowed ({2}).", paramName, value.length(), additionalReqParamsMaxSize);
+              logger.debugv("The OIDC additional parameter '{0}''s size is longer ({1}) than allowed ({2}).", paramName, sanitizedValue.length(), additionalReqParamsMaxSize);
               break;
             }
 
           }
 
           logger.debugv("Adding OIDC additional parameter ''{0}'' as additional parameter.", paramName);
-          currentAdditionalReqParamMaxOverallSize += value.length();
-          additionalReqParams.put(paramName, value);
+          currentAdditionalReqParamMaxOverallSize += sanitizedValue.length();
+          additionalReqParams.put(paramName, sanitizedValue);
         }
     }
 
@@ -228,6 +231,7 @@ public abstract class AuthzEndpointRequestParser {
         String paramValue = getParameter(paramName);
 
         if (paramValue != null) {
+            paramValue = StringUtil.removeControlCharacters(paramValue);
             int maxLength = config.getMaxLengthForTheParameter(paramName, false);
             if (paramValue.length() > maxLength) {
                 logger.warnf("The size of OIDC parameter '%s' size is longer (%d) than allowed (%d). %s", paramName, paramValue.length(), maxLength, additionalReqParamsFailFast ? "Request not allowed." : "Ignoring the parameter.");

--- a/services/src/test/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParserSanitizationTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParserSanitizationTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.protocol.oidc.endpoints.request;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.services.resteasy.HttpRequestImpl;
+import org.keycloak.services.resteasy.ResteasyKeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+import org.keycloak.utils.ScopeUtil;
+
+import org.jboss.resteasy.mock.MockHttpRequest;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+/**
+ * Unit tests for log injection vulnerability fix in AuthzEndpointRequestParser.
+ * Tests verify that ANSI escape codes and control characters are properly
+ * sanitized from OIDC parameters.
+ */
+public class AuthzEndpointRequestParserSanitizationTest {
+
+    private static KeycloakSession session;
+
+    @BeforeClass
+    public static void setup() {
+        HttpRequest httpRequest = new HttpRequestImpl(
+            MockHttpRequest.create("GET", URI.create("https://keycloak.org/"),
+            URI.create("https://keycloak.org"))
+        );
+
+        Profile.defaults();
+        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
+
+        Config.init(new Config.ConfigProvider() {
+            @Override
+            public String getProvider(String spi) {
+                return null;
+            }
+
+            @Override
+            public String getDefaultProvider(String spi) {
+                return null;
+            }
+
+            @Override
+            public Config.Scope scope(String... scope) {
+                return ScopeUtil.createScope(new HashMap<>());
+            }
+        });
+
+        ResteasyKeycloakSessionFactory sessionFactory = new ResteasyKeycloakSessionFactory();
+        sessionFactory.init();
+        session = new ResteasyKeycloakSession(sessionFactory);
+        session.getContext().setHttpRequest(httpRequest);
+    }
+
+    @Test
+    public void testSanitizeClientIdWithANSICodes() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.CLIENT_ID_PARAM, "fake_client\r\n\u001B[32m[FORGED INFO]\u001B[0m");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.clientId);
+        assertFalse("Newlines should be removed", request.clientId.contains("\r"));
+        assertFalse("Newlines should be removed", request.clientId.contains("\n"));
+        assertFalse("ANSI codes should be removed", request.clientId.contains("\u001B"));
+        assertEquals("fake_client[FORGED INFO]", request.clientId);
+    }
+
+
+    @Test
+    public void testSanitizeScopeWithURLEncodedANSI() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.SCOPE_PARAM, "openid%1B[31mprofile%1B[0m");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.scope);
+        assertFalse("ANSI codes should be removed", request.scope.contains("\u001B"));
+        // URL-encoded ANSI codes are removed
+        assertEquals("openidprofile", request.scope);
+    }
+
+    @Test
+    public void testSanitizeResponseTypeWithTabs() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.RESPONSE_TYPE_PARAM, "code\t\tid_token");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.responseType);
+        assertFalse("Tabs should be removed", request.responseType.contains("\t"));
+        assertEquals("codeid_token", request.responseType);
+    }
+
+    @Test
+    public void testSanitizeStateWithNewlineInjection() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.STATE_PARAM, "valid_state\r\n[FAKE] Log entry");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.state);
+        assertFalse("Carriage return should be removed", request.state.contains("\r"));
+        assertFalse("Newline should be removed", request.state.contains("\n"));
+        assertEquals("valid_state[FAKE] Log entry", request.state);
+    }
+
+    @Test
+    public void testSanitizeLoginHintWithControlCharacters() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.LOGIN_HINT_PARAM, "admin@example.com");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.loginHint);
+        assertFalse("Control characters should be removed",
+            request.loginHint.matches(".*[\\x00-\\x1F\\x7F].*"));
+        assertEquals("admin@example.com", request.loginHint);
+    }
+
+    @Test
+    public void testSanitizeNonceWithMixedAttackVectors() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.NONCE_PARAM, "nonce123\r\n\u001B[32mFAKE\u001B[0m\tvalue");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertAll(
+                () -> assertNotNull(request.nonce),
+                () -> assertFalse("Newlines should be removed", request.nonce.contains("\r")),
+                () -> assertFalse("Newlines should be removed", request.nonce.contains("\n")),
+                () -> assertFalse("Tabs should be removed", request.nonce.contains("\t")),
+                () -> assertFalse("ANSI codes should be removed", request.nonce.contains("\u001B")),
+                () -> assertEquals("nonce123FAKEvalue", request.nonce)
+         );
+
+    }
+
+    @Test
+    public void testSanitizeAdditionalParametersAreSanitized() {
+        TestParser parser = new TestParser(session);
+        parser.params.put("custom_param", "value\r\n\u001B[31minjected\u001B[0m");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        String customParam = request.additionalReqParams.get("custom_param");
+        assertAll(
+                () -> assertNotNull(customParam),
+                () -> assertFalse("Control characters should be removed from additional params", customParam.contains("\r")),
+                () -> assertFalse("Control characters should be removed from additional params", customParam.contains("\n")),
+                () -> assertFalse("ANSI codes should be removed from additional params", customParam.contains("\u001B")),
+                () -> assertEquals("valueinjected", customParam)
+        );
+
+    }
+
+    @Test
+    public void testNormalStringsUnchanged() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.CLIENT_ID_PARAM, "my-client-123");
+        parser.params.put(OIDCLoginProtocol.SCOPE_PARAM, "openid profile email");
+        parser.params.put(OIDCLoginProtocol.STATE_PARAM, "abc123xyz");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertEquals("my-client-123", request.clientId);
+        assertEquals("openid profile email", request.scope);
+        assertEquals("abc123xyz", request.state);
+    }
+
+
+    @Test
+    public void testDeleteCharacter_0x7F_IsRemoved() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.CLIENT_ID_PARAM, "client\u007Fid");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.clientId);
+        assertFalse("DELETE character should be removed", request.clientId.contains("\u007F"));
+        assertEquals("clientid", request.clientId);
+    }
+
+    @Test
+    public void testCombinedAttackVector() {
+        TestParser parser = new TestParser(session);
+        parser.params.put(OIDCLoginProtocol.CLIENT_ID_PARAM, "client%0D%0A%1B[32m[FORGED]%1B[0m%09%00");
+
+        AuthorizationEndpointRequest request = new AuthorizationEndpointRequest();
+        parser.parseRequest(request);
+
+        assertNotNull(request.clientId);
+        assertFalse("No control characters should remain", request.clientId.matches(".*[\\x00-\\x1F\\x7F].*"));
+        assertEquals("client[FORGED]", request.clientId);
+    }
+
+
+    private static class TestParser extends AuthzEndpointRequestParser {
+        private Map<String, String> params = new HashMap<>();
+
+        public TestParser(KeycloakSession session) {
+            super(session);
+        }
+
+        @Override
+        protected String getParameter(String paramName) {
+            return params.get(paramName);
+        }
+
+        @Override
+        protected Integer getIntParameter(String paramName) {
+            String val = params.get(paramName);
+            return val == null ? null : Integer.valueOf(val);
+        }
+
+        @Override
+        protected Set<String> keySet() {
+            return params.keySet();
+        }
+    }
+}


### PR DESCRIPTION
Fix log injection vulnerability in OIDC endpoints

  - Added StringUtil.removeControlCharacters() for sanitization
  - Sanitize all OIDC parameters in AuthzEndpointRequestParser
  - Sanitize all form parameters in TokenEndpoint
  - Always remove control chars
    JBossLoggingEventListenerProvider
  - Added tests

Closes #47681