### PR TITLE
[26.4] Typo in ClientAdapter.isFrontchannelLogout()

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/ClientAdapter.java
@@ -217,7 +217,7 @@ public class ClientAdapter implements ClientModel, CachedObject {
     }
 
     public boolean isFrontchannelLogout() {
-        if (isUpdated()) return updated.isPublicClient();
+        if (isUpdated()) return updated.isFrontchannelLogout();
         return cached.isFrontchannelLogout();
     }
 


### PR DESCRIPTION
closes #48432


(cherry picked from commit 82c809c7b46df59400836cc08fb0e50cc321e6c5)

@mposolda @ahus1 Could you please check it? Thanks!
