### PR TITLE
Optimize SQL statements and transactions for cacheless profile

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -210,6 +210,12 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
         }
         expirationTask.start();
         if (factory.getProviderFactory(AuthenticationSessionProvider.class) instanceof JpaAuthenticationSessionProviderFactory) {
+            // Based on our internal knowledge on the JpaAuthenticationSessionProviderFactory, we can now assume that
+            // all actions on the authentication sessions are done with pessimistic locking in place. With this knowledge,
+            // we can later INSERT user session and client sessions and can be sure that there are no concurrent transactions
+            // running to do the same due pessimistic lock created earlier.
+            // TODO: In a future version, we might have a method in AuthenticationSessionProvider to query about that
+            // behavior to avoid reflection and internal knowledge.
             pessimisticLockingAuthenticationSession = true;
         }
     }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProviderFactory.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.keycloak.Config;
+import org.keycloak.authentication.jpa.JpaAuthenticationSessionProviderFactory;
 import org.keycloak.cluster.ClusterProvider;
 import org.keycloak.common.Profile;
 import org.keycloak.common.util.MultiSiteUtils;
@@ -64,6 +65,7 @@ import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
+import org.keycloak.sessions.AuthenticationSessionProvider;
 
 import org.jboss.logging.Logger;
 
@@ -101,6 +103,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
     private PersisterLastSessionRefreshStore persisterLastSessionRefreshStore;
     private boolean useCaches;
     private int expirationPeriodSeconds;
+    private boolean pessimisticLockingAuthenticationSession;
 
     @Override
     public UserSessionProvider create(KeycloakSession session) {
@@ -206,6 +209,9 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
             expirationTask = ExpirationTaskFactory.create(session, expirationPeriodSeconds);
         }
         expirationTask.start();
+        if (factory.getProviderFactory(AuthenticationSessionProvider.class) instanceof JpaAuthenticationSessionProviderFactory) {
+            pessimisticLockingAuthenticationSession = true;
+        }
     }
 
     public void initializePersisterLastSessionRefreshStore(final KeycloakSessionFactory sessionFactory) {
@@ -357,7 +363,7 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
 
     @Override
     public Set<Class<? extends Provider>> dependsOn() {
-        return Set.of(InfinispanConnectionProvider.class, InfinispanTransactionProvider.class);
+        return Set.of(InfinispanConnectionProvider.class, InfinispanTransactionProvider.class, AuthenticationSessionProvider.class);
     }
 
     public boolean useCaches() {
@@ -402,12 +408,14 @@ public class InfinispanUserSessionProviderFactory implements UserSessionProvider
     private PersistentTransaction createPersistentTransaction(KeycloakSession session) {
         var sessionTx = new UserSessionPersistentChangelogBasedTransaction(session,
                 sessionCacheHolder,
-                offlineSessionCacheHolder);
+                offlineSessionCacheHolder,
+                pessimisticLockingAuthenticationSession);
 
         var clientSessionTx = new ClientSessionPersistentChangelogBasedTransaction(session,
                 clientSessionCacheHolder,
                 offlineClientSessionCacheHolder,
-                sessionTx);
+                sessionTx,
+                pessimisticLockingAuthenticationSession);
 
         var transactionProvider = session.getProvider(InfinispanTransactionProvider.class);
         transactionProvider.registerTransaction(sessionTx);

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/ClientSessionPersistentChangelogBasedTransaction.java
@@ -41,13 +41,16 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
 
     private static final Logger LOG = Logger.getLogger(ClientSessionPersistentChangelogBasedTransaction.class);
     private final UserSessionPersistentChangelogBasedTransaction userSessionTx;
+    private final boolean pessimisticLockingAuthenticationSession;
 
     public ClientSessionPersistentChangelogBasedTransaction(KeycloakSession session,
                                                             CacheHolder<EmbeddedClientSessionKey, AuthenticatedClientSessionEntity> cacheHolder,
                                                             CacheHolder<EmbeddedClientSessionKey, AuthenticatedClientSessionEntity> offlineCacheHolder,
-                                                            UserSessionPersistentChangelogBasedTransaction userSessionTx) {
+                                                            UserSessionPersistentChangelogBasedTransaction userSessionTx,
+                                                            boolean pessimisticLockingAuthenticationSession) {
         super(session, CLIENT_SESSION_CACHE_NAME, cacheHolder, offlineCacheHolder);
         this.userSessionTx = userSessionTx;
+        this.pessimisticLockingAuthenticationSession = pessimisticLockingAuthenticationSession;
     }
 
     public void setUserSessionId(Collection<EmbeddedClientSessionKey> keys, String userSessionId, boolean offline) {
@@ -120,10 +123,9 @@ public class ClientSessionPersistentChangelogBasedTransaction extends Persistent
     protected boolean lockDatabaseEntity(RealmModel realm, EmbeddedClientSessionKey clientSessionKey, boolean offline, SessionUpdateTask.CacheOperation operation) {
         if (operation == SessionUpdateTask.CacheOperation.ADD_IF_ABSENT) {
             // There might be concurrent inserts for the same key, which can lead to conflicts.
-            // In the future, we could lock the user session optimistically,
-            // but then the alternative path of a separate transaction would always need to lock that entity as well all the time (not only opportunistically).
+            // If the authentication session was locked pessimistically, we can still perform the insert safely.
             // See UserSessionConcurrencyTest#testConcurrentNotesChange for a test.
-            return false;
+            return pessimisticLockingAuthenticationSession;
         } else {
             return kcSession.getProvider(UserSessionPersisterProvider.class).lockClientSession(realm, clientSessionKey.userSessionId(), clientSessionKey.clientId(), offline, operation == SessionUpdateTask.CacheOperation.REMOVE);
         }

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/changes/UserSessionPersistentChangelogBasedTransaction.java
@@ -35,11 +35,14 @@ import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.U
 public class UserSessionPersistentChangelogBasedTransaction extends PersistentSessionsChangelogBasedTransaction<String, UserSessionEntity> {
 
     private static final Logger LOG = Logger.getLogger(UserSessionPersistentChangelogBasedTransaction.class);
+    private final boolean pessimisticLockingAuthenticationSession;
 
     public UserSessionPersistentChangelogBasedTransaction(KeycloakSession session,
                                                           CacheHolder<String, UserSessionEntity> cacheHolder,
-                                                          CacheHolder<String, UserSessionEntity> offlineCacheHolder) {
+                                                          CacheHolder<String, UserSessionEntity> offlineCacheHolder,
+                                                          boolean pessimisticLockingAuthenticationSession) {
         super(session, USER_SESSION_CACHE_NAME, cacheHolder, offlineCacheHolder);
+        this.pessimisticLockingAuthenticationSession = pessimisticLockingAuthenticationSession;
     }
 
     public SessionEntityWrapper<UserSessionEntity> get(RealmModel realm, String key, UserSessionModel userSession, boolean offline) {
@@ -159,8 +162,8 @@ public class UserSessionPersistentChangelogBasedTransaction extends PersistentSe
     protected boolean lockDatabaseEntity(RealmModel realm, String userSessionId, boolean offline, SessionUpdateTask.CacheOperation operation) {
         if (operation == SessionUpdateTask.CacheOperation.ADD_IF_ABSENT) {
             // There might be concurrent inserts for the same key, which can lead to conflicts. One could lock the user instead, but that could lead to other problems.
-            // Then the alternative path of a separate transaction would always need to lock that entity as well all the time (not only opportunistically).
-            return false;
+            // If the authentication session was locked pessimistically, we can still perform the insert safely.
+            return pessimisticLockingAuthenticationSession;
         }
         return kcSession.getProvider(UserSessionPersisterProvider.class).lockUserSession(realm, userSessionId, offline, operation == SessionUpdateTask.CacheOperation.REMOVE);
     }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionEntity.java
@@ -17,7 +17,6 @@
 
 package org.keycloak.authentication.jpa;
 
-import java.io.Serializable;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
@@ -35,7 +34,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Table(name = "AUTH_SESSION")
 @DynamicUpdate
-@IdClass(AuthenticationSessionEntity.Key.class)
+@IdClass(AuthenticationSessionKey.class)
 public class AuthenticationSessionEntity {
 
     @Id
@@ -227,32 +226,4 @@ public class AuthenticationSessionEntity {
                 '}';
     }
 
-    public static class Key implements Serializable {
-        private RootAuthenticationSessionEntity rootAuthenticationSession;
-        private String tabId;
-
-        public Key() {
-        }
-
-        public Key(RootAuthenticationSessionEntity rootAuthenticationSession, String tabId) {
-            this.rootAuthenticationSession = rootAuthenticationSession;
-            this.tabId = tabId;
-        }
-
-        public RootAuthenticationSessionEntity getRootAuthenticationSession() {
-            return rootAuthenticationSession;
-        }
-
-        public void setRootAuthenticationSession(RootAuthenticationSessionEntity rootAuthenticationSession) {
-            this.rootAuthenticationSession = rootAuthenticationSession;
-        }
-
-        public String getTabId() {
-            return tabId;
-        }
-
-        public void setTabId(String tabId) {
-            this.tabId = tabId;
-        }
-    }
 }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionEntity.java
@@ -17,13 +17,14 @@
 
 package org.keycloak.authentication.jpa;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -34,15 +35,17 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Table(name = "AUTH_SESSION")
 @DynamicUpdate
+@IdClass(AuthenticationSessionEntity.Key.class)
 public class AuthenticationSessionEntity {
+
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ROOT_AUTH_SESSION_ID")
+    private RootAuthenticationSessionEntity rootAuthenticationSession;
 
     @Id
     @Column(name = "TAB_ID", length = 36)
     private String tabId;
-
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    @JoinColumn(name = "ROOT_AUTH_SESSION_ID")
-    private RootAuthenticationSessionEntity rootAuthenticationSession;
 
     @Column(name = "CLIENT_UUID")
     private String clientUUID;
@@ -222,5 +225,34 @@ public class AuthenticationSessionEntity {
                 "tabId='" + tabId + '\'' +
                 ", rootAuthenticationSessionId=" + (rootAuthenticationSession != null ? rootAuthenticationSession.getId() : null) + // avoid lazy-load just for a log message.
                 '}';
+    }
+
+    public static class Key implements Serializable {
+        private RootAuthenticationSessionEntity rootAuthenticationSession;
+        private String tabId;
+
+        public Key() {
+        }
+
+        public Key(RootAuthenticationSessionEntity rootAuthenticationSession, String tabId) {
+            this.rootAuthenticationSession = rootAuthenticationSession;
+            this.tabId = tabId;
+        }
+
+        public RootAuthenticationSessionEntity getRootAuthenticationSession() {
+            return rootAuthenticationSession;
+        }
+
+        public void setRootAuthenticationSession(RootAuthenticationSessionEntity rootAuthenticationSession) {
+            this.rootAuthenticationSession = rootAuthenticationSession;
+        }
+
+        public String getTabId() {
+            return tabId;
+        }
+
+        public void setTabId(String tabId) {
+            this.tabId = tabId;
+        }
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionKey.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionKey.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.jpa;
+
+import java.util.Objects;
+
+public record AuthenticationSessionKey(RootAuthenticationSessionEntity rootAuthenticationSession, String tabId) {
+    public AuthenticationSessionKey {
+        Objects.requireNonNull(rootAuthenticationSession);
+        Objects.requireNonNull(tabId);
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -101,6 +101,8 @@ public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransactio
         }
         var model = transientSessions.get(id);
         if (model != null && Objects.equals(model.getRealm().getId(), realm.getId())) {
+            // NOTE: Check if this session belongs to the correct realm to avoid a wrong cross-reference
+            // as a second line of defense.
             return model;
         }
 

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -18,6 +18,8 @@
 package org.keycloak.authentication.jpa;
 
 import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import jakarta.persistence.EntityManager;
@@ -26,7 +28,9 @@ import jakarta.persistence.LockModeType;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.AbstractKeycloakTransaction;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakTransaction;
 import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.utils.SessionExpiration;
@@ -41,6 +45,8 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
 
     private final KeycloakSession session;
     private final int authSessionsLimit;
+    private final Map<String, RootAuthenticationSessionAdapter> transientSessions = new HashMap<>();
+    private KeycloakTransaction transaction;
 
     public JpaAuthenticationSessionProvider(KeycloakSession session, int authSessionsLimit) {
         this.session = Objects.requireNonNull(session);
@@ -50,8 +56,28 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
     @Override
     public RootAuthenticationSessionModel createRootAuthenticationSession(RealmModel realm) {
         var model = RootAuthenticationSessionAdapter.create(session, realm, SecretGenerator.SECURE_ID_GENERATOR.get(), Time.currentTime(), authSessionsLimit);
-        getEntityManager().persist(model.getEntity());
+        // Those newly created authentication sessions with a random ID do not exist in the database, so there can not be any conflict.
+        // For resource owner password grants, those sessions are created temporarily, so we only insert them if they are not removed within the same session.
+        transientSessions.put(model.getEntity().getId(), model);
+        prepareTransaction();
         return model;
+    }
+
+    private void prepareTransaction() {
+        if (transaction == null) {
+            transaction = new AbstractKeycloakTransaction() {
+                @Override
+                protected void commitImpl() {
+                    transientSessions.forEach((key, value) -> getEntityManager().persist(value.getEntity()));
+                }
+
+                @Override
+                protected void rollbackImpl() {
+
+                }
+            };
+            session.getTransactionManager().enlistPrepare(transaction);
+        }
     }
 
     @Override
@@ -82,6 +108,10 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
         if (id == null) {
             return null;
         }
+        var model = transientSessions.get(id);
+        if (model != null && Objects.equals(model.getRealm().getId(), realm.getId())) {
+            return model;
+        }
 
         var em = getEntityManager();
         var entity = em.find(RootAuthenticationSessionEntity.class, id, LockModeType.PESSIMISTIC_WRITE);
@@ -99,6 +129,9 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
 
     @Override
     public void removeRootAuthenticationSession(RealmModel realm, RootAuthenticationSessionModel authenticationSession) {
+        if (transientSessions.remove(authenticationSession.getId()) != null) {
+            return;
+        }
         var em = getEntityManager();
         if (authenticationSession instanceof RootAuthenticationSessionAdapter adapter) {
             em.remove(adapter.getEntity());

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProvider.java
@@ -39,7 +39,7 @@ import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import org.jboss.logging.Logger;
 
-public class JpaAuthenticationSessionProvider implements AuthenticationSessionProvider {
+public class JpaAuthenticationSessionProvider extends AbstractKeycloakTransaction implements AuthenticationSessionProvider {
 
     private final static Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -47,6 +47,7 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
     private final int authSessionsLimit;
     private final Map<String, RootAuthenticationSessionAdapter> transientSessions = new HashMap<>();
     private KeycloakTransaction transaction;
+    private boolean enlisted;
 
     public JpaAuthenticationSessionProvider(KeycloakSession session, int authSessionsLimit) {
         this.session = Objects.requireNonNull(session);
@@ -64,19 +65,9 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
     }
 
     private void prepareTransaction() {
-        if (transaction == null) {
-            transaction = new AbstractKeycloakTransaction() {
-                @Override
-                protected void commitImpl() {
-                    transientSessions.forEach((key, value) -> getEntityManager().persist(value.getEntity()));
-                }
-
-                @Override
-                protected void rollbackImpl() {
-
-                }
-            };
-            session.getTransactionManager().enlistPrepare(transaction);
+        if (!enlisted) {
+            enlisted = true;
+            session.getTransactionManager().enlistPrepare(this);
         }
     }
 
@@ -158,5 +149,14 @@ public class JpaAuthenticationSessionProvider implements AuthenticationSessionPr
 
     private EntityManager getEntityManager() {
         return session.getProvider(JpaConnectionProvider.class).getEntityManager();
+    }
+
+    @Override
+    protected void commitImpl() {
+        transientSessions.forEach((key, value) -> getEntityManager().persist(value.getEntity()));
+    }
+
+    @Override
+    protected void rollbackImpl() {
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProviderFactory.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/JpaAuthenticationSessionProviderFactory.java
@@ -38,11 +38,12 @@ import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
+import org.keycloak.sessions.AuthenticationSessionProvider;
 import org.keycloak.sessions.AuthenticationSessionProviderFactory;
 
 import org.jboss.logging.Logger;
 
-public class JpaAuthenticationSessionProviderFactory implements AuthenticationSessionProviderFactory<JpaAuthenticationSessionProvider>, EnvironmentDependentProviderFactory, ServerInfoAwareProviderFactory {
+public class JpaAuthenticationSessionProviderFactory implements AuthenticationSessionProviderFactory<AuthenticationSessionProvider>, EnvironmentDependentProviderFactory, ServerInfoAwareProviderFactory {
 
     private final static Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
     public static final String PROVIDER_ID = "jpa";

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
@@ -134,7 +134,7 @@ class RootAuthenticationSessionAdapter implements RootAuthenticationSessionModel
 
     @Override
     public void removeAuthenticationSessionByTabId(String tabId) {
-        entity.getAuthenticationSessions().remove(tabId);
+        entity.getAuthenticationSessions().remove(tabId).setRootAuthenticationSession(null);
         if (adapters != null) {
             adapters.remove(tabId);
         }

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionAdapter.java
@@ -134,7 +134,7 @@ class RootAuthenticationSessionAdapter implements RootAuthenticationSessionModel
 
     @Override
     public void removeAuthenticationSessionByTabId(String tabId) {
-        entity.getAuthenticationSessions().remove(tabId).setRootAuthenticationSession(null);
+        session.getProvider(JpaConnectionProvider.class).getEntityManager().remove(entity.getAuthenticationSessions().remove(tabId));
         if (adapters != null) {
             adapters.remove(tabId);
         }

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/JpaUserSessionPersisterProvider.java
@@ -73,6 +73,8 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     private final KeycloakSession session;
     private final EntityManager em;
     private final int expirationBatch;
+    private final Set<PersistentUserSessionEntity.Key> userSessionNotInDatabaseCache = new HashSet<>();
+    private final Set<PersistentClientSessionEntity.Key> clientSessionNotInDatabaseCache = new HashSet<>();
 
     public JpaUserSessionPersisterProvider(KeycloakSession session, EntityManager em, int expirationBatch) {
         this.session = session;
@@ -97,6 +99,7 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         entity.setBrokerSessionId(userSession.getBrokerSessionId());
         entity.setRememberMe(userSession.isRememberMe());
         em.persist(entity);
+        userSessionNotInDatabaseCache.remove(new PersistentUserSessionEntity.Key(userSession.getId(), offlineStr));
     }
 
     @Override
@@ -121,7 +124,14 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
         String offlineStr = offlineToString(offline);
         boolean exists = false;
 
-        PersistentClientSessionEntity entity = em.find(PersistentClientSessionEntity.class, new PersistentClientSessionEntity.Key(userSessionId, clientId, clientStorageProvider, externalClientId, offlineStr));
+        PersistentClientSessionEntity entity = null;
+        PersistentClientSessionEntity.Key key = new PersistentClientSessionEntity.Key(userSessionId, clientId, clientStorageProvider, externalClientId, offlineStr);
+        if (!clientSessionNotInDatabaseCache.contains(key)) {
+            entity = em.find(PersistentClientSessionEntity.class, key);
+        } else {
+            clientSessionNotInDatabaseCache.remove(key);
+        }
+
         if (entity != null) {
             // client session can already exist in some circumstances (EG. in case it was already present, but expired in the infinispan, but not yet expired in the DB)
             exists = true;
@@ -295,12 +305,19 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
 
     @Override
     public UserSessionModel loadUserSession(RealmModel realm, String userSessionId, boolean offline) {
-
         String offlineStr = offlineToString(offline);
 
-        PersistentUserSessionEntity entity = em.find(PersistentUserSessionEntity.class, new PersistentUserSessionEntity.Key(userSessionId, offlineStr));
-        if (entity != null && !Objects.equals(entity.getRealmId(), realm.getId())) {
-            entity = null;
+        PersistentUserSessionEntity.Key key = new PersistentUserSessionEntity.Key(userSessionId, offlineStr);
+
+        PersistentUserSessionEntity entity = null;
+        if (!userSessionNotInDatabaseCache.contains(key)) {
+            entity = em.find(PersistentUserSessionEntity.class, key);
+            if (entity == null) {
+                userSessionNotInDatabaseCache.add(key);
+            }
+            if (entity != null && !Objects.equals(entity.getRealmId(), realm.getId())) {
+                entity = null;
+            }
         }
 
         return handleSingleQuery(entity, offlineStr);
@@ -429,9 +446,15 @@ public class JpaUserSessionPersisterProvider implements UserSessionPersisterProv
     public AuthenticatedClientSessionModel loadClientSession(RealmModel realm, ClientModel client, UserSessionModel userSession, boolean offline) {
         PersistentClientSessionEntity.Key key = getClientSessionKey(client.getId(), userSession.getId(), offline);
 
-        PersistentClientSessionEntity entity = em.find(PersistentClientSessionEntity.class, key);
-        if (entity != null && !Objects.equals(entity.getRealmId(), realm.getId())) {
-            entity = null;
+        PersistentClientSessionEntity entity = null;
+        if (!clientSessionNotInDatabaseCache.contains(key)) {
+            entity = em.find(PersistentClientSessionEntity.class, key);
+            if (entity == null) {
+                clientSessionNotInDatabaseCache.add(key);
+            }
+            if (entity != null && !Objects.equals(entity.getRealmId(), realm.getId())) {
+                entity = null;
+            }
         }
 
         return entity != null ? toAdapter(realm, client, userSession, entity) : null;

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -292,10 +292,10 @@
             </not>
         </preConditions>
         <createTable tableName="AUTH_SESSION">
-            <column name="TAB_ID" type="VARCHAR(36)">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="PK_AUTH_SESSION"/>
-            </column>
             <column name="ROOT_AUTH_SESSION_ID" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="TAB_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="CLIENT_UUID" type="VARCHAR(255)"/>
@@ -313,23 +313,14 @@
             <column name="USER_SESSION_NOTES" type="TEXT"/>
         </createTable>
 
+        <addPrimaryKey tableName="AUTH_SESSION" columnNames="ROOT_AUTH_SESSION_ID, TAB_ID" constraintName="PK_AUTH_SESSION" />
+
         <addForeignKeyConstraint baseColumnNames="ROOT_AUTH_SESSION_ID"
                                  baseTableName="AUTH_SESSION"
                                  constraintName="FK_AUTH_SESSION_ROOT"
                                  referencedColumnNames="ID"
                                  referencedTableName="ROOT_AUTH_SESSION"
                                  onDelete="CASCADE"/>
-    </changeSet>
-
-    <changeSet author="keycloak" id="26.7.0-persistent-auth-session-index">
-        <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
-            <not>
-                <indexExists indexName="IDX_AUTH_SESSION_ROOT"/>
-            </not>
-        </preConditions>
-        <createIndex tableName="AUTH_SESSION" indexName="IDX_AUTH_SESSION_ROOT">
-            <column name="ROOT_AUTH_SESSION_ID"/>
-        </createIndex>
     </changeSet>
 
     <changeSet author="keycloak" id="26.7.0-single-use-object-table">

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -44,6 +44,7 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.enums.SslRequired;
 import org.keycloak.common.util.Base64Url;
 import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.crypto.ECDSAAlgorithm;
 import org.keycloak.crypto.JavaAlgorithm;
@@ -59,6 +60,7 @@ import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.keys.GeneratedEddsaKeyProviderFactory;
 import org.keycloak.keys.KeyProvider;
 import org.keycloak.models.Constants;
+import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.utils.KeycloakModelUtils;
@@ -113,6 +115,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -201,7 +205,34 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
     @Test
     public void accessTokenRequest() throws Exception {
+        runOnServerMaster.run(session -> {
+            Statistics stats = statistics(session);
+            stats.setStatisticsEnabled(true);
+            stats.clear();
+        });
+
         oauth.doLogin("test-user@localhost", "password");
+
+        runOnServerMaster.run(session -> {
+            Statistics stats = statistics(session);
+            if (!Profile.isFeatureEnabled(Profile.Feature.CACHELESS) && Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
+                assertEquals(1, stats.getEntityStatistics("org.keycloak.models.jpa.session.PersistentUserSessionEntity").getInsertCount());
+                assertEquals(4, stats.getSuccessfulTransactionCount());
+            } else if (Profile.isFeatureEnabled(Profile.Feature.CACHELESS)) {
+                // user session
+                assertEquals(0, stats.getEntityStatistics("org.keycloak.models.jpa.session.PersistentUserSessionEntity").getUpdateCount());
+                assertEquals(1, stats.getEntityStatistics("org.keycloak.models.jpa.session.PersistentUserSessionEntity").getInsertCount());
+                assertEquals(0, stats.getEntityStatistics("org.keycloak.models.jpa.session.PersistentUserSessionEntity").getFetchCount());
+                // authentication session
+                assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getLoadCount());
+                assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getUpdateCount());
+                assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getInsertCount());
+                assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getDeleteCount());
+                assertEquals(0, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getFetchCount());
+                // Total transactions: Open login page, submit password, perform code-to-token exchange = 3 transactions
+                assertEquals(3, stats.getSuccessfulTransactionCount());
+            }
+        });
 
         EventRepresentation loginEvent = EventAssertion.expectLoginSuccess(events.poll()).getEvent();
 
@@ -276,6 +307,13 @@ public class AccessTokenTest extends AbstractKeycloakTest {
         assertEquals(oauth.parseRefreshToken(response.getRefreshToken()).getId(), event.getDetails().get(Details.REFRESH_TOKEN_ID));
         assertEquals(sessionId, token.getSessionState());
 
+    }
+
+    private static Statistics statistics(KeycloakSession session) {
+        return session.getProvider(JpaConnectionProvider.class).getEntityManager()
+                .getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/AccessTokenTest.java
@@ -205,6 +205,11 @@ public class AccessTokenTest extends AbstractKeycloakTest {
 
     @Test
     public void accessTokenRequest() throws Exception {
+        // Avoid existing authentication session to interfere with Hibernate statistics count
+        oauth.openLoginForm();
+        driver.manage().deleteAllCookies();
+        driver.get("about:blank");
+
         runOnServerMaster.run(session -> {
             Statistics stats = statistics(session);
             stats.setStatisticsEnabled(true);
@@ -225,7 +230,7 @@ public class AccessTokenTest extends AbstractKeycloakTest {
                 assertEquals(0, stats.getEntityStatistics("org.keycloak.models.jpa.session.PersistentUserSessionEntity").getFetchCount());
                 // authentication session
                 assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getLoadCount());
-                assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getUpdateCount());
+                assertEquals(0, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getUpdateCount());
                 assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getInsertCount());
                 assertEquals(1, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getDeleteCount());
                 assertEquals(0, stats.getEntityStatistics("org.keycloak.authentication.jpa.RootAuthenticationSessionEntity").getFetchCount());

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionConcurrencyTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/session/UserSessionConcurrencyTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
+import org.keycloak.common.Profile;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
@@ -82,6 +83,21 @@ public class UserSessionConcurrencyTest extends KeycloakModelTest {
 
         // Create/Update client session's notes concurrently
         CountDownLatch cdl = new CountDownLatch(20 * CLIENTS_COUNT);
+        if (Profile.Feature.CACHELESS.isAvailable()) {
+            // In cachless mode, the authentication sessions are pessimistically locked,
+            // therefore there can be no concurrency with the when creating client sessions.
+            IntStream.range(0, CLIENTS_COUNT)
+                    .forEach(i -> inComittedTransaction(i, (session, n) -> {
+                        RealmModel realm = session.realms().getRealm(realmId);
+                        session.getContext().setRealm(realm);
+                        ClientModel client = realm.getClientByClientId("client" + n);
+
+                        UserSessionModel uSession = session.sessions().getUserSession(realm, uId);
+                        session.sessions().createClientSession(realm, client, uSession);
+
+                        return null;
+                    }));
+        }
         IntStream.range(0, 20 * CLIENTS_COUNT).parallel()
                 .forEach(i -> inComittedTransaction(i, (session, n) -> { try {
                     RealmModel realm = session.realms().getRealm(realmId);


### PR DESCRIPTION
Closes #49697

Before when submitting a username and password to the login form: 

<img width="476" height="994" alt="603032181-4f02e827-9f1d-4c91-bcf6-068651158d13" src="https://github.com/user-attachments/assets/c5a2d9a3-c50b-4a61-bba6-d121b524a19e" />

After: 

<img width="556" height="954" alt="image" src="https://github.com/user-attachments/assets/ae3beced-5a14-4460-b9b3-feb656f6f2dd" />


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->


Before for resource owner credential grant: 

<img width="499" height="1138" alt="image" src="https://github.com/user-attachments/assets/515fdac2-0fac-4fd7-94dd-e6dde542c1a0" />

After with fewer spans, no insert/update/delete for the authentication session, and no separate transaction for the user session: 

<img width="578" height="1203" alt="image" src="https://github.com/user-attachments/assets/2f25e861-f868-4c43-8d99-f63f0e5bc6c8" />

