### PR TITLE
cache wirit so that we don't need to create the bindings each build (#49360)

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -1,5 +1,5 @@
 name: Setup PNPM
-description: Sets up Node.js and runs PNPM so dependencies are installed.
+description: Sets up Node.js, enables Wireit and PNPM caching, and installs dependencies.
 
 inputs:
   node-version:
@@ -21,6 +21,9 @@ runs:
 
     - name: PNPM store cache
       uses: ./.github/actions/pnpm-store-cache
+
+    - name: Set up Wireit GitHub Actions caching
+      uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/js-ci.yml
+++ b/.github/workflows/js-ci.yml
@@ -293,10 +293,6 @@ jobs:
 
       - uses: ./.github/actions/pnpm-setup
 
-      - name: Generate bindings
-        run: pnpm --fail-if-no-match --filter ${{ env.WORKSPACE }} generate:openapi
-        working-directory: js
-
       - name: Run tests
         run: pnpm --fail-if-no-match --filter ${{ env.WORKSPACE }} run test
         working-directory: js

--- a/.github/workflows/js-wireit-cache.yml
+++ b/.github/workflows/js-wireit-cache.yml
@@ -1,0 +1,34 @@
+name: Warm JS Wireit cache
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'js/**'
+      - 'services/**'
+      - 'rest/admin-ui-ext/**'
+      - 'themes/**'
+      - '.github/actions/pnpm-setup/**'
+      - '.github/workflows/js-wireit-cache.yml'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  warm-wireit-cache:
+    name: Warm Wireit cache on main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: ./.github/actions/pnpm-setup
+
+      - name: Build Keycloak Admin Client
+        run: pnpm --fail-if-no-match --filter @keycloak/keycloak-admin-client build
+        working-directory: js

--- a/js/libs/keycloak-admin-client/package.json
+++ b/js/libs/keycloak-admin-client/package.json
@@ -48,7 +48,10 @@
       "command": "eslint ."
     },
     "test": {
-      "command": "TS_NODE_PROJECT=tsconfig.test.json mocha --recursive \"test/**/*.spec.ts\" --timeout 10000"
+      "command": "TS_NODE_PROJECT=tsconfig.test.json mocha --recursive \"test/**/*.spec.ts\" --timeout 10000",
+      "dependencies": [
+        "build"
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
* cache wirit so that we don't need to create the bindings each build

fixes: #47999
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

* fixed pr comments

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

* make test dependend on build so that we have the kiota binding

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

* pr review fixes

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

---------

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>
(cherry picked from commit 50e77908c8fafcc0b8d443e2cb21e4e3a7f0a5e0)
