### PR TITLE
Add /admin/realms/{realm}/authentication/policies resource

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/CibaPolicyRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/CibaPolicyRepresentation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+public class CibaPolicyRepresentation {
+    private String backchannelTokenDeliveryMode;
+    private int expiresIn;
+    private int interval;
+    private String authRequestedUserHint;
+
+    public String getBackchannelTokenDeliveryMode() {
+        return backchannelTokenDeliveryMode;
+    }
+
+    public void setBackchannelTokenDeliveryMode(String backchannelTokenDeliveryMode) {
+        this.backchannelTokenDeliveryMode = backchannelTokenDeliveryMode;
+    }
+
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(int expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public int getInterval() {
+        return interval;
+    }
+
+    public void setInterval(int interval) {
+        this.interval = interval;
+    }
+
+    public String getAuthRequestedUserHint() {
+        return authRequestedUserHint;
+    }
+
+    public void setAuthRequestedUserHint(String authRequestedUserHint) {
+        this.authRequestedUserHint = authRequestedUserHint;
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/idm/OTPPolicyRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/OTPPolicyRepresentation.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+public class OTPPolicyRepresentation {
+    private String type;
+    private String algorithm;
+    private Integer digits;
+    private Integer period;
+    private Integer initialCounter;
+    private int lookAheadWindow;
+    private boolean isCodeReusable;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    public void setAlgorithm(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public Integer getDigits() {
+        return digits;
+    }
+
+    public void setDigits(Integer digits) {
+        this.digits = digits;
+    }
+
+    public Integer getPeriod() {
+        return period;
+    }
+
+    public void setPeriod(Integer period) {
+        this.period = period;
+    }
+
+    public Integer getInitialCounter() {
+        return initialCounter;
+    }
+
+    public void setInitialCounter(Integer initialCounter) {
+        this.initialCounter = initialCounter;
+    }
+
+    public int getLookAheadWindow() {
+        return lookAheadWindow;
+    }
+
+    public void setLookAheadWindow(int lookAheadWindow) {
+        this.lookAheadWindow = lookAheadWindow;
+    }
+
+    public boolean isCodeReusable() {
+        return isCodeReusable;
+    }
+
+    public void setCodeReusable(boolean isCodeReusable) {
+        this.isCodeReusable = isCodeReusable;
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/idm/PasswordPolicyValueRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/PasswordPolicyValueRepresentation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+public class PasswordPolicyValueRepresentation {
+    private String id;
+    private Object value;
+
+    public PasswordPolicyValueRepresentation() {
+    }
+
+    public PasswordPolicyValueRepresentation(String id, Object value) {
+        this.id = id;
+        this.value = value;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return this.id + "=" + String.valueOf(this.value);
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/idm/WebAuthnPolicyRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/WebAuthnPolicyRepresentation.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.representations.idm;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.keycloak.crypto.Algorithm;
+
+public class WebAuthnPolicyRepresentation {
+    private String rpEntityName;
+    private List<String> signatureAlgorithms;
+    private String rpId;
+    private String attestationConveyancePreference;
+    private String authenticatorAttachment;
+    private String requireResidentKey;
+    private String userVerificationRequirement;
+    private Integer createTimeout;
+    private Boolean avoidSameAuthenticatorRegister;
+    private List<String> acceptableAaguids;
+    private List<String> extraOrigins;
+    private Boolean passkeysEnabled;
+    private String mediation;
+
+    final private static Set<String> supportedSignatureAlgorithms = new LinkedHashSet<>(Arrays.asList(
+            Algorithm.ES256,
+            Algorithm.ES384,
+            Algorithm.ES512,
+            Algorithm.RS256,
+            Algorithm.RS384,
+            Algorithm.ES512,
+            Algorithm.Ed25519,
+            "RS1"
+    ));
+
+    public String getRpEntityName() {
+        return rpEntityName;
+    }
+
+    public void setRpEntityName(String rpEntityName) {
+        this.rpEntityName = rpEntityName;
+    }
+
+    public List<String> getSignatureAlgorithms() {
+        return signatureAlgorithms == null ? null : signatureAlgorithms.stream().filter(supportedSignatureAlgorithms::contains).collect(Collectors.toList());
+    }
+
+    public void setSignatureAlgorithms(List<String> signatureAlgorithms) {
+        this.signatureAlgorithms = signatureAlgorithms;
+    }
+
+    public String getRpId() {
+        return rpId;
+    }
+
+    public void setRpId(String rpId) {
+        this.rpId = rpId;
+    }
+
+    public String getAttestationConveyancePreference() {
+        return attestationConveyancePreference;
+    }
+
+    public void setAttestationConveyancePreference(String attestationConveyancePreference) {
+        this.attestationConveyancePreference = attestationConveyancePreference;
+    }
+
+    public String getAuthenticatorAttachment() {
+        return authenticatorAttachment;
+    }
+
+    public void setAuthenticatorAttachment(String authenticatorAttachment) {
+        this.authenticatorAttachment = authenticatorAttachment;
+    }
+
+    public String getRequireResidentKey() {
+        return requireResidentKey;
+    }
+
+    public void setRequireResidentKey(String requireResidentKey) {
+        this.requireResidentKey = requireResidentKey;
+    }
+
+    public String getUserVerificationRequirement() {
+        return userVerificationRequirement;
+    }
+
+    public void setUserVerificationRequirement(String userVerificationRequirement) {
+        this.userVerificationRequirement = userVerificationRequirement;
+    }
+
+    public Integer getCreateTimeout() {
+        return createTimeout;
+    }
+
+    public void setCreateTimeout(Integer createTimeout) {
+        this.createTimeout = createTimeout;
+    }
+
+    public Boolean getAvoidSameAuthenticatorRegister() {
+        return avoidSameAuthenticatorRegister;
+    }
+
+    public void setAvoidSameAuthenticatorRegister(Boolean avoidSameAuthenticatorRegister) {
+        this.avoidSameAuthenticatorRegister = avoidSameAuthenticatorRegister;
+    }
+
+    public List<String> getAcceptableAaguids() {
+        return acceptableAaguids;
+    }
+
+    public void setAcceptableAaguids(List<String> acceptableAaguids) {
+        this.acceptableAaguids = acceptableAaguids;
+    }
+
+    public List<String> getExtraOrigins() {
+        return extraOrigins;
+    }
+
+    public void setExtraOrigins(List<String> extraOrigins) {
+        this.extraOrigins = extraOrigins;
+    }
+
+    public Boolean getPasskeysEnabled() {
+        return passkeysEnabled;
+    }
+
+    public void setPasskeysEnabled(Boolean passkeysEnabled) {
+        this.passkeysEnabled = passkeysEnabled;
+    }
+
+    public String getMediation() {
+        return mediation;
+    }
+
+    public void setMediation(String mediation) {
+        this.mediation = mediation;
+    }
+}

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/AuthenticationManagementResource.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/resource/AuthenticationManagementResource.java
@@ -36,11 +36,15 @@ import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.AuthenticatorConfigInfoRepresentation;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
+import org.keycloak.representations.idm.CibaPolicyRepresentation;
 import org.keycloak.representations.idm.ConfigPropertyRepresentation;
+import org.keycloak.representations.idm.OTPPolicyRepresentation;
+import org.keycloak.representations.idm.PasswordPolicyValueRepresentation;
 import org.keycloak.representations.idm.RequiredActionConfigInfoRepresentation;
 import org.keycloak.representations.idm.RequiredActionConfigRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderSimpleRepresentation;
+import org.keycloak.representations.idm.WebAuthnPolicyRepresentation;
 
 /**
  * @author <a href="mailto:mstrukel@redhat.com">Marko Strukelj</a>
@@ -256,4 +260,54 @@ public interface AuthenticationManagementResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     void updateAuthenticatorConfig(@PathParam("id") String id, AuthenticatorConfigRepresentation config);
+
+    @Path("policies/password-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<PasswordPolicyValueRepresentation> getPasswordPolicy();
+
+    @Path("policies/password-policy")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updatePasswordPolicy(List<PasswordPolicyValueRepresentation> rep);
+
+    @Path("policies/otp-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    OTPPolicyRepresentation getOTPPolicy();
+
+    @Path("policies/otp-policy")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateOTPPolicy(OTPPolicyRepresentation rep);
+
+    @Path("policies/webauthn-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    WebAuthnPolicyRepresentation getWebAuthnPolicy();
+
+    @Path("policies/webauthn-policy")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateWebAuthnPolicy(WebAuthnPolicyRepresentation rep);
+
+    @Path("policies/webauthn-passwordless-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    WebAuthnPolicyRepresentation getWebAuthnPasswordlessPolicy();
+
+    @Path("policies/webauthn-passwordless-policy")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateWebAuthnPasswordlessPolicy(WebAuthnPolicyRepresentation rep);
+
+    @Path("policies/ciba-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    CibaPolicyRepresentation getCibaPolicy();
+
+    @Path("policies/ciba-policy")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    void updateCibaPolicy(CibaPolicyRepresentation rep);
 }

--- a/js/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/CibaPolicy.tsx
@@ -6,15 +6,15 @@ import {
   ButtonVariant,
   PageSection,
 } from "@patternfly/react-core";
-import { useEffect } from "react";
+import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { SelectControl, TextControl } from "@keycloak/keycloak-ui-shared";
+import { SelectControl, TextControl, useFetch } from "@keycloak/keycloak-ui-shared";
 import { useAdminClient } from "../../admin-client";
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
 import { FormAccess } from "../../components/form/FormAccess";
 import { useRealm } from "../../context/realm-context/RealmContext";
-import { convertFormValuesToObject, convertToFormValues } from "../../util";
+import CibaPolicyRepresentation from "libs/keycloak-admin-client/lib/defs/cibaPolicyRepresentation"
 
 const CIBA_BACKHANNEL_TOKEN_DELIVERY_MODES = ["poll", "ping"] as const;
 const CIBA_EXPIRES_IN_MIN = 10;
@@ -27,37 +27,33 @@ type CibaPolicyProps = {
   realmUpdated: (realm: RealmRepresentation) => void;
 };
 
-type FormFields = Omit<
-  RealmRepresentation,
-  "clients" | "components" | "groups"
->;
-
 export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
-  const form = useForm<FormFields>({ mode: "onChange" });
+  const form = useForm<CibaPolicyRepresentation>({ mode: "onChange" });
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
+  const { reset } = form;
+  const [key, setKey] = useState(0);
+  const refresh = () => setKey(new Date().getTime());
 
-  const setupForm = (realm: RealmRepresentation) =>
-    convertToFormValues(realm, form.setValue);
+  const setupForm = (policy: CibaPolicyRepresentation) => reset(policy);
 
-  useEffect(() => setupForm(realm), []);
+  useFetch(
+    () => adminClient.authenticationManagement.getCibaPolicy({ realm: realmName }),
+    (policy) => {
+      setupForm(policy);
+    },
+    [key],
+  );
 
-  const onSubmit = async (formValues: FormFields) => {
+  const onSubmit = async (formValues: CibaPolicyRepresentation) => {
     try {
-      await adminClient.realms.update(
-        { realm: realmName },
-        convertFormValuesToObject(formValues),
-      );
-
-      const updatedRealm = await adminClient.realms.findOne({
-        realm: realmName,
-      });
-
+      await adminClient.authenticationManagement.updateCibaPolicy({ realm: realmName }, formValues);
+      const updatedRealm = await adminClient.realms.findOne({realm: realmName});
       realmUpdated(updatedRealm!);
-      setupForm(updatedRealm!);
+      refresh();
       addAlert(t("updateCibaSuccess"), AlertVariant.success);
     } catch (error) {
       addError("updateCibaError", error);
@@ -73,7 +69,7 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
       >
         <FormProvider {...form}>
           <SelectControl
-            name="attributes.cibaBackchannelTokenDeliveryMode"
+            name="backchannelTokenDeliveryMode"
             label={t("cibaBackchannelTokenDeliveryMode")}
             labelIcon={t("cibaBackchannelTokenDeliveryModeHelp")}
             options={CIBA_BACKHANNEL_TOKEN_DELIVERY_MODES.map((mode) => ({
@@ -83,7 +79,7 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
             controller={{ defaultValue: "" }}
           />
           <TextControl
-            name="attributes.cibaExpiresIn"
+            name="expiresIn"
             type="number"
             min={CIBA_EXPIRES_IN_MIN}
             max={CIBA_EXPIRES_IN_MAX}
@@ -104,10 +100,10 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
             }}
           />
           <TextControl
-            name="attributes.cibaInterval"
+            name="interval"
             type="number"
-            min={CIBA_EXPIRES_IN_MIN}
-            max={CIBA_EXPIRES_IN_MAX}
+            min={CIBA_INTERVAL_MIN}
+            max={CIBA_INTERVAL_MAX}
             label={t("cibaInterval")}
             labelIcon={t("cibaIntervalHelp")}
             rules={{
@@ -125,7 +121,7 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
             }}
           />
           <SelectControl
-            name="attributes.cibaAuthRequestedUserHint"
+            name="authRequestedUserHint"
             label={t("cibaAuthRequestedUserHint")}
             labelIcon={t("cibaAuthRequestedUserHintHelp")}
             options={["login_hint", "id_token_hint", "login_hint_token"]}
@@ -145,7 +141,7 @@ export const CibaPolicy = ({ realm, realmUpdated }: CibaPolicyProps) => {
           <Button
             data-testid="reload"
             variant={ButtonVariant.link}
-            onClick={() => setupForm({ ...realm })}
+            onClick={() => refresh()}
           >
             {t("reload")}
           </Button>

--- a/js/apps/admin-ui/src/authentication/policies/OtpPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/OtpPolicy.tsx
@@ -1,10 +1,12 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import type OtpPolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/otpPolicyRepresentation"
 import {
   HelpItem,
   NumberControl,
   SelectControl,
   SwitchControl,
   useAlerts,
+  useFetch,
 } from "@keycloak/keycloak-ui-shared";
 import {
   ActionGroup,
@@ -17,7 +19,7 @@ import {
   PageSection,
   Radio,
 } from "@patternfly/react-core";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../admin-client";
@@ -37,26 +39,20 @@ type OtpPolicyProps = {
   realmUpdated: (realm: RealmRepresentation) => void;
 };
 
-type FormFields = Omit<
-  RealmRepresentation,
-  "clients" | "components" | "groups" | "users" | "federatedUsers"
->;
-
 export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
-  const form = useForm<FormFields>({
+  const form = useForm<OtpPolicyRepresentation>({
     mode: "onChange",
     defaultValues: {
-      otpPolicyType: realm.otpPolicyType ?? POLICY_TYPES[0],
-      otpPolicyAlgorithm:
-        realm.otpPolicyAlgorithm ?? `Hmac${OTP_HASH_ALGORITHMS[0]}`,
-      otpPolicyDigits: realm.otpPolicyDigits ?? NUMBER_OF_DIGITS[0],
-      otpPolicyLookAheadWindow: realm.otpPolicyLookAheadWindow ?? 1,
-      otpPolicyPeriod: realm.otpPolicyPeriod ?? 30,
-      otpPolicyInitialCounter: realm.otpPolicyInitialCounter ?? 30,
-      otpPolicyCodeReusable: realm.otpPolicyCodeReusable ?? false,
+      type: POLICY_TYPES[0],
+      algorithm: `Hmac${OTP_HASH_ALGORITHMS[0]}`,
+      digits: NUMBER_OF_DIGITS[0],
+      lookAheadWindow: 1,
+      period: 30,
+      initialCounter: 30,
+      codeReusable: false,
     },
   });
   const {
@@ -68,10 +64,13 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
   const { realm: realmName } = useRealm();
   const { addAlert, addError } = useAlerts();
   const localeSort = useLocaleSort();
+  
+  const [key, setKey] = useState(0);
+  const refresh = () => setKey(new Date().getTime());
 
-  const otpType = useWatch({ name: "otpPolicyType", control });
+  const otpType = useWatch({ name: "type", control });
 
-  const setupForm = (formValues: FormFields) => reset(formValues);
+  const setupForm = (formValues: OtpPolicyRepresentation) => reset(formValues);
 
   const supportedApplications = useMemo(() => {
     const labels = (realm.otpSupportedApplications ?? []).map((key) =>
@@ -81,14 +80,22 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
     return localeSort(labels, (label) => label);
   }, [realm.otpSupportedApplications]);
 
-  const onSubmit = async (formValues: FormFields) => {
+  useFetch(
+    () => adminClient.authenticationManagement.getOtpPolicy({ realm: realmName }),
+    (otpPolicy) => {
+      setupForm(otpPolicy);
+    },
+    [key],
+  );
+
+  const onSubmit = async (formValues: OtpPolicyRepresentation) => {
     try {
-      await adminClient.realms.update({ realm: realmName }, formValues);
+      await adminClient.authenticationManagement.updateOtpPolicy({ realm: realmName }, formValues);
       const updatedRealm = await adminClient.realms.findOne({
         realm: realmName,
       });
       realmUpdated(updatedRealm!);
-      setupForm(updatedRealm!);
+      refresh();
       addAlert(t("updateOtpSuccess"), AlertVariant.success);
     } catch (error) {
       addError("updateOtpError", error);
@@ -112,7 +119,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
             hasNoPaddingTop
           >
             <Controller
-              name="otpPolicyType"
+              name="type"
               data-testid="otpPolicyType"
               defaultValue={POLICY_TYPES[0]}
               control={control}
@@ -124,7 +131,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
                       id={type}
                       data-testid={type}
                       isChecked={value === type}
-                      name="otpPolicyType"
+                      name="type"
                       onChange={() => onChange(type)}
                       label={t(`policyType.${type}`)}
                       className="keycloak__otp_policies_authentication__policy-type"
@@ -135,7 +142,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
             />
           </FormGroup>
           <SelectControl
-            name="otpPolicyAlgorithm"
+            name="algorithm"
             label={t("otpHashAlgorithm")}
             labelIcon={t("otpHashAlgorithmHelp")}
             options={OTP_HASH_ALGORITHMS.map((type) => ({
@@ -155,7 +162,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
             hasNoPaddingTop
           >
             <Controller
-              name="otpPolicyDigits"
+              name="digits"
               data-testid="otpPolicyDigits"
               defaultValue={NUMBER_OF_DIGITS[0]}
               control={control}
@@ -167,7 +174,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
                       id={`digit-${type}`}
                       data-testid={`digit-${type}`}
                       isChecked={field.value === type}
-                      name="otpPolicyDigits"
+                      name="digits"
                       onChange={() => field.onChange(type)}
                       label={type}
                       className="keycloak__otp_policies_authentication__number-of-digits"
@@ -178,14 +185,14 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
             />
           </FormGroup>
           <NumberControl
-            name="otpPolicyLookAheadWindow"
+            name="lookAheadWindow"
             label={t("lookAround")}
             labelIcon={t("lookAroundHelp")}
             controller={{ defaultValue: 1, rules: { min: 0 } }}
           />
           {otpType === POLICY_TYPES[0] && (
             <TimeSelectorControl
-              name="otpPolicyPeriod"
+              name="period"
               label={t("otpPolicyPeriod")}
               labelIcon={t("otpPolicyPeriodHelp")}
               units={["second", "minute"]}
@@ -203,7 +210,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
           )}
           {otpType === POLICY_TYPES[1] && (
             <NumberControl
-              name="otpPolicyInitialCounter"
+              name="initialCounter"
               label={t("initialCounter")}
               labelIcon={t("initialCounterHelp")}
               controller={{ defaultValue: 30, rules: { min: 1, max: 120 } }}
@@ -231,7 +238,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
 
           {otpType === POLICY_TYPES[0] && (
             <SwitchControl
-              name="otpPolicyCodeReusable"
+              name="codeReusable"
               label={t("otpPolicyCodeReusable")}
               labelIcon={t("otpPolicyCodeReusableHelp")}
               labelOn={t("on")}
@@ -251,7 +258,7 @@ export const OtpPolicy = ({ realm, realmUpdated }: OtpPolicyProps) => {
             <Button
               data-testid="reload"
               variant={ButtonVariant.link}
-              onClick={() => reset({ ...realm })}
+              onClick={() => refresh()}
             >
               {t("reload")}
             </Button>

--- a/js/apps/admin-ui/src/authentication/policies/PasswordPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/PasswordPolicy.tsx
@@ -1,4 +1,5 @@
 import type PasswordPolicyTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/passwordPolicyTypeRepresentation";
+import type PasswordPolicyValueRepresentation from "libs/keycloak-admin-client/lib/defs/passwordPolicyValueRepresentation";
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import {
   ActionGroup,
@@ -22,11 +23,11 @@ import {
   SelectOption,
 } from "@patternfly/react-core";
 import { PlusCircleIcon } from "@patternfly/react-icons";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useAdminClient } from "../../admin-client";
-import { useAlerts } from "@keycloak/keycloak-ui-shared";
+import { useAlerts, useFetch } from "@keycloak/keycloak-ui-shared";
 import { FormAccess } from "../../components/form/FormAccess";
 import { useRealm } from "../../context/realm-context/RealmContext";
 import { useServerInfo } from "../../context/server-info/ServerInfoProvider";
@@ -94,10 +95,13 @@ export const PasswordPolicy = ({
   const { adminClient } = useAdminClient();
 
   const { t } = useTranslation();
-  const { passwordPolicies } = useServerInfo();
+  const { passwordPolicies: passwordPolicyTypes } = useServerInfo();
 
   const { addAlert, addError } = useAlerts();
-  const { realm: realmName, refresh } = useRealm();
+  const { realm: realmName } = useRealm();
+
+  const [key, setKey] = useState(0);
+  const refresh = () => setKey(new Date().getTime());
 
   const [rows, setRows] = useState<PasswordPolicyTypeRepresentation[]>([]);
   const onSelect = (row: PasswordPolicyTypeRepresentation) => {
@@ -115,26 +119,31 @@ export const PasswordPolicy = ({
     formState: { isDirty },
   } = form;
 
-  const setupForm = (realm: RealmRepresentation) => {
+  const setupForm = (passwordPolicyValues: PasswordPolicyValueRepresentation[]) => {
     reset();
-    const values = parsePolicy(realm.passwordPolicy || "", passwordPolicies!);
+    const values = parsePolicy(passwordPolicyValues, passwordPolicyTypes!);
     values.forEach((v) => {
       setValue(v.id!, v.value!);
     });
     setRows(values);
   };
 
-  useEffect(() => setupForm(realm), []);
+  useFetch(
+    () => adminClient.authenticationManagement.getPasswordPolicy({ realm: realmName }),
+    (passwordPolicyValues) => {
+      setupForm(passwordPolicyValues);
+    },
+    [key],
+  );
 
   const save = async (values: SubmittedValues) => {
-    const updatedRealm = {
-      ...realm,
-      passwordPolicy: serializePolicy(rows, values),
-    };
+    const passwordPolicyValues = serializePolicy(rows, values);
     try {
-      await adminClient.realms.update({ realm: realmName }, updatedRealm);
-      realmUpdated(updatedRealm);
-      setupForm(updatedRealm);
+      await adminClient.authenticationManagement.updatePasswordPolicy({ realm: realmName }, passwordPolicyValues);
+      const updatedRealm = await adminClient.realms.findOne({
+        realm: realmName,
+      });
+      realmUpdated(updatedRealm!);
       refresh();
       addAlert(t("updatePasswordPolicySuccess"), AlertVariant.success);
     } catch (error) {
@@ -184,7 +193,7 @@ export const PasswordPolicy = ({
                   <Button
                     data-testid="reload"
                     variant={ButtonVariant.link}
-                    onClick={() => setupForm(realm)}
+                    onClick={() => refresh()}
                   >
                     {t("reload")}
                   </Button>

--- a/js/apps/admin-ui/src/authentication/policies/WebauthnPolicy.tsx
+++ b/js/apps/admin-ui/src/authentication/policies/WebauthnPolicy.tsx
@@ -1,4 +1,5 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
+import type WebAuthnPolicyRepresentation from "@keycloak/keycloak-admin-client/lib/defs/webAuthnPolicyRepresentation"
 import type { FieldValues } from "react-hook-form";
 import {
   ActionGroup,
@@ -12,7 +13,7 @@ import {
   TextContent,
 } from "@patternfly/react-core";
 import { QuestionCircleIcon } from "@patternfly/react-icons";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { FormProvider, useForm, Validate } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
@@ -20,6 +21,7 @@ import {
   SelectControl,
   SwitchControl,
   TextControl,
+  useFetch,
   useHelp,
 } from "@keycloak/keycloak-ui-shared";
 import { useAlerts } from "@keycloak/keycloak-ui-shared";
@@ -125,8 +127,9 @@ export const WebauthnPolicy = ({
   const { addAlert, addError } = useAlerts();
   const { realm: realmName } = useRealm();
   const { enabled } = useHelp();
-  const form = useForm({ mode: "onChange" });
+  const form = useForm<WebAuthnPolicyRepresentation>({ mode: "onChange" }) 
   const {
+    reset,
     setValue,
     handleSubmit,
     watch,
@@ -136,31 +139,46 @@ export const WebauthnPolicy = ({
   const namePrefix = isPasswordLess
     ? "webAuthnPolicyPasswordless"
     : "webAuthnPolicy";
+    
+  const [key, setKey] = useState(0);
+  const refresh = () => setKey(new Date().getTime());
 
-  const setupForm = (realm: RealmRepresentation) =>
-    convertToFormValues(realm, setValue);
+  const setupForm = (formValues: WebAuthnPolicyRepresentation) => reset(formValues);
 
-  useEffect(() => setupForm(realm), []);
-
-  const onSubmit = async (realm: RealmRepresentation) => {
-    const submittedRealm = convertFormValuesToObject(realm);
-    try {
-      await adminClient.realms.update({ realm: realmName }, submittedRealm);
-      realmUpdated(submittedRealm);
-      setupForm(submittedRealm);
-      addAlert(t("webAuthnUpdateSuccess"), AlertVariant.success);
-    } catch (error) {
-      addError("webAuthnUpdateError", error);
+  useFetch(
+    () => isPasswordLess ? 
+      adminClient.authenticationManagement.getWebAuthnPasswordlessPolicy({ realm: realmName }) : 
+      adminClient.authenticationManagement.getWebAuthnPolicy({ realm: realmName }),
+    (policy) => {
+      setupForm(policy);
+    },
+    [key],
+  );
+  
+  const onSubmit = 
+    async (formValues: WebAuthnPolicyRepresentation) => {
+      try {
+        if (isPasswordLess) {
+          await adminClient.authenticationManagement.updateWebAuthnPasswordlessPolicy({ realm: realmName }, formValues);
+        } else {
+          await adminClient.authenticationManagement.updateWebAuthnPolicy({ realm: realmName }, formValues);
+        }
+        const updatedRealm = await adminClient.realms.findOne({realm: realmName});
+        realmUpdated(updatedRealm!);
+        refresh();
+        addAlert(t("webAuthnUpdateSuccess"), AlertVariant.success);
+      } catch (error) {
+        addError("webAuthnUpdateError", error);
+      }
     }
-  };
 
   const isFeatureEnabled = useIsFeatureEnabled();
-  const acceptableAAGUIDs = watch(`${namePrefix}AcceptableAaguids`, []);
+  const acceptableAAGUIDs = watch(`acceptableAaguids`, []);
 
   return (
     <PageSection variant="light">
       {enabled && (
-        <Popover bodyContent={t(`${namePrefix}FormHelp`)}>
+        <Popover bodyContent={t(`formHelp`)}>
           <TextContent className="keycloak__section_intro__help">
             <Text>
               <QuestionCircleIcon /> {t("webauthnIntro")}
@@ -177,25 +195,25 @@ export const WebauthnPolicy = ({
       >
         <FormProvider {...form}>
           <TextControl
-            name={`${namePrefix}RpEntityName`}
+            name={`rpEntityName`}
             label={t("webAuthnPolicyRpEntityName")}
             labelIcon={t("webAuthnPolicyRpEntityNameHelp")}
             rules={{ required: t("required") }}
           />
           <WebauthnSelect
-            name={`${namePrefix}SignatureAlgorithms`}
+            name={`signatureAlgorithms`}
             label={t("webAuthnPolicySignatureAlgorithms")}
             labelIcon={t("webAuthnPolicySignatureAlgorithmsHelp")}
             options={SIGNATURE_ALGORITHMS}
             isMultiSelect
           />
           <TextControl
-            name={`${namePrefix}RpId`}
+            name={`rpId`}
             label={t("webAuthnPolicyRpId")}
             labelIcon={t("webAuthnPolicyRpIdHelp")}
           />
           <WebauthnSelect
-            name={`${namePrefix}AttestationConveyancePreference`}
+            name={`attestationConveyancePreference`}
             label={t("webAuthnPolicyAttestationConveyancePreference")}
             labelIcon={t("webAuthnPolicyAttestationConveyancePreferenceHelp")}
             options={ATTESTATION_PREFERENCE}
@@ -214,28 +232,28 @@ export const WebauthnPolicy = ({
             }}
           />
           <WebauthnSelect
-            name={`${namePrefix}AuthenticatorAttachment`}
+            name={`authenticatorAttachment`}
             label={t("webAuthnPolicyAuthenticatorAttachment")}
             labelIcon={t("webAuthnPolicyAuthenticatorAttachmentHelp")}
             options={AUTHENTICATOR_ATTACHMENT}
             labelPrefix="authenticatorAttachment"
           />
           <WebauthnSelect
-            name={`${namePrefix}RequireResidentKey`}
+            name={`requireResidentKey`}
             label={t("webAuthnPolicyRequireResidentKey")}
             labelIcon={t("webAuthnPolicyRequireResidentKeyHelp")}
             options={RESIDENT_KEY_OPTIONS}
             labelPrefix="residentKey"
           />
           <WebauthnSelect
-            name={`${namePrefix}UserVerificationRequirement`}
+            name={`userVerificationRequirement`}
             label={t("webAuthnPolicyUserVerificationRequirement")}
             labelIcon={t("webAuthnPolicyUserVerificationRequirementHelp")}
             options={USER_VERIFY}
             labelPrefix="userVerify"
           />
           <TimeSelectorControl
-            name={`${namePrefix}CreateTimeout`}
+            name={`createTimeout`}
             label={t("webAuthnPolicyCreateTimeout")}
             labelIcon={t("webAuthnPolicyCreateTimeoutHelp")}
             units={["second", "minute", "hour"]}
@@ -251,7 +269,7 @@ export const WebauthnPolicy = ({
             }}
           />
           <SwitchControl
-            name={`${namePrefix}AvoidSameAuthenticatorRegister`}
+            name={`avoidSameAuthenticatorRegister`}
             label={t("webAuthnPolicyAvoidSameAuthenticatorRegister")}
             labelIcon={t("webAuthnPolicyAvoidSameAuthenticatorRegisterHelp")}
             labelOn={t("on")}
@@ -268,7 +286,7 @@ export const WebauthnPolicy = ({
             }
           >
             <MultiLineInput
-              name={`${namePrefix}AcceptableAaguids`}
+              name={`acceptableAaguids`}
               aria-label={t("webAuthnPolicyAcceptableAaguids")}
               addButtonLabel="addAaguids"
             />
@@ -284,7 +302,7 @@ export const WebauthnPolicy = ({
             }
           >
             <MultiLineInput
-              name={`${namePrefix}ExtraOrigins`}
+              name={`extraOrigins`}
               aria-label={t("webAuthnPolicyExtraOrigins")}
               addButtonLabel="addOrigins"
             />
@@ -292,15 +310,15 @@ export const WebauthnPolicy = ({
           {isPasswordLess && isFeatureEnabled(Feature.Passkeys) && (
             <>
               <SwitchControl
-                name={`${namePrefix}PasskeysEnabled`}
+                name={`passkeysEnabled`}
                 label={t("webAuthnPolicyPasskeysEnabled")}
                 labelIcon={t("webAuthnPolicyPasskeysEnabledHelp")}
                 labelOn={t("on")}
                 labelOff={t("off")}
               />
-              {watch(`${namePrefix}PasskeysEnabled`) && (
+              {watch(`passkeysEnabled`) && (
                 <WebauthnSelect
-                  name={`${namePrefix}Mediation`}
+                  name={`mediation`}
                   label={t("webAuthnPolicyMediation")}
                   labelIcon={t("webAuthnPolicyMediationHelp")}
                   options={MEDIATION_OPTIONS}
@@ -323,7 +341,7 @@ export const WebauthnPolicy = ({
           <Button
             data-testid="reload"
             variant={ButtonVariant.link}
-            onClick={() => setupForm(realm)}
+            onClick={() => refresh()}
           >
             {t("reload")}
           </Button>

--- a/js/apps/admin-ui/src/authentication/policies/util.ts
+++ b/js/apps/admin-ui/src/authentication/policies/util.ts
@@ -1,30 +1,28 @@
 import type PasswordPolicyTypeRepresentation from "@keycloak/keycloak-admin-client/lib/defs/passwordPolicyTypeRepresentation";
+import type PasswordPolicyValueRepresentation from "@keycloak/keycloak-admin-client/lib/defs/passwordPolicyValueRepresentation";
 
 export type SubmittedValues = {
   [index: string]: string;
 };
-
-const POLICY_SEPARATOR = " and ";
 
 export const serializePolicy = (
   policies: PasswordPolicyTypeRepresentation[],
   submitted: SubmittedValues,
 ) =>
   policies
-    .map((policy) => `${policy.id}(${submitted[policy.id!]})`)
-    .join(POLICY_SEPARATOR);
+    .map((policy) => {
+      return {id: policy.id!, value: submitted[policy.id!]};
+    });
 
 type PolicyValue = PasswordPolicyTypeRepresentation & {
   value?: string;
 };
 
 export const parsePolicy = (
-  value: string,
+  value: PasswordPolicyValueRepresentation[],
   policies: PasswordPolicyTypeRepresentation[],
 ) =>
   value
-    .split(POLICY_SEPARATOR)
-    .map(parsePolicyToken)
     .reduce<PolicyValue[]>((result, { id, value }) => {
       const matchingPolicy = policies.find((policy) => policy.id === id);
 
@@ -35,26 +33,3 @@ export const parsePolicy = (
       return result.concat({ ...matchingPolicy, value });
     }, []);
 
-type PolicyTokenParsed = {
-  id: string;
-  value?: string;
-};
-
-function parsePolicyToken(token: string): PolicyTokenParsed {
-  const valueStart = token.indexOf("(");
-
-  if (valueStart === -1) {
-    return { id: token.trim() };
-  }
-
-  const id = token.substring(0, valueStart).trim();
-  const valueEnd = token.lastIndexOf(")");
-
-  if (valueEnd === -1) {
-    return { id };
-  }
-
-  const value = token.substring(valueStart + 1, valueEnd).trim();
-
-  return { id, value };
-}

--- a/js/apps/admin-ui/test/autentication/flow.ts
+++ b/js/apps/admin-ui/test/autentication/flow.ts
@@ -92,10 +92,6 @@ export async function goToCIBAPolicyTab(page: Page) {
   await page.getByTestId("tab-ciba-policy").click();
 }
 
-export async function addPolicy(page: Page, value: string) {
-  await selectItem(page, page.getByTestId("add-policy"), value);
-}
-
 const toKey = (name: string) => {
   return name.replace(/\s/g, "-");
 };

--- a/js/apps/admin-ui/test/autentication/flows.spec.ts
+++ b/js/apps/admin-ui/test/autentication/flows.spec.ts
@@ -12,7 +12,6 @@ import {
 import { confirmModal } from "../utils/modal.ts";
 import { goToAuthentication } from "../utils/sidebar.ts";
 import {
-  assertEmptyTable,
   clickRowKebabItem,
   clickTableRowItem,
   getRowByCellText,
@@ -21,7 +20,6 @@ import {
 import {
   addCondition,
   addExecution,
-  addPolicy,
   addSubFlow,
   assertDefaultSwitchPolicyEnabled,
   assertRowExists,
@@ -39,6 +37,7 @@ import {
   goToRequiredActions,
   goToWebAuthnTab,
 } from "./flow.ts";
+import { addPolicy } from "./policies.ts"
 
 test.describe("Authentication flows", () => {
   test("searches for an existing flow", async ({ page }) => {
@@ -286,24 +285,6 @@ test.describe("Required actions", () => {
       "Updated required action successfully",
     );
     await assertSwitchPolicyChecked(page, action);
-  });
-});
-
-test.describe("Password policies tab", () => {
-  test("adds password policies", async ({ page }) => {
-    await using testBed = await createTestBed();
-
-    await login(page, {
-      to: toAuthentication({ realm: testBed.realm, tab: "policies" }),
-    });
-
-    await assertEmptyTable(page);
-    await addPolicy(page, "Not Recently Used");
-    await clickSaveButton(page);
-    await assertNotificationMessage(
-      page,
-      "Password policies successfully updated",
-    );
   });
 });
 

--- a/js/apps/admin-ui/test/autentication/policies-ciba.spec.ts
+++ b/js/apps/admin-ui/test/autentication/policies-ciba.spec.ts
@@ -22,7 +22,7 @@ import {
   setExpiresInput,
   setIntervalInput,
 } from "./policies-ciba.ts";
-
+ 
 test.describe("Authentication - Policies - CIBA", () => {
   test("displays the initial state", async ({ page }) => {
     await using testBed = await createTestBed();

--- a/js/apps/admin-ui/test/autentication/policies-ciba.ts
+++ b/js/apps/admin-ui/test/autentication/policies-ciba.ts
@@ -39,7 +39,7 @@ export async function clearExpiresInput(page: Page) {
   return getExpiresInput(page).clear();
 }
 
-export const expiresInput = "attributes.cibaExpiresIn";
+export const expiresInput = "expiresIn";
 function getExpiresInput(page: Page) {
   return page.getByTestId(expiresInput);
 }
@@ -58,7 +58,7 @@ export async function clearIntervalInput(page: Page) {
   return getIntervalInput(page).clear();
 }
 
-export const intervalInput = "attributes.cibaInterval";
+export const intervalInput = "interval";
 function getIntervalInput(page: Page) {
   return page.getByTestId(intervalInput);
 }

--- a/js/apps/admin-ui/test/autentication/policies.spec.ts
+++ b/js/apps/admin-ui/test/autentication/policies.spec.ts
@@ -5,15 +5,42 @@ import { clickSaveButton } from "../utils/form.ts";
 import { login } from "../utils/login.ts";
 import { assertNotificationMessage } from "../utils/masthead.ts";
 import {
+  addPolicy,
   assertSupportedApplications,
   fillSelects,
   goToOTPPolicyTab,
+  goToPasswordPolicyTab,
   goToWebauthnPage,
   goToWebauthnPasswordlessPage,
   increaseInitialCounter,
   setPolicyType,
   setWebAuthnPolicyCreateTimeout,
 } from "./policies.ts";
+import { assertEmptyTable } from "../utils/table.ts"
+
+test.describe("Password policies tab", () => {
+  test("adds password policies", async ({ page }) => {
+    await using testBed = await createTestBed();
+
+    await login(page, {
+      to: toAuthentication({ realm: testBed.realm, tab: "policies" }),
+    });
+
+    await goToPasswordPolicyTab(page);
+
+    // check initial state
+    await assertEmptyTable(page);
+
+    // save a new policy
+    await addPolicy(page, "Not Recently Used");
+
+    await clickSaveButton(page);
+    await assertNotificationMessage(
+      page,
+      "Password policies successfully updated",
+    );
+  });
+});
 
 test.describe("OTP policies tab", () => {
   test("changes to hotp", async ({ page }) => {
@@ -54,9 +81,9 @@ test.describe("Webauthn policies tabs", () => {
     await goToWebauthnPage(page);
 
     await fillSelects(page, {
-      webAuthnPolicyAttestationConveyancePreference: "Indirect",
-      webAuthnPolicyRequireResidentKey: "Yes",
-      webAuthnPolicyUserVerificationRequirement: "Preferred",
+      attestationConveyancePreference: "Indirect",
+      requireResidentKey: "Yes",
+      userVerificationRequirement: "Preferred",
     });
 
     await setWebAuthnPolicyCreateTimeout(page, 30);
@@ -77,9 +104,9 @@ test.describe("Webauthn policies tabs", () => {
     await goToWebauthnPasswordlessPage(page);
 
     await fillSelects(page, {
-      webAuthnPolicyPasswordlessAttestationConveyancePreference: "Indirect",
-      webAuthnPolicyPasswordlessRequireResidentKey: "Yes",
-      webAuthnPolicyPasswordlessUserVerificationRequirement: "Preferred",
+      attestationConveyancePreference: "Indirect",
+      requireResidentKey: "Yes",
+      userVerificationRequirement: "Preferred",
     });
 
     await clickSaveButton(page);

--- a/js/apps/admin-ui/test/autentication/policies.ts
+++ b/js/apps/admin-ui/test/autentication/policies.ts
@@ -1,6 +1,14 @@
 import { type Page, expect } from "@playwright/test";
 import { selectItem } from "../utils/form.ts";
 
+export async function goToPasswordPolicyTab(page: Page) {
+  await page.getByTestId("passwordPolicy").click();
+}
+
+export async function addPolicy(page: Page, value: string) {
+  await selectItem(page, page.getByTestId("add-policy"), value);
+}
+
 export async function goToOTPPolicyTab(page: Page) {
   await page.getByTestId("otpPolicy").click();
 }
@@ -18,7 +26,7 @@ export async function setPolicyType(page: Page, type: string) {
 }
 
 export async function increaseInitialCounter(page: Page) {
-  await page.locator("#otpPolicyInitialCounter").getByLabel("Plus").click();
+  await page.locator("#initialCounter").getByLabel("Plus").click();
 }
 
 export async function goToWebauthnPage(page: Page) {
@@ -40,5 +48,5 @@ export async function setWebAuthnPolicyCreateTimeout(
   page: Page,
   value: number,
 ) {
-  await page.getByTestId("webAuthnPolicyCreateTimeout").fill(String(value));
+  await page.getByTestId("createTimeout").fill(String(value));
 }

--- a/js/libs/keycloak-admin-client/src/defs/cibaPolicyRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/cibaPolicyRepresentation.ts
@@ -1,0 +1,9 @@
+/**
+ * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_cibapolicyrepresentation
+ */
+export default interface CibaPolicyRepresentation {
+  backchannelTokenDeliveryMode: string;
+  expiresIn: number;
+  poolingInterval: number;
+  authRequestedUserHint: string;
+}

--- a/js/libs/keycloak-admin-client/src/defs/otpPolicyRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/otpPolicyRepresentation.ts
@@ -1,0 +1,12 @@
+/**
+ * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_otppolicyrepresentation
+ */
+export default interface OtpPolicyRepresentation {
+  type: string;
+  algorithm: string;
+  digits: number;
+  lookAheadWindow: number;
+  period?: number;
+  initialCounter?: number;
+  codeReusable: boolean;
+}

--- a/js/libs/keycloak-admin-client/src/defs/passwordPolicyValueRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/passwordPolicyValueRepresentation.ts
@@ -1,0 +1,7 @@
+/**
+ * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_passwordpolicyvaluerepresentation
+ */
+export default interface PasswordPolicyValueRepresentation {
+  id: string;
+  value?: string;
+}

--- a/js/libs/keycloak-admin-client/src/defs/webAuthnPolicyRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/webAuthnPolicyRepresentation.ts
@@ -1,0 +1,18 @@
+/**
+ * https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_webauthnpolicyrepresentation
+ */
+export default interface WebAuthnPolicyRepresentation {
+  rpEntityName: string;
+  signatureAlgorithms: string[];
+  rpId: string;
+  attestationConveyancePreference: string;
+  authenticatorAttachment: string;
+  requireResidentKey: string;
+  userVerificationRequirement: string;
+  createTimeout: number;
+  avoidSameAuthenticatorRegister: boolean;
+  acceptableAaguids: string[];
+  extraOrigins: string[];
+  passkeysEnabled: boolean;
+  mediation?: string;
+}

--- a/js/libs/keycloak-admin-client/src/resources/authenticationManagement.ts
+++ b/js/libs/keycloak-admin-client/src/resources/authenticationManagement.ts
@@ -9,6 +9,10 @@ import type AuthenticatorConfigInfoRepresentation from "../defs/authenticatorCon
 import type RequiredActionProviderSimpleRepresentation from "../defs/requiredActionProviderSimpleRepresentation.js";
 import type RequiredActionConfigInfoRepresentation from "../defs/requiredActionConfigInfoRepresentation.js";
 import type RequiredActionConfigRepresentation from "../defs/requiredActionConfigRepresentation.js";
+import type PasswordPolicyValueRepresentation from "../defs/passwordPolicyValueRepresentation.js";
+import type OtpPolicyRepresentation from "../defs/otpPolicyRepresentation.js";
+import type WebAuthnPolicyRepresentation from "../defs/webAuthnPolicyRepresentation.js";
+import type CibaPolicyRepresentation from "../defs/cibaPolicyRepresentation.js";
 
 export class AuthenticationManagement extends Resource<{ realm?: string }> {
   /**
@@ -312,6 +316,91 @@ export class AuthenticationManagement extends Resource<{ realm?: string }> {
     method: "DELETE",
     path: "/config/{id}",
     urlParamKeys: ["id"],
+  });
+
+  public getPasswordPolicy = this.makeRequest<
+    {},
+    PasswordPolicyValueRepresentation[]
+  >({
+    method: "GET",
+    path: "/policies/password-policy",
+  });
+
+  public updatePasswordPolicy = this.makeUpdateRequest<
+    {},
+    PasswordPolicyValueRepresentation[],
+    void
+  >({
+    method: "PUT",
+    path: "/policies/password-policy",
+  });
+
+  public getOtpPolicy = this.makeRequest<
+    {},
+    OtpPolicyRepresentation
+  >({
+    method: "GET",
+    path: "/policies/otp-policy",
+  });
+
+  public updateOtpPolicy = this.makeUpdateRequest<
+    {},
+    OtpPolicyRepresentation,
+    void
+  >({
+    method: "PUT",
+    path: "/policies/otp-policy",
+  });
+
+  public getWebAuthnPolicy = this.makeRequest<
+    {},
+    WebAuthnPolicyRepresentation
+  >({
+    method: "GET",
+    path: "/policies/webauthn-policy",
+  });
+
+  public updateWebAuthnPolicy = this.makeUpdateRequest<
+    {},
+    WebAuthnPolicyRepresentation,
+    void
+  >({
+    method: "PUT",
+    path: "/policies/webauthn-policy",
+  });
+
+  public getWebAuthnPasswordlessPolicy = this.makeRequest<
+    {},
+    WebAuthnPolicyRepresentation
+  >({
+    method: "GET",
+    path: "/policies/webauthn-passwordless-policy",
+  });
+
+  public updateWebAuthnPasswordlessPolicy = this.makeUpdateRequest<
+    {},
+    WebAuthnPolicyRepresentation,
+    void
+  >({
+    method: "PUT",
+    path: "/policies/webauthn-passwordless-policy",
+  });
+
+  public getCibaPolicy = this.makeRequest<
+    {},
+    CibaPolicyRepresentation
+  >({
+    method: "GET",
+    path: "/policies/ciba-policy",
+  });
+
+  public updateCibaPolicy = this.makeUpdateRequest<
+    {},
+    CibaPolicyRepresentation,
+    void
+  >({
+    method: "PUT",
+    path: "/policies/ciba-policy",
   });
 
   constructor(client: KeycloakAdminClient) {

--- a/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java
+++ b/server-spi-private/src/main/java/org/keycloak/events/admin/ResourceType.java
@@ -76,6 +76,11 @@ public enum ResourceType {
     /**
      *
      */
+    , AUTHENTICATION_POLICY
+
+    /**
+     *
+     */
     , IDENTITY_PROVIDER
 
     /**

--- a/server-spi-private/src/main/java/org/keycloak/policy/ForceExpiredPasswordPolicyProviderFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/policy/ForceExpiredPasswordPolicyProviderFactory.java
@@ -70,7 +70,7 @@ public class ForceExpiredPasswordPolicyProviderFactory implements PasswordPolicy
 
     @Override
     public String getConfigType() {
-        return PasswordPolicyProvider.STRING_CONFIG_TYPE;
+        return PasswordPolicyProvider.INT_CONFIG_TYPE;
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/AuthenticationManagementResource.java
@@ -57,15 +57,24 @@ import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.AuthenticationExecutionModel;
 import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.CibaConfig;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.OTPPolicy;
+import org.keycloak.models.PasswordPolicy;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RequiredActionConfigModel;
 import org.keycloak.models.RequiredActionProviderModel;
+import org.keycloak.models.WebAuthnPolicy;
+import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.utils.Base32;
 import org.keycloak.models.utils.DefaultAuthenticationFlows;
+import org.keycloak.models.utils.HmacOTP;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
+import org.keycloak.policy.PasswordPolicyProvider;
+import org.keycloak.policy.PasswordPolicyProviderFactory;
 import org.keycloak.provider.ConfiguredProvider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderFactory;
@@ -74,11 +83,15 @@ import org.keycloak.representations.idm.AuthenticationExecutionRepresentation;
 import org.keycloak.representations.idm.AuthenticationFlowRepresentation;
 import org.keycloak.representations.idm.AuthenticatorConfigInfoRepresentation;
 import org.keycloak.representations.idm.AuthenticatorConfigRepresentation;
+import org.keycloak.representations.idm.CibaPolicyRepresentation;
 import org.keycloak.representations.idm.ConfigPropertyRepresentation;
 import org.keycloak.representations.idm.ErrorRepresentation;
+import org.keycloak.representations.idm.OTPPolicyRepresentation;
+import org.keycloak.representations.idm.PasswordPolicyValueRepresentation;
 import org.keycloak.representations.idm.RequiredActionConfigInfoRepresentation;
 import org.keycloak.representations.idm.RequiredActionConfigRepresentation;
 import org.keycloak.representations.idm.RequiredActionProviderRepresentation;
+import org.keycloak.representations.idm.WebAuthnPolicyRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
@@ -87,6 +100,8 @@ import org.keycloak.utils.CredentialHelper;
 import org.keycloak.utils.RequiredActionHelper;
 import org.keycloak.utils.ReservedCharValidator;
 
+import com.webauthn4j.data.AttestationConveyancePreference;
+import com.webauthn4j.data.AuthenticatorAttachment;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
@@ -1684,5 +1699,426 @@ public class AuthenticationManagementResource {
         exists.setConfig(RepresentationToModel.removeEmptyString(rep.getConfig()));
         realm.updateAuthenticatorConfig(exists);
         adminEvent.operation(OperationType.UPDATE).resource(ResourceType.AUTHENTICATOR_CONFIG).resourcePath(session.getContext().getUri()).representation(rep).success();
+    }
+
+    @Path("policies/password-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(
+            summary = "Read Password Authentication Policy"
+    )
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public List<PasswordPolicyValueRepresentation> getPasswordPolicy() {
+        auth.realm().requireViewRealm();
+
+        List<PasswordPolicyValueRepresentation> values = new LinkedList<>();
+        for (String key : realm.getPasswordPolicy().getPolicies()) {
+            values.add(new PasswordPolicyValueRepresentation(key, realm.getPasswordPolicy().getPolicyConfig(key)));
+        }
+
+        return values;
+    }
+
+    @Path("policies/password-policy")
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Update Password Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public void updatePasswordPolicy(List<PasswordPolicyValueRepresentation> rep) {
+        auth.realm().requireManageRealm();
+
+        validatePasswordPolicyRepresentation(rep);
+
+        PasswordPolicy.Builder builder = PasswordPolicy.build();
+        rep.forEach((row) -> builder.put(row.getId(), row.getValue() != null ? row.getValue().toString() : null));
+        realm.setPasswordPolicy(builder.build(session));
+
+        adminEvent.operation(OperationType.UPDATE)
+                .resource(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(session.getContext().getUri())
+                .representation(rep)
+                .success();
+    }
+
+    private void validatePasswordPolicyRepresentation(final List<PasswordPolicyValueRepresentation> rep) {
+        Map<String, String> config = session.getKeycloakSessionFactory()
+                .getProviderFactoriesStream(PasswordPolicyProvider.class)
+                .map(PasswordPolicyProviderFactory.class::cast)
+                .collect(Collectors.toMap(
+                        PasswordPolicyProviderFactory::getId,
+                        factory -> factory.getConfigType() == null ? "" : factory.getConfigType()
+                ));
+
+        List<String> unknownTypeIds = rep.stream()
+                .map(PasswordPolicyValueRepresentation::getId)
+                .filter(id -> !config.containsKey(id))
+                .collect(Collectors.toList());
+        if (!unknownTypeIds.isEmpty()) {
+            throw new BadRequestException("Unknown password policy type(s): " + String.join(", ", unknownTypeIds));
+        }
+
+        List<String> invalidValues = rep.stream()
+                .filter(item -> {
+                    switch (config.get(item.getId())) {
+                        case PasswordPolicyProvider.INT_CONFIG_TYPE:
+                            if (item.getValue() == null) {
+                                return true;
+                            }
+                            try {
+                                Integer.parseInt(item.getValue().toString());
+                                return false;
+                            } catch (NumberFormatException e) {
+                                return true;
+                            }
+                        case PasswordPolicyProvider.STRING_CONFIG_TYPE:
+                            return item.getValue() == null || !(item.getValue() instanceof String);
+                        default:
+                            return false;
+                    }
+                })
+                .map(item -> {
+                    return item.getId() + " got \"" + item.getValue() + "\" but expects a value of type " + config.get(item.getId());
+                })
+                .collect(Collectors.toList());
+        if (!invalidValues.isEmpty()) {
+            throw new BadRequestException("Invalid values: " + String.join(", ", invalidValues));
+        }
+    }
+
+    @Path("policies/otp-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Read OTP Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public OTPPolicyRepresentation getOTPPolicy() {
+        auth.realm().requireViewRealm();
+
+        OTPPolicyRepresentation policy = new OTPPolicyRepresentation();
+        policy.setType(realm.getOTPPolicy().getType());
+        policy.setAlgorithm(realm.getOTPPolicy().getAlgorithm());
+        policy.setDigits(realm.getOTPPolicy().getDigits());
+        policy.setLookAheadWindow(realm.getOTPPolicy().getLookAheadWindow());
+        policy.setPeriod(realm.getOTPPolicy().getPeriod());
+        policy.setInitialCounter(realm.getOTPPolicy().getInitialCounter());
+        policy.setCodeReusable(realm.getOTPPolicy().isCodeReusable());
+
+        return policy;
+    }
+
+    @Path("policies/otp-policy")
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Update OTP Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public void updateOTPPolicy(final OTPPolicyRepresentation rep) {
+        auth.realm().requireManageRealm();
+
+        validateOtpPolicyRepresentation(rep);
+
+        OTPPolicy otpPolicy = new OTPPolicy();
+        otpPolicy.setType(rep.getType());
+        otpPolicy.setAlgorithm(rep.getAlgorithm());
+        otpPolicy.setDigits(rep.getDigits());
+        otpPolicy.setLookAheadWindow(rep.getLookAheadWindow());
+        otpPolicy.setPeriod(rep.getPeriod());
+        otpPolicy.setInitialCounter(rep.getInitialCounter());
+        otpPolicy.setCodeReusable(rep.isCodeReusable());
+
+        realm.setOTPPolicy(otpPolicy);
+
+        adminEvent.operation(OperationType.UPDATE)
+                .resource(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(session.getContext().getUri())
+                .representation(rep)
+                .success();
+    }
+
+    private void validateOtpPolicyRepresentation(final OTPPolicyRepresentation rep) {
+        List<String> supportedTypes = List.of(OTPCredentialModel.TOTP, OTPCredentialModel.HOTP);
+        if (rep.getType() == null) {
+            throw new BadRequestException("type is required");
+        }
+        if (!supportedTypes.contains(rep.getType())) {
+            throw new BadRequestException("type must be " + String.join(", ", supportedTypes));
+        }
+        if (rep.getAlgorithm() == null) {
+            throw new BadRequestException("algorithm is required");
+        }
+        List<String> supportedAlgorithms = List.of(HmacOTP.HMAC_SHA1, HmacOTP.HMAC_SHA256, HmacOTP.HMAC_SHA512);
+        if (!supportedAlgorithms.contains(rep.getAlgorithm())) {
+            throw new BadRequestException("algorithm must be " + String.join(", ", supportedAlgorithms));
+        }
+        if (!List.of(6, 8).contains(rep.getDigits())) {
+            throw new BadRequestException("digits must be 6 or 8");
+        }
+        if (rep.getType().equals(OTPCredentialModel.TOTP) && rep.getPeriod() == null) {
+            throw new BadRequestException("period field is required in totp mode");
+        }
+        if (rep.getType().equals(OTPCredentialModel.HOTP) && rep.getInitialCounter() == null) {
+            throw new BadRequestException("initalCounter field is required in htop mode");
+        }
+    }
+
+    @Path("policies/webauthn-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Read WebAuthn Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public WebAuthnPolicyRepresentation getWebAuthnPolicy() {
+        auth.realm().requireViewRealm();
+
+        WebAuthnPolicyRepresentation policy = new WebAuthnPolicyRepresentation();
+        policy.setRpEntityName(realm.getWebAuthnPolicy().getRpEntityName());
+        policy.setSignatureAlgorithms(realm.getWebAuthnPolicy().getSignatureAlgorithm());
+        policy.setRpId(realm.getWebAuthnPolicy().getRpId());
+        policy.setAttestationConveyancePreference(realm.getWebAuthnPolicy().getAttestationConveyancePreference());
+        policy.setAuthenticatorAttachment(realm.getWebAuthnPolicy().getAuthenticatorAttachment());
+        policy.setRequireResidentKey(realm.getWebAuthnPolicy().getRequireResidentKey());
+        policy.setUserVerificationRequirement(realm.getWebAuthnPolicy().getUserVerificationRequirement());
+        policy.setCreateTimeout(realm.getWebAuthnPolicy().getCreateTimeout());
+        policy.setAvoidSameAuthenticatorRegister(realm.getWebAuthnPolicy().isAvoidSameAuthenticatorRegister());
+        policy.setAcceptableAaguids(realm.getWebAuthnPolicy().getAcceptableAaguids());
+        policy.setExtraOrigins(realm.getWebAuthnPolicy().getExtraOrigins());
+
+        return policy;
+    }
+
+    @Path("policies/webauthn-policy")
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Update WebAuthn Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public void updateWebAuthnPolicy(final WebAuthnPolicyRepresentation rep) {
+        auth.realm().requireManageRealm();
+
+        validateWebAuthnPolicyRepresentation(rep, false);
+
+        WebAuthnPolicy webAuthnPolicy = new WebAuthnPolicy();
+        webAuthnPolicy.setRpEntityName(rep.getRpEntityName());
+        webAuthnPolicy.setSignatureAlgorithm(rep.getSignatureAlgorithms());
+        webAuthnPolicy.setRpId(rep.getRpId());
+        webAuthnPolicy.setAttestationConveyancePreference(rep.getAttestationConveyancePreference());
+        webAuthnPolicy.setAuthenticatorAttachment(rep.getAuthenticatorAttachment());
+        webAuthnPolicy.setRequireResidentKey(rep.getRequireResidentKey());
+        webAuthnPolicy.setUserVerificationRequirement(rep.getUserVerificationRequirement());
+        webAuthnPolicy.setCreateTimeout(rep.getCreateTimeout());
+        webAuthnPolicy.setAvoidSameAuthenticatorRegister(rep.getAvoidSameAuthenticatorRegister());
+        webAuthnPolicy.setAcceptableAaguids(rep.getAcceptableAaguids());
+        webAuthnPolicy.setExtraOrigins(rep.getExtraOrigins());
+
+        realm.setWebAuthnPolicy(webAuthnPolicy);
+
+        adminEvent.operation(OperationType.UPDATE)
+                .resource(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(session.getContext().getUri())
+                .representation(rep)
+                .success();
+    }
+
+    @Path("policies/webauthn-passwordless-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Read WebAuthn Passwordless Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public WebAuthnPolicyRepresentation getWebAuthnPasswordlessPolicy() {
+        auth.realm().requireViewRealm();
+
+        WebAuthnPolicyRepresentation policy = new WebAuthnPolicyRepresentation();
+        policy.setRpEntityName(realm.getWebAuthnPolicyPasswordless().getRpEntityName());
+        policy.setSignatureAlgorithms(realm.getWebAuthnPolicyPasswordless().getSignatureAlgorithm());
+        policy.setRpId(realm.getWebAuthnPolicyPasswordless().getRpId());
+        policy.setAttestationConveyancePreference(realm.getWebAuthnPolicyPasswordless().getAttestationConveyancePreference());
+        policy.setAuthenticatorAttachment(realm.getWebAuthnPolicyPasswordless().getAuthenticatorAttachment());
+        policy.setRequireResidentKey(realm.getWebAuthnPolicyPasswordless().getRequireResidentKey());
+        policy.setUserVerificationRequirement(realm.getWebAuthnPolicyPasswordless().getUserVerificationRequirement());
+        policy.setCreateTimeout(realm.getWebAuthnPolicyPasswordless().getCreateTimeout());
+        policy.setAvoidSameAuthenticatorRegister(realm.getWebAuthnPolicyPasswordless().isAvoidSameAuthenticatorRegister());
+        policy.setAcceptableAaguids(realm.getWebAuthnPolicyPasswordless().getAcceptableAaguids());
+        policy.setExtraOrigins(realm.getWebAuthnPolicyPasswordless().getExtraOrigins());
+        policy.setPasskeysEnabled(realm.getWebAuthnPolicyPasswordless().isPasskeysEnabled());
+        policy.setMediation(realm.getWebAuthnPolicyPasswordless().getMediation());
+
+        return policy;
+    }
+
+    @Path("policies/webauthn-passwordless-policy")
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Update WebAuthn Passwordless Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public void updateWebAuthnPasswordlessPolicy(final WebAuthnPolicyRepresentation rep) {
+        auth.realm().requireManageRealm();
+
+        validateWebAuthnPolicyRepresentation(rep, true);
+
+        WebAuthnPolicy webAuthnPolicy = new WebAuthnPolicy();
+        webAuthnPolicy.setRpEntityName(rep.getRpEntityName());
+        webAuthnPolicy.setSignatureAlgorithm(rep.getSignatureAlgorithms());
+        webAuthnPolicy.setRpId(rep.getRpId());
+        webAuthnPolicy.setAttestationConveyancePreference(rep.getAttestationConveyancePreference());
+        webAuthnPolicy.setAuthenticatorAttachment(rep.getAuthenticatorAttachment());
+        webAuthnPolicy.setRequireResidentKey(rep.getRequireResidentKey());
+        webAuthnPolicy.setUserVerificationRequirement(rep.getUserVerificationRequirement());
+        webAuthnPolicy.setCreateTimeout(rep.getCreateTimeout());
+        webAuthnPolicy.setAvoidSameAuthenticatorRegister(rep.getAvoidSameAuthenticatorRegister());
+        webAuthnPolicy.setAcceptableAaguids(rep.getAcceptableAaguids());
+        webAuthnPolicy.setExtraOrigins(rep.getExtraOrigins());
+        webAuthnPolicy.setPasskeysEnabled(rep.getPasskeysEnabled());
+        webAuthnPolicy.setMediation(rep.getMediation());
+
+        realm.setWebAuthnPolicyPasswordless(webAuthnPolicy);
+
+        adminEvent.operation(OperationType.UPDATE)
+                .resource(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(session.getContext().getUri())
+                .representation(rep)
+                .success();
+    }
+
+    private void validateWebAuthnPolicyRepresentation(final WebAuthnPolicyRepresentation rep, boolean isPasswordless) {
+        if (rep.getRpEntityName() == null || rep.getRpEntityName().isBlank()) {
+            throw new BadRequestException("RP Entity Name is required");
+        }
+        if (rep.getSignatureAlgorithms() == null || rep.getSignatureAlgorithms().isEmpty()) {
+            throw new BadRequestException("At least one signature algorithm is required");
+        }
+        if (rep.getAttestationConveyancePreference() == null || !List.of(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED, AttestationConveyancePreference.NONE.toString(), AttestationConveyancePreference.INDIRECT.toString(), AttestationConveyancePreference.DIRECT.toString()).contains(rep.getAttestationConveyancePreference())) {
+            throw new BadRequestException("Unsupported attestation conveyance preference");
+        }
+        if (rep.getRequireResidentKey() == null || !List.of(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED, Constants.WEBAUTHN_POLICY_OPTION_YES, Constants.WEBAUTHN_POLICY_OPTION_NO).contains(rep.getRequireResidentKey())) {
+            throw new BadRequestException("Unsupported require resident key option");
+        }
+        if (rep.getAuthenticatorAttachment() == null || !List.of(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED, AuthenticatorAttachment.PLATFORM.toString(), AuthenticatorAttachment.CROSS_PLATFORM.toString()).contains(rep.getAuthenticatorAttachment())) {
+            throw new BadRequestException("Unsupported authenticator attachment");
+        }
+        if (rep.getUserVerificationRequirement() == null || !List.of(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED, Constants.WEBAUTHN_POLICY_OPTION_REQUIRED, Constants.WEBAUTHN_POLICY_OPTION_PREFERED, Constants.WEBAUTHN_POLICY_OPTION_DISCOURAGED).contains(rep.getUserVerificationRequirement())) {
+            throw new BadRequestException("Unsupported user verification requirement");
+        }
+        if (isPasswordless) {
+            if (rep.getPasskeysEnabled() != null && rep.getPasskeysEnabled()) {
+                if (rep.getMediation() == null || !List.of("conditional", "none", "optional", "required", "silent").contains(rep.getMediation())) {
+                    throw new BadRequestException("Unsupported mediation requirement");
+                }
+            }
+        }
+    }
+
+    @Path("policies/ciba-policy")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Read Ciba Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "200", description = "OK"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public CibaPolicyRepresentation getCibaPolicy() {
+        auth.realm().requireViewRealm();
+
+        CibaPolicyRepresentation policy = new CibaPolicyRepresentation();
+        policy.setBackchannelTokenDeliveryMode(realm.getCibaPolicy().getBackchannelTokenDeliveryMode());
+        policy.setExpiresIn(realm.getCibaPolicy().getExpiresIn());
+        policy.setInterval(realm.getCibaPolicy().getPoolingInterval());
+        policy.setAuthRequestedUserHint(realm.getCibaPolicy().getAuthRequestedUserHint());
+
+        return policy;
+    }
+
+    @Path("policies/ciba-policy")
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @NoCache
+    @Tag(name = KeycloakOpenAPI.Admin.Tags.AUTHENTICATION_MANAGEMENT)
+    @Operation(summary = "Update Ciba Authentication Policy")
+    @APIResponses(value = {
+        @APIResponse(responseCode = "204", description = "No Content"),
+        @APIResponse(responseCode = "400", description = "Bad Request"),
+        @APIResponse(responseCode = "403", description = "Forbidden")
+    })
+    public void updateCibaPolicy(final CibaPolicyRepresentation rep) {
+        auth.realm().requireManageRealm();
+
+        validateCibaPolicyRepresentation(rep);
+
+        CibaConfig cibaPolicy = CibaConfig.fromModel(realm);
+        cibaPolicy.setBackchannelTokenDeliveryMode(rep.getBackchannelTokenDeliveryMode());
+        cibaPolicy.setExpiresIn(rep.getExpiresIn());
+        cibaPolicy.setPoolingInterval(rep.getInterval());
+        cibaPolicy.setAuthRequestedUserHint(rep.getAuthRequestedUserHint());
+
+        adminEvent.operation(OperationType.UPDATE)
+                .resource(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(session.getContext().getUri())
+                .representation(rep)
+                .success();
+    }
+
+    private void validateCibaPolicyRepresentation(final CibaPolicyRepresentation rep) {
+        if (!CibaConfig.CIBA_SUPPORTED_MODES.contains(rep.getBackchannelTokenDeliveryMode())) {
+            throw new BadRequestException("backchannelTokenDeliveryMode only supports " + String.join(", ", CibaConfig.CIBA_SUPPORTED_MODES));
+        }
+        if (rep.getExpiresIn() < 10) {
+            throw new BadRequestException("expiresIn must be greater than or equal to 10");
+        }
+        if (rep.getExpiresIn() > 600) {
+            throw new BadRequestException("expiresIn must be less than or equal to 600");
+        }
+        if (rep.getInterval() < 0) {
+            throw new BadRequestException("interval must be greater than or equal to 0");
+        }
+        if (rep.getInterval() > 600) {
+            throw new BadRequestException("interval must be less than or equal to 600");
+        }
+        if (rep.getAuthRequestedUserHint() == null) {
+            throw new BadRequestException("authRequestedUserHint is required");
+        }
+        if (!rep.getAuthRequestedUserHint().equals(CibaConfig.DEFAULT_CIBA_POLICY_AUTH_REQUESTED_USER_HINT)) {
+            throw new BadRequestException("authRequestedUserHint currently only supports \"login_hint\".");
+        }
     }
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/events/AdminEventAssertion.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/events/AdminEventAssertion.java
@@ -4,14 +4,17 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.keycloak.common.util.reflections.Reflections;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.representations.idm.AdminEventRepresentation;
 import org.keycloak.representations.idm.AuthDetailsRepresentation;
+import org.keycloak.representations.idm.PasswordPolicyValueRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.util.JsonSerialization;
 
@@ -153,22 +156,44 @@ public class AdminEventAssertion {
             Assertions.assertNull(event.getRepresentation());
         } else {
             try {
-                if (expectedRep instanceof List) {
-                    // List of roles. All must be available in actual representation
-                    List<RoleRepresentation> expectedRoles = (List<RoleRepresentation>) expectedRep;
-                    List<RoleRepresentation> actualRoles = JsonSerialization.readValue(new ByteArrayInputStream(actualRepresentation.getBytes()), new TypeReference<>() {});
+                if (expectedRep instanceof List expectedList) {
+                    if (expectedList.isEmpty()) {
+                        List<Object> actualRep = JsonSerialization.readValue(new ByteArrayInputStream(actualRepresentation.getBytes()), new TypeReference<>() {});
+                        Assertions.assertEquals(actualRep.size(), 0);
+                    } else if (expectedList.get(0) instanceof RoleRepresentation) {
+                        // List of roles. All must be available in actual representation
+                        List<RoleRepresentation> expectedRoles = (List<RoleRepresentation>) expectedRep;
+                        List<RoleRepresentation> actualRoles = JsonSerialization.readValue(new ByteArrayInputStream(actualRepresentation.getBytes()), new TypeReference<>() {});
 
-                    Map<String, String> expectedRolesMap = new HashMap<>();
-                    for (RoleRepresentation role : expectedRoles) {
-                        expectedRolesMap.put(role.getId(), role.getName());
+                        Map<String, String> expectedRolesMap = new HashMap<>();
+                        for (RoleRepresentation role : expectedRoles) {
+                            expectedRolesMap.put(role.getId(), role.getName());
+                        }
+
+                        Map<String, String> actualRolesMap = new HashMap<>();
+                        for (RoleRepresentation role : actualRoles) {
+                            actualRolesMap.put(role.getId(), role.getName());
+                        }
+
+                        Assertions.assertEquals(expectedRolesMap, actualRolesMap);
+                    } else if (expectedList.get(0) instanceof PasswordPolicyValueRepresentation) {
+                        List<PasswordPolicyValueRepresentation> expectedReps = (List<PasswordPolicyValueRepresentation>) expectedList;
+                        List<PasswordPolicyValueRepresentation> actualReps = JsonSerialization.readValue(new ByteArrayInputStream(actualRepresentation.getBytes()), new TypeReference<>() {});
+
+                        Set<String> expectedSet = new HashSet<>();
+                        for (PasswordPolicyValueRepresentation rep : expectedReps) {
+                            expectedSet.add(rep.toString());
+                        }
+
+                        Set<String> actualSet = new HashSet<>();
+                        for (PasswordPolicyValueRepresentation rep : actualReps) {
+                            actualSet.add(rep.toString());
+                        }
+
+                        Assertions.assertEquals(expectedSet, actualSet);
+                    } else {
+                        Assertions.assertEquals(expectedList, actualRepresentation);
                     }
-
-                    Map<String, String> actualRolesMap = new HashMap<>();
-                    for (RoleRepresentation role : actualRoles) {
-                        actualRolesMap.put(role.getId(), role.getName());
-                    }
-                    Assertions.assertEquals(expectedRolesMap, actualRolesMap);
-
                 } else if (expectedRep instanceof Map<?, ?> expectedRepMap) {
                     Map<?, ?> actualRepMap = JsonSerialization.readValue(actualRepresentation, Map.class);
                     for (Map.Entry<?, ?> entry : expectedRepMap.entrySet()) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/AbstractPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/AbstractPolicyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.authentication;
+
+import org.keycloak.admin.client.resource.AuthenticationManagementResource;
+import org.keycloak.testframework.annotations.InjectAdminEvents;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.events.AdminEvents;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.tests.admin.AbstractPermissionsTest;
+
+import org.junit.jupiter.api.BeforeEach;
+
+public class AbstractPolicyTest extends AbstractPermissionsTest {
+
+    @InjectRealm(config = TestRealm.class, ref = "policy-test")
+    ManagedRealm managedRealm;
+    AuthenticationManagementResource authMgmtResource;
+
+    @InjectAdminEvents(realmRef = "policy-test")
+    AdminEvents adminEvents;
+
+    @BeforeEach
+    public void before() {
+        authMgmtResource = managedRealm.admin().flows();
+    }
+
+    protected static class TestRealm extends PermissionsTestRealmConfig1 {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return super.configure(realm)
+                    .adminPermissionsEnabled(true)
+                    .adminEventsEnabled(true)
+                    .adminEventsDetailsEnabled(true);
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/CibaPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/CibaPolicyTest.java
@@ -1,0 +1,289 @@
+package org.keycloak.tests.admin.authentication;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.CibaConfig;
+import org.keycloak.representations.idm.CibaPolicyRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.tests.utils.admin.AdminEventPaths;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest
+public class CibaPolicyTest extends AbstractPolicyTest {
+
+    @AfterEach
+    public void after() {
+        CibaPolicyRepresentation rep = new CibaPolicyRepresentation();
+        rep.setBackchannelTokenDeliveryMode(CibaConfig.DEFAULT_CIBA_POLICY_TOKEN_DELIVERY_MODE);
+        rep.setInterval(CibaConfig.DEFAULT_CIBA_POLICY_INTERVAL);
+        rep.setExpiresIn(CibaConfig.DEFAULT_CIBA_POLICY_EXPIRES_IN);
+        rep.setAuthRequestedUserHint(CibaConfig.DEFAULT_CIBA_POLICY_AUTH_REQUESTED_USER_HINT);
+        authMgmtResource.updateCibaPolicy(rep);
+    }
+
+    @Test
+    public void testGetCibaPolicyReturnsDefaultPolicy() {
+        CibaPolicyRepresentation result = authMgmtResource.getCibaPolicy();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(CibaConfig.DEFAULT_CIBA_POLICY_TOKEN_DELIVERY_MODE, result.getBackchannelTokenDeliveryMode());
+        Assertions.assertEquals(CibaConfig.DEFAULT_CIBA_POLICY_INTERVAL, result.getInterval());
+        Assertions.assertEquals(CibaConfig.DEFAULT_CIBA_POLICY_EXPIRES_IN, result.getExpiresIn());
+        Assertions.assertEquals(CibaConfig.DEFAULT_CIBA_POLICY_AUTH_REQUESTED_USER_HINT, result.getAuthRequestedUserHint());
+    }
+
+    @Test
+    public void testGetCibaPolicyReturnsAllFields() {
+        CibaPolicyRepresentation result = authMgmtResource.getCibaPolicy();
+
+        Assertions.assertNotNull(result.getBackchannelTokenDeliveryMode());
+        Assertions.assertNotNull(result.getExpiresIn());
+        Assertions.assertNotNull(result.getInterval());
+        Assertions.assertNotNull(result.getAuthRequestedUserHint());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyPersistsAllFields() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setBackchannelTokenDeliveryMode(CibaConfig.CIBA_SUPPORTED_MODES.get(1));
+        rep.setExpiresIn(300);
+        rep.setInterval(10);
+        authMgmtResource.updateCibaPolicy(rep);
+
+        CibaPolicyRepresentation result = authMgmtResource.getCibaPolicy();
+        Assertions.assertEquals(rep.getBackchannelTokenDeliveryMode(), result.getBackchannelTokenDeliveryMode());
+        Assertions.assertEquals(300, result.getExpiresIn());
+        Assertions.assertEquals(10, result.getInterval());
+        Assertions.assertEquals(rep.getAuthRequestedUserHint(), result.getAuthRequestedUserHint());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyAllSupportedBackchannelTokenDeliveryModes() {
+        for (String mode : CibaConfig.CIBA_SUPPORTED_MODES) {
+            CibaPolicyRepresentation rep = validCibaPolicy();
+            rep.setBackchannelTokenDeliveryMode(mode);
+            authMgmtResource.updateCibaPolicy(rep);
+
+            Assertions.assertEquals(mode,
+                    authMgmtResource.getCibaPolicy().getBackchannelTokenDeliveryMode(),
+                    "Failed for backchannelTokenDeliveryMode: " + mode);
+        }
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnUnsupportedBackchannelTokenDeliveryMode() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setBackchannelTokenDeliveryMode("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnNullBackchannelTokenDeliveryMode() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setBackchannelTokenDeliveryMode(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnEmptyBackchannelTokenDeliveryMode() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setBackchannelTokenDeliveryMode("");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyExpiresInAtLowerBoundary() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setExpiresIn(10);
+        authMgmtResource.updateCibaPolicy(rep);
+
+        Assertions.assertEquals(10, authMgmtResource.getCibaPolicy().getExpiresIn());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyExpiresInAtUpperBoundary() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setExpiresIn(600);
+        authMgmtResource.updateCibaPolicy(rep);
+
+        Assertions.assertEquals(600, authMgmtResource.getCibaPolicy().getExpiresIn());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnExpiresInBelowMinimum() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setExpiresIn(9);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnExpiresInOfZero() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setExpiresIn(0);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnNegativeExpiresIn() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setExpiresIn(-1);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnExpiresInAboveMaximum() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setExpiresIn(601);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyIntervalAtLowerBoundary() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setInterval(0);
+        authMgmtResource.updateCibaPolicy(rep);
+
+        Assertions.assertEquals(0, authMgmtResource.getCibaPolicy().getInterval());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyIntervalAtUpperBoundary() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setInterval(600);
+        authMgmtResource.updateCibaPolicy(rep);
+
+        Assertions.assertEquals(600, authMgmtResource.getCibaPolicy().getInterval());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnNegativeInterval() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setInterval(-1);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnIntervalAboveMaximum() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setInterval(601);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnUnsupportedAuthRequestedUserHint() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setAuthRequestedUserHint("id_token_hint");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnEmptyAuthRequestedUserHint() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setAuthRequestedUserHint("");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyFailsOnNullAuthRequestedUserHint() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        rep.setAuthRequestedUserHint(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateCibaPolicyOverwritesPreviousPolicy() {
+        CibaPolicyRepresentation first = validCibaPolicy();
+        first.setExpiresIn(100);
+        authMgmtResource.updateCibaPolicy(first);
+
+        CibaPolicyRepresentation second = validCibaPolicy();
+        second.setExpiresIn(200);
+        authMgmtResource.updateCibaPolicy(second);
+
+        Assertions.assertEquals(200, authMgmtResource.getCibaPolicy().getExpiresIn());
+    }
+
+    @Test
+    public void testUpdateCibaPolicyIsIdempotent() {
+        CibaPolicyRepresentation rep = validCibaPolicy();
+        authMgmtResource.updateCibaPolicy(rep);
+        authMgmtResource.updateCibaPolicy(rep);
+
+        CibaPolicyRepresentation result = authMgmtResource.getCibaPolicy();
+        Assertions.assertEquals(rep.getExpiresIn(), result.getExpiresIn());
+        Assertions.assertEquals(rep.getInterval(), result.getInterval());
+    }
+
+    @Test
+    public void testGetCibaPolicyRequiresViewRealmPermission() {
+        Assertions.assertThrows(
+                ForbiddenException.class,
+                () -> clients.get("view-users").realm(managedRealm.getId()).flows().getCibaPolicy()
+        );
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().getCibaPolicy()
+        );
+    }
+
+    @Test
+    public void testUpdateCibaPolicyRequiresManageRealmPermission() {
+        Assertions.assertThrows(
+                ForbiddenException.class,
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().updateCibaPolicy(validCibaPolicy())
+        );
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("manage-realm").realm(managedRealm.getId()).flows().updateCibaPolicy(validCibaPolicy())
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicySuccessTriggersAdminEvent() {
+        authMgmtResource.updateCibaPolicy(validCibaPolicy());
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.UPDATE)
+                .resourceType(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(AdminEventPaths.cibaPolicyPath())
+                .representation(validCibaPolicy());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailureDoesNotTriggerAdminEvent() {
+        CibaPolicyRepresentation rep = new CibaPolicyRepresentation();
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateCibaPolicy(rep)
+        );
+
+        Assertions.assertNull(adminEvents.poll());
+    }
+
+    private CibaPolicyRepresentation validCibaPolicy() {
+        CibaPolicyRepresentation rep = new CibaPolicyRepresentation();
+        rep.setBackchannelTokenDeliveryMode(CibaConfig.CIBA_SUPPORTED_MODES.get(0));
+        rep.setExpiresIn(120);
+        rep.setInterval(5);
+        rep.setAuthRequestedUserHint(CibaConfig.DEFAULT_CIBA_POLICY_AUTH_REQUESTED_USER_HINT);
+        return rep;
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/OTPPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/OTPPolicyTest.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.authentication;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.OTPPolicy;
+import org.keycloak.representations.idm.OTPPolicyRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.tests.utils.admin.AdminEventPaths;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest
+public class OTPPolicyTest extends AbstractPolicyTest {
+
+    @Test
+    public void testGetOTPPolicyReturnsAllFields() {
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertNotNull(result.getType());
+        Assertions.assertNotNull(result.getAlgorithm());
+        Assertions.assertNotNull(result.getDigits());
+        Assertions.assertNotNull(result.getPeriod());
+        Assertions.assertNotNull(result.getInitialCounter());
+        Assertions.assertNotNull(result.getLookAheadWindow());
+        Assertions.assertNotNull(result.isCodeReusable());
+    }
+
+    @Test
+    public void testGetOTPPolicyReturnsDefaultPolicy() {
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.getType(), result.getType());
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.getAlgorithm(), result.getAlgorithm());
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.getDigits(), result.getDigits());
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.getPeriod(), result.getPeriod());
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.getInitialCounter(), result.getInitialCounter());
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.getLookAheadWindow(), result.getLookAheadWindow());
+        Assertions.assertEquals(OTPPolicy.DEFAULT_POLICY.isCodeReusable(), result.isCodeReusable());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyTotpHmacSHA1With6digits() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm("HmacSHA1");
+        rep.setDigits(6);
+        authMgmtResource.updateOTPPolicy(rep);
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals("totp", result.getType());
+        Assertions.assertEquals("HmacSHA1", result.getAlgorithm());
+        Assertions.assertEquals(6, result.getDigits());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyTotpHmacSHA256With8digits() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm("HmacSHA256");
+        rep.setDigits(8);
+        authMgmtResource.updateOTPPolicy(rep);
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals("totp", result.getType());
+        Assertions.assertEquals("HmacSHA256", result.getAlgorithm());
+        Assertions.assertEquals(8, result.getDigits());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyTotpHmacSHA512() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm("HmacSHA512");
+        authMgmtResource.updateOTPPolicy(rep);
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals("HmacSHA512", result.getAlgorithm());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyHotp() {
+        OTPPolicyRepresentation rep = validHotpPolicy();
+        authMgmtResource.updateOTPPolicy(rep);
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals("hotp", result.getType());
+        Assertions.assertEquals("HmacSHA256", result.getAlgorithm());
+        Assertions.assertEquals(8, result.getDigits());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyPersistsAllFields() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setPeriod(60);
+        rep.setInitialCounter(10);
+        rep.setLookAheadWindow(5);
+        rep.setCodeReusable(true);
+        authMgmtResource.updateOTPPolicy(rep);
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals(5, result.getLookAheadWindow());
+        Assertions.assertEquals(60, result.getPeriod());
+        Assertions.assertEquals(10, result.getInitialCounter());
+        Assertions.assertTrue(result.isCodeReusable());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyOverwritesPreviousPolicy() {
+        authMgmtResource.updateOTPPolicy(validTotpPolicy());
+        authMgmtResource.updateOTPPolicy(validHotpPolicy());
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals("hotp", result.getType());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyIsIdempotent() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        authMgmtResource.updateOTPPolicy(rep);
+        authMgmtResource.updateOTPPolicy(rep);
+
+        OTPPolicyRepresentation result = authMgmtResource.getOTPPolicy();
+        Assertions.assertEquals("totp", result.getType());
+        Assertions.assertEquals("HmacSHA1", result.getAlgorithm());
+        Assertions.assertEquals(6, result.getDigits());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnUnsupportedType() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setType("unsupportedType");
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnNullType() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setType(null);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnEmptyType() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setType("");
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnCaseSensitiveType() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setType("TOTP");
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnUnsupportedAlgorithm() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm("HmacMD5");
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnNullAlgorithm() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm(null);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnEmptyAlgorithm() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm("");
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnCaseSensitiveAlgorithm() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setAlgorithm("hmacsha1");
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnUnsupportedDigits() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setDigits(7);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnZeroDigits() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setDigits(0);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnNegativeDigits() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setDigits(-1);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnMissingTotpPeriod() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setPeriod(null);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsOnMissingHotpInitialCounter() {
+        OTPPolicyRepresentation rep = validHotpPolicy();
+        rep.setInitialCounter(null);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailsWhenMultipleFieldsAreInvalid() {
+        OTPPolicyRepresentation rep = validTotpPolicy();
+        rep.setType("invalidType");
+        rep.setAlgorithm("invalidAlgorithm");
+        rep.setDigits(5);
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+    }
+
+    @Test
+    public void testGetOTPPolicyRequiresViewRealmPermission() {
+        Assertions.assertThrows(
+                ForbiddenException.class,
+                () -> clients.get("view-users").realm(managedRealm.getId()).flows().getOTPPolicy()
+        );
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().getOTPPolicy()
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicyRequiresManageRealmPermission() {
+        Assertions.assertThrows(
+                ForbiddenException.class,
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().updateOTPPolicy(validTotpPolicy())
+        );
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("manage-realm").realm(managedRealm.getId()).flows().updateOTPPolicy(validTotpPolicy())
+        );
+    }
+
+    @Test
+    public void testUpdateOTPPolicySuccessTriggersAdminEvent() {
+        authMgmtResource.updateOTPPolicy(validHotpPolicy());
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.UPDATE)
+                .resourceType(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(AdminEventPaths.otpPolicyPath())
+                .representation(validHotpPolicy());
+    }
+
+    @Test
+    public void testUpdateOTPPolicyFailureDoesNotTriggerAdminEvent() {
+        OTPPolicyRepresentation rep = new OTPPolicyRepresentation();
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateOTPPolicy(rep)
+        );
+
+        Assertions.assertNull(adminEvents.poll());
+    }
+
+    private OTPPolicyRepresentation validTotpPolicy() {
+        OTPPolicyRepresentation rep = new OTPPolicyRepresentation();
+        rep.setType("totp");
+        rep.setAlgorithm("HmacSHA1");
+        rep.setDigits(6);
+        rep.setLookAheadWindow(1);
+        rep.setPeriod(30);
+        rep.setInitialCounter(0);
+        rep.setCodeReusable(false);
+        return rep;
+    }
+
+    private OTPPolicyRepresentation validHotpPolicy() {
+        OTPPolicyRepresentation rep = new OTPPolicyRepresentation();
+        rep.setType("hotp");
+        rep.setAlgorithm("HmacSHA256");
+        rep.setDigits(8);
+        rep.setLookAheadWindow(2);
+        rep.setPeriod(60);
+        rep.setInitialCounter(1);
+        rep.setCodeReusable(true);
+        return rep;
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/PasswordPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/PasswordPolicyTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.authentication;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+
+import org.keycloak.crypto.hash.Argon2PasswordHashProviderFactory;
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.PasswordPolicy;
+import org.keycloak.policy.AgePasswordPolicyProviderFactory;
+import org.keycloak.policy.DenylistPasswordPolicyProviderFactory;
+import org.keycloak.policy.DigitsPasswordPolicyProviderFactory;
+import org.keycloak.policy.HistoryPasswordPolicyProviderFactory;
+import org.keycloak.policy.LengthPasswordPolicyProviderFactory;
+import org.keycloak.policy.LowerCasePasswordPolicyProviderFactory;
+import org.keycloak.policy.MaxAuthAgePasswordPolicyProviderFactory;
+import org.keycloak.policy.MaximumLengthPasswordPolicyProviderFactory;
+import org.keycloak.policy.NotContainsUsernamePasswordPolicyProviderFactory;
+import org.keycloak.policy.NotEmailPasswordPolicyProviderFactory;
+import org.keycloak.policy.NotUsernamePasswordPolicyProviderFactory;
+import org.keycloak.policy.RegexPatternsPasswordPolicyProviderFactory;
+import org.keycloak.policy.SpecialCharsPasswordPolicyProviderFactory;
+import org.keycloak.policy.UpperCasePasswordPolicyProviderFactory;
+import org.keycloak.representations.idm.PasswordPolicyValueRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.tests.policy.PasswordPolicyTest.PasswordPolicyServerConfig;
+import org.keycloak.tests.utils.admin.AdminEventPaths;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest(config = PasswordPolicyServerConfig.class)
+public class PasswordPolicyTest extends AbstractPolicyTest {
+
+    @AfterEach
+    public void after() {
+        authMgmtResource.updatePasswordPolicy(List.of());
+        adminEvents.clear();
+    }
+
+    @Test
+    public void testGetPasswordPolicyEmptyByDefault() {
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(0, result.size(), result.toString());
+    }
+
+    @Test
+    public void testUpdatePasswordPolicy() {
+        authMgmtResource.updatePasswordPolicy(List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE,
+                        AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS)));
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(PasswordPolicy.PASSWORD_AGE, result.get(0).getId());
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyOverwritesExistingPolicy() {
+        authMgmtResource.updatePasswordPolicy(List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE,
+                        AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS)
+        ));
+
+        // Overwrite with a completely different policy
+        authMgmtResource.updatePasswordPolicy(List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.FORCE_EXPIRED_ID, 365)
+        ));
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(PasswordPolicy.FORCE_EXPIRED_ID, result.get(0).getId());
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyWithEmptyListClearsPolicy() {
+        authMgmtResource.updatePasswordPolicy(List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE,
+                        AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS)));
+
+        authMgmtResource.updatePasswordPolicy(List.of());
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyWithAllSupportedPolicies() {
+        List<PasswordPolicyValueRepresentation> allOptions = Arrays.asList(
+                new PasswordPolicyValueRepresentation(DigitsPasswordPolicyProviderFactory.ID, 1),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.FORCE_EXPIRED_ID, 365),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.HASH_ALGORITHM_ID, Argon2PasswordHashProviderFactory.ID),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.HASH_ITERATIONS_ID, 10),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_HISTORY_ID, HistoryPasswordPolicyProviderFactory.DEFAULT_VALUE),
+                new PasswordPolicyValueRepresentation(LengthPasswordPolicyProviderFactory.ID, 8),
+                new PasswordPolicyValueRepresentation(LowerCasePasswordPolicyProviderFactory.ID, 1),
+                new PasswordPolicyValueRepresentation(MaximumLengthPasswordPolicyProviderFactory.ID, MaximumLengthPasswordPolicyProviderFactory.DEFAULT_MAX_LENGTH),
+                new PasswordPolicyValueRepresentation(NotUsernamePasswordPolicyProviderFactory.ID, null),
+                new PasswordPolicyValueRepresentation(NotContainsUsernamePasswordPolicyProviderFactory.ID, null),
+                new PasswordPolicyValueRepresentation(RegexPatternsPasswordPolicyProviderFactory.ID, "password"),
+                new PasswordPolicyValueRepresentation(SpecialCharsPasswordPolicyProviderFactory.ID, 1),
+                new PasswordPolicyValueRepresentation(UpperCasePasswordPolicyProviderFactory.ID, 1),
+                new PasswordPolicyValueRepresentation(DenylistPasswordPolicyProviderFactory.ID, "test-password-blacklist.txt"),
+                new PasswordPolicyValueRepresentation(NotEmailPasswordPolicyProviderFactory.ID, null),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.RECOVERY_CODES_WARNING_THRESHOLD_ID, 4),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.MAX_AUTH_AGE_ID, MaxAuthAgePasswordPolicyProviderFactory.DEFAULT_MAX_AUTH_AGE),
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE, AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS)
+        );
+
+        authMgmtResource.updatePasswordPolicy(allOptions);
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(allOptions.size(), result.size());
+
+        Set<String> resultIds = result.stream()
+                .map(PasswordPolicyValueRepresentation::getId)
+                .collect(Collectors.toSet());
+        allOptions.forEach(opt -> Assertions.assertTrue(
+                resultIds.contains(opt.getId()),
+                "Missing policy: " + opt.getId()
+        ));
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsOnUnknownPolicyType() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation("nonExistentPolicy", 365)
+                ))
+        );
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsOnMultipleUnknownPolicyTypes() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(Arrays.asList(
+                        new PasswordPolicyValueRepresentation("unknown1", 1),
+                        new PasswordPolicyValueRepresentation("unknown2", 2))));
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsWhenMixedValidAndInvalidEntries() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(Arrays.asList(
+                        new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE,
+                                AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS),
+                        new PasswordPolicyValueRepresentation("invalidPolicy", 999)
+                ))
+        );
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsWhenIntPolicyReceivesString() {
+        // FORCE_EXPIRED_ID expects an Integer
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation(PasswordPolicy.FORCE_EXPIRED_ID, "year")
+                ))
+        );
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsWhenIntPolicyReceivesNull() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation(PasswordPolicy.FORCE_EXPIRED_ID, null)
+                ))
+        );
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsWhenIntPolicyReceivesBoolean() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation(PasswordPolicy.HASH_ITERATIONS_ID, true))));
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsWhenStringPolicyReceivesInteger() {
+        // HASH_ALGORITHM_ID expects a String
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation(PasswordPolicy.HASH_ALGORITHM_ID, 123)
+                ))
+        );
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailsWhenStringPolicyReceivesNull() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation(PasswordPolicy.HASH_ALGORITHM_ID, null))));
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyAcceptsNullValueForOnOffPolicies() {
+        authMgmtResource.updatePasswordPolicy(List.of(
+                new PasswordPolicyValueRepresentation(NotUsernamePasswordPolicyProviderFactory.ID, null)));
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(NotUsernamePasswordPolicyProviderFactory.ID, result.get(0).getId());
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyAcceptsIntegerParsableStringsInIntPolicies() {
+        authMgmtResource.updatePasswordPolicy(List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.FORCE_EXPIRED_ID, "365")));
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(PasswordPolicy.FORCE_EXPIRED_ID, result.get(0).getId());
+        Assertions.assertEquals(365, result.get(0).getValue());
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyApplyingSamePolicyTwiceIsIdempotent() {
+        List<PasswordPolicyValueRepresentation> policy = List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE,
+                        AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS)
+        );
+
+        authMgmtResource.updatePasswordPolicy(policy);
+        authMgmtResource.updatePasswordPolicy(policy);
+
+        List<PasswordPolicyValueRepresentation> result = authMgmtResource.getPasswordPolicy();
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertEquals(PasswordPolicy.PASSWORD_AGE, result.get(0).getId());
+    }
+
+    @Test
+    public void testGetPasswordPolicyRequiresViewRealmPermission() {
+        Assertions.assertThrows(
+                ForbiddenException.class,
+                () -> clients.get("view-users").realm(managedRealm.getId()).flows().getPasswordPolicy()
+        );
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().getPasswordPolicy()
+        );
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyRequiresManageRealmPermission() {
+        Assertions.assertThrows(
+                ForbiddenException.class,
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().updatePasswordPolicy(List.of()));
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("manage-realm").realm(managedRealm.getId()).flows().updatePasswordPolicy(List.of()));
+    }
+
+    @Test
+    public void testUpdatePasswordPolicySuccessTriggersAdminEvent() {
+        List<PasswordPolicyValueRepresentation> policies = List.of(
+                new PasswordPolicyValueRepresentation(PasswordPolicy.PASSWORD_AGE,
+                        AgePasswordPolicyProviderFactory.DEFAULT_AGE_DAYS));
+
+        authMgmtResource.updatePasswordPolicy(policies);
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.UPDATE)
+                .resourceType(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(AdminEventPaths.passwordPolicyPath())
+                .representation(policies);
+    }
+
+    @Test
+    public void testUpdatePasswordPolicyFailureDoesNotTriggerAdminEvent() {
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updatePasswordPolicy(List.of(
+                        new PasswordPolicyValueRepresentation("nonExistentPolicy", 365)
+                ))
+        );
+
+        Assertions.assertNull(adminEvents.poll());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/WebAuthnPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/WebAuthnPolicyTest.java
@@ -1,0 +1,727 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin.authentication;
+
+import java.util.List;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
+
+import org.keycloak.events.admin.OperationType;
+import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.Constants;
+import org.keycloak.representations.idm.WebAuthnPolicyRepresentation;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.tests.utils.admin.AdminEventPaths;
+
+import com.webauthn4j.data.AttestationConveyancePreference;
+import com.webauthn4j.data.AuthenticatorAttachment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest
+public class WebAuthnPolicyTest extends AbstractPolicyTest {
+
+    @AfterEach
+    public void after() {
+        authMgmtResource.updateWebAuthnPolicy(validWebAuthnPolicy());
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(validPasswordlessPolicy());
+    }
+
+    @Test
+    public void testGetWebAuthnPolicyReturnsDefaultPolicy() {
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPolicy();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("keycloak", result.getRpEntityName());
+        Assertions.assertEquals(List.of("ES256"), result.getSignatureAlgorithms());
+    }
+
+    @Test
+    public void testGetWebAuthnPasswordlessPolicyReturnsDefaultPolicy() {
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPasswordlessPolicy();
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("keycloak", result.getRpEntityName());
+        Assertions.assertEquals(List.of("ES256"), result.getSignatureAlgorithms());
+    }
+
+    @Test
+    public void testGetWebAuthnPolicyReturnsAllBaseFields() {
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPolicy();
+
+        Assertions.assertNotNull(result.getRpEntityName());
+        Assertions.assertNotNull(result.getSignatureAlgorithms());
+        Assertions.assertNotNull(result.getRpId());
+        Assertions.assertNotNull(result.getAttestationConveyancePreference());
+        Assertions.assertNotNull(result.getAuthenticatorAttachment());
+        Assertions.assertNotNull(result.getRequireResidentKey());
+        Assertions.assertNotNull(result.getUserVerificationRequirement());
+        Assertions.assertNotNull(result.getCreateTimeout());
+        Assertions.assertNotNull(result.getAvoidSameAuthenticatorRegister());
+        Assertions.assertNotNull(result.getAcceptableAaguids());
+        Assertions.assertNotNull(result.getExtraOrigins());
+    }
+
+    @Test
+    public void testGetWebAuthnPolicyDoesNotExposePasswordlessFields() {
+        // passkeys/mediation are passwordless-only; must not leak into this endpoint
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPolicy();
+
+        Assertions.assertNull(result.getPasskeysEnabled());
+        Assertions.assertNull(result.getMediation());
+    }
+
+    @Test
+    public void testGetWebAuthnPasswordlessPolicyReturnsPasswordlessExclusiveFields() {
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPasswordlessPolicy();
+        Assertions.assertNotNull(result.getPasskeysEnabled());
+
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicyWithPasskeys();
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+        Assertions.assertNotNull(authMgmtResource.getWebAuthnPasswordlessPolicy().getMediation());
+    }
+
+    @Test
+    public void testGetWebAuthnPasswordlessPolicyIsIsolatedFromWebAuthnPolicy() {
+        WebAuthnPolicyRepresentation webauthn = validWebAuthnPolicy();
+        webauthn.setRpEntityName("webauthn-app");
+        authMgmtResource.updateWebAuthnPolicy(webauthn);
+
+        WebAuthnPolicyRepresentation passwordless = validPasswordlessPolicy();
+        passwordless.setRpEntityName("passwordless-app");
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(passwordless);
+
+        Assertions.assertEquals("webauthn-app",
+                authMgmtResource.getWebAuthnPolicy().getRpEntityName());
+        Assertions.assertEquals("passwordless-app",
+                authMgmtResource.getWebAuthnPasswordlessPolicy().getRpEntityName());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyPersistsAllFields() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setRpEntityName("myapp");
+        rep.setSignatureAlgorithms(List.of("ES256", "RS256"));
+        rep.setRpId("myapp.example.com");
+        rep.setAttestationConveyancePreference(AttestationConveyancePreference.DIRECT.toString());
+        rep.setAuthenticatorAttachment(AuthenticatorAttachment.PLATFORM.toString());
+        rep.setRequireResidentKey(Constants.WEBAUTHN_POLICY_OPTION_YES);
+        rep.setUserVerificationRequirement(Constants.WEBAUTHN_POLICY_OPTION_REQUIRED);
+        rep.setCreateTimeout(60);
+        rep.setAvoidSameAuthenticatorRegister(true);
+        rep.setAcceptableAaguids(List.of("aaguid-1", "aaguid-2"));
+        rep.setExtraOrigins(List.of("https://extra.example.com"));
+        authMgmtResource.updateWebAuthnPolicy(rep);
+
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPolicy();
+        Assertions.assertEquals("myapp", result.getRpEntityName());
+        Assertions.assertEquals(List.of("ES256", "RS256"), result.getSignatureAlgorithms());
+        Assertions.assertEquals("myapp.example.com", result.getRpId());
+        Assertions.assertEquals(AttestationConveyancePreference.DIRECT.toString(), result.getAttestationConveyancePreference());
+        Assertions.assertEquals(AuthenticatorAttachment.PLATFORM.toString(), result.getAuthenticatorAttachment());
+        Assertions.assertEquals(Constants.WEBAUTHN_POLICY_OPTION_YES, result.getRequireResidentKey());
+        Assertions.assertEquals(Constants.WEBAUTHN_POLICY_OPTION_REQUIRED, result.getUserVerificationRequirement());
+        Assertions.assertEquals(60, result.getCreateTimeout());
+        Assertions.assertTrue(result.getAvoidSameAuthenticatorRegister());
+        Assertions.assertEquals(List.of("aaguid-1", "aaguid-2"), result.getAcceptableAaguids());
+        Assertions.assertEquals(List.of("https://extra.example.com"), result.getExtraOrigins());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyPersistsAllFields() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setRpEntityName("passwordless-app");
+        rep.setSignatureAlgorithms(List.of("ES256", "RS256"));
+        rep.setRpId("passwordless.example.com");
+        rep.setAttestationConveyancePreference(AttestationConveyancePreference.INDIRECT.toString());
+        rep.setAuthenticatorAttachment(AuthenticatorAttachment.CROSS_PLATFORM.toString());
+        rep.setRequireResidentKey(Constants.WEBAUTHN_POLICY_OPTION_NO);
+        rep.setUserVerificationRequirement(Constants.WEBAUTHN_POLICY_OPTION_PREFERED);
+        rep.setCreateTimeout(120);
+        rep.setAvoidSameAuthenticatorRegister(true);
+        rep.setAcceptableAaguids(List.of("aaguid-A", "aaguid-B"));
+        rep.setExtraOrigins(List.of("https://extra.example.com"));
+        rep.setPasskeysEnabled(true);
+        rep.setMediation("required");
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+
+        WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPasswordlessPolicy();
+        Assertions.assertEquals("passwordless-app", result.getRpEntityName());
+        Assertions.assertEquals(List.of("ES256", "RS256"), result.getSignatureAlgorithms());
+        Assertions.assertEquals("passwordless.example.com", result.getRpId());
+        Assertions.assertEquals(AttestationConveyancePreference.INDIRECT.toString(), result.getAttestationConveyancePreference());
+        Assertions.assertEquals(AuthenticatorAttachment.CROSS_PLATFORM.toString(), result.getAuthenticatorAttachment());
+        Assertions.assertEquals(Constants.WEBAUTHN_POLICY_OPTION_NO, result.getRequireResidentKey());
+        Assertions.assertEquals(Constants.WEBAUTHN_POLICY_OPTION_PREFERED, result.getUserVerificationRequirement());
+        Assertions.assertEquals(120, result.getCreateTimeout());
+        Assertions.assertTrue(result.getAvoidSameAuthenticatorRegister());
+        Assertions.assertEquals(List.of("aaguid-A", "aaguid-B"), result.getAcceptableAaguids());
+        Assertions.assertEquals(List.of("https://extra.example.com"), result.getExtraOrigins());
+        Assertions.assertEquals(true, result.getPasskeysEnabled());
+        Assertions.assertEquals("required", result.getMediation());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyPersistsPasskeysDisabled() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setPasskeysEnabled(false);
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+        Assertions.assertFalse(
+                authMgmtResource.getWebAuthnPasswordlessPolicy().getPasskeysEnabled());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnBlankRpEntityName() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setRpEntityName("");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnBlankRpEntityName() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setRpEntityName("");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnWhitespaceOnlyRpEntityName() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setRpEntityName("   ");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnWhitespaceOnlyRpEntityName() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setRpEntityName("   ");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnEmptySignatureAlgorithms() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setSignatureAlgorithms(List.of());
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnEmptySignatureAlgorithms() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setSignatureAlgorithms(List.of());
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnUnsupportedSignatureAlgorithms() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setSignatureAlgorithms(List.of("unsupported"));
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnUnsupportedSignatureAlgorithms() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setSignatureAlgorithms(List.of("unsupported"));
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyAllAttestationConveyancePreferences() {
+        List<String> preferences = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                AttestationConveyancePreference.NONE.toString(),
+                AttestationConveyancePreference.INDIRECT.toString(),
+                AttestationConveyancePreference.DIRECT.toString());
+        for (String pref : preferences) {
+            WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+            rep.setAttestationConveyancePreference(pref);
+            authMgmtResource.updateWebAuthnPolicy(rep);
+            Assertions.assertEquals(pref,
+                    authMgmtResource.getWebAuthnPolicy().getAttestationConveyancePreference(),
+                    "Failed for attestation preference: " + pref);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyAllAttestationConveyancePreferences() {
+        List<String> preferences = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                AttestationConveyancePreference.NONE.toString(),
+                AttestationConveyancePreference.INDIRECT.toString(),
+                AttestationConveyancePreference.DIRECT.toString());
+        for (String pref : preferences) {
+            WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+            rep.setAttestationConveyancePreference(pref);
+            authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+            Assertions.assertEquals(pref,
+                    authMgmtResource.getWebAuthnPasswordlessPolicy().getAttestationConveyancePreference(),
+                    "Failed for attestation preference: " + pref);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnNullAttestationConveyancePreference() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setAttestationConveyancePreference(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnNullAttestationConveyancePreference() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setAttestationConveyancePreference(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnUnsupportedAttestationConveyancePreference() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setAttestationConveyancePreference("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnUnsupportedAttestationConveyancePreference() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setAttestationConveyancePreference("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyAllRequireResidentKeyOptions() {
+        List<String> preferences = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                Constants.WEBAUTHN_POLICY_OPTION_YES,
+                Constants.WEBAUTHN_POLICY_OPTION_NO);
+        for (String option : preferences) {
+            WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+            rep.setRequireResidentKey(option);
+            authMgmtResource.updateWebAuthnPolicy(rep);
+            Assertions.assertEquals(option,
+                    authMgmtResource.getWebAuthnPolicy().getRequireResidentKey(),
+                    "Failed for requireResidentKey: " + option);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyAllRequireResidentKeyOptions() {
+        List<String> preferences = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                Constants.WEBAUTHN_POLICY_OPTION_YES,
+                Constants.WEBAUTHN_POLICY_OPTION_NO);
+        for (String option : preferences) {
+            WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+            rep.setRequireResidentKey(option);
+            authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+            Assertions.assertEquals(option,
+                    authMgmtResource.getWebAuthnPasswordlessPolicy().getRequireResidentKey(),
+                    "Failed for requireResidentKey: " + option);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnNullRequireResidentKey() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setRequireResidentKey(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnNullRequireResidentKey() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setRequireResidentKey(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnUnsupportedRequireResidentKey() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setRequireResidentKey("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnUnsupportedRequireResidentKey() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setRequireResidentKey("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyAllAuthenticatorAttachmentOptions() {
+        List<String> options = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                AuthenticatorAttachment.PLATFORM.toString(),
+                AuthenticatorAttachment.CROSS_PLATFORM.toString());
+        for (String attachment : options) {
+            WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+            rep.setAuthenticatorAttachment(attachment);
+            authMgmtResource.updateWebAuthnPolicy(rep);
+            Assertions.assertEquals(attachment,
+                    authMgmtResource.getWebAuthnPolicy().getAuthenticatorAttachment(),
+                    "Failed for authenticatorAttachment: " + attachment);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyAllAuthenticatorAttachmentOptions() {
+        List<String> options = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                AuthenticatorAttachment.PLATFORM.toString(),
+                AuthenticatorAttachment.CROSS_PLATFORM.toString());
+        for (String attachment : options) {
+            WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+            rep.setAuthenticatorAttachment(attachment);
+            authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+            Assertions.assertEquals(attachment,
+                    authMgmtResource.getWebAuthnPasswordlessPolicy().getAuthenticatorAttachment(),
+                    "Failed for authenticatorAttachment: " + attachment);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnNullAuthenticatorAttachment() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setAuthenticatorAttachment(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnNullAuthenticatorAttachment() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setAuthenticatorAttachment(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnUnsupportedAuthenticatorAttachment() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setAuthenticatorAttachment("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnUnsupportedAuthenticatorAttachment() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setAuthenticatorAttachment("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyAllUserVerificationRequirements() {
+        List<String> options = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                Constants.WEBAUTHN_POLICY_OPTION_REQUIRED,
+                Constants.WEBAUTHN_POLICY_OPTION_PREFERED,
+                Constants.WEBAUTHN_POLICY_OPTION_DISCOURAGED);
+        for (String requirement : options) {
+            WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+            rep.setUserVerificationRequirement(requirement);
+            authMgmtResource.updateWebAuthnPolicy(rep);
+            Assertions.assertEquals(requirement,
+                    authMgmtResource.getWebAuthnPolicy().getUserVerificationRequirement(),
+                    "Failed for userVerificationRequirement: " + requirement);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyAllUserVerificationRequirements() {
+        List<String> options = List.of(
+                Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED,
+                Constants.WEBAUTHN_POLICY_OPTION_REQUIRED,
+                Constants.WEBAUTHN_POLICY_OPTION_PREFERED,
+                Constants.WEBAUTHN_POLICY_OPTION_DISCOURAGED);
+        for (String requirement : options) {
+            WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+            rep.setUserVerificationRequirement(requirement);
+            authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+            Assertions.assertEquals(requirement,
+                    authMgmtResource.getWebAuthnPasswordlessPolicy().getUserVerificationRequirement(),
+                    "Failed for userVerificationRequirement: " + requirement);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnNullUserVerificationRequirement() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setUserVerificationRequirement(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnNullUserVerificationRequirement() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setUserVerificationRequirement(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailsOnUnsupportedUserVerificationRequirement() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setUserVerificationRequirement("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnUnsupportedUserVerificationRequirement() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setUserVerificationRequirement("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyAllValidMediationValuesWithPasskeysEnabled() {
+        for (String mediation : List.of("conditional", "none", "optional", "required", "silent")) {
+            WebAuthnPolicyRepresentation rep = validPasswordlessPolicyWithPasskeys();
+            rep.setMediation(mediation);
+            authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+
+            WebAuthnPolicyRepresentation result = authMgmtResource.getWebAuthnPasswordlessPolicy();
+            Assertions.assertTrue(result.getPasskeysEnabled(),
+                    "passkeysEnabled should be true for mediation: " + mediation);
+            Assertions.assertEquals(mediation, result.getMediation(),
+                    "Mediation mismatch for: " + mediation);
+        }
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnNullMediationWhenPasskeysEnabled() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicyWithPasskeys();
+        rep.setMediation(null);
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailsOnUnsupportedMediationWhenPasskeysEnabled() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicyWithPasskeys();
+        rep.setMediation("unsupported");
+        Assertions.assertThrows(BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyMediationNotValidatedWhenPasskeysDisabled() {
+        // Validation gate is skipped entirely when passkeysEnabled == false
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setPasskeysEnabled(false);
+        rep.setMediation("unsupported");
+        Assertions.assertDoesNotThrow(
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyMediationNotValidatedWhenPasskeysNull() {
+        // Validation gate is also skipped when passkeysEnabled == null
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        rep.setPasskeysEnabled(null);
+        rep.setMediation("unsupported");
+        Assertions.assertDoesNotThrow(
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep));
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyOverwritesPreviousPolicy() {
+        WebAuthnPolicyRepresentation first = validWebAuthnPolicy();
+        first.setRpEntityName("first-app");
+        authMgmtResource.updateWebAuthnPolicy(first);
+
+        WebAuthnPolicyRepresentation second = validWebAuthnPolicy();
+        second.setRpEntityName("second-app");
+        authMgmtResource.updateWebAuthnPolicy(second);
+
+        Assertions.assertEquals("second-app",
+                authMgmtResource.getWebAuthnPolicy().getRpEntityName());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyOverwritesPreviousPolicy() {
+        WebAuthnPolicyRepresentation first = validPasswordlessPolicy();
+        first.setRpEntityName("first-passwordless");
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(first);
+
+        WebAuthnPolicyRepresentation second = validPasswordlessPolicy();
+        second.setRpEntityName("second-passwordless");
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(second);
+
+        Assertions.assertEquals("second-passwordless",
+                authMgmtResource.getWebAuthnPasswordlessPolicy().getRpEntityName());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyIsIdempotent() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        authMgmtResource.updateWebAuthnPolicy(rep);
+        authMgmtResource.updateWebAuthnPolicy(rep);
+
+        Assertions.assertEquals(rep.getRpEntityName(),
+                authMgmtResource.getWebAuthnPolicy().getRpEntityName());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyIsIdempotent() {
+        WebAuthnPolicyRepresentation rep = validPasswordlessPolicy();
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(rep);
+
+        Assertions.assertEquals(rep.getRpEntityName(),
+                authMgmtResource.getWebAuthnPasswordlessPolicy().getRpEntityName());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyRequiresViewRealmPermission() {
+        Assertions.assertThrows(ForbiddenException.class,
+                () -> clients.get("view-users").realm(managedRealm.getId()).flows().getWebAuthnPolicy());
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().getWebAuthnPolicy()
+        );
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyRequiresViewRealmPermission() {
+        Assertions.assertThrows(ForbiddenException.class,
+                () -> clients.get("view-users").realm(managedRealm.getId()).flows().getWebAuthnPasswordlessPolicy());
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().getWebAuthnPasswordlessPolicy()
+        );
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyRequiresManageRealmPermission() {
+        Assertions.assertThrows(ForbiddenException.class,
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().updateWebAuthnPolicy(validWebAuthnPolicy()));
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("manage-realm").realm(managedRealm.getId()).flows()
+                        .updateWebAuthnPolicy(validWebAuthnPolicy())
+        );
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyRequiresManageRealmPermission() {
+        Assertions.assertThrows(ForbiddenException.class,
+                () -> clients.get("view-realm").realm(managedRealm.getId()).flows().updateWebAuthnPasswordlessPolicy(validPasswordlessPolicy()));
+        Assertions.assertDoesNotThrow(
+                () -> clients.get("manage-realm").realm(managedRealm.getId()).flows()
+                        .updateWebAuthnPasswordlessPolicy(validPasswordlessPolicy())
+        );
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicySuccessTriggersAdminEvent() {
+        authMgmtResource.updateWebAuthnPolicy(validWebAuthnPolicy());
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.UPDATE)
+                .resourceType(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(AdminEventPaths.webAuthnPolicyPath())
+                .representation(validWebAuthnPolicy());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicySuccessTriggersAdminEvent() {
+        authMgmtResource.updateWebAuthnPasswordlessPolicy(validPasswordlessPolicy());
+
+        AdminEventAssertion.assertSuccess(adminEvents.poll())
+                .operationType(OperationType.UPDATE)
+                .resourceType(ResourceType.AUTHENTICATION_POLICY)
+                .resourcePath(AdminEventPaths.webAuthnPasswordlessPolicyPath())
+                .representation(validPasswordlessPolicy());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPolicyFailureDoesNotTriggerAdminEvent() {
+        WebAuthnPolicyRepresentation rep = new WebAuthnPolicyRepresentation();
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPolicy(rep)
+        );
+
+        Assertions.assertNull(adminEvents.poll());
+    }
+
+    @Test
+    public void testUpdateWebAuthnPasswordlessPolicyFailureDoesNotTriggerAdminEvent() {
+        WebAuthnPolicyRepresentation rep = new WebAuthnPolicyRepresentation();
+
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> authMgmtResource.updateWebAuthnPasswordlessPolicy(rep)
+        );
+
+        Assertions.assertNull(adminEvents.poll());
+    }
+
+    private WebAuthnPolicyRepresentation validWebAuthnPolicy() {
+        WebAuthnPolicyRepresentation rep = new WebAuthnPolicyRepresentation();
+        rep.setRpEntityName("keycloak");
+        rep.setSignatureAlgorithms(List.of("ES256"));
+        rep.setRpId("");
+        rep.setAttestationConveyancePreference(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED);
+        rep.setAuthenticatorAttachment(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED);
+        rep.setRequireResidentKey(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED);
+        rep.setUserVerificationRequirement(Constants.DEFAULT_WEBAUTHN_POLICY_NOT_SPECIFIED);
+        rep.setCreateTimeout(0);
+        rep.setAvoidSameAuthenticatorRegister(false);
+        rep.setAcceptableAaguids(List.of());
+        rep.setExtraOrigins(List.of());
+        return rep;
+    }
+
+    private WebAuthnPolicyRepresentation validPasswordlessPolicy() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setPasskeysEnabled(false);
+        rep.setMediation(null);
+        return rep;
+    }
+
+    private WebAuthnPolicyRepresentation validPasswordlessPolicyWithPasskeys() {
+        WebAuthnPolicyRepresentation rep = validWebAuthnPolicy();
+        rep.setPasskeysEnabled(true);
+        rep.setMediation("conditional");
+        return rep;
+    }
+}

--- a/tests/utils/src/main/java/org/keycloak/tests/utils/admin/AdminEventPaths.java
+++ b/tests/utils/src/main/java/org/keycloak/tests/utils/admin/AdminEventPaths.java
@@ -489,6 +489,36 @@ public class AdminEventPaths {
         return uri.toString();
     }
 
+    public static String passwordPolicyPath() {
+        URI uri = UriBuilder.fromUri(authMgmtBasePath()).path(AuthenticationManagementResource.class, "updatePasswordPolicy")
+                .build();
+        return uri.toString();
+    }
+
+    public static String otpPolicyPath() {
+        URI uri = UriBuilder.fromUri(authMgmtBasePath()).path(AuthenticationManagementResource.class, "updateOTPPolicy")
+                .build();
+        return uri.toString();
+    }
+
+    public static String webAuthnPolicyPath() {
+        URI uri = UriBuilder.fromUri(authMgmtBasePath()).path(AuthenticationManagementResource.class, "updateWebAuthnPolicy")
+                .build();
+        return uri.toString();
+    }
+
+    public static String webAuthnPasswordlessPolicyPath() {
+        URI uri = UriBuilder.fromUri(authMgmtBasePath()).path(AuthenticationManagementResource.class, "updateWebAuthnPasswordlessPolicy")
+                .build();
+        return uri.toString();
+    }
+
+    public static String cibaPolicyPath() {
+        URI uri = UriBuilder.fromUri(authMgmtBasePath()).path(AuthenticationManagementResource.class, "updateCibaPolicy")
+                .build();
+        return uri.toString();
+    }
+
     // ATTACK DETECTION
 
     public static String attackDetectionClearBruteForceForUserPath(String username) {


### PR DESCRIPTION
Closes #46741

## Summary

This PR introduces new resources to read and update realm authentication policies, specifically `Password`, `OTP`, `WebAuthn`, `WebAuthn Passwordless` and `Ciba`, programmatically.

## Scope

This PR introduces new REST endpoints under `/admin/realm/{realmName}/authentication/policies/{policy}` in the Authentication Management resource, providing structured read/update access to realm authentication policies that were previously only configurable through the broader realm representation.

## What’s changed?

### New Endpoints

- `GET/PUT policies/password-policy` — read and update the realm's password policy as a typed list of `PasswordPolicyValueRepresentation` (named after the existing `PasswordPolicyTypeRepresentation`), replacing the opaque string-based policy format with a structured, validated API.
- `GET/PUT policies/otp-policy` — read and update the OTP policy (TOTP/HOTP), including type, algorithm, digits, period, and code reusability settings.
- `GET/PUT policies/webauthn-policy` — read and update the standard WebAuthn policy, covering RP entity name, signature algorithms, authenticator attachment, attestation conveyance, and resident key requirements.
- `GET/PUT policies/webauthn-passwordless-policy` — read and update the WebAuthn passwordless policy, which extends the standard WebAuthn policy with passkeys support and mediation configuration.
- `GET/PUT policies/ciba-policy` — read and update the CIBA policy, including backchannel token delivery mode, expiry, polling interval, and user hint configuration.

### Validation
- All PUT endpoints perform server-side validation and return 400 Bad Request on unsupported values, out-of-range numerics, or type mismatches, with descriptive error messages.

### Authorization

- `GET` requests require `view-realm` permission.
- `PUT` requests require `manage-realm` permission.

`403 Forbidden` response is generated if proper authorization is missing.

### Audit
- Admin Events now has a new resource type to capture the changes in authentication policies: `ResourceType.AUTHENTICATION_POLICY`. 
- Successful `PUT` requests generate an event that can be viewed under “Admin Events” in the dashboard when Admin Events are enabled.

### User Interface
Policies tabs, under Authentication page in Realm settings, are now using the new resources to load and update the policies. 
They are no longer concatenating the changed polices with `RealmRepresentation` and call `PUT /admin/realm/{realmName}`.

### Testing
- Integration tests are added for all five endpoint pairs, covering happy-path persistence, field-level validation, boundary conditions, idempotency, policy isolation, and authorization (view vs. manage realm permissions).
- UI changes has been verified to work as expected through browser tests (and manual tests).


## Out of scope
It’s still possible to update these policies using the old `PUT /realm/{realm}` API resource. This is solely to maintain the ability to export/import realms with the same policy configurations. Changing/Removing this behavior is out of scope for this PR.
