### PR TITLE
[OID4VCI] Default Credential offer lifespan is too short

### DIFF
--- a/js/apps/admin-ui/src/components/time-selector/TimeSelectorControl.tsx
+++ b/js/apps/admin-ui/src/components/time-selector/TimeSelectorControl.tsx
@@ -23,6 +23,7 @@ export type TimeSelectorControlProps<
     name: string;
     label?: string;
     labelIcon?: string;
+    className?: string;
     controller: Omit<ControllerProps, "name" | "render">;
   };
 
@@ -34,6 +35,7 @@ export const TimeSelectorControl = <
   label,
   controller,
   labelIcon,
+  className,
   ...rest
 }: TimeSelectorControlProps<T, P>) => {
   const {
@@ -61,6 +63,7 @@ export const TimeSelectorControl = <
         render={({ field }) => (
           <TimeSelector
             {...rest}
+            className={className}
             id={name}
             data-testid={name}
             value={field.value}

--- a/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/TokensTab.tsx
@@ -71,7 +71,7 @@ export const RealmSettingsTokensTab = ({
   const { control, register, reset, formState, handleSubmit } =
     useFormContext<RealmRepresentation>();
   const credentialOfferLifespanDefaultValue =
-    realm.attributes?.["credentialOfferLifespanS"] ?? 30;
+    realm.attributes?.["credentialOfferLifespanS"] ?? 300;
 
   // Show a global error notification if validation fails
   const onError = () => {
@@ -677,6 +677,7 @@ export const RealmSettingsTokensTab = ({
             )}
             label={t("oid4vciNonceLifetime")}
             labelIcon={t("oid4vciNonceLifetimeHelp")}
+            className="c-nonce-lifetime"
             controller={{
               defaultValue: 60,
               rules: { min: 30 },
@@ -690,6 +691,7 @@ export const RealmSettingsTokensTab = ({
             )}
             label={t("credentialOfferLifespan")}
             labelIcon={t("credentialOfferLifespanHelp")}
+            className="credential-offer-lifespan"
             controller={{
               defaultValue: credentialOfferLifespanDefaultValue,
               rules: { min: 30 },
@@ -703,6 +705,7 @@ export const RealmSettingsTokensTab = ({
             )}
             label={t("signedMetadataLifespan")}
             labelIcon={t("signedMetadataLifespanHelp")}
+            className="signed-metadata-lifespan"
             controller={{
               defaultValue: 60,
             }}

--- a/js/apps/admin-ui/test/realm-settings/oid4vci-attributes.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/oid4vci-attributes.spec.ts
@@ -5,7 +5,7 @@ import { createTestBed } from "../support/testbed.ts";
 import adminClient from "../utils/AdminClient.js";
 import { SERVER_URL, ROOT_PATH } from "../utils/constants.ts";
 import { login } from "../utils/login.js";
-import { selectItem } from "../utils/form.ts";
+import { changeTimeUnit, selectItem } from "../utils/form.ts";
 
 test("OID4VCI section is hidden in Tokens tab when verifiable credentials are disabled", async ({
   page,
@@ -69,13 +69,15 @@ test("should render fields and save values with correct attribute keys", async (
   const nonceField = page.getByTestId(
     "attributes.vc🍺c-nonce-lifetime-seconds",
   );
-  const preAuthField = page.getByTestId("attributes.credentialOfferLifespanS");
+  const credentialOfferLifespanField = page.getByTestId(
+    "attributes.credentialOfferLifespanS",
+  );
 
   await expect(nonceField).toBeVisible();
-  await expect(preAuthField).toBeVisible();
+  await expect(credentialOfferLifespanField).toBeVisible();
 
   await nonceField.fill("60");
-  await preAuthField.fill("120");
+  await credentialOfferLifespanField.fill("120");
   await page.getByTestId("tokens-tab-save").click();
   await expect(
     page.getByText("Realm successfully updated").first(),
@@ -85,7 +87,7 @@ test("should render fields and save values with correct attribute keys", async (
   expect(realmData).toBeDefined();
   // TimeSelector converts values based on selected unit (60 minutes = 3600 seconds, 120 seconds = 120 seconds)
   expect(realmData?.attributes?.["vc.c-nonce-lifetime-seconds"]).toBe("3600");
-  expect(realmData?.attributes?.["credentialOfferLifespanS"]).toBe("120");
+  expect(realmData?.attributes?.["credentialOfferLifespanS"]).toBe("7200");
 });
 
 test("should persist values after page refresh", async ({ page }) => {
@@ -103,10 +105,12 @@ test("should persist values after page refresh", async ({ page }) => {
   const nonceField = page.getByTestId(
     "attributes.vc🍺c-nonce-lifetime-seconds",
   );
-  const preAuthField = page.getByTestId("attributes.credentialOfferLifespanS");
+  const credentialOfferLifespanField = page.getByTestId(
+    "attributes.credentialOfferLifespanS",
+  );
 
   await nonceField.fill("60");
-  await preAuthField.fill("120");
+  await credentialOfferLifespanField.fill("120");
   await page.getByTestId("tokens-tab-save").click();
   await expect(
     page.getByText("Realm successfully updated").first(),
@@ -132,12 +136,12 @@ test("should persist values after page refresh", async ({ page }) => {
   const nonceValue = parseInt(
     realmData?.attributes?.["vc.c-nonce-lifetime-seconds"] || "0",
   );
-  const preAuthValue = parseInt(
+  const credentialOfferLifespanValue = parseInt(
     realmData?.attributes?.["credentialOfferLifespanS"] || "0",
   );
 
   expect(nonceValue).toBeGreaterThan(0);
-  expect(preAuthValue).toBeGreaterThan(0);
+  expect(credentialOfferLifespanValue).toBeGreaterThan(0);
 });
 
 test("should validate form fields and save valid values", async ({ page }) => {
@@ -155,21 +159,23 @@ test("should validate form fields and save valid values", async ({ page }) => {
   const nonceField = page.getByTestId(
     "attributes.vc🍺c-nonce-lifetime-seconds",
   );
-  const preAuthField = page.getByTestId("attributes.credentialOfferLifespanS");
+  const credentialOfferLifespanField = page.getByTestId(
+    "attributes.credentialOfferLifespanS",
+  );
   const saveButton = page.getByTestId("tokens-tab-save");
 
   // Test that fields are visible and can be filled
   await expect(nonceField).toBeVisible();
-  await expect(preAuthField).toBeVisible();
+  await expect(credentialOfferLifespanField).toBeVisible();
   await expect(saveButton).toBeVisible();
 
   // Test with valid values - this should work
   await nonceField.clear();
-  await preAuthField.clear();
+  await credentialOfferLifespanField.clear();
 
   // Fill with smaller, more reasonable values for testing
   await nonceField.fill("60");
-  await preAuthField.fill("120");
+  await credentialOfferLifespanField.fill("120");
 
   // Save button should be enabled when form has values
   await expect(saveButton).toBeEnabled();
@@ -188,12 +194,12 @@ test("should validate form fields and save valid values", async ({ page }) => {
   const nonceValue = parseInt(
     realmData?.attributes?.["vc.c-nonce-lifetime-seconds"] || "0",
   );
-  const preAuthValue = parseInt(
+  const credentialOfferLifespanValue = parseInt(
     realmData?.attributes?.["credentialOfferLifespanS"] || "0",
   );
 
   expect(nonceValue).toBeGreaterThan(0);
-  expect(preAuthValue).toBeGreaterThan(0);
+  expect(credentialOfferLifespanValue).toBeGreaterThan(0);
 });
 
 test("should show validation error for values below minimum threshold", async ({
@@ -213,12 +219,19 @@ test("should show validation error for values below minimum threshold", async ({
   const nonceField = page.getByTestId(
     "attributes.vc🍺c-nonce-lifetime-seconds",
   );
-  const preAuthField = page.getByTestId("attributes.credentialOfferLifespanS");
+  const credentialOfferLifespanField = page.getByTestId(
+    "attributes.credentialOfferLifespanS",
+  );
   const saveButton = page.getByTestId("tokens-tab-save");
 
   // Fill with values below the minimum threshold (29 seconds)
   await nonceField.fill("29");
-  await preAuthField.fill("29");
+  await credentialOfferLifespanField.fill("29");
+  await changeTimeUnit(
+    page,
+    "Seconds",
+    "#credential-offer-lifespan-select-menu",
+  );
 
   await saveButton.click();
 

--- a/js/apps/admin-ui/test/utils/form.ts
+++ b/js/apps/admin-ui/test/utils/form.ts
@@ -78,7 +78,7 @@ async function clickOption(page: Page, option: string) {
 
 export async function changeTimeUnit(
   page: Page,
-  unit: "Minutes" | "Hours" | "Days",
+  unit: "Seconds" | "Minutes" | "Hours" | "Days",
   inputType: string,
 ) {
   await page.locator(inputType).click();

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultExportImportManager.java
@@ -134,6 +134,13 @@ import org.keycloak.validation.ValidationUtil;
 
 import org.jboss.logging.Logger;
 
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_CODE_LIFESPAN;
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_CODE_LIFESPAN_LOGIN;
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_CODE_LIFESPAN_USER_ACTION;
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_TOKEN_LIFESPAN;
+import static org.keycloak.models.Constants.DEFAULT_ACTION_TOKEN_GENERATED_BY_ADMIN_LIFESPAN;
+import static org.keycloak.models.Constants.DEFAULT_SESSION_IDLE_TIMEOUT;
+import static org.keycloak.models.Constants.DEFAULT_SESSION_MAX_LIFESPAN;
 import static org.keycloak.models.utils.DefaultRequiredActions.getDefaultRequiredActionCaseInsensitively;
 import static org.keycloak.models.utils.ModelToRepresentation.stripRealmAttributesIncludedAsFields;
 import static org.keycloak.models.utils.RepresentationToModel.createCredentials;
@@ -241,7 +248,7 @@ public class DefaultExportImportManager implements ExportImportManager {
         else newRealm.setRefreshTokenMaxReuse(0);
 
         if (rep.getAccessTokenLifespan() != null) newRealm.setAccessTokenLifespan(rep.getAccessTokenLifespan());
-        else newRealm.setAccessTokenLifespan(300);
+        else newRealm.setAccessTokenLifespan(DEFAULT_ACCESS_TOKEN_LIFESPAN);
 
         if (rep.getAccessTokenLifespanForImplicitFlow() != null)
             newRealm.setAccessTokenLifespanForImplicitFlow(rep.getAccessTokenLifespanForImplicitFlow());
@@ -249,9 +256,9 @@ public class DefaultExportImportManager implements ExportImportManager {
             newRealm.setAccessTokenLifespanForImplicitFlow(Constants.DEFAULT_ACCESS_TOKEN_LIFESPAN_FOR_IMPLICIT_FLOW_TIMEOUT);
 
         if (rep.getSsoSessionIdleTimeout() != null) newRealm.setSsoSessionIdleTimeout(rep.getSsoSessionIdleTimeout());
-        else newRealm.setSsoSessionIdleTimeout(1800);
+        else newRealm.setSsoSessionIdleTimeout(DEFAULT_SESSION_IDLE_TIMEOUT);
         if (rep.getSsoSessionMaxLifespan() != null) newRealm.setSsoSessionMaxLifespan(rep.getSsoSessionMaxLifespan());
-        else newRealm.setSsoSessionMaxLifespan(36000);
+        else newRealm.setSsoSessionMaxLifespan(DEFAULT_SESSION_MAX_LIFESPAN);
         if (rep.getSsoSessionMaxLifespanRememberMe() != null) newRealm.setSsoSessionMaxLifespanRememberMe(rep.getSsoSessionMaxLifespanRememberMe());
         if (rep.getSsoSessionIdleTimeoutRememberMe() != null) newRealm.setSsoSessionIdleTimeoutRememberMe(rep.getSsoSessionIdleTimeoutRememberMe());
         if (rep.getOfflineSessionIdleTimeout() != null)
@@ -277,19 +284,19 @@ public class DefaultExportImportManager implements ExportImportManager {
             newRealm.setClientOfflineSessionMaxLifespan(rep.getClientOfflineSessionMaxLifespan());
 
         if (rep.getAccessCodeLifespan() != null) newRealm.setAccessCodeLifespan(rep.getAccessCodeLifespan());
-        else newRealm.setAccessCodeLifespan(60);
+        else newRealm.setAccessCodeLifespan(DEFAULT_ACCESS_CODE_LIFESPAN);
 
         if (rep.getAccessCodeLifespanUserAction() != null)
             newRealm.setAccessCodeLifespanUserAction(rep.getAccessCodeLifespanUserAction());
-        else newRealm.setAccessCodeLifespanUserAction(300);
+        else newRealm.setAccessCodeLifespanUserAction(DEFAULT_ACCESS_CODE_LIFESPAN_USER_ACTION);
 
         if (rep.getAccessCodeLifespanLogin() != null)
             newRealm.setAccessCodeLifespanLogin(rep.getAccessCodeLifespanLogin());
-        else newRealm.setAccessCodeLifespanLogin(1800);
+        else newRealm.setAccessCodeLifespanLogin(DEFAULT_ACCESS_CODE_LIFESPAN_LOGIN);
 
         if (rep.getActionTokenGeneratedByAdminLifespan() != null)
             newRealm.setActionTokenGeneratedByAdminLifespan(rep.getActionTokenGeneratedByAdminLifespan());
-        else newRealm.setActionTokenGeneratedByAdminLifespan(12 * 60 * 60);
+        else newRealm.setActionTokenGeneratedByAdminLifespan(DEFAULT_ACTION_TOKEN_GENERATED_BY_ADMIN_LIFESPAN);
 
         if (rep.getActionTokenGeneratedByUserLifespan() != null)
             newRealm.setActionTokenGeneratedByUserLifespan(rep.getActionTokenGeneratedByUserLifespan());

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -53,6 +53,9 @@ public final class Constants {
     public static final String AUTHZ_UMA_AUTHORIZATION = "uma_authorization";
     public static final String[] AUTHZ_DEFAULT_AUTHORIZATION_ROLES = {AUTHZ_UMA_AUTHORIZATION};
 
+    // 5 minutes
+    public static final int DEFAULT_ACCESS_TOKEN_LIFESPAN = 300;
+
     // 15 minutes
     public static final int DEFAULT_ACCESS_TOKEN_LIFESPAN_FOR_IMPLICIT_FLOW_TIMEOUT = 900;
     // 30 days
@@ -65,6 +68,23 @@ public final class Constants {
 
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT = 1800; // 30 minutes
     public static final int DEFAULT_SESSION_MAX_LIFESPAN = 36000; // 10 hours
+
+    /**
+     * Default "Login timeout" (in the admin console). 30 minutes
+     */
+    public static final int DEFAULT_ACCESS_CODE_LIFESPAN_LOGIN = 1800;
+
+    /**
+     * Default "Client Login Timeout" (in the admin console). 1 minute
+     */
+    public static final int DEFAULT_ACCESS_CODE_LIFESPAN = 60;
+
+    /**
+     * Default for both "Login action timeout" and "User-Initiated Action Lifespan" (in the admin console). 5 minutes
+     */
+    public static final int DEFAULT_ACCESS_CODE_LIFESPAN_USER_ACTION = 300;
+
+    public static final int DEFAULT_ACTION_TOKEN_GENERATED_BY_ADMIN_LIFESPAN = 12 * 60 * 60;
 
     public static final String DEFAULT_WEBAUTHN_POLICY_SIGNATURE_ALGORITHMS = Algorithm.ES256+","+Algorithm.RS256;
     public static final String DEFAULT_WEBAUTHN_POLICY_RP_ENTITY_NAME = "keycloak";

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -69,6 +69,7 @@ import org.keycloak.jose.jwk.JWKParser;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakSession;
@@ -180,7 +181,11 @@ public class OID4VCIssuerEndpoint {
     private AuthenticationManager.AuthResult cachedAuthResult;
 
     public static final String CREDENTIAL_OFFER_LIFESPAN_REALM_ATTRIBUTE_KEY = "credentialOfferLifespanS";
-    public static final int DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S = 30;
+
+    /**
+     * Default credential-offer lifespan is same as default "User-Initiated Action Lifespan" (5 minutes)
+     */
+    public static final int DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S = Constants.DEFAULT_ACCESS_CODE_LIFESPAN_USER_ACTION;
 
     public static final String DEFLATE_COMPRESSION = "DEF";
     public static final String NONCE_PATH = "nonce";

--- a/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
+++ b/services/src/main/java/org/keycloak/services/managers/ApplianceBootstrap.java
@@ -38,6 +38,11 @@ import org.keycloak.services.ServicesLogger;
 import org.keycloak.userprofile.UserProfileProvider;
 import org.keycloak.utils.StringUtil;
 
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_CODE_LIFESPAN;
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_CODE_LIFESPAN_LOGIN;
+import static org.keycloak.models.Constants.DEFAULT_ACCESS_CODE_LIFESPAN_USER_ACTION;
+import static org.keycloak.models.Constants.DEFAULT_SESSION_IDLE_TIMEOUT;
+import static org.keycloak.models.Constants.DEFAULT_SESSION_MAX_LIFESPAN;
 import static org.keycloak.models.UserModel.IS_TEMP_ADMIN_ATTR_NAME;
 
 /**
@@ -78,17 +83,17 @@ public class ApplianceBootstrap {
         realm.setEnabled(true);
         realm.addRequiredCredential(CredentialRepresentation.PASSWORD);
         realm.setDefaultSignatureAlgorithm(Constants.DEFAULT_SIGNATURE_ALGORITHM);
-        realm.setSsoSessionIdleTimeout(1800);
+        realm.setSsoSessionIdleTimeout(DEFAULT_SESSION_IDLE_TIMEOUT);
         realm.setAccessTokenLifespan(60);
         realm.setAccessTokenLifespanForImplicitFlow(Constants.DEFAULT_ACCESS_TOKEN_LIFESPAN_FOR_IMPLICIT_FLOW_TIMEOUT);
-        realm.setSsoSessionMaxLifespan(36000);
+        realm.setSsoSessionMaxLifespan(DEFAULT_SESSION_MAX_LIFESPAN);
         realm.setOfflineSessionIdleTimeout(Constants.DEFAULT_OFFLINE_SESSION_IDLE_TIMEOUT);
         // KEYCLOAK-7688 Offline Session Max for Offline Token
         realm.setOfflineSessionMaxLifespanEnabled(false);
         realm.setOfflineSessionMaxLifespan(Constants.DEFAULT_OFFLINE_SESSION_MAX_LIFESPAN);
-        realm.setAccessCodeLifespan(60);
-        realm.setAccessCodeLifespanUserAction(300);
-        realm.setAccessCodeLifespanLogin(1800);
+        realm.setAccessCodeLifespan(DEFAULT_ACCESS_CODE_LIFESPAN);
+        realm.setAccessCodeLifespanUserAction(DEFAULT_ACCESS_CODE_LIFESPAN_USER_ACTION);
+        realm.setAccessCodeLifespanLogin(DEFAULT_ACCESS_CODE_LIFESPAN_LOGIN);
         realm.setSslRequired(SslRequired.EXTERNAL);
         realm.setRegistrationAllowed(false);
         realm.setRegistrationEmailAsUsername(false);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCActionTest.java
@@ -112,6 +112,9 @@ public class OID4VCActionTest extends OID4VCIssuerTestBase {
                 .details(Details.VERIFIABLE_CREDENTIAL_TARGET_CLIENT_ID, client.getClientId())
                 .type(EventType.VERIFIABLE_CREDENTIAL_CREATE_OFFER);
 
+        // Wait 2 minutes (just to test that credential-offer with default expiration (5 minutes) will not expire)
+        timeOffSet.set(120);
+
         // Refresh screen. Should be still same credential-offer as before and test that there are not new events
         driver.navigate().refresh();
         credentialOfferPage.assertCurrent();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
@@ -178,6 +178,8 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
 
     @Test
     public void testAuthCodeOffer_Anonymous_expiredOffer() throws Exception {
+        // Bigger accessToken lifespan to avoid same timeout like credential-offer (to enforce that accessToken is still valid in the credential-request, when credential-offer would be invalid)
+        testRealm.updateWithCleanup(r -> r.accessTokenLifespan(600));
 
         var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCAuthorizationDetailsFlowPreAuthTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCAuthorizationDetailsFlowPreAuthTestBase.java
@@ -696,6 +696,9 @@ public abstract class OID4VCAuthorizationDetailsFlowPreAuthTestBase extends OID4
 
     @Test
     public void testCompleteFlowWithExpiredCredentialOffer() throws Exception {
+        // Bigger accessToken lifespan to avoid same timeout like credential-offer (to enforce that accessToken is still valid in the credential-request, when credential-offer would be invalid)
+        testRealm.updateWithCleanup(r -> r.accessTokenLifespan(600));
+
         AccessTokenResponse tokenResponse = preAuthzCodeSuccessful();
         // Make sure that offer is expired
         timeOffSet.set(DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S + 10);


### PR DESCRIPTION
closes #49442

The only "real" change in this PR is changing the timeout in `OID4VCIssuerEndpoint.DEFAULT_CREDENTIAL_OFFER_LIFESPAN_S` from 30 seconds to 300 seconds (See GH issue for more details).

Other changes are just using defined constants from the class `Constants` instead of hardcoded constants in the codebase, but all those lifespans are still same as before.
