### PR TITLE
Filtering out headers from external IP addresses in Traefik

### DIFF
--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -67,26 +67,61 @@ http:
         - /certs/keycloak1-cert.pem # <3>
         - /certs/keycloak2-cert.pem
 
+  middlewares:
+    filter-headers:
+      headers:
+        customRequestHeaders:
+          # Prevent external spoofing of proxy identity headers (IP, protocol, host, path).
+          # Traefik re-adds its own verified values after stripping client-supplied ones.
+          Forwarded: "" # <4>
+          X-Forwarded-For: ""
+          X-Forwarded-Proto: ""
+          X-Forwarded-Host: ""
+          X-Forwarded-Port: ""
+          X-Forwarded-Server: ""
+          X-Forwarded-Prefix: ""
+          X-Forwarded-Access-Token: ""
+          # Prevent external spoofing of reverse-proxy metadata headers
+          X-Original-Forwarded-For: ""
+          X-Original-URL: ""
+          X-Original-Method: ""
+          X-Real-IP: ""
+          # Prevent external tracing context injection (W3C Trace Context / Baggage)
+          Traceparent: ""
+          Tracestate: ""
+          Baggage: ""
+          # Prevent external tracing context injection (Zipkin, Jaeger, OpenTracing)
+          B3: ""
+          X-B3-Traceid: ""
+          X-B3-Spanid: ""
+          X-B3-Parentspanid: ""
+          X-B3-Sampled: ""
+          X-B3-Flags: ""
+          Uber-Trace-Id: ""
+          X-Ot-Span-Context: ""
+
   routers:
     keycloak:
       entryPoints:
         - keycloak
-      rule: "PathPrefix(`/`)" # <4>
-      tls: {} # <5>
+      rule: "PathPrefix(`/`)" # <5>
+      middlewares:
+        - filter-headers # <6>
+      tls: {} # <7>
       service: keycloak
 
   services:
     keycloak:
       loadBalancer:
-        serversTransport: keycloak-transport # <6>
+        serversTransport: keycloak-transport # <8>
         healthCheck:
-          path: /health/ready # <7>
+          path: /health/ready # <9>
           port: 9000
           scheme: https
           interval: "5s"
           timeout: "3s"
         servers:
-          - url: "https://keycloak1:8443" # <8>
+          - url: "https://keycloak1:8443" # <10>
           - url: "https://keycloak2:8443"
 ----
 
@@ -96,12 +131,17 @@ This is the externally trusted certificate that browsers verify.
 {project_name} is configured to require client authentication and will verify this certificate against its truststore.
 <3> The public certificates of each {project_name} backend server.
 Traefik verifies each backend server's TLS certificate against these entries, ensuring the connection goes to a trusted {project_name} instance and not an impersonator.
-<4> Routes all incoming requests to the {project_name} service.
-<5> Enables TLS on the router, allowing Traefik to terminate the incoming TLS connection from the client and inspect HTTP traffic.
-<6> Links the load balancer to the named transport above, activating mTLS for all connections to the backend {project_name} servers.
-<7> Configures link:https://doc.traefik.io/traefik/reference/routing-configuration/http/service/#health-check[HTTP health checks] against {project_name}'s readiness endpoint on the management port (`9000`) over HTTPS.
+<4> The `customRequestHeaders` entries with an empty string value remove HTTP headers from incoming requests before forwarding them to {project_name}.
+This prevents external clients from spoofing proxy identity headers (such as `Forwarded`, `+X-Forwarded-*+`, and `X-Real-IP`), injecting authentication-related headers (such as `X-Forwarded-Access-Token`), or injecting distributed tracing context (such as W3C Trace Context, Zipkin B3, or Jaeger headers).
+Unlike HAProxy, Traefik does not support regex-based header matching, so each header variant must be listed explicitly.
+For the full list of recommended headers to filter, see the <@links.server id="reverseproxy" anchor="header-filtering-recommendations"/> {section}.
+<5> Routes all incoming requests to the {project_name} service.
+<6> Attaches the `filter-headers` middleware to the router so it applies to all incoming requests.
+<7> Enables TLS on the router, allowing Traefik to terminate the incoming TLS connection from the client and inspect HTTP traffic.
+<8> Links the load balancer to the named transport above, activating mTLS for all connections to the backend {project_name} servers.
+<9> Configures link:https://doc.traefik.io/traefik/reference/routing-configuration/http/service/#health-check[HTTP health checks] against {project_name}'s readiness endpoint on the management port (`9000`) over HTTPS.
 The management port does not require client authentication, so no mTLS client certificate is needed for health check connections.
-<8> The backend {project_name} servers.
+<10> The backend {project_name} servers.
 Traefik load-balances requests across both instances using round-robin.
 
 [[keycloak-configuration-traefik-reencrypt]]

--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -86,6 +86,8 @@ http:
           X-Original-URL: ""
           X-Original-Method: ""
           X-Real-IP: ""
+          X-Forwarded-Tls-Client-Cert: ""
+          X-Forwarded-Tls-Client-Cert-Info: ""
           # Prevent external tracing context injection (W3C Trace Context / Baggage)
           Traceparent: ""
           Tracestate: ""
@@ -131,15 +133,15 @@ This is the externally trusted certificate that browsers verify.
 {project_name} is configured to require client authentication and will verify this certificate against its truststore.
 <3> The public certificates of each {project_name} backend server.
 Traefik verifies each backend server's TLS certificate against these entries, ensuring the connection goes to a trusted {project_name} instance and not an impersonator.
-<4> The `customRequestHeaders` entries with an empty string value remove HTTP headers from incoming requests before forwarding them to {project_name}.
-This prevents external clients from spoofing proxy identity headers (such as `Forwarded`, `+X-Forwarded-*+`, and `X-Real-IP`), injecting authentication-related headers (such as `X-Forwarded-Access-Token`), or injecting distributed tracing context (such as W3C Trace Context, Zipkin B3, or Jaeger headers).
+<4> To remove an HTTP header from requests forwarded to {project_name}, define a key-value entry in `customRequestHeaders` where the key is the name of the HTTP header and the value is an empty string to indicate the header should be removed.
+Removing specific HTTP headers prevents external clients from spoofing proxy identity headers (such as `Forwarded`, `+X-Forwarded-*+`, and `X-Real-IP`), injecting authentication-related headers (such as `X-Forwarded-Access-Token`), or injecting distributed tracing context (such as W3C Trace Context, Zipkin B3, or Jaeger headers).
 Unlike HAProxy, Traefik does not support regex-based header matching, so each header variant must be listed explicitly.
 For the full list of recommended headers to filter, see the <@links.server id="reverseproxy" anchor="header-filtering-recommendations"/> {section}.
 <5> Routes all incoming requests to the {project_name} service.
-<6> Attaches the `filter-headers` middleware to the router so it applies to all incoming requests.
+<6> Attaches the `filter-headers` middleware to the router so that the `customRequestHeaders` rules defined in <4> are applied to all incoming requests.
 <7> Enables TLS on the router, allowing Traefik to terminate the incoming TLS connection from the client and inspect HTTP traffic.
 <8> Links the load balancer to the named transport above, activating mTLS for all connections to the backend {project_name} servers.
-<9> Configures link:https://doc.traefik.io/traefik/reference/routing-configuration/http/service/#health-check[HTTP health checks] against {project_name}'s readiness endpoint on the management port (`9000`) over HTTPS.
+<9> Configures link:https://doc.traefik.io/traefik/routing/services/#health-check[HTTP health checks] against {project_name}'s readiness endpoint on the management port (`9000`) over HTTPS.
 The management port does not require client authentication, so no mTLS client certificate is needed for health check connections.
 <10> The backend {project_name} servers.
 Traefik load-balances requests across both instances using round-robin.
@@ -186,7 +188,7 @@ This allows Traefik to perform HTTPS health checks against the management port (
 
 The Traefik health check settings determine how long it takes for the proxy to detect that a {project_name} instance is shutting down and that connections should no longer be routed to it.
 
-With the health check settings from the <<dynamic-configuration-keycloak-yaml, configuration above>> (`interval: 5s`, `timeout: 3s`), it takes up to 8 seconds (`interval + timeout`) for Traefik to mark a {project_name} instance as down.
+With the health check settings from the configuration above (`interval: 5s`, `timeout: 3s`), it takes up to 8 seconds (`interval + timeout`) for Traefik to mark a {project_name} instance as down.
 During this period, {project_name} must remain running to serve in-flight requests.
 Therefore, you need to configure the `--shutdown-delay` to be at least as long as the detection time:
 


### PR DESCRIPTION
This PR implements  header filtering at the Traefik proxy layer for the `reencrypt` . 
keycloak quickstart repo : https://github.com/keycloak/keycloak-quickstarts/pull/764

Closes #49092
Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
