### PR TITLE
Fix CIBA bypassing brute force protection

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
@@ -53,6 +53,7 @@ import org.keycloak.protocol.oidc.grants.ciba.resolvers.CIBALoginUserResolver;
 import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.services.ErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.managers.BruteForceProtector;
 import org.keycloak.util.JsonSerialization;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -290,7 +291,19 @@ public class BackchannelAuthenticationEndpoint extends AbstractCibaEndpoint {
                     "invalid user hint", Response.Status.BAD_REQUEST);
         }
 
-        if (user == null || !user.isEnabled())
+        if (user == null)
+            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid user", Response.Status.BAD_REQUEST);
+
+        BruteForceProtector protector = session.getProvider(BruteForceProtector.class);
+        if (protector != null) {
+            if (protector.isPermanentlyLockedOut(session, realm, user)) {
+                throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "user permanently locked", Response.Status.BAD_REQUEST);
+            }
+            if (protector.isTemporarilyDisabled(session, realm, user)) {
+                throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "user temporarily disabled", Response.Status.BAD_REQUEST);
+            }
+        }
+        if (!user.isEnabled())
             throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid user", Response.Status.BAD_REQUEST);
 
         return user;

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/ciba/endpoints/BackchannelAuthenticationEndpoint.java
@@ -30,6 +30,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
+import org.keycloak.authentication.authenticators.util.AuthenticatorUtils;
 import org.keycloak.events.Details;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.events.EventType;
@@ -291,20 +292,16 @@ public class BackchannelAuthenticationEndpoint extends AbstractCibaEndpoint {
                     "invalid user hint", Response.Status.BAD_REQUEST);
         }
 
-        if (user == null)
-            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid user", Response.Status.BAD_REQUEST);
 
         BruteForceProtector protector = session.getProvider(BruteForceProtector.class);
-        if (protector != null) {
-            if (protector.isPermanentlyLockedOut(session, realm, user)) {
-                throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "user permanently locked", Response.Status.BAD_REQUEST);
-            }
-            if (protector.isTemporarilyDisabled(session, realm, user)) {
-                throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "user temporarily disabled", Response.Status.BAD_REQUEST);
-            }
+        boolean isInvalidUser = (user == null || !user.isEnabled());
+        if (!isInvalidUser && AuthenticatorUtils.getDisabledByBruteForceEventError(protector, session, realm, user) != null) {
+            isInvalidUser = true;
         }
-        if (!user.isEnabled())
-            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid user", Response.Status.BAD_REQUEST);
+
+        if (isInvalidUser) {
+            throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST, "invalid_user", Response.Status.BAD_REQUEST);
+        }
 
         return user;
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -2581,7 +2581,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(username).send();
             assertThat(response.getStatusCode(), is(equalTo(400)));
             assertThat(response.getError(), is(OAuthErrorException.INVALID_REQUEST));
-            assertThat(response.getErrorDescription(), is("user temporarily disabled"));
+            assertThat(response.getErrorDescription(), is("invalid_user"));
 
             // Clear brute force lockout
             managedRealm.admin().attackDetection().clearBruteForceForUser(user.getId());
@@ -2665,7 +2665,7 @@ public class CIBATest extends AbstractClientPoliciesTest {
             AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(username).send();
             assertThat(response.getStatusCode(), is(equalTo(400)));
             assertThat(response.getError(), is(OAuthErrorException.INVALID_REQUEST));
-            assertThat(response.getErrorDescription(), is("user permanently locked"));
+            assertThat(response.getErrorDescription(), is("invalid_user"));
 
             // Clear brute force lockout and re-enable user (permanent lockout disables the account)
             managedRealm.admin().attackDetection().clearBruteForceForUser(user.getId());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/CIBATest.java
@@ -2526,6 +2526,182 @@ public class CIBATest extends AbstractClientPoliciesTest {
         }
     }
 
+    @Test
+    public void testBackchannelAuthnReqWithBruteForceProtectedUser() throws Exception {
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        RealmRepresentation realmRep = null;
+        RealmRepresentation backupRealm = null;
+        Boolean originalDirectAccessGrantsEnabled = null;
+        try {
+            final String username = "nutzername-gelb";
+
+            clientResource = AdminApiUtil.findClientByClientId(managedRealm.admin(), TEST_CLIENT_NAME);
+            clientRep = clientResource.toRepresentation();
+
+            // Enable direct access grants for password grant to work
+            originalDirectAccessGrantsEnabled = clientRep.isDirectAccessGrantsEnabled();
+            clientRep.setDirectAccessGrantsEnabled(true);
+            clientResource.update(clientRep);
+
+            prepareCIBASettings(clientResource, clientRep);
+            oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+            oauth.client(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD);
+
+            // Enable brute force protection on realm
+            realmRep = managedRealm.admin().toRepresentation();
+            backupRealm = new RealmRepresentation();
+            backupRealm.setBruteForceProtected(realmRep.isBruteForceProtected());
+            backupRealm.setFailureFactor(realmRep.getFailureFactor());
+            backupRealm.setMaxDeltaTimeSeconds(realmRep.getMaxDeltaTimeSeconds());
+
+            realmRep.setBruteForceProtected(true);
+            realmRep.setFailureFactor(2);
+            realmRep.setMaxDeltaTimeSeconds(60);
+            managedRealm.admin().update(realmRep);
+
+            List<UserRepresentation> users = managedRealm.admin().users().search(username);
+            assertThat(users.size(), is(1));
+            UserRepresentation user = users.get(0);
+
+            // Trigger brute force lockout with failed login attempts
+            for (int i = 0; i < 3; i++) {
+                oauth.client(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD);
+                oauth.passwordGrantRequest(username, "wrongpassword").send();
+            }
+
+            // Verify user is actually locked by checking brute force status
+            Map<String, Object> userAttackInfo = managedRealm.admin().attackDetection().bruteForceUserStatus(user.getId());
+            assertThat((Boolean) userAttackInfo.get("disabled"), is(true));
+            // numFailures should be at least failureFactor (2), 3rd attempt after lock may not increment counter
+            assertThat((Integer) userAttackInfo.get("numFailures"), is(equalTo(2)));
+
+            // Verify user is temporarily disabled due to brute force
+            // Backchannel Authentication Request should fail
+            AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(username).send();
+            assertThat(response.getStatusCode(), is(equalTo(400)));
+            assertThat(response.getError(), is(OAuthErrorException.INVALID_REQUEST));
+            assertThat(response.getErrorDescription(), is("user temporarily disabled"));
+
+            // Clear brute force lockout
+            managedRealm.admin().attackDetection().clearBruteForceForUser(user.getId());
+
+            // Verify CIBA works after clearing lockout
+            response = oauth.ciba().backchannelAuthenticationRequest(username).send();
+            assertThat(response.getStatusCode(), is(equalTo(200)));
+            assertThat(response.getAuthReqId(), notNullValue());
+        } finally {
+            revertCIBASettings(clientResource, clientRep);
+            // Restore direct access grants setting
+            if (clientResource != null && clientRep != null && originalDirectAccessGrantsEnabled != null) {
+                clientRep.setDirectAccessGrantsEnabled(originalDirectAccessGrantsEnabled);
+                clientResource.update(clientRep);
+            }
+            // Restore realm brute force settings
+            if (realmRep != null && backupRealm != null) {
+                realmRep.setBruteForceProtected(backupRealm.isBruteForceProtected());
+                realmRep.setFailureFactor(backupRealm.getFailureFactor());
+                realmRep.setMaxDeltaTimeSeconds(backupRealm.getMaxDeltaTimeSeconds());
+                managedRealm.admin().update(realmRep);
+            }
+        }
+    }
+
+    @Test
+    public void testBackchannelAuthnReqWithPermanentlyLockedUser() throws Exception {
+        ClientResource clientResource = null;
+        ClientRepresentation clientRep = null;
+        RealmRepresentation realmRep = null;
+        RealmRepresentation backupRealm = null;
+        Boolean originalDirectAccessGrantsEnabled = null;
+        try {
+            final String username = "nutzername-schwarz";
+
+            clientResource = AdminApiUtil.findClientByClientId(managedRealm.admin(), TEST_CLIENT_NAME);
+            clientRep = clientResource.toRepresentation();
+
+            // Enable direct access grants for password grant to work
+            originalDirectAccessGrantsEnabled = clientRep.isDirectAccessGrantsEnabled();
+            clientRep.setDirectAccessGrantsEnabled(true);
+            clientResource.update(clientRep);
+
+            prepareCIBASettings(clientResource, clientRep);
+            oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+            oauth.client(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD);
+
+            realmRep = managedRealm.admin().toRepresentation();
+            backupRealm = new RealmRepresentation();
+            backupRealm.setBruteForceProtected(realmRep.isBruteForceProtected());
+            backupRealm.setFailureFactor(realmRep.getFailureFactor());
+            backupRealm.setMaxDeltaTimeSeconds(realmRep.getMaxDeltaTimeSeconds());
+            backupRealm.setPermanentLockout(realmRep.isPermanentLockout());
+            backupRealm.setMaxTemporaryLockouts(realmRep.getMaxTemporaryLockouts());
+
+            realmRep.setBruteForceProtected(true);
+            realmRep.setFailureFactor(2);
+            realmRep.setMaxDeltaTimeSeconds(60);
+            realmRep.setPermanentLockout(true);
+            // Enable permanent lockout brute force protection on realm
+            realmRep.setMaxTemporaryLockouts(0);
+            managedRealm.admin().update(realmRep);
+
+            List<UserRepresentation> users = managedRealm.admin().users().search(username);
+            assertThat(users.size(), is(1));
+            UserRepresentation user = users.get(0);
+
+            // Trigger permanent brute force lockout with failed login attempts
+            for (int i = 0; i < 3; i++) {
+                oauth.client(TEST_CLIENT_NAME, TEST_CLIENT_PASSWORD);
+                oauth.passwordGrantRequest(username, "wrongpassword").send();
+            }
+
+            // Verify user is actually locked by checking brute force status
+            Map<String, Object> userAttackInfo = managedRealm.admin().attackDetection().bruteForceUserStatus(user.getId());
+            assertThat((Boolean) userAttackInfo.get("disabled"), is(true));
+            // numFailures should be at least failureFactor (2), 3rd attempt after lock may not increment counter
+            assertThat((Integer) userAttackInfo.get("numFailures"), is(equalTo(2)));
+
+            // Verify user is permanently locked
+            AuthenticationRequestAcknowledgement response = oauth.ciba().backchannelAuthenticationRequest(username).send();
+            assertThat(response.getStatusCode(), is(equalTo(400)));
+            assertThat(response.getError(), is(OAuthErrorException.INVALID_REQUEST));
+            assertThat(response.getErrorDescription(), is("user permanently locked"));
+
+            // Clear brute force lockout and re-enable user (permanent lockout disables the account)
+            managedRealm.admin().attackDetection().clearBruteForceForUser(user.getId());
+            user.setEnabled(true);
+            managedRealm.admin().users().get(user.getId()).update(user);
+
+            // Verify CIBA works after clearing permanent lockout and re-enabling user
+            response = oauth.ciba().backchannelAuthenticationRequest(username).send();
+            assertThat(response.getStatusCode(), is(equalTo(200)));
+            assertThat(response.getAuthReqId(), notNullValue());
+        } finally {
+            revertCIBASettings(clientResource, clientRep);
+            // Restore direct access grants setting
+            if (clientResource != null && clientRep != null && originalDirectAccessGrantsEnabled != null) {
+                clientRep.setDirectAccessGrantsEnabled(originalDirectAccessGrantsEnabled);
+                clientResource.update(clientRep);
+            }
+            // Re-enable user if permanently locked (permanent lockout disables the account)
+            List<UserRepresentation> users = managedRealm.admin().users().search("nutzername-gelb");
+            if (!users.isEmpty()) {
+                UserRepresentation userToRestore = users.get(0);
+                userToRestore.setEnabled(true);
+                managedRealm.admin().users().get(userToRestore.getId()).update(userToRestore);
+            }
+            // Restore realm brute force settings
+            if (realmRep != null && backupRealm != null) {
+                realmRep.setBruteForceProtected(backupRealm.isBruteForceProtected());
+                realmRep.setFailureFactor(backupRealm.getFailureFactor());
+                realmRep.setMaxDeltaTimeSeconds(backupRealm.getMaxDeltaTimeSeconds());
+                realmRep.setPermanentLockout(backupRealm.isPermanentLockout());
+                realmRep.setMaxTemporaryLockouts(backupRealm.getMaxTemporaryLockouts());
+                managedRealm.admin().update(realmRep);
+            }
+        }
+    }
+
     private void testBackchannelAuthenticationFlowNotRegisterSigAlgInAdvanceWithSignedAuthentication(String clientName, boolean useRequestUri, String requestedSigAlg, String sigAlg, int statusCode, String errorDescription) throws Exception {
         String clientId = createClientDynamically(clientName, (OIDCClientRepresentation clientRep) -> {
             List<String> grantTypes = Optional.ofNullable(clientRep.getGrantTypes()).orElse(new ArrayList<>());


### PR DESCRIPTION
Added brute force checks to CIBA backchannel authentication to prevent locked users from authenticating. Includes tests for temporary and permanent lockout scenarios.

Closes #49432
