### PR TITLE
Add form revert logic for tab providers

### DIFF
--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -102,6 +102,7 @@ export const PageHandler = ({
           </Button>
           {providerType === PAGE_PROVIDER ? (
             <Button
+              data-testid="cancel"
               variant="link"
               component={(props) => (
                 <Link
@@ -113,7 +114,11 @@ export const PageHandler = ({
               {t("cancel")}
             </Button>
           ) : (
-            <Button variant="link" onClick={() => form.reset()}>
+            <Button
+              data-testid="cancel"
+              variant="link"
+              onClick={() => form.reset()}
+            >
               {t("revert")}
             </Button>
           )}

--- a/js/apps/admin-ui/src/page/PageHandler.tsx
+++ b/js/apps/admin-ui/src/page/PageHandler.tsx
@@ -14,7 +14,7 @@ import { useAdminClient } from "../admin-client";
 import { DynamicComponents } from "../components/dynamic/DynamicComponents";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useParams } from "../utils/useParams";
-import { type PAGE_PROVIDER, TAB_PROVIDER } from "./constants";
+import { PAGE_PROVIDER, TAB_PROVIDER } from "./constants";
 import { toPage } from "./routes";
 
 type PageHandlerProps = {
@@ -100,17 +100,23 @@ export const PageHandler = ({
           <Button data-testid="save" type="submit">
             {t("save")}
           </Button>
-          <Button
-            variant="link"
-            component={(props) => (
-              <Link
-                {...props}
-                to={toPage({ realm: realmName, providerId: providerId! })}
-              />
-            )}
-          >
-            {t("cancel")}
-          </Button>
+          {providerType === PAGE_PROVIDER ? (
+            <Button
+              variant="link"
+              component={(props) => (
+                <Link
+                  {...props}
+                  to={toPage({ realm: realmName, providerId: providerId! })}
+                />
+              )}
+            >
+              {t("cancel")}
+            </Button>
+          ) : (
+            <Button variant="link" onClick={() => form.reset()}>
+              {t("revert")}
+            </Button>
+          )}
         </ActionGroup>
       </Form>
     </PageSection>


### PR DESCRIPTION
Closes #47432.
Fixes an issue in the admin UI custom tab extension where clicking the cancel button triggers an incorrect redirection. 
- If the provider is a `PAGE_PROVIDER`, the "Cancel" button (which redirects the user) is displayed.
- If the provider is a `TAB_PROVIDER`, a "Revert" button is displayed instead, which resets the form state without redirecting.