### PR TITLE
Fix NPE in convertDeprecatedCredentialsFormat when credential fields are null

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -253,12 +253,20 @@ public class RepresentationToModel {
                         logger.warnf("Using deprecated 'credentials' format in JSON representation for user '%s'. It will be removed in future versions", user.getUsername());
 
                         if (PasswordCredentialModel.TYPE.equals(cred.getType()) || PasswordCredentialModel.PASSWORD_HISTORY.equals(cred.getType())) {
+                            if (cred.getHashIterations() == null || cred.getAlgorithm() == null || cred.getHashedSaltedValue() == null || cred.getSalt() == null) {
+                                throw new ModelException("Incomplete deprecated credential format for user '" + user.getUsername()
+                                        + "': password credential requires hashIterations, algorithm, hashedSaltedValue, and salt");
+                            }
                             PasswordCredentialData credentialData = new PasswordCredentialData(cred.getHashIterations(), cred.getAlgorithm());
                             cred.setCredentialData(JsonSerialization.writeValueAsString(credentialData));
                             // Created this manually to avoid conversion from Base64 and back
                             cred.setSecretData("{\"value\":\"" + cred.getHashedSaltedValue() + "\",\"salt\":\"" + cred.getSalt() + "\"}");
                             cred.setPriority(10);
                         } else if (OTPCredentialModel.TOTP.equals(cred.getType()) || OTPCredentialModel.HOTP.equals(cred.getType())) {
+                            if (cred.getDigits() == null || cred.getCounter() == null || cred.getPeriod() == null || cred.getAlgorithm() == null || cred.getHashedSaltedValue() == null) {
+                                throw new ModelException("Incomplete deprecated credential format for user '" + user.getUsername()
+                                        + "': OTP credential requires digits, counter, period, algorithm, and hashedSaltedValue");
+                            }
                             OTPCredentialData credentialData = new OTPCredentialData(cred.getType(), cred.getDigits(), cred.getCounter(), cred.getPeriod(), cred.getAlgorithm(), null);
                             OTPSecretData secretData = new OTPSecretData(cred.getHashedSaltedValue());
                             cred.setCredentialData(JsonSerialization.writeValueAsString(credentialData));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/UsersTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/UsersTest.java
@@ -19,10 +19,13 @@ package org.keycloak.tests.admin;
 
 import java.util.List;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserProvider;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -375,6 +378,22 @@ public class UsersTest {
         assertThat(realm.admin().users().search("User", true), hasSize(1));
         assertThat(realm.admin().users().search("USER", true), hasSize(1));
         assertThat(realm.admin().users().search("Use", true), hasSize(0));
+    }
+
+    @Test
+    public void createUserWithIncompleteDeprecatedPasswordCredentialReturnsBadRequest() {
+        UserRepresentation user = UserBuilder.create()
+                .username("incomplete-cred-user")
+                .enabled(true)
+                .build();
+
+        CredentialRepresentation cred = new CredentialRepresentation();
+        cred.setType(CredentialRepresentation.PASSWORD);
+        user.setCredentials(List.of(cred));
+
+        try (Response response = realm.admin().users().create(user)) {
+            assertThat(response.getStatus(), is(Response.Status.BAD_REQUEST.getStatusCode()));
+        }
     }
 
     private void createUser(UserRepresentation user) {


### PR DESCRIPTION
## Summary
- Validate required fields before converting deprecated credential format in `RepresentationToModel.convertDeprecatedCredentialsFormat()`
- Throws `ModelException` (returned as 400 Bad Request) instead of crashing with NPE (500 Internal Server Error)
- Covers both password credentials (`hashIterations`, `algorithm`, `hashedSaltedValue`, `salt`) and OTP credentials (`digits`, `counter`, `period`, `algorithm`, `hashedSaltedValue`)

## Why
When creating a user via the Admin REST API with an incomplete deprecated credential payload (e.g. `{"type": "password"}` with null value), the `Integer` unboxing of `getHashIterations()` causes an uncaught `NullPointerException`.

## Test plan
- [x] Added integration test `UsersTest#createUserWithIncompleteDeprecatedPasswordCredentialReturnsBadRequest`
- [x] Verified test fails without fix (500) and passes with fix (400)
- [x] `./mvnw spotless:check` passes

## AI Disclosure
This fix was developed with assistance from Claude Code (AI). The author has reviewed, understands, and can explain all changes.

Closes #41640