### PR TITLE
Login page title should use full width when locale selector is hidden

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
+++ b/themes/src/main/resources/theme/keycloak.v2/login/resources/css/styles.css
@@ -134,7 +134,7 @@ hr {
 }
 
 @media (min-width: 768px) {
-    div.pf-v5-c-login__main-header {
+    div.pf-v5-c-login__main-header:has(.pf-v5-c-login__main-header-utilities) {
         grid-template-columns: 70% 30%;
     }
 }


### PR DESCRIPTION
- Closes #49378
- uses `:has(.pf-v5-c-login__main-header-utilities)` to conditionally apply the grid split, so the `70% / 30%` layout only takes effect when the locale selector is rendered
- no changes if the i18n is enabled

| Before | After |
  |--------|-------|
  | <img width="400" alt="Before" src="https://github.com/user-attachments/assets/d2cb8f30-c4d5-4fc5-b6f4-5f7e3c176ce0" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/bc6a4cfe-2d63-4463-857d-2868cb7dcf47" /> |
  | <img width="400" alt="Before" src="https://github.com/user-attachments/assets/12b3d411-04de-45e4-bd06-6a8c4e5bce80" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/3f566040-50d8-4016-92d5-d2e5f7826e7a" /> |

@edewit @ssilvert Could you please check it? Thanks!
