### PR TITLE
POC to block non-central repositories

### DIFF
--- a/.github/actions/java-setup/action.yml
+++ b/.github/actions/java-setup/action.yml
@@ -20,3 +20,6 @@ runs:
       with:
         distribution: ${{ inputs.distribution }}
         java-version: ${{ inputs.java-version }}
+    - id: block-non-maven-central-repositories
+      run: cp .github/settings-block-repositories.xml ~/.m2/settings.xml
+      shell: bash

--- a/.github/settings-block-repositories.xml
+++ b/.github/settings-block-repositories.xml
@@ -1,0 +1,9 @@
+<settings>
+      <mirrors>
+        <mirror>
+          <id>block-external-repositories</id>
+          <url>file:///nosuch</url>
+          <mirrorOf>*,!central</mirrorOf>
+        </mirror>
+      </mirrors>
+</settings>

--- a/adapters/saml/wildfly/wildfly-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/pom.xml
@@ -96,12 +96,6 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.wildfly.legacy.test</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/adapters/saml/wildfly/wildfly-subsystem/pom.xml
+++ b/adapters/saml/wildfly/wildfly-subsystem/pom.xml
@@ -96,6 +96,12 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wildfly.legacy.test</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Everything we need seems to be published to central, so we should just pull everything from there, except some legacy WF testing stuff which needs to be figured out if we want to do this. This is a bit of a hacky way to achieve it though, but seems like the best you can do with Maven :/

Signed-off-by: stianst <stianst@gmail.com>
