### PR TITLE
Fix for Deprecate KeycloakContext.getRequestHeader closes #49249

### DIFF
--- a/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
+++ b/server-spi/src/main/java/org/keycloak/models/KeycloakContext.java
@@ -38,6 +38,13 @@ public interface KeycloakContext {
     URI getAuthServerUrl();
 
     String getContextPath();
+    
+     /**
+     * @deprecated Use {@link #getHttpRequest()} to obtain the request headers.
+     */
+    @Deprecated
+    HttpHeaders getRequestHeaders();
+    
 
     /**
      * Returns the URI assuming it is a frontend request. To resolve URI for a backend request use {@link #getUri(UrlType)}
@@ -55,8 +62,6 @@ public interface KeycloakContext {
      * @return
      */
     KeycloakUriInfo getUri(UrlType type);
-
-    HttpHeaders getRequestHeaders();
 
     /**
      * Will always return null. You should not need access to a general context object.

--- a/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
+++ b/services/src/main/java/org/keycloak/services/DefaultKeycloakContext.java
@@ -103,12 +103,7 @@ public abstract class DefaultKeycloakContext implements KeycloakContext {
         return getUri(UrlType.FRONTEND);
     }
 
-    /**
-     * @deprecated
-     * Use {@link #getHttpRequest()} to obtain the request headers.
-     * @return
-     */
-    @Deprecated
+  
     @Override
     public HttpHeaders getRequestHeaders() {
         return getHttpRequest().getHttpHeaders();


### PR DESCRIPTION
closes #49249 
