### PR TITLE
Fix backchannel logout token including sid on admin logout-all-sessions

### DIFF
--- a/docs/documentation/server_admin/topics/clients/oidc/con-basic-settings.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-basic-settings.adoc
@@ -125,7 +125,11 @@ There will be also one item on the consent screen about this client itself.
 *Backchannel logout URL*:: URL that will cause the client to log itself out when a logout request is sent to this realm (via end_session_endpoint). The logout is done by sending logout token as specified in the OIDC Backchannel logout specification. If omitted, the logout request might be sent to the specified `Admin URL` (if configured) in the format specific to {project_name} adapters. If even `Admin URL` is not configured, no logout request will be sent to the client. This option is applicable just if `Front channel logout` option is OFF.
 
 *Backchannel logout session required*::
-Specifies whether a session ID Claim is included in the Logout Token when the *Backchannel Logout URL* is used.
+Specifies whether a session ID (`sid`) claim is included in the Logout Token when the *Backchannel Logout URL* is used.
++
+Per the https://openid.net/specs/openid-connect-backchannel-1_0.html[OIDC Back-Channel Logout 1.0 specification], a Logout Token that contains `sid` instructs the Relying Party to terminate only the identified session. A Logout Token without `sid` instructs the Relying Party to terminate all sessions for the identified user (`sub`).
++
+{project_name} applies this distinction automatically when an administrator triggers a logout via the user management REST API (`DELETE /admin/realms/{realm}/users/{id}/sessions`): if the user has more than one active online session, the `sid` claim is omitted from the Logout Token so that the Relying Party terminates all sessions. If only one session is active, `sid` is retained because there is no ambiguity about which session to terminate.
 
 *Backchannel logout revoke offline sessions*:: Specifies whether a revoke_offline_access event is included in the Logout Token when the Backchannel Logout URL is used. {project_name} will revoke offline sessions when receiving a Logout Token with this event.
 

--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocol.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocol.java
@@ -117,6 +117,12 @@ public interface LoginProtocol extends Provider {
     Response sendError(ClientModel client, ClientData clientData, Error error);
 
     Response backchannelLogout(UserSessionModel userSession, AuthenticatedClientSessionModel clientSession);
+
+    default Response backchannelLogout(UserSessionModel userSession, AuthenticatedClientSessionModel clientSession,
+                                       boolean logoutAllUserSessions) {
+        return backchannelLogout(userSession, clientSession);
+    }
+
     Response frontchannelLogout(UserSessionModel userSession, AuthenticatedClientSessionModel clientSession);
 
     /**

--- a/server-spi/src/main/java/org/keycloak/models/TokenManager.java
+++ b/server-spi/src/main/java/org/keycloak/models/TokenManager.java
@@ -82,4 +82,10 @@ public interface TokenManager {
     String encryptAlgorithm(TokenCategory category);
 
     LogoutToken initLogoutToken(ClientModel client, UserModel user, AuthenticatedClientSessionModel clientSessionModel);
+
+    default LogoutToken initLogoutToken(ClientModel client, UserModel user,
+                                        AuthenticatedClientSessionModel clientSessionModel,
+                                        boolean logoutAllUserSessions) {
+        return initLogoutToken(client, user, clientSessionModel);
+    }
 }

--- a/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
+++ b/services/src/main/java/org/keycloak/jose/jws/DefaultTokenManager.java
@@ -348,8 +348,16 @@ public class DefaultTokenManager implements TokenManager {
         return defaultValue;
     }
 
+    @Override
     public LogoutToken initLogoutToken(ClientModel client, UserModel user,
                                        AuthenticatedClientSessionModel clientSession) {
+        return initLogoutToken(client, user, clientSession, false);
+    }
+
+    @Override
+    public LogoutToken initLogoutToken(ClientModel client, UserModel user,
+                                       AuthenticatedClientSessionModel clientSession,
+                                       boolean logoutAllUserSessions) {
         LogoutToken token = new LogoutToken();
         token.id(SecretGenerator.getInstance().generateSecureID());
         token.issuedNow();
@@ -361,7 +369,7 @@ public class DefaultTokenManager implements TokenManager {
         token.addAudience(client.getClientId());
 
         OIDCAdvancedConfigWrapper oidcAdvancedConfigWrapper = OIDCAdvancedConfigWrapper.fromClientModel(client);
-        if (oidcAdvancedConfigWrapper.isBackchannelLogoutSessionRequired()){
+        if (oidcAdvancedConfigWrapper.isBackchannelLogoutSessionRequired() && !logoutAllUserSessions) {
             token.setSid(clientSession.getUserSession().getId());
         }
         if (oidcAdvancedConfigWrapper.getBackchannelLogoutRevokeOfflineTokens()){

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -469,9 +469,16 @@ public class OIDCLoginProtocol implements LoginProtocol {
 
     @Override
     public Response backchannelLogout(UserSessionModel userSession, AuthenticatedClientSessionModel clientSession) {
+        return backchannelLogout(userSession, clientSession, false);
+    }
+
+    @Override
+    public Response backchannelLogout(UserSessionModel userSession, AuthenticatedClientSessionModel clientSession,
+                                      boolean logoutAllUserSessions) {
         ClientModel client = clientSession.getClient();
         if (OIDCAdvancedConfigWrapper.fromClientModel(clientSession.getClient()).getBackchannelLogoutUrl() != null) {
-            return new ResourceAdminManager(session).logoutClientSessionWithBackchannelLogoutUrl(client, clientSession);
+            return new ResourceAdminManager(session).logoutClientSessionWithBackchannelLogoutUrl(client, clientSession,
+                    logoutAllUserSessions);
         } else {
             return new ResourceAdminManager(session).logoutClientSession(realm, client, clientSession);
         }

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -542,6 +542,12 @@ public class AuthenticationManager {
     private static Response backchannelLogoutClientSession(KeycloakSession session, RealmModel realm,
             AuthenticatedClientSessionModel clientSession, AuthenticationSessionModel logoutAuthSession,
             UriInfo uriInfo, HttpHeaders headers) {
+        return backchannelLogoutClientSession(session, realm, clientSession, logoutAuthSession, uriInfo, headers, false);
+    }
+
+    private static Response backchannelLogoutClientSession(KeycloakSession session, RealmModel realm,
+            AuthenticatedClientSessionModel clientSession, AuthenticationSessionModel logoutAuthSession,
+            UriInfo uriInfo, HttpHeaders headers, boolean logoutAllUserSessions) {
         UserSessionModel userSession = clientSession.getUserSession();
         ClientModel client = clientSession.getClient();
 
@@ -573,7 +579,7 @@ public class AuthenticationManager {
                     .setHttpHeaders(headers)
                     .setUriInfo(uriInfo);
 
-            Response clientSessionLogout = protocol.backchannelLogout(userSession, clientSession);
+            Response clientSessionLogout = protocol.backchannelLogout(userSession, clientSession, logoutAllUserSessions);
 
             setClientLogoutAction(logoutAuthSession, client.getId(), AuthenticationSessionModel.Action.LOGGED_OUT);
 
@@ -706,6 +712,25 @@ public class AuthenticationManager {
                 .forEach(userSession ->
                                 backchannelLogoutUserSessionFromClient(session, realm, userSession, client, uriInfo, headers)
                         );
+    }
+
+    /**
+     * Sends one sid-less backchannel logout token per unique client across the given user sessions. Per the OIDC
+     * Back-Channel Logout spec a token without {@code sid} terminates all of the user's sessions at the RP, so one
+     * token per client suffices. Each visited client session is marked {@link Action#LOGGED_OUT} so a later
+     * {@link #backchannelLogout} pass does not notify the same client again.
+     */
+    public static void backchannelLogoutUserClientsOnce(KeycloakSession session, RealmModel realm,
+            List<UserSessionModel> userSessions, UriInfo uriInfo, HttpHeaders headers) {
+        Set<String> notifiedClients = new HashSet<>();
+        for (UserSessionModel userSession : userSessions) {
+            for (AuthenticatedClientSessionModel clientSession : userSession.getAuthenticatedClientSessions().values()) {
+                if (notifiedClients.add(clientSession.getClient().getId())) {
+                    backchannelLogoutClientSession(session, realm, clientSession, null, uriInfo, headers, true);
+                }
+                clientSession.setAction(Action.LOGGED_OUT.name());
+            }
+        }
     }
 
     public static Response browserLogout(KeycloakSession session,

--- a/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/ResourceAdminManager.java
@@ -171,6 +171,11 @@ public class ResourceAdminManager {
 
     public Response logoutClientSessionWithBackchannelLogoutUrl(ClientModel resource,
             AuthenticatedClientSessionModel clientSession) {
+        return logoutClientSessionWithBackchannelLogoutUrl(resource, clientSession, false);
+    }
+
+    public Response logoutClientSessionWithBackchannelLogoutUrl(ClientModel resource,
+            AuthenticatedClientSessionModel clientSession, boolean logoutAllUserSessions) {
         String backchannelLogoutUrl = getBackchannelLogoutUrl(session, resource);
 
         if (backchannelLogoutUrl == null) {
@@ -194,12 +199,12 @@ public class ResourceAdminManager {
                           "clientId='%s' clientSessionId='%s' host='%s' backchannelLogoutUrl='%s'",
                     resource.getClientId(), clientSession.getId(), host, backchannelLogoutUrl);
             String currentHostMgmtUrl = backchannelLogoutUrl.replace(CLIENT_SESSION_HOST_PROPERTY, host);
-            return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl);
+            return sendBackChannelLogoutRequestToClientUri(resource, clientSession, currentHostMgmtUrl, logoutAllUserSessions);
         } else {
             logger.debugf("Attempting backchannel-logout for client. " +
                           "clientId='%s' clientSessionId='%s' backchannelLogoutUrl='%s'",
                     resource.getClientId(), clientSession.getId(), backchannelLogoutUrl);
-            return sendBackChannelLogoutRequestToClientUri(resource, clientSession, backchannelLogoutUrl);
+            return sendBackChannelLogoutRequestToClientUri(resource, clientSession, backchannelLogoutUrl, logoutAllUserSessions);
         }
     }
 
@@ -214,6 +219,12 @@ public class ResourceAdminManager {
 
     protected Response sendBackChannelLogoutRequestToClientUri(ClientModel resource,
                                                               AuthenticatedClientSessionModel clientSessionModel, String managementUrl) {
+        return sendBackChannelLogoutRequestToClientUri(resource, clientSessionModel, managementUrl, false);
+    }
+
+    protected Response sendBackChannelLogoutRequestToClientUri(ClientModel resource,
+                                                              AuthenticatedClientSessionModel clientSessionModel, String managementUrl,
+                                                              boolean logoutAllUserSessions) {
         UserModel user = clientSessionModel.getUserSession().getUser();
 
         HttpPost post = null;
@@ -221,7 +232,7 @@ public class ResourceAdminManager {
         try {
             session.getContext().setClient(resource);
 
-            LogoutToken logoutToken = session.tokens().initLogoutToken(resource, user, clientSessionModel);
+            LogoutToken logoutToken = session.tokens().initLogoutToken(resource, user, clientSessionModel, logoutAllUserSessions);
             String token = session.tokens().encode(logoutToken);
             if (logger.isDebugEnabled()) {
                 logger.debugf("Sending backchannel-logout request to client. " +

--- a/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UserResource.java
@@ -690,10 +690,18 @@ public class UserResource {
             session.users().setNotBeforeForUser(realm, user, Time.currentTime());
         }
 
-        session.sessions().getUserSessionsStream(realm, user)
-                .collect(Collectors.toList()) // collect to avoid concurrent modification as backchannelLogout removes the user sessions.
-                .forEach(userSession -> AuthenticationManager.backchannelLogout(session, realm, userSession,
-                        session.getContext().getUri(), clientConnection, headers, true));
+        List<UserSessionModel> userSessions = session.sessions().getUserSessionsStream(realm, user)
+                .collect(Collectors.toList()); // collect to avoid concurrent modification as backchannelLogout removes the user sessions.
+
+        if (userSessions.size() > 1) {
+            // More than one active session: omit sid so each RP terminates all of them (one token per client).
+            AuthenticationManager.backchannelLogoutUserClientsOnce(session, realm, userSessions,
+                    session.getContext().getUri(), headers);
+        }
+
+        // Local cleanup + broker logout; clients notified above are skipped (already marked LOGGED_OUT).
+        userSessions.forEach(userSession -> AuthenticationManager.backchannelLogout(session, realm, userSession,
+                session.getContext().getUri(), clientConnection, headers, true));
         adminEvent.operation(OperationType.ACTION).resourcePath(session.getContext().getUri()).success();
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutAdminLogoutAllTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/BackchannelLogoutAdminLogoutAllTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.oauth;
+
+import java.util.List;
+
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.representations.LogoutToken;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserSessionRepresentation;
+import org.keycloak.testsuite.AbstractTestRealmKeycloakTest;
+import org.keycloak.testsuite.updaters.ClientAttributeUpdater;
+import org.keycloak.testsuite.util.ClientManager;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.OAuthClient;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests for backchannel logout sid claim behaviour when admin invokes logout for all user sessions (issue #22914).
+ *
+ * @author <a href="mailto:jakub.choc@pm.me">Jakub Choc</a>
+ */
+public class BackchannelLogoutAdminLogoutAllTest extends AbstractTestRealmKeycloakTest {
+
+    private static final String BACKCHANNEL_LOGOUT_URL = OAuthClient.APP_ROOT + "/admin/backchannelLogout";
+
+    @Override
+    public void configureTestRealm(RealmRepresentation testRealm) {
+    }
+
+    @Before
+    public void setUp() {
+        ClientManager.realm(adminClient.realm("test")).clientId("test-app").directAccessGrant(true);
+        testingClient.testApp().clearAdminActions();
+    }
+
+    @Test
+    public void adminLogoutAllSessions_singleSession_logoutTokenHasSid() throws Exception {
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, "test", "test-app")
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, BACKCHANNEL_LOGOUT_URL)
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_SESSION_REQUIRED, "true")
+                .update()) {
+
+            loginUser();
+            String userId = findUser("test-user@localhost").getId();
+
+            adminClient.realm("test").users().get(userId).logout();
+
+            String rawLogoutToken = testingClient.testApp().getBackChannelRawLogoutToken();
+            assertNotNull(rawLogoutToken);
+
+            LogoutToken logoutToken = new JWSInput(rawLogoutToken).readJsonContent(LogoutToken.class);
+
+            // single session: sid is kept, no ambiguity
+            assertNotNull(logoutToken.getSubject());
+            assertNotNull(logoutToken.getSid());
+        }
+    }
+
+    @Test
+    public void adminLogoutAllSessions_multipleSessions_logoutTokenHasNoSid() throws Exception {
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, "test", "test-app")
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, BACKCHANNEL_LOGOUT_URL)
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_SESSION_REQUIRED, "true")
+                .update()) {
+
+            loginUser();
+            String userId = findUser("test-user@localhost").getId();
+
+            // create a second session via password grant
+            AccessTokenResponse session2 = oauth.doPasswordGrantRequest("test-user@localhost", "password");
+            assertNull(session2.getError());
+
+            List<UserSessionRepresentation> sessions =
+                    adminClient.realm("test").users().get(userId).getUserSessions();
+            assertEquals(2, sessions.size());
+
+            adminClient.realm("test").users().get(userId).logout();
+
+            String rawLogoutToken = testingClient.testApp().getBackChannelRawLogoutToken();
+            assertNotNull(rawLogoutToken);
+
+            LogoutToken logoutToken = new JWSInput(rawLogoutToken).readJsonContent(LogoutToken.class);
+
+            // multiple sessions: sid must be absent so RP terminates all sessions for this sub
+            assertNotNull(logoutToken.getSubject());
+            assertNull(logoutToken.getSid());
+
+            // the client is notified exactly once (one sid-less token covers all of the user's sessions),
+            // not once per session - so no further token is delivered
+            assertNull(testingClient.testApp().getBackChannelRawLogoutToken());
+        }
+    }
+
+    @Test
+    public void userInitiatedLogout_singleSession_logoutTokenHasSid() throws Exception {
+        try (ClientAttributeUpdater ignored = ClientAttributeUpdater.forClient(adminClient, "test", "test-app")
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_URL, BACKCHANNEL_LOGOUT_URL)
+                .setAttribute(OIDCConfigAttributes.BACKCHANNEL_LOGOUT_SESSION_REQUIRED, "true")
+                .update()) {
+
+            AccessTokenResponse tokenResponse = loginUser();
+
+            oauth.logoutForm()
+                    .idTokenHint(tokenResponse.getIdToken())
+                    .postLogoutRedirectUri(OAuthClient.APP_AUTH_ROOT)
+                    .open();
+
+            String rawLogoutToken = testingClient.testApp().getBackChannelRawLogoutToken();
+            assertNotNull(rawLogoutToken);
+
+            LogoutToken logoutToken = new JWSInput(rawLogoutToken).readJsonContent(LogoutToken.class);
+
+            // regression guard: user-initiated logout must still include sid
+            assertNotNull(logoutToken.getSubject());
+            assertNotNull(logoutToken.getSid());
+        }
+    }
+
+    private AccessTokenResponse loginUser() {
+        oauth.doLogin("test-user@localhost", "password");
+        String code = oauth.parseLoginResponse().getCode();
+        return oauth.doAccessTokenRequest(code);
+    }
+}


### PR DESCRIPTION
## Closes #22914

## Problem

When an admin logs a user out via the REST API (`DELETE /admin/realms/{realm}/users/{id}/sessions`) and that user has **more than one active session**, the backchannel logout token wrongly included a `sid` (session ID) claim.

Per the [OIDC Back-Channel Logout 1.0 spec](https://openid.net/specs/openid-connect-backchannel-1_0.html):
- a logout token **with** `sid` tells the RP to terminate **only that one** session,
- a logout token **without** `sid` tells the RP to terminate **all** sessions for the subject (`sub`).

So an admin "log out all sessions" action was effectively telling the RP to drop only a single session.

## Fix

When the user has more than one active online session, `UserResource.logout()` now sends **exactly one logout token per unique client, without `sid`**, and then delegates to the existing `backchannelLogout` flow for local session cleanup and broker logout.

The per-client notification is dispatched through the regular `AuthenticationManager.backchannelLogoutClientSession` path (new helper `backchannelLogoutUserClientsOnce`), which means:
- clients configured with either a **Backchannel Logout URL** or a legacy **Admin URL** are both handled,
- a failure to notify one client does **not** abort logout for the others (per-client error isolation is preserved).

A single-session admin logout, and all other logout paths (user-initiated, session timeout, password reset, broker logout), keep the `sid` claim and are unaffected.

## Behaviour

| Situation | `sid` in token | Tokens per client |
|---|---|---|
| Admin logout, user has 1 session | present | 1 |
| Admin logout, user has 2+ sessions | omitted | 1 (deduplicated) |
| User-initiated / timeout / password reset / broker logout | unchanged | unchanged |

## Implementation notes

- `sid` suppression itself happens in `DefaultTokenManager#initLogoutToken` via a new `logoutAllUserSessions` flag, threaded down through `ResourceAdminManager`, `OIDCLoginProtocol` and `LoginProtocol` (new default/overload methods keep the change backward compatible for other protocols).
- Deduplication (one token per client across all the user's sessions) lives in `AuthenticationManager.backchannelLogoutUserClientsOnce`, which marks the visited client sessions `LOGGED_OUT` so the subsequent cleanup pass does not notify the same client again.

## Testing

New `BackchannelLogoutAdminLogoutAllTest`:
- `adminLogoutAllSessions_singleSession_logoutTokenHasSid` — single session → token keeps `sub` **and** `sid`.
- `adminLogoutAllSessions_multipleSessions_logoutTokenHasNoSid` — two sessions → token has `sub`, `sid` is **absent**, and **no second token** is delivered to the same client (deduplication guard).
- `userInitiatedLogout_singleSession_logoutTokenHasSid` — regression guard: user-initiated logout still includes `sid`.

## Known limitation (pre-existing)

Offline sessions are not counted when deciding whether to suppress `sid`, since `getUserSessionsStream` returns only online sessions.
