### PR TITLE
fix(keycloak-admin-client): type TokenResponse expiresIn as number

### DIFF
--- a/js/libs/keycloak-admin-client/src/utils/auth.ts
+++ b/js/libs/keycloak-admin-client/src/utils/auth.ts
@@ -29,7 +29,7 @@ export interface Settings {
 
 export interface TokenResponseRaw {
   access_token: string;
-  expires_in: string;
+  expires_in: number;
   refresh_expires_in: number;
   refresh_token: string;
   token_type: string;
@@ -41,7 +41,7 @@ export interface TokenResponseRaw {
 
 export interface TokenResponse {
   accessToken: string;
-  expiresIn: string;
+  expiresIn: number;
   refreshExpiresIn: number;
   refreshToken: string;
   tokenType: string;


### PR DESCRIPTION
The `TokenResponseRaw.expires_in` and `TokenResponse.expiresIn` fields in `@keycloak/keycloak-admin-client` were typed as strings, even though Keycloak itself returns numbers and `getToken()` performs no coercion. This forced consumers to wrap the value in `Number(...)` to satisfy the declared type. The two fields are now typed as `number` to match the actual runtime value and the sibling `refresh_expires_in` / `refreshExpiresIn` fields.

Resolves #49481

### Changes
- `js/libs/keycloak-admin-client/src/utils/auth.ts`: changed `expires_in` on `TokenResponseRaw` from `string` to `number`.
- `js/libs/keycloak-admin-client/src/utils/auth.ts`: changed `expiresIn` on `TokenResponse` from `string` to `number`.