### PR TITLE
fix chinese locale label

### DIFF
--- a/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
+++ b/services/src/main/java/org/keycloak/theme/DefaultThemeManager.java
@@ -331,6 +331,8 @@ public class DefaultThemeManager implements ThemeManager {
         }
 
         protected void addlocaleTranslations(Locale locale, Properties m) throws IOException {
+            Locale currentLocale = Locale.forLanguageTag(resolveChineseLocale(locale.toLanguageTag()));
+
             for (String l : getProperties().getProperty("locales", "").split(",")) {
                 l = l.trim();
                 String key = "locale_" + l;
@@ -338,17 +340,10 @@ public class DefaultThemeManager implements ThemeManager {
                 if (label != null) {
                     continue;
                 }
-                String rl = l;
-                // This is mapping old locale codes to the new locale codes for Simplified and Traditional Chinese.
-                // Once the existing locales have been moved, this code can be removed.
-                if (l.equals("zh-CN")) {
-                    rl = "zh-Hans";
-                } else if (l.equals("zh-TW")) {
-                    rl = "zh-Hant";
-                }
+                String rl = resolveChineseLocale(l);
                 Locale loc = Locale.forLanguageTag(rl);
                 label = capitalize(loc.getDisplayName(locale), locale);
-                if (!Objects.equals(loc, locale)) {
+                if (!Objects.equals(loc, currentLocale)) {
                     label += " (" + capitalize(loc.getDisplayName(loc), loc) + ")";
                 }
                 m.put(key, label);
@@ -404,6 +399,17 @@ public class DefaultThemeManager implements ThemeManager {
             for (final String propertyName : properties.stringPropertyNames()) {
                 properties.setProperty(propertyName, StringPropertyReplacer.replaceProperties(properties.getProperty(propertyName), SystemEnvProperties.UNFILTERED::getProperty));
             }
+        }
+
+        private String resolveChineseLocale(String locale) {
+            // This is mapping old locale codes to the new locale codes for Simplified and Traditional Chinese.
+            // Once the existing locales have been moved, this code can be removed.
+            if (locale.equals("zh-CN")) {
+                return "zh-Hans";
+            } else if (locale.equals("zh-TW")) {
+                return "zh-Hant";
+            }
+            return locale;
         }
     }
 


### PR DESCRIPTION
Fixes #49742 

This PR fixes duplicate locale labels for Simplified and Traditional Chinese.

The existing locale mapping (`zh-CN` → `zh-Hans`, `zh-TW` → `zh-Hant`) was only applied to the displayed locale, but not to the current locale before comparison. As a result, Keycloak treated them as different locales and appended the native name again.

To make the code more clean and easy to remove in future, I extracted the existing mapping (from #41267) into a helper method and apply it before comparing the locales.