### PR TITLE
Remove redundant pnpm overrides from JS workspace

### DIFF
--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -5,15 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  picomatch@^2: ^2.3.2
-  flatted: ^3.4.2
-  minimatch@~3: ^3.1.4
-  minimatch@~9: ^9.0.7
+  serialize-javascript: ^7.0.5
   brace-expansion@^1: ^1.1.13
   brace-expansion@^2: ^2.0.3
-  '@isaacs/brace-expansion@^5': ^5.0.1
-  serialize-javascript: ^7.0.5
-  diff@^4: ^4.0.4
   diff@^7: ^8.0.3
   '@microsoft/api-extractor': ^7.58.7
   jquery@^3: ^3.7.1

--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -27,15 +27,9 @@ ignoredOptionalDependencies:
   - patternfly-bootstrap-combobox
   - patternfly-bootstrap-treeview
 overrides:
-  picomatch@^2: ^2.3.2
-  flatted: ^3.4.2
-  minimatch@~3: ^3.1.4
-  minimatch@~9: ^9.0.7
+  serialize-javascript: ^7.0.5
   'brace-expansion@^1': ^1.1.13
   'brace-expansion@^2': ^2.0.3
-  '@isaacs/brace-expansion@^5': ^5.0.1
-  serialize-javascript: ^7.0.5
-  diff@^4: ^4.0.4
   diff@^7: ^8.0.3
   '@microsoft/api-extractor': ^7.58.7
   jquery@^3: ^3.7.1


### PR DESCRIPTION
## Summary

- Removes six pnpm overrides that no longer affect resolved dependency versions: `picomatch@^2`, `flatted`, `minimatch@~3`, `minimatch@~9`, `@isaacs/brace-expansion@^5`, and `diff@^4`.
- Keeps overrides still required for `mocha` transitive dependencies in `keycloak-admin-client`: `serialize-javascript` and `diff@^7`.
- Bumps the `serialize-javascript` override floor from `^7.0.3` to `^7.0.5` to match the fully patched advisory range.

## Rationale

These overrides were added during the pnpm 11 upgrade (#48975) as security floors. Re-testing shows the removed ones are redundant today — pnpm already resolves to patched versions without them. Removing them reduces lockfile churn and review noise on future installs.

