### PR TITLE
Fix Azure/Aurora "Upload flaky tests" fails with 409 Conflict on dupl…

### DIFF
--- a/.github/actions/upload-flaky-tests/action.yml
+++ b/.github/actions/upload-flaky-tests/action.yml
@@ -53,3 +53,4 @@ runs:
         name: flaky-tests-${{ github.job }}-${{ join(matrix.*, '-') }}
         path: ${{ steps.flaky-tests.outputs.flakes }}
         if-no-files-found: error
+        overwrite: true


### PR DESCRIPTION
…icate artifact name

Closes #49577

Minor tradeoff is that if an earlier phase produces flaky tests and a later phase fails hard, those flaky test reports are now lost (previously the intermediate upload would have captured them). At the same time, original setup had its own gap, where phase 3 flaky tests were lost if phase 2 failed.

This edge case could be solved by adding `if always()` on the final upload, but since no other job in CI does that, I opted just for the deletion.