### PR TITLE
Move wireit cache to pnpm-store-cache so it's used both by js-ci.yml and ci.yml

### DIFF
--- a/.github/actions/pnpm-setup/action.yml
+++ b/.github/actions/pnpm-setup/action.yml
@@ -22,9 +22,6 @@ runs:
     - name: PNPM store cache
       uses: ./.github/actions/pnpm-store-cache
 
-    - name: Set up Wireit GitHub Actions caching
-      uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2
-
     - name: Install dependencies
       shell: bash
       run: pnpm install --prefer-offline --frozen-lockfile

--- a/.github/actions/pnpm-store-cache/action.yml
+++ b/.github/actions/pnpm-store-cache/action.yml
@@ -20,3 +20,4 @@ runs:
 
     - name: Set up Wireit GitHub Actions caching
       uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2
+      if: runner.os != 'Windows'

--- a/.github/actions/pnpm-store-cache/action.yml
+++ b/.github/actions/pnpm-store-cache/action.yml
@@ -17,3 +17,6 @@ runs:
           ~/AppData/Local/pnpm/store
           ~/Library/pnpm/store
         key: ${{ runner.os }}-${{ steps.weekly-cache-key.outputs.key }}
+
+    - name: Set up Wireit GitHub Actions caching
+      uses: google/wireit@9d7c2e5346f8ef1b1ab6014c4e96c74e234f7ed5 # setup-github-actions-caching/v2


### PR DESCRIPTION
Signed-off-by: stianst <stianst@gmail.com>
