### PR TITLE
Upgrade to Infinispan 16.0.13

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc
@@ -114,7 +114,7 @@ For more details on the Operator configuration, see the https://www.keycloak.org
 
 {project_name} now uses Infinispan 16.0 for embedded distributed caching. This upgrade brings improved performance, enhanced security, and better support for zero-downtime upgrades in patch releases.
 
-If you are using an external {jdgserver_name} server, for example in a multi-cluster setup, you should upgrade to version 16.0 as this is the version {project_name} was tested with.
+If you are using an external {jdgserver_name} server, for example in a multi-cluster setup, you should upgrade to version 16.0.13 as this is the version {project_name} was tested with.
 
 When upgrading the external {jdgserver_name}, the following changes are necessary:
 

--- a/docs/guides/high-availability/examples/generated/ispn-single.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-single.yaml
@@ -318,8 +318,8 @@ spec:
   expose:
     type: Route
   configMapName: "cluster-config"
-  image: quay.io/infinispan/server:16.0.8
-  version: 16.0.8
+  image: quay.io/infinispan/server:16.0.13
+  version: 16.0.13
   configListener:
     enabled: false
   container:

--- a/docs/guides/high-availability/examples/generated/ispn-site-a.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-site-a.yaml
@@ -349,7 +349,7 @@ spec:
     type: Route
   configMapName: "cluster-config"
   image: 
-  version: 16.0.8
+  version: 16.0.13
   configListener:
     enabled: false
   container:

--- a/docs/guides/high-availability/examples/generated/ispn-site-b.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-site-b.yaml
@@ -349,7 +349,7 @@ spec:
     type: Route
   configMapName: "cluster-config"
   image: 
-  version: 16.0.8
+  version: 16.0.13
   configListener:
     enabled: false
   container:

--- a/docs/guides/high-availability/examples/generated/ispn-volatile.yaml
+++ b/docs/guides/high-availability/examples/generated/ispn-volatile.yaml
@@ -521,7 +521,7 @@ spec:
     type: Route
   configMapName: "cluster-config"
   image: 
-  version: 16.0.8
+  version: 16.0.13
   configListener:
     enabled: false
   container:

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,8 @@
         <hibernate-orm.plugin.version>6.2.13.Final</hibernate-orm.plugin.version>
         <hibernate.c3p0.version>6.2.13.Final</hibernate.c3p0.version>
         <microprofile-metrics-api.version>5.1.2</microprofile-metrics-api.version>
-        <infinispan.version>16.0.8</infinispan.version>
-        <protostream.version>6.0.6</protostream.version> <!-- For the annotation processor: keep in sync with the version shipped with Infinispan -->
+        <infinispan.version>16.0.13</infinispan.version>
+        <protostream.version>6.0.7</protostream.version> <!-- For the annotation processor: keep in sync with the version shipped with Infinispan -->
         <protostream.plugin.version>${protostream.version}</protostream.plugin.version>
 
         <!--JAKARTA-->


### PR DESCRIPTION
Bumps the embedded Infinispan dependency from 16.0.8 to 16.0.13 and updates the corresponding `protostream.version` to 6.0.7 to stay in sync with the version shipped with Infinispan 16.0.13.

Also refreshes the example deployment manifests and the upgrading guide to reference the new version.

### Changes
- `pom.xml` — bump `infinispan.version` to `16.0.13` and `protostream.version` to `6.0.7`.
- `docs/guides/high-availability/examples/generated/ispn-{single,site-a,site-b,volatile}.yaml` — update `image`/`version` to `16.0.13`.
- `docs/documentation/upgrading/topics/changes/changes-26_6_0.adoc` — recommend the new `16.0.13` version for external {jdgserver_name} servers.

Closes #49206