### PR TITLE
Fix Themes cross-reference

### DIFF
--- a/docs/documentation/server_admin/topics/realms/themes.adoc
+++ b/docs/documentation/server_admin/topics/realms/themes.adoc
@@ -26,4 +26,4 @@ Email theme::
   Whenever {project_name} has to send out an email, it uses templates defined in this theme to craft the email.
 
 .Additional resources
-* The link:{developerguide_link}[{developerguide_name}] describes how to create a new theme or modify existing ones.
+* For details on creating or modifying themes, see link:{ui_customization_deploying_themes}[Deploying Themes] in the {ui_customization_guide_name}.

--- a/docs/documentation/topics/templates/document-attributes.adoc
+++ b/docs/documentation/topics/templates/document-attributes.adoc
@@ -73,7 +73,6 @@
 :developerguide_name_short: Server Developer
 :developerguide_link: {project_doc_base_url}/server_development/
 :developerguide_link_latest: {project_doc_base_url_latest}/server_development/
-:developerguide_deploying_themes: https://www.keycloak.org/ui-customization/themes#_deploying_themes
 :developerguide_actiontoken_name: Action Token Handler SPI
 :developerguide_actiontoken_link: {developerguide_link}#_action_token_handler_spi
 :developerguide_jsproviders_name: JavaScript Providers
@@ -155,3 +154,7 @@
 :securing_apps_token_exchange_link: {securing_apps_base_link}/token-exchange
 :securing_apps_dpop_link: {securing_apps_base_link}/dpop
 :securing_apps_token_exchange_name: Token exchange Documentation
+
+:ui_customization_guide_name: UI Customization Guide
+:ui_customization_guide_link: {project_doc_base_url}/ui-customization/
+:ui_customization_deploying_themes: https://www.keycloak.org/ui-customization/themes#_deploying_themes

--- a/docs/guides/attributes.adoc
+++ b/docs/guides/attributes.adoc
@@ -41,3 +41,6 @@
 :kubernetes: Kubernetes
 :keycloak_benchmark_link: https://www.keycloak.org/keycloak-benchmark/
 :keycloak_benchmark_name: Keycloak Benchmark Project
+:ui_customization_guide_name: UI Customization Guide
+:ui_customization_guide_link: {project_doc_base_url}/ui-customization/
+

--- a/docs/guides/server/directory-structure.adoc
+++ b/docs/guides/server/directory-structure.adoc
@@ -33,6 +33,6 @@ Under the {project_name} install root there exists a number of folders:
 ** *logs/* - default directory for file logging - see <@links.server id="logging"/>
 * *lib/* - used internally
 * *providers/* - directory for user provided dependencies - see <@links.server id="configuration-provider"/> for extending the server and <@links.server id="db"/> for an example of adding a JDBC driver.
-* *themes/* - directory for customizations to the Admin Console, Account Console, and login page - see {ui_customization_guide_link}themes[Working with themes]
+* *themes/* - directory for customizations to the Admin Console, Account Console, and login page - see the <@links.uicustomization id="themes"/> {section}.
 
 </@tmpl.guide>

--- a/docs/guides/server/directory-structure.adoc
+++ b/docs/guides/server/directory-structure.adoc
@@ -33,6 +33,6 @@ Under the {project_name} install root there exists a number of folders:
 ** *logs/* - default directory for file logging - see <@links.server id="logging"/>
 * *lib/* - used internally
 * *providers/* - directory for user provided dependencies - see <@links.server id="configuration-provider"/> for extending the server and <@links.server id="db"/> for an example of adding a JDBC driver.
-* *themes/* - directory for customizations to the Admin Console - see https://www.keycloak.org/docs/latest/server_development/#_themes[Developing Themes]
+* *themes/* - directory for customizations to the Admin Console, Account Console, and login page - see {ui_customization_guide_link}themes[Working with themes]
 
 </@tmpl.guide>


### PR DESCRIPTION
Closes #49222

Please merge so we address issues about incorrect links to the missing themes chapter, which is no longer in the Server Development Guide.
