### PR TITLE
Fix: Auto-refresh expired external IDP tokens for OAuth2 providers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -455,6 +455,48 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             return exchangeNotLinked(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
         }
 
+        // Attempt to refresh the stored token if it is expired or about to expire
+        try {
+            if (model.getToken().startsWith("{")) {
+                OAuthResponse previousResponse = JsonSerialization.readValue(model.getToken(), OAuthResponse.class);
+                Long exp = previousResponse.getAccessTokenExpiration();
+                if (needsRefresh(exp)) {
+                    if (previousResponse.getRefreshToken() != null) {
+                        try {
+                            OAuthResponse newResponse = refreshToken(previousResponse, session);
+                            if (newResponse.getExpiresIn() != null && newResponse.getExpiresIn() > 0) {
+                                long accessTokenExpiration = Time.currentTime() + newResponse.getExpiresIn();
+                                newResponse.setAccessTokenExpiration(accessTokenExpiration);
+                            }
+                            model.setToken(JsonSerialization.writeValueAsString(newResponse));
+                            session.users().updateFederatedIdentity(realm, tokenSubject, model);
+                        } catch (WebApplicationException e) {
+                            // Refresh failed, treat as expired
+                            logger.debugf("Failed to refresh stored token for identity provider %s: %s", getConfig().getAlias(), e.getMessage());
+                            model.setToken(null);
+                            session.users().updateFederatedIdentity(realm, tokenSubject, model);
+                            if (event != null) {
+                                event.detail(Details.REASON, "requested_issuer token expired");
+                                event.error(Errors.INVALID_TOKEN);
+                            }
+                            return exchangeTokenExpired(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
+                        }
+                    } else {
+                        // Token is expired and there is no refresh token available
+                        model.setToken(null);
+                        session.users().updateFederatedIdentity(realm, tokenSubject, model);
+                        if (event != null) {
+                            event.detail(Details.REASON, "requested_issuer token expired");
+                            event.error(Errors.INVALID_TOKEN);
+                        }
+                        return exchangeTokenExpired(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to refresh token", e);
+        }
+
         String accessToken = extractTokenFromResponse(model.getToken(), getAccessTokenResponseParameter());
         if (accessToken == null) {
             model.setToken(null);


### PR DESCRIPTION
## Summary

Fixes #14644 - External IDP tokens are not refreshed automatically for OAuth2 IDPs when retrieving the external token.

## Problem

When retrieving external IDP tokens via the token exchange (V2) path, the base `AbstractOAuth2IdentityProvider.exchangeStoredToken()` did not attempt to refresh expired access tokens using the stored refresh token.

This was already working for:
- The V1 `retrieveToken()` path
- The `OIDCIdentityProvider` override of `exchangeStoredToken()`

But pure OAuth2 providers (like GitHub) that don't use the OIDC subclass were returning expired tokens without attempting refresh.

## Fix

Added refresh logic to `AbstractOAuth2IdentityProvider.exchangeStoredToken()` that mirrors the existing V1 behavior:
- If the stored access token is expired/expiring and a refresh token exists, attempt to refresh and persist the new tokens.
- If refresh fails, clear the stored token and return `token_expired`.
- If no refresh token is available, clear and return `token_expired`.

The refresh uses the existing `needsRefresh()` and `refreshToken()` methods already present in the class, and respects the `minValidityToken` configuration.

## Testing

- Verified compilation passes.
- The logic mirrors the already-tested V1 `retrieveToken()` path and the `OIDCIdentityProvider.exchangeStoredToken()` override.