### PR TITLE
fix: mark read-only profile fields disabled

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/actions/RequiredActionUpdateProfileTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/actions/RequiredActionUpdateProfileTest.java
@@ -66,7 +66,9 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.ElementClickInterceptedException;
+import org.openqa.selenium.WebElement;
 
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_ADMIN;
 import static org.keycloak.userprofile.config.UPConfigUtils.ROLE_USER;
@@ -81,6 +83,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class RequiredActionUpdateProfileTest {
 
     private static final String PASSWORD = PasswordGenerateUtil.generatePassword();
+    private static final String DISABLED_FORM_CONTROL_CLASS = "pf-m-disabled";
 
     @InjectRealm(config = RequiredActionUpdateProfileRealmConfig.class)
     ManagedRealm realm;
@@ -137,6 +140,34 @@ public class RequiredActionUpdateProfileTest {
         Assertions.assertEquals("test-user@localhost", user.getUsername());
         // email changed so verify that emailVerified flag is reset
         Assertions.assertEquals(false, user.isEmailVerified());
+    }
+
+    @Test
+    public void readOnlyProfileFieldsHaveDisabledFormControlClass() {
+        UserProfileResource userProfile = realm.admin().users().userProfile();
+        UPConfig configuration = userProfile.getConfiguration();
+        UPConfig readOnlyLastNameConfiguration = configuration.clone();
+        readOnlyLastNameConfiguration.addOrReplaceAttribute(new UPAttribute(UserModel.LAST_NAME,
+                new UPAttributePermissions(Set.of(ROLE_USER, ROLE_ADMIN), Set.of(ROLE_ADMIN))));
+
+        try {
+            userProfile.update(readOnlyLastNameConfiguration);
+
+            oauth.openLoginForm();
+            loginPage.fillLogin("test-user@localhost", PASSWORD);
+            loginPage.submit();
+
+            updateProfilePage.assertCurrent();
+
+            WebElement lastNameInput = updateProfilePage.getElementById(UserModel.LAST_NAME);
+
+            Assertions.assertNotNull(lastNameInput);
+            Assertions.assertFalse(lastNameInput.isEnabled());
+            Assertions.assertTrue(lastNameInput.findElement(By.xpath("..")).getAttribute("class")
+                    .contains(DISABLED_FORM_CONTROL_CLASS));
+        } finally {
+            userProfile.update(configuration);
+        }
     }
 
     @Test

--- a/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
@@ -43,6 +43,7 @@ kcFormPasswordVisibilityIconShow=fa-eye fas
 kcFormPasswordVisibilityIconHide=fa-eye-slash fas
 kcFormControlToggleIcon=pf-v5-c-form-control__toggle-icon
 kcFormActionGroupClass=pf-v5-c-form__actions pf-v5-u-pt-xs
+kcFormDisabledClass=pf-m-disabled
 kcFormReadOnlyClass=pf-m-readonly
 
 kcPanelClass=pf-v5-c-panel pf-m-raised

--- a/themes/src/main/resources/theme/keycloak.v2/login/user-profile-commons.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/user-profile-commons.ftl
@@ -87,7 +87,7 @@
 </#macro>
 
 <#macro inputTag attribute value>
-	<span class="${properties.kcInputClass} <#if error?has_content>${properties.kcError}</#if>">
+	<span class="${properties.kcInputClass}<#if error?has_content> ${properties.kcError}</#if><#if attribute.readOnly> ${properties.kcFormDisabledClass!}</#if>">
 		<input type="<@inputTagType attribute=attribute/>" id="${attribute.name}" name="${attribute.name}" value="${(value!'')}" class="${properties.kcInputClass!}"
 			aria-invalid="<#if messagesPerField.existsError('${attribute.name}')>true</#if>"
 			<#if attribute.readOnly>disabled</#if>
@@ -122,7 +122,7 @@
 </#macro>
 
 <#macro textareaTag attribute>
-	<span class="${properties.kcInputClass!}">
+	<span class="${properties.kcInputClass!}<#if attribute.readOnly> ${properties.kcFormDisabledClass!}</#if>">
 	<textarea id="${attribute.name}" name="${attribute.name}"
 		aria-invalid="<#if messagesPerField.existsError('${attribute.name}')>true</#if>"
 		<#if attribute.readOnly>disabled</#if>
@@ -134,7 +134,7 @@
 </#macro>
 
 <#macro selectTag attribute>
-	<div class="${properties.kcInputClass!}">
+	<div class="${properties.kcInputClass!}<#if attribute.readOnly> ${properties.kcFormDisabledClass!}</#if>">
 		<select id="${attribute.name}" name="${attribute.name}"
 			aria-invalid="<#if messagesPerField.existsError('${attribute.name}')>true</#if>"
 			<#if attribute.readOnly>disabled</#if>


### PR DESCRIPTION
Fixes #49406

### Summary
- Add the PatternFly disabled modifier to read-only user profile form-control wrappers in the keycloak.v2 login theme.
- Cover the update-profile required action with a regression test that verifies a read-only profile field is disabled and its wrapper has `pf-m-disabled`.

### Verification
- `./mvnw.cmd -q -pl themes -am -DskipTests -DskipITs package`
- `git diff --check`

### AI assistance
- Used an AI coding agent to help generate and verify this change; I reviewed the final diff and take responsibility for the contribution.