### PR TITLE
fix: enforce user profile attribute permissions on group and organization members endpoints

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -31,6 +31,13 @@ Additionally, some methods where updated for consistency across the builders:
 The alias of an Identity Provider can no longer be changed after creation via the Admin REST API. Attempts to update the alias will result in a `400 Bad Request` error.
 Previously, although the admin console UI already treated the alias as read-only, the REST API still allowed alias changes.
 
+=== User profile metadata no longer returned on user search
+
+When searching for users using the Admin REST API, the user profile metadata is no longer included for each user in the search results.
+
+This change was made to improve performance of user search operations, as fetching user profile metadata for each user can be resource-intensive.
+The user profile metadata can still be retrieved when fetching a specific user by their identifier.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 

--- a/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/BruteForceUsersResource.java
+++ b/rest/admin-ui-ext/src/main/java/org/keycloak/admin/ui/rest/BruteForceUsersResource.java
@@ -27,9 +27,6 @@ import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.UserPermissionEvaluator;
-import org.keycloak.userprofile.UserProfile;
-import org.keycloak.userprofile.UserProfileContext;
-import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.utils.SearchQueryUtils;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -91,6 +88,8 @@ public class BruteForceUsersResource {
                 : SearchQueryUtils.getFields(searchQuery);
 
         Stream<UserModel> userModels = Stream.empty();
+        boolean briefRep = Boolean.TRUE.equals(briefRepresentation);
+
         if (search != null) {
             SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
             if (prefix != null) {
@@ -103,7 +102,7 @@ public class BruteForceUsersResource {
                 if (enabled != null) {
                     attributes.put(UserModel.ENABLED, enabled.toString());
                 }
-                return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
+                return searchForUser(attributes, realm, userPermissionEvaluator, briefRep, firstResult,
                         maxResults, false);
             }
         } else if (last != null || first != null || email != null || username != null || emailVerified != null
@@ -139,18 +138,18 @@ public class BruteForceUsersResource {
 
             attributes.putAll(searchAttributes);
 
-            return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
+            return searchForUser(attributes, realm, userPermissionEvaluator, briefRep, firstResult,
                     maxResults, true);
         } else {
-            return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
+            return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRep,
                     firstResult, maxResults, false);
         }
 
-        return toRepresentation(realm, userPermissionEvaluator, briefRepresentation, userModels);
+        return toRepresentation(realm, userPermissionEvaluator, briefRep, userModels);
 
     }
 
-    private Stream<BruteUser> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {
+    private Stream<BruteUser> searchForUser(Map<String, String> attributes, RealmModel realm, UserPermissionEvaluator usersEvaluator, boolean briefRep, Integer firstResult, Integer maxResults, Boolean includeServiceAccounts) {
         attributes.put(UserModel.INCLUDE_SERVICE_ACCOUNT, includeServiceAccounts.toString());
 
         if (Profile.isFeatureEnabled(Profile.Feature.ADMIN_FINE_GRAINED_AUTHZ)) {
@@ -160,27 +159,19 @@ public class BruteForceUsersResource {
             }
         }
 
-        return toRepresentation(realm, usersEvaluator, briefRepresentation, session.users().searchForUserStream(realm, attributes, firstResult, maxResults));
+        return toRepresentation(realm, usersEvaluator, briefRep, session.users().searchForUserStream(realm, attributes, firstResult, maxResults));
     }
 
     private Stream<BruteUser> toRepresentation(RealmModel realm, UserPermissionEvaluator usersEvaluator,
-            Boolean briefRepresentation, Stream<UserModel> userModels) {
-        boolean briefRepresentationB = briefRepresentation != null && briefRepresentation;
-
+            boolean briefRep, Stream<UserModel> userModels) {
         if (!AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
             usersEvaluator.grantIfNoPermission(session.getAttribute(UserModel.GROUPS) != null);
             userModels = userModels.filter(usersEvaluator::canView);
             usersEvaluator.grantIfNoPermission(session.getAttribute(UserModel.GROUPS) != null);
         }
 
-        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
-
         return userModels.map(user -> {
-            UserProfile profile = provider.create(UserProfileContext.USER_API, user);
-            UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
-            UserRepresentation userRep = briefRepresentationB ?
-                    ModelToRepresentation.toBriefRepresentation(user, rep, false) :
-                    ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
+            UserRepresentation userRep = ModelToRepresentation.toRepresentation(session, user, briefRep);
             userRep.setAccess(usersEvaluator.getAccessForListing(user));
             return userRep;
         }).map(this::getBruteForceStatus);

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -131,6 +131,9 @@ import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
 import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.storage.StorageId;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
 
@@ -342,6 +345,21 @@ public class ModelToRepresentation {
                 rep.setAttributes(attrs);
             }
         }
+
+        return rep;
+    }
+
+    public static UserRepresentation toRepresentation(KeycloakSession session, UserModel user, boolean brief) {
+        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
+        UserProfile profile = provider.create(UserProfileContext.USER_API, user);
+        UserRepresentation rep = profile.toRepresentation(!brief);
+        RealmModel realm = session.getContext().getRealm();
+
+        rep = brief ?
+                ModelToRepresentation.toBriefRepresentation(user, rep, false) :
+                ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
+
+        rep.setUserProfileMetadata(null);
 
         return rep;
     }

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
@@ -62,6 +62,9 @@ import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.services.resources.admin.RoleMapperResource;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.userprofile.UserProfileProvider;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
@@ -308,9 +311,13 @@ public class OrganizationGroupResource {
     }
 
     private MemberRepresentation toMemberRepresentation(RealmModel realm, UserModel user, Boolean briefRepresentation) {
-        UserRepresentation userRep = Boolean.TRUE.equals(briefRepresentation)
-                ? ModelToRepresentation.toBriefRepresentation(user)
-                : ModelToRepresentation.toRepresentation(session, realm, user);
+        boolean briefRepresentationB = Boolean.TRUE.equals(briefRepresentation);
+        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
+        UserProfile profile = provider.create(UserProfileContext.USER_API, user);
+        UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
+        UserRepresentation userRep = briefRepresentationB
+                ? ModelToRepresentation.toBriefRepresentation(user, rep, false)
+                : ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
 
         MemberRepresentation memberRep = new MemberRepresentation(userRep);
         memberRep.setMembershipType(

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationGroupResource.java
@@ -62,9 +62,6 @@ import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.services.resources.admin.RoleMapperResource;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
-import org.keycloak.userprofile.UserProfile;
-import org.keycloak.userprofile.UserProfileContext;
-import org.keycloak.userprofile.UserProfileProvider;
 
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.extensions.Extension;
@@ -307,23 +304,18 @@ public class OrganizationGroupResource {
                                                    @QueryParam("briefRepresentation") Boolean briefRepresentation) {
         RealmModel realm = session.getContext().getRealm();
         return session.users().getGroupMembersStream(realm, group, firstResult, maxResults)
-                .map(user -> toMemberRepresentation(realm, user, briefRepresentation));
+                .map(user -> toMemberRepresentation(user, briefRepresentation));
     }
 
-    private MemberRepresentation toMemberRepresentation(RealmModel realm, UserModel user, Boolean briefRepresentation) {
-        boolean briefRepresentationB = Boolean.TRUE.equals(briefRepresentation);
-        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
-        UserProfile profile = provider.create(UserProfileContext.USER_API, user);
-        UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
-        UserRepresentation userRep = briefRepresentationB
-                ? ModelToRepresentation.toBriefRepresentation(user, rep, false)
-                : ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
-
+    private MemberRepresentation toMemberRepresentation(UserModel user, Boolean briefRepresentation) {
+        boolean briefRep = Boolean.TRUE.equals(briefRepresentation);
+        UserRepresentation userRep = ModelToRepresentation.toRepresentation(session, user, briefRep);
         MemberRepresentation memberRep = new MemberRepresentation(userRep);
+
         memberRep.setMembershipType(
-            organizationProvider.isManagedMember(organization, user)
-                ? MembershipType.MANAGED
-                : MembershipType.UNMANAGED
+                organizationProvider.isManagedMember(organization, user)
+                        ? MembershipType.MANAGED
+                        : MembershipType.UNMANAGED
         );
 
         return memberRep;

--- a/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
+++ b/services/src/main/java/org/keycloak/organization/admin/resource/OrganizationMemberResource.java
@@ -354,7 +354,7 @@ public class OrganizationMemberResource {
     }
 
     private MemberRepresentation toRepresentation(UserModel member) {
-        MemberRepresentation result = new MemberRepresentation(ModelToRepresentation.toRepresentation(session, realm, member));
+        MemberRepresentation result = new MemberRepresentation(ModelToRepresentation.toRepresentation(session, member, false));
         result.setMembershipType(provider.isManagedMember(organization, member) ? MembershipType.MANAGED : MembershipType.UNMANAGED);
         return result;
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -57,9 +57,6 @@ import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
-import org.keycloak.userprofile.UserProfile;
-import org.keycloak.userprofile.UserProfileContext;
-import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.utils.GroupUtils;
 import org.keycloak.utils.ProfileHelper;
 
@@ -337,17 +334,10 @@ public class GroupResource {
 
         firstResult = firstResult != null ? firstResult : 0;
         maxResults = maxResults != null ? maxResults : Constants.DEFAULT_MAX_RESULTS;
-        boolean briefRepresentationB = briefRepresentation != null && briefRepresentation;
+        boolean briefRep = Boolean.TRUE.equals(briefRepresentation);
 
-        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
         return session.users().getGroupMembersStream(realm, group, firstResult, maxResults)
-                .map(user -> {
-                    UserProfile profile = provider.create(UserProfileContext.USER_API, user);
-                    UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
-                    return briefRepresentationB
-                            ? ModelToRepresentation.toBriefRepresentation(user, rep, false)
-                            : ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
-                });
+                .map(user -> ModelToRepresentation.toRepresentation(session, user, briefRep));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/GroupResource.java
@@ -57,6 +57,9 @@ import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionManagement;
 import org.keycloak.services.resources.admin.fgap.AdminPermissions;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.utils.GroupUtils;
 import org.keycloak.utils.ProfileHelper;
 
@@ -336,10 +339,15 @@ public class GroupResource {
         maxResults = maxResults != null ? maxResults : Constants.DEFAULT_MAX_RESULTS;
         boolean briefRepresentationB = briefRepresentation != null && briefRepresentation;
 
+        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
         return session.users().getGroupMembersStream(realm, group, firstResult, maxResults)
-                .map(user -> briefRepresentationB
-                        ? ModelToRepresentation.toBriefRepresentation(user)
-                        : ModelToRepresentation.toRepresentation(session, realm, user));
+                .map(user -> {
+                    UserProfile profile = provider.create(UserProfileContext.USER_API, user);
+                    UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
+                    return briefRepresentationB
+                            ? ModelToRepresentation.toBriefRepresentation(user, rep, false)
+                            : ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
+                });
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -52,7 +52,6 @@ import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleContainerModel;
 import org.keycloak.models.RoleModel;
-import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
 import org.keycloak.representations.idm.ManagementPermissionReference;
@@ -595,11 +594,10 @@ public class RoleContainerResource extends RoleResource {
             throw new NotFoundException("Could not find role");
         }
 
-        final Function<UserModel, UserRepresentation> toRepresentation = briefRepresentation != null && briefRepresentation
-                ? ModelToRepresentation::toBriefRepresentation
-                : user -> ModelToRepresentation.toRepresentation(session, realm, user);
+        boolean briefRep = Boolean.TRUE.equals(briefRepresentation);
+
         return session.users().getRoleMembersStream(realm, role, firstResult, maxResults)
-                .map(toRepresentation);
+                .map((u) -> ModelToRepresentation.toRepresentation(session, u, briefRep));
     }
 
     /**

--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -70,7 +70,6 @@ import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 import org.keycloak.services.resources.admin.fgap.UserPermissionEvaluator;
 import org.keycloak.services.util.DateUtil;
 import org.keycloak.userprofile.UserProfile;
-import org.keycloak.userprofile.UserProfileContext;
 import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.utils.SearchQueryUtils;
 
@@ -569,7 +568,7 @@ public class UsersResource {
     }
 
     private Stream<UserRepresentation> toRepresentation(RealmModel realm, UserPermissionEvaluator usersEvaluator, Boolean briefRepresentation, Stream<UserModel> userModels) {
-        boolean briefRepresentationB = briefRepresentation != null && briefRepresentation;
+        boolean briefRep = Boolean.TRUE.equals(briefRepresentation);
 
         if (!AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
             usersEvaluator.grantIfNoPermission(session.getAttribute(UserModel.GROUPS) != null);
@@ -577,15 +576,9 @@ public class UsersResource {
             usersEvaluator.grantIfNoPermission(session.getAttribute(UserModel.GROUPS) != null);
         }
 
-        UserProfileProvider provider = session.getProvider(UserProfileProvider.class);
-
         return userModels
                 .map(user -> {
-                    UserProfile profile = provider.create(UserProfileContext.USER_API, user);
-                    UserRepresentation rep = profile.toRepresentation(!briefRepresentationB);
-                    UserRepresentation userRep = briefRepresentationB ?
-                            ModelToRepresentation.toBriefRepresentation(user, rep, false) :
-                            ModelToRepresentation.toRepresentation(session, realm, user, rep, false);
+                    UserRepresentation userRep = ModelToRepresentation.toRepresentation(session, user, briefRep);
                     userRep.setAccess(usersEvaluator.getAccessForListing(user));
                     return userRep;
                 });

--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
@@ -48,6 +48,7 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.GroupModel;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ErrorRepresentation;
@@ -56,7 +57,6 @@ import org.keycloak.representations.idm.MappingsRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
-import org.keycloak.models.UserModel;
 import org.keycloak.representations.userprofile.config.UPAttribute;
 import org.keycloak.representations.userprofile.config.UPAttributePermissions;
 import org.keycloak.representations.userprofile.config.UPConfig;
@@ -1019,10 +1019,13 @@ public class GroupTest extends AbstractGroupTest {
             adminEvents.poll(); // consume GROUP_MEMBERSHIP event
 
             // Group members endpoint must respect user profile attribute permissions
-            List<UserRepresentation> members = group.members(null, null);
-            assertEquals(1, members.size());
-            assertNull(members.get(0).getEmail());
-            assertNull(members.get(0).getFirstName());
+            for (Boolean briefRep : List.of(Boolean.TRUE, Boolean.FALSE)) {
+                List<UserRepresentation> members = group.members(null, null, briefRep);
+                assertEquals(1, members.size());
+                assertNull(members.get(0).getEmail());
+                assertNull(members.get(0).getFirstName());
+                assertNull(members.get(0).getUserProfileMetadata());
+            }
 
             // User list endpoint must show the same filtering (parity check)
             List<UserRepresentation> userList = realm.users().search(userName, true);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/group/GroupTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -55,6 +56,9 @@ import org.keycloak.representations.idm.MappingsRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
 import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.testframework.annotations.InjectAdminClient;
 import org.keycloak.testframework.annotations.InjectHttpClient;
@@ -965,6 +969,69 @@ public class GroupTest extends AbstractGroupTest {
         } finally {
             cfg.setUnmanagedAttributePolicy(null);
             upResource.update(cfg);
+        }
+    }
+
+    @Test
+    public void testGroupMembersRespectsUserProfileAttributePermissions() {
+        RealmResource realm = managedRealm.admin();
+        String groupName = "profile-perm-group";
+        String userName = "profile-perm-user";
+
+        UserProfileResource upResource = realm.users().userProfile();
+        UPConfig originalCfg = upResource.getConfiguration();
+
+        try {
+            // Restrict email and firstName to user-role only — admins (USER_API context) cannot view them
+            UPConfig cfg = upResource.getConfiguration();
+
+            UPAttribute emailAttr = cfg.getAttribute(UserModel.EMAIL);
+            if (emailAttr == null) {
+                emailAttr = new UPAttribute(UserModel.EMAIL);
+            }
+            emailAttr.setPermissions(new UPAttributePermissions(Set.of("user"), Set.of("user")));
+            cfg.addOrReplaceAttribute(emailAttr);
+
+            UPAttribute firstNameAttr = cfg.getAttribute(UserModel.FIRST_NAME);
+            if (firstNameAttr == null) {
+                firstNameAttr = new UPAttribute(UserModel.FIRST_NAME);
+            }
+            firstNameAttr.setPermissions(new UPAttributePermissions(Set.of("user"), Set.of("user")));
+            cfg.addOrReplaceAttribute(firstNameAttr);
+
+            upResource.update(cfg);
+            adminEvents.poll(); // consume the user profile UPDATE event
+
+            String groupId = createGroup(managedRealm, GroupBuilder.create().name(groupName).build());
+            GroupResource group = managedRealm.admin().groups().group(groupId);
+
+            UserRepresentation userRep = UserBuilder.create()
+                    .username(userName)
+                    .firstName("Test")
+                    .email(userName + "@test.com")
+                    .build();
+            UsersResource users = realm.users();
+            Response response = users.create(userRep);
+            String userUuid = ApiUtil.getCreatedId(response);
+            managedRealm.cleanup().add(r -> r.users().get(userUuid).remove());
+            adminEvents.poll(); // consume CREATE USER event
+            users.get(userUuid).joinGroup(groupId);
+            adminEvents.poll(); // consume GROUP_MEMBERSHIP event
+
+            // Group members endpoint must respect user profile attribute permissions
+            List<UserRepresentation> members = group.members(null, null);
+            assertEquals(1, members.size());
+            assertNull(members.get(0).getEmail());
+            assertNull(members.get(0).getFirstName());
+
+            // User list endpoint must show the same filtering (parity check)
+            List<UserRepresentation> userList = realm.users().search(userName, true);
+            assertEquals(1, userList.size());
+            assertNull(userList.get(0).getEmail());
+            assertNull(userList.get(0).getFirstName());
+
+        } finally {
+            upResource.update(originalCfg);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmRolesUserTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/realm/RealmRolesUserTest.java
@@ -4,14 +4,23 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.admin.client.resource.RoleResource;
+import org.keycloak.admin.client.resource.UserProfileResource;
 import org.keycloak.admin.client.resource.UserResource;
+import org.keycloak.models.UserModel;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
+import org.keycloak.representations.userprofile.config.UPConfig;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.Assertions;
@@ -22,6 +31,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @KeycloakIntegrationTest
 public class RealmRolesUserTest extends AbstractRealmRolesTest {
@@ -124,6 +134,67 @@ public class RealmRolesUserTest extends AbstractRealmRolesTest {
 
         roleUserMembers = roleResource.getUserMembers(true, 2, 1);
         assertThat(roleUserMembers, is(empty()));
+    }
+
+    @Test
+    public void testUsersInRoleRespectsUserProfileAttributePermissions() {
+        UserProfileResource upResource = managedRealm.admin().users().userProfile();
+        UPConfig originalCfg = upResource.getConfiguration();
+
+        try {
+            // Restrict email and firstName to user-role only: admins (USER_API context) cannot view them
+            UPConfig cfg = upResource.getConfiguration();
+            UPAttribute emailAttr = cfg.getAttribute(UserModel.EMAIL);
+            if (emailAttr == null) {
+                emailAttr = new UPAttribute(UserModel.EMAIL);
+            }
+            emailAttr.setPermissions(new UPAttributePermissions(Set.of("user"), Set.of("user")));
+            cfg.addOrReplaceAttribute(emailAttr);
+
+            UPAttribute firstNameAttr = cfg.getAttribute(UserModel.FIRST_NAME);
+            if (firstNameAttr == null) {
+                firstNameAttr = new UPAttribute(UserModel.FIRST_NAME);
+            }
+            firstNameAttr.setPermissions(new UPAttributePermissions(Set.of("user"), Set.of("user")));
+            cfg.addOrReplaceAttribute(firstNameAttr);
+
+            upResource.update(cfg);
+
+            String userName = "role-profile-perm-user";
+            UserRepresentation userRep = UserBuilder.create()
+                    .username(userName)
+                    .firstName("Test")
+                    .email(userName + "@test.com")
+                    .build();
+            Response response = managedRealm.admin().users().create(userRep);
+            String userId = ApiUtil.getCreatedId(response);
+            managedRealm.cleanup().add(r -> r.users().get(userId).remove());
+
+            RoleResource roleResource = managedRealm.admin().roles().get("role-with-users");
+            managedRealm.admin().users().get(userId).roles().realmLevel().add(List.of(roleResource.toRepresentation()));
+
+            // Full representation: email and firstName must be filtered by user profile permissions
+            List<UserRepresentation> members = roleResource.getUserMembers().stream()
+                    .filter(u -> userName.equals(u.getUsername()))
+                    .toList();
+            assertEquals(1, members.size());
+            assertNull(members.get(0).getEmail());
+            assertNull(members.get(0).getFirstName());
+            assertNull(members.get(0).getUserProfileMetadata());
+
+            // Brief representation: same attribute filtering must apply
+            for (Boolean briefRep : List.of(Boolean.TRUE, Boolean.FALSE)) {
+                List<UserRepresentation> briefMembers = roleResource.getUserMembers(briefRep, 0, 100).stream()
+                        .filter(u -> userName.equals(u.getUsername()))
+                        .toList();
+                assertEquals(1, briefMembers.size());
+                assertNull(briefMembers.get(0).getEmail());
+                assertNull(briefMembers.get(0).getFirstName());
+                assertNull(briefMembers.get(0).getUserProfileMetadata());
+            }
+        } finally {
+            upResource.update(originalCfg);
+        }
     }
 
     private static List<String> extractUsernames(Collection<UserRepresentation> users) {

--- a/tests/base/src/test/java/org/keycloak/tests/organization/admin/OrganizationMemberTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/organization/admin/OrganizationMemberTest.java
@@ -1,0 +1,70 @@
+package org.keycloak.tests.organization.admin;
+
+import java.util.List;
+import java.util.Set;
+
+import org.keycloak.admin.client.resource.OrganizationResource;
+import org.keycloak.admin.client.resource.UserProfileResource;
+import org.keycloak.models.UserModel;
+import org.keycloak.representations.idm.MemberRepresentation;
+import org.keycloak.representations.idm.OrganizationRepresentation;
+import org.keycloak.representations.userprofile.config.UPAttribute;
+import org.keycloak.representations.userprofile.config.UPAttributePermissions;
+import org.keycloak.representations.userprofile.config.UPConfig;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest
+public class OrganizationMemberTest extends AbstractOrganizationTest {
+
+    @Test
+    public void testUserProfileAttributePermissions() {
+        OrganizationRepresentation org = createOrganization();
+        OrganizationResource orgResource = realm.admin().organizations().get(org.getId());
+        MemberRepresentation member = addMember(orgResource, memberEmail, "Test", "User");
+
+        UserProfileResource upResource = realm.admin().users().userProfile();
+        UPConfig originalCfg = upResource.getConfiguration();
+
+        try {
+            // Restrict email and firstName to user-role only: admins (USER_API context) cannot view them
+            UPConfig cfg = upResource.getConfiguration();
+
+            UPAttribute emailAttr = cfg.getAttribute(UserModel.EMAIL);
+            if (emailAttr == null) {
+                emailAttr = new UPAttribute(UserModel.EMAIL);
+            }
+            emailAttr.setPermissions(new UPAttributePermissions(Set.of("user"), Set.of("user")));
+            cfg.addOrReplaceAttribute(emailAttr);
+
+            UPAttribute firstNameAttr = cfg.getAttribute(UserModel.FIRST_NAME);
+            if (firstNameAttr == null) {
+                firstNameAttr = new UPAttribute(UserModel.FIRST_NAME);
+            }
+            firstNameAttr.setPermissions(new UPAttributePermissions(Set.of("user"), Set.of("user")));
+            cfg.addOrReplaceAttribute(firstNameAttr);
+
+            upResource.update(cfg);
+
+            // List endpoint: email and firstName must be filtered by user profile permissions
+            List<MemberRepresentation> members = orgResource.members().search(memberEmail, true, 0, 10);
+            assertEquals(1, members.size());
+            assertNull(members.get(0).getEmail());
+            assertNull(members.get(0).getFirstName());
+            assertNull(members.get(0).getUserProfileMetadata());
+
+            // Single member endpoint: same filtering must apply
+            MemberRepresentation fetched = orgResource.members().member(member.getId()).toRepresentation();
+            assertNull(fetched.getEmail());
+            assertNull(fetched.getFirstName());
+            assertNull(fetched.getUserProfileMetadata());
+
+        } finally {
+            upResource.update(originalCfg);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #49174

### Problem

The `GET /admin/realms/{realm}/groups/{id}/members` and organization group members
endpoints did not enforce user profile attribute permissions. When user profile
configuration denied admin view of specific attributes (e.g. `email`, `firstName`),
those attributes were still returned in group member responses, inconsistent with
`GET /admin/realms/{realm}/users/` which correctly hid them.

**CVSS:** CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N (2.7 Low)

### Root Cause

`GroupResource.getMembers()` and `OrganizationGroupResource.toMemberRepresentation()`
called `ModelToRepresentation.toRepresentation(session, realm, user)` directly (with
`setUserAttributes=true`), which copies all attributes from the `UserModel` without
going through the `UserProfile` permission filter.

### Fix

Both endpoints now mirror the approach used in `UsersResource.toRepresentation()`:

1. Create a `UserProfile` via `UserProfileProvider.create(UserProfileContext.USER_API, user)`
2. Call `profile.toRepresentation()` — which internally calls `DefaultAttributes.getReadable()`,
   filtering attributes where `metadata.canView()` returns false
3. Pass the pre-filtered representation to `ModelToRepresentation` with `setUserAttributes=false`

### Testing

Added `GroupTest.testGroupMembersRespectsUserProfileAttributePermissions` which:
- Configures user profile to restrict `email` and `firstName` to user-role only (denying admin view)
- Asserts both attributes are `null` in the group members response
- Verifies parity with the user list endpoint (which already behaved correctly)
