### PR TITLE
Update lodash to >=4.17.24

### DIFF
--- a/js/pnpm-workspace.yaml
+++ b/js/pnpm-workspace.yaml
@@ -39,7 +39,7 @@ overrides:
   diff@^7: ^8.0.3
   '@microsoft/api-extractor': ^7.58.7
   jquery@^3: ^3.7.1
-  lodash: ^4.17.23
+  lodash: ^4.17.24
   mdast-util-to-hast: ^13.2.1
 allowBuilds:
   '@swc/core': true


### PR DESCRIPTION
Update the lodash version override in pnpm-workspace.yaml from 4.17.23 to 4.17.24 to resolve known CVEs in lodash 4.17.21 and earlier versions.

This follows the update requirement from issue #49534.

Closes #49534
