### PR TITLE
Skip returning user sessions when the caller does not have permissions to view the user

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_8_0.adoc
@@ -13,6 +13,10 @@ In minor or patch releases, {project_name} will only introduce breaking changes 
 
 When calling {project_name}'s experimental AuthZEN endpoints, the caller now needs to be an authenticated confidential client's access token. Previously, it could be called with a user's access token.
 
+=== Client session listings filter sessions by user visibility
+
+The Admin REST API endpoints for listing client sessions (`GET /admin/realms/\{realm}/clients/\{id}/user-sessions` and `GET /admin/realms/\{realm}/clients/\{id}/offline-sessions`) now filter out sessions belonging to users that the caller does not have permission to view. Previously, any caller with the `view-clients` role could see all user sessions for a client, potentially exposing user identities to callers without the `view-users` role. After upgrading, callers without `view-users` permission will see fewer results from these endpoints.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/InfinispanUserSessionProvider.java
@@ -485,10 +485,11 @@ public class InfinispanUserSessionProvider implements UserSessionProvider, Sessi
     @Override
     public Stream<UserSessionModel> readOnlyStreamOfflineUserSessions(RealmModel realm, ClientModel client, int skip, int maxResults) {
         var expiration = new SessionExpirationPredicates(realm, true, Time.currentTime());
-        return session.getProvider(UserSessionPersisterProvider.class)
-                .readOnlyUserSessionStream(realm, client, true, skip, maxResults)
-                .filter(Predicate.not(expiration::isUserSessionExpired))
-                .filter(s -> s.getUser() != null);
+        return paginatedStream(session.getProvider(UserSessionPersisterProvider.class)
+                        .readOnlyUserSessionStream(realm, client, true, -1, -1)
+                        .filter(Predicate.not(expiration::isUserSessionExpired))
+                        .filter(s -> s.getUser() != null),
+                skip, maxResults);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/sessions/infinispan/PersistentUserSessionProvider.java
@@ -443,9 +443,10 @@ public class PersistentUserSessionProvider implements UserSessionProvider, Sessi
 
     private Stream<UserSessionModel> readOnlyStream(RealmModel realm, ClientModel client, boolean offline, int skip, int maxResults) {
         var expiration = new SessionExpirationPredicates(realm, offline, Time.currentTime());
-        return session.getProvider(UserSessionPersisterProvider.class).readOnlyUserSessionStream(realm, client, offline, skip, maxResults)
-                .filter(Predicate.not(expiration::isUserSessionExpired))
-                .filter(s -> s.getUser() != null);
+        return paginatedStream(session.getProvider(UserSessionPersisterProvider.class).readOnlyUserSessionStream(realm, client, offline, -1, -1)
+                        .filter(Predicate.not(expiration::isUserSessionExpired))
+                        .filter(s -> s.getUser() != null),
+                skip, maxResults);
     }
 
     protected void onRemoveUserSessionsEvent(String realmId) {

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -112,6 +112,7 @@ import org.jboss.resteasy.reactive.NoCache;
 @Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
 public class ClientResource {
     protected static final Logger logger = Logger.getLogger(ClientResource.class);
+    private static final String HIDDEN_USER_PLACEHOLDER = "(hidden)";
     protected final RealmModel realm;
     private final AdminPermissionEvaluator auth;
     private final AdminEventBuilder adminEvent;
@@ -574,7 +575,7 @@ public class ClientResource {
         auth.clients().requireView(client);
         return session.sessions()
                 .readOnlyStreamUserSessions(client.getRealm(), client, computeFirstResult(firstResult), computeMaxResults(maxResults))
-                .map(ModelToRepresentation::toRepresentation);
+                .map(userSession -> hideUserInfoIfNeeded(ModelToRepresentation.toRepresentation(userSession), userSession.getUser()));
     }
 
     /**
@@ -621,7 +622,7 @@ public class ClientResource {
         auth.clients().requireView(client);
         return session.sessions()
                 .readOnlyStreamOfflineUserSessions(client.getRealm(), client, computeFirstResult(firstResult), computeMaxResults(maxResults))
-                .map(this::toUserSessionRepresentation);
+                .map(userSession -> hideUserInfoIfNeeded(toUserSessionRepresentation(userSession), userSession.getUser()));
     }
 
     /**
@@ -883,6 +884,29 @@ public class ClientResource {
         var clientSession = userSession.getAuthenticatedClientSessionByClient(client.getClientId());
         if (clientSession != null) {
             rep.setLastAccess(Time.toMillis(clientSession.getTimestamp()));
+        }
+        return rep;
+    }
+
+    /**
+     * Masks the user identifying fields of a session representation when the caller does not have
+     * permission to view the user owning that session. The session entry is still returned, but
+     * {@code userId} and {@code username} are replaced with a placeholder so that {@code view-clients}
+     * alone cannot be used to enumerate which users are logged into a client.
+     * <p>
+     * The check is performed per session against the specific user, reusing the same per-user
+     * {@code canView} check as {@code SessionsResource.clientSessions} in the admin-ui-ext module,
+     * but masking the identity fields rather than filtering the session out, so that a caller with
+     * fine-grained view access to only some users still sees those users while the rest stay masked.
+     *
+     * @param rep  the session representation to mask in place.
+     * @param user the user owning the session, already resolved while building {@code rep}.
+     * @return the (possibly masked) representation.
+     */
+    private UserSessionRepresentation hideUserInfoIfNeeded(UserSessionRepresentation rep, UserModel user) {
+        if (user == null || !auth.users().canView(user)) {
+            rep.setUserId(HIDDEN_USER_PLACEHOLDER);
+            rep.setUsername(HIDDEN_USER_PLACEHOLDER);
         }
         return rep;
     }

--- a/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ClientResource.java
@@ -101,6 +101,8 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.NoCache;
 
+import static org.keycloak.utils.StreamsUtil.paginatedStream;
+
 
 /**
  * Base resource class for managing one particular client of a realm.
@@ -112,7 +114,6 @@ import org.jboss.resteasy.reactive.NoCache;
 @Extension(name = KeycloakOpenAPI.Profiles.ADMIN, value = "")
 public class ClientResource {
     protected static final Logger logger = Logger.getLogger(ClientResource.class);
-    private static final String HIDDEN_USER_PLACEHOLDER = "(hidden)";
     protected final RealmModel realm;
     private final AdminPermissionEvaluator auth;
     private final AdminEventBuilder adminEvent;
@@ -573,9 +574,11 @@ public class ClientResource {
     @Operation( summary = "Get user sessions for client. Returns a list of user sessions associated with this client.\n")
     public Stream<UserSessionRepresentation> getUserSessions(@Parameter(description = "Paging offset") @QueryParam("first") Integer firstResult, @Parameter(description = "Maximum results size.") @QueryParam("max") @DefaultValue(Constants.DEFAULT_MAX_RESULTS_STR) Integer maxResults) {
         auth.clients().requireView(client);
-        return session.sessions()
-                .readOnlyStreamUserSessions(client.getRealm(), client, computeFirstResult(firstResult), computeMaxResults(maxResults))
-                .map(userSession -> hideUserInfoIfNeeded(ModelToRepresentation.toRepresentation(userSession), userSession.getUser()));
+        return paginatedStream(session.sessions()
+                        .readOnlyStreamUserSessions(client.getRealm(), client, -1, -1)
+                        .filter(userSession -> auth.users().canView(userSession.getUser())),
+                computeFirstResult(firstResult), computeMaxResults(maxResults))
+                .map(ModelToRepresentation::toRepresentation);
     }
 
     /**
@@ -620,9 +623,11 @@ public class ClientResource {
     @Operation( summary = "Get offline sessions for client. Returns a list of offline user sessions associated with this client")
     public Stream<UserSessionRepresentation> getOfflineUserSessions(@Parameter(description = "Paging offset") @QueryParam("first") Integer firstResult, @Parameter(description = "Maximum results size.") @QueryParam("max") @DefaultValue(Constants.DEFAULT_MAX_RESULTS_STR) Integer maxResults) {
         auth.clients().requireView(client);
-        return session.sessions()
-                .readOnlyStreamOfflineUserSessions(client.getRealm(), client, computeFirstResult(firstResult), computeMaxResults(maxResults))
-                .map(userSession -> hideUserInfoIfNeeded(toUserSessionRepresentation(userSession), userSession.getUser()));
+        return paginatedStream(session.sessions()
+                        .readOnlyStreamOfflineUserSessions(client.getRealm(), client, -1, -1)
+                        .filter(userSession -> auth.users().canView(userSession.getUser())),
+                computeFirstResult(firstResult), computeMaxResults(maxResults))
+                .map(this::toUserSessionRepresentation);
     }
 
     /**
@@ -884,29 +889,6 @@ public class ClientResource {
         var clientSession = userSession.getAuthenticatedClientSessionByClient(client.getClientId());
         if (clientSession != null) {
             rep.setLastAccess(Time.toMillis(clientSession.getTimestamp()));
-        }
-        return rep;
-    }
-
-    /**
-     * Masks the user identifying fields of a session representation when the caller does not have
-     * permission to view the user owning that session. The session entry is still returned, but
-     * {@code userId} and {@code username} are replaced with a placeholder so that {@code view-clients}
-     * alone cannot be used to enumerate which users are logged into a client.
-     * <p>
-     * The check is performed per session against the specific user, reusing the same per-user
-     * {@code canView} check as {@code SessionsResource.clientSessions} in the admin-ui-ext module,
-     * but masking the identity fields rather than filtering the session out, so that a caller with
-     * fine-grained view access to only some users still sees those users while the rest stay masked.
-     *
-     * @param rep  the session representation to mask in place.
-     * @param user the user owning the session, already resolved while building {@code rep}.
-     * @return the (possibly masked) representation.
-     */
-    private UserSessionRepresentation hideUserInfoIfNeeded(UserSessionRepresentation rep, UserModel user) {
-        if (user == null || !auth.users().canView(user)) {
-            rep.setUserId(HIDDEN_USER_PLACEHOLDER);
-            rep.setUsername(HIDDEN_USER_PLACEHOLDER);
         }
         return rep;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/SessionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/SessionTest.java
@@ -17,25 +17,41 @@
 
 package org.keycloak.tests.admin.client;
 
+import java.util.Arrays;
 import java.util.List;
 
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.Constants;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
+import org.keycloak.testframework.admin.AdminClientFactory;
+import org.keycloak.testframework.annotations.InjectAdminClientFactory;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.InjectUser;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.CredentialBuilder;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.realm.UserConfig;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.LoginPage;
+import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +67,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @KeycloakIntegrationTest
 public class SessionTest {
 
-    @InjectRealm
+    // Dedicated public direct-access-grant client used only to authenticate the role-restricted admin
+    // clients. Kept separate from "test-app" so admin logins do not pollute the user-session lists under test.
+    private static final String ADMIN_AUTH_CLIENT_ID = "test-admin-client";
+
+    @InjectRealm(config = SessionTestRealmConfig.class)
     ManagedRealm managedRealm;
 
     @InjectUser(config = SessionTestUserConfig.class)
@@ -59,6 +79,9 @@ public class SessionTest {
 
     @InjectOAuthClient
     OAuthClient oauth;
+
+    @InjectAdminClientFactory
+    AdminClientFactory adminClientFactory;
 
     @InjectPage
     LoginPage loginPage;
@@ -128,6 +151,131 @@ public class SessionTest {
         assertTrue(rep.isRememberMe());
 
         AccountHelper.logout(managedRealm.admin(), user.getUsername());
+    }
+
+    @Test
+    @DatabaseTest
+    public void testGetUserSessionsHidesUserInfoWithoutViewUsers() {
+        Keycloak viewClientsOnly = createRealmAdmin("view-clients-admin", AdminRoles.VIEW_CLIENTS);
+        Keycloak viewClientsAndUsers = createRealmAdmin("view-clients-users-admin", AdminRoles.VIEW_CLIENTS, AdminRoles.VIEW_USERS);
+
+        // Create a user session via direct grant
+        AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest(user.getUsername(), user.getPassword());
+        assertEquals(200, tokenResponse.getStatusCode());
+
+        try {
+            String clientUuid = AdminApiUtil.findClientByClientId(managedRealm.admin(), "test-app").toRepresentation().getId();
+            UserRepresentation testUserRep = user.admin().toRepresentation();
+
+            // Caller WITHOUT view-users: the session is still returned, but userId/username are masked
+            UserSessionRepresentation masked = getSingleUserSession(viewClientsOnly, clientUuid);
+            assertEquals("(hidden)", masked.getUserId());
+            assertEquals("(hidden)", masked.getUsername());
+            // Non-identifying fields must remain intact
+            assertEquals("test-app", masked.getClients().get(clientUuid));
+            assertNotNull(masked.getIpAddress());
+            assertTrue(masked.getStart() > 0);
+
+            // Caller WITH view-users: real values are exposed
+            UserSessionRepresentation full = getSingleUserSession(viewClientsAndUsers, clientUuid);
+            assertEquals(testUserRep.getId(), full.getUserId());
+            assertEquals(testUserRep.getUsername(), full.getUsername());
+        } finally {
+            AccountHelper.logout(managedRealm.admin(), user.getUsername());
+        }
+    }
+
+    @Test
+    @DatabaseTest
+    public void testGetOfflineUserSessionsHidesUserInfoWithoutViewUsers() {
+        Keycloak viewClientsOnly = createRealmAdmin("offline-view-clients-admin", AdminRoles.VIEW_CLIENTS);
+        Keycloak viewClientsAndUsers = createRealmAdmin("offline-view-clients-users-admin", AdminRoles.VIEW_CLIENTS, AdminRoles.VIEW_USERS);
+
+        // Create an offline user session via direct grant requesting offline_access
+        oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
+        try {
+            AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest(user.getUsername(), user.getPassword());
+            assertEquals(200, tokenResponse.getStatusCode());
+
+            String clientUuid = AdminApiUtil.findClientByClientId(managedRealm.admin(), "test-app").toRepresentation().getId();
+            UserRepresentation testUserRep = user.admin().toRepresentation();
+
+            // Caller WITHOUT view-users: the offline session is still returned, but userId/username are masked
+            UserSessionRepresentation masked = getSingleOfflineUserSession(viewClientsOnly, clientUuid);
+            assertEquals("(hidden)", masked.getUserId());
+            assertEquals("(hidden)", masked.getUsername());
+            assertEquals("test-app", masked.getClients().get(clientUuid));
+
+            // Caller WITH view-users: real values are exposed
+            UserSessionRepresentation full = getSingleOfflineUserSession(viewClientsAndUsers, clientUuid);
+            assertEquals(testUserRep.getId(), full.getUserId());
+            assertEquals(testUserRep.getUsername(), full.getUsername());
+        } finally {
+            oauth.scope(null);
+            user.admin().logout();
+        }
+    }
+
+    private UserSessionRepresentation getSingleUserSession(Keycloak adminClient, String clientUuid) {
+        List<UserSessionRepresentation> sessions = adminClient.realm(managedRealm.getName())
+                .clients().get(clientUuid).getUserSessions(0, 5);
+        assertEquals(1, sessions.size());
+        return sessions.get(0);
+    }
+
+    private UserSessionRepresentation getSingleOfflineUserSession(Keycloak adminClient, String clientUuid) {
+        List<UserSessionRepresentation> sessions = adminClient.realm(managedRealm.getName())
+                .clients().get(clientUuid).getOfflineUserSessions(0, 5);
+        assertEquals(1, sessions.size());
+        return sessions.get(0);
+    }
+
+    /**
+     * Creates a realm user holding the given {@code realm-management} client roles and returns an admin client
+     * authenticated as that user, so permission boundaries can be exercised. The user and client are registered
+     * for cleanup.
+     */
+    private Keycloak createRealmAdmin(String username, String... realmManagementRoles) {
+        UserRepresentation adminUser = UserBuilder.create()
+                .username(username)
+                .name(username, username)
+                .email(username + "@localhost.com")
+                .emailVerified(true)
+                .enabled(true)
+                .build();
+
+        String userId;
+        try (Response response = managedRealm.admin().users().create(adminUser)) {
+            userId = ApiUtil.getCreatedId(response);
+        }
+        managedRealm.cleanup().add(r -> r.users().delete(userId));
+        managedRealm.admin().users().get(userId).resetPassword(CredentialBuilder.password("password").build());
+
+        String realmManagementUuid = managedRealm.admin().clients()
+                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
+        List<RoleRepresentation> roles = Arrays.stream(realmManagementRoles)
+                .map(roleName -> managedRealm.admin().clients().get(realmManagementUuid).roles().get(roleName).toRepresentation())
+                .toList();
+        managedRealm.admin().users().get(userId).roles().clientLevel(realmManagementUuid).add(roles);
+
+        return adminClientFactory.create()
+                .realm(managedRealm.getName())
+                .username(username)
+                .password("password")
+                .clientId(ADMIN_AUTH_CLIENT_ID)
+                .grantType(OAuth2Constants.PASSWORD)
+                .autoClose()
+                .build();
+    }
+
+    private static class SessionTestRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm.clients(ClientBuilder.create(ADMIN_AUTH_CLIENT_ID)
+                    .publicClient(true)
+                    .directAccessGrantsEnabled(true));
+        }
     }
 
     private static class SessionTestUserConfig implements UserConfig {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/client/SessionTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/client/SessionTest.java
@@ -17,17 +17,13 @@
 
 package org.keycloak.tests.admin.client;
 
-import java.util.Arrays;
 import java.util.List;
-
-import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.models.AdminRoles;
 import org.keycloak.models.Constants;
-import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.UserSessionRepresentation;
 import org.keycloak.testframework.admin.AdminClientFactory;
@@ -38,7 +34,6 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
 import org.keycloak.testframework.realm.ClientBuilder;
-import org.keycloak.testframework.realm.CredentialBuilder;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.ManagedUser;
 import org.keycloak.testframework.realm.RealmBuilder;
@@ -47,7 +42,6 @@ import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.realm.UserConfig;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.LoginPage;
-import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.suites.DatabaseTest;
 import org.keycloak.tests.utils.admin.AdminApiUtil;
 import org.keycloak.testsuite.util.AccountHelper;
@@ -155,9 +149,9 @@ public class SessionTest {
 
     @Test
     @DatabaseTest
-    public void testGetUserSessionsHidesUserInfoWithoutViewUsers() {
-        Keycloak viewClientsOnly = createRealmAdmin("view-clients-admin", AdminRoles.VIEW_CLIENTS);
-        Keycloak viewClientsAndUsers = createRealmAdmin("view-clients-users-admin", AdminRoles.VIEW_CLIENTS, AdminRoles.VIEW_USERS);
+    public void testGetUserSessionsHidesSessionsWithoutViewUsers() {
+        Keycloak viewClientsOnly = createRealmAdminClient("view-clients-admin");
+        Keycloak viewClientsAndUsers = createRealmAdminClient("view-clients-users-admin");
 
         // Create a user session via direct grant
         AccessTokenResponse tokenResponse = oauth.doPasswordGrantRequest(user.getUsername(), user.getPassword());
@@ -165,21 +159,14 @@ public class SessionTest {
 
         try {
             String clientUuid = AdminApiUtil.findClientByClientId(managedRealm.admin(), "test-app").toRepresentation().getId();
-            UserRepresentation testUserRep = user.admin().toRepresentation();
 
-            // Caller WITHOUT view-users: the session is still returned, but userId/username are masked
-            UserSessionRepresentation masked = getSingleUserSession(viewClientsOnly, clientUuid);
-            assertEquals("(hidden)", masked.getUserId());
-            assertEquals("(hidden)", masked.getUsername());
-            // Non-identifying fields must remain intact
-            assertEquals("test-app", masked.getClients().get(clientUuid));
-            assertNotNull(masked.getIpAddress());
-            assertTrue(masked.getStart() > 0);
+            // Caller WITHOUT view-users: the session is not returned
+            List<UserSessionRepresentation> sessions = viewClientsOnly.realm(managedRealm.getName())
+                    .clients().get(clientUuid).getUserSessions(0, 5);
+            assertEquals(0, sessions.size());
 
-            // Caller WITH view-users: real values are exposed
-            UserSessionRepresentation full = getSingleUserSession(viewClientsAndUsers, clientUuid);
-            assertEquals(testUserRep.getId(), full.getUserId());
-            assertEquals(testUserRep.getUsername(), full.getUsername());
+            // Caller WITH view-users: row is returned
+            getSingleUserSession(viewClientsAndUsers, clientUuid);
         } finally {
             AccountHelper.logout(managedRealm.admin(), user.getUsername());
         }
@@ -187,9 +174,9 @@ public class SessionTest {
 
     @Test
     @DatabaseTest
-    public void testGetOfflineUserSessionsHidesUserInfoWithoutViewUsers() {
-        Keycloak viewClientsOnly = createRealmAdmin("offline-view-clients-admin", AdminRoles.VIEW_CLIENTS);
-        Keycloak viewClientsAndUsers = createRealmAdmin("offline-view-clients-users-admin", AdminRoles.VIEW_CLIENTS, AdminRoles.VIEW_USERS);
+    public void testGetOfflineUserSessionsHidesUserSessionsWithoutViewUsers() {
+        Keycloak viewClientsOnly = createRealmAdminClient("view-clients-admin");
+        Keycloak viewClientsAndUsers = createRealmAdminClient("view-clients-users-admin");
 
         // Create an offline user session via direct grant requesting offline_access
         oauth.scope(OAuth2Constants.OFFLINE_ACCESS);
@@ -198,18 +185,14 @@ public class SessionTest {
             assertEquals(200, tokenResponse.getStatusCode());
 
             String clientUuid = AdminApiUtil.findClientByClientId(managedRealm.admin(), "test-app").toRepresentation().getId();
-            UserRepresentation testUserRep = user.admin().toRepresentation();
 
-            // Caller WITHOUT view-users: the offline session is still returned, but userId/username are masked
-            UserSessionRepresentation masked = getSingleOfflineUserSession(viewClientsOnly, clientUuid);
-            assertEquals("(hidden)", masked.getUserId());
-            assertEquals("(hidden)", masked.getUsername());
-            assertEquals("test-app", masked.getClients().get(clientUuid));
+            // Caller WITHOUT view-users: the offline session is not returned
+            List<UserSessionRepresentation> sessions = viewClientsOnly.realm(managedRealm.getName())
+                    .clients().get(clientUuid).getOfflineUserSessions(0, 5);
+            assertEquals(0, sessions.size());
 
-            // Caller WITH view-users: real values are exposed
-            UserSessionRepresentation full = getSingleOfflineUserSession(viewClientsAndUsers, clientUuid);
-            assertEquals(testUserRep.getId(), full.getUserId());
-            assertEquals(testUserRep.getUsername(), full.getUsername());
+            // Caller WITH view-users: row is returned
+            getSingleOfflineUserSession(viewClientsAndUsers, clientUuid);
         } finally {
             oauth.scope(null);
             user.admin().logout();
@@ -230,34 +213,7 @@ public class SessionTest {
         return sessions.get(0);
     }
 
-    /**
-     * Creates a realm user holding the given {@code realm-management} client roles and returns an admin client
-     * authenticated as that user, so permission boundaries can be exercised. The user and client are registered
-     * for cleanup.
-     */
-    private Keycloak createRealmAdmin(String username, String... realmManagementRoles) {
-        UserRepresentation adminUser = UserBuilder.create()
-                .username(username)
-                .name(username, username)
-                .email(username + "@localhost.com")
-                .emailVerified(true)
-                .enabled(true)
-                .build();
-
-        String userId;
-        try (Response response = managedRealm.admin().users().create(adminUser)) {
-            userId = ApiUtil.getCreatedId(response);
-        }
-        managedRealm.cleanup().add(r -> r.users().delete(userId));
-        managedRealm.admin().users().get(userId).resetPassword(CredentialBuilder.password("password").build());
-
-        String realmManagementUuid = managedRealm.admin().clients()
-                .findByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID).get(0).getId();
-        List<RoleRepresentation> roles = Arrays.stream(realmManagementRoles)
-                .map(roleName -> managedRealm.admin().clients().get(realmManagementUuid).roles().get(roleName).toRepresentation())
-                .toList();
-        managedRealm.admin().users().get(userId).roles().clientLevel(realmManagementUuid).add(roles);
-
+    private Keycloak createRealmAdminClient(String username) {
         return adminClientFactory.create()
                 .realm(managedRealm.getName())
                 .username(username)
@@ -271,10 +227,27 @@ public class SessionTest {
     private static class SessionTestRealmConfig implements RealmConfig {
 
         @Override
-        public RealmBuilder configure(RealmBuilder realm) {
-            return realm.clients(ClientBuilder.create(ADMIN_AUTH_CLIENT_ID)
+        public RealmBuilder configure(RealmBuilder builder) {
+            builder.clients(ClientBuilder.create(ADMIN_AUTH_CLIENT_ID)
                     .publicClient(true)
                     .directAccessGrantsEnabled(true));
+            builder.users(
+                    UserBuilder.create()
+                            .username("view-clients-admin")
+                            .name("view-clients-admin", "view-clients-admin")
+                            .email("view-clients-admin@localhost.com")
+                            .emailVerified(true)
+                            .password("password")
+                            .clientRoles(Constants.REALM_MANAGEMENT_CLIENT_ID, AdminRoles.VIEW_CLIENTS),
+                    UserBuilder.create()
+                            .username("view-clients-users-admin")
+                            .name("view-clients-users-admin", "view-clients-users-admin")
+                            .email("view-clients-users-admin@localhost.com")
+                            .emailVerified(true)
+                            .password("password")
+                            .clientRoles(Constants.REALM_MANAGEMENT_CLIENT_ID, AdminRoles.VIEW_CLIENTS, AdminRoles.VIEW_USERS)
+            );
+            return builder;
         }
     }
 


### PR DESCRIPTION
GET .../clients/{id}/user-sessions and .../offline-sessions only required view-clients, allowing callers to enumerate which users are logged into a client without permission to view those users.

The new setup removes those sessions from the list

Closes #48858