### PR TITLE
Fix null value when permitted domains is not set in SecureRedirectUrisEnforcerExecutor

### DIFF
--- a/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
+++ b/js/apps/admin-ui/src/components/dynamic/MultivaluedStringComponent.tsx
@@ -5,7 +5,14 @@ import { MultiLineInput } from "../multi-line-input/MultiLineInput";
 import type { ComponentProps } from "./components";
 
 function convertDefaultValue(formValue?: any): string[] {
-  return formValue && Array.isArray(formValue) ? formValue : [formValue];
+  if (Array.isArray(formValue)) {
+    const values = formValue.filter(
+      (value) => value !== null && value !== undefined,
+    );
+    return values.length > 0 ? values : [""];
+  }
+
+  return formValue !== null && formValue !== undefined ? [formValue] : [""];
 }
 
 export const MultiValuedStringComponent = ({

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
@@ -485,7 +485,10 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
             }
 
             if (config.getAllowPermittedDomains() != null && !config.getAllowPermittedDomains().isEmpty()) {
-                if (!matchDomains(config.getAllowPermittedDomains())) {
+                List<String> validPermittedDomains = config.getAllowPermittedDomains().stream()
+                        .filter(domain -> domain != null && !domain.isBlank())
+                        .toList();
+                if (!validPermittedDomains.isEmpty() && !matchDomains(validPermittedDomains)) {
                     logger.debugv("Invalid NormalUri: no permitted domain matched - input = {0}", uri.toString());
                     return false;
                 }

--- a/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
@@ -407,6 +407,41 @@ public class SecureRedirectUrisEnforcerExecutorTest {
         ).forEach(i->checkSuccess(i, false));
     }
 
+    @Test
+    public void successNormalUri_BlankOnlyPermittedDomainsNotEnforced() {
+        // A permitted-domains list that contains only the empty-string default should be treated as "no restriction"
+        ArrayNode arrayNode = JsonSerialization.mapper.createArrayNode();
+        arrayNode.add("");
+        configuration.set(ALLOW_PERMITTED_DOMAINS, arrayNode);
+
+        checkSuccess("https://example.org/realms/master", false);
+        checkSuccess("https://other.org/path", false);
+    }
+
+    @Test
+    public void normalUri_BlankEntriesMixedWithValidPermittedDomains() {
+        // Blank entries in the permitted-domains list must be ignored; valid entries still enforced
+        ArrayNode arrayNode = JsonSerialization.mapper.createArrayNode();
+        arrayNode.add("");
+        arrayNode.add("example.org");
+        configuration.set(ALLOW_PERMITTED_DOMAINS, arrayNode);
+
+        checkSuccess("https://example.org/realms/master", false);
+        checkFail("https://other.org/realms/master", false, SecureRedirectUrisEnforcerExecutor.ERR_NORMALURI);
+    }
+
+    @Test
+    public void normalUri_NullEntriesMixedWithValidPermittedDomains() {
+        // Null entries in the permitted-domains list must be ignored; valid entries still enforced
+        ArrayNode arrayNode = JsonSerialization.mapper.createArrayNode();
+        arrayNode.addNull();
+        arrayNode.add("example.org");
+        configuration.set(ALLOW_PERMITTED_DOMAINS, arrayNode);
+
+        checkSuccess("https://example.org/realms/master", false);
+        checkFail("https://other.org/realms/master", false, SecureRedirectUrisEnforcerExecutor.ERR_NORMALURI);
+    }
+
     private void permittedDomains(String... domains) {
         ArrayNode arrayNode = JsonSerialization.mapper.createArrayNode();
         Arrays.stream(domains).forEach(arrayNode::add);


### PR DESCRIPTION
Addresses a `NullPointerException`  in SecureRedirectUrisEnforcerExecutor when allow permitted domains is left intentional empty in the admin console. 

Changes:
- Updated MultivaluedStringComponent#convertDefaultValue to return an empty array when the value is null, instead of adding null to the array.
- Added an additional null check for config.getAllowPermittedDomains() in SecureRedirectUrisEnforcerExecutor.

I am not sure whether both changes are necessary. The null check in SecureRedirectUrisEnforcerExecutor may be sufficient on its own.
I am also unsure whether changing MultivaluedStringComponent could affect other code paths that rely on its current behavior. 

Feedback on the preferred approach is much welcome.

Closes #49252

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
