### PR TITLE
Reject indefinite-length encoding in ASN1Decoder.readLength()

### DIFF
--- a/authz/client/src/main/java/org/keycloak/authorization/client/util/crypto/ASN1Decoder.java
+++ b/authz/client/src/main/java/org/keycloak/authorization/client/util/crypto/ASN1Decoder.java
@@ -131,7 +131,7 @@ class ASN1Decoder {
         }
 
         if (length == 0x80) {
-            return -1;      // indefinite-length encoding
+            throw new IOException("Indefinite-length encoding not supported in DER");
         }
 
         if (length > 127) {


### PR DESCRIPTION
Closes #49495

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
