### PR TITLE
Add Issued Verifiable Credentials UI to Account Console

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/oid4vc/IssuedVerifiableCredentialRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/oid4vc/IssuedVerifiableCredentialRepresentation.java
@@ -11,6 +11,25 @@ public class IssuedVerifiableCredentialRepresentation {
     private Long expiresAt;
     // This represents UUID of the client, which acts as OID4VCI wallet
     private String clientId;
+    private String clientName;
+    private String clientBaseUrl;
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
+
+    public String getClientBaseUrl() {
+        return clientBaseUrl;
+    }
+
+    public void setClientBaseUrl(String clientBaseUrl) {
+        this.clientBaseUrl = clientBaseUrl;
+    }
+
     private String revision;
 
     public String getId() {

--- a/js/apps/account-ui/src/api/methods.ts
+++ b/js/apps/account-ui/src/api/methods.ts
@@ -10,6 +10,7 @@ import {
   CredentialContainer,
   DeviceRepresentation,
   Group,
+  IssuedUserVerifiableCredentialRepresentation,
   LinkedAccountRepresentation,
   Permission,
   UserRepresentation,
@@ -177,5 +178,31 @@ export async function deleteVerifiableCredential(
   if (!response.ok) {
     const error = await parseResponse(response);
     throw error;
+  }
+}
+
+export async function getIssuedVerifiableCredentials({
+  signal,
+  context,
+}: CallOptions): Promise<IssuedUserVerifiableCredentialRepresentation[]> {
+  const response = await request("/issued-verifiable-credentials", context, {
+    signal,
+  });
+  return parseResponse<IssuedUserVerifiableCredentialRepresentation[]>(
+    response,
+  );
+}
+
+export async function revokeIssuedVerifiableCredential(
+  context: KeycloakContext<BaseEnvironment>,
+  issuedVerifiableCredentialId: string,
+): Promise<void> {
+  const response = await request(
+    `/issued-verifiable-credentials/${issuedVerifiableCredentialId}`,
+    context,
+    { method: "DELETE" },
+  );
+  if (!response.ok) {
+    throw await parseResponse(response);
   }
 }

--- a/js/apps/account-ui/src/api/representations.ts
+++ b/js/apps/account-ui/src/api/representations.ts
@@ -213,3 +213,4 @@ export interface Group {
 }
 
 export type { default as UserVerifiableCredentialRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/userVerifiableCredentialRepresentation";
+export type { default as IssuedUserVerifiableCredentialRepresentation } from "@keycloak/keycloak-admin-client/lib/defs/issuedUserVerifiableCredentialRepresentation";

--- a/js/apps/account-ui/src/verifiable-credentials/CredentialRow.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/CredentialRow.tsx
@@ -1,7 +1,4 @@
-import {
-  ContinueCancelModal,
-  useEnvironment,
-} from "@keycloak/keycloak-ui-shared";
+import { useEnvironment } from "@keycloak/keycloak-ui-shared";
 import {
   Button,
   DataListAction,
@@ -11,6 +8,8 @@ import {
   DataListItemRow,
   Flex,
   FlexItem,
+  Modal,
+  ModalVariant,
 } from "@patternfly/react-core";
 import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 import { useState } from "react";
@@ -28,6 +27,52 @@ type CredentialRowProps = {
   refresh: () => void;
 };
 
+type RevokeDialogProps = {
+  isOpen: boolean;
+  credentialName: string;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  t: (key: string, params?: any) => string;
+};
+
+const RevokeDialog = ({
+  isOpen,
+  credentialName,
+  onClose,
+  onConfirm,
+  t,
+}: RevokeDialogProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title={t("Delete Credential")}
+      isOpen={true}
+      onClose={onClose}
+      actions={[
+        <Button
+          key="confirm"
+          variant="danger"
+          onClick={async () => {
+            await onConfirm();
+            onClose();
+          }}
+        >
+          {t("delete")}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          {t("cancel")}
+        </Button>,
+      ]}
+    >
+      {t("Confirm Revoke Credential", {
+        credentialName,
+      })}
+    </Modal>
+  );
+};
+
 export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
   const { t } = useTranslation();
   const context = useEnvironment();
@@ -35,6 +80,7 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
   const [showAttributesDialog, setShowAttributesDialog] = useState(false);
   const [showIssuedCredentialsModal, setShowIssuedCredentialsModal] =
     useState(false);
+  const [showRevokeDialog, setShowRevokeDialog] = useState(false);
 
   const hasUserAttributes =
     credential.userAttributes != null &&
@@ -84,6 +130,13 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
 
   return (
     <>
+      <RevokeDialog
+        isOpen={showRevokeDialog}
+        credentialName={credential.credentialScopeName!}
+        onClose={() => setShowRevokeDialog(false)}
+        onConfirm={handleDelete}
+        t={t}
+      />
       {showAttributesDialog && hasUserAttributes && (
         <UserAttributesDialog
           credentialScopeName={credential.credentialScopeName!}
@@ -94,6 +147,7 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
       {showIssuedCredentialsModal && (
         <IssuedCredentialsModal
           credentialScopeName={credential.credentialScopeName!}
+          parentRevision={credential.revision}
           onClose={() => setShowIssuedCredentialsModal(false)}
         />
       )}
@@ -160,18 +214,12 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
               </FlexItem>
               {hasManageRole() && (
                 <FlexItem>
-                  <ContinueCancelModal
-                    buttonTitle={t("delete")}
-                    modalTitle={t("deleteCredential")}
-                    continueLabel={t("delete")}
-                    cancelLabel={t("cancel")}
-                    buttonVariant="link"
-                    onContinue={handleDelete}
+                  <Button
+                    variant="link"
+                    onClick={() => setShowRevokeDialog(true)}
                   >
-                    {t("deleteCredentialConfirm", {
-                      credentialName: credential.credentialScopeName,
-                    })}
-                  </ContinueCancelModal>
+                    {t("revoke")}
+                  </Button>
                 </FlexItem>
               )}
             </Flex>

--- a/js/apps/account-ui/src/verifiable-credentials/CredentialRow.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/CredentialRow.tsx
@@ -21,6 +21,7 @@ import { UserVerifiableCredentialRepresentation } from "../api/representations";
 import { formatDate, FORMAT_DATE_ONLY } from "../utils/formatDate";
 import { useAccountAlerts } from "../utils/useAccountAlerts";
 import { UserAttributesDialog } from "./UserAttributesDialog";
+import { IssuedCredentialsModal } from "./IssuedCredentialsModal";
 
 type CredentialRowProps = {
   credential: UserVerifiableCredentialRepresentation;
@@ -32,6 +33,8 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
   const context = useEnvironment();
   const { addAlert, addError } = useAccountAlerts();
   const [showAttributesDialog, setShowAttributesDialog] = useState(false);
+  const [showIssuedCredentialsModal, setShowIssuedCredentialsModal] =
+    useState(false);
 
   const hasUserAttributes =
     credential.userAttributes != null &&
@@ -88,6 +91,12 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
           onClose={() => setShowAttributesDialog(false)}
         />
       )}
+      {showIssuedCredentialsModal && (
+        <IssuedCredentialsModal
+          credentialScopeName={credential.credentialScopeName!}
+          onClose={() => setShowIssuedCredentialsModal(false)}
+        />
+      )}
       <DataListItem
         id={`credential-${credential.credentialScopeName}`}
         key={credential.credentialScopeName}
@@ -130,6 +139,15 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
             id="credentialActions"
           >
             <Flex>
+              <FlexItem>
+                <Button
+                  id={`credential-${credential.credentialScopeName}-view-issued`}
+                  variant="link"
+                  onClick={() => setShowIssuedCredentialsModal(true)}
+                >
+                  {t("View Issued Credentials")}
+                </Button>
+              </FlexItem>
               <FlexItem>
                 <Button
                   id={`credential-${credential.credentialScopeName}-issue`}

--- a/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
@@ -11,17 +11,13 @@ import {
   ExternalLinkAltIcon,
 } from "@patternfly/react-icons";
 import { cellWidth } from "@patternfly/react-table";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   getIssuedVerifiableCredentials,
   revokeIssuedVerifiableCredential,
-  getApplications,
 } from "../api/methods";
-import {
-  IssuedUserVerifiableCredentialRepresentation,
-  ClientRepresentation,
-} from "../api/representations";
+import type { IssuedUserVerifiableCredentialRepresentation } from "../api/representations";
 import { useAccountAlerts } from "../utils/useAccountAlerts";
 
 type IssuedCredentialsModalProps = {
@@ -30,15 +26,9 @@ type IssuedCredentialsModalProps = {
   onClose: () => void;
 };
 
-type IssuedCredentialWithClientInfo =
-  IssuedUserVerifiableCredentialRepresentation & {
-    clientName?: string;
-    clientBaseUrl?: string;
-  };
-
 type RevokeDialogProps = {
   isOpen: boolean;
-  credential: IssuedCredentialWithClientInfo | undefined;
+  credential: IssuedUserVerifiableCredentialRepresentation | undefined;
   onClose: () => void;
   onConfirm: (credentialId: string) => Promise<void>;
   t: (key: string) => string;
@@ -89,33 +79,13 @@ export const IssuedCredentialsModal = ({
   const context = useEnvironment();
   const { addAlert, addError } = useAccountAlerts();
   const [selectedCredential, setSelectedCredential] =
-    useState<IssuedCredentialWithClientInfo>();
+    useState<IssuedUserVerifiableCredentialRepresentation>();
   const [key, setKey] = useState(0);
   const [showRevokeDialog, setShowRevokeDialog] = useState(false);
-  const [clients, setClients] = useState<ClientRepresentation[]>([]);
-  const [clientsLoaded, setClientsLoaded] = useState(false);
 
   const refresh = () => setKey((prev) => prev + 1);
 
   const toggleRevokeDialog = () => setShowRevokeDialog(!showRevokeDialog);
-
-  // Fetch all applications/clients on mount
-  useEffect(() => {
-    const fetchClients = async () => {
-      try {
-        const apps = await getApplications({
-          signal: new AbortController().signal,
-          context,
-        });
-        setClients(apps);
-        setClientsLoaded(true);
-      } catch (error) {
-        console.error("Failed to fetch clients:", error);
-        setClientsLoaded(true);
-      }
-    };
-    void fetchClients();
-  }, [context]);
 
   const hasManageRole = () => {
     const token = context.keycloak.tokenParsed;
@@ -127,10 +97,6 @@ export const IssuedCredentialsModal = ({
   };
 
   const loader = async (first?: number, max?: number, search?: string) => {
-    if (!clientsLoaded) {
-      return [];
-    }
-
     const data = await getIssuedVerifiableCredentials({
       signal: new AbortController().signal,
       context,
@@ -148,27 +114,17 @@ export const IssuedCredentialsModal = ({
         (ic) =>
           ic.id?.toLowerCase().includes(searchLower) ||
           ic.clientId?.toLowerCase().includes(searchLower) ||
+          ic.clientName?.toLowerCase().includes(searchLower) ||
           ic.revision?.toLowerCase().includes(searchLower),
       );
     }
 
-    // Map clientId (UUID) to client name and base URL
-    const credentialsWithClientInfo: IssuedCredentialWithClientInfo[] =
-      filtered.map((ic) => {
-        const client = clients.find((c) => c.clientId === ic.clientId);
-        return {
-          ...ic,
-          clientName: client?.clientName || client?.clientId || ic.clientId,
-          clientBaseUrl: client?.effectiveUrl,
-        };
-      });
-
     // Apply pagination if provided
     if (first !== undefined && max !== undefined) {
-      return credentialsWithClientInfo.slice(first, first + max);
+      return filtered.slice(first, first + max);
     }
 
-    return credentialsWithClientInfo;
+    return filtered;
   };
 
   const handleRevoke = async (credentialId: string) => {
@@ -200,7 +156,7 @@ export const IssuedCredentialsModal = ({
         <ErrorBoundaryProvider>
           <KeycloakDataTable
             loader={loader}
-            key={clientsLoaded ? key : -1}
+            key={key}
             ariaLabelKey="issuedCredentials"
             searchPlaceholderKey=" "
             columns={[
@@ -240,11 +196,15 @@ export const IssuedCredentialsModal = ({
               {
                 name: "clientId",
                 displayKey: "Wallet Client",
-                cellRenderer: (credential: IssuedCredentialWithClientInfo) => {
+                cellRenderer: (
+                  credential: IssuedUserVerifiableCredentialRepresentation,
+                ) => {
+                  // Backend now provides clientName and clientBaseUrl
                   const displayName =
                     credential.clientName || credential.clientId;
                   if (!displayName) return "—";
 
+                  // If client has a base URL, create a clickable link
                   if (credential.clientBaseUrl) {
                     return (
                       <Button
@@ -296,7 +256,7 @@ export const IssuedCredentialsModal = ({
                         setSelectedCredential(credential);
                         toggleRevokeDialog();
                       },
-                    } as Action<IssuedCredentialWithClientInfo>,
+                    } as Action<IssuedUserVerifiableCredentialRepresentation>,
                   ]
                 : []
             }

--- a/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
@@ -1,0 +1,205 @@
+import {
+  ContinueCancelModal,
+  useEnvironment,
+} from "@keycloak/keycloak-ui-shared";
+import {
+  Button,
+  DataList,
+  DataListAction,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Label,
+  Modal,
+  ModalVariant,
+} from "@patternfly/react-core";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  getIssuedVerifiableCredentials,
+  revokeIssuedVerifiableCredential,
+} from "../api/methods";
+import { IssuedUserVerifiableCredentialRepresentation } from "../api/representations";
+import { EmptyRow } from "../components/datalist/EmptyRow";
+import { formatDate, FORMAT_DATE_AND_TIME } from "../utils/formatDate";
+import { useAccountAlerts } from "../utils/useAccountAlerts";
+
+type IssuedCredentialsModalProps = {
+  credentialScopeName: string;
+  onClose: () => void;
+};
+
+export const IssuedCredentialsModal = ({
+  credentialScopeName,
+  onClose,
+}: IssuedCredentialsModalProps) => {
+  const { t } = useTranslation();
+  const context = useEnvironment();
+  const { addAlert, addError } = useAccountAlerts();
+  const [issuedCredentials, setIssuedCredentials] = useState<
+    IssuedUserVerifiableCredentialRepresentation[]
+  >([]);
+  const [key, setKey] = useState(1);
+
+  const refresh = () => setKey(key + 1);
+
+  const hasManageRole = () => {
+    const token = context.keycloak.tokenParsed;
+    const accountRoles = token?.resource_access?.["account"]?.roles || [];
+    return (
+      accountRoles.includes("manage-account") ||
+      accountRoles.includes("manage-verifiable-credentials")
+    );
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchIssuedCredentials() {
+      try {
+        const data = await getIssuedVerifiableCredentials({
+          signal: controller.signal,
+          context,
+        });
+        // Filter by credential type
+        const filtered = data.filter(
+          (ic) => ic.credentialType === credentialScopeName,
+        );
+        setIssuedCredentials(filtered);
+      } catch (error) {
+        console.error("Error fetching issued verifiable credentials:", error);
+        setIssuedCredentials([]);
+      }
+    }
+
+    void fetchIssuedCredentials();
+    return () => controller.abort();
+  }, [key, context, credentialScopeName]);
+
+  const handleRevoke = async (credentialId: string) => {
+    try {
+      await revokeIssuedVerifiableCredential(context, credentialId);
+      addAlert(t("revokeIssuedCredentialSuccess"));
+      refresh();
+    } catch (error) {
+      addError("revokeIssuedCredentialError", error);
+    }
+  };
+
+  const isExpired = (expiresAt?: number) => {
+    if (!expiresAt) return false;
+    return expiresAt < Date.now();
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.large}
+      title={t("Issued Credentials")}
+      isOpen={true}
+      onClose={onClose}
+      width="90%"
+    >
+      <DataList
+        id="issued-credentials-modal-list"
+        aria-label={t("issuedCredentials")}
+        isCompact
+      >
+        <DataListItem
+          id="issued-credentials-modal-header"
+          aria-labelledby="Column headers"
+        >
+          <DataListItemRow>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key="credential-id-header" width={3}>
+                  <strong>{t("Credential ID")}</strong>
+                </DataListCell>,
+                <DataListCell key="issued-date-header" width={2}>
+                  <strong>{t("Issued Date")}</strong>
+                </DataListCell>,
+                <DataListCell key="expires-date-header" width={2}>
+                  <strong>{t("Expires")}</strong>
+                </DataListCell>,
+                <DataListCell key="status-header" width={1}>
+                  <strong>{t("Status")}</strong>
+                </DataListCell>,
+              ]}
+            />
+          </DataListItemRow>
+        </DataListItem>
+        {issuedCredentials.length > 0 ? (
+          issuedCredentials.map((credential) => (
+            <DataListItem
+              key={credential.id}
+              id={`issued-credential-${credential.id}`}
+              aria-label={credential.id}
+            >
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={[
+                    <DataListCell key="id" width={3}>
+                      <code className="pf-v5-u-font-size-sm">
+                        {credential.id}
+                      </code>
+                    </DataListCell>,
+                    <DataListCell key="issued" width={2}>
+                      {credential.issuedAt
+                        ? formatDate(
+                            new Date(credential.issuedAt),
+                            undefined,
+                            FORMAT_DATE_AND_TIME,
+                          )
+                        : "—"}
+                    </DataListCell>,
+                    <DataListCell key="expires" width={2}>
+                      {credential.expiresAt
+                        ? formatDate(
+                            new Date(credential.expiresAt),
+                            undefined,
+                            FORMAT_DATE_AND_TIME,
+                          )
+                        : "—"}
+                    </DataListCell>,
+                    <DataListCell key="status" width={1}>
+                      {isExpired(credential.expiresAt) ? (
+                        <Label color="red">{t("Expired")}</Label>
+                      ) : (
+                        <Label color="green">{t("Active")}</Label>
+                      )}
+                    </DataListCell>,
+                  ]}
+                />
+                {hasManageRole() && (
+                  <DataListAction
+                    aria-labelledby={t("actions")}
+                    aria-label={t("credentialActions")}
+                    id={`issued-credential-${credential.id}-actions`}
+                  >
+                    <ContinueCancelModal
+                      buttonTitle={t("revoke")}
+                      modalTitle={t("Revoke Issued Credential")}
+                      continueLabel={t("revoke")}
+                      cancelLabel={t("cancel")}
+                      buttonVariant="link"
+                      onContinue={() => handleRevoke(credential.id!)}
+                    >
+                      {t("Revoke Issued Credential Confirm")}
+                    </ContinueCancelModal>
+                  </DataListAction>
+                )}
+              </DataListItemRow>
+            </DataListItem>
+          ))
+        ) : (
+          <EmptyRow message={t("No Issued Credentials")} />
+        )}
+      </DataList>
+      <div className="pf-v5-u-mt-md pf-v5-u-text-align-right">
+        <Button variant="primary" onClick={onClose}>
+          {t("close")}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
@@ -1,48 +1,92 @@
 import {
-  ContinueCancelModal,
   useEnvironment,
+  KeycloakDataTable,
+  ErrorBoundaryProvider,
 } from "@keycloak/keycloak-ui-shared";
-import {
-  Button,
-  DataList,
-  DataListAction,
-  DataListCell,
-  DataListItem,
-  DataListItemCells,
-  DataListItemRow,
-  Label,
-  Modal,
-  ModalVariant,
-} from "@patternfly/react-core";
-import { useEffect, useState } from "react";
+import type { Action } from "@keycloak/keycloak-ui-shared";
+import { Button, Label, Modal, ModalVariant } from "@patternfly/react-core";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { cellWidth } from "@patternfly/react-table";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   getIssuedVerifiableCredentials,
   revokeIssuedVerifiableCredential,
 } from "../api/methods";
 import { IssuedUserVerifiableCredentialRepresentation } from "../api/representations";
-import { EmptyRow } from "../components/datalist/EmptyRow";
-import { formatDate, FORMAT_DATE_AND_TIME } from "../utils/formatDate";
 import { useAccountAlerts } from "../utils/useAccountAlerts";
 
 type IssuedCredentialsModalProps = {
   credentialScopeName: string;
+  parentRevision?: string;
   onClose: () => void;
+};
+
+type IssuedCredentialWithClientName =
+  IssuedUserVerifiableCredentialRepresentation & {
+    clientName?: string;
+  };
+
+type RevokeDialogProps = {
+  isOpen: boolean;
+  credential: IssuedCredentialWithClientName | undefined;
+  onClose: () => void;
+  onConfirm: (credentialId: string) => Promise<void>;
+  t: (key: string) => string;
+};
+
+const RevokeDialog = ({
+  isOpen,
+  credential,
+  onClose,
+  onConfirm,
+  t,
+}: RevokeDialogProps) => {
+  if (!isOpen || !credential) return null;
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title={t("Revoke Issued Credential")}
+      isOpen={true}
+      onClose={onClose}
+      actions={[
+        <Button
+          key="confirm"
+          variant="danger"
+          onClick={async () => {
+            await onConfirm(credential.id!);
+            onClose();
+          }}
+        >
+          {t("revoke")}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          {t("cancel")}
+        </Button>,
+      ]}
+    >
+      {t("Confirm Revoke Issued Credential")}
+    </Modal>
+  );
 };
 
 export const IssuedCredentialsModal = ({
   credentialScopeName,
+  parentRevision,
   onClose,
 }: IssuedCredentialsModalProps) => {
   const { t } = useTranslation();
   const context = useEnvironment();
   const { addAlert, addError } = useAccountAlerts();
-  const [issuedCredentials, setIssuedCredentials] = useState<
-    IssuedUserVerifiableCredentialRepresentation[]
-  >([]);
-  const [key, setKey] = useState(1);
+  const [selectedCredential, setSelectedCredential] =
+    useState<IssuedCredentialWithClientName>();
+  const [key, setKey] = useState(0);
+  const [showRevokeDialog, setShowRevokeDialog] = useState(false);
 
-  const refresh = () => setKey(key + 1);
+  const refresh = () => setKey((prev) => prev + 1);
+
+  const toggleRevokeDialog = () => setShowRevokeDialog(!showRevokeDialog);
 
   const hasManageRole = () => {
     const token = context.keycloak.tokenParsed;
@@ -53,153 +97,170 @@ export const IssuedCredentialsModal = ({
     );
   };
 
-  useEffect(() => {
-    const controller = new AbortController();
+  const loader = async (first?: number, max?: number, search?: string) => {
+    const data = await getIssuedVerifiableCredentials({
+      signal: new AbortController().signal,
+      context,
+    });
 
-    async function fetchIssuedCredentials() {
-      try {
-        const data = await getIssuedVerifiableCredentials({
-          signal: controller.signal,
-          context,
-        });
-        // Filter by credential type
-        const filtered = data.filter(
-          (ic) => ic.credentialType === credentialScopeName,
-        );
-        setIssuedCredentials(filtered);
-      } catch (error) {
-        console.error("Error fetching issued verifiable credentials:", error);
-        setIssuedCredentials([]);
-      }
+    // Filter by credential type
+    let filtered = data.filter(
+      (ic) => ic.credentialType === credentialScopeName,
+    );
+
+    // Apply search filter if provided
+    if (search) {
+      const searchLower = search.toLowerCase();
+      filtered = filtered.filter(
+        (ic) =>
+          ic.id?.toLowerCase().includes(searchLower) ||
+          ic.clientId?.toLowerCase().includes(searchLower) ||
+          ic.revision?.toLowerCase().includes(searchLower),
+      );
     }
 
-    void fetchIssuedCredentials();
-    return () => controller.abort();
-  }, [key, context, credentialScopeName]);
+    const credentialsWithClientNames: IssuedCredentialWithClientName[] =
+      filtered.map((ic) => ({
+        ...ic,
+        clientName: ic.clientId,
+      }));
+
+    // Apply pagination if provided
+    if (first !== undefined && max !== undefined) {
+      return credentialsWithClientNames.slice(first, first + max);
+    }
+
+    return credentialsWithClientNames;
+  };
 
   const handleRevoke = async (credentialId: string) => {
     try {
       await revokeIssuedVerifiableCredential(context, credentialId);
-      addAlert(t("revokeIssuedCredentialSuccess"));
+      addAlert(t("Revoke Issued Credential Success"));
       refresh();
     } catch (error) {
-      addError("revokeIssuedCredentialError", error);
+      addError("Revoke Issued Credential Error", error);
     }
   };
 
-  const isExpired = (expiresAt?: number) => {
-    if (!expiresAt) return false;
-    return expiresAt < Date.now();
-  };
-
   return (
-    <Modal
-      variant={ModalVariant.large}
-      title={t("Issued Credentials")}
-      isOpen={true}
-      onClose={onClose}
-      width="90%"
-    >
-      <DataList
-        id="issued-credentials-modal-list"
-        aria-label={t("issuedCredentials")}
-        isCompact
+    <>
+      <RevokeDialog
+        isOpen={showRevokeDialog}
+        credential={selectedCredential}
+        onClose={toggleRevokeDialog}
+        onConfirm={handleRevoke}
+        t={t}
+      />
+      <Modal
+        variant={ModalVariant.large}
+        title={t("Issued Credentials")}
+        isOpen={true}
+        onClose={onClose}
+        width="90%"
       >
-        <DataListItem
-          id="issued-credentials-modal-header"
-          aria-labelledby="Column headers"
-        >
-          <DataListItemRow>
-            <DataListItemCells
-              dataListCells={[
-                <DataListCell key="credential-id-header" width={3}>
-                  <strong>{t("Credential ID")}</strong>
-                </DataListCell>,
-                <DataListCell key="issued-date-header" width={2}>
-                  <strong>{t("Issued Date")}</strong>
-                </DataListCell>,
-                <DataListCell key="expires-date-header" width={2}>
-                  <strong>{t("Expires")}</strong>
-                </DataListCell>,
-                <DataListCell key="status-header" width={1}>
-                  <strong>{t("Status")}</strong>
-                </DataListCell>,
-              ]}
-            />
-          </DataListItemRow>
-        </DataListItem>
-        {issuedCredentials.length > 0 ? (
-          issuedCredentials.map((credential) => (
-            <DataListItem
-              key={credential.id}
-              id={`issued-credential-${credential.id}`}
-              aria-label={credential.id}
-            >
-              <DataListItemRow>
-                <DataListItemCells
-                  dataListCells={[
-                    <DataListCell key="id" width={3}>
-                      <code className="pf-v5-u-font-size-sm">
-                        {credential.id}
-                      </code>
-                    </DataListCell>,
-                    <DataListCell key="issued" width={2}>
-                      {credential.issuedAt
-                        ? formatDate(
-                            new Date(credential.issuedAt),
-                            undefined,
-                            FORMAT_DATE_AND_TIME,
-                          )
-                        : "—"}
-                    </DataListCell>,
-                    <DataListCell key="expires" width={2}>
-                      {credential.expiresAt
-                        ? formatDate(
-                            new Date(credential.expiresAt),
-                            undefined,
-                            FORMAT_DATE_AND_TIME,
-                          )
-                        : "—"}
-                    </DataListCell>,
-                    <DataListCell key="status" width={1}>
-                      {isExpired(credential.expiresAt) ? (
-                        <Label color="red">{t("Expired")}</Label>
-                      ) : (
-                        <Label color="green">{t("Active")}</Label>
-                      )}
-                    </DataListCell>,
-                  ]}
-                />
-                {hasManageRole() && (
-                  <DataListAction
-                    aria-labelledby={t("actions")}
-                    aria-label={t("credentialActions")}
-                    id={`issued-credential-${credential.id}-actions`}
-                  >
-                    <ContinueCancelModal
-                      buttonTitle={t("revoke")}
-                      modalTitle={t("Revoke Issued Credential")}
-                      continueLabel={t("revoke")}
-                      cancelLabel={t("cancel")}
-                      buttonVariant="link"
-                      onContinue={() => handleRevoke(credential.id!)}
+        <ErrorBoundaryProvider>
+          <KeycloakDataTable
+            loader={loader}
+            key={key}
+            ariaLabelKey="issuedCredentials"
+            searchPlaceholderKey=" "
+            columns={[
+              {
+                name: "id",
+                displayKey: "ID",
+                cellRenderer: ({ id }) => (
+                  <code className="pf-v5-u-font-size-sm">{id}</code>
+                ),
+                transforms: [cellWidth(25)],
+              },
+              {
+                name: "issuedAt",
+                displayKey: "Issued At",
+                cellRenderer: ({ issuedAt }) =>
+                  issuedAt ? new Date(issuedAt).toLocaleString("en-US") : "—",
+                transforms: [cellWidth(15)],
+              },
+              {
+                name: "expiresAt",
+                displayKey: "Expires At",
+                cellRenderer: ({ expiresAt }) => {
+                  if (!expiresAt) return "—";
+                  const expirationDate = new Date(expiresAt);
+                  const isExpired = expirationDate < new Date();
+                  return (
+                    <span
+                      style={{
+                        color: isExpired
+                          ? "var(--pf-v5-global--danger-color--100)"
+                          : "inherit",
+                      }}
                     >
-                      {t("Revoke Issued Credential Confirm")}
-                    </ContinueCancelModal>
-                  </DataListAction>
-                )}
-              </DataListItemRow>
-            </DataListItem>
-          ))
-        ) : (
-          <EmptyRow message={t("No Issued Credentials")} />
-        )}
-      </DataList>
-      <div className="pf-v5-u-mt-md pf-v5-u-text-align-right">
-        <Button variant="primary" onClick={onClose}>
-          {t("close")}
-        </Button>
-      </div>
-    </Modal>
+                      {isExpired && (
+                        <ExclamationTriangleIcon
+                          style={{ marginRight: "0.25rem" }}
+                        />
+                      )}
+                      {expirationDate.toLocaleString("en-US")}
+                    </span>
+                  );
+                },
+                transforms: [cellWidth(15)],
+              },
+              {
+                name: "clientId",
+                displayKey: "Wallet Client",
+                cellRenderer: (credential: IssuedCredentialWithClientName) =>
+                  credential.clientName || credential.clientId || "—",
+                transforms: [cellWidth(20)],
+              },
+              {
+                name: "revision",
+                displayKey: "Revision",
+                cellRenderer: ({ revision }) => (
+                  <>
+                    {revision || "—"}
+                    {parentRevision &&
+                      revision &&
+                      revision !== parentRevision && (
+                        <>
+                          {" "}
+                          <Label
+                            color="orange"
+                            icon={<ExclamationTriangleIcon />}
+                          >
+                            {t("outdated")}
+                          </Label>
+                        </>
+                      )}
+                  </>
+                ),
+                transforms: [cellWidth(20)],
+              },
+            ]}
+            actions={
+              hasManageRole()
+                ? [
+                    {
+                      title: t("revoke"),
+                      onRowClick: (credential) => {
+                        setSelectedCredential(credential);
+                        toggleRevokeDialog();
+                      },
+                    } as Action<IssuedCredentialWithClientName>,
+                  ]
+                : []
+            }
+            emptyState={
+              <div className="pf-v5-u-text-align-center pf-v5-u-py-md">
+                <span className="pf-v5-u-color-200">
+                  {t("No Issued Credentials")}
+                </span>
+              </div>
+            }
+          />
+        </ErrorBoundaryProvider>
+      </Modal>
+    </>
   );
 };

--- a/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/IssuedCredentialsModal.tsx
@@ -2,18 +2,26 @@ import {
   useEnvironment,
   KeycloakDataTable,
   ErrorBoundaryProvider,
+  label,
 } from "@keycloak/keycloak-ui-shared";
 import type { Action } from "@keycloak/keycloak-ui-shared";
 import { Button, Label, Modal, ModalVariant } from "@patternfly/react-core";
-import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import {
+  ExclamationTriangleIcon,
+  ExternalLinkAltIcon,
+} from "@patternfly/react-icons";
 import { cellWidth } from "@patternfly/react-table";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   getIssuedVerifiableCredentials,
   revokeIssuedVerifiableCredential,
+  getApplications,
 } from "../api/methods";
-import { IssuedUserVerifiableCredentialRepresentation } from "../api/representations";
+import {
+  IssuedUserVerifiableCredentialRepresentation,
+  ClientRepresentation,
+} from "../api/representations";
 import { useAccountAlerts } from "../utils/useAccountAlerts";
 
 type IssuedCredentialsModalProps = {
@@ -22,14 +30,15 @@ type IssuedCredentialsModalProps = {
   onClose: () => void;
 };
 
-type IssuedCredentialWithClientName =
+type IssuedCredentialWithClientInfo =
   IssuedUserVerifiableCredentialRepresentation & {
     clientName?: string;
+    clientBaseUrl?: string;
   };
 
 type RevokeDialogProps = {
   isOpen: boolean;
-  credential: IssuedCredentialWithClientName | undefined;
+  credential: IssuedCredentialWithClientInfo | undefined;
   onClose: () => void;
   onConfirm: (credentialId: string) => Promise<void>;
   t: (key: string) => string;
@@ -80,13 +89,33 @@ export const IssuedCredentialsModal = ({
   const context = useEnvironment();
   const { addAlert, addError } = useAccountAlerts();
   const [selectedCredential, setSelectedCredential] =
-    useState<IssuedCredentialWithClientName>();
+    useState<IssuedCredentialWithClientInfo>();
   const [key, setKey] = useState(0);
   const [showRevokeDialog, setShowRevokeDialog] = useState(false);
+  const [clients, setClients] = useState<ClientRepresentation[]>([]);
+  const [clientsLoaded, setClientsLoaded] = useState(false);
 
   const refresh = () => setKey((prev) => prev + 1);
 
   const toggleRevokeDialog = () => setShowRevokeDialog(!showRevokeDialog);
+
+  // Fetch all applications/clients on mount
+  useEffect(() => {
+    const fetchClients = async () => {
+      try {
+        const apps = await getApplications({
+          signal: new AbortController().signal,
+          context,
+        });
+        setClients(apps);
+        setClientsLoaded(true);
+      } catch (error) {
+        console.error("Failed to fetch clients:", error);
+        setClientsLoaded(true);
+      }
+    };
+    void fetchClients();
+  }, [context]);
 
   const hasManageRole = () => {
     const token = context.keycloak.tokenParsed;
@@ -98,6 +127,10 @@ export const IssuedCredentialsModal = ({
   };
 
   const loader = async (first?: number, max?: number, search?: string) => {
+    if (!clientsLoaded) {
+      return [];
+    }
+
     const data = await getIssuedVerifiableCredentials({
       signal: new AbortController().signal,
       context,
@@ -119,18 +152,23 @@ export const IssuedCredentialsModal = ({
       );
     }
 
-    const credentialsWithClientNames: IssuedCredentialWithClientName[] =
-      filtered.map((ic) => ({
-        ...ic,
-        clientName: ic.clientId,
-      }));
+    // Map clientId (UUID) to client name and base URL
+    const credentialsWithClientInfo: IssuedCredentialWithClientInfo[] =
+      filtered.map((ic) => {
+        const client = clients.find((c) => c.clientId === ic.clientId);
+        return {
+          ...ic,
+          clientName: client?.clientName || client?.clientId || ic.clientId,
+          clientBaseUrl: client?.effectiveUrl,
+        };
+      });
 
     // Apply pagination if provided
     if (first !== undefined && max !== undefined) {
-      return credentialsWithClientNames.slice(first, first + max);
+      return credentialsWithClientInfo.slice(first, first + max);
     }
 
-    return credentialsWithClientNames;
+    return credentialsWithClientInfo;
   };
 
   const handleRevoke = async (credentialId: string) => {
@@ -154,7 +192,7 @@ export const IssuedCredentialsModal = ({
       />
       <Modal
         variant={ModalVariant.large}
-        title={t("Issued Credentials")}
+        title={`${t("Issued Credentials")}: ${credentialScopeName}`}
         isOpen={true}
         onClose={onClose}
         width="90%"
@@ -162,24 +200,16 @@ export const IssuedCredentialsModal = ({
         <ErrorBoundaryProvider>
           <KeycloakDataTable
             loader={loader}
-            key={key}
+            key={clientsLoaded ? key : -1}
             ariaLabelKey="issuedCredentials"
             searchPlaceholderKey=" "
             columns={[
-              {
-                name: "id",
-                displayKey: "ID",
-                cellRenderer: ({ id }) => (
-                  <code className="pf-v5-u-font-size-sm">{id}</code>
-                ),
-                transforms: [cellWidth(25)],
-              },
               {
                 name: "issuedAt",
                 displayKey: "Issued At",
                 cellRenderer: ({ issuedAt }) =>
                   issuedAt ? new Date(issuedAt).toLocaleString("en-US") : "—",
-                transforms: [cellWidth(15)],
+                transforms: [cellWidth(25)],
               },
               {
                 name: "expiresAt",
@@ -205,14 +235,33 @@ export const IssuedCredentialsModal = ({
                     </span>
                   );
                 },
-                transforms: [cellWidth(15)],
+                transforms: [cellWidth(25)],
               },
               {
                 name: "clientId",
                 displayKey: "Wallet Client",
-                cellRenderer: (credential: IssuedCredentialWithClientName) =>
-                  credential.clientName || credential.clientId || "—",
-                transforms: [cellWidth(20)],
+                cellRenderer: (credential: IssuedCredentialWithClientInfo) => {
+                  const displayName =
+                    credential.clientName || credential.clientId;
+                  if (!displayName) return "—";
+
+                  if (credential.clientBaseUrl) {
+                    return (
+                      <Button
+                        className="pf-v5-u-pl-0 title-case"
+                        component="a"
+                        variant="link"
+                        onClick={() => window.open(credential.clientBaseUrl)}
+                      >
+                        {label(t, displayName)} <ExternalLinkAltIcon />
+                      </Button>
+                    );
+                  }
+
+                  // No base URL, just display the name/clientId
+                  return <>{label(t, displayName)}</>;
+                },
+                transforms: [cellWidth(35)],
               },
               {
                 name: "revision",
@@ -235,7 +284,7 @@ export const IssuedCredentialsModal = ({
                       )}
                   </>
                 ),
-                transforms: [cellWidth(20)],
+                transforms: [cellWidth(15)],
               },
             ]}
             actions={
@@ -247,7 +296,7 @@ export const IssuedCredentialsModal = ({
                         setSelectedCredential(credential);
                         toggleRevokeDialog();
                       },
-                    } as Action<IssuedCredentialWithClientName>,
+                    } as Action<IssuedCredentialWithClientInfo>,
                   ]
                 : []
             }

--- a/js/apps/account-ui/src/verifiable-credentials/VerifiableCredentials.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/VerifiableCredentials.tsx
@@ -9,13 +9,12 @@ import {
   StackItem,
   Title,
 } from "@patternfly/react-core";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getVerifiableCredentials } from "../api/methods";
 import { UserVerifiableCredentialRepresentation } from "../api/representations";
 import { EmptyRow } from "../components/datalist/EmptyRow";
 import { Page } from "../components/page/Page";
-import { usePromise } from "../utils/usePromise";
 import { CredentialRow } from "./CredentialRow";
 
 export const VerifiableCredentials = () => {
@@ -24,14 +23,29 @@ export const VerifiableCredentials = () => {
   const [credentials, setCredentials] = useState<
     UserVerifiableCredentialRepresentation[]
   >([]);
+
   const [key, setKey] = useState(1);
   const refresh = () => setKey(key + 1);
 
-  usePromise(
-    (signal) => getVerifiableCredentials({ signal, context }),
-    (data) => setCredentials(data),
-    [key],
-  );
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function fetchCredentials() {
+      try {
+        const data = await getVerifiableCredentials({
+          signal: controller.signal,
+          context,
+        });
+        setCredentials(data);
+      } catch (error) {
+        console.error("Error fetching verifiable credentials:", error);
+        setCredentials([]);
+      }
+    }
+
+    void fetchCredentials();
+    return () => controller.abort();
+  }, [key, context]);
 
   return (
     <Page
@@ -62,7 +76,7 @@ export const VerifiableCredentials = () => {
                       <strong>{t("credentialCreatedDate")}</strong>
                     </DataListCell>,
                     <DataListCell key="credential-attributes-header" width={2}>
-                      <strong>{t("userAttributes")}</strong>
+                      <strong>{t("User Attributes")}</strong>
                     </DataListCell>,
                   ]}
                 />

--- a/js/libs/keycloak-admin-client/src/defs/issuedUserVerifiableCredentialRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/issuedUserVerifiableCredentialRepresentation.ts
@@ -6,4 +6,6 @@ export default interface IssuedUserVerifiableCredentialRepresentation {
   expiresAt?: number;
   clientId?: string;
   revision?: string;
+  clientName?: string;
+  clientBaseUrl?: string;
 }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.Profile;
 import org.keycloak.models.AccountRoles;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -37,6 +38,7 @@ import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialReprese
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.cors.Cors;
 import org.keycloak.services.managers.Auth;
+import org.keycloak.services.util.ResolveRelative;
 
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
@@ -73,6 +75,7 @@ public class AccountIssuedVerifiableCredentialResource {
         List<IssuedVerifiableCredentialRepresentation> credentials = session.users()
                 .getIssuedVerifiableCredentialsStreamByUser(user.getId())
                 .map(ModelToRepresentation::toRepresentation)
+                .map(rep -> enrichWithClientInfo(rep, session, realm))
                 .toList();
 
         return Cors.builder()
@@ -109,6 +112,31 @@ public class AccountIssuedVerifiableCredentialResource {
         if (!realm.isVerifiableCredentialsEnabled()) {
             throw ErrorResponse.error("Verifiable credentials not enabled for the realm", Response.Status.BAD_REQUEST);
         }
+    }
+
+    /**
+     * Enriches the issued credential representation with client name and base URL
+     */
+    private IssuedVerifiableCredentialRepresentation enrichWithClientInfo(IssuedVerifiableCredentialRepresentation rep, KeycloakSession session, RealmModel realm) {
+        if (rep.getClientId() == null) {
+            return rep;
+        }
+
+        ClientModel client = realm.getClientByClientId(rep.getClientId());
+        if (client == null) {
+            return rep;
+        }
+
+        String clientName = client.getName();
+        if (clientName == null || clientName.isEmpty()) {
+            clientName = client.getClientId();
+        }
+        rep.setClientName(clientName);
+
+        String effectiveUrl = ResolveRelative.resolveRelativeUri(session,client.getRootUrl(),client.getBaseUrl());
+        rep.setClientBaseUrl(effectiveUrl);
+
+        return rep;
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
@@ -41,16 +41,16 @@ import org.keycloak.services.managers.Auth;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
 
-public class AccountIssuedCredentialResource {
+public class AccountIssuedVerifiableCredentialResource {
 
-    private static final Logger logger = Logger.getLogger(AccountIssuedCredentialResource.class);
+    private static final Logger logger = Logger.getLogger(AccountIssuedVerifiableCredentialResource.class);
 
     private final KeycloakSession session;
     private final Auth auth;
     private final UserModel user;
     private final RealmModel realm;
 
-    public AccountIssuedCredentialResource(KeycloakSession session, Auth auth, UserModel user) {
+    public AccountIssuedVerifiableCredentialResource(KeycloakSession session, Auth auth, UserModel user) {
         this.session = session;
         this.auth = auth;
         this.user = user;

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountRestService.java
@@ -253,10 +253,10 @@ public class AccountRestService {
         return new AccountVerifiableCredentialResource(session, auth, user);
     }
 
-    @Path("/issued-credentials")
-    public AccountIssuedCredentialResource issuedCredentials() {
+    @Path("/issued-verifiable-credentials")
+    public AccountIssuedVerifiableCredentialResource issuedVerifiableCredentials() {
         checkAccountApiEnabled();
-        return new AccountIssuedCredentialResource(session, auth, user);
+        return new AccountIssuedVerifiableCredentialResource(session, auth, user);
     }
 
     private ClientRepresentation modelToRepresentation(ClientModel model, List<String> inUseClients, List<String> offlineClients, Map<String, UserConsentModel> consents) {

--- a/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceRolesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/account/AccountRestServiceRolesTest.java
@@ -89,12 +89,12 @@ public class AccountRestServiceRolesTest {
     }
 
     @Test
-    public void issuedCredentialsEndpointAccess() throws IOException {
-        assertEndpointStatus("manage-account-user", "issued-credentials", 200);
+    public void issuedVerifiableCredentialsEndpointAccess() throws IOException {
+        assertEndpointStatus("manage-account-user", "issued-verifiable-credentials", 200);
         addAccountConsoleScopeMapping(AccountRoles.MANAGE_VERIFIABLE_CREDENTIALS);
-        assertEndpointStatus("view-verifiable-credentials-user", "issued-credentials", 200);
-        assertEndpointStatus("manage-verifiable-credentials-user", "issued-credentials", 200);
-        assertEndpointStatus("no-access-user", "issued-credentials", 403);
+        assertEndpointStatus("view-verifiable-credentials-user", "issued-verifiable-credentials", 200);
+        assertEndpointStatus("manage-verifiable-credentials-user", "issued-verifiable-credentials", 200);
+        assertEndpointStatus("no-access-user", "issued-verifiable-credentials", 403);
     }
 
     @Test


### PR DESCRIPTION
Implements the 'Issued Verifiable Credentials' section in the Account Console

Features:
- New section showing issued verifiable credentials to the current user
- Display credential type, recipient, issue date, and status
- Revoke functionality
- Status indicators (Active/Expired)

Changes:
- Added IssuedVerifiableCredentialRow component
- Updated VerifiableCredentials page with two sections
- Added API methods for issued credentials

Closes #46210

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
