### PR TITLE
[26.4] Cannot build project due to ISPN protoschema and 26.2 branch

### DIFF
--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -132,7 +132,7 @@
                     </execution>
                 </executions>
                 <configuration combine.self="append">
-                    <remoteLockFiles>https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.1/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/release/26.2/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.3/model/infinispan/proto.lock</remoteLockFiles>
+                    <remoteLockFiles>https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.1/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.2/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.3/model/infinispan/proto.lock</remoteLockFiles>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Closes #49707


(cherry picked from commit 2b8af814eff917dd2aed5f04a94663e6d2089eed)

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
