### PR TITLE
Fix migration when MySQL is using group replication and the user consent tables are not empty

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/CreateTableAsSelectGuard.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/CreateTableAsSelectGuard.java
@@ -1,0 +1,46 @@
+package org.keycloak.connections.jpa.updater.liquibase.custom;
+
+import java.util.regex.Pattern;
+
+import liquibase.database.Database;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AbstractSqlGenerator;
+import liquibase.statement.core.RawSqlStatement;
+
+/**
+ * Rejects {@code CREATE TABLE ... AS SELECT} on MySQL — incompatible with Group Replication (ERROR 3098).
+ * Only raw SQL from {@link CustomKeycloakTask} subclasses needs guarding, as XML changelogs cannot express this pattern.
+ */
+public class CreateTableAsSelectGuard extends AbstractSqlGenerator<RawSqlStatement> {
+
+    private static final Pattern CTAS_PATTERN = Pattern.compile("(?i)CREATE\\s+TABLE\\s+\\S+\\s+AS\\s+SELECT");
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE + 100;
+    }
+
+    @Override
+    public boolean supports(RawSqlStatement statement, Database database) {
+        return database instanceof MySQLDatabase;
+    }
+
+    @Override
+    public ValidationErrors validate(RawSqlStatement statement, Database database, SqlGeneratorChain<RawSqlStatement> chain) {
+        return new ValidationErrors();
+    }
+
+    @Override
+    public Sql[] generateSql(RawSqlStatement statement, Database database, SqlGeneratorChain<RawSqlStatement> chain) {
+        String sql = statement.getSql().trim();
+        if (CTAS_PATTERN.matcher(sql).find()) {
+            throw new RuntimeException("CREATE TABLE ... AS SELECT is incompatible with MySQL Group Replication "
+                    + "(ERROR 3098). Use CREATE TABLE with inline PRIMARY KEY followed by INSERT INTO ... SELECT. "
+                    + "Found: " + sql);
+        }
+        return chain.generateSql(statement, database);
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate25_0_0_MySQL_ConsentConstraints.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/updater/liquibase/custom/JpaUpdate25_0_0_MySQL_ConsentConstraints.java
@@ -35,15 +35,14 @@ public class JpaUpdate25_0_0_MySQL_ConsentConstraints extends CustomKeycloakTask
                         " AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE)"
         ));
         statements.add(new RawSqlStatement(
-                "  CREATE TABLE TEMP_USER_CONSENT_IDS" +
-                        " AS SELECT uc.ID FROM "+userConsentTable+" uc INNER JOIN (" +
+                "CREATE TABLE TEMP_USER_CONSENT_IDS (ID VARCHAR(36) NOT NULL, PRIMARY KEY (ID))"
+        ));
+        statements.add(new RawSqlStatement(
+                "INSERT INTO TEMP_USER_CONSENT_IDS SELECT uc.ID FROM " + userConsentTable + " uc INNER JOIN (" +
                         " SELECT CLIENT_ID, USER_ID, MAX(LAST_UPDATED_DATE) AS MAX_UPDATED_DATE" +
                         " FROM "+userConsentTable+" GROUP BY CLIENT_ID, USER_ID HAVING COUNT(*) > 1 )" +
                         " max_dates ON uc.CLIENT_ID = max_dates.CLIENT_ID" +
                         " AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE"
-        ));
-        statements.add(new RawSqlStatement(
-                "ALTER TABLE TEMP_USER_CONSENT_IDS ADD PRIMARY KEY (ID)"
         ));
         statements.add(new DeleteStatement(null, null, database.correctObjectName("USER_CONSENT", Table.class))
                 .setWhere("ID IN (SELECT ID FROM TEMP_USER_CONSENT_IDS)"));
@@ -58,15 +57,14 @@ public class JpaUpdate25_0_0_MySQL_ConsentConstraints extends CustomKeycloakTask
                         " AND uc.EXTERNAL_CLIENT_ID = max_dates.EXTERNAL_CLIENT_ID AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE )"
         ));
         statements.add(new RawSqlStatement(
-                "CREATE TABLE TEMP_USER_CONSENT_IDS2" +
-                        " AS SELECT uc.ID FROM "+userConsentTable+" uc INNER JOIN (" +
+                "CREATE TABLE TEMP_USER_CONSENT_IDS2 (ID VARCHAR(36) NOT NULL, PRIMARY KEY (ID))"
+        ));
+        statements.add(new RawSqlStatement(
+                "INSERT INTO TEMP_USER_CONSENT_IDS2 SELECT uc.ID FROM " + userConsentTable + " uc INNER JOIN (" +
                         " SELECT CLIENT_STORAGE_PROVIDER, EXTERNAL_CLIENT_ID, USER_ID, MAX(LAST_UPDATED_DATE) AS MAX_UPDATED_DATE" +
                         " FROM "+userConsentTable+" GROUP BY CLIENT_STORAGE_PROVIDER, EXTERNAL_CLIENT_ID, USER_ID HAVING COUNT(*) > 1 )" +
                         " max_dates ON uc.CLIENT_STORAGE_PROVIDER = max_dates.CLIENT_STORAGE_PROVIDER" +
-                        " AND uc.EXTERNAL_CLIENT_ID = max_dates.EXTERNAL_CLIENT_ID AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE;"
-        ));
-        statements.add(new RawSqlStatement(
-                "ALTER TABLE TEMP_USER_CONSENT_IDS2 ADD PRIMARY KEY (ID)"
+                        " AND uc.EXTERNAL_CLIENT_ID = max_dates.EXTERNAL_CLIENT_ID AND uc.USER_ID = max_dates.USER_ID AND uc.LAST_UPDATED_DATE = max_dates.MAX_UPDATED_DATE"
         ));
         statements.add(new DeleteStatement(null, null, database.correctObjectName("USER_CONSENT", Table.class))
                 .setWhere("ID IN (SELECT ID FROM TEMP_USER_CONSENT_IDS2)"));

--- a/model/jpa/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/model/jpa/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -17,3 +17,4 @@
 
 org.keycloak.connections.jpa.updater.liquibase.lock.CustomInsertLockRecordGenerator
 org.keycloak.connections.jpa.updater.liquibase.lock.CustomLockDatabaseChangeLogGenerator
+org.keycloak.connections.jpa.updater.liquibase.custom.CreateTableAsSelectGuard


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/49550

The idea here is to avoid `CREATE TABLE ... AS SELECT` pattern for MySQL and detect via automated test if someone tries to use it again. This should prevent future issues when users use https://dev.mysql.com/doc/refman/9.7/en/server-system-variables.html#sysvar_sql_require_primary_key. I have spend hours on alternative approaches of testing, but all would require more time, as the migration tests are quite slow and we would need to use manual DB migration strategy and either different DB setup or doing basically the same - checking the changelog for a regex.