### PR TITLE
Revert back to use Java 25 in FIPS CI scripts (26.6)

### DIFF
--- a/.github/scripts/run-fips-it.sh
+++ b/.github/scripts/run-fips-it.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
-JAVA_VERSION=21
+JAVA_VERSION=25
 
 rm -f /etc/system-fips
 dnf install -y "java-${JAVA_VERSION}-openjdk-devel"

--- a/.github/scripts/run-fips-ut.sh
+++ b/.github/scripts/run-fips-ut.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-JAVA_VERSION=21
+JAVA_VERSION=25
 
 rm -f /etc/system-fips
 dnf install -y "java-${JAVA_VERSION}-openjdk-devel"


### PR DESCRIPTION
Closes #49194

PR:             https://github.com/keycloak/keycloak/pull/49290
Commit:         https://github.com/keycloak/keycloak/commit/090549c7dede0a14502ac049e45cb2a0e95e0f66
PR branch:      backport-49290-26.6
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.6

