### PR TITLE
Write transactions touching ephemeral data asynchronously on PostgreSQL

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -62,6 +62,13 @@ The experimental feature `dynamic-scopes` has been renamed to `parameterized-sco
 
 The corresponding Java model methods in `ClientScopeModel` (`isDynamicScope()`, `setIsDynamicScope()`, `getDynamicScopeRegexp()`) and constants (`IS_DYNAMIC_SCOPE`, `DYNAMIC_SCOPE_REGEXP`) have been deprecated in favor of their `parameterized` counterparts. The deprecated methods and constants will be removed in a future major release. The underlying database attribute names (`is.dynamic.scope`, `dynamic.scope.regexp`) are automatically migrated to `is.parameterized.scope` and `parameterized.scope.regexp` during upgrade.
 
+=== Asynchronous commit on PostgreSQL databases
+
+Transactions that update only ephemeral tables like persisted user sessions, client sessions, login failures, or events will use PostgreSQL's async commit feature.
+Logouts will still force a synchronous commit.
+
+You can opt out of this feature by setting `+--spi-connections-jpa--quarkus--async-commit=false+`
+
 === Parameterized scopes now require a parameter type
 
 When the `parameterized-scopes` feature is enabled, creating or updating a parameterized scope via the Admin REST API now requires a `parameterized.scope.type` attribute. Available types are `string`, `integer`, `boolean`, `username`, and `custom`. The `custom` type additionally requires a `parameterized.scope.regexp` attribute with a valid regular expression. Requests using the old regexp-only format (without a type) are rejected.

--- a/docs/guides/server/db.adoc
+++ b/docs/guides/server/db.adoc
@@ -298,6 +298,13 @@ Default: `10s`.
 
 == Preparing for PostgreSQL
 
+=== Asynchronous commits
+
+Transactions that update only ephemeral tables like persisted user sessions, client sessions, login failures, or events will use PostgreSQL's async commit feature.
+Logouts will still force a synchronous commit.
+
+You can opt out of this feature by setting `+--spi-connections-jpa--quarkus--async-commit=false+`
+
 === Writer and reader instances
 
 When running PostgreSQL reader and writer instances, {project_name} needs to always connect to the writer instance to do its work.
@@ -337,6 +344,8 @@ Secure the connection by adding the options:
 
 [[preparing-keycloak-for-amazon-aurora-postgresql]]
 == Preparing for Amazon Aurora PostgreSQL
+
+Asynchronous commits, an optimization for PostgreSQL databases, are disabled when logical replication is enabled as they might conflict with Debezium change data capture.
 
 When using Amazon Aurora PostgreSQL, the https://github.com/awslabs/aws-advanced-jdbc-wrapper[Amazon Web Services JDBC Driver] offers additional features like transfer of database connections when a writer instance changes in a Multi-AZ setup.
 This driver is not part of the distribution and needs to be installed before it can be used.

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/AuthenticationSessionEntity.java
@@ -29,13 +29,15 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Table(name = "AUTH_SESSION")
 @DynamicUpdate
 @IdClass(AuthenticationSessionKey.class)
-public class AuthenticationSessionEntity {
+public class AuthenticationSessionEntity implements AsynchronousCommitAllowed {
 
     @Id
     @ManyToOne(fetch = FetchType.LAZY)

--- a/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/authentication/jpa/RootAuthenticationSessionEntity.java
@@ -33,6 +33,8 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 import org.hibernate.annotations.DynamicUpdate;
 
 @NamedQueries({
@@ -58,7 +60,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Table(name = "ROOT_AUTH_SESSION")
 @DynamicUpdate
-public class RootAuthenticationSessionEntity {
+public class RootAuthenticationSessionEntity implements AsynchronousCommitAllowed {
 
     @Id
     @Column(name = "ID", length = 36)

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
@@ -27,6 +27,7 @@ import jakarta.persistence.EntityManagerFactory;
 
 import org.hibernate.Session;
 import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventType;
@@ -145,7 +146,8 @@ public class AsyncCommitIntegrator implements PreInsertEventListener, PreUpdateE
      */
     private static boolean isAuroraWithLogicalReplication(SessionFactoryImplementor sf) {
         try {
-            Connection connection = sf.getJdbcServices().getBootstrapJdbcConnectionAccess().obtainConnection();
+            JdbcConnectionAccess bootstrapJdbcConnectionAccess = sf.getJdbcServices().getBootstrapJdbcConnectionAccess();
+            Connection connection = bootstrapJdbcConnectionAccess.obtainConnection();
             try {
                 try (Statement stmt = connection.createStatement();
                      ResultSet rs = stmt.executeQuery("SELECT aurora_version()")) {
@@ -161,7 +163,7 @@ public class AsyncCommitIntegrator implements PreInsertEventListener, PreUpdateE
                     return rs.next() && "logical".equals(rs.getString(1));
                 }
             } finally {
-                sf.getJdbcServices().getBootstrapJdbcConnectionAccess().releaseConnection(connection);
+                bootstrapJdbcConnectionAccess.releaseConnection(connection);
             }
         } catch (SQLException e) {
             logger.warn("Failed to detect Aurora/logical replication status; disabling asynchronous commit optimization", e);

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/AsyncCommitIntegrator.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.jpa;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+
+import jakarta.persistence.EntityManagerFactory;
+
+import org.hibernate.Session;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PreDeleteEvent;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreInsertEvent;
+import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreUpdateEvent;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.jboss.logging.Logger;
+
+/**
+ * Hibernate event listener that enables asynchronous commit for PostgreSQL transactions
+ * that only modify entities implementing {@link AsynchronousCommitAllowed}.
+ * <p>
+ * On PostgreSQL, issues {@code SET LOCAL synchronous_commit TO OFF} before commit when
+ * all modified entities in the transaction allow it. This skips the WAL fsync wait,
+ * improving throughput for ephemeral data. The database remains crash-consistent;
+ * only the last few milliseconds of such transactions may be lost on a crash.
+ * <p>
+ * On non-PostgreSQL databases, {@link #registerListeners(EntityManagerFactory)} is a no-op.
+ *
+ * @author Alexander Schwartz
+ */
+public class AsyncCommitIntegrator implements PreInsertEventListener, PreUpdateEventListener, PreDeleteEventListener {
+
+    private static final Logger logger = Logger.getLogger(AsyncCommitIntegrator.class);
+
+    private static final String SYNC_REQUIRED = "kc.sync_commit_required";
+    private static final String CALLBACK_REGISTERED = "kc.async_commit.registered";
+
+    /**
+     * Registers asynchronous commit listeners on the given {@link EntityManagerFactory}
+     * if the underlying database is PostgreSQL. No-op for other databases.
+     */
+    public static void registerListeners(EntityManagerFactory emf) {
+        SessionFactoryImplementor sf = emf.unwrap(SessionFactoryImplementor.class);
+        if (!(sf.getJdbcServices().getDialect() instanceof PostgreSQLDialect)) {
+            return;
+        }
+
+        if (isAuroraWithLogicalReplication(sf)) {
+            logger.warn("Asynchronous commit optimization disabled: Aurora PostgreSQL with logical replication " +
+                    "detected. Aurora may not deliver async-committed transactions to logical decoding consumers.");
+            return;
+        }
+
+        AsyncCommitIntegrator listener = new AsyncCommitIntegrator();
+        var registry = sf.getEventEngine().getListenerRegistry();
+        registry.appendListeners(EventType.PRE_INSERT, listener);
+        registry.appendListeners(EventType.PRE_UPDATE, listener);
+        registry.appendListeners(EventType.PRE_DELETE, listener);
+
+        logger.debug("Registered asynchronous commit listeners for PostgreSQL");
+    }
+
+    @Override
+    public boolean onPreInsert(PreInsertEvent event) {
+        handleEntity(event.getEntity(), event.getSession(), AsynchronousCommitAllowed.EntityOperationType.INSERT);
+        return false;
+    }
+
+    @Override
+    public boolean onPreUpdate(PreUpdateEvent event) {
+        handleEntity(event.getEntity(), event.getSession(), AsynchronousCommitAllowed.EntityOperationType.UPDATE);
+        return false;
+    }
+
+    @Override
+    public boolean onPreDelete(PreDeleteEvent event) {
+        handleEntity(event.getEntity(), event.getSession(), AsynchronousCommitAllowed.EntityOperationType.DELETE);
+        return false;
+    }
+
+    private void handleEntity(Object entity, SharedSessionContractImplementor session, AsynchronousCommitAllowed.EntityOperationType opType) {
+        if (!(session instanceof Session s)) {
+            return;
+        }
+
+        Map<String, Object> props = s.getProperties();
+
+        if (Boolean.TRUE.equals(props.get(SYNC_REQUIRED))) {
+            return;
+        }
+
+        if (props.get(CALLBACK_REGISTERED) == null) {
+            s.setProperty(CALLBACK_REGISTERED, Boolean.TRUE);
+            session.getTransactionCompletionCallbacks().registerCallback(
+                    (SharedSessionContractImplementor sess) -> {
+                        if (!Boolean.TRUE.equals(((Session) sess).getProperties().get(SYNC_REQUIRED))) {
+                            sess.doWork(AsyncCommitIntegrator::setAsyncCommit);
+                        }
+                    }
+            );
+        }
+
+        if (entity instanceof AsynchronousCommitAllowed asyncEntity) {
+            if (!asyncEntity.isAsyncCommitAllowed(opType)) {
+                s.setProperty(SYNC_REQUIRED, Boolean.TRUE);
+            }
+        } else {
+            s.setProperty(SYNC_REQUIRED, Boolean.TRUE);
+        }
+    }
+
+    /**
+     * Detects Aurora PostgreSQL with logical replication enabled — a combination where
+     * {@code SET LOCAL synchronous_commit TO OFF} can cause committed transactions to
+     * never appear (or appear with extreme delay) in logical decoding consumers like Debezium.
+     * <p>
+     * Detection: {@code SELECT aurora_version()} only exists on Aurora (throws on standard PG);
+     * {@code SHOW wal_level = 'logical'} indicates a CDC consumer may be reading the WAL.
+     * Fails safe (returns {@code true}) on unexpected errors to avoid silent CDC data loss.
+     *
+     * @see <a href="https://repost.aws/questions/QU_4m9WIVUQ1aC-w4v2MzC7g">Aurora PostgreSQL does not perform logical decoding when synchronous_commit = off</a>
+     */
+    private static boolean isAuroraWithLogicalReplication(SessionFactoryImplementor sf) {
+        try {
+            Connection connection = sf.getJdbcServices().getBootstrapJdbcConnectionAccess().obtainConnection();
+            try {
+                try (Statement stmt = connection.createStatement();
+                     ResultSet rs = stmt.executeQuery("SELECT aurora_version()")) {
+                    if (!rs.next()) {
+                        return false;
+                    }
+                } catch (SQLException e) {
+                    return false;
+                }
+
+                try (Statement stmt = connection.createStatement();
+                     ResultSet rs = stmt.executeQuery("SHOW wal_level")) {
+                    return rs.next() && "logical".equals(rs.getString(1));
+                }
+            } finally {
+                sf.getJdbcServices().getBootstrapJdbcConnectionAccess().releaseConnection(connection);
+            }
+        } catch (SQLException e) {
+            logger.warn("Failed to detect Aurora/logical replication status; disabling asynchronous commit optimization", e);
+            return true;
+        }
+    }
+
+    private static void setAsyncCommit(Connection connection) throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("SET LOCAL synchronous_commit TO OFF");
+        }
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/connections/jpa/AsynchronousCommitAllowed.java
+++ b/model/jpa/src/main/java/org/keycloak/connections/jpa/AsynchronousCommitAllowed.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.jpa;
+
+/**
+ * Marker interface for JPA entities that can tolerate asynchronous commit.
+ * <p>
+ * When a transaction only modifies entities that implement this interface (and whose
+ * {@link #isAsyncCommitAllowed(EntityOperationType)} returns {@code true} for the
+ * respective operation). See {@link AsyncCommitIntegrator} for details.
+ * This is currently only supported for PostgreSQL databases.
+ * <p>
+ * Entities that do NOT implement this interface are considered "important" — any modification
+ * to them forces synchronous commit for the entire transaction.
+ *
+ * @author Alexander Schwartz
+ */
+public interface AsynchronousCommitAllowed {
+
+    enum EntityOperationType {
+        INSERT, UPDATE, DELETE
+    }
+
+    /**
+     * Whether this entity allows asynchronous commit for the given operation type.
+     * <p>
+     * Returning {@code false} for any operation that occurs during a transaction
+     * will force synchronous commit for the entire transaction.
+     *
+     * @param operationType the type of database operation being performed
+     * @return {@code true} if the operation can tolerate asynchronous commit
+     */
+    default boolean isAsyncCommitAllowed(EntityOperationType operationType) {
+        return true;
+    }
+
+}

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/AdminEventEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/AdminEventEntity.java
@@ -22,12 +22,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 /**
  * @author <a href="mailto:giriraj.sharma27@gmail.com">Giriraj Sharma</a>
  */
 @Entity
 @Table(name="ADMIN_EVENT_ENTITY")
-public class AdminEventEntity {
+public class AdminEventEntity implements AsynchronousCommitAllowed {
 
     @Id
     @Column(name="ID", length = 36)

--- a/model/jpa/src/main/java/org/keycloak/events/jpa/EventEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/events/jpa/EventEntity.java
@@ -22,12 +22,14 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 /**
  * @author <a href="mailto:sthorger@redhat.com">Stian Thorgersen</a>
  */
 @Entity
 @Table(name="EVENT_ENTITY")
-public class EventEntity {
+public class EventEntity implements AsynchronousCommitAllowed {
 
     @Id
     @Column(name="ID", length = 36)

--- a/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/LoginFailureEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/loginfailures/jpa/LoginFailureEntity.java
@@ -27,6 +27,8 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 /**
  * This holds information about failed logins.
  * <p>
@@ -55,7 +57,7 @@ import jakarta.persistence.Table;
 @Entity
 @IdClass(LoginFailureKey.class)
 @Table(name = "LOGIN_FAILURE")
-public class LoginFailureEntity {
+public class LoginFailureEntity implements AsynchronousCommitAllowed {
 
     @Id
     @Column(name = "REALM_ID", length = 36)

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentClientSessionEntity.java
@@ -29,6 +29,8 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 import org.hibernate.annotations.DynamicUpdate;
 
 /**
@@ -68,7 +70,14 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @DynamicUpdate
 @IdClass(PersistentClientSessionEntity.Key.class)
-public class PersistentClientSessionEntity {
+public class PersistentClientSessionEntity implements AsynchronousCommitAllowed {
+
+    @Override
+    public boolean isAsyncCommitAllowed(EntityOperationType operationType) {
+        // If a session is removed by revoking this client's refresh token,
+        // this needs to be durable to prevent a security relevant timing attack
+        return operationType != EntityOperationType.DELETE;
+    }
 
     public static final String LOCAL = "local";
     public static final String EXTERNAL = "external";

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/session/PersistentUserSessionEntity.java
@@ -29,6 +29,7 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
 import org.keycloak.storage.jpa.KeyUtils;
 
 import org.hibernate.annotations.DynamicUpdate;
@@ -119,7 +120,14 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @DynamicUpdate
 @IdClass(PersistentUserSessionEntity.Key.class)
-public class PersistentUserSessionEntity {
+public class PersistentUserSessionEntity implements AsynchronousCommitAllowed {
+
+    @Override
+    public boolean isAsyncCommitAllowed(EntityOperationType operationType) {
+        // If a session is removed via a user logout,
+        // this needs to be durable to prevent a security relevant timing attack
+        return operationType != EntityOperationType.DELETE;
+    }
 
     @Id
     @Column(name="USER_SESSION_ID", length = 36)

--- a/model/jpa/src/main/java/org/keycloak/singleobject/jpa/SingleUseObjectEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/singleobject/jpa/SingleUseObjectEntity.java
@@ -26,6 +26,8 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
+import org.keycloak.connections.jpa.AsynchronousCommitAllowed;
+
 @NamedQueries({
         @NamedQuery(
                 name = "insertOrOverwriteSingleUseObject",
@@ -65,7 +67,13 @@ import jakarta.persistence.Table;
  */
 @Entity
 @Table(name = "SINGLE_USE_OBJECT")
-public class SingleUseObjectEntity {
+public class SingleUseObjectEntity implements AsynchronousCommitAllowed {
+
+    @Override
+    public boolean isAsyncCommitAllowed(EntityOperationType operationType) {
+        // Removing a single-use token from the store must be committed to be durable to avoid security issues
+        return operationType != EntityOperationType.DELETE;
+    }
 
     @Id
     @Column(name = "ID", length = 255)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/storage/database/jpa/QuarkusJpaConnectionProviderFactory.java
@@ -37,6 +37,7 @@ import org.keycloak.common.Version;
 import org.keycloak.common.util.Environment;
 import org.keycloak.config.DatabaseOptions;
 import org.keycloak.config.database.Database;
+import org.keycloak.connections.jpa.AsyncCommitIntegrator;
 import org.keycloak.connections.jpa.updater.JpaUpdaterProvider;
 import org.keycloak.connections.jpa.util.JpaUtils;
 import org.keycloak.migration.MigrationModelManager;
@@ -101,6 +102,9 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
     @Override
     public void postInit(KeycloakSessionFactory factory) {
         super.postInit(factory);
+        if (config.getBoolean("asyncCommit", true)) {
+            AsyncCommitIntegrator.registerListeners(entityManagerFactory);
+        }
 
         checkMySQLWaitTimeout();
         checkMSSQLIsolationLevel();
@@ -172,6 +176,12 @@ public class QuarkusJpaConnectionProviderFactory extends AbstractJpaConnectionPr
                 .name("migrationExport")
                 .type("string")
                 .helpText("Path for where to write manual database initialization/migration file.")
+                .add()
+                .property()
+                .name("asyncCommit")
+                .type("boolean")
+                .helpText("If enabled, transactions that only modify ephemeral entities (such as authentication sessions or events) use asynchronous commit on PostgreSQL, skipping the WAL fsync wait. This improves throughput but means the last few milliseconds of such transactions may be lost on a crash. Automatically disabled on Aurora PostgreSQL when logical replication is active.")
+                .defaultValue(true)
                 .add()
                 .build();
     }


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

Closes #49739

Kudos to @pruivo who brought up a commit optimization in one of our 1:1 discussion. 

Opening the login page and posting the correct credentials see a significant improvement. 

Exchanging the code-to-token and logout are still synchronous commits, to avoid code replay, and to ensure that logouts are persistent.  

To be discussed: Maybe removing code-to-token can also be an asynchronous commit, as those tokens are short-lived? 

Before: 

<img width="1326" height="267" alt="image" src="https://github.com/user-attachments/assets/f07221ad-3e30-40cb-82fe-bfad69f915cf" />

After: 

<img width="1327" height="268" alt="image" src="https://github.com/user-attachments/assets/d19b59f8-d22d-417c-8665-b5e53625f1d4" />

