### PR TITLE
Disable caches or reduce cache expiry

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/CacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/CacheManager.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
+import org.keycloak.cluster.ClusterEvent;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.cache.infinispan.entities.Revisioned;
@@ -236,5 +237,24 @@ public abstract class CacheManager {
 
     public void invalidateCacheKey(String key, Set<String> invalidations) {
         invalidations.add(key);
+    }
+
+    /**
+     * Handles a cluster-wide cache clear event by clearing all entries from this cache manager.
+     *
+     * @param ignored The cluster event (unused).
+     */
+    public void onClearEvent(ClusterEvent ignored) {
+        clear();
+    }
+
+    /**
+     * Handles a cluster-wide invalidation event by delegating to {@link #invalidationEventReceived(InvalidationEvent)}.
+     *
+     * @param event The cluster event, which must be an {@link InvalidationEvent}.
+     */
+    public void onInvalidateEvent(ClusterEvent event) {
+        assert event instanceof InvalidationEvent;
+        invalidationEventReceived((InvalidationEvent) event);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/InfinispanCacheRealmProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/InfinispanCacheRealmProviderFactory.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.cache.infinispan;
 
 import org.keycloak.Config;
-import org.keycloak.cluster.ClusterEvent;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.models.KeycloakSession;
@@ -26,10 +25,12 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.cache.CacheRealmProvider;
 import org.keycloak.models.cache.CacheRealmProviderFactory;
 import org.keycloak.models.cache.infinispan.entities.Revisioned;
-import org.keycloak.models.cache.infinispan.events.InvalidationEvent;
 
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
+
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.REALM_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.REALM_REVISIONS_CACHE_NAME;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -53,24 +54,15 @@ public class InfinispanCacheRealmProviderFactory implements CacheRealmProviderFa
         if (realmCache == null) {
             synchronized (this) {
                 if (realmCache == null) {
-                    Cache<String, Revisioned> cache = session.getProvider(InfinispanConnectionProvider.class).getCache(InfinispanConnectionProvider.REALM_CACHE_NAME);
-                    Cache<String, Long> revisions = session.getProvider(InfinispanConnectionProvider.class).getCache(InfinispanConnectionProvider.REALM_REVISIONS_CACHE_NAME);
+                    var ispnProvider = session.getProvider(InfinispanConnectionProvider.class);
+                    var cluster = session.getProvider(ClusterProvider.class);
+
+                    Cache<String, Revisioned> cache = ispnProvider.getCache(REALM_CACHE_NAME);
+                    Cache<String, Long> revisions = ispnProvider.getCache(REALM_REVISIONS_CACHE_NAME);
                     realmCache = new RealmCacheManager(cache, revisions);
 
-                    ClusterProvider cluster = session.getProvider(ClusterProvider.class);
-                    cluster.registerListener(REALM_INVALIDATION_EVENTS, (ClusterEvent event) -> {
-
-                        InvalidationEvent invalidationEvent = (InvalidationEvent) event;
-                        realmCache.invalidationEventReceived(invalidationEvent);
-
-                    });
-
-                    cluster.registerListener(REALM_CLEAR_CACHE_EVENTS, (ClusterEvent event) -> {
-
-                        realmCache.clear();
-
-                    });
-
+                    cluster.registerListener(REALM_INVALIDATION_EVENTS, realmCache::onInvalidateEvent);
+                    cluster.registerListener(REALM_CLEAR_CACHE_EVENTS, realmCache::onClearEvent);
                     log.debug("Registered cluster listeners");
                 }
             }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/InfinispanUserCacheProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/InfinispanUserCacheProviderFactory.java
@@ -18,31 +18,31 @@
 package org.keycloak.models.cache.infinispan;
 
 import org.keycloak.Config;
-import org.keycloak.cluster.ClusterEvent;
 import org.keycloak.cluster.ClusterProvider;
+import org.keycloak.common.Profile;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.cache.UserCache;
 import org.keycloak.models.cache.UserCacheProviderFactory;
 import org.keycloak.models.cache.infinispan.entities.Revisioned;
-import org.keycloak.models.cache.infinispan.events.InvalidationEvent;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
 
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
 
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.USER_REVISIONS_CACHE_NAME;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
-public class InfinispanUserCacheProviderFactory implements UserCacheProviderFactory {
+public class InfinispanUserCacheProviderFactory implements UserCacheProviderFactory, EnvironmentDependentProviderFactory {
 
     private static final Logger log = Logger.getLogger(InfinispanUserCacheProviderFactory.class);
     public static final String USER_CLEAR_CACHE_EVENTS = "USER_CLEAR_CACHE_EVENTS";
     public static final String USER_INVALIDATION_EVENTS = "USER_INVALIDATION_EVENTS";
 
     protected volatile UserCacheManager userCache;
-
-
 
     @Override
     public UserCache create(KeycloakSession session) {
@@ -54,25 +54,15 @@ public class InfinispanUserCacheProviderFactory implements UserCacheProviderFact
         if (userCache == null) {
             synchronized (this) {
                 if (userCache == null) {
-                    Cache<String, Revisioned> cache = session.getProvider(InfinispanConnectionProvider.class).getCache(InfinispanConnectionProvider.USER_CACHE_NAME);
-                    Cache<String, Long> revisions = session.getProvider(InfinispanConnectionProvider.class).getCache(InfinispanConnectionProvider.USER_REVISIONS_CACHE_NAME);
+                    var ispnProvider = session.getProvider(InfinispanConnectionProvider.class);
+                    var cluster = session.getProvider(ClusterProvider.class);
+
+                    Cache<String, Revisioned> cache = ispnProvider.getCache(InfinispanConnectionProvider.USER_CACHE_NAME);
+                    Cache<String, Long> revisions = ispnProvider.getCache(USER_REVISIONS_CACHE_NAME);
                     userCache = new UserCacheManager(cache, revisions);
 
-                    ClusterProvider cluster = session.getProvider(ClusterProvider.class);
-
-                    cluster.registerListener(USER_INVALIDATION_EVENTS, (ClusterEvent event) -> {
-
-                        InvalidationEvent invalidationEvent = (InvalidationEvent) event;
-                        userCache.invalidationEventReceived(invalidationEvent);
-
-                    });
-
-                    cluster.registerListener(USER_CLEAR_CACHE_EVENTS, (ClusterEvent event) -> {
-
-                        userCache.clear();
-
-                    });
-
+                    cluster.registerListener(USER_INVALIDATION_EVENTS, userCache::onInvalidateEvent);
+                    cluster.registerListener(USER_CLEAR_CACHE_EVENTS, userCache::onClearEvent);
                     log.debug("Registered cluster listeners");
                 }
             }
@@ -95,5 +85,10 @@ public class InfinispanUserCacheProviderFactory implements UserCacheProviderFact
     @Override
     public String getId() {
         return "default";
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return config.getBoolean("enabled", !Profile.isFeatureEnabled(Profile.Feature.CACHELESS));
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheManager.java
@@ -44,13 +44,6 @@ public class UserCacheManager extends CacheManager {
         return logger;
     }
 
-    @Override
-    public void clear() {
-        cache.clear();
-        revisions.clear();
-    }
-
-
     public void userUpdatedInvalidations(String userId, String username, String email, String realmId, Set<String> invalidations) {
         invalidations.add(userId);
         if (email != null) invalidations.add(UserCacheSession.getUserByEmailCacheKey(realmId, email));

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -107,7 +107,7 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     protected Set<String> realmInvalidations = new HashSet<>();
     protected Set<InvalidationEvent> invalidationEvents = new HashSet<>(); // Events to be sent across cluster
     protected Map<String, UserModel> managedUsers = new HashMap<>();
-    private StoreManagers datastoreProvider;
+    private final StoreManagers datastoreProvider;
 
     public UserCacheSession(UserCacheManager cache, KeycloakSession session) {
         this.cache = cache;

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/InfinispanCacheStoreFactoryProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/authorization/InfinispanCacheStoreFactoryProviderFactory.java
@@ -18,7 +18,6 @@
 package org.keycloak.models.cache.infinispan.authorization;
 
 import org.keycloak.Config;
-import org.keycloak.cluster.ClusterEvent;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.models.KeycloakSession;
@@ -26,11 +25,12 @@ import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.models.cache.authorization.CachedStoreFactoryProvider;
 import org.keycloak.models.cache.authorization.CachedStoreProviderFactory;
 import org.keycloak.models.cache.infinispan.entities.Revisioned;
-import org.keycloak.models.cache.infinispan.events.InvalidationEvent;
 
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
 
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHORIZATION_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHORIZATION_REVISIONS_CACHE_NAME;
 import static org.keycloak.models.cache.infinispan.InfinispanCacheRealmProviderFactory.REALM_CLEAR_CACHE_EVENTS;
 
 /**
@@ -55,21 +55,16 @@ public class InfinispanCacheStoreFactoryProviderFactory implements CachedStorePr
         if (storeCache == null) {
             synchronized (this) {
                 if (storeCache == null) {
-                    Cache<String, Revisioned> cache = session.getProvider(InfinispanConnectionProvider.class).getCache(InfinispanConnectionProvider.AUTHORIZATION_CACHE_NAME);
-                    Cache<String, Long> revisions = session.getProvider(InfinispanConnectionProvider.class).getCache(InfinispanConnectionProvider.AUTHORIZATION_REVISIONS_CACHE_NAME);
+                    var ispnProvider = session.getProvider(InfinispanConnectionProvider.class);
+                    var cluster = session.getProvider(ClusterProvider.class);
+
+                    Cache<String, Revisioned> cache = ispnProvider.getCache(AUTHORIZATION_CACHE_NAME);
+                    Cache<String, Long> revisions = ispnProvider.getCache(AUTHORIZATION_REVISIONS_CACHE_NAME);
                     storeCache = new StoreFactoryCacheManager(cache, revisions);
-                    ClusterProvider cluster = session.getProvider(ClusterProvider.class);
 
-                    cluster.registerListener(AUTHORIZATION_INVALIDATION_EVENTS, (ClusterEvent event) -> {
-
-                        InvalidationEvent invalidationEvent = (InvalidationEvent) event;
-                        storeCache.invalidationEventReceived(invalidationEvent);
-
-                    });
-
-                    cluster.registerListener(AUTHORIZATION_CLEAR_CACHE_EVENTS, (ClusterEvent event) -> storeCache.clear());
-                    cluster.registerListener(REALM_CLEAR_CACHE_EVENTS, (ClusterEvent event) -> storeCache.clear());
-
+                    cluster.registerListener(AUTHORIZATION_INVALIDATION_EVENTS, storeCache::onInvalidateEvent);
+                    cluster.registerListener(AUTHORIZATION_CLEAR_CACHE_EVENTS, storeCache::onClearEvent);
+                    cluster.registerListener(REALM_CLEAR_CACHE_EVENTS, storeCache::onClearEvent);
                     log.debug("Registered cluster listeners");
                 }
             }

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/CacheConfigurator.java
@@ -18,19 +18,26 @@
 package org.keycloak.spi.infinispan.impl.embedded;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Duration;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.DurationConverter;
 import org.keycloak.config.CachingOptions;
+import org.keycloak.config.OptionsUtil;
 import org.keycloak.marshalling.Marshalling;
 import org.keycloak.models.sessions.infinispan.InfinispanUserSessionProviderFactory;
 import org.keycloak.models.sessions.infinispan.entities.LoginFailureEntity;
 import org.keycloak.models.sessions.infinispan.entities.RemoteAuthenticatedClientSessionEntity;
 import org.keycloak.models.sessions.infinispan.entities.RemoteUserSessionEntity;
 import org.keycloak.models.sessions.infinispan.entities.RootAuthenticationSessionEntity;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.util.TimeQuantity;
@@ -90,9 +97,12 @@ public final class CacheConfigurator {
     private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String MAX_COUNT_SUFFIX = "MaxCount";
+    private static final String LIFESPAN_SUFFIX = "Lifespan";
     private static final String OWNER_SUFFIX = "Owners";
     private static final int STATE_TRANSFER_CHUNK_SIZE = 16;
     private static final int MIN_NUM_OWNERS_REMOTE_CACHE = 2;
+    private static final long DEFAULT_LIFESPAN = Duration.ofSeconds(10).toMillis();
+    private static final int DISABLED_LIFESPAN = -1;
 
     private CacheConfigurator() {
     }
@@ -388,6 +398,38 @@ public final class CacheConfigurator {
         };
     }
 
+    /**
+     * Configures the entry lifespan for the local caches (realm, user, and authorization).
+     * <p>
+     * When the {@link Profile.Feature#CACHELESS} feature is enabled, the default lifespan is set to
+     * {@link #DEFAULT_LIFESPAN} milliseconds; otherwise, entries are immortal by default.
+     *
+     * @param holder The {@link ConfigurationBuilderHolder} where the caches are configured.
+     * @param config The Keycloak configuration, which may provide per-cache lifespan overrides.
+     * @throws IllegalStateException if a cache is not defined in the {@code holder}.
+     */
+    public static void configureLocalCachesExpiration(ConfigurationBuilderHolder holder, Config.Scope config) {
+        var defaultLifespan = Profile.isFeatureEnabled(Profile.Feature.CACHELESS) ? DEFAULT_LIFESPAN : DISABLED_LIFESPAN;
+        Stream.of(AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME)
+                .forEach(name -> setExpiration(holder, config, name, defaultLifespan));
+    }
+
+    /**
+     * Adds the lifespan configuration properties for the local caches (realm, user, and authorization) to the given
+     * provider configuration builder.
+     *
+     * @param builder The {@link ProviderConfigurationBuilder} to add the properties to.
+     */
+    public static void addExpirationConfiguration(ProviderConfigurationBuilder builder) {
+        Stream.of(AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME)
+                .forEach(name -> builder.property()
+                        .name(CacheConfigurator.lifespanConfigKey(name))
+                        .helpText("Sets the lifespan of stored objects for cache %s. A zero or negative value makes the entries immortal, i.e., they never expire. %s".formatted(name, OptionsUtil.DURATION_DESCRIPTION))
+                        .label("lifespan")
+                        .type(ProviderConfigProperty.STRING_TYPE)
+                        .add());
+    }
+
     // private methods below
 
     private static void configureSessionExpirationReaper(ConfigurationBuilder builder) {
@@ -450,6 +492,16 @@ public final class CacheConfigurator {
 
     public static String maxCountConfigKey(String name) {
         return name + MAX_COUNT_SUFFIX;
+    }
+
+    /**
+     * Returns the SPI configuration key for the lifespan of the given cache.
+     *
+     * @param name The cache name.
+     * @return The configuration key, e.g. {@code "realmLifespan"}.
+     */
+    public static String lifespanConfigKey(String name) {
+        return name + LIFESPAN_SUFFIX;
     }
 
     public static String numOwnerConfigKey(String name) {
@@ -556,5 +608,17 @@ public final class CacheConfigurator {
 
     private static boolean isClustered(ConfigurationBuilderHolder holder) {
         return holder.getGlobalConfigurationBuilder().transport().getTransport() != null;
+    }
+
+    private static void setExpiration(ConfigurationBuilderHolder holder, Config.Scope config, String cacheName, long defaultLifespan) {
+        var builder = holder.getNamedConfigurationBuilders().get(cacheName);
+        if (builder == null) {
+            throw cacheNotFound(cacheName);
+        }
+        var lifespan = Optional.ofNullable(DurationConverter.parseDuration(config.get(lifespanConfigKey(cacheName))))
+                .map(Duration::toMillis)
+                .map(value -> value <= 0 ? DISABLED_LIFESPAN : value)
+                .orElse(defaultLifespan);
+        builder.expiration().lifespan(lifespan, TimeUnit.MILLISECONDS);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/DefaultCacheEmbeddedConfigProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/spi/infinispan/impl/embedded/DefaultCacheEmbeddedConfigProviderFactory.java
@@ -57,6 +57,7 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.C
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_MAX_COUNT_CACHES;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOCAL_CACHE_NAMES;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOCAL_MAX_COUNT_CACHES;
+import static org.keycloak.spi.infinispan.impl.embedded.CacheConfigurator.addExpirationConfiguration;
 import static org.keycloak.spi.infinispan.impl.embedded.JGroupsConfigurator.createJGroupsProperties;
 
 /**
@@ -133,6 +134,7 @@ public class DefaultCacheEmbeddedConfigProviderFactory implements CacheEmbeddedC
                         .add());
         createTopologyProperties(builder);
         createJGroupsProperties(builder);
+        addExpirationConfiguration(builder);
         return builder.build();
     }
 
@@ -211,6 +213,7 @@ public class DefaultCacheEmbeddedConfigProviderFactory implements CacheEmbeddedC
         if (JGroupsConfigurator.isClustered(holder)) {
             KeycloakModelUtils.runJobInTransaction(factory, session -> JGroupsConfigurator.configureJGroups(config, holder, session));
         }
+        CacheConfigurator.configureLocalCachesExpiration(holder, config);
         configureMetrics(config, holder);
     }
 

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigKeepAliveDistTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/cli/dist/ClusterConfigKeepAliveDistTest.java
@@ -40,10 +40,13 @@ import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
 import org.junit.jupiter.api.Test;
 
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.AUTHORIZATION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NUM_OWNERS;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_CLIENT_SESSION_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.OFFLINE_USER_SESSION_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.REALM_CACHE_NAME;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.USER_CACHE_NAME;
 import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.USER_SESSION_CACHE_NAME;
 
 import static io.restassured.RestAssured.when;
@@ -73,6 +76,93 @@ public class ClusterConfigKeepAliveDistTest {
         for (String cache : maxCountCaches) {
             Configuration config = getCacheConfiguration(cache);
             assertEquals(maxCount, config.memory().maxCount());
+        }
+    }
+
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    void testLifespanApplied(KeycloakRunner runner) {
+        long expectedLifespanMs = 30000;
+        String[] caches = {AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME};
+
+        List<String> args = new ArrayList<>();
+        args.add("start-dev");
+        for (String cache : caches) {
+            args.add("--spi-cache-embedded--default--%s-lifespan=30s".formatted(cache));
+        }
+        runner.run(args);
+
+        for (String cache : caches) {
+            Configuration config = getCacheConfiguration(cache);
+            assertEquals(expectedLifespanMs, config.expiration().lifespan(),
+                    "Wrong lifespan for cache " + cache);
+        }
+    }
+
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    void testDefaultLifespanIsImmortal(KeycloakRunner runner) {
+        String[] caches = {AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME};
+
+        runner.run("start-dev");
+
+        for (String cache : caches) {
+            Configuration config = getCacheConfiguration(cache);
+            assertEquals(-1, config.expiration().lifespan(),
+                    "Expected immortal entries (lifespan=-1) for cache " + cache);
+        }
+    }
+
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    void testDefaultLifespanWithCachelessFeature(KeycloakRunner runner) {
+        String[] caches = {AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME};
+
+        runner.run("start-dev", "--features=cacheless");
+
+        for (String cache : caches) {
+            Configuration config = getCacheConfiguration(cache);
+            assertEquals(10000, config.expiration().lifespan(),
+                    "Expected 10s default lifespan for cache " + cache);
+        }
+    }
+
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    void testZeroOrNegativeLifespanFallsBackToDefault(KeycloakRunner runner) {
+        String[] caches = {AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME};
+
+        List<String> args = new ArrayList<>();
+        args.add("start-dev");
+        args.add("--spi-cache-embedded--default--%s-lifespan=0s".formatted(AUTHORIZATION_CACHE_NAME));
+        args.add("--spi-cache-embedded--default--%s-lifespan=-30s".formatted(REALM_CACHE_NAME));
+        args.add("--spi-cache-embedded--default--%s-lifespan=0".formatted(USER_CACHE_NAME));
+        runner.run(args);
+
+        for (String cache : caches) {
+            Configuration config = getCacheConfiguration(cache);
+            assertEquals(-1, config.expiration().lifespan(),
+                    "Expected immortal entries (lifespan=-1) for cache " + cache);
+        }
+    }
+
+    @Test
+    @TestProvider(TestRealmResourceTestProvider.class)
+    void testZeroOrNegativeLifespanOverridesCachelessDefault(KeycloakRunner runner) {
+        String[] caches = {AUTHORIZATION_CACHE_NAME, REALM_CACHE_NAME, USER_CACHE_NAME};
+
+        List<String> args = new ArrayList<>();
+        args.add("start-dev");
+        args.add("--features=cacheless");
+        args.add("--spi-cache-embedded--default--%s-lifespan=0s".formatted(AUTHORIZATION_CACHE_NAME));
+        args.add("--spi-cache-embedded--default--%s-lifespan=-1s".formatted(REALM_CACHE_NAME));
+        args.add("--spi-cache-embedded--default--%s-lifespan=0".formatted(USER_CACHE_NAME));
+        runner.run(args);
+
+        for (String cache : caches) {
+            Configuration config = getCacheConfiguration(cache);
+            assertEquals(-1, config.expiration().lifespan(),
+                    "Expected immortal entries (lifespan=-1) for cache " + cache + " even with cacheless feature enabled");
         }
     }
 


### PR DESCRIPTION
Closes #49652

Added an SPI option to the 3 local caches. By default, entries are immortal unless `cacheless` is enabled, in which case the default is 10 seconds. 

It can be configured independently whether `cacheless` is used or not. 

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
