### PR TITLE
[codex] Add admin client assertion authentication

### DIFF
--- a/integration/admin-client/pom.xml
+++ b/integration/admin-client/pom.xml
@@ -65,6 +65,11 @@
             <version>${resteasy.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-multipart-provider</artifactId>
             <version>${resteasy.version}</version>
@@ -82,6 +87,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Config.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Config.java
@@ -17,6 +17,10 @@
 
 package org.keycloak.admin.client;
 
+import java.util.function.Supplier;
+
+import org.keycloak.admin.client.token.ClientAssertion;
+
 import static org.keycloak.OAuth2Constants.CLIENT_CREDENTIALS;
 import static org.keycloak.OAuth2Constants.PASSWORD;
 
@@ -31,6 +35,7 @@ public class Config {
     private String password;
     private String clientId;
     private String clientSecret;
+    private Supplier<ClientAssertion> clientAssertionSupplier;
     private String grantType;
     private String scope;
     private boolean useDPoP = false;
@@ -40,12 +45,18 @@ public class Config {
     }
 
     public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType, String scope) {
+        this(serverUrl, realm, username, password, clientId, clientSecret, null, grantType, scope);
+    }
+
+    public Config(String serverUrl, String realm, String username, String password, String clientId, String clientSecret,
+                  Supplier<ClientAssertion> clientAssertionSupplier, String grantType, String scope) {
         this.serverUrl = serverUrl;
         this.realm = realm;
         this.username = username;
         this.password = password;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.clientAssertionSupplier = clientAssertionSupplier;
         this.grantType = grantType;
         checkGrantType(grantType);
         this.scope = scope;
@@ -99,8 +110,16 @@ public class Config {
         this.clientSecret = clientSecret;
     }
 
+    public Supplier<ClientAssertion> getClientAssertionSupplier() {
+        return clientAssertionSupplier;
+    }
+
+    public void setClientAssertionSupplier(Supplier<ClientAssertion> clientAssertionSupplier) {
+        this.clientAssertionSupplier = clientAssertionSupplier;
+    }
+
     public boolean isPublicClient() {
-        return clientSecret == null;
+        return clientSecret == null && clientAssertionSupplier == null;
     }
 
     public String getScope() {

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -19,6 +19,7 @@ package org.keycloak.admin.client;
 import java.net.URI;
 import java.util.Iterator;
 import java.util.ServiceLoader;
+import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 
 import jakarta.ws.rs.client.Client;
@@ -31,6 +32,7 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RealmsResource;
 import org.keycloak.admin.client.resource.ServerInfoResource;
 import org.keycloak.admin.client.spi.ResteasyClientProvider;
+import org.keycloak.admin.client.token.ClientAssertion;
 import org.keycloak.admin.client.token.TokenManager;
 
 import static org.keycloak.OAuth2Constants.PASSWORD;
@@ -87,8 +89,9 @@ public class Keycloak implements AutoCloseable {
     private final Client client;
     private boolean closed = false;
 
-    Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, String grantType, Client resteasyClient, String authtoken, String scope, boolean useDPoP) {
-        config = new Config(serverUrl, realm, username, password, clientId, clientSecret, grantType, scope);
+    Keycloak(String serverUrl, String realm, String username, String password, String clientId, String clientSecret,
+             Supplier<ClientAssertion> clientAssertionSupplier, String grantType, Client resteasyClient, String authtoken, String scope, boolean useDPoP) {
+        config = new Config(serverUrl, realm, username, password, clientId, clientSecret, clientAssertionSupplier, grantType, scope);
         config.setUseDPoP(useDPoP);
         client = resteasyClient != null ? resteasyClient : newRestEasyClient(null, null, false);
         authToken = authtoken;
@@ -128,14 +131,14 @@ public class Keycloak implements AutoCloseable {
      * @return Java admin client instance
      */
     public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, Object customJacksonProvider, boolean disableTrustManager, String authToken, String scope) {
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager), authToken, scope, false);
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, null, PASSWORD, newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager), authToken, scope, false);
     }
 
     /**
      * See {@link #getInstance(String, String, String, String, String, String, SSLContext, Object, boolean, String, String)} for the details about the parameters and their default values
      */
     public static Keycloak getInstance(String serverUrl, String realm, String username, String password, String clientId, String clientSecret, SSLContext sslContext, Object customJacksonProvider, boolean disableTrustManager, String authToken) {
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, PASSWORD, newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager), authToken, null, false);
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, null, PASSWORD, newRestEasyClient(customJacksonProvider, sslContext, disableTrustManager), authToken, null, false);
     }
 
     /**

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/KeycloakBuilder.java
@@ -17,7 +17,11 @@
 
 package org.keycloak.admin.client;
 
+import java.util.function.Supplier;
+
 import jakarta.ws.rs.client.Client;
+
+import org.keycloak.admin.client.token.ClientAssertion;
 
 import static org.keycloak.OAuth2Constants.PASSWORD;
 
@@ -61,6 +65,7 @@ public class KeycloakBuilder {
     private String password;
     private String clientId;
     private String clientSecret;
+    private Supplier<ClientAssertion> clientAssertionSupplier;
     private String grantType;
     private Client resteasyClient;
     private String authorization;
@@ -105,6 +110,11 @@ public class KeycloakBuilder {
 
     public KeycloakBuilder clientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+        return this;
+    }
+
+    public KeycloakBuilder clientAssertion(Supplier<ClientAssertion> clientAssertionSupplier) {
+        this.clientAssertionSupplier = clientAssertionSupplier;
         return this;
     }
 
@@ -161,11 +171,11 @@ public class KeycloakBuilder {
             }
         }
 
-        if (authorization == null && clientId == null) {
+        if (authorization == null && clientAssertionSupplier == null && clientId == null) {
             throw new IllegalStateException("clientId required");
         }
 
-        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, grantType, resteasyClient, authorization, scope, useDPoP);
+        return new Keycloak(serverUrl, realm, username, password, clientId, clientSecret, clientAssertionSupplier, grantType, resteasyClient, authorization, scope, useDPoP);
     }
 
     private KeycloakBuilder() {

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/ClientAssertion.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/ClientAssertion.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.token;
+
+import java.util.Objects;
+
+import org.keycloak.OAuth2Constants;
+
+public class ClientAssertion {
+
+    private final String type;
+    private final String value;
+
+    public static ClientAssertion jwt(String jwt) {
+        return new ClientAssertion(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT, jwt);
+    }
+
+    public ClientAssertion(String type, String value) {
+        this.type = Objects.requireNonNull(type, "type");
+        this.value = Objects.requireNonNull(value, "value");
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/token/TokenManager.java
@@ -18,6 +18,7 @@
 package org.keycloak.admin.client.token;
 
 import java.security.KeyPair;
+import java.util.function.Supplier;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.client.Client;
@@ -32,6 +33,8 @@ import org.keycloak.common.util.KeyUtils;
 import org.keycloak.common.util.Time;
 import org.keycloak.representations.AccessTokenResponse;
 
+import static org.keycloak.OAuth2Constants.CLIENT_ASSERTION;
+import static org.keycloak.OAuth2Constants.CLIENT_ASSERTION_TYPE;
 import static org.keycloak.OAuth2Constants.CLIENT_ID;
 import static org.keycloak.OAuth2Constants.GRANT_TYPE;
 import static org.keycloak.OAuth2Constants.PASSWORD;
@@ -57,7 +60,7 @@ public class TokenManager {
     public TokenManager(Config config, Client client) {
         this.config = config;
         WebTarget target = client.target(config.getServerUrl());
-        if (!config.isPublicClient()) {
+        if (!config.isPublicClient() && config.getClientAssertionSupplier() == null) {
             target.register(new BasicAuthFilter(config.getClientId(), config.getClientSecret()));
         }
 
@@ -96,9 +99,7 @@ public class TokenManager {
             form.param(SCOPE, config.getScope());
         }
 
-        if (config.isPublicClient()) {
-            form.param(CLIENT_ID, config.getClientId());
-        }
+        addClientAuthentication(form);
 
         int requestTime = Time.currentTime();
         synchronized (this) {
@@ -117,9 +118,7 @@ public class TokenManager {
         Form form = new Form().param(GRANT_TYPE, REFRESH_TOKEN)
                               .param(REFRESH_TOKEN, currentToken.getRefreshToken());
 
-        if (config.isPublicClient()) {
-            form.param(CLIENT_ID, config.getClientId());
-        }
+        addClientAuthentication(form);
 
         try {
             int requestTime = Time.currentTime();
@@ -139,9 +138,7 @@ public class TokenManager {
 
         Form form = new Form().param(REFRESH_TOKEN, currentToken.getRefreshToken());
 
-        if (config.isPublicClient()) {
-            form.param(CLIENT_ID, config.getClientId());
-        }
+        addClientAuthentication(form);
 
         tokenService.logout(config.getRealm(), form.asMap());
         currentToken = null;
@@ -156,6 +153,17 @@ public class TokenManager {
     }
 
     private synchronized boolean refreshTokenExpired() { return (Time.currentTime() + minTokenValidity) >= refreshExpirationTime; }
+
+    private void addClientAuthentication(Form form) {
+        Supplier<ClientAssertion> clientAssertionSupplier = config.getClientAssertionSupplier();
+        if (clientAssertionSupplier != null) {
+            ClientAssertion clientAssertion = clientAssertionSupplier.get();
+            form.param(CLIENT_ASSERTION_TYPE, clientAssertion.getType());
+            form.param(CLIENT_ASSERTION, clientAssertion.getValue());
+        } else if (config.isPublicClient()) {
+            form.param(CLIENT_ID, config.getClientId());
+        }
+    }
 
     /**
      * Invalidates the current token, but only when it is equal to the token passed as an argument.

--- a/integration/admin-client/src/test/java/org/keycloak/admin/client/token/TokenManagerClientAssertionTest.java
+++ b/integration/admin-client/src/test/java/org/keycloak/admin/client/token/TokenManagerClientAssertionTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.client.token;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TokenManagerClientAssertionTest {
+
+    private static final String REALM = "test";
+
+    private HttpServer server;
+    private String serverUrl;
+    private final List<RecordedRequest> requests = new ArrayList<>();
+
+    @Before
+    public void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", this::recordRequest);
+        server.start();
+        serverUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @After
+    public void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    public void grantTokenSendsClientAssertionWithoutClientId() {
+        Keycloak keycloak = adminClient(assertionSupplier());
+
+        keycloak.tokenManager().grantToken();
+
+        RecordedRequest request = requests.get(0);
+        assertEquals("/realms/test/protocol/openid-connect/token", request.path);
+        assertEquals(OAuth2Constants.CLIENT_CREDENTIALS, request.param(OAuth2Constants.GRANT_TYPE));
+        assertEquals(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT, request.param(OAuth2Constants.CLIENT_ASSERTION_TYPE));
+        assertEquals("signed-jwt-1", request.param(OAuth2Constants.CLIENT_ASSERTION));
+        assertNull(request.param(OAuth2Constants.CLIENT_ID));
+        assertNull(request.headers.getFirst("Authorization"));
+    }
+
+    @Test
+    public void grantTokenUsesNewAssertionFromSupplierEachTime() {
+        Keycloak keycloak = adminClient(assertionSupplier());
+
+        keycloak.tokenManager().grantToken();
+        keycloak.tokenManager().grantToken();
+
+        assertEquals("signed-jwt-1", requests.get(0).param(OAuth2Constants.CLIENT_ASSERTION));
+        assertEquals("signed-jwt-2", requests.get(1).param(OAuth2Constants.CLIENT_ASSERTION));
+    }
+
+    @Test
+    public void refreshTokenSendsClientAssertion() {
+        Keycloak keycloak = adminClient(assertionSupplier());
+
+        keycloak.tokenManager().grantToken();
+        keycloak.tokenManager().refreshToken();
+
+        RecordedRequest request = requests.get(1);
+        assertEquals("/realms/test/protocol/openid-connect/token", request.path);
+        assertEquals(OAuth2Constants.REFRESH_TOKEN, request.param(OAuth2Constants.GRANT_TYPE));
+        assertEquals("refresh-token-1", request.param(OAuth2Constants.REFRESH_TOKEN));
+        assertEquals(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT, request.param(OAuth2Constants.CLIENT_ASSERTION_TYPE));
+        assertEquals("signed-jwt-2", request.param(OAuth2Constants.CLIENT_ASSERTION));
+        assertNull(request.param(OAuth2Constants.CLIENT_ID));
+    }
+
+    @Test
+    public void logoutSendsClientAssertion() {
+        Keycloak keycloak = adminClient(assertionSupplier());
+
+        keycloak.tokenManager().grantToken();
+        keycloak.tokenManager().logout();
+
+        RecordedRequest request = requests.get(1);
+        assertEquals("/realms/test/protocol/openid-connect/logout", request.path);
+        assertEquals("refresh-token-1", request.param(OAuth2Constants.REFRESH_TOKEN));
+        assertEquals(OAuth2Constants.CLIENT_ASSERTION_TYPE_JWT, request.param(OAuth2Constants.CLIENT_ASSERTION_TYPE));
+        assertEquals("signed-jwt-2", request.param(OAuth2Constants.CLIENT_ASSERTION));
+        assertNull(request.param(OAuth2Constants.CLIENT_ID));
+    }
+
+    @Test
+    public void clientAssertionTakesPrecedenceOverClientSecretBasicAuthentication() {
+        Keycloak keycloak = KeycloakBuilder.builder()
+                .serverUrl(serverUrl)
+                .realm(REALM)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .clientId("admin-client")
+                .clientSecret("ignored-secret")
+                .clientAssertion(assertionSupplier())
+                .build();
+
+        keycloak.tokenManager().grantToken();
+
+        RecordedRequest request = requests.get(0);
+        assertEquals("signed-jwt-1", request.param(OAuth2Constants.CLIENT_ASSERTION));
+        assertNull(request.headers.getFirst("Authorization"));
+    }
+
+    private Keycloak adminClient(Supplier<ClientAssertion> clientAssertionSupplier) {
+        return KeycloakBuilder.builder()
+                .serverUrl(serverUrl)
+                .realm(REALM)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .clientAssertion(clientAssertionSupplier)
+                .build();
+    }
+
+    private Supplier<ClientAssertion> assertionSupplier() {
+        AtomicInteger counter = new AtomicInteger();
+        return () -> ClientAssertion.jwt("signed-jwt-" + counter.incrementAndGet());
+    }
+
+    private void recordRequest(HttpExchange exchange) throws IOException {
+        RecordedRequest request = new RecordedRequest(exchange.getRequestURI().getPath(), exchange.getRequestHeaders(), parseForm(readRequestBody(exchange)));
+        requests.add(request);
+
+        if (request.path.endsWith("/logout")) {
+            exchange.sendResponseHeaders(204, -1);
+            return;
+        }
+
+        String response = "{\"access_token\":\"access-token-" + requests.size()
+                + "\",\"expires_in\":60,\"refresh_expires_in\":60,\"refresh_token\":\"refresh-token-"
+                + requests.size() + "\",\"token_type\":\"Bearer\"}";
+        byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, responseBytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(responseBytes);
+        }
+    }
+
+    private String readRequestBody(HttpExchange exchange) throws IOException {
+        try (InputStream is = exchange.getRequestBody(); ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = is.read(buffer)) != -1) {
+                baos.write(buffer, 0, read);
+            }
+            return new String(baos.toByteArray(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private Map<String, String> parseForm(String body) throws IOException {
+        Map<String, String> form = new HashMap<>();
+        if (body.isEmpty()) {
+            return form;
+        }
+        for (String pair : body.split("&")) {
+            int separator = pair.indexOf('=');
+            String key = separator == -1 ? pair : pair.substring(0, separator);
+            String value = separator == -1 ? "" : pair.substring(separator + 1);
+            form.put(urlDecode(key), urlDecode(value));
+        }
+        return form;
+    }
+
+    private String urlDecode(String value) throws IOException {
+        return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+    }
+
+    private static class RecordedRequest {
+
+        private final String path;
+        private final Headers headers;
+        private final Map<String, String> form;
+
+        private RecordedRequest(String path, Headers headers, Map<String, String> form) {
+            this.path = path;
+            this.headers = headers;
+            this.form = form;
+        }
+
+        private String param(String name) {
+            return form.get(name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a `ClientAssertion` value type and `KeycloakBuilder.clientAssertion(...)` supplier hook for Admin Client token requests.
- Send supplied client assertions instead of client secret basic authentication for grant, refresh, and logout requests.
- Add focused Admin Client tests covering grant, repeated supplier use, refresh, logout, and client-secret precedence behavior.

Fixes #49282

## Testing

- `./mvnw -pl integration/admin-client -am -Dtest=TokenManagerClientAssertionTest test`
