### PR TITLE
Fix #14644

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -255,18 +255,7 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
     @Override
     public Response retrieveToken(KeycloakSession session, FederatedIdentityModel identity) {
         try {
-            if (identity.getToken().startsWith("{")) {
-                OAuthResponse previousResponse = JsonSerialization.readValue(identity.getToken(), OAuthResponse.class);
-                Long exp = previousResponse.getAccessTokenExpiration();
-                if (needsRefresh(exp) && previousResponse.getRefreshToken() != null) {
-                    OAuthResponse newResponse = refreshToken(previousResponse, session);
-                    if (newResponse.getExpiresIn() != null && newResponse.getExpiresIn() > 0) {
-                        long accessTokenExpiration = Time.currentTime() + newResponse.getExpiresIn();
-                        newResponse.setAccessTokenExpiration(accessTokenExpiration);
-                    }
-                    identity.setToken(JsonSerialization.writeValueAsString(newResponse));
-                }
-            }
+            refreshStoredTokenIfNeeded(session, identity);
         } catch (IOException e) {
             ErrorRepresentation error = new ErrorRepresentation();
             error.setErrorMessage("Unable to refresh token");
@@ -280,7 +269,34 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
         return exp != null && exp != 0 && exp < Time.currentTime() + getConfig().getMinValidityToken();
     }
 
-    private OAuthResponse refreshToken(OAuthResponse previousResponse, KeycloakSession session) throws IOException {
+    protected boolean refreshStoredTokenIfNeeded(KeycloakSession session, FederatedIdentityModel identity) throws IOException {
+        if (!identity.getToken().startsWith("{")) {
+            return false;
+        }
+
+        OAuthResponse previousResponse = JsonSerialization.readValue(identity.getToken(), OAuthResponse.class);
+        Long exp = previousResponse.getAccessTokenExpiration();
+        if (!needsRefresh(exp) || previousResponse.getRefreshToken() == null) {
+            return false;
+        }
+
+        OAuthResponse newResponse = refreshToken(previousResponse, session);
+        if (newResponse.getRefreshToken() == null && previousResponse.getRefreshToken() != null) {
+            newResponse.setRefreshToken(previousResponse.getRefreshToken());
+            newResponse.setRefreshExpiresIn(previousResponse.getRefreshExpiresIn());
+        }
+        if (newResponse.getIdToken() == null && previousResponse.getIdToken() != null) {
+            newResponse.setIdToken(previousResponse.getIdToken());
+        }
+        if (newResponse.getExpiresIn() != null && newResponse.getExpiresIn() > 0) {
+            long accessTokenExpiration = Time.currentTime() + newResponse.getExpiresIn();
+            newResponse.setAccessTokenExpiration(accessTokenExpiration);
+        }
+        identity.setToken(JsonSerialization.writeValueAsString(newResponse));
+        return true;
+    }
+
+    protected OAuthResponse refreshToken(OAuthResponse previousResponse, KeycloakSession session) throws IOException {
         try (VaultStringSecret vaultStringSecret = session.vault().getStringSecret(getConfig().getClientSecret())) {
             SimpleHttpRequest refreshTokenRequest = getRefreshTokenRequest(session, previousResponse.getRefreshToken(), getConfig().getClientId(), vaultStringSecret.get().orElse(getConfig().getClientSecret()));
             try (SimpleHttpResponse refreshTokenResponse = refreshTokenRequest.asResponse()) {
@@ -293,14 +309,6 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
                             Response.status(Response.Status.BAD_GATEWAY).entity(error).type(MediaType.APPLICATION_JSON).build());
                 }
                 OAuthResponse newResponse = JsonSerialization.readValue(response, OAuthResponse.class);
-
-                if (newResponse.getRefreshToken() == null && previousResponse.getRefreshToken() != null) {
-                    newResponse.setRefreshToken(previousResponse.getRefreshToken());
-                    newResponse.setRefreshExpiresIn(previousResponse.getRefreshExpiresIn());
-                }
-                if (newResponse.getIdToken() == null && previousResponse.getIdToken() != null) {
-                    newResponse.setIdToken(previousResponse.getIdToken());
-                }
                 return newResponse;
             }
         }
@@ -453,6 +461,14 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
                 event.error(Errors.INVALID_TOKEN);
             }
             return exchangeNotLinked(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
+        }
+
+        try {
+            if (refreshStoredTokenIfNeeded(session, model)) {
+                session.users().updateFederatedIdentity(realm, tokenSubject, model);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
 
         String accessToken = extractTokenFromResponse(model.getToken(), getAccessTokenResponseParameter());

--- a/services/src/test/java/org/keycloak/test/broker/oidc/AbstractOAuth2IdentityProviderTest.java
+++ b/services/src/test/java/org/keycloak/test/broker/oidc/AbstractOAuth2IdentityProviderTest.java
@@ -24,7 +24,10 @@ import org.keycloak.broker.oidc.AbstractOAuth2IdentityProvider;
 import org.keycloak.broker.oidc.OAuth2IdentityProviderConfig;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
 import org.keycloak.broker.provider.IdentityBrokerException;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.IdentityProviderModel;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -187,6 +190,58 @@ public class AbstractOAuth2IdentityProviderTest {
 		Assert.assertNull(response.getRefreshExpiresIn()); // Should return null, not throw NPE
 	}
 
+	@Test
+	public void refreshStoredTokenIfNeeded_refreshesExpiredToken() throws IOException {
+		TestProvider tested = getTested();
+		AbstractOAuth2IdentityProvider.OAuthResponse storedResponse = new AbstractOAuth2IdentityProvider.OAuthResponse();
+		storedResponse.setToken("old-access-token");
+		storedResponse.setRefreshToken("old-refresh-token");
+		storedResponse.setAccessTokenExpiration((long) Time.currentTime() - 1);
+
+		AbstractOAuth2IdentityProvider.OAuthResponse refreshedResponse = new AbstractOAuth2IdentityProvider.OAuthResponse();
+		refreshedResponse.setToken("new-access-token");
+		refreshedResponse.setRefreshToken("new-refresh-token");
+		refreshedResponse.setExpiresIn(3600L);
+		tested.refreshedResponse = refreshedResponse;
+
+		FederatedIdentityModel identity = new FederatedIdentityModel("oauth2", "user", "username",
+				JsonSerialization.writeValueAsString(storedResponse));
+
+		Assert.assertTrue(tested.refreshStoredTokenForTest(identity));
+
+		AbstractOAuth2IdentityProvider.OAuthResponse updatedResponse =
+				JsonSerialization.readValue(identity.getToken(), AbstractOAuth2IdentityProvider.OAuthResponse.class);
+		Assert.assertEquals("new-access-token", updatedResponse.getToken());
+		Assert.assertEquals("new-refresh-token", updatedResponse.getRefreshToken());
+		Assert.assertTrue(updatedResponse.getAccessTokenExpiration() > Time.currentTime());
+	}
+
+	@Test
+	public void refreshStoredTokenIfNeeded_preservesRefreshTokenWhenProviderDoesNotRotate() throws IOException {
+		TestProvider tested = getTested();
+		AbstractOAuth2IdentityProvider.OAuthResponse storedResponse = new AbstractOAuth2IdentityProvider.OAuthResponse();
+		storedResponse.setToken("old-access-token");
+		storedResponse.setRefreshToken("old-refresh-token");
+		storedResponse.setRefreshExpiresIn(7200L);
+		storedResponse.setAccessTokenExpiration((long) Time.currentTime() - 1);
+
+		AbstractOAuth2IdentityProvider.OAuthResponse refreshedResponse = new AbstractOAuth2IdentityProvider.OAuthResponse();
+		refreshedResponse.setToken("new-access-token");
+		refreshedResponse.setExpiresIn(3600L);
+		tested.refreshedResponse = refreshedResponse;
+
+		FederatedIdentityModel identity = new FederatedIdentityModel("oauth2", "user", "username",
+				JsonSerialization.writeValueAsString(storedResponse));
+
+		Assert.assertTrue(tested.refreshStoredTokenForTest(identity));
+
+		AbstractOAuth2IdentityProvider.OAuthResponse updatedResponse =
+				JsonSerialization.readValue(identity.getToken(), AbstractOAuth2IdentityProvider.OAuthResponse.class);
+		Assert.assertEquals("new-access-token", updatedResponse.getToken());
+		Assert.assertEquals("old-refresh-token", updatedResponse.getRefreshToken());
+		Assert.assertEquals(Long.valueOf(7200), updatedResponse.getRefreshExpiresIn());
+	}
+
 	private OAuth2IdentityProviderConfig getConfig(final String autorizationUrl, final String defaultScope, final String clientId, final Boolean isLoginHint, final Boolean passMaxAge) {
 		IdentityProviderModel model = new IdentityProviderModel();
 		OAuth2IdentityProviderConfig config = new OAuth2IdentityProviderConfig(model);
@@ -199,6 +254,7 @@ public class AbstractOAuth2IdentityProviderTest {
 	}
 
 	private static class TestProvider extends AbstractOAuth2IdentityProvider<OAuth2IdentityProviderConfig> {
+		private OAuthResponse refreshedResponse;
 
 		public TestProvider(OAuth2IdentityProviderConfig config) {
 			super(null, config);
@@ -213,6 +269,15 @@ public class AbstractOAuth2IdentityProviderTest {
 		protected BrokeredIdentityContext doGetFederatedIdentity(String accessToken) {
 			return new BrokeredIdentityContext(accessToken, getConfig());
 		};
+
+		boolean refreshStoredTokenForTest(FederatedIdentityModel identity) throws IOException {
+			return refreshStoredTokenIfNeeded(null, identity);
+		}
+
+		@Override
+		protected OAuthResponse refreshToken(OAuthResponse previousResponse, KeycloakSession session) {
+			return refreshedResponse;
+		}
 
 	};
 


### PR DESCRIPTION
## Fix #14644\n\nImplemented the token refresh fix for generic OAuth2 stored external tokens.\n\nChanged [AbstractOAuth2IdentityProvider.java](/tmp/bounty-keycloak_14644-h9w4ymh7/repo/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java:272) so stored JSON tokens are refreshed when expired before they are returned or exchanged, and the refreshed token is persisted in the federated identity during stored-token exchange. It also preserves the prior refresh token/id token when the upstr\n\n---\n*Auto-generated bounty fix*