### PR TITLE
Fix Keycloak Admin Client CI failures in JS module after silent Kiota bump

### DIFF
--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -37,6 +37,9 @@
     },
     "generate:openapi": {
       "command": "kiota generate -l typescript -d openapi.yaml -c AdminClient -n ApiSdk -o ./src/generated --clean-output",
+      "env": {
+        "KIOTA_VERSION": "v1.31.1"
+      },
       "files": [
         "openapi.yaml"
       ],


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/49639


See https://github.com/microsoft/kiota/issues/7755 for more details. We didn't catch this as the Kiota wrapper is using "latest" unless the env is defined. Also `package.json` doesn't seem to officially support comments, I didn't try if our tools could tolerate it though (I'm bit in hurry), we should just open follow-up issue to not forget to remove this.

I think this should pass as the `.wireit` cache should recognize that something has changed and regenerate files, but if it doesn't, we may need to force it.

Steps to reproduce the issue in `keycloak/js/libs/keycloak-admin-client`:

```bash
#fail:
rm -rf src/generated lib .wireit
pnpm run build
TS_NODE_PROJECT=tsconfig.test.json npx mocha --recursive "test/clientsV2.spec.ts" --timeout 10000

#pass:
rm -rf src/generated lib .wireit
KIOTA_VERSION=v1.31.1 pnpm run build
TS_NODE_PROJECT=tsconfig.test.json npx mocha --recursive "test/clientsV2.spec.ts" --timeout 10000
```