### PR TITLE
Fix FreeMarkerLoginFormsProvider calling handleThemeResources twice p…

### DIFF
--- a/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/FreeMarkerLoginFormsProvider.java
@@ -503,7 +503,7 @@ public class FreeMarkerLoginFormsProvider implements LoginFormsProvider {
         if (realm != null) {
             RealmBean realmBean = new RealmBean(realm);
             attributes.put("realm", realmBean);
-            attributes.put("title", getMessage("loginTitle", realmBean.getDisplayName()));
+            attributes.put("title", formatMessage(new FormMessage(null, "loginTitle", realmBean.getDisplayName()), messagesBundle, locale));
 
             IdentityProviderBean idpBean = new IdentityProviderBean(session, realm, baseUriWithCodeAndClientId, context);
 


### PR DESCRIPTION
…er render

Fixes #49718

getMessage() in createCommonAttributes() internally called formatMessage(FormMessage), which re-resolved theme and locale from scratch via handleThemeResources(). This caused a redundant load of the message bundle (theme.getEnhancedMessages) and theme properties (theme.getProperties) on every login page render.

Replace getMessage() with the direct formatMessage(message, messagesBundle, locale) overload, using the already-resolved bundle and locale already available as parameters in createCommonAttributes().

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
