### PR TITLE
Document changes for the Prevent access to the Admin API from external IP address

### DIFF
--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -102,14 +102,36 @@ http:
           Uber-Trace-Id: ""
           X-Ot-Span-Context: ""
 
+    # Allowed source IP ranges. Replace with your internal IP address ranges. # <5>
+    ip-allowlist:
+      ipAllowList:
+        sourceRange:
+          - 192.168.0.0/16
+          - 172.16.0.0/12
+          - 10.0.0.0/8
+          - 127.0.0.0/8
+
   routers:
-    keycloak:
+    # Public router: accessible from any source IP address. # <6>
+    keycloak-public:
       entryPoints:
         - keycloak
-      rule: "PathPrefix(`/`)" # <5>
+      rule: "PathPrefix(`/realms/`) || PathPrefix(`/resources/`) || PathPrefix(`/.well-known/`)"
       middlewares:
-        - filter-headers # <6>
-      tls: {} # <7>
+        - filter-headers
+      tls: {}
+      service: keycloak
+
+    # Internal router: all other paths are restricted to the allowed source IP ranges. # <7>
+    keycloak-internal:
+      entryPoints:
+        - keycloak
+      rule: "PathPrefix(`/`)"
+      priority: 1
+      middlewares:
+        - filter-headers
+        - ip-allowlist
+      tls: {}
       service: keycloak
 
   services:
@@ -134,12 +156,18 @@ This is the externally trusted certificate that browsers verify.
 <3> The public certificates of each {project_name} backend server.
 Traefik verifies each backend server's TLS certificate against these entries, ensuring the connection goes to a trusted {project_name} instance and not an impersonator.
 <4> To remove an HTTP header from requests forwarded to {project_name}, define a key-value entry in `customRequestHeaders` where the key is the name of the HTTP header and the value is an empty string to indicate the header should be removed.
-Removing specific HTTP headers prevents external clients from spoofing proxy identity headers (such as `Forwarded`, `+X-Forwarded-*+`, and `X-Real-IP`), injecting authentication-related headers (such as `X-Forwarded-Access-Token`), or injecting distributed tracing context (such as W3C Trace Context, Zipkin B3, or Jaeger headers).
+Removing specific HTTP headers prevents external clients from spoofing proxy identity headers (such as `Forwarded`, `X-Forwarded-*`, and `X-Real-IP`), injecting authentication-related headers (such as `X-Forwarded-Access-Token`), or injecting distributed tracing context (such as W3C Trace Context, Zipkin B3, or Jaeger headers).
 Unlike HAProxy, Traefik does not support regex-based header matching, so each header variant must be listed explicitly.
 For the full list of recommended headers to filter, see the <@links.server id="reverseproxy" anchor="header-filtering-recommendations"/> {section}.
-<5> Routes all incoming requests to the {project_name} service.
-<6> Attaches the `filter-headers` middleware to the router so that the `customRequestHeaders` rules defined in <4> are applied to all incoming requests.
-<7> Enables TLS on the router, allowing Traefik to terminate the incoming TLS connection from the client and inspect HTTP traffic.
+<5> Restricts access so that only public {project_name} paths are reachable from external networks.
+Requests to non-public paths (such as the Admin API or Admin Console) are only allowed from the configured internal IP ranges.
+Replace the example ranges with your internal IP address ranges.
+For the full list of paths and recommendations, see the <@links.server id="reverseproxy" anchor="_exposed_path_recommendations"/> {section}.
+<6> The public router matches only the paths that must be reachable by external clients (`/realms/`, `/resources/`, and `/.well-known/`) and is therefore not subject to the IP allowlist.
+The `filter-headers` middleware and `tls` settings apply as on the internal router.
+With these settings, the redirect to the welcome screen or Admin UI will not work from external IP addresses, and this is expected.
+<7> The internal router matches all remaining paths and additionally applies the `ip-allowlist` middleware, so these paths are only reachable from the allowed source IP ranges.
+The `priority: 1` is set deliberately low so that Traefik always evaluates the more specific public router first; only requests that do not match a public path fall through to this router.
 <8> Links the load balancer to the named transport above, activating mTLS for all connections to the backend {project_name} servers.
 <9> Configures link:https://doc.traefik.io/traefik/routing/services/#health-check[HTTP health checks] against {project_name}'s readiness endpoint on the management port (`9000`) over HTTPS.
 The management port does not require client authentication, so no mTLS client certificate is needed for health check connections.


### PR DESCRIPTION
This PR updates Keycloak's official documentation wrt the  Prevent access to the Admin API from external IP address for Traefik .

The actual working code example for this configuration was implemented in the quickstarts repository: https://github.com/keycloak/keycloak-quickstarts/pull/771

Closes #49370
Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
