### PR TITLE
ROPC Grant Policy Bypass for reject-ropc-grant

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -1229,6 +1229,10 @@ public class TokenManager {
             return idToken;
         }
 
+        public ClientSessionContext getClientSessionCtx() {
+            return clientSessionCtx;
+        }
+
         public AccessTokenResponseBuilder code(OAuth2Code code) {
             this.code = code;
             return this;

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/LogoutEndpoint.java
@@ -496,7 +496,7 @@ public class LogoutEndpoint {
         }
 
         try {
-            session.clientPolicy().triggerOnEvent(new LogoutRequestContext(form));
+            session.clientPolicy().triggerOnEvent(new LogoutRequestContext(client, form));
             refreshToken = form.getFirst(OAuth2Constants.REFRESH_TOKEN);
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenIntrospectionEndpoint.java
@@ -108,7 +108,7 @@ public class TokenIntrospectionEndpoint {
         }
 
         try {
-            session.clientPolicy().triggerOnEvent(new TokenIntrospectContext(formParams));
+            session.clientPolicy().triggerOnEvent(new TokenIntrospectContext(session.getContext().getClient(), formParams));
             token = formParams.getFirst(PARAM_TOKEN);
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -104,7 +104,7 @@ public class TokenRevocationEndpoint {
         checkParameterDuplicated(formParams);
 
         try {
-            session.clientPolicy().triggerOnEvent(new TokenRevokeContext(formParams));
+            session.clientPolicy().triggerOnEvent(new TokenRevokeContext(client, formParams));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
@@ -131,7 +131,7 @@ public class TokenRevocationEndpoint {
         event.success();
 
         try {
-            session.clientPolicy().triggerOnEvent(new TokenRevokeResponseContext(formParams));
+            session.clientPolicy().triggerOnEvent(new TokenRevokeResponseContext(client, formParams));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -175,16 +175,6 @@ public class UserInfoEndpoint {
                 .event(EventType.USER_INFO_REQUEST)
                 .detail(Details.AUTH_METHOD, Details.VALIDATE_ACCESS_TOKEN);
 
-        try {
-            session.clientPolicy().triggerOnEvent(new UserInfoRequestContext(tokenForUserInfo));
-        } catch (ClientPolicyException cpe) {
-            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
-            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
-            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
-            event.error(cpe.getError());
-            throw error.error(cpe.getError()).errorDescription(cpe.getErrorDetail()).status(cpe.getErrorStatus()).build();
-        }
-
         if (tokenForUserInfo.getToken() == null) {
             event.detail(Details.REASON, "Missing token");
             event.error(Errors.INVALID_TOKEN);
@@ -314,6 +304,16 @@ public class UserInfoEndpoint {
 
         // Existence of authenticatedClientSession for our client already handled before
         AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(clientModel.getId());
+
+        try {
+            session.clientPolicy().triggerOnEvent(new UserInfoRequestContext(clientSession, tokenForUserInfo));
+        } catch (ClientPolicyException cpe) {
+            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
+            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
+            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+            event.error(cpe.getError());
+            throw error.error(cpe.getError()).errorDescription(cpe.getErrorDetail()).status(cpe.getErrorStatus()).build();
+        }
 
         // Retrieve by access token scope parameter
         ClientSessionContext clientSessionCtx = DefaultClientSessionContext.fromClientSessionAndScopeParameter(clientSession, token.getScope(), session);

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
@@ -60,7 +60,7 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
         String resourceParameter = formParams.getFirst(OAuth2Constants.RESOURCE);
 
         try {
-            session.clientPolicy().triggerOnEvent(new TokenRefreshContext(formParams, client));
+            session.clientPolicy().triggerOnEvent(new TokenRefreshContext(formParams, client, scopeParameter));
             refreshToken = formParams.getFirst(OAuth2Constants.REFRESH_TOKEN);
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/clientpolicy/context/PushedAuthorizationRequestContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/clientpolicy/context/PushedAuthorizationRequestContext.java
@@ -19,17 +19,22 @@ package org.keycloak.protocol.oidc.par.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
+import org.keycloak.services.clientpolicy.context.ScopeParameterContext;
 
-public class PushedAuthorizationRequestContext implements ClientPolicyContext {
+public class PushedAuthorizationRequestContext implements ClientPolicyContext, ClientModelContext, ScopeParameterContext {
 
+    private final ClientModel client;
     private final MultivaluedMap<String, String> requestParameters;
     private AuthorizationEndpointRequest request;
 
-    public PushedAuthorizationRequestContext(AuthorizationEndpointRequest request,
+    public PushedAuthorizationRequestContext(ClientModel client, AuthorizationEndpointRequest request,
             MultivaluedMap<String, String> requestParameters) {
+        this.client = client;
         this.request = request;
         this.requestParameters = requestParameters;
     }
@@ -45,5 +50,15 @@ public class PushedAuthorizationRequestContext implements ClientPolicyContext {
 
     public MultivaluedMap<String, String> getRequestParameters() {
         return requestParameters;
+    }
+
+    @Override
+    public ClientModel getClient() {
+        return client;
+    }
+
+    @Override
+    public String getScopeParameter() {
+        return request.getScope();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -155,7 +155,7 @@ public class ParEndpoint extends AbstractParEndpoint {
         }
 
         try {
-            session.clientPolicy().triggerOnEvent(new PushedAuthorizationRequestContext(authorizationRequest, decodedFormParameters));
+            session.clientPolicy().triggerOnEvent(new PushedAuthorizationRequestContext(client, authorizationRequest, decodedFormParameters));
         } catch (ClientPolicyException cpe) {
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAttributesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAttributesCondition.java
@@ -27,9 +27,12 @@ import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepres
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
 import org.keycloak.services.clientpolicy.context.PreAuthorizationRequestContext;
 
 import org.jboss.logging.Logger;
+
+import static org.keycloak.services.clientpolicy.ClientPolicyEvent.PRE_AUTHORIZATION_REQUEST;
 
 /**
  * @author <a href="mailto:yoshiyuki.tabata.jy@hitachi.com">Yoshiyuki Tabata</a>
@@ -67,38 +70,17 @@ public class ClientAttributesCondition extends AbstractClientPolicyConditionProv
 
     @Override
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
-        switch (context.getEvent()) {
-            case PRE_AUTHORIZATION_REQUEST:
-                PreAuthorizationRequestContext paContext = (PreAuthorizationRequestContext) context;
-                ClientModel client = session.getContext().getRealm().getClientByClientId(paContext.getClientId());
-                if (isAttributesMatched(client)) return ClientPolicyVote.YES;
-                return ClientPolicyVote.NO;
-            case AUTHORIZATION_REQUEST:
-            case TOKEN_REQUEST:
-            case TOKEN_RESPONSE:
-            case SERVICE_ACCOUNT_TOKEN_REQUEST:
-            case SERVICE_ACCOUNT_TOKEN_RESPONSE:
-            case TOKEN_REFRESH:
-            case TOKEN_REFRESH_RESPONSE:
-            case TOKEN_REVOKE:
-            case TOKEN_INTROSPECT:
-            case USERINFO_REQUEST:
-            case LOGOUT_REQUEST:
-            case BACKCHANNEL_AUTHENTICATION_REQUEST:
-            case BACKCHANNEL_TOKEN_REQUEST:
-            case BACKCHANNEL_TOKEN_RESPONSE:
-            case PUSHED_AUTHORIZATION_REQUEST:
-            case REGISTERED:
-            case UPDATE:
-            case UPDATED:
-            case TOKEN_EXCHANGE_REQUEST:
-            case JWT_AUTHORIZATION_GRANT:
-            case SAML_AUTHN_REQUEST:
-            case SAML_LOGOUT_REQUEST:
-                boolean attributesMatched = isAttributesMatched(session.getContext().getClient());
-                return attributesMatched ? ClientPolicyVote.YES : ClientPolicyVote.NO;
-            default:
-                return ClientPolicyVote.ABSTAIN;
+        if (context.getEvent() == PRE_AUTHORIZATION_REQUEST) {
+            PreAuthorizationRequestContext paContext = (PreAuthorizationRequestContext) context;
+            ClientModel client = session.getContext().getRealm().getClientByClientId(paContext.getClientId());
+            if (isAttributesMatched(client)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else if (context instanceof ClientModelContext) {
+            ClientModel client = ((ClientModelContext) context).getClient();
+            if (isAttributesMatched(client)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else {
+            return ClientPolicyVote.ABSTAIN;
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientProtocolCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientProtocolCondition.java
@@ -24,6 +24,9 @@ import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyVote;
 import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
+
+import static org.keycloak.services.clientpolicy.ClientPolicyEvent.REGISTER;
 
 /**
  *
@@ -68,41 +71,24 @@ public class ClientProtocolCondition extends AbstractClientPolicyConditionProvid
 
     @Override
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
-        switch (context.getEvent()) {
-            case AUTHORIZATION_REQUEST:
-            case TOKEN_REQUEST:
-            case TOKEN_RESPONSE:
-            case SERVICE_ACCOUNT_TOKEN_REQUEST:
-            case SERVICE_ACCOUNT_TOKEN_RESPONSE:
-            case TOKEN_REFRESH:
-            case TOKEN_REFRESH_RESPONSE:
-            case TOKEN_REVOKE:
-            case TOKEN_INTROSPECT:
-            case USERINFO_REQUEST:
-            case LOGOUT_REQUEST:
-            case UPDATE:
-            case UPDATED:
-            case REGISTERED:
-            case TOKEN_REVOKE_RESPONSE:
-            case JWT_AUTHORIZATION_GRANT:
-            case SAML_AUTHN_REQUEST:
-            case SAML_LOGOUT_REQUEST:
-                if (isCorrectProtocolFromContext()) {
-                    return ClientPolicyVote.YES;
-                }
+        if (context.getEvent() == REGISTER) {
+            if (isCorrectProtocolFromRepresentation((ClientCRUDContext)context)) {
+                return ClientPolicyVote.YES;
+            }
+            return ClientPolicyVote.NO;
+        } else if (context instanceof ClientModelContext) {
+            ClientModel client = ((ClientModelContext) context).getClient();
+            if (isCorrectClientProtocol(client)) {
+                return ClientPolicyVote.YES;
+            } else {
                 return ClientPolicyVote.NO;
-            case REGISTER:
-                if (isCorrectProtocolFromRepresentation((ClientCRUDContext)context)) {
-                    return ClientPolicyVote.YES;
-                }
-                return ClientPolicyVote.NO;
-            default:
-                return ClientPolicyVote.ABSTAIN;
+            }
+        } else {
+            return ClientPolicyVote.ABSTAIN;
         }
     }
 
-    public boolean isCorrectProtocolFromContext() {
-        ClientModel client = session.getContext().getClient();
+    private boolean isCorrectClientProtocol(ClientModel client) {
         if (client != null) {
             String protocol = client.getProtocol();
             if (protocol != null) {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
@@ -29,9 +29,12 @@ import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepres
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyVote;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
 import org.keycloak.services.clientpolicy.context.PreAuthorizationRequestContext;
 
 import org.jboss.logging.Logger;
+
+import static org.keycloak.services.clientpolicy.ClientPolicyEvent.PRE_AUTHORIZATION_REQUEST;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
@@ -69,38 +72,17 @@ public class ClientRolesCondition extends AbstractClientPolicyConditionProvider<
 
     @Override
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
-        switch (context.getEvent()) {
-            case PRE_AUTHORIZATION_REQUEST:
-                PreAuthorizationRequestContext paContext = (PreAuthorizationRequestContext) context;
-                ClientModel client = session.getContext().getRealm().getClientByClientId(paContext.getClientId());
-                if (isRolesMatched(client)) return ClientPolicyVote.YES;
-                return ClientPolicyVote.NO;
-            case AUTHORIZATION_REQUEST:
-            case TOKEN_REQUEST:
-            case TOKEN_RESPONSE:
-            case SERVICE_ACCOUNT_TOKEN_REQUEST:
-            case SERVICE_ACCOUNT_TOKEN_RESPONSE:
-            case TOKEN_REFRESH:
-            case TOKEN_REFRESH_RESPONSE:
-            case TOKEN_REVOKE:
-            case TOKEN_INTROSPECT:
-            case USERINFO_REQUEST:
-            case LOGOUT_REQUEST:
-            case BACKCHANNEL_AUTHENTICATION_REQUEST:
-            case BACKCHANNEL_TOKEN_REQUEST:
-            case BACKCHANNEL_TOKEN_RESPONSE:
-            case PUSHED_AUTHORIZATION_REQUEST:
-            case REGISTERED:
-            case UPDATE:
-            case UPDATED:
-            case TOKEN_EXCHANGE_REQUEST:
-            case JWT_AUTHORIZATION_GRANT:
-            case SAML_AUTHN_REQUEST:
-            case SAML_LOGOUT_REQUEST:
-                if (isRolesMatched(session.getContext().getClient())) return ClientPolicyVote.YES;
-                return ClientPolicyVote.NO;
-            default:
-                return ClientPolicyVote.ABSTAIN;
+        if (context.getEvent() == PRE_AUTHORIZATION_REQUEST) {
+            PreAuthorizationRequestContext paContext = (PreAuthorizationRequestContext) context;
+            ClientModel client = session.getContext().getRealm().getClientByClientId(paContext.getClientId());
+            if (isRolesMatched(client)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else if (context instanceof ClientModelContext) {
+            ClientModel client = ((ClientModelContext) context).getClient();
+            if (isRolesMatched(client)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else {
+            return ClientPolicyVote.ABSTAIN;
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/AbstractSamlRequestContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/AbstractSamlRequestContext.java
@@ -30,7 +30,7 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
  * @author rmartinc
  * @param <T> The saml request type
  */
-public abstract class AbstractSamlRequestContext<T> implements ClientPolicyContext {
+public abstract class AbstractSamlRequestContext<T> implements ClientPolicyContext, ClientModelContext {
 
     protected final T request;
     protected final ClientModel client;
@@ -60,6 +60,7 @@ public abstract class AbstractSamlRequestContext<T> implements ClientPolicyConte
      * Getter for the client model doing the request.
      * @return The client model
      */
+    @Override
     public ClientModel getClient() {
         return client;
     }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientRegisteredContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientRegisteredContext.java
@@ -21,7 +21,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.resources.admin.AdminAuth;
 
-public class AdminClientRegisteredContext extends AbstractAdminClientCRUDContext {
+public class AdminClientRegisteredContext extends AbstractAdminClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel registeredClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientUnregisterContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientUnregisterContext.java
@@ -21,7 +21,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.resources.admin.AdminAuth;
 
-public class AdminClientUnregisterContext extends AbstractAdminClientCRUDContext {
+public class AdminClientUnregisterContext extends AbstractAdminClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel targetClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientUpdateContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientUpdateContext.java
@@ -22,7 +22,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.resources.admin.AdminAuth;
 
-public class AdminClientUpdateContext extends AbstractAdminClientCRUDContext {
+public class AdminClientUpdateContext extends AbstractAdminClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientRepresentation proposedClientRepresentation;
     private final ClientModel targetClient;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientUpdatedContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientUpdatedContext.java
@@ -22,7 +22,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.resources.admin.AdminAuth;
 
-public class AdminClientUpdatedContext extends AbstractAdminClientCRUDContext {
+public class AdminClientUpdatedContext extends AbstractAdminClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientRepresentation proposedClientRepresentation;
     private final ClientModel updatedClient;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientViewContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/AdminClientViewContext.java
@@ -21,7 +21,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.resources.admin.AdminAuth;
 
-public class AdminClientViewContext extends AbstractAdminClientCRUDContext {
+public class AdminClientViewContext extends AbstractAdminClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel targetClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/ClientCRUDClientAvailableContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/ClientCRUDClientAvailableContext.java
@@ -1,0 +1,14 @@
+package org.keycloak.services.clientpolicy.context;
+
+import org.keycloak.models.ClientModel;
+
+/**
+ * Context for client CRUD in cases when client model is already available (registered/read/update/updated/deleted)
+ */
+public interface ClientCRUDClientAvailableContext extends ClientCRUDContext, ClientModelContext {
+
+    @Override
+    default ClientModel getClient() {
+        return getTargetClient();
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientRegisteredContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientRegisteredContext.java
@@ -23,7 +23,7 @@ import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientregistration.ClientRegistrationContext;
 
-public class DynamicClientRegisteredContext extends AbstractDynamicClientCRUDContext {
+public class DynamicClientRegisteredContext extends AbstractDynamicClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel registeredClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientUnregisterContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientUnregisterContext.java
@@ -23,7 +23,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
-public class DynamicClientUnregisterContext extends AbstractDynamicClientCRUDContext {
+public class DynamicClientUnregisterContext extends AbstractDynamicClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel targetClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientUpdateContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientUpdateContext.java
@@ -24,7 +24,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientregistration.ClientRegistrationContext;
 
-public class DynamicClientUpdateContext extends AbstractDynamicClientCRUDContext {
+public class DynamicClientUpdateContext extends AbstractDynamicClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel clientToBeUpdated;
     private final ClientRepresentation proposedClientRepresentation;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientUpdatedContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientUpdatedContext.java
@@ -23,7 +23,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
-public class DynamicClientUpdatedContext extends AbstractDynamicClientCRUDContext {
+public class DynamicClientUpdatedContext extends AbstractDynamicClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel updatedClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientViewContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/DynamicClientViewContext.java
@@ -23,7 +23,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
-public class DynamicClientViewContext extends AbstractDynamicClientCRUDContext {
+public class DynamicClientViewContext extends AbstractDynamicClientCRUDContext implements ClientCRUDClientAvailableContext {
 
     private final ClientModel targetClient;
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/LogoutRequestContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/LogoutRequestContext.java
@@ -19,22 +19,25 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class LogoutRequestContext implements ClientPolicyContext {
+public class LogoutRequestContext implements ClientPolicyContext, ClientModelContext {
 
+    private final ClientModel client;
     private final MultivaluedMap<String, String> params;
 
-    public LogoutRequestContext(MultivaluedMap<String, String> params) {
+    public LogoutRequestContext(ClientModel client, MultivaluedMap<String, String> params) {
+        this.client = client;
         this.params = params;
     }
 
-    public LogoutRequestContext() {
-        this(null);
+    public LogoutRequestContext(ClientModel client) {
+        this(client, null);
     }
 
     @Override
@@ -44,5 +47,10 @@ public class LogoutRequestContext implements ClientPolicyContext {
 
     public MultivaluedMap<String, String> getParams() {
         return params;
+    }
+
+    @Override
+    public ClientModel getClient() {
+        return client;
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenIntrospectContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenIntrospectContext.java
@@ -19,17 +19,20 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class TokenIntrospectContext implements ClientPolicyContext {
+public class TokenIntrospectContext implements ClientPolicyContext, ClientModelContext {
 
+    private final ClientModel client;
     private final MultivaluedMap<String, String> params;
 
-    public TokenIntrospectContext(MultivaluedMap<String, String> params) {
+    public TokenIntrospectContext(ClientModel client, MultivaluedMap<String, String> params) {
+        this.client = client;
         this.params = params;
     }
 
@@ -42,4 +45,8 @@ public class TokenIntrospectContext implements ClientPolicyContext {
         return params;
     }
 
+    @Override
+    public ClientModel getClient() {
+        return client;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRefreshContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRefreshContext.java
@@ -26,14 +26,16 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class TokenRefreshContext implements ClientPolicyContext {
+public class TokenRefreshContext implements ClientPolicyContext, ClientModelContext, ScopeParameterContext {
 
     private final MultivaluedMap<String, String> params;
     private final ClientModel client;
+    private final String scope;
 
-    public TokenRefreshContext(MultivaluedMap<String, String> params, ClientModel client) {
+    public TokenRefreshContext(MultivaluedMap<String, String> params, ClientModel client, String scope) {
         this.params = params;
         this.client = client;
+        this.scope = scope;
     }
 
     @Override
@@ -45,7 +47,13 @@ public class TokenRefreshContext implements ClientPolicyContext {
         return params;
     }
 
+    @Override
     public ClientModel getClient() {
         return client;
+    }
+
+    @Override
+    public String getScopeParameter() {
+        return scope;
     }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRefreshResponseContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRefreshResponseContext.java
@@ -19,6 +19,7 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
@@ -26,7 +27,7 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class TokenRefreshResponseContext implements ClientPolicyContext {
+public class TokenRefreshResponseContext implements ClientPolicyContext, ClientPolicyClientSessionContext {
 
     private final MultivaluedMap<String, String> params;
     private final TokenManager.AccessTokenResponseBuilder accessTokenResponseBuilder;
@@ -50,4 +51,8 @@ public class TokenRefreshResponseContext implements ClientPolicyContext {
         return accessTokenResponseBuilder;
     }
 
+    @Override
+    public AuthenticatedClientSessionModel getClientSession() {
+        return this.accessTokenResponseBuilder.getClientSessionCtx().getClientSession();
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRevokeContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRevokeContext.java
@@ -19,17 +19,20 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class TokenRevokeContext implements ClientPolicyContext {
+public class TokenRevokeContext implements ClientPolicyContext, ClientModelContext {
 
+    private final ClientModel client;
     private final MultivaluedMap<String, String> params;
 
-    public TokenRevokeContext(MultivaluedMap<String, String> params) {
+    public TokenRevokeContext(ClientModel client, MultivaluedMap<String, String> params) {
+        this.client = client;
         this.params = params;
     }
 
@@ -42,4 +45,8 @@ public class TokenRevokeContext implements ClientPolicyContext {
         return params;
     }
 
+    @Override
+    public ClientModel getClient() {
+        return client;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRevokeResponseContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/TokenRevokeResponseContext.java
@@ -19,17 +19,20 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.models.ClientModel;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class TokenRevokeResponseContext implements ClientPolicyContext {
+public class TokenRevokeResponseContext implements ClientPolicyContext, ClientModelContext {
 
+    private final ClientModel client;
     private final MultivaluedMap<String, String> params;
 
-    public TokenRevokeResponseContext(MultivaluedMap<String, String> params) {
+    public TokenRevokeResponseContext(ClientModel client, MultivaluedMap<String, String> params) {
+        this.client = client;
         this.params = params;
     }
 
@@ -42,4 +45,8 @@ public class TokenRevokeResponseContext implements ClientPolicyContext {
         return params;
     }
 
+    @Override
+    public ClientModel getClient() {
+        return client;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/UserInfoRequestContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/UserInfoRequestContext.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.clientpolicy.context;
 
+import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.protocol.oidc.endpoints.UserInfoEndpoint;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
@@ -24,11 +25,13 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
-public class UserInfoRequestContext implements ClientPolicyContext {
+public class UserInfoRequestContext implements ClientPolicyContext, ClientPolicyClientSessionContext {
 
+    private AuthenticatedClientSessionModel clientSession;
     private UserInfoEndpoint.TokenForUserInfo tokenForUserInfo;
 
-    public UserInfoRequestContext(UserInfoEndpoint.TokenForUserInfo tokenForUserInfo) {
+    public UserInfoRequestContext(AuthenticatedClientSessionModel clientSession, UserInfoEndpoint.TokenForUserInfo tokenForUserInfo) {
+        this.clientSession = clientSession;
         this.tokenForUserInfo = tokenForUserInfo;
     }
 
@@ -41,4 +44,8 @@ public class UserInfoRequestContext implements ClientPolicyContext {
         return tokenForUserInfo;
     }
 
+    @Override
+    public AuthenticatedClientSessionModel getClientSession() {
+        return clientSession;
+    }
 }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -601,7 +601,7 @@ public class AuthenticationManager {
         }
 
         try {
-            session.clientPolicy().triggerOnEvent(new LogoutRequestContext());
+            session.clientPolicy().triggerOnEvent(new LogoutRequestContext(client));
         } catch (ClientPolicyException cpe) {
             event.event(EventType.LOGOUT);
             event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -70,6 +70,8 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientAttributesConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextConditionFactory;
@@ -122,9 +124,12 @@ import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
 import static org.keycloak.OAuth2Constants.SCOPE_PHONE;
+import static org.keycloak.protocol.oidc.OIDCConfigAttributes.USE_REFRESH_TOKEN;
 import static org.keycloak.testsuite.AbstractAdminTest.loadJson;
 import static org.keycloak.testsuite.admin.AdminApiUtil.findClientResourceByClientId;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createAnyClientConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientAttributesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientProtocolConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientRolesConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientScopesConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientUpdateContextConditionConfig;
@@ -944,29 +949,17 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
     }
 
     @Test
-    public void testRejectResourceOwnerCredentialsGrantExecutor() throws Exception {
-
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithAnyClientCondition() throws Exception {
         String clientId = generateSuffixedName(CLIENT_NAME);
         String clientSecret = "secret";
 
-        createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
-            clientRep.setSecret(clientSecret);
-            clientRep.setStandardFlowEnabled(Boolean.TRUE);
-            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
-            clientRep.setPublicClient(Boolean.FALSE);
-        });
-
-        // register profiles
-        String json = (new ClientProfilesBuilder()).addProfile(
-                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
-                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
-                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
-                        .toRepresentation()
-        ).toString();
-        updateProfiles(json);
+        // Create client
+        createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
 
         // register policies
-        json = (new ClientPoliciesBuilder()).addPolicy(
+        String json = (new ClientPoliciesBuilder()).addPolicy(
                 (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Porisii desu", Boolean.TRUE)
                         .addCondition(AnyClientConditionFactory.PROVIDER_ID,
                                 createAnyClientConditionConfig())
@@ -989,24 +982,13 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         String clientId = generateSuffixedName(CLIENT_NAME);
         String clientSecret = "secret";
 
-        createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
-            clientRep.setSecret(clientSecret);
-            clientRep.setStandardFlowEnabled(Boolean.TRUE);
-            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
-            clientRep.setPublicClient(Boolean.FALSE);
-        });
+        // Create client
+        createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
 
-        // register profiles
-        String json = (new ClientProfilesBuilder()).addProfile(
-                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
-                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
-                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
-                        .toRepresentation()
-        ).toString();
-        updateProfiles(json);
-
-        // register policies
-        json = (new ClientPoliciesBuilder()).addPolicy(
+        // register policies - client scopes condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
                 (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
                         .addCondition(ClientScopesConditionFactory.PROVIDER_ID,
                                 createClientScopesConditionConfig(ClientScopesConditionFactory.ANY, Arrays.asList(SCOPE_PHONE)))
@@ -1033,6 +1015,120 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         } finally {
             oauth.scope(origScope);
         }
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientProtocolCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        // Create client
+        createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
+
+        // register policies - client protocol condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientProtocolConditionFactory.PROVIDER_ID,
+                                createClientProtocolConditionConfig(OIDCLoginProtocol.LOGIN_PROTOCOL))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+        assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientRolesCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        // Create client
+        String clientUUID = createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
+
+        // add the role to the client to execute condition
+        adminClient.realm(REALM_NAME).clients().get(clientUUID).roles().create(RoleBuilder.create().name(SAMPLE_CLIENT_ROLE).build());
+
+        // register policies - client roles condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientRolesConditionFactory.PROVIDER_ID,
+                                createClientRolesConditionConfig(List.of(SAMPLE_CLIENT_ROLE)))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+        assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientAttributesCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        // Create client
+        String clientUUID = createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
+
+        // add the role to the client to execute condition
+        adminClient.realm(REALM_NAME).clients().get(clientUUID).roles().create(RoleBuilder.create().name(SAMPLE_CLIENT_ROLE).build());
+
+        // register policies - client attributes condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientAttributesConditionFactory.PROVIDER_ID,
+                                createClientAttributesConditionConfig(new MultivaluedHashMap<>() {
+                                    {
+                                        putSingle(USE_REFRESH_TOKEN, "true");
+                                    }
+                                }))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+        assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+    }
+
+    private String createClientForResourceOwnerPasswordCredential(String clientId, String clientSecret) throws ClientPolicyException {
+        return createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
+            clientRep.setSecret(clientSecret);
+            clientRep.setStandardFlowEnabled(Boolean.TRUE);
+            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
+            clientRep.setPublicClient(Boolean.FALSE);
+            clientRep.getAttributes().put(USE_REFRESH_TOKEN, "true"); // Just some attribute to be able to test clientAttributes condition
+        });
+    }
+
+    private void registerClientProfileWithResourceOwnerRejectExecutor() throws Exception {
+        String json = (new ClientProfilesBuilder()).addProfile(
+                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
+                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
+                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -52,6 +52,7 @@ import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
 import org.keycloak.services.clientpolicy.condition.ClientAttributesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolCondition;
 import org.keycloak.services.clientpolicy.condition.ClientRolesCondition;
 import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextCondition;
@@ -428,6 +429,12 @@ public final class ClientPoliciesUtil {
     public static ClientAccessTypeCondition.Configuration createClientAccessTypeConditionConfig(List<String> types) {
         ClientAccessTypeCondition.Configuration config = new ClientAccessTypeCondition.Configuration();
         config.setType(types);
+        return config;
+    }
+
+    public static ClientProtocolCondition.Configuration createClientProtocolConditionConfig(String protocol) {
+        ClientProtocolCondition.Configuration config = new ClientProtocolCondition.Configuration();
+        config.setProtocol(protocol);
         return config;
     }
 


### PR DESCRIPTION
closes #49436

- PR follows on the approach introduced by https://github.com/keycloak/keycloak/issues/46936 .

- The `ClientRolesCondition`, `ClientAttributesCondition` and `ClientProtocolCondition` were updated to retrieve client from the contract provided by `ClientModelContext` interface instead of using fragile/error-prone approach of explicitly listing all the "context" types for which the particular condition should be triggered. This improvement likely fixed some additional bugs (as for example `UserInfoContext` did not had client available in `session.getContext().getClient()` before this PR)

- Most of the changed files in this PR are for updating some individual client policy contexts (implementations of `ClientPolicyContext` interface) to implement `ClientModelContext` (or `ClientPolicyClientSessionContext`) to be able to retrieve the client from the particular context. Few of the contexts already implemented this and hence did not need any updates.

- The `ClientScopesCondition` did not needed to be fixed as it was fixed already by https://github.com/keycloak/keycloak/issues/46933 in the Keycloak 26.6.0 (CVE report was against 26.5.4). However this was not yet backported to 26.4 or 26.2. So when backporting this to 26.4 (or 26.2), the corresponding upstream PR for the above will need to be backported as well . The backports to 26.4 (and 26.2) may probably need to either backport also https://github.com/keycloak/keycloak/issues/46936 or fixed it differently just by explicitly listing `RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST` in the corresponding conditions

- The PR will likely break "Testsuite deprecation" check as it adds more than 100 lines to `ClientPoliciesTest`, but I hope this can be accepted due the fact that it requires backport to 26.4 and/or 26.2 where new testsuite is not yet polished...
