### PR TITLE
Return consistent error when deleting Keycloak-managed clients

### DIFF
--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -23,7 +23,6 @@ import org.keycloak.events.admin.v2.AdminEventV2Builder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelException;
-import org.keycloak.models.ModelValidationException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
@@ -200,10 +199,7 @@ public class DefaultClientService implements ClientService {
 
         permissions.clients().requireManage(client);
         try {
-            AdminPermissionsSchema.SCHEMA.throwExceptionIfAdminPermissionClient(session, client.getId());
             session.clientPolicy().triggerOnEvent(new AdminClientUnregisterContext(client, permissions.adminAuth()));
-        } catch (ModelValidationException e) {
-            throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);
         } catch (ClientPolicyException e) {
             throw new ServiceException(e.getErrorDetail(), Response.Status.BAD_REQUEST);
         }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2AuthorizationTest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2AuthorizationTest.java
@@ -358,7 +358,7 @@ public class ClientApiV2AuthorizationTest extends AbstractClientApiV2Test {
         try (var response = getClientApi(realmAdminAdminClient, getRealmName(), adminPermissionsClientRep.getClientId()).deleteClient()) {
             assertThat(response.getStatus(), is(400));
             var body = response.readEntity(String.class);
-            assertThat(body, containsString("Not supported for this client"));
+            assertThat(body, containsString("Could not delete client"));
         }
 
         // Verify the client still exists (was not deleted)

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.crypto.Algorithm;
+import org.keycloak.models.utils.SystemClientUtil;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -36,11 +37,12 @@ public final class Constants {
     public static final String ACCOUNT_CONSOLE_CLIENT_ID = "account-console";
     public static final String BROKER_SERVICE_CLIENT_ID = "broker";
     public static final String REALM_MANAGEMENT_CLIENT_ID = "realm-management";
+    public static final String ADMIN_PERMISSIONS_CLIENT_ID = "admin-permissions";
 
     public static final String AUTH_BASE_URL_PROP = "${authBaseUrl}";
     public static final String AUTH_ADMIN_URL_PROP = "${authAdminUrl}";
 
-    public static final Collection<String> defaultClients = Arrays.asList(ACCOUNT_MANAGEMENT_CLIENT_ID, ACCOUNT_CONSOLE_CLIENT_ID, ADMIN_CLI_CLIENT_ID, BROKER_SERVICE_CLIENT_ID, REALM_MANAGEMENT_CLIENT_ID, ADMIN_CONSOLE_CLIENT_ID);
+    public static final Collection<String> defaultClients = Arrays.asList(ACCOUNT_MANAGEMENT_CLIENT_ID, ACCOUNT_CONSOLE_CLIENT_ID, ADMIN_CLI_CLIENT_ID, BROKER_SERVICE_CLIENT_ID, REALM_MANAGEMENT_CLIENT_ID, ADMIN_CONSOLE_CLIENT_ID, ADMIN_PERMISSIONS_CLIENT_ID, SystemClientUtil.SYSTEM_CLIENT_ID);
 
     public static final String INSTALLED_APP_URN = "urn:ietf:wg:oauth:2.0:oob";
 
@@ -222,8 +224,6 @@ public final class Constants {
 
     //attribute name used to mark a client as realm client
     public static final String REALM_CLIENT = "realm_client";
-
-    public static final String ADMIN_PERMISSIONS_CLIENT_ID = "admin-permissions";
 
     // Note used to store the authentication flow requested
     public static final String REQUESTED_AUTHENTICATION_FLOW = "requested-authentication-flow";

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -39,7 +39,6 @@ import jakarta.ws.rs.core.Response.Status;
 
 import org.keycloak.OAuthErrorException;
 import org.keycloak.authorization.admin.AuthorizationService;
-import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.client.clienttype.ClientTypeException;
 import org.keycloak.common.ClientConnection;
 import org.keycloak.common.Profile;
@@ -259,8 +258,6 @@ public class ClientResource {
         if (client == null) {
             throw new NotFoundException("Could not find client");
         }
-
-        AdminPermissionsSchema.SCHEMA.throwExceptionIfAdminPermissionClient(session, client.getId());
 
         ClientRepresentation clientRepresentation = new ClientRepresentation();
         clientRepresentation.setId(client.getId());

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -51,6 +51,7 @@ import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.Constants;
+import org.keycloak.models.utils.SystemClientUtil;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
@@ -454,7 +455,8 @@ public class ClientTest {
 
     @Test
     public void removeInternalClientExpectingBadRequestException() {
-        defaultClients.stream().filter(Predicate.not(REALM_MANAGEMENT_CLIENT_ID::equals)).forEach(defaultClient -> {
+        Set<String> excluded = Set.of(REALM_MANAGEMENT_CLIENT_ID, Constants.ADMIN_PERMISSIONS_CLIENT_ID, SystemClientUtil.SYSTEM_CLIENT_ID);
+        defaultClients.stream().filter(Predicate.not(excluded::contains)).forEach(defaultClient -> {
             final String defaultClientId = AdminApiUtil.findClientByClientId(managedRealm.admin(), defaultClient)
                     .toRepresentation().getId();
 
@@ -478,6 +480,32 @@ public class ClientTest {
                             .toRepresentation().getId();
                     managedRealm.admin().clients().get(testRealmClientId).remove();
                 });
+    }
+
+    @Test
+    public void removeSystemClientExpectingBadRequestException() {
+        ClientRepresentation rep = new ClientRepresentation();
+        rep.setClientId(SystemClientUtil.SYSTEM_CLIENT_ID);
+        rep.setEnabled(true);
+
+        String id;
+        try (Response response = managedRealm.admin().clients().create(rep)) {
+            id = ApiUtil.getCreatedId(response);
+        }
+
+        try {
+            BadRequestException ex = assertThrows(BadRequestException.class, () -> managedRealm.admin().clients().get(id).remove());
+            OAuth2ErrorRepresentation error = ex.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            assertThat(error.getError(), is("invalid_request"));
+            assertThat(error.getErrorDescription(), is("Could not delete client"));
+        } finally {
+            // rename away from the protected clientId so the test can clean up after itself
+            ClientResource clientResource = managedRealm.admin().clients().get(id);
+            ClientRepresentation created = clientResource.toRepresentation();
+            created.setClientId("system-cleanup-" + id);
+            clientResource.update(created);
+            clientResource.remove();
+        }
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/PermissionRESTTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authz/fgap/PermissionRESTTest.java
@@ -29,6 +29,7 @@ import org.keycloak.models.AdminRoles;
 import org.keycloak.models.Constants;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
@@ -50,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -71,6 +73,9 @@ public class PermissionRESTTest extends AbstractPermissionTest {
             fail("Expected Exception wasn't thrown.");
         } catch (Exception ex) {
             assertThat(ex, instanceOf(BadRequestException.class));
+            OAuth2ErrorRepresentation error = ((BadRequestException) ex).getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            assertThat(error.getError(), is("invalid_request"));
+            assertThat(error.getErrorDescription(), is("Could not delete client"));
         }
     }
 


### PR DESCRIPTION
## Description

Deleting the admin-permissions client on the v1 Admin API (the one the Admin Console uses) returned 400 `{"error":"unknown_error"}`, so the console showed "Could not delete client: unknown_error". 
The guard threw a `ModelValidationException` that v1 never translated, while v2 did, so the two APIs were also inconsistent.

This adds `admin-permissions` and `_system` to `Constants.defaultClients`, so the existing `ClientManager.isInternalClient()` check inside `removeClient()` blocks their deletion automatically, returning a consistent 400 "Could not delete client" (invalid_request) on both v1 and v2, the same path that already protects account, realm-management, etc.

Closes #49674

## Fix Result Video

[client-delete-flow-fix.webm](https://github.com/user-attachments/assets/7ce08a1b-3c3b-410f-9c17-280ddf8e1d9e)
