### PR TITLE
fix(admin-ui): default SAML IdP signature switches to enabled

### DIFF
--- a/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
+++ b/js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx
@@ -243,6 +243,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         <DefaultSwitchControl
           name="config.wantAssertionsSigned"
           label={t("wantAssertionsSigned")}
+          defaultValue="true"
           isDisabled={readOnly}
           stringify
         />
@@ -274,6 +275,7 @@ const Fields = ({ readOnly }: DescriptorSettingsProps) => {
         <DefaultSwitchControl
           name="config.validateSignature"
           label={t("validateSignature")}
+          defaultValue="true"
           isDisabled={readOnly}
           stringify
         />

--- a/js/apps/admin-ui/test/identity-providers/saml-signature-defaults.spec.ts
+++ b/js/apps/admin-ui/test/identity-providers/saml-signature-defaults.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+import { login } from "../utils/login.ts";
+
+const addSamlProviderUrl =
+  "http://localhost:8080/admin/master/console/#/master/identity-providers/saml/add";
+
+test("should enable SAML signature switches by default", async ({ page }) => {
+  await login(page);
+  await page.goto(addSamlProviderUrl);
+
+  const wantAssertionsSigned = page.getByTestId("config.wantAssertionsSigned");
+  await wantAssertionsSigned.waitFor({ state: "attached" });
+  await expect(wantAssertionsSigned).toBeChecked();
+
+  const validateSignature = page.getByTestId("config.validateSignature");
+  await validateSignature.waitFor({ state: "attached" });
+  await expect(validateSignature).toBeChecked();
+});

--- a/js/apps/admin-ui/test/identity-providers/saml.ts
+++ b/js/apps/admin-ui/test/identity-providers/saml.ts
@@ -46,7 +46,6 @@ export async function editSAMLSettings(page: Page, samlProviderName: string) {
   // Toggle SAML switches
   const switches = [
     "config.allowCreate",
-    "config.wantAssertionsSigned",
     "config.wantAssertionsEncrypted",
     "config.forceAuthn",
   ];


### PR DESCRIPTION
When creating a new SAML identity provider from the Admin UI, the "Want Assertions signed" and "Validate signature" toggles were not enabled by default. Because Keycloak aims to be secure by default, these options should be checked when a new provider is added.

The change updates `js/apps/admin-ui/src/identity-providers/add/DescriptorSettings.tsx` so the two corresponding `DefaultSwitchControl` elements pass `defaultValue={"true"}`, mirroring the existing default for `config.sendIdTokenOnLogout`. No server-side or backend defaults are modified.

Resolves #48717

Changes:
- Set `defaultValue` to `"true"` on the `config.wantAssertionsSigned` switch in the SAML IdP add form.
- Set `defaultValue` to `"true"` on the `config.validateSignature` switch in the SAML IdP add form.
- Add a Playwright e2e spec (`saml-signature-defaults.spec.ts`) that logs in, opens the SAML IdP add page, and asserts both switches are checked by default.