### PR TITLE
fix: remove unused code and modernize generics in embedded-ldap util classes

### DIFF
--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/KerberosKeytabCreator.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/KerberosKeytabCreator.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.keycloak.util.ldap;
 
 import java.io.File;
@@ -47,7 +46,7 @@ public class KerberosKeytabCreator {
      * @throws java.io.IOException
      */
     public static void main(String[] args) throws IOException {
-        if (args == null || args.length != 3) {
+        if (args.length != 3) {
             System.out.println("Kerberos keytab generator");
             System.out.println("-------------------------");
             System.out.println("Arguments missing or invalid. Required arguments are: <principalName> <passPhrase> <outputKeytabFile>");
@@ -77,9 +76,8 @@ public class KerberosKeytabCreator {
             throws IOException {
         final KerberosTime timeStamp = new KerberosTime();
         final int principalType = 1; // KRB5_NT_PRINCIPAL
-
         final Keytab keytab = Keytab.getInstance();
-        final List<KeytabEntry> entries = new ArrayList<KeytabEntry>();
+        final List<KeytabEntry> entries = new ArrayList<>();
         for (Map.Entry<EncryptionType, EncryptionKey> keyEntry : KerberosKeyFactory.getKerberosKeys(principalName, passPhrase)
                 .entrySet()) {
             System.out.println("Adding keytab entry of type: " + keyEntry.getKey().getName());

--- a/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/RangedAttributeInterceptor.java
+++ b/util/embedded-ldap/src/main/java/org/keycloak/util/ldap/RangedAttributeInterceptor.java
@@ -29,7 +29,6 @@ import org.apache.directory.api.ldap.model.entry.Attribute;
 import org.apache.directory.api.ldap.model.entry.Entry;
 import org.apache.directory.api.ldap.model.entry.Value;
 import org.apache.directory.api.ldap.model.exception.LdapException;
-import org.apache.directory.api.ldap.model.schema.AttributeType;
 import org.apache.directory.api.ldap.model.schema.AttributeTypeOptions;
 import org.apache.directory.server.core.api.filtering.EntryFilter;
 import org.apache.directory.server.core.api.filtering.EntryFilteringCursor;
@@ -63,7 +62,6 @@ public class RangedAttributeInterceptor extends BaseInterceptor {
             this.name = name;
             this.min = min;
             this.max = max;
-            AttributeType type = new AttributeType(name);
         }
 
         private Entry prepareEntry(Entry e) {


### PR DESCRIPTION
What this PR does

Removed unused `AttributeType` instantiation in `RangedAttributeInterceptor` constructor (dead code) Removed the now unused `AttributeType` import from `RangedAttributeInterceptor` Replaced verbose `new ArrayList<KeytabEntry>()` with diamond operator `new ArrayList<>()` in `KerberosKeytabCreator` Removed redundant `args == null` check in KerberosKeytabCreator.main()` since the JVM never passes null as the args array

Files changed
util/embedded-ldap/src/main/java/org/keycloak/util/ldap/RangedAttributeInterceptor.java`
util/embedded-ldap/src/main/java/org/keycloak/util/ldap/KerberosKeytabCreator.java`

Closes #49466