### PR TITLE
[Login UI] Improve credential selector layout

### DIFF
--- a/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
+++ b/themes/src/main/resources/theme/keycloak.v2/login/select-authenticator.ftl
@@ -15,7 +15,7 @@
                     <input type="hidden" name="authenticationExecution" value="${authenticationSelection.authExecId}">
                 </form>
                 <div role="button" class="${properties.kcSelectAuthListItemClass!}" onclick="document.forms[${authenticationSelection?index}].requestSubmit()" tabindex="0">
-                    <div class="pf-v5-c-data-list__item-content">
+                    <div class="pf-v5-c-data-list__item-content pf-v5-u-flex-wrap-wrap">
                         <div class="${properties.kcSelectAuthListItemIconClass!}">
                             <i class="${properties['${authenticationSelection.iconCssClass}']!authenticationSelection.iconCssClass} ${properties.kcSelectAuthListItemIconPropertyClass!}"></i>
                         </div>

--- a/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
+++ b/themes/src/main/resources/theme/keycloak.v2/login/theme.properties
@@ -82,7 +82,7 @@ kcSelectAuthListItemHeadingClass=pf-v5-u-font-family-heading select-auth-box-hea
 kcSelectAuthListItemBodyClass=pf-v5-c-data-list__cell pf-m-no-fill pf-v5-u-pt-md pf-v5-u-pb-md
 kcSelectAuthListItemIconClass=pf-v5-c-data-list__cell pf-m-icon pf-v5-u-display-flex pf-v5-u-pt-0 pf-v5-u-align-items-center 
 kcSelectAuthListItemFillClass=pf-v5-c-data-list__item-action
-kcSelectAuthListItemDescriptionClass=pf-v5-c-data-list__cell pf-m-no-fill select-auth-box-desc
+kcSelectAuthListItemDescriptionClass=pf-v5-c-data-list__cell pf-m-no-fill pf-v5-u-w-100 pf-v5-u-pt-0 pf-v5-u-font-size-sm pf-v5-u-color-200 select-auth-box-desc
 kcSelectAuthListItemSubtitleClass=pf-v5-u-color-200 pf-v5-u-font-size-sm
 kcSelectAuthListItemArrowIconClass=fa fa-angle-right fa-lg
 


### PR DESCRIPTION
- Closes #49711

## Old
<img width="816" height="808" alt="Screenshot From 2026-06-05 10-43-37" src="https://github.com/user-attachments/assets/2ef574ea-7a16-433a-afc1-bdfe8b8fab53" />

## New
<img width="816" height="808" alt="Screenshot From 2026-06-05 10-57-21" src="https://github.com/user-attachments/assets/b49b98ef-4c9e-4317-bd84-7b0b094aa8af" />

@keycloak/core-authn Could you please check it? Thanks!