### PR TITLE
Keycloak 49467 add null check is public client

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java
@@ -548,10 +548,10 @@ public class DescriptionConverter {
         if (oidcClient.isUseRefreshToken()) {
             grantTypes.add(OAuth2Constants.REFRESH_TOKEN);
         }
-        if (!client.isPublicClient() && oidcClient.isStandardTokenExchangeEnabled()) {
+        if (Boolean.FALSE.equals(client.isPublicClient()) && oidcClient.isStandardTokenExchangeEnabled()) {
             grantTypes.add(OAuth2Constants.TOKEN_EXCHANGE_GRANT_TYPE);
         }
-        if (!client.isPublicClient() && oidcClient.getJWTAuthorizationGrantEnabled()) {
+        if (Boolean.FALSE.equals(client.isPublicClient()) && oidcClient.getJWTAuthorizationGrantEnabled()) {
             grantTypes.add(OAuth2Constants.JWT_AUTHORIZATION_GRANT);
         }
         return grantTypes;


### PR DESCRIPTION
## Summary

Add null-safe comparison for client.isPublicClient() in DescriptionConverter.getOIDCGrantTypes() to prevent potential NPE from automatic unboxing of Boolean wrapper type.

## Problem

In services/src/main/java/org/keycloak/services/clientregistration/oidc/DescriptionConverter.java (lines 551-556), client.isPublicClient() was used without null check. Since isPublicClient() returns Boolean (not primitive boolean), if the value is null, Java auto-unboxing throws a NullPointerException.

## Fix

Changed to null-safe comparison using Boolean.FALSE.equals(). This matches patterns already used elsewhere in the codebase (ClientResource.java:836 and AbstractClientRegistrationProvider.java:144).

## Testing

- Code compiles successfully
- Follows existing null-safety patterns

Fixes #49467