### PR TITLE
Authorization Services: NullPointerException in UMA permission grant …

### DIFF
--- a/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
+++ b/services/src/main/java/org/keycloak/authorization/authorization/AuthorizationTokenService.java
@@ -663,9 +663,9 @@ public class AuthorizationTokenService {
                         if (permissionScopes != null) {
                             permissionScopes.retainAll(scopes);
                         }
+                        // the permission is explicitly granted by the owner, mark this permission as granted so that we don't run the evaluation engine on it
+                        resourcePermission.setGranted(true);
                     }
-                    // the permission is explicitly granted by the owner, mark this permission as granted so that we don't run the evaluation engine on it
-                    resourcePermission.setGranted(true);
                 }
 
                 Resource serverResource = resourceStore.findByName(resourceServer, resourceId);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/UserManagedAccessTest.java
@@ -16,27 +16,24 @@
  */
 package org.keycloak.testsuite.authz;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.authorization.AuthorizationProvider;
 import org.keycloak.authorization.client.AuthorizationDeniedException;
 import org.keycloak.authorization.client.resource.PermissionResource;
 import org.keycloak.authorization.client.resource.ProtectionResource;
 import org.keycloak.authorization.client.util.HttpResponseException;
+import org.keycloak.authorization.model.PermissionTicket;
+import org.keycloak.authorization.model.Resource;
+import org.keycloak.authorization.model.ResourceServer;
+import org.keycloak.authorization.model.Scope;
+import org.keycloak.authorization.store.StoreFactory;
 import org.keycloak.events.EventType;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.authorization.AuthorizationRequest;
 import org.keycloak.representations.idm.authorization.AuthorizationResponse;
@@ -48,7 +45,23 @@ import org.keycloak.representations.idm.authorization.ResourcePermissionRepresen
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.keycloak.testsuite.AssertEvents;
+import org.keycloak.testsuite.runonserver.RunOnServer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
@@ -696,6 +709,42 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         assertPermissions(permissions, "Resource A");
         assertTrue(permissions.isEmpty());
     }
+    
+    @Test
+    public void testGrantedTicketReferencesRemovedScope() throws Exception {
+        resource = addResource("Resource Drift", "marta", true, "ScopeA", "ScopeB");
+
+        ResourcePermissionRepresentation permission = new ResourcePermissionRepresentation();
+        permission.setName(resource.getName() + " Permission");
+        permission.addResource(resource.getId());
+        permission.addPolicy("Only Owner Policy");
+        getClient(getRealm()).authorization().permissions().resource().create(permission).close();
+
+        // Remove ScopeA from the resource, then create a stale granted ticket at the model level.
+        ResourceRepresentation resourceRep = getAuthzClient().protection().resource().findById(resource.getId());
+        Set<ScopeRepresentation> updatedScopes = new HashSet<>(resourceRep.getScopes());
+        updatedScopes.removeIf(s -> "ScopeA".equals(s.getName()));
+        resourceRep.setScopes(updatedScopes);
+        getAuthzClient().protection().resource().update(resourceRep);
+
+        testingClient.server().run(StaleTicketCreator.forResource(resource.getName(), "marta", "ScopeA", "kolo"));
+
+        // kolo sends a UMA grant request with permission=resourceName#ScopeA
+        AuthorizationRequest request = new AuthorizationRequest();
+        request.addPermission(resource.getName(), "ScopeA");
+
+        try {
+            getAuthzClient().authorization("kolo", "password").authorize(request);
+            fail("Should be denied — ScopeA is no longer associated with the resource");
+        } catch (AuthorizationDeniedException e) {
+            // expected
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof HttpResponseException) {
+                int status = ((HttpResponseException) e.getCause()).getStatusCode();
+                assertNotEquals("Server returned HTTP 500", 500, status);
+            }
+        }
+    }
 
     @Test
     public void testResourceIsUserManagedCheck() throws Exception {
@@ -727,5 +776,32 @@ public class UserManagedAccessTest extends AbstractResourceServerTest {
         AccessToken token = toAccessToken(response.getToken());
         AccessToken.Authorization authorization = token.getAuthorization();
         return new ArrayList<>(authorization.getPermissions());
+    }
+
+    /**
+     * Separate class so that {@code RunOnServer} lambda serialization does not trigger loading
+     * of the outer test class, which imports {@code authz-client} types absent from the Quarkus
+     * server classpath.
+     */
+    static class StaleTicketCreator {
+        static RunOnServer forResource(
+                String resourceName, String ownerUsername, String scopeName, String requesterUsername) {
+            return session -> {
+                RealmModel realm = session.realms().getRealmByName("authz-test");
+                session.getContext().setRealm(realm);
+                AuthorizationProvider authz = session.getProvider(AuthorizationProvider.class);
+                StoreFactory sf = authz.getStoreFactory();
+
+                ClientModel client = session.clients().getClientByClientId(realm, "resource-server-test");
+                ResourceServer rs = sf.getResourceServerStore().findByClient(client);
+                String ownerId = session.users().getUserByUsername(realm, ownerUsername).getId();
+                Resource resource = sf.getResourceStore().findByName(rs, resourceName, ownerId);
+                Scope scope = sf.getScopeStore().findByName(rs, scopeName);
+
+                String requesterId = session.users().getUserByUsername(realm, requesterUsername).getId();
+                PermissionTicket ticket = sf.getPermissionTicketStore().create(rs, resource, scope, requesterId);
+                ticket.setGrantedTimestamp(System.currentTimeMillis());
+            };
+        }
     }
 }


### PR DESCRIPTION
…when stale permission ticket references removed scope

Closes #48986


(cherry picked from commit 3f05e7b763c77b32849a3e3ab1a17e4a264b5b6e)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
