### PR TITLE
Add target version prefix to backport script

### DIFF
--- a/.github/scripts/pr-backport.sh
+++ b/.github/scripts/pr-backport.sh
@@ -58,7 +58,7 @@ if [ "$MERGE_COMMIT" == "" ]; then
 fi
 
 PR_BRANCH=backport-$PR-$TARGET
-PR_BODY=$(gh pr view $PR --json body | jq -r .body)
+PR_TITLE="[$TARGET] $(gh pr view $PR --json title | jq -r .title)"
 
 echo_header "Details"
 echo "PR Body:        $PR_BODY"
@@ -86,7 +86,7 @@ echo_header "Push '$PR_BRANCH' to 'origin' remote"
 git push origin $PR_BRANCH:$PR_BRANCH --set-upstream
 
 echo_header "Opening web browser to create pull request"
-gh pr create -B $TARGET_BRANCH -f -w
+gh pr create -B $TARGET_BRANCH -t "$PR_TITLE" -b "$(git log -1 --format=%b)" -w
 
 echo_header "Checkout to $WORK_BRANCH branch"
 git checkout $WORK_BRANCH


### PR DESCRIPTION
- Closes #49385
- Works as expected
- It's just a tiny improvement to not manually add the versions for every backported PR :grin: 

Examples:

For PR in the main branch: 
- #49223

`./.github/scripts/pr-backport.sh 49223 26.6` -> creates a PR with title `[26.6] Fix Themes cross-reference`
`./.github/scripts/pr-backport.sh 49223 26.4` -> creates a PR with title `[26.4] Fix Themes cross-reference`

@stianst Could you please check it? Or do you also use the script when backporting from the kc-private repo to the main? Thanks