### PR TITLE
Remove noisy console.error in the fetchWithError function

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
+++ b/js/libs/keycloak-admin-client/src/utils/fetchWithError.ts
@@ -22,7 +22,6 @@ export async function fetchWithError(
   if (!response.ok) {
     const responseData = await parseResponse(response);
     const message = getErrorMessage(responseData);
-    console.error(message, response.status, responseData);
     throw new NetworkError(message, {
       response,
       responseData,


### PR DESCRIPTION
This pull request makes a small change to the `fetchWithError` utility function. It removes a noisy `console.error` statement that was previously logging error messages, HTTP status, and response data to the console.
We have our own (json) handler, and this lib should not alter our logging behavior.

Closes #49612