### PR TITLE
Better handling of token parameters sent to the token endpoint

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_3.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_3.adoc
@@ -22,6 +22,17 @@ realm administrator or any permission that grants the `view` scope on the user.
 Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
 It also lists significant changes to internal APIs.
 
+=== Maximum length of the token parameters in the OIDC token endpoint
+
+When the OIDC token endpoint request (or OAuth2 token endpoint request) is sent, a new limit exists for the maximum length of "token" OIDC/OAuth2 parameter. The maximum length of each "normal" parameter is still 4,000 characters as in previous version.
+However maximum length of the "token" parameter is increased to 20,000 characters. Also when limit for the "token" parameter is reached, the parameter will not be ignored, but request will fail.
+
+As "token" parameter is considered a parameter containing possibly long token (for example long JWT or SAML assertion) with unbounded data (For example possibly big amount of roles inside JWT).
+Applies for example for parameters like `subject_token` sent in case of the Token exchange grant.
+
+If you want to increase or lower those numbers, start the server with the option `req-token-params-default-max-size` for the default maximum length of the
+OIDC/OAuth2 token parameter or you can use something such as `req-params-max-size` for one specific parameter. For more details, see the `login-protocol` provider configuration in the link:{allproviderconfigguide_link}[{allproviderconfigguide_name}].
+
 === CORS requests with an invalid Origin are now rejected before endpoint logic runs
 
 Cross-origin requests sent to OIDC endpoints (such as the token, userinfo, token revocation, logout, and PAR endpoints) are now validated against the client's configured Web Origins before the endpoint reaches its authentication and request-processing logic. Previously, requests carrying an `Origin` header that did not match any of the client's allowed Web Origins could be processed up to the point where the response was about to be returned, which could result in inconsistent error responses depending on how far the request progressed.

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantType.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantType.java
@@ -64,6 +64,15 @@ public interface OAuth2GrantType extends Provider {
     }
 
     /**
+     * Name of the "token" parameters, which this grant type supports. As 'token' parameter is considered a parameter containing possibly long
+     * token (for example big JWT or SAML assertion) with unbounded data (For example possibly big amount of roles inside JWT).
+     * Example of such parameter is for example 'subject_token' parameter case of token exchange grant.
+     *
+     * @return set of strings with the "token" parameters supported by this grant type
+     */
+    Set<String> getTokenParameterNames();
+
+    /**
      * Processes grant request.
      * @param context grant request context
      *

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -67,7 +67,9 @@ import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_R
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_REQ_PARAMS_MAX_NUMBER;
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_REQ_PARAMS_MAX_OVERALL_SIZE;
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_REQ_PARAMS_MAX_SIZE;
+import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_REQ_TOKEN_PARAMS_FAIL_FAST;
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE;
+import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -125,11 +127,13 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     public static final String ORGANIZATION_SCOPE_CONSENT_TEXT = "${organizationScopeConsentText}";
 
     public static final String CONFIG_OIDC_REQ_PARAMS_DEFAULT_MAX_SIZE = "req-params-default-max-size";
+    public static final String CONFIG_OIDC_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE = "req-token-params-default-max-size";
     public static final String CONFIG_OIDC_REQ_PARAMS_MAX_SIZE_PREFIX = "req-params-max-size";
     public static final String CONFIG_OIDC_ADD_REQ_PARAMS_MAX_NUMBER = "add-req-params-max-number";
     public static final String CONFIG_OIDC_ADD_REQ_PARAMS_MAX_SIZE = "add-req-params-max-size";
     public static final String CONFIG_OIDC_ADD_REQ_PARAMS_MAX_OVERALL_SIZE = "add-req-params-max-overall-size";
     public static final String CONFIG_OIDC_ADD_REQ_PARAMS_FAIL_FAST = "add-req-params-fail-fast";
+    public static final String CONFIG_OIDC_ADD_REQ_TOKEN_PARAMS_FAIL_FAST = "add-req-token-params-fail-fast";
 
     /**
      * @deprecated To be removed in Keycloak 27
@@ -601,6 +605,13 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                             "'. It is needed to add the name of the parameter after this prefix into the configuration. In this example, the '" + OIDCLoginProtocol.LOGIN_HINT_PARAM + "' parameter is used, but this format is supported for any known standard OIDC/OAuth2 parameter.")
                     .add()
                 .property()
+                    .name(CONFIG_OIDC_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE)
+                    .type("int")
+                    .helpText("Maximum default length of the 'token' parameter sent to the OIDC token endpoint. As 'token' parameter is considered a parameter containing possibly long token (for example big JWT or SAML assertion) with unbounded data (For example possibly big amount of roles inside JWT). " +
+                            "Example of such parameter is for example 'subject_token' parameter case of token exchange grant.")
+                    .defaultValue(DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE)
+                    .add()
+                .property()
                     .name(CONFIG_OIDC_ADD_REQ_PARAMS_MAX_NUMBER)
                     .type("int")
                     .helpText("Maximum number of additional request parameters sent to the OIDC authentication or token endpoints. As 'additional request parameter' is meant some custom parameter not directly treated as standard OIDC/OAuth2 protocol parameter. Additional parameters might be useful for example to add custom claims to the OIDC token (in case that also particular protocol mappers are configured).")
@@ -624,6 +635,15 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
                     .helpText("Whether the fail-fast strategy should be enforced in case if the limit for some standard OIDC parameter or additional OIDC parameter is not met for the parameters sent to the OIDC authentication or token endpoints." +
                             " If false, then all additional request parameters to not meet the configuration are silently ignored. If true, an exception will be raised and request to the OIDC authentication or token endpoints will not be allowed.")
                     .defaultValue(DEFAULT_ADDITIONAL_REQ_PARAMS_FAIL_FAST)
+                    .add()
+                .property()
+                    .name(CONFIG_OIDC_ADD_REQ_TOKEN_PARAMS_FAIL_FAST)
+                    .type("boolean")
+                    .helpText("Whether the fail-fast strategy should be enforced in case if the limit for some 'token' parameter is not met for the parameters sent to the OIDC token endpoint." +
+                            " If false, then all additional request parameters to not meet the configuration are silently ignored. If true, an exception will be raised and request to the OIDC token endpoints will not be allowed. " +
+                            "As 'token' parameter is considered a parameter containing possibly long token (for example big JWT or SAML assertion) with unbounded data (For example possibly big amount of roles inside JWT). " +
+                            "Example of such parameter is for example 'subject_token' parameter case of token exchange grant.")
+                    .defaultValue(DEFAULT_ADDITIONAL_REQ_TOKEN_PARAMS_FAIL_FAST)
                     .add()
                 .property()
                     .name(CONFIG_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK)

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCProviderConfig.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCProviderConfig.java
@@ -12,7 +12,7 @@ public class OIDCProviderConfig {
     private final Config.Scope config;
 
     /**
-     * Maximum default length of the standard OIDC parameter sent to the OIDC authentication request.
+     * Maximum default length of the standard OIDC parameter sent to the OIDC authentication or token request.
      */
     public static final int DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE = 4000;
 
@@ -26,6 +26,15 @@ public class OIDCProviderConfig {
     private Map<String, Integer> DEFAULT_MAX_PARAMS_SIZES = Map.of(
             OIDCLoginProtocol.LOGIN_HINT_PARAM, 255 // Aligned with user-profile configuration for username and email
     );
+
+    /**
+     * Maximum default length of the standard OIDC parameter sent to the OIDC token request in case the parameter is "token" parameter.
+     * As "token" parameter is considered a parameter containing long token (for example JWT or SAML assertion) with unbounded data (For example possibly big amount of roles inside JWT).
+     * Applies for example for parameters like "subject_token" sent in case of token exchange grant.
+     */
+    public static final int DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE = 20000;
+
+    private final int reqTokenParamsDefaultMaxSize;
 
     /**
      * Default value for {@link #additionalReqParamsMaxNumber} if case no configuration property is set.
@@ -57,6 +66,20 @@ public class OIDCProviderConfig {
      * that to not meet the configuration are silently ignored. If <code>true</code> an exception will be raised.
      */
     private final boolean additionalReqParamsFailFast;
+
+    /**
+     * Default value for {@link #additionalReqTokenParamsFailFast} in case no configuration property is set.
+     */
+    public static final boolean DEFAULT_ADDITIONAL_REQ_TOKEN_PARAMS_FAIL_FAST = true;
+
+    /**
+     * Whether the fail-fast strategy should be enforced for "token" parameters. If <code>false</code> all additional request parameters
+     * that to not meet the configuration are silently ignored. If <code>true</code> an exception will be raised.
+     *
+     * As "token" parameter is considered a parameter containing long token (for example JWT or SAML assertion) with unbounded data (For example possibly big amount of roles inside JWT).
+     * Applies for example for parameters like "subject_token" sent in case of token exchange grant.
+     */
+    private final boolean additionalReqTokenParamsFailFast;
 
     /**
      * Default value for {@link #additionalReqParamsMaxOverallSize} in case no configuration property is set.
@@ -91,10 +114,12 @@ public class OIDCProviderConfig {
         this.config = config;
 
         this.reqParamsDefaultMaxSize = config.getInt(OIDCLoginProtocolFactory.CONFIG_OIDC_REQ_PARAMS_DEFAULT_MAX_SIZE, DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE);
+        this.reqTokenParamsDefaultMaxSize = config.getInt(OIDCLoginProtocolFactory.CONFIG_OIDC_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE, DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE);
         this.additionalReqParamsMaxNumber = config.getInt(OIDCLoginProtocolFactory.CONFIG_OIDC_ADD_REQ_PARAMS_MAX_NUMBER, DEFAULT_ADDITIONAL_REQ_PARAMS_MAX_NUMBER);
         this.additionalReqParamsMaxSize = config.getInt(OIDCLoginProtocolFactory.CONFIG_OIDC_ADD_REQ_PARAMS_MAX_SIZE, DEFAULT_ADDITIONAL_REQ_PARAMS_MAX_SIZE);
         this.additionalReqParamsMaxOverallSize = config.getInt(OIDCLoginProtocolFactory.CONFIG_OIDC_ADD_REQ_PARAMS_MAX_OVERALL_SIZE, DEFAULT_ADDITIONAL_REQ_PARAMS_MAX_OVERALL_SIZE);
         this.additionalReqParamsFailFast = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_OIDC_ADD_REQ_PARAMS_FAIL_FAST, DEFAULT_ADDITIONAL_REQ_PARAMS_FAIL_FAST);
+        this.additionalReqTokenParamsFailFast = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_OIDC_ADD_REQ_TOKEN_PARAMS_FAIL_FAST, DEFAULT_ADDITIONAL_REQ_TOKEN_PARAMS_FAIL_FAST);
 
         this.allowMultipleAudiencesForJwtClientAuthentication = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_OIDC_ALLOW_MULTIPLE_AUDIENCES_FOR_JWT_CLIENT_AUTHENTICATION, DEFAULT_ALLOW_MULTIPLE_AUDIENCES_FOR_JWT_CLIENT_AUTHENTICATION);
         this.allowTokenIntrospectionWithoutAudienceCheck = config.getBoolean(OIDCLoginProtocolFactory.CONFIG_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK, DEFAULT_ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK);
@@ -109,8 +134,8 @@ public class OIDCProviderConfig {
         return additionalReqParamsMaxSize;
     }
 
-    public boolean isAdditionalReqParamsFailFast() {
-        return additionalReqParamsFailFast;
+    public boolean isAdditionalReqParamsFailFast(boolean isTokenParam) {
+        return isTokenParam ? additionalReqTokenParamsFailFast : additionalReqParamsFailFast;
     }
 
     public int getAdditionalReqParamsMaxOverallSize() {
@@ -131,10 +156,11 @@ public class OIDCProviderConfig {
 
     /**
      * @param paramName Parameter name. Expected to be one of the known OIDC parameters
+     * @param isTokenParam If this parameter represents token (like for example JWT)
      *
      * @return maximum length for the specified OIDC parameter
      */
-    public int getMaxLengthForTheParameter(String paramName) {
+    public int getMaxLengthForTheParameter(String paramName, boolean isTokenParam) {
         // Configured value for the particular OIDC parameter
         Integer paramMaxSize = config.getInt(OIDCLoginProtocolFactory.CONFIG_OIDC_REQ_PARAMS_MAX_SIZE_PREFIX + "--" + paramName);
 
@@ -145,7 +171,7 @@ public class OIDCProviderConfig {
 
         // Fallback to default for all standard OIDC parameters
         if (paramMaxSize == null) {
-            paramMaxSize = reqParamsDefaultMaxSize;
+            paramMaxSize = isTokenParam ? reqTokenParamsDefaultMaxSize : reqParamsDefaultMaxSize;
         }
 
         return paramMaxSize;

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.xml.namespace.QName;
 
 import jakarta.ws.rs.Consumes;
@@ -235,6 +236,7 @@ public class TokenEndpoint {
     protected void checkParameters() {
         OIDCLoginProtocol loginProtocol = (OIDCLoginProtocol) session.getProvider(LoginProtocol.class, OIDCLoginProtocol.LOGIN_PROTOCOL);
         OIDCProviderConfig config = loginProtocol.getConfig();
+        Set<String> tokenParamNames = grant.getTokenParameterNames();
 
         Map<String, List<String>> paramsCopy = new HashMap<>(formParams);
         for (Map.Entry<String, List<String>> param : paramsCopy.entrySet()) {
@@ -242,10 +244,14 @@ public class TokenEndpoint {
             int totalLengthOfParamValues = param.getValue().stream()
                     .map(String::length)
                     .reduce(0, Integer::sum);
-            int maxLength = config.getMaxLengthForTheParameter(paramName);
+
+            // Does this parameter represent a token (typically JWT or SAML assertion)?
+            boolean isTokenParam = tokenParamNames.contains(paramName);
+
+            int maxLength = config.getMaxLengthForTheParameter(paramName, isTokenParam);
             if (totalLengthOfParamValues > maxLength) {
-                LOGGER.warnf("The size of OIDC parameter '%s' is longer (%d) than allowed (%d). %s", paramName, totalLengthOfParamValues, maxLength, config.isAdditionalReqParamsFailFast() ? "Request not allowed." : "Ignoring the parameter.");
-                if (config.isAdditionalReqParamsFailFast()) {
+                LOGGER.warnf("The size of OIDC parameter '%s' is longer (%d) than allowed (%d). %s", paramName, totalLengthOfParamValues, maxLength, config.isAdditionalReqParamsFailFast(isTokenParam) ? "Request not allowed." : "Ignoring the parameter.");
+                if (config.isAdditionalReqParamsFailFast(isTokenParam)) {
                     throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, "The size of OIDC parameter '" + paramName + "' is longer than allowed.",
                             Response.Status.BAD_REQUEST);
                 } else {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/request/AuthzEndpointRequestParser.java
@@ -110,7 +110,7 @@ public abstract class AuthzEndpointRequestParser {
         this.config = loginProtocol.getConfig();
         this.additionalReqParamsMaxNumber = config.getAdditionalReqParamsMaxNumber();
         this.additionalReqParamsMaxSize = config.getAdditionalReqParamsMaxSize();
-        this.additionalReqParamsFailFast = config.isAdditionalReqParamsFailFast();
+        this.additionalReqParamsFailFast = config.isAdditionalReqParamsFailFast(false);
         this.additionalReqParamsMaxOverallSize = config.getAdditionalReqParamsMaxOverallSize();
     }
 
@@ -228,7 +228,7 @@ public abstract class AuthzEndpointRequestParser {
         String paramValue = getParameter(paramName);
 
         if (paramValue != null) {
-            int maxLength = config.getMaxLengthForTheParameter(paramName);
+            int maxLength = config.getMaxLengthForTheParameter(paramName, false);
             if (paramValue.length() > maxLength) {
                 logger.warnf("The size of OIDC parameter '%s' size is longer (%d) than allowed (%d). %s", paramName, paramValue.length(), maxLength, additionalReqParamsFailFast ? "Request not allowed." : "Ignoring the parameter.");
                 if (additionalReqParamsFailFast) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/AuthorizationCodeGrantType.java
@@ -17,7 +17,9 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 
@@ -291,5 +293,10 @@ public class AuthorizationCodeGrantType extends OAuth2GrantTypeBase {
             logger.debugf(e, "Failed to parse authorization_details for comparison");
             return false;
         }
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ClientCredentialsGrantType.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.util.Collections;
+import java.util.Set;
+
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuthErrorException;
@@ -148,6 +151,11 @@ public class ClientCredentialsGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.CLIENT_LOGIN;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/JWTAuthorizationGrantType.java
@@ -18,6 +18,7 @@
 package org.keycloak.protocol.oidc.grants;
 
 import java.util.List;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 
@@ -214,5 +215,10 @@ public class JWTAuthorizationGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.JWT_AUTHORIZATION_GRANT;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Set.of(OAuth2Constants.ASSERTION);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PermissionGrantType.java
@@ -18,6 +18,7 @@
 package org.keycloak.protocol.oidc.grants;
 
 import java.util.List;
+import java.util.Set;
 
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -193,6 +194,11 @@ public class PermissionGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.PERMISSION_TOKEN;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Set.of("claim_token", "subject_token");
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -19,8 +19,10 @@ package org.keycloak.protocol.oidc.grants;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 
@@ -254,6 +256,11 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.VERIFIABLE_CREDENTIAL_PRE_AUTHORIZED_GRANT;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.util.Collections;
+import java.util.Set;
+
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -115,6 +118,11 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.REFRESH_TOKEN;
+    }
+    
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ResourceOwnerPasswordCredentialsGrantType.java
@@ -17,6 +17,9 @@
 
 package org.keycloak.protocol.oidc.grants;
 
+import java.util.Collections;
+import java.util.Set;
+
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -177,6 +180,11 @@ public class ResourceOwnerPasswordCredentialsGrantType extends OAuth2GrantTypeBa
     @Override
     public EventType getEventType() {
         return EventType.LOGIN;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/TokenExchangeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/TokenExchangeGrantType.java
@@ -33,6 +33,9 @@ import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.context.TokenExchangeRequestContext;
 
+import static org.keycloak.OAuth2Constants.ACTOR_TOKEN;
+import static org.keycloak.OAuth2Constants.SUBJECT_TOKEN;
+
 /**
  * OAuth 2.0 Authorization Code Grant
  * https://datatracker.ietf.org/doc/html/rfc8693#section-2.1
@@ -100,5 +103,10 @@ public class TokenExchangeGrantType extends OAuth2GrantTypeBase {
     @Override
     public Set<String> getSupportedMultivaluedRequestParameters() {
         return SUPPORTED_DUPLICATED_PARAMETERS;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Set.of(SUBJECT_TOKEN, ACTOR_TOKEN);
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/CibaGrantType.java
@@ -18,7 +18,9 @@
 
 package org.keycloak.protocol.oidc.grants.ciba;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
@@ -300,6 +302,11 @@ public class CibaGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.AUTHREQID_TO_TOKEN;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/device/DeviceGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/device/DeviceGrantType.java
@@ -18,7 +18,9 @@
 package org.keycloak.protocol.oidc.grants.device;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
@@ -365,6 +367,11 @@ public class DeviceGrantType extends OAuth2GrantTypeBase {
     @Override
     public EventType getEventType() {
         return EventType.OAUTH2_DEVICE_CODE_TO_TOKEN;
+    }
+
+    @Override
+    public Set<String> getTokenParameterNames() {
+        return Collections.emptySet();
     }
 
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UmaGrantTypeTest.java
@@ -38,6 +38,8 @@ import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.AuthzClient;
 import org.keycloak.authorization.client.representation.TokenIntrospectionResponse;
+import org.keycloak.authorization.client.util.HttpResponseException;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolService;
@@ -45,6 +47,7 @@ import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.authorization.AuthorizationRequest;
 import org.keycloak.representations.idm.authorization.AuthorizationResponse;
 import org.keycloak.representations.idm.authorization.Permission;
 import org.keycloak.representations.idm.authorization.PermissionRequest;
@@ -65,6 +68,8 @@ import org.apache.http.message.BasicNameValuePair;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE;
+import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE;
 import static org.keycloak.testsuite.util.oauth.OAuthClient.AUTH_SERVER_ROOT;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -616,6 +621,52 @@ public class UmaGrantTypeTest extends AbstractResourceServerTest {
 
         clientRepresentation.getAttributes().put(OIDCConfigAttributes.USE_REFRESH_TOKEN, "true");
         client.update(clientRepresentation);
+    }
+
+    @Test
+    public void testUsingBigSubjectToken() {
+        AuthzClient authzClient = getAuthzClient();
+
+        // Request 1: Using service-account credentials works
+        AuthorizationRequest request = new AuthorizationRequest();
+        AuthorizationResponse response = authzClient.authorization().authorize(request);
+        assertNotNull(response.getToken());
+
+        // Request 2: Using invalid subject_token should fail
+        request = new AuthorizationRequest();
+        request.setSubjectToken(SecretGenerator.getInstance().randomString(10));
+        try {
+            authzClient.authorization().authorize(request);
+            fail("should fail, invalid subject_token");
+        } catch (Exception e) {
+            Throwable expected = e.getCause();
+            assertEquals(400, HttpResponseException.class.cast(expected).getStatusCode());
+            assertTrue(HttpResponseException.class.cast(expected).toString().contains("unauthorized_client"));
+        }
+
+        // Request 3: Using invalid subject_token with length bigger than 4000 characters should fail
+        request = new AuthorizationRequest();
+        request.setSubjectToken(SecretGenerator.getInstance().randomString(DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE + 10));
+        try {
+            authzClient.authorization().authorize(request);
+            fail("should fail, invalid subject_token of length " + DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE + 10);
+        } catch (Exception e) {
+            Throwable expected = e.getCause();
+            assertEquals(400, HttpResponseException.class.cast(expected).getStatusCode());
+            assertTrue(HttpResponseException.class.cast(expected).toString().contains("unauthorized_client"));
+        }
+
+        // Request 4: Using invalid subject_token with length bigger than 20000 characters should fail
+        request = new AuthorizationRequest();
+        request.setSubjectToken(SecretGenerator.getInstance().randomString(DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE + 10));
+        try {
+            authzClient.authorization().authorize(request);
+            fail("should fail, invalid subject_token of length " + DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE + 10);
+        } catch (Exception e) {
+            Throwable expected = e.getCause();
+            assertEquals(400, HttpResponseException.class.cast(expected).getStatusCode());
+            assertTrue(HttpResponseException.class.cast(expected).toString().contains("invalid_request"));
+        }
     }
 
     private String getIdToken(String username, String password) {


### PR DESCRIPTION
closes #49435


- The maximum size of the "token" parameter sent to the OIDC token endpoint is increased from 4000 characters to the 20000 characters as 4000 characters is too low for the bigger tokens (like EG. access tokens with bigger amount of roles). At the same time, if limit for some "token" parameter is reached, the request fails instead of the parameter being ignored.

- Introduced new configuration options to the `OIDCLoginProtocolFactory` for maximum size of the "token" parameter and for fail-fast for the "token" parameters (true by default). Upgrading guide updated about this.

