### PR TITLE
fix(admin): block TOCTOU rename bypass of protected admin roles

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleByIdResource.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -170,6 +171,9 @@ public class RoleByIdResource extends RoleResource {
     public void updateRole(final @Parameter(description = "id of role") @PathParam("role-id") String id, final RoleRepresentation rep) {
         RoleModel role = getRoleModel(id);
         auth.roles().requireManage(role);
+        if (isProtectedAdminRoleRename(role, rep.getName()) && !auth.realm().canManageRealm()) {
+            throw new ForbiddenException("Cannot rename a protected admin role");
+        }
         updateRole(rep, role, realm, session);
 
         if (role.isClientRole()) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleContainerResource.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
@@ -332,6 +333,9 @@ public class RoleContainerResource extends RoleResource {
         RoleModel role = roleContainer.getRole(roleName);
         if (role == null) {
             throw new NotFoundException("Could not find role");
+        }
+        if (isProtectedAdminRoleRename(role, rep.getName()) && !auth.realm().canManageRealm()) {
+            throw new ForbiddenException("Cannot rename a protected admin role");
         }
         try {
             updateRole(rep, role, realm, session);

--- a/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java
@@ -28,9 +28,12 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.UriInfo;
 
+import org.keycloak.Config;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
@@ -118,6 +121,38 @@ public abstract class RoleResource {
                 role.removeAttribute(attr);
             }
         }
+    }
+
+    /**
+     * Returns true when the rename involves a protected admin role name and requires
+     * full realm-management permission. Renaming TO a protected name is blocked for any
+     * container; renaming FROM one is only blocked for admin containers (realm or realm-management client).
+     */
+    protected boolean isProtectedAdminRoleRename(RoleModel role, String newName) {
+        boolean currentNameProtected = AdminRoles.ALL_ROLES.contains(role.getName());
+        boolean newNameProtected = newName != null && AdminRoles.ALL_ROLES.contains(newName);
+
+        if (!currentNameProtected && !newNameProtected) {
+            return false;
+        }
+
+        // Renaming TO a protected name is blocked for any container.
+        if (newNameProtected) {
+            return true;
+        }
+
+        // Renaming FROM a protected name: only guard admin containers.
+        if (role.getContainer() instanceof RealmModel) {
+            return true;
+        }
+        if (role.getContainer() instanceof ClientModel client) {
+            String adminClientId = realm.getName().equals(Config.getAdminRealm())
+                    ? Config.getAdminRealm() + "-realm"
+                    : Constants.REALM_MANAGEMENT_CLIENT_ID;
+            ClientModel adminClient = realm.getClientByClientId(adminClientId);
+            return adminClient != null && adminClient.equals(client);
+        }
+        return false;
     }
 
     protected void addComposites(AdminPermissionEvaluator auth, AdminEventBuilder adminEvent, UriInfo uriInfo, List<RoleRepresentation> roles, RoleModel role) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/RoleByIdResourceTest.java
@@ -18,6 +18,7 @@
 package org.keycloak.tests.admin;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -28,13 +29,22 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
 
+import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RoleByIdResource;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.Constants;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.testframework.admin.AdminClientFactory;
+import org.keycloak.testframework.annotations.InjectAdminClientFactory;
 import org.keycloak.testframework.annotations.InjectAdminEvents;
 import org.keycloak.testframework.annotations.InjectClient;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -77,6 +87,9 @@ public class RoleByIdResourceTest {
 
     @InjectAdminEvents
     AdminEvents adminEvents;
+
+    @InjectAdminClientFactory
+    AdminClientFactory adminClientFactory;
 
     private RoleByIdResource resource;
 
@@ -366,5 +379,184 @@ public class RoleByIdResourceTest {
 
     private void cacheMissingRoleName(String missingRoleName) {
         assertThrows(NotFoundException.class, () -> managedRealm.admin().roles().get(missingRoleName).toRepresentation());
+    }
+
+    /**
+     * see #49427
+     */
+    @Test
+    @DatabaseTest
+    public void testRenameProtectedRoleBlockedForDelegatedAdmin() {
+        createDelegatedAdminUser("delegated-admin", "password", AdminRoles.MANAGE_CLIENTS);
+
+        ClientRepresentation rmClient = managedRealm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation realmAdminRole = managedRealm.admin().clients()
+                .get(rmClient.getId()).roles().get(AdminRoles.REALM_ADMIN).toRepresentation();
+
+        try (Keycloak delegatedClient = adminClientFactory.create()
+                .realm(managedRealm.getName())
+                .username("delegated-admin")
+                .password("password")
+                .clientId(Constants.ADMIN_CLI_CLIENT_ID)
+                .build()) {
+
+            RoleRepresentation renamed = new RoleRepresentation();
+            renamed.setId(realmAdminRole.getId());
+            renamed.setName("temp-role");
+
+            Assertions.assertThrows(ForbiddenException.class, () ->
+                    delegatedClient.realm(managedRealm.getName()).rolesById()
+                            .updateRole(realmAdminRole.getId(), renamed));
+        }
+    }
+
+    /**
+     * see #49427
+     */
+    @Test
+    @DatabaseTest
+    public void testRenamingToProtectedRoleNameBlockedForDelegatedAdmin() {
+        createDelegatedAdminUser("delegated-admin2", "password", AdminRoles.MANAGE_CLIENTS);
+
+        String attackerClientId = "attacker-client-" + new Random().nextInt(10000);
+        try (Keycloak delegatedClient = adminClientFactory.create()
+                .realm(managedRealm.getName())
+                .username("delegated-admin2")
+                .password("password")
+                .clientId(Constants.ADMIN_CLI_CLIENT_ID)
+                .build()) {
+
+            // Create a client and a role the delegated admin owns
+            Response resp = delegatedClient.realm(managedRealm.getName()).clients()
+                    .create(clientRepresentation(attackerClientId));
+            String attackerClientUuid = resp.getLocation().getPath().replaceAll(".*/", "");
+            resp.close();
+
+            delegatedClient.realm(managedRealm.getName()).clients()
+                    .get(attackerClientUuid).roles().create(roleRepresentation("innocent-role"));
+
+            RoleRepresentation innocentRole = delegatedClient.realm(managedRealm.getName()).clients()
+                    .get(attackerClientUuid).roles().get("innocent-role").toRepresentation();
+
+            // Attempt to rename innocent-role → realm-admin
+            RoleRepresentation renamed = new RoleRepresentation();
+            renamed.setId(innocentRole.getId());
+            renamed.setName(AdminRoles.REALM_ADMIN);
+
+            Assertions.assertThrows(ForbiddenException.class, () ->
+                    delegatedClient.realm(managedRealm.getName()).rolesById()
+                            .updateRole(innocentRole.getId(), renamed));
+        }
+    }
+
+    /**
+     * see #49427 — named-role endpoint (PUT /roles/{role-name}) must also be guarded.
+     */
+    @Test
+    @DatabaseTest
+    public void testRenameProtectedRoleBlockedViaNamedRoleEndpoint() {
+        createDelegatedAdminUser("delegated-admin3", "password", AdminRoles.MANAGE_CLIENTS);
+
+        ClientRepresentation rmClient = managedRealm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+
+        try (Keycloak delegatedClient = adminClientFactory.create()
+                .realm(managedRealm.getName())
+                .username("delegated-admin3")
+                .password("password")
+                .clientId(Constants.ADMIN_CLI_CLIENT_ID)
+                .build()) {
+
+            RoleRepresentation renamed = new RoleRepresentation();
+            renamed.setName("temp-role");
+
+            Assertions.assertThrows(ForbiddenException.class, () ->
+                    delegatedClient.realm(managedRealm.getName()).clients()
+                            .get(rmClient.getId()).roles().get(AdminRoles.REALM_ADMIN)
+                            .update(renamed));
+        }
+    }
+
+    /**
+     * see #49427
+    */
+    @Test
+    @DatabaseTest
+    public void testTOCTOURenameCompositeAttackPrevented() {
+        createDelegatedAdminUser("toctou-attacker", "password", AdminRoles.MANAGE_CLIENTS);
+
+        ClientRepresentation rmClient = managedRealm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation realmAdminRole = managedRealm.admin().clients()
+                .get(rmClient.getId()).roles().get(AdminRoles.REALM_ADMIN).toRepresentation();
+
+        try (Keycloak delegatedClient = adminClientFactory.create()
+                .realm(managedRealm.getName())
+                .username("toctou-attacker")
+                .password("password")
+                .clientId(Constants.ADMIN_CLI_CLIENT_ID)
+                .build()) {
+
+            // Step 1: rename realm-admin → temp-role must be blocked
+            RoleRepresentation renamed = new RoleRepresentation();
+            renamed.setId(realmAdminRole.getId());
+            renamed.setName("temp-role");
+
+            Assertions.assertThrows(ForbiddenException.class, () ->
+                    delegatedClient.realm(managedRealm.getName()).rolesById()
+                            .updateRole(realmAdminRole.getId(), renamed));
+
+            // Confirm realm-admin name is unchanged
+            RoleRepresentation unchanged = managedRealm.admin().clients()
+                    .get(rmClient.getId()).roles().get(AdminRoles.REALM_ADMIN).toRepresentation();
+            assertEquals(AdminRoles.REALM_ADMIN, unchanged.getName());
+        }
+    }
+
+    private void createDelegatedAdminUser(String username, String password, String clientRoleName) {
+        UserRepresentation user = new UserRepresentation();
+        user.setUsername(username);
+        user.setEnabled(true);
+        user.setEmailVerified(true);
+        user.setFirstName("Delegated");
+        user.setLastName("Admin");
+        user.setEmail(username + "@test.local");
+
+        Response resp = managedRealm.admin().users().create(user);
+        String userId = resp.getLocation().getPath().replaceAll(".*/", "");
+        resp.close();
+
+        CredentialRepresentation cred = new CredentialRepresentation();
+        cred.setType(CredentialRepresentation.PASSWORD);
+        cred.setValue(password);
+        cred.setTemporary(false);
+        managedRealm.admin().users().get(userId).resetPassword(cred);
+
+        ClientRepresentation rmClient = managedRealm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0);
+        RoleRepresentation role = managedRealm.admin().clients()
+                .get(rmClient.getId()).roles().get(clientRoleName).toRepresentation();
+        managedRealm.admin().users().get(userId).roles()
+                .clientLevel(rmClient.getId()).add(Collections.singletonList(role));
+
+        // query-clients is required so the delegated admin can look up clients
+        RoleRepresentation queryClients = managedRealm.admin().clients()
+                .get(rmClient.getId()).roles().get(AdminRoles.QUERY_CLIENTS).toRepresentation();
+        managedRealm.admin().users().get(userId).roles()
+                .clientLevel(rmClient.getId()).add(Collections.singletonList(queryClients));
+    }
+
+    private ClientRepresentation clientRepresentation(String clientId) {
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(clientId);
+        client.setEnabled(true);
+        return client;
+    }
+
+    private RoleRepresentation roleRepresentation(String name) {
+        RoleRepresentation role = new RoleRepresentation();
+        role.setName(name);
+        return role;
     }
 }


### PR DESCRIPTION
## Summary

Closes #49427

A delegated admin holding only `manage-clients` could exploit two gaps in role-rename validation to escalate to full `realm-admin` privileges.

### Attack 1 — TOCTOU via rename-away

The `checkAdminRoles` composite guard is name-based: it checks `role.getName()` against `AdminRoles.ALL_ROLES`. Before this fix, no guard ran during a rename, enabling this sequence:

1. Rename `realm-admin` → `temp-role` — the name leaves `ALL_ROLES`; the composite guard goes blind.
2. Add `temp-role` as a composite child of an attacker-controlled role.
3. Rename `temp-role` → `realm-admin` — composites are stored by role ID, so the link persists.

Any user assigned the attacker-controlled role now transitively holds full `realm-admin` privileges.

### Attack 2 — Rename-to bypass

A delegated admin creates an innocent role on their own client and renames it to `"realm-admin"`. That role now passes name-based guards even though it was never a real admin role.

---

## Changes

### `RoleResource` — new `isProtectedAdminRoleRename(role, newName)`

Core helper shared by both update endpoints. Two-tier logic:

- **Rename TO a protected name** (`newName ∈ ALL_ROLES`): blocked unconditionally for any container. Stops Attack 2.
- **Rename FROM a protected name** (`role.getName() ∈ ALL_ROLES`): blocked only when the role belongs to an admin container (the realm itself, or the `realm-management` / `master-realm` client). Container scoping avoids false positives for custom client roles whose names coincidentally collide with an admin role string.

### `RoleByIdResource` — `PUT /roles-by-id/{id}`

Guard applied after `requireManage()` and before `updateRole()`. A delegated admin that passes `requireManage` but lacks `canManageRealm()` is rejected with `403 Forbidden`.

### `RoleContainerResource` — `PUT /roles/{name}` and `PUT /clients/{id}/roles/{name}` (additional fix)

This endpoint was **entirely unguarded**. Patching only `RoleByIdResource` would leave the vulnerability trivially bypassable via the named-role URL. The same guard is applied here to deliver a complete remediation.

### `RoleByIdResourceTest` — 4 new integration tests

Each test creates a delegated admin with only `manage-clients` and verifies a specific attack vector is blocked:

| Test | Scenario |
|---|---|
| `testRenameProtectedRoleBlockedForDelegatedAdmin` | Cannot rename `realm-admin` → `temp-role` via ID endpoint |
| `testRenamingToProtectedRoleNameBlockedForDelegatedAdmin` | Cannot rename an innocent custom client role → `realm-admin` via ID endpoint |
| `testRenameProtectedRoleBlockedViaNamedRoleEndpoint` | Cannot rename `realm-admin` → `temp-role` via named-role endpoint |
| `testTOCTOURenameCompositeAttackPrevented` | Full TOCTOU sequence blocked at step 1; `realm-admin` name confirmed unchanged |

---

## Test plan

- [ ] All four new tests in `RoleByIdResourceTest` pass
- [ ] Existing role management tests in `RoleByIdResourceTest` and `RoleContainerResourceTest` are unaffected
- [ ] A full realm admin (with `manage-realm`) can still rename admin roles normally