### PR TITLE
fix: refresh expired external IDP tokens for OAuth2 providers

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -455,6 +455,57 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             return exchangeNotLinked(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
         }
 
+        try {
+            String modelTokenString = model.getToken();
+            if (modelTokenString.startsWith("{")) {
+                OAuthResponse previousResponse = JsonSerialization.readValue(modelTokenString, OAuthResponse.class);
+                Long exp = previousResponse.getAccessTokenExpiration();
+                if (needsRefresh(exp) && previousResponse.getRefreshToken() != null) {
+                    OAuthResponse newResponse = refreshToken(previousResponse, session);
+                    if (newResponse.getExpiresIn() != null && newResponse.getExpiresIn() > 0) {
+                        long accessTokenExpiration = Time.currentTime() + newResponse.getExpiresIn();
+                        newResponse.setAccessTokenExpiration(accessTokenExpiration);
+                    }
+                    model.setToken(JsonSerialization.writeValueAsString(newResponse));
+                    session.users().updateFederatedIdentity(realm, tokenSubject, model);
+
+                    String accessToken = extractTokenFromResponse(model.getToken(), getAccessTokenResponseParameter());
+                    if (accessToken == null) {
+                        if (event != null) {
+                            event.detail(Details.REASON, "requested_issuer token expired");
+                            event.error(Errors.INVALID_TOKEN);
+                        }
+                        return exchangeTokenExpired(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
+                    }
+                    AccessTokenResponse tokenResponse = new AccessTokenResponse();
+                    tokenResponse.setToken(accessToken);
+                    tokenResponse.setExpiresIn(newResponse.getExpiresIn());
+                    return buildTokenResponse(uriInfo, event, authorizedClient, tokenUserSession, tokenResponse, OAuth2Constants.ACCESS_TOKEN_TYPE);
+                } else if (exp != null && exp <= Time.currentTime() && previousResponse.getRefreshToken() == null) {
+                    // Token is expired and no refresh token available
+                    model.setToken(null);
+                    session.users().updateFederatedIdentity(realm, tokenSubject, model);
+                    if (event != null) {
+                        event.detail(Details.REASON, "requested_issuer token expired");
+                        event.error(Errors.INVALID_TOKEN);
+                    }
+                    return exchangeTokenExpired(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
+                }
+            }
+        } catch (IOException e) {
+            logger.warn("Error refreshing stored token for identity provider " + getConfig().getAlias(), e);
+        } catch (WebApplicationException e) {
+            logger.warn("Error refreshing stored token for identity provider " + getConfig().getAlias(), e);
+            // Refresh failed - clear the stored token and report expired
+            model.setToken(null);
+            session.users().updateFederatedIdentity(realm, tokenSubject, model);
+            if (event != null) {
+                event.detail(Details.REASON, "requested_issuer token expired");
+                event.error(Errors.INVALID_TOKEN);
+            }
+            return exchangeTokenExpired(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
+        }
+
         String accessToken = extractTokenFromResponse(model.getToken(), getAccessTokenResponseParameter());
         if (accessToken == null) {
             model.setToken(null);


### PR DESCRIPTION
## Summary

Fixes #14644

External IDP tokens are not refreshed automatically for OAuth2 identity providers (e.g., GitHub) when retrieving the external token via the V2 API (`retrieveToken(session, identity, userSession, user)`).

## Problem

The V1 `retrieveToken(session, identity)` method in `AbstractOAuth2IdentityProvider` already checks token expiration and refreshes when needed. The `OIDCIdentityProvider` also overrides `exchangeStoredToken()` with proper refresh handling. However, the base `AbstractOAuth2IdentityProvider.exchangeStoredToken()` (used by GitHub and other OAuth2-only IDPs) simply returned the stored token as-is, even when expired.

## Fix

Added token expiration checking and automatic refresh logic to `exchangeStoredToken()` in `AbstractOAuth2IdentityProvider`, consistent with:
- The existing V1 path in the same class (lines 256-277)
- The OIDC override in `OIDCIdentityProvider.exchangeStoredToken()`

The fix:
1. Parses the stored token JSON to check `accessTokenExpiration`
2. If the token needs refresh and a refresh token is available, performs the refresh
3. Updates the stored federated identity with the new token
4. If the token is expired and no refresh token is available, reports token expired
5. Handles refresh failures gracefully by clearing the stored token

## Testing

- Build compiles successfully
- Logic mirrors the already-tested V1 path and OIDC override