### PR TITLE
Cleanup issued vcs when related entities are deleted

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -436,6 +436,12 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         if (found == null) return false;
 
         em.remove(found);
+
+        em.createNamedQuery("deleteIssuedVcsByUserAndType")
+                .setParameter("userId", userId)
+                .setParameter("credentialType", credentialScopeName)
+                .executeUpdate();
+
         em.flush();
         return true;
     }
@@ -616,6 +622,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
                     .setParameter("clientId", client.getId())
                     .executeUpdate();
             em.createNamedQuery("deleteUserConsentsByClient")
+                    .setParameter("clientId", client.getId())
+                    .executeUpdate();
+            em.createNamedQuery("deleteIssuedVcsByClient")
                     .setParameter("clientId", client.getId())
                     .executeUpdate();
         } else {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IssuedVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IssuedVerifiableCredentialEntity.java
@@ -19,6 +19,8 @@ import jakarta.persistence.Table;
         @NamedQuery(name="deleteIssuedVcsByRealm", query="delete from IssuedVerifiableCredentialEntity vc where vc.user IN (select u from UserEntity u where u.realmId = :realmId)"),
         @NamedQuery(name="deleteIssuedVcsByUser",  query="delete from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId"),
         @NamedQuery(name="deleteIssuedVcsByClientScope", query="delete from IssuedVerifiableCredentialEntity vc where vc.credentialType = :scopeName"),
+        @NamedQuery(name="deleteIssuedVcsByClient", query="delete from IssuedVerifiableCredentialEntity vc where vc.clientId = :clientId"),
+        @NamedQuery(name="deleteIssuedVcsByUserAndType", query="delete from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId and vc.credentialType = :credentialType"),
 })
 public class IssuedVerifiableCredentialEntity {
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/IssuedVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/IssuedVerifiableCredentialTest.java
@@ -4,17 +4,21 @@ import java.util.List;
 
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.UserVerifiableCredentialModel;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
 import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.suites.DatabaseTest;
 
@@ -30,6 +34,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 
 
@@ -198,6 +203,104 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
         assertThat(afterRevoke, empty());
     }
 
+    @Test
+    @DatabaseTest
+    public void testIssuedVCDeletedWhenUserVCDeleted() {
+        String userId = createUser();
+        String clientId = createTestClient("wallet-client");
+
+        // Create UserVC and IssuedVC
+        createIssuedVcViaModelLayer(userId, CREDENTIAL_TYPE_1, clientId, "rev-001");
+
+        // Verify IssuedVC exists
+        UserResource userResource = managedRealm.admin().users().get(userId);
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds = userResource.verifiableCredentials().getIssuedCredentials();
+        assertThat(issuedCreds, hasSize(1));
+        assertEquals(CREDENTIAL_TYPE_1, issuedCreds.get(0).getCredentialType());
+
+        // Delete UserVerifiableCredential
+        userResource.verifiableCredentials().revokeCredential(CREDENTIAL_TYPE_1);
+
+        // Verify IssuedVC is also deleted
+        List<IssuedVerifiableCredentialRepresentation> afterDelete = userResource.verifiableCredentials().getIssuedCredentials();
+        assertThat(afterDelete, empty());
+    }
+
+    @Test
+    @DatabaseTest
+    public void testIssuedVCDeletedWhenClientDeleted() {
+        String userId = createUser();
+        String walletClientId = createTestClient("test-wallet");
+
+        // Issue 2 credentials from this wallet
+        createIssuedVcViaModelLayer(userId, CREDENTIAL_TYPE_1, walletClientId, "rev-001");
+        createIssuedVcViaModelLayer(userId, CREDENTIAL_TYPE_2, walletClientId, "rev-002");
+
+        // Verify issuedVCs exist
+        UserResource userResource = managedRealm.admin().users().get(userId);
+        assertThat(userResource.verifiableCredentials().getIssuedCredentials(), hasSize(2));
+
+        // Delete the wallet client via REST API
+        managedRealm.admin().clients().get(walletClientId).remove();
+
+        // Verify all IssuedVCs from this wallet are deleted
+        List<IssuedVerifiableCredentialRepresentation> afterDelete = userResource.verifiableCredentials().getIssuedCredentials();
+        assertThat(afterDelete, empty());
+    }
+
+    @Test
+    @DatabaseTest
+    public void testIssuedVCDeletedWhenUserDeleted() {
+        String userId = createUser();
+        String clientId = createTestClient("wallet-client");
+
+        // Create 2 VCs
+        createIssuedVcViaModelLayer(userId, CREDENTIAL_TYPE_1, clientId, "rev-001");
+        createIssuedVcViaModelLayer(userId, CREDENTIAL_TYPE_2, clientId, "rev-002");
+
+        // Verify both exist
+        UserResource userResource = managedRealm.admin().users().get(userId);
+        assertThat(userResource.verifiableCredentials().getIssuedCredentials(), hasSize(2));
+        assertThat(userResource.verifiableCredentials().getCredentials(), hasSize(2));
+
+        // Delete user
+        managedRealm.runCleanup();
+
+        // Verify user and all VCs are deleted
+        runOnServer.run(session -> {
+            assertNull(session.users().getUserById(session.getContext().getRealm(), userId));
+            assertEquals(0,  session.users().getIssuedVerifiableCredentialsStreamByUser(userId).count());
+        });
+    }
+
+    @Test
+    @DatabaseTest
+    public void testIssuedVCDeletedWhenClientScopeDeleted() {
+        String userId = createUser();
+        String clientId = createTestClient("wallet-client");
+
+        // Create client scope
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("test-scope");
+        scopeRep.setProtocol("oid4vc");
+        Response resp = managedRealm.admin().clientScopes().create(scopeRep);
+        String scopeId = ApiUtil.getCreatedId(resp);
+        resp.close();
+        adminEvents.clear();
+
+        // Create IssuedVC
+        createIssuedVcViaModelLayer(userId, "test-scope", clientId, "rev-001");
+
+        UserResource userResource = managedRealm.admin().users().get(userId);
+        assertThat(userResource.verifiableCredentials().getIssuedCredentials(), hasSize(1));
+
+        // Delete client scope
+        managedRealm.admin().clientScopes().get(scopeId).remove();
+
+        // Verify IssuedVC deleted
+        assertThat(userResource.verifiableCredentials().getIssuedCredentials(), empty());
+    }
+
     // Helper methods
 
     protected void createIssuedVcViaModelLayer(String userId, String credentialType,
@@ -221,6 +324,18 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
             }
             session.users().addIssuedVerifiableCredential(model);
         });
+    }
+
+    private String createTestClient(String clientName) {
+        ClientRepresentation clientRep = new ClientRepresentation();
+        clientRep.setClientId(clientName);
+        clientRep.setEnabled(true);
+
+        Response resp = managedRealm.admin().clients().create(clientRep);
+        String clientId = ApiUtil.getCreatedId(resp);
+        resp.close();
+        adminEvents.clear();
+        return clientId;
     }
 
     public static class IssuedVcTestRealmConfig implements RealmConfig {


### PR DESCRIPTION
Closes #49382

Added two JPA queries for 1 e 3 cases.  For (1) I used a JPA query instead of adding a DB foreign key constraint, just to avoid too many changes.

Added tests also for the other cases.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
