### PR TITLE
[26.6] Validate sequence length against the remaining elements in the buffer

### DIFF
--- a/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/BERDecoder.java
+++ b/federation/ldap/src/main/java/org/keycloak/storage/ldap/idm/store/ldap/BERDecoder.java
@@ -110,18 +110,25 @@ public class BERDecoder {
 
         // Short form.
         if ((length & 0x80) == 0) {
+            if (length > encoded.remaining()) {
+                throw new DecodeException("Length " + length + " exceeds remaining buffer size " + encoded.remaining());
+            }
             return length;
         }
 
-        // Long form.
+        // Long form. numBytes == 0 is the indefinite form, which is not supported.
         int numBytes = length & 0x7F;
-        if (numBytes > 4) {
+        if (numBytes == 0 || numBytes > 4) {
             throw new DecodeException("Cannot handle more than 4 bytes of length, got " + numBytes + " bytes");
         }
 
         length = 0;
         for (int i = 0; i < numBytes; i++) {
             length = (length << 8) | (encoded.get() & 0xFF);
+        }
+
+        if (length < 0 || length > encoded.remaining()) {
+            throw new DecodeException("Length " + length + " exceeds remaining buffer size " + encoded.remaining());
         }
 
         return length;

--- a/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyControlTest.java
+++ b/federation/ldap/src/test/java/org/keycloak/storage/ldap/idm/store/ldap/control/PasswordPolicyControlTest.java
@@ -33,7 +33,7 @@ public class PasswordPolicyControlTest {
     public void testDecodeResponseValueWithWarningAndError() {
         // SEQUENCE { warning timeBeforeExpiration(5), error changeAfterReset(2) }
         // Note: we don't currently support warning, but at least make sure it doesn't break decoding.
-        PasswordPolicyControl control = new PasswordPolicyControl(new byte[] { 0x30, 0x08, (byte) 0x80, 0x02, 0x01, 0x05, (byte) 0x81, 0x01, 0x02 });
+        PasswordPolicyControl control = new PasswordPolicyControl(new byte[] { 0x30, 0x07, (byte) 0x80, 0x02, 0x01, 0x05, (byte) 0x81, 0x01, 0x02 });
         Assert.assertTrue(control.changeAfterReset());
     }
 
@@ -64,6 +64,9 @@ public class PasswordPolicyControlTest {
         // Sequence with invalid length.
         new PasswordPolicyControl(new byte[] { 0x30, (byte) 0xFF, (byte) 0x82, 0x01, 0x02 });
 
+        // Indefinite-length form (0x80) is not supported.
+        new PasswordPolicyControl(new byte[] { 0x30, (byte) 0x80, (byte) 0x81, 0x01, 0x02, 0x00, 0x00 });
+
         // Sequence payload shorter than indicated.
         new PasswordPolicyControl(new byte[] { 0x30, 0x03 });
 
@@ -72,6 +75,26 @@ public class PasswordPolicyControlTest {
 
         // Invalid CHOICE tag.
         new PasswordPolicyControl(new byte[] { 0x30, 0x03, (byte) 0x82, 0x01, 0x02 });
+    }
+
+    @Test
+    public void testDecodeErrorWithOversizedBERLength() {
+        // 0x30 0x06 = SEQUENCE (startSequence discards the length without bounds-checking)
+        // 0x81      = error [1] tag
+        // 0x84 0x7F 0xFF 0xFF 0xFF = long-form length: numBytes=4, value=Integer.MAX_VALUE
+        PasswordPolicyControl control = new PasswordPolicyControl(
+                new byte[] { 0x30, 0x06, (byte) 0x81, (byte) 0x84, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF });
+        Assert.assertFalse(control.changeAfterReset());
+    }
+
+    @Test
+    public void testDecodeErrorWithOversizedShortFormBERLength() {
+        // 0x30 0x02 = SEQUENCE, length 2
+        // 0x81      = error [1] tag
+        // 0x0A      = short-form length: value=10, but 0 bytes remain in the buffer
+        PasswordPolicyControl control = new PasswordPolicyControl(
+                new byte[] { 0x30, 0x02, (byte) 0x81, 0x0A });
+        Assert.assertFalse(control.changeAfterReset());
     }
 
 


### PR DESCRIPTION
Closes #49434

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
