### PR TITLE
[26.4] ROPC Grant Policy Bypass for reject-ropc-grant

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
@@ -69,6 +69,7 @@ public class ClientAccessTypeCondition extends AbstractClientPolicyConditionProv
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
         switch (context.getEvent()) {
             case AUTHORIZATION_REQUEST:
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
             case TOKEN_REQUEST:
             case TOKEN_RESPONSE:
             case SERVICE_ACCOUNT_TOKEN_REQUEST:

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAttributesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAttributesCondition.java
@@ -90,6 +90,7 @@ public class ClientAttributesCondition extends AbstractClientPolicyConditionProv
             case REGISTERED:
             case UPDATE:
             case UPDATED:
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
             case SAML_AUTHN_REQUEST:
             case SAML_LOGOUT_REQUEST:
                 if (isAttributesMatched(session.getContext().getClient())) return ClientPolicyVote.YES;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientProtocolCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientProtocolCondition.java
@@ -83,6 +83,7 @@ public class ClientProtocolCondition extends AbstractClientPolicyConditionProvid
             case UPDATE:
             case UPDATED:
             case REGISTERED:
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
             case SAML_AUTHN_REQUEST:
             case SAML_LOGOUT_REQUEST:
                 if (isCorrectProtocolFromContext()) {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientRolesCondition.java
@@ -92,6 +92,7 @@ public class ClientRolesCondition extends AbstractClientPolicyConditionProvider<
             case REGISTERED:
             case UPDATE:
             case UPDATED:
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
             case SAML_AUTHN_REQUEST:
             case SAML_LOGOUT_REQUEST:
                 if (isRolesMatched(session.getContext().getClient())) return ClientPolicyVote.YES;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientScopesCondition.java
@@ -39,6 +39,7 @@ import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyVote;
 import org.keycloak.services.clientpolicy.context.AuthorizationRequestContext;
+import org.keycloak.services.clientpolicy.context.ResourceOwnerPasswordCredentialsContext;
 import org.keycloak.services.clientpolicy.context.ServiceAccountTokenRequestContext;
 import org.keycloak.services.clientpolicy.context.ServiceAccountTokenResponseContext;
 import org.keycloak.services.clientpolicy.context.TokenExchangeRequestContext;
@@ -117,6 +118,9 @@ public class ClientScopesCondition extends AbstractClientPolicyConditionProvider
                 return ClientPolicyVote.NO;
             case TOKEN_EXCHANGE_REQUEST:
                 if (isScopeMatched(((TokenExchangeRequestContext) context).getTokenExchangeContext())) return ClientPolicyVote.YES;
+                return ClientPolicyVote.NO;
+            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
+                if (isScopeMatched(((ResourceOwnerPasswordCredentialsContext) context).getScope(), session.getContext().getClient())) return ClientPolicyVote.YES;
                 return ClientPolicyVote.NO;
             default:
                 return ClientPolicyVote.ABSTAIN;

--- a/services/src/main/java/org/keycloak/services/clientpolicy/context/ResourceOwnerPasswordCredentialsContext.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/context/ResourceOwnerPasswordCredentialsContext.java
@@ -19,6 +19,7 @@ package org.keycloak.services.clientpolicy.context;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 
@@ -36,6 +37,10 @@ public class ResourceOwnerPasswordCredentialsContext implements ClientPolicyCont
     @Override
     public ClientPolicyEvent getEvent() {
         return ClientPolicyEvent.RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST;
+    }
+
+    public String getScope() {
+        return this.params.getFirst(OAuth2Constants.SCOPE);
     }
 
     public MultivaluedMap<String, String> getParams() {

--- a/services/src/main/resources/keycloak-lax-client-policies.json
+++ b/services/src/main/resources/keycloak-lax-client-policies.json
@@ -1,0 +1,44 @@
+{
+    "policies": [
+        {
+           "name": "Openid-connect OAuth 2.1 confidential client",
+           "description": "Openid-connect confidential client policy to ensure OAuth 2.1 specification.",
+           "enabled": true,
+           "conditions": [
+               {
+                   "condition": "client-type",
+                   "configuration": {
+                       "protocol": "openid-connect"
+                   }
+               },
+               {
+                   "condition": "client-access-type",
+                   "configuration": {
+                       "type": [
+                           "confidential"
+                       ]
+                   }
+               }
+           ],
+           "profiles": [
+               "oauth-2-1-for-confidential-client"
+           ]
+       },
+       {
+           "name": "Saml secure client (signatures, post, https)",
+           "description": "Saml policy to ensure signatures, POST binding and https URLs.",
+           "enabled": true,
+           "conditions": [
+               {
+                   "condition": "client-type",
+                   "configuration": {
+                       "protocol": "saml"
+                   }
+               }
+           ],
+           "profiles": [
+               "saml-security-profile"
+           ]
+       }
+   ]
+}

--- a/services/src/main/resources/lax-security-profile.json
+++ b/services/src/main/resources/lax-security-profile.json
@@ -1,5 +1,5 @@
 {
   "name":"lax",
   "client-profiles":"keycloak-default-client-profiles",
-  "client-policies":null
+  "client-policies":"keycloak-lax-client-policies"
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -149,6 +149,11 @@ import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
 
+import static org.keycloak.OAuth2Constants.SCOPE_PHONE;
+
+
+import static org.junit.Assert.assertNotNull;
+
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
  */
@@ -586,7 +591,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
 
         try (ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CLIENT)) {
             ClientRepresentation clientRep = cau.getResource().toRepresentation();
-            Assert.assertNotNull(clientRep);
+            assertNotNull(clientRep);
             OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseMtlsHoKToken(true);
             cau.update();
             checkMtlsFlow();
@@ -619,7 +624,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
 
         try (ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CLIENT)) {
             ClientRepresentation clientRep = cau.getResource().toRepresentation();
-            Assert.assertNotNull(clientRep);
+            assertNotNull(clientRep);
             OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseMtlsHoKToken(true);
             cau.update();
             // Check login.
@@ -978,6 +983,57 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
         assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
 
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientScopeCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
+            clientRep.setSecret(clientSecret);
+            clientRep.setStandardFlowEnabled(Boolean.TRUE);
+            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
+            clientRep.setPublicClient(Boolean.FALSE);
+        });
+
+        // register profiles
+        String json = (new ClientProfilesBuilder()).addProfile(
+                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
+                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
+                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        // register policies
+        json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientScopesConditionFactory.PROVIDER_ID,
+                                createClientScopesConditionConfig(ClientScopesConditionFactory.ANY, Arrays.asList(SCOPE_PHONE)))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+        assertEquals(200, response.getStatusCode());
+        assertNotNull(response.getAccessToken());
+        assertNull(response.getError());
+
+        // Request with "scope=phone" should not be permitted
+        String origScope = oauth.config().getScope();
+        try {
+            oauth.scope(SCOPE_PHONE);
+            response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+            assertEquals(400, response.getStatusCode());
+            assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+            assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+        } finally {
+            oauth.scope(origScope);
+        }
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -46,6 +46,8 @@ import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureClientA
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createSecureSigningAlgorithmForSignedJwtEnforceExecutorConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionConditionConfig;
 import static org.keycloak.testsuite.util.ClientPoliciesUtil.createTestRaiseExeptionExecutorConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientAttributesConditionConfig;
+import static org.keycloak.testsuite.util.ClientPoliciesUtil.createClientProtocolConditionConfig;
 
 import java.io.IOException;
 import java.net.URL;
@@ -105,6 +107,8 @@ import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientAttributesConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextConditionFactory;
@@ -150,9 +154,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import static org.keycloak.OAuth2Constants.SCOPE_PHONE;
-
-
-import static org.junit.Assert.assertNotNull;
+import static org.keycloak.protocol.oidc.OIDCConfigAttributes.USE_REFRESH_TOKEN;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
@@ -591,7 +593,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
 
         try (ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CLIENT)) {
             ClientRepresentation clientRep = cau.getResource().toRepresentation();
-            assertNotNull(clientRep);
+            Assert.assertNotNull(clientRep);
             OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseMtlsHoKToken(true);
             cau.update();
             checkMtlsFlow();
@@ -624,7 +626,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
 
         try (ClientAttributeUpdater cau = ClientAttributeUpdater.forClient(adminClient, REALM_NAME, TEST_CLIENT)) {
             ClientRepresentation clientRep = cau.getResource().toRepresentation();
-            assertNotNull(clientRep);
+            Assert.assertNotNull(clientRep);
             OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep).setUseMtlsHoKToken(true);
             cau.update();
             // Check login.
@@ -945,29 +947,17 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
     }
 
     @Test
-    public void testRejectResourceOwnerCredentialsGrantExecutor() throws Exception {
-
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithAnyClientCondition() throws Exception {
         String clientId = generateSuffixedName(CLIENT_NAME);
         String clientSecret = "secret";
 
-        createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
-            clientRep.setSecret(clientSecret);
-            clientRep.setStandardFlowEnabled(Boolean.TRUE);
-            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
-            clientRep.setPublicClient(Boolean.FALSE);
-        });
-
-        // register profiles
-        String json = (new ClientProfilesBuilder()).addProfile(
-                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
-                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
-                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
-                        .toRepresentation()
-        ).toString();
-        updateProfiles(json);
+        // Create client
+        createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
 
         // register policies
-        json = (new ClientPoliciesBuilder()).addPolicy(
+        String json = (new ClientPoliciesBuilder()).addPolicy(
                 (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Porisii desu", Boolean.TRUE)
                         .addCondition(AnyClientConditionFactory.PROVIDER_ID,
                                 createAnyClientConditionConfig())
@@ -990,24 +980,13 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         String clientId = generateSuffixedName(CLIENT_NAME);
         String clientSecret = "secret";
 
-        createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
-            clientRep.setSecret(clientSecret);
-            clientRep.setStandardFlowEnabled(Boolean.TRUE);
-            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
-            clientRep.setPublicClient(Boolean.FALSE);
-        });
+        // Create client
+        createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
 
-        // register profiles
-        String json = (new ClientProfilesBuilder()).addProfile(
-                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
-                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
-                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
-                        .toRepresentation()
-        ).toString();
-        updateProfiles(json);
-
-        // register policies
-        json = (new ClientPoliciesBuilder()).addPolicy(
+        // register policies - client scopes condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
                 (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
                         .addCondition(ClientScopesConditionFactory.PROVIDER_ID,
                                 createClientScopesConditionConfig(ClientScopesConditionFactory.ANY, Arrays.asList(SCOPE_PHONE)))
@@ -1019,7 +998,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         oauth.client(clientId, clientSecret);
         AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
         assertEquals(200, response.getStatusCode());
-        assertNotNull(response.getAccessToken());
+        Assert.assertNotNull(response.getAccessToken());
         assertNull(response.getError());
 
         // Request with "scope=phone" should not be permitted
@@ -1034,6 +1013,120 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         } finally {
             oauth.scope(origScope);
         }
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientProtocolCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        // Create client
+        createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
+
+        // register policies - client protocol condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientProtocolConditionFactory.PROVIDER_ID,
+                                createClientProtocolConditionConfig(OIDCLoginProtocol.LOGIN_PROTOCOL))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+        assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientRolesCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        // Create client
+        String clientUUID = createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
+
+        // add the role to the client to execute condition
+        adminClient.realm(REALM_NAME).clients().get(clientUUID).roles().create(RoleBuilder.create().name(SAMPLE_CLIENT_ROLE).build());
+
+        // register policies - client roles condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientRolesConditionFactory.PROVIDER_ID,
+                                createClientRolesConditionConfig(List.of(SAMPLE_CLIENT_ROLE)))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+        assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+    }
+
+    @Test
+    public void testRejectResourceOwnerCredentialsGrantExecutorWithClientAttributesCondition() throws Exception {
+        String clientId = generateSuffixedName(CLIENT_NAME);
+        String clientSecret = "secret";
+
+        // Create client
+        String clientUUID = createClientForResourceOwnerPasswordCredential(clientId, clientSecret);
+        // Register profile
+        registerClientProfileWithResourceOwnerRejectExecutor();
+
+        // add the role to the client to execute condition
+        adminClient.realm(REALM_NAME).clients().get(clientUUID).roles().create(RoleBuilder.create().name(SAMPLE_CLIENT_ROLE).build());
+
+        // register policies - client attributes condition
+        String json = (new ClientPoliciesBuilder()).addPolicy(
+                (new ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Het Eerste Beleid", Boolean.TRUE)
+                        .addCondition(ClientAttributesConditionFactory.PROVIDER_ID,
+                                createClientAttributesConditionConfig(new MultivaluedHashMap<>() {
+                                    {
+                                        putSingle(USE_REFRESH_TOKEN, "true");
+                                    }
+                                }))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        oauth.client(clientId, clientSecret);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_GRANT, response.getError());
+        assertEquals("resource owner password credentials grant is prohibited.", response.getErrorDescription());
+    }
+
+    private String createClientForResourceOwnerPasswordCredential(String clientId, String clientSecret) throws ClientPolicyException {
+        return createClientByAdmin(clientId, (ClientRepresentation clientRep) -> {
+            clientRep.setSecret(clientSecret);
+            clientRep.setStandardFlowEnabled(Boolean.TRUE);
+            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
+            clientRep.setPublicClient(Boolean.FALSE);
+            clientRep.getAttributes().put(USE_REFRESH_TOKEN, "true"); // Just some attribute to be able to test clientAttributes condition
+        });
+    }
+
+    private void registerClientProfileWithResourceOwnerRejectExecutor() throws Exception {
+        String json = (new ClientProfilesBuilder()).addProfile(
+                (new ClientProfileBuilder()).createProfile(PROFILE_NAME, "Purofairu desu")
+                        .addExecutor(RejectResourceOwnerPasswordCredentialsGrantExecutorFactory.PROVIDER_ID,
+                                createRejectisResourceOwnerPasswordCredentialsGrantExecutorConfig(Boolean.TRUE))
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/LightWeightAccessTokenTest.java
@@ -58,6 +58,7 @@ import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
+import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.executor.UseLightweightAccessTokenExecutorFactory;
 import org.keycloak.testsuite.admin.ApiUtil;
 import org.keycloak.testsuite.arquillian.annotation.EnableFeature;
@@ -636,6 +637,43 @@ public class LightWeightAccessTokenTest extends AbstractClientPoliciesTest {
         }
 
         setScopeProtocolMapper("master", OIDCLoginProtocolFactory.BASIC_SCOPE, "sub", true, false, false);
+    }
+
+    @Test
+    public void testPublicClientWithLightweightAccessTokenViaDirectGrant() throws Exception {
+        // Setup client policy with client-access-type=public + lightweight token executor
+        String json = (new ClientPoliciesUtil.ClientProfilesBuilder()).addProfile(
+                (new ClientPoliciesUtil.ClientProfileBuilder()).createProfile(PROFILE_NAME, "Lightweight Token for Public Clients")
+                        .addExecutor(UseLightweightAccessTokenExecutorFactory.PROVIDER_ID, null)
+                        .toRepresentation()
+        ).toString();
+        updateProfiles(json);
+
+        json = (new ClientPoliciesUtil.ClientPoliciesBuilder()).addPolicy(
+                (new ClientPoliciesUtil.ClientPolicyBuilder()).createPolicy(POLICY_NAME, "Public Client Policy", Boolean.TRUE)
+                        .addCondition(ClientAccessTypeConditionFactory.PROVIDER_ID,
+                                ClientPoliciesUtil.createClientAccessTypeConditionConfig(List.of(ClientAccessTypeConditionFactory.TYPE_PUBLIC)))
+                        .addProfile(PROFILE_NAME)
+                        .toRepresentation()
+        ).toString();
+        updatePolicies(json);
+
+        // Create public client with direct access grants
+        String publicClientId = generateSuffixedName("public-direct-grant-client");
+        createClientByAdmin(publicClientId, (ClientRepresentation clientRep) -> {
+            clientRep.setPublicClient(Boolean.TRUE);
+            clientRep.setDirectAccessGrantsEnabled(Boolean.TRUE);
+        });
+
+        // Perform direct access grant (POST with username/password)
+        oauth.client(publicClientId);
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_NAME, TEST_USER_PASSWORD);
+
+        // Verify lightweight token
+        AccessToken token = oauth.verifyToken(response.getAccessToken());
+        AccessTokenContext ctx = testingClient.testing(REALM_NAME).getTokenContext(token.getId());
+        Assert.assertEquals(AccessTokenContext.TokenType.LIGHTWEIGHT, ctx.getTokenType());
+        Assert.assertEquals(TEST_USER_PASSWORD, ctx.getGrantType());
     }
 
     private void removeSession(final String sessionId) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/securityprofile/LaxSecurityProfileTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/securityprofile/LaxSecurityProfileTest.java
@@ -46,8 +46,8 @@ import org.keycloak.testsuite.util.ClientBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-@SetDefaultProvider(spi = "security-profile", providerId = "default", config = {"name", "strict-security-profile"})
-public class StrictSecurityProfileTest extends AbstractTestRealmKeycloakTest {
+@SetDefaultProvider(spi = "security-profile", providerId = "default", config = {"name", "lax-security-profile"})
+public class LaxSecurityProfileTest extends AbstractTestRealmKeycloakTest {
 
     @Override
     public void configureTestRealm(RealmRepresentation testRealm) {
@@ -62,7 +62,6 @@ public class StrictSecurityProfileTest extends AbstractTestRealmKeycloakTest {
         Assert.assertNotNull(policies.getGlobalPolicies());
         MatcherAssert.assertThat(policies.getGlobalPolicies().stream().map(ClientPolicyRepresentation::getName).collect(Collectors.toList()),
                 Matchers.containsInAnyOrder("Openid-connect OAuth 2.1 confidential client",
-                        "Openid-connect OAuth 2.1 public client",
                         "Saml secure client (signatures, post, https)"));
         // try creating a global policy fails
         ClientPoliciesRepresentation policiesRep = new ClientPoliciesRepresentation();
@@ -115,45 +114,6 @@ public class StrictSecurityProfileTest extends AbstractTestRealmKeycloakTest {
         // Doublecheck global policies were not changed
         clientPoliciesRep = getClientPolicies();
         org.keycloak.testsuite.Assert.assertEquals(origGlobalPolicies, clientPoliciesRep.getGlobalPolicies());
-    }
-
-    @Test
-    public void testCreatePublicOpenIdConnectClientSecure() {
-        RealmResource realm = testRealm();
-        ClientRepresentation clientRep = ClientBuilder.create()
-                .name("test-client-policy-app")
-                .clientId("test-client-policy-app")
-                .publicClient()
-                .protocol(OIDCLogin.OIDC)
-                .baseUrl("https://www.keycloak.org")
-                .redirectUris("https://www.keycloak.org")
-                .build();
-        clientRep.setImplicitFlowEnabled(true);
-        OIDCAdvancedConfigWrapper wrapper = OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep);
-        wrapper.setPostLogoutRedirectUris(Collections.singletonList("https://www.keycloak.org"));
-        wrapper.setPkceCodeChallengeMethod(OIDCLoginProtocol.PKCE_METHOD_PLAIN);
-
-        // set the redirect uri to unsecure http
-        clientRep.setRedirectUris(Collections.singletonList("http://www.keycloak.org"));
-        Response resp = realm.clients().create(clientRep);
-        Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
-        OAuth2ErrorRepresentation error = resp.readEntity(OAuth2ErrorRepresentation.class);
-        Assert.assertEquals(OAuthErrorException.INVALID_REQUEST, error.getError());
-        Assert.assertEquals("Invalid Redirect Uri: invalid uri", error.getErrorDescription());
-        clientRep.setRedirectUris(Collections.singletonList("https://www.keycloak.org"));
-
-        // create OK
-        resp = realm.clients().create(clientRep);
-        Assert.assertEquals(Response.Status.CREATED.getStatusCode(), resp.getStatus());
-        String id = ApiUtil.getCreatedId(resp);
-        getCleanup().addClientUuid(id);
-
-        // check everything is auto-configure for security as the policy has auto-configure
-        clientRep = realm.clients().get(id).toRepresentation();
-        wrapper = OIDCAdvancedConfigWrapper.fromClientRepresentation(clientRep);
-        Assert.assertEquals(OIDCLoginProtocol.PKCE_METHOD_S256, wrapper.getPkceCodeChallengeMethod());
-        Assert.assertFalse(clientRep.isImplicitFlowEnabled());
-        Assert.assertFalse(clientRep.isDirectAccessGrantsEnabled());
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/util/ClientPoliciesUtil.java
@@ -43,6 +43,7 @@ import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyEvent;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeCondition;
 import org.keycloak.services.clientpolicy.condition.ClientAttributesCondition;
+import org.keycloak.services.clientpolicy.condition.ClientProtocolCondition;
 import org.keycloak.services.clientpolicy.condition.ClientRolesCondition;
 import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
 import org.keycloak.services.clientpolicy.condition.ClientUpdaterContextCondition;
@@ -394,6 +395,12 @@ public final class ClientPoliciesUtil {
     public static ClientAccessTypeCondition.Configuration createClientAccessTypeConditionConfig(List<String> types) {
         ClientAccessTypeCondition.Configuration config = new ClientAccessTypeCondition.Configuration();
         config.setType(types);
+        return config;
+    }
+
+    public static ClientProtocolCondition.Configuration createClientProtocolConditionConfig(String protocol) {
+        ClientProtocolCondition.Configuration config = new ClientProtocolCondition.Configuration();
+        config.setProtocol(protocol);
         return config;
     }
 


### PR DESCRIPTION
closes #46933
closes #49436
Closes #45740

The backport of #46933 , #49436 and #45740 to branch `release/26.4` .

Besides `ClientAttributesCondition`, `ClientProtocolCondition` and `ClientRolesCondition`, which are fixed by #49436, the PR also fixes the `ClientScopesCondition`, which was not backported to 26.4 yet (the related GH issue is  #46933) and `ClientAccessType` condition (related GH issue #45740 )

The PR updates code differently than the original PR for https://github.com/keycloak/keycloak/pull/49474 as the client-policies code changed in the meantime due some refactorings, new grant additions etc, so clean backport would require backporting of much more changes and would be much more effort and fragile. So rather not doing it (also considering that 26.4 branch is going to be decommissioned in few months in September)

Instead, I've just fixed in "conservative" way by directly adding the missing "contexts" to the corresponding conditions. The `ClientPoliciesTest` works the same as in `main` to make sure that all conditions in question are triggered during resource-owner-password credential grant.

