### PR TITLE
Add validation on Authorization Header with Bearer for client registration

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/ClientRegistrationAuth.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.Config;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authentication.AuthenticationProcessor;
+import org.keycloak.common.util.ObjectUtil;
 import org.keycloak.common.util.Time;
 import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
@@ -90,12 +91,24 @@ public class ClientRegistrationAuth {
             return;
         }
 
-        String[] split = authorizationHeader.split(" ");
-        if (!split[0].equalsIgnoreCase("bearer")) {
+        int indexOfSpace = authorizationHeader.indexOf(' ');
+
+        if (indexOfSpace <= 0) {
             return;
         }
 
-        token = split[1];
+        String typeString = authorizationHeader.substring(0, indexOfSpace);
+        String tokenString = authorizationHeader.substring(indexOfSpace + 1);
+
+        if (!typeString.equalsIgnoreCase(TokenUtil.TOKEN_TYPE_BEARER)) {
+            return;
+        }
+
+        if (ObjectUtil.isBlank(tokenString) || tokenString.contains(" ")) {
+            return;
+        }
+
+        token = tokenString;
 
         ClientRegistrationTokenUtils.TokenVerification tokenVerification = ClientRegistrationTokenUtils.verifyToken(session, realm, token);
         if (tokenVerification.getError() != null) {

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationAuthTest.java
@@ -1,0 +1,93 @@
+package org.keycloak.tests.client;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
+import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@KeycloakIntegrationTest
+public class ClientRegistrationAuthTest {
+
+    @InjectRealm
+    ManagedRealm realm;
+
+    @InjectSimpleHttp
+    SimpleHttp simpleHttp;
+
+    @Test
+    public void testSuccess() throws IOException {
+        test("Bearer ", true);
+    }
+
+    @Test
+    public void testSuccess_BearerLowerCase() throws IOException {
+        test("bearer ", true);
+    }
+
+    @Test
+    public void testSuccess_BearerUpperCase() throws IOException {
+        test("BEARER ", true);
+    }
+
+    @Test
+    public void testSuccess_BearerMixedCase() throws IOException {
+        test("BeArEr ", true);
+    }
+
+    @Test
+    public void testFailure_TwoSpaces() throws IOException {
+        test("Bearer  ", false);
+    }
+
+    @Test
+    public void testFailure_MultiSpaces() throws IOException {
+        test("Bearer     ", false);
+    }
+
+    @Test
+    public void testFailure_TabSymbol() throws IOException {
+        test("Bearer\t", false);
+    }
+
+    private void test(String authPrefix, boolean success) throws IOException {
+        String token = createInitialAccessToken();
+        OIDCClientRepresentation client = new OIDCClientRepresentation();
+        client.setClientName("test-auth-client");
+
+        try (SimpleHttpResponse response = simpleHttp.doPost(getOidcUrl())
+                .json(client)
+                .header("Authorization", authPrefix + token)
+                .asResponse()) {
+            int expectedStatus = success
+                ? Response.Status.CREATED.getStatusCode()
+                : Response.Status.FORBIDDEN.getStatusCode();
+            Assertions.assertEquals(expectedStatus, response.getStatus());
+
+            if (success) {
+                OIDCClientRepresentation responseClient = response.asJson(OIDCClientRepresentation.class);
+                String id = realm.admin().clients().findByClientId(responseClient.getClientId()).get(0).getId();
+                realm.admin().clients().get(id).remove();
+            }
+        }
+    }
+
+    private String createInitialAccessToken() {
+        ClientInitialAccessCreatePresentation initialAccessCreatePresentation = new ClientInitialAccessCreatePresentation(0, 100);
+        return realm.admin().clientInitialAccess().create(initialAccessCreatePresentation).getToken();
+    }
+
+    private String getOidcUrl() {
+        return realm.getBaseUrl() + "/clients-registrations/openid-connect";
+    }
+}


### PR DESCRIPTION
Closes #49433

Add same validation of https://github.com/keycloak/keycloak/issues/45649 but for Client Registration.


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
