### PR TITLE
Change TokenManager.isValidScope to always consider dynamic scopes

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -768,11 +768,16 @@ public class TokenManager {
      * otherwise, the scope wasn't parsed correctly
      * <p>
      *
+     * @param session
      * @param scopes
      * @param authorizationRequestContext authorizationRequestContext. It is not null just if dynamic scopes feature is enabled
      * @param client
      * @return
      */
+    public static boolean isValidScope(KeycloakSession session, String scopes, AuthorizationRequestContext authorizationRequestContext, ClientModel client) {
+        return isValidScope(session, scopes, client, null);
+    }
+
     public static boolean isValidScope(KeycloakSession session, String scopes, AuthorizationRequestContext authorizationRequestContext, ClientModel client, UserModel user) {
         if (scopes == null) {
             return true;
@@ -850,6 +855,10 @@ public class TokenManager {
         }
 
         return true;
+    }
+
+    public static boolean isValidScope(KeycloakSession session, String scopes, ClientModel client) {
+        return isValidScope(session, scopes, client, null);
     }
 
     public static boolean isValidScope(KeycloakSession session, String scopes, ClientModel client, UserModel user) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -853,7 +853,12 @@ public class TokenManager {
     }
 
     public static boolean isValidScope(KeycloakSession session, String scopes, ClientModel client, UserModel user) {
-        return isValidScope(session, scopes, null, client, user);
+        if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
+            AuthorizationRequestContext authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, scopes);
+            return isValidScope(session, scopes, authorizationRequestContext, client, user);
+        } else {
+            return isValidScope(session, scopes, null, client, user);
+        }
     }
 
     public static Stream<String> parseScopeParameter(String scopeParam) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -286,7 +286,7 @@ public class AuthorizationEndpointChecker {
     }
 
     public void checkValidScope() throws AuthorizationCheckException {
-        if (!TokenManager.isValidScope(session, request.getScope(), request.getAuthorizationRequestContext(), client, null)) {
+        if (!TokenManager.isValidScope(session, request.getScope(), request.getAuthorizationRequestContext(), client)) {
             ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.SCOPE_PARAM);
             String errorMessage = "Invalid scopes: " + request.getScope();
             event.detail(Details.REASON, errorMessage);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -29,7 +29,6 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
-import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
@@ -287,13 +286,7 @@ public class AuthorizationEndpointChecker {
     }
 
     public void checkValidScope() throws AuthorizationCheckException {
-        boolean validScopes;
-        if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            validScopes = TokenManager.isValidScope(session, request.getScope(), request.getAuthorizationRequestContext(), client, null);
-        } else {
-            validScopes = TokenManager.isValidScope(session, request.getScope(), client, null);
-        }
-        if (!validScopes) {
+        if (!TokenManager.isValidScope(session, request.getScope(), request.getAuthorizationRequestContext(), client, null)) {
             ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.SCOPE_PARAM);
             String errorMessage = "Invalid scopes: " + request.getScope();
             event.detail(Details.REASON, errorMessage);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -248,7 +248,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
     protected String getRequestedScopes() {
         String scope = formParams.getFirst(OAuth2Constants.SCOPE);
 
-        if (!TokenManager.isValidScope(session, scope, client, null)) {
+        if (!TokenManager.isValidScope(session, scope, client)) {
             String errorMessage = "Invalid scopes: " + scope;
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -31,7 +31,6 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.common.ClientConnection;
-import org.keycloak.common.Profile;
 import org.keycloak.constants.AdapterConstants;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -53,7 +52,6 @@ import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorManager;
 import org.keycloak.protocol.oidc.rar.InvalidAuthorizationDetailsException;
 import org.keycloak.protocol.oidc.utils.AuthorizeClientUtil;
-import org.keycloak.rar.AuthorizationRequestContext;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;
@@ -62,7 +60,6 @@ import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.cors.Cors;
-import org.keycloak.services.util.AuthorizationContextUtil;
 import org.keycloak.services.util.MtlsHoKTokenUtil;
 import org.keycloak.sessions.RootAuthenticationSessionModel;
 import org.keycloak.util.TokenUtil;
@@ -251,15 +248,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
     protected String getRequestedScopes() {
         String scope = formParams.getFirst(OAuth2Constants.SCOPE);
 
-        boolean validScopes;
-        if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            AuthorizationRequestContext authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, scope);
-            validScopes = TokenManager.isValidScope(session, scope, authorizationRequestContext, client, null);
-        } else {
-            validScopes = TokenManager.isValidScope(session, scope, client, null);
-        }
-
-        if (!validScopes) {
+        if (!TokenManager.isValidScope(session, scope, client, null)) {
             String errorMessage = "Invalid scopes: " + scope;
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -224,7 +224,7 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
     protected String getRequestedScope(AccessToken token, List<ClientModel> targetAudienceClients) {
         String scope = formParams.getFirst(OAuth2Constants.SCOPE);
 
-        if (!TokenManager.isValidScope(session, scope, client, null)) {
+        if (!TokenManager.isValidScope(session, scope, client)) {
             String errorMessage = "Invalid scopes: " + scope;
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);

--- a/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/tokenexchange/StandardTokenExchangeProvider.java
@@ -45,14 +45,12 @@ import org.keycloak.protocol.oidc.TokenExchangeContext;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.encode.AccessTokenContext;
 import org.keycloak.protocol.oidc.encode.TokenContextEncoderProvider;
-import org.keycloak.rar.AuthorizationRequestContext;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.managers.AuthenticationSessionManager;
-import org.keycloak.services.util.AuthorizationContextUtil;
 import org.keycloak.services.util.DPoPUtil;
 import org.keycloak.services.util.MtlsHoKTokenUtil;
 import org.keycloak.services.util.UserSessionUtil;
@@ -226,15 +224,7 @@ public class StandardTokenExchangeProvider extends AbstractTokenExchangeProvider
     protected String getRequestedScope(AccessToken token, List<ClientModel> targetAudienceClients) {
         String scope = formParams.getFirst(OAuth2Constants.SCOPE);
 
-        boolean validScopes;
-        if (Profile.isFeatureEnabled(Profile.Feature.DYNAMIC_SCOPES)) {
-            AuthorizationRequestContext authorizationRequestContext = AuthorizationContextUtil.getAuthorizationRequestContextFromScopes(session, client, scope);
-            validScopes = TokenManager.isValidScope(session, scope, authorizationRequestContext, client, null);
-        } else {
-            validScopes = TokenManager.isValidScope(session, scope, client, null);
-        }
-
-        if (!validScopes) {
+        if (!TokenManager.isValidScope(session, scope, client, null)) {
             String errorMessage = "Invalid scopes: " + scope;
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.INVALID_REQUEST);

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/CibaProvider.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/CibaProvider.java
@@ -1,0 +1,201 @@
+package org.keycloak.testframework.oauth;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response.Status;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.protocol.oidc.grants.ciba.CibaGrantType;
+import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelRequest;
+import org.keycloak.protocol.oidc.grants.ciba.channel.HttpAuthenticationChannelProvider;
+import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.util.JsonSerialization;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class CibaProvider implements Closeable {
+
+    public static final String CONTEXT_REQUEST_AUTH_CHANNEL = "/ciba/request-authentication-channel";
+    public static final String CONTEXT_PUSH_NOTIFICATION = "/ciba/push-ciba-client-notification";
+    public static final String DUMMY_KEY = "channel_request_dummy_key";
+
+    private final HttpServer httpServer;
+    private final ConcurrentMap<String, CibaAuthenticationChannelRequest> authenticationChannelRequests = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, ClientNotificationEndpointRequest> cibaClientNotifications = new ConcurrentHashMap<>();
+
+    public CibaProvider(HttpServer httpServer) {
+        this.httpServer = httpServer;
+        httpServer.createContext(CONTEXT_REQUEST_AUTH_CHANNEL, (HttpExchange exchange) -> this.handleRequestAuthChannel(exchange));
+        httpServer.createContext(CONTEXT_PUSH_NOTIFICATION, (HttpExchange exchange) -> this.handlePushNotification(exchange));
+    }
+
+    public CibaAuthenticationChannelRequest getAuthChannel(String bindingMessage) {
+        if (bindingMessage == null) {
+            bindingMessage = DUMMY_KEY;
+        }
+        return authenticationChannelRequests.get(bindingMessage);
+    }
+
+    public ClientNotificationEndpointRequest getPushedCibaClientNotification(String clientNotificationToken) {
+        ClientNotificationEndpointRequest request = cibaClientNotifications.remove(clientNotificationToken);
+        if (request == null) {
+            request = new ClientNotificationEndpointRequest();
+        }
+        return request;
+    }
+
+    @Override
+    public void close() {
+        httpServer.removeContext(CONTEXT_REQUEST_AUTH_CHANNEL);
+    }
+
+    private int handleRequestAuthChannel(HttpExchange exchange) throws IOException {
+        String token = extractTokenStringFromAuthHeader(exchange.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+        if (token == null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "Failed to parse bearer token");
+        }
+
+        AccessToken bearerToken;
+        try {
+            bearerToken = new JWSInput(token).readJsonContent(AccessToken.class);
+        } catch (JWSInputException e) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "Failed to parse bearer token");
+        }
+
+        // required
+        String authenticationChannelId = bearerToken.getId();
+        if (authenticationChannelId == null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "missing parameter : " + HttpAuthenticationChannelProvider.AUTHENTICATION_CHANNEL_ID);
+        }
+
+        // parse the content to receive the request
+        AuthenticationChannelRequest request;
+        try (InputStream is = exchange.getRequestBody()) {
+            request = JsonSerialization.readValue(is, AuthenticationChannelRequest.class);
+        } catch (IOException e) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "Invalid request");
+        }
+
+        String loginHint = request.getLoginHint();
+        if (loginHint == null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "missing parameter : " + CibaGrantType.LOGIN_HINT);
+        }
+
+        if (request.getConsentRequired() == null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "missing parameter : " + CibaGrantType.IS_CONSENT_REQUIRED);
+        }
+
+        String scope = request.getScope();
+        if (scope == null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "missing parameter : " + OAuth2Constants.SCOPE);
+        }
+
+        // optional
+        // for testing purpose
+        String bindingMessage = request.getBindingMessage();
+        if (bindingMessage != null && bindingMessage.equals("GODOWN")) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "intentional error : GODOWN");
+        }
+
+        // binding_message is optional so that it can be null .
+        // only one CIBA flow without binding_message can be accepted per test method by this test mechanism.
+        if (bindingMessage == null) {
+            bindingMessage = DUMMY_KEY;
+        }
+
+        authenticationChannelRequests.put(bindingMessage, new CibaAuthenticationChannelRequest(request, token));
+
+        exchange.sendResponseHeaders(Status.CREATED.getStatusCode(), -1);
+        return Status.CREATED.getStatusCode();
+    }
+
+    private int handlePushNotification(HttpExchange exchange) throws IOException {
+        String token = extractTokenStringFromAuthHeader(exchange.getRequestHeaders().getFirst(HttpHeaders.AUTHORIZATION));
+        if (token == null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "Failed to parse bearer token");
+        }
+
+        // parse the content to receive the request
+        ClientNotificationEndpointRequest request;
+        try (InputStream is = exchange.getRequestBody()) {
+            request = JsonSerialization.readValue(is, ClientNotificationEndpointRequest.class);
+        } catch (IOException e) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "Invalid request");
+        }
+
+        ClientNotificationEndpointRequest existing = cibaClientNotifications.putIfAbsent(token, request);
+        if (existing != null) {
+            return errorRespose(exchange, Status.BAD_REQUEST.getStatusCode(), "There is already entry for clientNotification "
+                    + token + ". Make sure to cleanup after previous tests.");
+        }
+
+        exchange.sendResponseHeaders(Status.NO_CONTENT.getStatusCode(), -1);
+        return Status.NO_CONTENT.getStatusCode();
+    }
+
+    private int errorRespose(HttpExchange exchange, int code, String message) throws IOException {
+        byte[] responseBytes = message.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set(HttpHeaders.CONTENT_TYPE, "text/plain; charset=UTF-8");
+        exchange.sendResponseHeaders(code, responseBytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(responseBytes);
+        }
+        return code;
+    }
+
+    private String extractTokenStringFromAuthHeader(String authHeader) {
+        if (authHeader == null) {
+            return null;
+        }
+
+        int indexOfSpace = authHeader.indexOf(' ');
+
+        if (indexOfSpace <= 0) {
+            return null;
+        }
+
+        return authHeader.substring(indexOfSpace + 1);
+    }
+
+    public static class CibaAuthenticationChannelRequest {
+
+        private String bearerToken;
+        private AuthenticationChannelRequest request;
+
+        public CibaAuthenticationChannelRequest(AuthenticationChannelRequest request, String bearerToken) {
+            this.request = request;
+            this.bearerToken = bearerToken;
+        }
+
+        public void setBearerToken(String bearerToken) {
+            this.bearerToken = bearerToken;
+        }
+
+        public String getBearerToken() {
+            return bearerToken;
+        }
+
+        public void setRequest(AuthenticationChannelRequest request) {
+            this.request = request;
+        }
+
+        public AuthenticationChannelRequest getRequest() {
+            return request;
+        }
+    }
+}

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/CibaProviderSupplier.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/CibaProviderSupplier.java
@@ -1,0 +1,40 @@
+package org.keycloak.testframework.oauth;
+
+import java.util.List;
+
+import org.keycloak.testframework.injection.DependenciesBuilder;
+import org.keycloak.testframework.injection.Dependency;
+import org.keycloak.testframework.injection.InstanceContext;
+import org.keycloak.testframework.injection.RequestedInstance;
+import org.keycloak.testframework.injection.Supplier;
+import org.keycloak.testframework.oauth.annotations.InjectCibaProvider;
+
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class CibaProviderSupplier implements Supplier<CibaProvider, InjectCibaProvider>{
+
+    @Override
+    public List<Dependency> getDependencies(RequestedInstance<CibaProvider, InjectCibaProvider> instanceContext) {
+        return DependenciesBuilder.create(HttpServer.class).build();
+    }
+
+    @Override
+    public CibaProvider getValue(InstanceContext<CibaProvider, InjectCibaProvider> instanceContext) {
+        HttpServer httpServer = instanceContext.getDependency(HttpServer.class);
+        return new CibaProvider(httpServer);
+    }
+
+    @Override
+    public boolean compatible(InstanceContext<CibaProvider, InjectCibaProvider> a, RequestedInstance<CibaProvider, InjectCibaProvider> b) {
+        return a.getAnnotation().equals(b.getAnnotation());
+    }
+
+    @Override
+    public void close(InstanceContext<CibaProvider, InjectCibaProvider> instanceContext) {
+        instanceContext.getValue().close();
+    }
+}

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthTestFrameworkExtension.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/OAuthTestFrameworkExtension.java
@@ -10,7 +10,7 @@ public class OAuthTestFrameworkExtension implements TestFrameworkExtension {
     @Override
     public List<Supplier<?, ?>> suppliers() {
         return List.of(new OAuthClientSupplier(), new TestAppSupplier(), new OAuthIdentityProviderSupplier(),
-                new CimdProviderSupplier(), new SectorIdentifierRedirectUrisSupplier());
+                new CimdProviderSupplier(), new SectorIdentifierRedirectUrisSupplier(), new CibaProviderSupplier());
     }
 
 }

--- a/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/annotations/InjectCibaProvider.java
+++ b/test-framework/oauth/src/main/java/org/keycloak/testframework/oauth/annotations/InjectCibaProvider.java
@@ -1,0 +1,18 @@
+package org.keycloak.testframework.oauth.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.keycloak.testframework.injection.LifeCycle;
+
+/**
+ *
+ * @author rmartinc
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InjectCibaProvider {
+    LifeCycle lifecycle() default LifeCycle.GLOBAL;
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/DynamicScopesOAuthGrantTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/DynamicScopesOAuthGrantTest.java
@@ -3,11 +3,17 @@ package org.keycloak.tests.oauth;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.common.Profile;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventType;
+import org.keycloak.models.CibaConfig;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.grants.ciba.CibaGrantTypeFactory;
+import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse;
+import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.testframework.annotations.InjectClient;
@@ -17,7 +23,9 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.testframework.events.EventAssertion;
 import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.oauth.CibaProvider;
 import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectCibaProvider;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ClientBuilder;
 import org.keycloak.testframework.realm.ClientConfig;
@@ -35,6 +43,7 @@ import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.testsuite.util.AccountHelper;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.ciba.AuthenticationRequestAcknowledgement;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -67,6 +76,9 @@ public class DynamicScopesOAuthGrantTest {
 
     @InjectEvents
     protected Events events;
+
+    @InjectCibaProvider
+    protected CibaProvider ciba;
 
     @InjectPage
     protected OAuthGrantPage grantPage;
@@ -233,11 +245,68 @@ public class DynamicScopesOAuthGrantTest {
         realm.admin().localization().deleteRealmLocalizationText("en", "dynamicConsentText");
     }
 
+    @Test
+    public void cibaGrant() throws Exception {
+        // client Backchannel Authentication Request
+        oauth.client(THIRD_PARTY_APP, "password");
+        oauth.scope("foo-dynamic-scope:param1");
+        AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(DEFAULT_USERNAME)
+                .bindingMessage("asdfghjkl")
+                .clientNotificationToken("client-notification-token")
+                .additionalParams(Map.of("user_device", "mobile"))
+                .send();
+        Assertions.assertTrue(response.isSuccess());
+        Assertions.assertNotNull(response.getAuthReqId());
+
+        // client Authentication Channel Request
+        CibaProvider.CibaAuthenticationChannelRequest clientAuthenticationChannelReq = ciba.getAuthChannel("asdfghjkl");
+        Assertions.assertTrue(clientAuthenticationChannelReq.getRequest().getConsentRequired());
+        MatcherAssert.assertThat(List.of(clientAuthenticationChannelReq.getRequest().getScope().split(" ")), Matchers.hasItems("foo-dynamic-scope:param1"));
+
+        // check ping is not still there
+        ClientNotificationEndpointRequest pushedClientNotification = ciba.getPushedCibaClientNotification("client-notification-token");
+        Assertions.assertNull(pushedClientNotification.getAuthReqId());
+
+        // client Authentication Channel completed
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(),
+                oauth.ciba().doAuthenticationChannelCallback(clientAuthenticationChannelReq.getBearerToken(), AuthenticationChannelResponse.Status.SUCCEED));
+
+        // Check clientNotification exists now for our authReqId
+        pushedClientNotification = ciba.getPushedCibaClientNotification("client-notification-token");
+        Assertions.assertEquals(pushedClientNotification.getAuthReqId(), response.getAuthReqId());
+
+        // client Token Request should be OK now
+        AccessTokenResponse tokenRes = oauth.ciba().doBackchannelAuthenticationTokenRequest(response.getAuthReqId());
+        Assertions.assertTrue(tokenRes.isSuccess());
+        EventAssertion.assertSuccess(events.poll())
+                .type(EventType.AUTHREQID_TO_TOKEN)
+                .hasSessionId()
+                .hasIpAddress()
+                .hasCodeId()
+                .hasUserId()
+                .clientId(THIRD_PARTY_APP)
+                .hasTokenId(Details.REFRESH_TOKEN_ID)
+                .hasAccessTokenId(CibaGrantTypeFactory.GRANT_SHORTCUT)
+                .details(Details.USERNAME, DEFAULT_USERNAME)
+                .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
+        MatcherAssert.assertThat(List.of(tokenRes.getScope().split(" ")), Matchers.hasItems("foo-dynamic-scope:param1"));
+
+        // assert consent is granted
+        List<Map<String, Object>> userConsents = AccountHelper.getUserConsents(realm.admin(), DEFAULT_USERNAME);
+        Assertions.assertTrue(((List) userConsents.get(0).get("grantedClientScopes")).stream().anyMatch(p -> p.equals("foo-dynamic-scope:param1")));
+
+        // do a refresh
+        tokenRes = oauth.doRefreshTokenRequest(tokenRes.getRefreshToken());
+        MatcherAssert.assertThat(List.of(tokenRes.getScope().split(" ")), Matchers.hasItems("foo-dynamic-scope:param1"));
+    }
+
     public static class DynamicScopesServerConfig implements KeycloakServerConfig {
 
         @Override
         public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
-            return config.features(Profile.Feature.DYNAMIC_SCOPES);
+            return config.features(Profile.Feature.DYNAMIC_SCOPES)
+                    .option("spi-ciba-auth-channel-ciba-http-auth-channel-http-authentication-channel-uri",
+                            "http://localhost:8500/ciba/request-authentication-channel");
         }
     }
 
@@ -262,7 +331,10 @@ public class DynamicScopesOAuthGrantTest {
                     .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
                     .consentRequired(Boolean.TRUE)
                     .redirectUris("*")
-                    .secret("password");
+                    .secret("password")
+                    .attribute(CibaConfig.CIBA_BACKCHANNEL_TOKEN_DELIVERY_MODE_PER_CLIENT, "ping")
+                    .attribute(CibaConfig.CIBA_BACKCHANNEL_CLIENT_NOTIFICATION_ENDPOINT, "http://localhost:8500/ciba/push-ciba-client-notification")
+                    .attribute(CibaConfig.OIDC_CIBA_GRANT_ENABLED, Boolean.TRUE.toString());
         }
     }
 }


### PR DESCRIPTION
Closes #49388

Checking dynamic scopes I detected that they were not working with CIBA. The reason is the `TokenManager.isValidScope` is not considering them. This PR changes this to always consider dynamic scopes if enabled. I have revised all calls to the method. Besides I have added the provider for CIBA in the test-framework following the same idea other https resources are integrated. The test uses the CIBA ping to test the two endpoints, I suppose with this the CIBA test classes can also be migrated to the new test-suite.