### PR TITLE
Remove custom providers from ExportImportTest

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/exportimport/ExportImportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/exportimport/ExportImportTest.java
@@ -68,7 +68,6 @@ import org.keycloak.testframework.remote.providers.runonserver.FetchOnServerWrap
 import org.keycloak.testframework.remote.providers.runonserver.RunOnServerException;
 import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
-import org.keycloak.tests.common.CustomProvidersServerConfig;
 import org.keycloak.tests.utils.Assert;
 import org.keycloak.tests.utils.JsonTestUtils;
 import org.keycloak.testsuite.util.runonserver.ExportImportHelper;
@@ -97,7 +96,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
  * @author Stan Silvert ssilvert@redhat.com (C) 2016 Red Hat Inc.
  */
-@KeycloakIntegrationTest(config = CustomProvidersServerConfig.class)
+@KeycloakIntegrationTest
 public class ExportImportTest {
 
     @InjectRealm(ref = "test-realm", fromJson = "testrealm.json", config = ExportImportRealmConfig.class, lifecycle = LifeCycle.METHOD)
@@ -112,7 +111,7 @@ public class ExportImportTest {
     @InjectAdminClient(mode = InjectAdminClient.Mode.BOOTSTRAP)
     Keycloak adminClient;
 
-    private static String REALM_NAME = "test-realm";
+    private static final String REALM_NAME = "test-realm";
 
     private static void setEventsConfig(RealmRepresentation realm) {
         realm.setEventsEnabled(true);

--- a/tests/base/src/test/java/org/keycloak/tests/exportimport/ExportImportUtil.java
+++ b/tests/base/src/test/java/org/keycloak/tests/exportimport/ExportImportUtil.java
@@ -80,7 +80,6 @@ import org.keycloak.storage.ldap.mappers.LDAPStorageMapper;
 import org.keycloak.testframework.remote.providers.runonserver.FetchOnServer;
 import org.keycloak.testframework.remote.providers.runonserver.FetchOnServerWrapper;
 import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
-import org.keycloak.tests.providers.federation.DummyUserFederationProviderFactory;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.util.JsonSerialization;
 
@@ -340,9 +339,6 @@ public class ExportImportUtil {
         Assertions.assertEquals(FullNameLDAPStorageMapperFactory.PROVIDER_ID, fullNameMapper.getProviderId());
         Assertions.assertEquals("cn", fullNameMapper.getConfig().getFirst(FullNameLDAPStorageMapper.LDAP_FULL_NAME_ATTRIBUTE));
         /////////////////
-
-        // Assert that federation link wasn't created during import
-        Assertions.assertNull(runOnServerMaster.fetch(getUserByUsernameFromFedProviderFactory(realm.getRealm(), "wburke")));
 
         // Test builtin authentication flows
         AuthenticationFlowRepresentation clientFlow = realmRsc.flows().getFlows().stream()
@@ -818,27 +814,6 @@ public class ExportImportUtil {
         };
     }
 
-    private static FetchOnServerWrapper<UserRepresentation> getUserByUsernameFromFedProviderFactory(String realmName, String userName) {
-        return new FetchOnServerWrapper<>() {
-
-            @Override
-            public FetchOnServer getRunOnServer() {
-                return session -> {
-                    RealmModel realm = session.realms().getRealmByName(realmName);
-                    if (realm == null) return null;
-                    DummyUserFederationProviderFactory factory = (DummyUserFederationProviderFactory) session.getKeycloakSessionFactory().getProviderFactory(UserStorageProvider.class, "dummy");
-                    UserModel user = factory.create(session, null).getUserByUsername(realm, userName);
-                    if (user == null) return null;
-                    return ModelToRepresentation.toRepresentation(session, realm, user);
-                };
-            }
-
-            @Override
-            public Class<UserRepresentation> getResultClass() {
-                return UserRepresentation.class;
-            }
-        };
-    }
     private static FetchOnServerWrapper<UserRepresentation> getUserByFederatedIdentity(
             String realmName,
             String identityProvider,


### PR DESCRIPTION
Closes #49644

The custom providers are flaky in windows jobs (JDKTestSuite). As the `ExportImportTest` just needs the custom-providers to check the `DummyUserFederationProviderFactory`, and that makes no sense because the `wburke` is a normal user. We don't really want to check if it is in the federated provider because that user is never going to be in the federation. Removing that check.
