### PR TITLE
fix: refresh expired token in exchangeStoredToken for V2/token-exchange

### DIFF
--- a/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/AbstractOAuth2IdentityProvider.java
@@ -455,6 +455,28 @@ public abstract class AbstractOAuth2IdentityProvider<C extends OAuth2IdentityPro
             return exchangeNotLinked(uriInfo, authorizedClient, tokenUserSession, tokenSubject);
         }
 
+        // Refresh the stored token if it has expired and a refresh token is available
+        try {
+            if (model.getToken().startsWith("{")) {
+                OAuthResponse previousResponse = JsonSerialization.readValue(model.getToken(), OAuthResponse.class);
+                Long exp = previousResponse.getAccessTokenExpiration();
+                if (needsRefresh(exp) && previousResponse.getRefreshToken() != null) {
+                    OAuthResponse newResponse = refreshToken(previousResponse, session);
+                    if (newResponse.getExpiresIn() != null && newResponse.getExpiresIn() > 0) {
+                        long accessTokenExpiration = Time.currentTime() + newResponse.getExpiresIn();
+                        newResponse.setAccessTokenExpiration(accessTokenExpiration);
+                    }
+                    model.setToken(JsonSerialization.writeValueAsString(newResponse));
+                    session.users().updateFederatedIdentity(realm, tokenSubject, model);
+                }
+            }
+        } catch (IOException e) {
+            ErrorRepresentation error = new ErrorRepresentation();
+            error.setErrorMessage("Unable to refresh token");
+            throw new WebApplicationException("Unable to refresh token", e,
+                    Response.status(Response.Status.BAD_GATEWAY).entity(error).type(MediaType.APPLICATION_JSON).build());
+        }
+
         String accessToken = extractTokenFromResponse(model.getToken(), getAccessTokenResponseParameter());
         if (accessToken == null) {
             model.setToken(null);


### PR DESCRIPTION
Fixes #49341

## Summary

The `exchangeStoredToken` method (used by V2 API `GET /realms/{realm}/broker/{alias}/token` and token exchange) returns the stored access token without checking expiration or attempting refresh. This causes expired tokens to be returned to callers, resulting in 401 errors.

## Root Cause

`exchangeStoredToken()` retrieves the stored token and extracts the access token directly, without:
1. Checking if the access token has expired
2. Attempting to use the refresh token to get a fresh access token

## Fix

Added the same refresh logic that was already applied to `retrieveToken()` (V1) in PR #39508:

- Parse stored token as JSON (`OAuthResponse`)
- Check if access token needs refresh via `needsRefresh()`
- If expired and refresh token available, call `refreshToken()` to get new token
- Update the persisted token with new expiration via `updateFederatedIdentity()`

## Verification

The fix follows the exact same pattern as the V1 fix in #39508. To verify:

1. Configure an OAuth2/OIDC external IDP with **Store Tokens** enabled
2. Log in via the external IDP
3. Wait for the access token to expire
4. Call `GET /realms/{realm}/broker/{alias}/token` (V2) or use token exchange
5. Verify a fresh (non-expired) access token is returned