### PR TITLE
[OID4VCI] Polishing of consents for OID4VCI client scopes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocolFactory.java
@@ -28,6 +28,7 @@ import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
@@ -109,5 +110,15 @@ public interface LoginProtocolFactory extends ProviderFactory<LoginProtocol> {
      */
     default boolean allowAsClientProtocol() {
         return true;
+    }
+
+    /**
+     * Callback method invoked when consent of specified user is being revoked for the specified client
+     *
+     * @param session Keycloak session
+     * @param client Client
+     * @param user user
+     */
+    default void onConsentRevoked(KeycloakSession session, ClientModel client, UserModel user) {
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/OID4VCLoginProtocolFactory.java
@@ -17,7 +17,10 @@
 
 package org.keycloak.protocol.oid4vc;
 
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
@@ -28,6 +31,7 @@ import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.ProtocolMapperModel;
@@ -41,16 +45,20 @@ import org.keycloak.protocol.LoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCSubjectIdMapper;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCUserAttributeMapper;
+import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.protocol.oid4vc.model.ProofType;
+import org.keycloak.protocol.oid4vc.utils.OID4VCUtil;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ErrorResponseException;
+import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
 
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_SUBJECT_ID;
+import static org.keycloak.OID4VCConstants.OID4VCI_ENABLED_ATTRIBUTE_KEY;
 import static org.keycloak.VCFormat.SD_JWT_VC;
 import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
 import static org.keycloak.models.ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE;
@@ -66,6 +74,7 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_T
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONFIGURATION_ID;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONTEXTS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CRYPTOGRAPHIC_BINDING_METHODS;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_DISPLAY;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_EXPIRY_IN_SECONDS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_EXPIRY_IN_SECONDS_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_FORMAT;
@@ -92,6 +101,7 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
 
 	public static final String PROTOCOL_ID = OID4VCIConstants.OID4VC_PROTOCOL;
     public static final String CREDENTIAL_TYPE_NATURAL_PERSON = "natural_person";
+    public static final String NATURAL_PERSON_SCOPE_CONSENT_TEXT = "${naturalPersonScopeConsentText}";
 
 	private final Map<String, ProtocolMapperModel> builtins = new HashMap<>();
 
@@ -136,6 +146,8 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
                 LOGGER.debugf("Add client scope: %s", scopeName);
                 clientScope = newRealm.addClientScope(String.format("%s_%s", OID4VC_PROTOCOL, scopeName));
                 clientScope.setDescription("OID4VCI credential scope that represents a natural person in format: " + format);
+                clientScope.setDisplayOnConsentScreen(true);
+                clientScope.setConsentScreenText(NATURAL_PERSON_SCOPE_CONSENT_TEXT);
                 clientScope.setProtocol(OID4VC_PROTOCOL);
                 clientScope.addProtocolMapper(builtins.get(SUBJECT_ID_MAPPER));
                 clientScope.addProtocolMapper(builtins.get(EMAIL_MAPPER));
@@ -147,6 +159,16 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
                         VC_BINDING_REQUIRED, "true",
                         VC_BINDING_REQUIRED_PROOF_TYPES, ProofType.JWT + "," + ProofType.ATTESTATION
                 )));
+
+                try {
+                    DisplayObject display = new DisplayObject();
+                    display.setName("Natural person verifiable credential");
+                    display.setLocale(Locale.ENGLISH.toLanguageTag());
+                    String displayStr = JsonSerialization.writeValueAsString(List.of(display));
+                    clientScopeRep.getAttributes().put(VC_DISPLAY, displayStr);
+                } catch (IOException ioe) {
+                    LOGGER.warnf(ioe, "Failed to initialize display in credential scope '%s'", scopeName);
+                }
 
                 addClientScopeDefaults(clientScopeRep);
                 RepresentationToModel.updateClientScope(clientScopeRep, clientScope);
@@ -251,6 +273,20 @@ public class OID4VCLoginProtocolFactory implements LoginProtocolFactory, OID4VCE
     @Override
     public boolean allowAsClientProtocol() {
         return false;
+    }
+
+    @Override
+    public void onConsentRevoked(KeycloakSession session, ClientModel client, UserModel user) {
+        boolean oid4vciEnabled = Boolean.parseBoolean(client.getAttributes().get(OID4VCI_ENABLED_ATTRIBUTE_KEY));
+        if (oid4vciEnabled) {
+            List<IssuedVerifiableCredentialModel> issuedCreds = OID4VCUtil.getIssuedVerifiableCredentialsByUserAndClient(session, user, client);
+            if (!issuedCreds.isEmpty()) {
+                LOGGER.tracef("Revoking %d issued verifiable credentials of user '%s' for wallet client '%s'", issuedCreds.size(), user.getUsername(), client.getClientId());
+            }
+            for (IssuedVerifiableCredentialModel issuedCred : issuedCreds) {
+                session.users().removeIssuedVerifiableCredential(issuedCred.getId());
+            }
+        }
     }
 
     // Private ---------------------------------------------------------------------------------------------------------

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialScopeRepresentation.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialScopeRepresentation.java
@@ -14,6 +14,7 @@ import org.keycloak.representations.idm.ClientScopeRepresentation;
 
 import static org.keycloak.models.ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VCT;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BINDING_REQUIRED;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_HASH_ALGORITHM;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_HASH_ALGORITHM_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_SD_JWT_VISIBLE_CLAIMS;
@@ -202,6 +203,18 @@ public class CredentialScopeRepresentation extends ClientScopeRepresentation {
 
     public CredentialScopeRepresentation setSigningAlg(String signingAlg) {
         return setAttribute(VC_SIGNING_ALG, signingAlg);
+    }
+
+    /**
+     *
+     * Whether cryptographic holder binding is required for this credential configuration.
+     */
+    public boolean isBindingRequired() {
+        return Boolean.parseBoolean(getAttribute(VC_BINDING_REQUIRED));
+    }
+
+    public CredentialScopeRepresentation setBindingRequired(boolean required) {
+        return setAttribute(VC_BINDING_REQUIRED, String.valueOf(required));
     }
 
     public List<String> getCryptographicBindingMethods() {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
@@ -2,8 +2,11 @@ package org.keycloak.protocol.oid4vc.utils;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
@@ -38,5 +41,11 @@ public class OID4VCUtil {
     public static boolean hasVerifiableCredential(KeycloakSession session, UserModel user, CredentialScopeModel credentialScope) {
         return session.users().getVerifiableCredentialsByUser(user.getId())
                 .anyMatch(credential -> credential.getCredentialScopeName().equals(credentialScope.getName()));
+    }
+
+    public static List<IssuedVerifiableCredentialModel> getIssuedVerifiableCredentialsByUserAndClient(KeycloakSession session, UserModel user, ClientModel client) {
+        return session.users().getIssuedVerifiableCredentialsStreamByUser(user.getId())
+                .filter(issuedCredential -> client.getId().equals(issuedCredential.getClientId()))
+                .toList();
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/UserConsentManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/UserConsentManager.java
@@ -27,6 +27,8 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.protocol.LoginProtocol;
+import org.keycloak.protocol.LoginProtocolFactory;
 
 import static org.keycloak.models.light.LightweightUserAdapter.isLightweightUser;
 
@@ -51,6 +53,11 @@ public class UserConsentManager {
         if (revokedConsent) {
             // Logout clientSessions for this user and client
             AuthenticationManager.backchannelLogoutUserFromClient(session, realm, user, client, session.getContext().getUri(), session.getContext().getRequestHeaders());
+
+            // Callback to login protocol factories
+            session.getKeycloakSessionFactory().getProviderFactoriesStream(LoginProtocol.class)
+                    .map(LoginProtocolFactory.class::cast)
+                    .forEach(loginProtocolFactory -> loginProtocolFactory.onConsentRevoked(session, client, user));
         }
 
         return revokedConsent || revokedOfflineToken;

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCClientScopeTest.java
@@ -18,8 +18,10 @@
 
 package org.keycloak.tests.oid4vc;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,11 +33,14 @@ import org.keycloak.admin.client.resource.ClientScopesResource;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.RealmsResource;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.protocol.oid4vc.model.DisplayObject;
 import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +48,8 @@ import org.junit.jupiter.api.Test;
 import static org.keycloak.VCFormat.JWT_VC;
 import static org.keycloak.VCFormat.SD_JWT_VC;
 import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
+import static org.keycloak.models.ClientScopeModel.CONSENT_SCREEN_TEXT;
+import static org.keycloak.models.ClientScopeModel.DISPLAY_ON_CONSENT_SCREEN;
 import static org.keycloak.models.ClientScopeModel.INCLUDE_IN_TOKEN_SCOPE;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VCT;
@@ -58,6 +65,7 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_BUILD_CONFIG_T
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONFIGURATION_ID;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONTEXTS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CRYPTOGRAPHIC_BINDING_METHODS;
+import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_DISPLAY;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_EXPIRY_IN_SECONDS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_EXPIRY_IN_SECONDS_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_FORMAT;
@@ -66,6 +74,7 @@ import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_INCLUDE_IN_MET
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SD_JWT_NUMBER_OF_DECOYS;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SD_JWT_NUMBER_OF_DECOYS_DEFAULT;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_SUPPORTED_TYPES;
+import static org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory.NATURAL_PERSON_SCOPE_CONSENT_TEXT;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -177,7 +186,7 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
     }
 
     @Test
-    public void testCreateRealmWithDefaultClientScopes() {
+    public void testCreateRealmWithDefaultClientScopes() throws IOException {
         RealmsResource realms = keycloak.realms();
         String realmName = "aux-oid4vci-realm";
         try {
@@ -211,6 +220,9 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
                 assertEquals("oid4vc_natural_person", attrs.remove(VC_SUPPORTED_TYPES));
                 assertEquals("oid4vc_natural_person", attrs.remove(VC_CONTEXTS));
                 assertEquals("oid4vc_natural_person", attrs.remove(VCT));
+                assertEquals("true", attrs.remove(DISPLAY_ON_CONSENT_SCREEN));
+                assertEquals(NATURAL_PERSON_SCOPE_CONSENT_TEXT, attrs.remove(CONSENT_SCREEN_TEXT));
+                assertDisplay(attrs.remove(VC_DISPLAY));
 
                 switch (attrs.remove(VC_FORMAT)) {
                     case JWT_VC: {
@@ -232,5 +244,15 @@ public class OID4VCClientScopeTest extends OID4VCIssuerTestBase {
         } finally {
             realms.realm(realmName).remove();
         }
+    }
+
+    private void assertDisplay(String displayStr) throws IOException {
+        DisplayObject expectedDisplay = new DisplayObject();
+        expectedDisplay.setName("Natural person verifiable credential");
+        expectedDisplay.setLocale(Locale.ENGLISH.toLanguageTag());
+
+        List<DisplayObject> display = JsonSerialization.readValue(displayStr, new TypeReference<List<DisplayObject>>() {
+        });
+        assertEquals(display, List.of(expectedDisplay));
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCConsentTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCConsentTest.java
@@ -1,0 +1,211 @@
+package org.keycloak.tests.oid4vc;
+
+import java.util.List;
+
+import jakarta.ws.rs.NotFoundException;
+
+import org.keycloak.events.Details;
+import org.keycloak.events.EventType;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.OAuthGrantPage;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_CODE;
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+import static org.keycloak.events.Details.GRANT_TYPE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Test for the scenarios where consent screen is required when issuing OID4VCI credentials.
+ * Related specification section: <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-user-consent">OID4VCI 15.1</a>
+ */
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+public class OID4VCConsentTest extends OID4VCIssuerTestBase {
+
+    protected OID4VCTestContext ctx;
+
+    @InjectUser(config = OID4VCConsentTestUserConfig.class)
+    ManagedUser user;
+
+    @InjectClient(ref = "oid4vci-consent-client", config = OID4VCConfidentialClientWithConsentRequired.class)
+    protected ManagedClient managedConsentClient;
+
+    @InjectPage
+    protected OAuthGrantPage grantPage;
+
+    @TestSetup
+    public void configureTestRealm() {
+        super.configureTestRealm();
+        CredentialScopeRepresentation sdJwtNaturalPerson = getCredentialScope(sdJwtTypeNaturalPersonScopeName);
+        sdJwtNaturalPerson.setBindingRequired(false);
+        testRealm.admin().clientScopes().get(sdJwtNaturalPerson.getId()).update(sdJwtNaturalPerson);
+    }
+
+    @BeforeEach
+    void setUp() {
+        // Clean up before starting
+        user.admin().logout();
+        try {
+            user.admin().revokeConsent("oid4vci-consent-client");
+        } catch (NotFoundException nfe) {
+            // Can ignore the case when consent not present
+        }
+    }
+
+    @Test
+    public void loginUserWithConsentScreen() {
+        ClientRepresentation consentClient = managedConsentClient.admin().toRepresentation();
+
+        loginUserAndObtainVC(consentClient, true, true, Details.CONSENT_VALUE_CONSENT_GRANTED);
+
+        // Consent screen not displayed again as consent was already granted
+        loginUserAndObtainVC(consentClient, false, false, Details.CONSENT_VALUE_PERSISTED_CONSENT);
+    }
+
+    @Test
+    public void loginUserWithRevokedConsent() {
+        ClientRepresentation consentClient = managedConsentClient.admin().toRepresentation();
+
+        // Login user and make sure consent screen displayed
+        loginUserAndObtainVC(consentClient,  true, true, Details.CONSENT_VALUE_CONSENT_GRANTED);
+        loginUserAndObtainVC(client, false, false, Details.CONSENT_VALUE_NO_CONSENT_REQUIRED);
+
+        // Check that issued-credentials are available
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds = user.admin().verifiableCredentials().getIssuedCredentials();
+        assertEquals(2, issuedCreds.size());
+        assertEquals(1, countOfIssuedCredsByClient(issuedCreds, managedConsentClient.getId()));
+        assertEquals(1, countOfIssuedCredsByClient(issuedCreds, managedClient.getId()));
+
+        // Revoke consent
+        user.admin().revokeConsent("oid4vci-consent-client");
+
+        // Check that issued-credential were revoked as well
+        issuedCreds = user.admin().verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, issuedCreds.size());
+        assertEquals(0, countOfIssuedCredsByClient(issuedCreds, managedConsentClient.getId()));
+        assertEquals(1, countOfIssuedCredsByClient(issuedCreds, managedClient.getId()));
+
+        // Re-login. Will require consent again
+        loginUserAndObtainVC(consentClient, false, true, Details.CONSENT_VALUE_CONSENT_GRANTED);
+
+        issuedCreds = user.admin().verifiableCredentials().getIssuedCredentials();
+        assertEquals(2, issuedCreds.size());
+        assertEquals(1, countOfIssuedCredsByClient(issuedCreds, managedConsentClient.getId()));
+        assertEquals(1, countOfIssuedCredsByClient(issuedCreds, managedClient.getId()));
+    }
+
+    private long countOfIssuedCredsByClient(List<IssuedVerifiableCredentialRepresentation> issuedCreds, String clientUUID) {
+        return issuedCreds.stream()
+                .filter(issuedCred -> clientUUID.equals(issuedCred.getClientId()))
+                .count();
+    }
+
+
+    private void loginUserAndObtainVC(ClientRepresentation client, boolean expectLoginFormDisplayed, boolean expectConsentScreenDisplayed, String expectedConsentEventDetail) {
+        oauth.client(client.getClientId(), client.getSecret());
+        wallet = new OID4VCBasicWallet(keycloak, oauth);
+        ctx = new OID4VCTestContext(client, getCredentialScope(sdJwtTypeNaturalPersonScopeName));
+
+        OID4VCBasicWallet.AuthorizationEndpointRequest request = wallet
+                .authorizationRequest()
+                .scope(ctx.getScope());
+        request.openLoginForm();
+
+        if (expectLoginFormDisplayed) {
+            request.fillLoginForm(user.getUsername(), TEST_PASSWORD);
+        }
+
+        if (expectConsentScreenDisplayed) {
+            grantPage.assertCurrent();
+            grantPage.assertGrants("User profile", "User roles", "Natural person verifiable credential");
+            grantPage.accept();
+        }
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(Details.CONSENT, expectedConsentEventDetail)
+                .type(EventType.LOGIN);
+
+        AuthorizationEndpointResponse authResponse = oauth.parseLoginResponse();
+        String authCode = authResponse.getCode();
+        assertNotNull(authCode, "No authCode");
+
+        // Build and send AccessTokenRequest
+        //
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode).send();
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken, "No accessToken");
+
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(credentialIdentifier, "Expected to have credential identifier");
+
+        String credentialConfigId = ctx.getAuthorizedCredentialConfigurationId();
+        assertEquals(sdJwtTypeNaturalPersonScopeName, credentialConfigId);
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(GRANT_TYPE, AUTHORIZATION_CODE)
+                .type(EventType.CODE_TO_TOKEN);
+
+        // Credential request
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+
+        EventAssertion.assertSuccess(events.poll())
+                .userId(user.getId())
+                .clientId(client.getClientId())
+                .details(Details.CREDENTIAL_TYPE, sdJwtTypeNaturalPersonScopeName)
+                .type(EventType.VERIFIABLE_CREDENTIAL_REQUEST);
+
+        CredentialResponse.Credential credentialObj = credResponse.getCredentials().get(0);
+        assertNotNull(credentialObj, "The first credential in the array should not be null");
+        IssuerSignedJWT issuerSignedJWT = SdJwtVP.of(credentialObj.getCredential().toString()).getIssuerSignedJWT();
+        assertEquals("oid4vc_natural_person", issuerSignedJWT.getPayload().get(CLAIM_NAME_VCT).asText());
+    }
+
+    public static class OID4VCConfidentialClientWithConsentRequired extends OID4VCConfidentialClient {
+
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return super.configure(client)
+                    .clientId("oid4vci-consent-client")
+                    .consentRequired(true);
+        }
+    }
+
+    public static class OID4VCConsentTestUserConfig extends OID4VCActionTest.OID4VCTestUserConfig {
+
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            return super.configure(user)
+                    .verifiableCredential(jwtTypeNaturalPersonScopeName)
+                    .verifiableCredential(sdJwtTypeNaturalPersonScopeName);
+        }
+    }
+
+
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuerTestBase.java
@@ -577,7 +577,7 @@ public abstract class OID4VCIssuerTestBase {
                     List.of(OID4VCConstants.KeyAttestationResistanceLevels.HIGH, OID4VCConstants.KeyAttestationResistanceLevels.MODERATE)
             );
             Map<String, String> sdJwtAttrs = Optional.ofNullable(sdJwtScope.getAttributes()).orElseGet(HashMap::new);
-            sdJwtAttrs.put(VC_BINDING_REQUIRED, "true");
+            sdJwtScope.setBindingRequired(true);
             sdJwtAttrs.put(VC_BINDING_REQUIRED_PROOF_TYPES, "jwt");
             sdJwtAttrs.put(VC_CRYPTOGRAPHIC_BINDING_METHODS, CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT);
             sdJwtScope.setAttributes(sdJwtAttrs);

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -522,6 +522,7 @@ credentialOfferTitle=Claim your {0}
 credentialOfferStep1=Claim your {0} by scanning the following QR code with your digital wallet in case it is on a different device. Alternatively, open the Offer URL directly if your digital wallet is available on this device.
 credentialOfferStep2=Continue with login to the application once you successfully obtained {0} to your wallet.
 credentialOfferUri=Offer URL
+naturalPersonScopeConsentText=Natural person verifiable credential
 
 # Identity provider
 identity-provider-redirector=Connect with another Identity Provider


### PR DESCRIPTION
closes #46195

- Adding the automated test for the OID4VCI client scopes being displayed on consent screen

- Filled the default consent screen text and displayName for the built-in OID4VCI client scopes (oid4vci_natural_person_sd , oid4vci_natural_person))

- When consent is revoked for particular user and client, the issued-verifiable credentials are revoked as well. This is consistent with the client sessions behavior (As during consent revocation, the clientSessions of particular user and client are also revoked)
