### PR TITLE
Propagate SAML session ID change setting in DeploymentBuilder

### DIFF
--- a/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/config/parsers/DeploymentBuilder.java
+++ b/adapters/saml/core/src/main/java/org/keycloak/adapters/saml/config/parsers/DeploymentBuilder.java
@@ -81,6 +81,7 @@ public class DeploymentBuilder {
         IDP idp = sp.getIdp();
         deployment.setSignatureCanonicalizationMethod(idp.getSignatureCanonicalizationMethod());
         deployment.setAutodetectBearerOnly(sp.isAutodetectBearerOnly());
+        deployment.setTurnOffChangeSessionIdOnLogin(sp.isTurnOffChangeSessionIdOnLogin());
         deployment.setKeepDOMAssertion(sp.isKeepDOMAssertion());
         deployment.setSignatureAlgorithm(SignatureAlgorithm.RSA_SHA256);
         if (idp.getSignatureAlgorithm() != null) {

--- a/adapters/saml/core/src/test/java/org/keycloak/adapters/saml/DeploymentBuilderTest.java
+++ b/adapters/saml/core/src/test/java/org/keycloak/adapters/saml/DeploymentBuilderTest.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 
 import org.keycloak.adapters.saml.config.parsers.DeploymentBuilder;
 import org.keycloak.adapters.saml.config.parsers.ResourceLoader;
+import org.keycloak.common.enums.SslRequired;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,15 +35,33 @@ public class DeploymentBuilderTest {
 
     @Test
     public void testPropertiesBasedRoleMapper() throws Exception {
-        InputStream is = getClass().getResourceAsStream("config/parsers/keycloak-saml-pem-keys.xml");
-        SamlDeployment deployment = new DeploymentBuilder().build(is, new ResourceLoader() {
+        SamlDeployment deployment = loadDeployment("config/parsers/keycloak-saml-pem-keys.xml");
+        Assert.assertNotNull(deployment);
+        Assert.assertNotNull(deployment.getSigningKeyPair().getPrivate());
+        Assert.assertNotNull(deployment.getSigningKeyPair().getPublic());
+    }
+
+    @Test
+    public void testDeploymentBuilderMapsConfiguration() throws Exception {
+        SamlDeployment deployment = loadDeployment("config/parsers/keycloak-saml-deployment-builder-mapping.xml");
+
+        Assert.assertNotNull(deployment);
+        Assert.assertEquals("http://localhost:8081/sales-post-sig/", deployment.getEntityID());
+        Assert.assertEquals(SslRequired.ALL, deployment.getSslRequired());
+        Assert.assertEquals("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", deployment.getNameIDPolicyFormat());
+        Assert.assertEquals("/logout.jsp", deployment.getLogoutPage());
+        Assert.assertTrue(deployment.isForceAuthentication());
+        Assert.assertTrue(deployment.isIsPassive());
+        Assert.assertTrue(deployment.turnOffChangeSessionIdOnLogin());
+    }
+
+    private SamlDeployment loadDeployment(String resource) throws Exception {
+        InputStream is = getClass().getResourceAsStream(resource);
+        return new DeploymentBuilder().build(is, new ResourceLoader() {
             @Override
             public InputStream getResourceAsStream(String resource) {
                 return this.getClass().getClassLoader().getResourceAsStream(resource);
             }
         });
-        Assert.assertNotNull(deployment);
-        Assert.assertNotNull(deployment.getSigningKeyPair().getPrivate());
-        Assert.assertNotNull(deployment.getSigningKeyPair().getPublic());
     }
 }

--- a/adapters/saml/core/src/test/resources/org/keycloak/adapters/saml/config/parsers/keycloak-saml-deployment-builder-mapping.xml
+++ b/adapters/saml/core/src/test/resources/org/keycloak/adapters/saml/config/parsers/keycloak-saml-deployment-builder-mapping.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2024 Red Hat, Inc. and/or its affiliates
+  ~  and other contributors as indicated by the @author tags.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<keycloak-saml-adapter xmlns="urn:keycloak:saml:adapter"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xsi:schemaLocation="urn:keycloak:saml:adapter http://www.keycloak.org/schema/keycloak_saml_adapter_1_13.xsd">
+    <SP entityID="http://localhost:8081/sales-post-sig/"
+        sslPolicy="ALL"
+        nameIDPolicyFormat="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+        logoutPage="/logout.jsp"
+        forceAuthentication="true"
+        isPassive="true"
+        turnOffChangeSessionIdOnLogin="true">
+        <IDP entityID="idp">
+            <SingleSignOnService requestBinding="POST"
+                                 bindingUrl="http://localhost:8081/realms/demo/protocol/saml"
+            />
+
+            <SingleLogoutService
+                    requestBinding="POST"
+                    responseBinding="POST"
+                    postBindingUrl="http://localhost:8081/realms/demo/protocol/saml"
+                    redirectBindingUrl="http://localhost:8081/realms/demo/protocol/saml"
+            />
+        </IDP>
+    </SP>
+</keycloak-saml-adapter>


### PR DESCRIPTION
## Summary
- preserve the `turnOffChangeSessionIdOnLogin` SP setting when `DeploymentBuilder` creates the runtime SAML deployment
- add a focused regression test covering the mapped SP configuration fields in `DeploymentBuilder`
## Testing
- [x] `.\mvnw.cmd -pl adapters/saml/core -am -Dtest=DeploymentBuilderTest test`
- [x] `.\mvnw.cmd spotless:apply`
## Issue
Closes #49601
## AI usage
AI agents were used to help draft and refine the code changes and test updates. All changes were reviewed and understood before submission.