### PR TITLE
More flexibility for client policies in identity-broker-api:v2

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/ClientPolicyRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/ClientPolicyRepresentation.java
@@ -30,6 +30,7 @@ public class ClientPolicyRepresentation {
     protected String name;
     protected String description;
     protected Boolean enabled;
+    protected String mode;
     protected List<ClientPolicyConditionRepresentation> conditions;
     protected List<String> profiles;
 
@@ -55,6 +56,14 @@ public class ClientPolicyRepresentation {
 
     public void setEnabled(Boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getMode() {
+        return mode;
+    }
+
+    public void setMode(String mode) {
+        this.mode = mode;
     }
 
     public List<ClientPolicyConditionRepresentation> getConditions() {

--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -1191,6 +1191,7 @@ SSOSessionSettings=SSO Session Settings
 directAccessHelp=This enables support for Direct Access Grants, which means that client has access to username/password of user and exchange it directly with Keycloak server for access token. In terms of OAuth2 specification, this enables support of 'Resource Owner Password Credentials Grant' for this client.
 groupHelp=Group to add the user in. Fill the full path of the group including path. For example\: '/root-group/child-group'.
 clientPolicyNameHelp=Display name of the policy
+clientPolicyModeHelp=Mode of the client policy. In the mode 'DEFAULT', at least one condition must evaluate to `yes`. None of the conditions must evaluate to `no`. Conditions, which evaluate to `abstain` are ignored. In the 'STRICT' mode, all conditions must evaluate to 'yes' in order for the policy to be applied.
 addressClaim.country.label=User Attribute Name for Country
 downloadType=this is information about the download type
 clustering=Clustering

--- a/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
+++ b/js/apps/admin-ui/src/realm-settings/NewClientPolicy.tsx
@@ -3,6 +3,7 @@ import type ClientProfileRepresentation from "@keycloak/keycloak-admin-client/li
 import {
   HelpItem,
   KeycloakTextArea,
+  SelectControl,
   TextControl,
   useAlerts,
   useFetch,
@@ -57,10 +58,13 @@ type FormFields = Required<ClientPolicyRepresentation>;
 const defaultValues: FormFields = {
   name: "",
   description: "",
+  mode: "DEFAULT",
   conditions: [],
   enabled: true,
   profiles: [],
 };
+
+const CLIENT_POLICY_MODES = ["DEFAULT", "STRICT"];
 
 type PolicyDetailAttributes = {
   idx: number;
@@ -346,6 +350,10 @@ export default function NewClientPolicy() {
     if (currentPolicy?.description !== undefined) {
       form.setValue("description", currentPolicy.description);
     }
+
+    if (currentPolicy?.mode !== undefined) {
+      form.setValue("mode", currentPolicy.mode);
+    }
   };
 
   const toggleModal = () => {
@@ -501,6 +509,15 @@ export default function NewClientPolicy() {
                 {...form.register("description")}
               />
             </FormGroup>
+            <SelectControl
+              name="mode"
+              label={t("mode")}
+              labelIcon={t("clientPolicyModeHelp")}
+              controller={{
+                defaultValue: "DEFAULT",
+              }}
+              options={CLIENT_POLICY_MODES}
+            />
             <ActionGroup>
               <Button
                 variant="primary"

--- a/js/libs/keycloak-admin-client/src/defs/clientPolicyRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/clientPolicyRepresentation.ts
@@ -7,6 +7,7 @@ export default interface ClientPolicyRepresentation {
   conditions?: ClientPolicyConditionRepresentation[];
   description?: string;
   enabled?: boolean;
+  mode?: string;
   name?: string;
   profiles?: string[];
 }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/ClientPoliciesUtil.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/ClientPoliciesUtil.java
@@ -522,7 +522,16 @@ public class ClientPoliciesUtil {
             policyRep.setName(proposedPolicyRep.getName());
             policyRep.setDescription(proposedPolicyRep.getDescription());
             policyRep.setEnabled(proposedPolicyRep.isEnabled() != null ? proposedPolicyRep.isEnabled() : Boolean.FALSE);
-            policyRep.setMode(proposedPolicyRep.getMode());
+
+            // Check if mode is valid
+            try {
+                if (proposedPolicyRep.getMode() != null) {
+                    Enum.valueOf(ClientPolicyMode.class, proposedPolicyRep.getMode());
+                }
+                policyRep.setMode(proposedPolicyRep.getMode());
+            } catch (IllegalArgumentException iae) {
+                throw new ClientPolicyException("Policy " + proposedPolicyRep.getName() + " has invalid mode");
+            }
 
             policyRep.setConditions(new ArrayList<>());
             if (proposedPolicyRep.getConditions() != null) {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/ClientPoliciesUtil.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/ClientPoliciesUtil.java
@@ -417,6 +417,10 @@ public class ClientPoliciesUtil {
             policyModel.setName(policyRep.getName());
             policyModel.setDescription(policyRep.getDescription());
             policyModel.setEnable(true);
+            ClientPolicyMode mode = policyRep.getMode() == null
+                    ? ClientPolicyMode.DEFAULT
+                    : Enum.valueOf(ClientPolicyMode.class, policyRep.getMode().toUpperCase());
+            policyModel.setMode(mode);
 
             List<ClientPolicyConditionProvider> conditions = new ArrayList<>();
             if (policyRep.getConditions() != null) {
@@ -518,6 +522,7 @@ public class ClientPoliciesUtil {
             policyRep.setName(proposedPolicyRep.getName());
             policyRep.setDescription(proposedPolicyRep.getDescription());
             policyRep.setEnabled(proposedPolicyRep.isEnabled() != null ? proposedPolicyRep.isEnabled() : Boolean.FALSE);
+            policyRep.setMode(proposedPolicyRep.getMode());
 
             policyRep.setConditions(new ArrayList<>());
             if (proposedPolicyRep.getConditions() != null) {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/ClientPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/ClientPolicy.java
@@ -31,6 +31,7 @@ class ClientPolicy implements Serializable {
     protected String name;
     protected String description;
     protected boolean enable;
+    protected ClientPolicyMode mode;
     protected List<ClientPolicyConditionProvider> conditions;
     protected List<String> profiles;
 
@@ -56,6 +57,14 @@ class ClientPolicy implements Serializable {
 
     public void setEnable(boolean enable) {
         this.enable = enable;
+    }
+
+    public ClientPolicyMode getMode() {
+        return mode;
+    }
+
+    public void setMode(ClientPolicyMode mode) {
+        this.mode = mode;
     }
 
     public List<ClientPolicyConditionProvider> getConditions() {

--- a/services/src/main/java/org/keycloak/services/clientpolicy/ClientPolicyMode.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/ClientPolicyMode.java
@@ -1,0 +1,14 @@
+package org.keycloak.services.clientpolicy;
+
+public enum ClientPolicyMode {
+
+    /**
+     * Default condition mode. At least one condition must evaluate to `yes`. None of the conditions must evaluate to `no`. Conditions, which evaluate to `abstain` are ignored
+     */
+    DEFAULT,
+
+    /**
+     * All conditions must evaluate to `yes`. None of the conditions must evaluate to `no` or `abstain`.
+     */
+    STRICT
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/DefaultClientPolicyManager.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/DefaultClientPolicyManager.java
@@ -103,8 +103,16 @@ public class DefaultClientPolicyManager implements ClientPolicyManager {
                     }
                 }
                 if (vote == ClientPolicyVote.ABSTAIN) {
-                    logger.tracev("CONDITION SKIP :: policy name = {0}, condition name = {1}, provider id = {2}", policy.getName(), condition.getName(), condition.getProviderId());
-                    continue;
+                    if (logger.isTraceEnabled()) {
+                        String modeMessage = policy.getMode() == ClientPolicyMode.STRICT ? "(NEGATIVE due the STRICT mode)" : "";
+                        logger.tracev("CONDITION SKIP {0}:: policy name = {1}, condition name = {2}, provider id = {3}",
+                                modeMessage, policy.getName(), condition.getName(), condition.getProviderId());
+                    }
+                    if (policy.getMode() == ClientPolicyMode.STRICT) {
+                        return false;
+                    } else {
+                        continue;
+                    }
                 } else if (vote == ClientPolicyVote.NO) {
                     logger.tracev("CONDITION NEGATIVE :: policy name = {0}, condition name = {1}, provider id = {2}", policy.getName(), condition.getName(), condition.getProviderId());
                     return false;

--- a/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientPolicyBuilder.java
+++ b/test-framework/builders/src/main/java/org/keycloak/testframework/realm/ClientPolicyBuilder.java
@@ -7,6 +7,8 @@ import java.util.List;
 import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
 import org.keycloak.representations.idm.ClientPolicyConditionRepresentation;
 import org.keycloak.representations.idm.ClientPolicyRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyMode;
+import org.keycloak.services.clientpolicy.condition.ClientScopesCondition;
 import org.keycloak.services.clientpolicy.condition.GrantTypeCondition;
 import org.keycloak.services.clientpolicy.condition.IdentityProviderCondition;
 import org.keycloak.util.JsonSerialization;
@@ -49,6 +51,14 @@ public class ClientPolicyBuilder extends Builder<ClientPolicyRepresentation> {
         return config;
     }
 
+    public static ClientScopesCondition.Configuration clientScopesConditionConfiguration(boolean negativeLogic, String type, String... scopes) {
+        ClientScopesCondition.Configuration config = new ClientScopesCondition.Configuration();
+        config.setNegativeLogic(negativeLogic);
+        config.setType(type);
+        config.setScopes(List.of(scopes));
+        return config;
+    }
+
     public ClientPolicyBuilder enabled(boolean enabled) {
         rep.setEnabled(enabled);
         return this;
@@ -61,6 +71,11 @@ public class ClientPolicyBuilder extends Builder<ClientPolicyRepresentation> {
 
     public ClientPolicyBuilder description(String description) {
         rep.setDescription(description);
+        return this;
+    }
+
+    public ClientPolicyBuilder mode(ClientPolicyMode mode) {
+        rep.setMode(mode.toString());
         return this;
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/broker/IdentityProviderStoreTokenV2Test.java
+++ b/tests/base/src/test/java/org/keycloak/tests/broker/IdentityProviderStoreTokenV2Test.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.keycloak.common.Profile;
 import org.keycloak.representations.idm.ClientPoliciesRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyMode;
+import org.keycloak.services.clientpolicy.condition.ClientScopesConditionFactory;
 import org.keycloak.services.clientpolicy.condition.IdentityProviderConditionFactory;
 import org.keycloak.services.clientpolicy.executor.RejectRequestExecutorFactory;
 import org.keycloak.testframework.annotations.InjectRealm;
@@ -139,6 +141,51 @@ public class IdentityProviderStoreTokenV2Test implements InterfaceIdentityProvid
                 .profile("executor")
                 .build()));
         realm.admin().clientPoliciesPoliciesResource().updatePolicies(policiesToUpdate);
+
+        externalTokens = doFetchExternalIdpToken(tokenResponse.getAccessToken());
+        Assertions.assertTrue(externalTokens.isSuccess());
+        checkSuccessfulTokenResponse(externalTokens);
+    }
+
+    // Configure client policies in a way that call identity-brokering API for retrieve external tokens of specified IDP is allowed just if internal token has specified scope (EG. 'phone')
+    @Test
+    public void testClientPoliciesWithIDPAndScopeCondition() {
+        realm.updateClientProfile(List.of(ClientProfileBuilder.create()
+                .name("reject-profile")
+                .description("Profile to reject request")
+                .executor(RejectRequestExecutorFactory.PROVIDER_ID, null)
+                .build()));
+
+        realm.updateClientPolicy(List.of(ClientPolicyBuilder.create()
+                .name("client policy")
+                .description("Policy to allow to call IDP brokering API for tokens from 'allowed-idp' just if incoming token has scope 'phone'")
+                .mode(ClientPolicyMode.STRICT)
+                .condition(IdentityProviderConditionFactory.PROVIDER_ID, ClientPolicyBuilder.identityProviderConditionConfiguration(false, IDP_ALIAS))
+                .condition(ClientScopesConditionFactory.PROVIDER_ID, ClientPolicyBuilder.clientScopesConditionConfiguration(true, ClientScopesConditionFactory.ANY,"phone"))
+                .profile("reject-profile")
+                .build()));
+
+        // Test calling the brokering API with the token without scope 'phone'. Request should be rejected
+        OAuthClient oauth = getOAuthClient();
+        oauth.openLoginForm();
+        loginWithIdP();
+
+        AccessTokenResponse tokenResponse = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
+        Assertions.assertTrue(tokenResponse.isSuccess());
+
+        AbstractHttpResponse externalTokens = doFetchExternalIdpToken(tokenResponse.getAccessToken());
+        Assertions.assertEquals(400, externalTokens.getStatusCode());
+        Assertions.assertEquals("Request not allowed", externalTokens.getErrorDescription());
+
+        logout();
+
+        // Test calling the brokering API with the token with scope 'phone'. Request should be allowed
+        oauth.scope("phone");
+        oauth.openLoginForm();
+        loginWithIdP();
+
+        tokenResponse = oauth.doAccessTokenRequest(oauth.parseLoginResponse().getCode());
+        Assertions.assertTrue(tokenResponse.isSuccess());
 
         externalTokens = doFetchExternalIdpToken(tokenResponse.getAccessToken());
         Assertions.assertTrue(externalTokens.isSuccess());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesLoadUpdateTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesLoadUpdateTest.java
@@ -33,6 +33,7 @@ import org.keycloak.representations.idm.ClientProfilesRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.services.clientpolicy.ClientPoliciesUtil;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ClientPolicyMode;
 import org.keycloak.services.clientpolicy.condition.ClientAccessTypeConditionFactory;
 import org.keycloak.services.clientpolicy.condition.ClientRolesConditionFactory;
 import org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory;
@@ -412,6 +413,42 @@ public class ClientPoliciesLoadUpdateTest extends AbstractClientPoliciesTest {
             return;
         }
         fail();
+    }
+
+    @Test
+    public void testPoliciesWithStrictMode() throws Exception {
+        String beforeUpdatePoliciesJson = ClientPoliciesUtil.convertClientPoliciesRepresentationToJson(getPolicies());
+
+        // Test invalid-mode would fail
+        ClientPolicyRepresentation clientPolicyRep =
+                (new ClientPolicyBuilder()).createPolicy(
+                                "builtin-duplicated-new-policy",
+                                "builtin duplicated new policy is ignored.",
+                                Boolean.TRUE)
+                        .addCondition(ClientRolesConditionFactory.PROVIDER_ID,
+                                createClientRolesConditionConfig(List.of(SAMPLE_CLIENT_ROLE)))
+                        .addProfile(FAPI1_BASELINE_PROFILE_NAME)
+                        .toRepresentation();
+        clientPolicyRep.setMode("INVALID");
+
+        String json = (new ClientPoliciesBuilder())
+                .addPolicy(clientPolicyRep)
+                .toString();
+        try {
+            updatePolicies(json);
+            fail("Not expected to update client policy with mode INVALID");
+        } catch (ClientPolicyException cpe) {
+            assertEquals("Bad Request", cpe.getErrorDetail());
+            String afterFailedUpdatePoliciesJson = ClientPoliciesUtil.convertClientPoliciesRepresentationToJson(getPolicies());
+            assertEquals(beforeUpdatePoliciesJson, afterFailedUpdatePoliciesJson);
+        }
+
+        // Test update with valid mode would be successful
+        clientPolicyRep.setMode(ClientPolicyMode.STRICT.toString());
+        json = (new ClientPoliciesBuilder())
+                .addPolicy(clientPolicyRep)
+                .toString();
+        updatePolicies(json);
     }
 
     @Test


### PR DESCRIPTION
closes #47410

PR introduces "Mode" option on client policy configuration. The "mode" is multi-select with options:
`DEFAULT` - client policy conditions are evaluated the same way as before this PR (at least one condition must be `yes`, none of the conditions must be `no`, conditions evaluated to `abstain` are ignored)
`STRICT` - all conditions must evaluate to `yes` (so `abstain` conditions are considered to not trigger policy, which is the difference in comparison to `DEFAULT` mode)

This allows to address use-cases like: Internal-to-external identity-broker API request for retrieve external token from IDP `facebook` is allowed just if internal token has scope `foo` . This is possible when `identity-provider-condition` is combined with the `client-scope-condition` (negative condition for the target scope) and together with client profile, which reject requests. See the test-case for the details (planning to document this as an example in the follow-up PR in the documentation).

If this approach is approved, I will follow with the documentation PR for this.
