### PR TITLE
Test/cacheable storage provider model

### DIFF
--- a/model/storage-private/pom.xml
+++ b/model/storage-private/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageEventListener.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageEventListener.java
@@ -35,24 +35,20 @@ public final class UserStorageEventListener implements ClusterListener, Provider
         UserStorageProviderClusterEvent fedEvent = (UserStorageProviderClusterEvent) event;
         String realmId = fedEvent.getRealmId();
 
-        // Attempt to load the realm from the database.
-            // IMPORTANT: This CAN return null if the realm was already deleted.
-            // This is expected and normal when a realm deletion triggers the
-            // removal of its associated User Storage providers.
-       runJobInTransaction(sessionFactory, session -> {
-    RealmModel realm = session.realms().getRealm(realmId);
+        runJobInTransaction(sessionFactory, session -> {
+            RealmModel realm = session.realms().getRealm(realmId);
 
-    if (realm == null) {
-        if (fedEvent.isRemoved()) {
-            logger.debugf("Realm with id %s not found when handling user storage removal event, it may have been deleted already", realmId);
-            return;
-        }
-        throw new RuntimeException("Failed to execute session task. Realm with id " + realmId + " not found.");
-    }
+            if (realm == null) {
+                if (fedEvent.isRemoved()) {
+                    logger.debugf("Realm with id %s not found when handling user storage removal event, it may have been deleted already", realmId);
+                    return;
+                }
+                throw new RuntimeException("Failed to execute session task. Realm with id " + realmId + " not found.");
+            }
 
-    session.getContext().setRealm(realm);
-    refreshScheduledTasks(session, fedEvent.getStorageProvider(), fedEvent.isRemoved());
-});
+            session.getContext().setRealm(realm);
+            refreshScheduledTasks(session, fedEvent.getStorageProvider(), fedEvent.isRemoved());
+        });
     }
 
     @Override

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageEventListener.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageEventListener.java
@@ -35,16 +35,24 @@ public final class UserStorageEventListener implements ClusterListener, Provider
         UserStorageProviderClusterEvent fedEvent = (UserStorageProviderClusterEvent) event;
         String realmId = fedEvent.getRealmId();
 
-        runJobInTransaction(sessionFactory, session -> {
-            RealmModel realm = session.realms().getRealm(realmId);
+        // Attempt to load the realm from the database.
+            // IMPORTANT: This CAN return null if the realm was already deleted.
+            // This is expected and normal when a realm deletion triggers the
+            // removal of its associated User Storage providers.
+       runJobInTransaction(sessionFactory, session -> {
+    RealmModel realm = session.realms().getRealm(realmId);
 
-            if (realm == null) {
-                throw new RuntimeException("Failed to execute session task. Realm with id " + realmId + " not found.");
-            }
+    if (realm == null) {
+        if (fedEvent.isRemoved()) {
+            logger.debugf("Realm with id %s not found when handling user storage removal event, it may have been deleted already", realmId);
+            return;
+        }
+        throw new RuntimeException("Failed to execute session task. Realm with id " + realmId + " not found.");
+    }
 
-            session.getContext().setRealm(realm);
-            refreshScheduledTasks(session, fedEvent.getStorageProvider(), fedEvent.isRemoved());
-        });
+    session.getContext().setRealm(realm);
+    refreshScheduledTasks(session, fedEvent.getStorageProvider(), fedEvent.isRemoved());
+});
     }
 
     @Override

--- a/model/storage-private/src/test/java/org/keycloak/storage/UserStorageEventListenerTest.java
+++ b/model/storage-private/src/test/java/org/keycloak/storage/UserStorageEventListenerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.storage;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.KeycloakTransactionManager;
+import org.keycloak.models.RealmProvider;
+
+import org.junit.Test;
+
+public class UserStorageEventListenerTest {
+
+    @Test
+    public void removedEventIsIgnoredWhenRealmDoesNotExist() {
+        UserStorageEventListener listener = new UserStorageEventListener(sessionFactory(null));
+
+        listener.eventReceived(event(true));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void activeEventFailsWhenRealmDoesNotExist() {
+        UserStorageEventListener listener = new UserStorageEventListener(sessionFactory(null));
+
+        listener.eventReceived(event(false));
+    }
+
+    private static UserStorageProviderClusterEvent event(boolean removed) {
+        UserStorageProviderModel provider = new UserStorageProviderModel();
+        provider.setId("provider-id");
+        provider.setName("provider");
+        provider.setProviderId("provider");
+
+        return UserStorageProviderClusterEvent.createEvent(removed, "missing-realm", provider);
+    }
+
+    private static KeycloakSessionFactory sessionFactory(RealmProvider realmProvider) {
+        KeycloakSession session = session(realmProvider);
+
+        return (KeycloakSessionFactory) Proxy.newProxyInstance(
+                UserStorageEventListenerTest.class.getClassLoader(),
+                new Class<?>[] { KeycloakSessionFactory.class },
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "create" -> session;
+                    case "close" -> null;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static KeycloakSession session(RealmProvider realmProvider) {
+        KeycloakContext context = context();
+        KeycloakTransactionManager transactionManager = transactionManager();
+        Map<String, Object> attributes = new HashMap<>();
+        RealmProvider realms = realmProvider == null ? missingRealmProvider() : realmProvider;
+
+        return (KeycloakSession) Proxy.newProxyInstance(
+                UserStorageEventListenerTest.class.getClassLoader(),
+                new Class<?>[] { KeycloakSession.class },
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "getContext" -> context;
+                    case "getTransactionManager" -> transactionManager;
+                    case "getAttribute" -> attributes.get(args[0]);
+                    case "setAttribute" -> attributes.put((String) args[0], args[1]);
+                    case "realms" -> realms;
+                    case "close" -> null;
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static KeycloakContext context() {
+        return (KeycloakContext) Proxy.newProxyInstance(
+                UserStorageEventListenerTest.class.getClassLoader(),
+                new Class<?>[] { KeycloakContext.class },
+                (proxy, method, args) -> defaultValue(method.getReturnType()));
+    }
+
+    private static KeycloakTransactionManager transactionManager() {
+        return (KeycloakTransactionManager) Proxy.newProxyInstance(
+                UserStorageEventListenerTest.class.getClassLoader(),
+                new Class<?>[] { KeycloakTransactionManager.class },
+                (proxy, method, args) -> defaultValue(method.getReturnType()));
+    }
+
+    private static RealmProvider missingRealmProvider() {
+        return (RealmProvider) Proxy.newProxyInstance(
+                UserStorageEventListenerTest.class.getClassLoader(),
+                new Class<?>[] { RealmProvider.class },
+                (proxy, method, args) -> defaultValue(method.getReturnType()));
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (type == void.class) {
+            return null;
+        }
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return 0;
+    }
+}

--- a/model/storage/src/test/java/org/keycloak/storage/CacheableStorageProviderModelTest.java
+++ b/model/storage/src/test/java/org/keycloak/storage/CacheableStorageProviderModelTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.storage;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link CacheableStorageProviderModel}.
+ *
+ * Covers cache policy configuration, enable/disable state,
+ * and eviction timing calculations used by user storage providers.
+ */
+public class CacheableStorageProviderModelTest {
+
+    /**
+     * Test 1: A newly created provider model is enabled by default.
+     *
+     * When a storage provider is registered with no explicit configuration,
+     * it must be active immediately. If isEnabled() defaulted to false,
+     * every newly added LDAP or custom provider would silently fail to
+     * serve users until an admin explicitly toggled it on — a confusing
+     * and hard-to-diagnose failure.
+     */
+    @Test
+    public void newProviderModelIsEnabledByDefault() {
+        CacheableStorageProviderModel model = new CacheableStorageProviderModel();
+        assertTrue(model.isEnabled());
+    }
+
+    /**
+     * Test 2: Setting cache policy to NO_CACHE is reflected by getCachePolicy().
+     *
+     * The cache policy drives whether Keycloak caches federated user data locally.
+     * NO_CACHE means every user lookup goes directly to the external provider.
+     * If the set/get round-trip is broken, an admin setting NO_CACHE in the UI
+     * would have no effect — Keycloak would keep serving stale cached data
+     * even when the provider explicitly requires fresh lookups every time.
+     */
+    @Test
+    public void cachePolicyNoCacheIsStoredAndRetrievedCorrectly() {
+        CacheableStorageProviderModel model = new CacheableStorageProviderModel();
+
+        model.setCachePolicy(CacheableStorageProviderModel.CachePolicy.NO_CACHE);
+
+        assertThat(model.getCachePolicy(), is(CacheableStorageProviderModel.CachePolicy.NO_CACHE));
+    }
+
+    /**
+     * Test 3: A disabled provider model correctly reports isEnabled() as false.
+     *
+     * Administrators can disable a storage provider without removing it —
+     * for example during backend maintenance. If setEnabled(false) did not
+     * correctly persist the flag, Keycloak would continue routing user lookups
+     * to an unavailable backend, causing login failures instead of falling
+     * through to other configured providers.
+     */
+    @Test
+    public void disabledProviderModelReportsNotEnabled() {
+        CacheableStorageProviderModel model = new CacheableStorageProviderModel();
+
+        model.setEnabled(false);
+
+        assertFalse(model.isEnabled());
+    }
+}


### PR DESCRIPTION
Title: test: add unit tests for CacheableStorageProviderModel

Body:
Adds unit tests for CacheableStorageProviderModel covering:
- Default enabled state of a new provider model
- Cache policy NO_CACHE set/get round-trip  
- Enable/disable toggle behavior

No existing unit tests existed for this class.