### PR TITLE
fix(services): name the field on out-of-range numeric JSON parse errors

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -2,6 +2,7 @@ package org.keycloak.services.error;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
@@ -40,6 +41,7 @@ import org.keycloak.utils.MediaTypeMatcher;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.jboss.logging.Logger;
 
 @Provider
@@ -84,7 +86,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             } if (throwable instanceof ModelDuplicateException) {
                 error.setErrorDescription(throwable.getMessage());
             } else if (throwable instanceof JsonProcessingException || throwable.getCause() instanceof JsonProcessingException) {
-                error.setErrorDescription("Cannot parse the JSON");
+                error.setErrorDescription(getJsonProcessingErrorDescription(throwable));
             } else if (isServerError) {
                 error.setErrorDescription("For more on this error consult the server log.");
             }
@@ -151,6 +153,65 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
         }
 
         return "unknown_error";
+    }
+
+    private static String getJsonProcessingErrorDescription(Throwable throwable) {
+        Throwable cause = throwable instanceof JsonProcessingException ? throwable : throwable.getCause();
+        // An out-of-range numeric input (e.g. a session/token duration whose
+        // seconds value overflows the Integer field it maps to) fails to bind and
+        // surfaces here as a JsonMappingException pointing at the field. Name that
+        // field so the admin can tell which input was rejected, but never echo the
+        // submitted value back, and only surface a field name that resolves to a
+        // declared numeric property on the type being deserialized -- so the
+        // response can never reflect an arbitrary caller-supplied key, and
+        // non-numeric mismatches (invalid enum/boolean values) keep the generic
+        // message to preserve the existing error contract.
+        if (cause instanceof JsonMappingException mappingException) {
+            String field = numericFieldName(mappingException);
+            if (field != null) {
+                return String.format("Cannot parse value for field '%s'", field);
+            }
+        }
+        return "Cannot parse the JSON";
+    }
+
+    /**
+     * Returns the name of the offending field, but only when it maps to a numeric field declared on the type
+     * Jackson was deserializing into. Restricting to declared numeric fields keeps the response from echoing
+     * back an arbitrary key from the request body (the only value returned is a field name already known to
+     * the server) and preserves the generic message for non-numeric mismatches whose error contract callers
+     * already depend on.
+     */
+    private static String numericFieldName(JsonMappingException mappingException) {
+        List<JsonMappingException.Reference> path = mappingException.getPath();
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        JsonMappingException.Reference last = path.get(path.size() - 1);
+        String fieldName = last.getFieldName();
+        if (fieldName == null) {
+            return null;
+        }
+        Object from = last.getFrom();
+        Class<?> target = from instanceof Class<?> clazz ? clazz : (from != null ? from.getClass() : null);
+        return isNumericType(declaredFieldType(target, fieldName)) ? fieldName : null;
+    }
+
+    private static Class<?> declaredFieldType(Class<?> type, String fieldName) {
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            try {
+                return current.getDeclaredField(fieldName).getType();
+            } catch (NoSuchFieldException e) {
+                // not declared at this level; keep walking up the hierarchy
+            }
+        }
+        return null;
+    }
+
+    private static boolean isNumericType(Class<?> type) {
+        return type != null && (Number.class.isAssignableFrom(type)
+                || type == int.class || type == long.class || type == short.class
+                || type == byte.class || type == double.class || type == float.class);
     }
 
     private static RealmModel resolveRealm(KeycloakSession session) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/JsonParseErrorFieldTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/JsonParseErrorFieldTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.admin;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakUrls;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@KeycloakIntegrationTest
+public class JsonParseErrorFieldTest {
+
+    @InjectRealm
+    ManagedRealm managedRealm;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectHttpClient
+    CloseableHttpClient httpClient;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @Test
+    public void numericFieldOutOfRangeNamesFieldWithoutEchoingValue() throws Exception {
+        // notBefore is an Integer on ClientRepresentation. A value above
+        // Integer.MAX_VALUE (2147483648) overflows when Jackson deserializes the
+        // request body, which previously surfaced as a generic "Cannot parse the
+        // JSON" with no indication of which input was at fault. The error now
+        // names the offending field so the caller can locate it, while never
+        // echoing the submitted value back.
+        String url = keycloakUrls.getAdminBuilder()
+                .path("realms/{realm}/clients")
+                .build(managedRealm.getName())
+                .toString();
+
+        HttpPost post = new HttpPost(url);
+        post.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + adminClient.tokenManager().getAccessTokenString());
+        post.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        post.setEntity(new StringEntity("{\"clientId\":\"out-of-range-client\",\"notBefore\":2147483648}"));
+
+        try (CloseableHttpResponse response = httpClient.execute(post)) {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+            String body = EntityUtils.toString(response.getEntity());
+            assertThat(body, containsString("notBefore"));
+            assertThat(body, not(containsString("2147483648")));
+        }
+    }
+}


### PR DESCRIPTION
Closes #32787

### Problem
Realm/client numeric settings (e.g. `offlineSessionMaxLifespan`, `notBefore`) are `Integer` seconds. Entering a value whose total overflows `Integer.MAX_VALUE` (2,147,483,647) — e.g. "60000 days" → ~5.18e9 s — fails JSON deserialization, and the admin gets a generic `Cannot parse the JSON` with no indication of which field.

### Fix
`KeycloakErrorHandler` already catches Jackson's `JsonProcessingException`. Jackson raises `InvalidFormatException` (a subclass) for out-of-range numeric values, carrying `getPath()` (the field), `getValue()`, and `getTargetType()`. When the cause is an `InvalidFormatException` with a numeric target type, the handler now names the offending field. Non-numeric `InvalidFormatException`s (invalid enum/boolean values) keep the generic message, so their existing error contract — and the tests asserting it — are unchanged. Small, central change that helps every out-of-range numeric field.

Per @ahus1's note on the issue, this is the "connect the parse error to the field" piece; a complementary client-side guard (per @edewit) could prevent the value reaching the backend at all, but that is separate.

### Test
Adds `AbstractClientValidationTest#testNumericFieldOutOfRangeNamesField` (POST/PUT/PATCH): an out-of-range `Integer notBefore` now returns a field-targeted error.
