### PR TITLE
Use BCFKS stores for the fips CI tests suites

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/suites/FipsNonStrictTestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/FipsNonStrictTestSuite.java
@@ -63,7 +63,7 @@ public class FipsNonStrictTestSuite {
                     .tlsEnabled(true)
                     .mTlsEnabled(true)
                     .keystoreFormat(KeystoreUtil.KeystoreFormat.BCFKS)
-                    .stores("keycloak.bcfks", "keycloak-truststore.pem", "client.bcfks", "keycloak-truststore.bcfks");
+                    .stores("keycloak.bcfks", "keycloak-truststore.bcfks", "client.bcfks", "keycloak-truststore.bcfks");
         }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/suites/FipsStrictTestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/FipsStrictTestSuite.java
@@ -66,7 +66,7 @@ public class FipsStrictTestSuite {
                     .tlsEnabled(true)
                     .mTlsEnabled(true)
                     .keystoreFormat(KeystoreUtil.KeystoreFormat.BCFKS)
-                    .stores("keycloak.bcfks", "keycloak-truststore.pem", "client.bcfks", "keycloak-truststore.bcfks");
+                    .stores("keycloak.bcfks", "keycloak-truststore.bcfks", "client.bcfks", "keycloak-truststore.bcfks");
         }
     }
 }


### PR DESCRIPTION
Closes #49723

Changing the pem for bcfks to make FIPS jobs work again in CI.
