### PR TITLE
Add adaptive login risk scoring

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticator.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.authn;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator;
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContextCollector;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthDecisionService;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AuthAction;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskScore;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskScoringService;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventType;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.messages.Messages;
+import org.keycloak.sessions.AuthenticationSessionModel;
+
+public class RiskScoreAuthenticator implements Authenticator {
+
+    public static final String RISK_STEP_UP = "risk.step_up";
+    public static final String RISK_LEVEL = "risk.level";
+    public static final String RISK_SCORE = "risk.score";
+
+    public static final String EVENT_RISK_SCORE = "risk_score";
+    public static final String EVENT_RISK_LEVEL = "risk_level";
+    public static final String EVENT_RISK_ACTION = "risk_action";
+    public static final String EVENT_RISK_FACTORS = "risk_factors";
+
+    private final LoginContextCollector contextCollector;
+    private final RiskScoringService scoringService;
+    private final AdaptiveAuthDecisionService decisionService;
+    private final OTPFormAuthenticator otpAuthenticator;
+
+    public RiskScoreAuthenticator() {
+        this(new LoginContextCollector(), new RiskScoringService(), new AdaptiveAuthDecisionService(),
+                new OTPFormAuthenticator());
+    }
+
+    RiskScoreAuthenticator(LoginContextCollector contextCollector, RiskScoringService scoringService,
+            AdaptiveAuthDecisionService decisionService, OTPFormAuthenticator otpAuthenticator) {
+        this.contextCollector = contextCollector;
+        this.scoringService = scoringService;
+        this.decisionService = decisionService;
+        this.otpAuthenticator = otpAuthenticator;
+    }
+
+    @Override
+    public void authenticate(AuthenticationFlowContext context) {
+        AdaptiveAuthPolicy policy = AdaptiveAuthPolicy.fromConfig(config(context));
+        LoginContext loginContext = contextCollector.collect(context, policy);
+        RiskScore riskScore = scoringService.score(loginContext, policy);
+        AuthAction action = decisionService.decide(riskScore, policy);
+
+        addEventDetails(context, loginContext, riskScore, action);
+
+        switch (action) {
+            case ALLOW -> context.success();
+            case STEP_UP_MFA, CHALLENGE -> stepUp(context, riskScore, otpAuthenticator);
+            case BLOCK -> block(context);
+        }
+    }
+
+    private static Map<String, String> config(AuthenticationFlowContext context) {
+        AuthenticatorConfigModel model = context.getAuthenticatorConfig();
+        return model == null || model.getConfig() == null ? Collections.emptyMap() : model.getConfig();
+    }
+
+    private static void addEventDetails(AuthenticationFlowContext context, LoginContext loginContext, RiskScore score,
+            AuthAction action) {
+        context.getEvent()
+                .detail(EVENT_RISK_SCORE, Integer.toString(score.getValue()))
+                .detail(EVENT_RISK_LEVEL, score.getLevel().name())
+                .detail(EVENT_RISK_ACTION, action.name())
+                .detail(EVENT_RISK_FACTORS, factorSummary(score));
+
+        String device = LoginContextCollector.currentDeviceFingerprint(loginContext.getUserAgent(), loginContext.getAcceptLanguage());
+        if (device != null) {
+            context.getEvent().detail(LoginContextCollector.EVENT_DETAIL_DEVICE, device);
+        }
+        if (loginContext.getGeoSignal() != null) {
+            context.getEvent().detail(LoginContextCollector.EVENT_DETAIL_GEO, loginContext.getGeoSignal());
+        }
+    }
+
+    static String factorSummary(RiskScore score) {
+        return score.getFactors().stream()
+                .map(RiskScoreAuthenticator::factorSummary)
+                .collect(Collectors.joining(","));
+    }
+
+    private static String factorSummary(RiskFactorResult factor) {
+        return factor.getFactor() + ":" + factor.getRawScore();
+    }
+
+    private static void stepUp(AuthenticationFlowContext context, RiskScore riskScore, OTPFormAuthenticator otpAuthenticator) {
+        AuthenticationSessionModel authSession = context.getAuthenticationSession();
+        authSession.setAuthNote(RISK_STEP_UP, Boolean.TRUE.toString());
+        authSession.setAuthNote(RISK_LEVEL, riskScore.getLevel().name());
+        authSession.setAuthNote(RISK_SCORE, Integer.toString(riskScore.getValue()));
+
+        if (context.getUser() == null) {
+            block(context);
+            return;
+        }
+
+        if (otpAuthenticator.configuredFor(context.getSession(), context.getRealm(), context.getUser())) {
+            otpAuthenticator.authenticate(context);
+            return;
+        }
+
+        block(context);
+    }
+
+    private static void block(AuthenticationFlowContext context) {
+        context.getEvent().event(EventType.LOGIN).error(Errors.ACCESS_DENIED);
+        Response challenge = context.form()
+                .setError(Messages.ACCESS_DENIED)
+                .createErrorPage(Response.Status.UNAUTHORIZED);
+        context.failure(AuthenticationFlowError.ACCESS_DENIED, challenge);
+    }
+
+    @Override
+    public void action(AuthenticationFlowContext context) {
+        if (Boolean.TRUE.toString().equals(context.getAuthenticationSession().getAuthNote(RISK_STEP_UP))) {
+            if (context.getUser() == null) {
+                block(context);
+                return;
+            }
+            otpAuthenticator.action(context);
+            return;
+        }
+        authenticate(context);
+    }
+
+    @Override
+    public boolean requiresUser() {
+        return false;
+    }
+
+    @Override
+    public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+        return true;
+    }
+
+    @Override
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticatorFactory.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticatorFactory.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.authn;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.authentication.AuthenticatorFactory;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+
+public class RiskScoreAuthenticatorFactory implements AuthenticatorFactory {
+
+    public static final String PROVIDER_ID = "risk-score-authenticator";
+    private static final RiskScoreAuthenticator SINGLETON = new RiskScoreAuthenticator();
+
+    private static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
+            AuthenticationExecutionModel.Requirement.REQUIRED,
+            AuthenticationExecutionModel.Requirement.DISABLED
+    };
+
+    @Override
+    public Authenticator create(KeycloakSession session) {
+        return SINGLETON;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Risk Score Authenticator";
+    }
+
+    @Override
+    public String getReferenceCategory() {
+        return null;
+    }
+
+    @Override
+    public boolean isConfigurable() {
+        return true;
+    }
+
+    @Override
+    public AuthenticationExecutionModel.Requirement[] getRequirementChoices() {
+        return REQUIREMENT_CHOICES;
+    }
+
+    @Override
+    public boolean isUserSetupAllowed() {
+        return false;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Evaluates contextual login risk and adapts authentication by allowing, requiring MFA, or blocking the login attempt.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of(
+                integer(AdaptiveAuthPolicy.LOW_RISK_THRESHOLD, "Low risk threshold",
+                        "Score at or above this value triggers medium-risk step-up behavior.",
+                        AdaptiveAuthPolicy.DEFAULT_LOW_RISK_THRESHOLD),
+                integer(AdaptiveAuthPolicy.HIGH_RISK_THRESHOLD, "High risk threshold",
+                        "Score at or above this value blocks authentication.",
+                        AdaptiveAuthPolicy.DEFAULT_HIGH_RISK_THRESHOLD),
+                integer(AdaptiveAuthPolicy.FAILED_ATTEMPTS_WEIGHT, "Failed attempts weight",
+                        "Weight applied to the failed login attempts strategy.",
+                        AdaptiveAuthPolicy.DEFAULT_FAILED_ATTEMPTS_WEIGHT),
+                integer(AdaptiveAuthPolicy.IP_RISK_WEIGHT, "IP risk weight",
+                        "Weight applied to the source IP strategy.",
+                        AdaptiveAuthPolicy.DEFAULT_IP_RISK_WEIGHT),
+                integer(AdaptiveAuthPolicy.DEVICE_RISK_WEIGHT, "Device risk weight",
+                        "Weight applied to the device/browser strategy.",
+                        AdaptiveAuthPolicy.DEFAULT_DEVICE_RISK_WEIGHT),
+                integer(AdaptiveAuthPolicy.BEHAVIOR_RISK_WEIGHT, "Behavior risk weight",
+                        "Weight applied to the login-time behavior strategy.",
+                        AdaptiveAuthPolicy.DEFAULT_BEHAVIOR_RISK_WEIGHT),
+                integer(AdaptiveAuthPolicy.GEO_RISK_WEIGHT, "Geo risk weight",
+                        "Weight applied to the header-based geolocation strategy.",
+                        AdaptiveAuthPolicy.DEFAULT_GEO_RISK_WEIGHT),
+                integer(AdaptiveAuthPolicy.FAILED_ATTEMPTS_THRESHOLD, "Failed attempts threshold",
+                        "Failure count that maps failed-attempt risk to a high raw score.",
+                        AdaptiveAuthPolicy.DEFAULT_FAILED_ATTEMPTS_THRESHOLD),
+                integer(AdaptiveAuthPolicy.NEW_IP_RISK_SCORE, "New IP risk score",
+                        "Raw risk score used when the source IP differs from recent successful login history.",
+                        AdaptiveAuthPolicy.DEFAULT_NEW_IP_RISK_SCORE),
+                integer(AdaptiveAuthPolicy.NEW_DEVICE_RISK_SCORE, "New device risk score",
+                        "Raw risk score used when the browser/device fingerprint differs from recent successful login history.",
+                        AdaptiveAuthPolicy.DEFAULT_NEW_DEVICE_RISK_SCORE),
+                integer(AdaptiveAuthPolicy.UNUSUAL_LOGIN_START_HOUR, "Unusual login start hour",
+                        "Start hour, in UTC, for the unusual login window.",
+                        AdaptiveAuthPolicy.DEFAULT_UNUSUAL_LOGIN_START_HOUR),
+                integer(AdaptiveAuthPolicy.UNUSUAL_LOGIN_END_HOUR, "Unusual login end hour",
+                        "End hour, in UTC, for the unusual login window.",
+                        AdaptiveAuthPolicy.DEFAULT_UNUSUAL_LOGIN_END_HOUR),
+                integer(AdaptiveAuthPolicy.UNUSUAL_LOGIN_RISK_SCORE, "Unusual login risk score",
+                        "Raw risk score used when login time is inside the unusual login window.",
+                        AdaptiveAuthPolicy.DEFAULT_UNUSUAL_LOGIN_RISK_SCORE),
+                integer(AdaptiveAuthPolicy.NEW_GEO_RISK_SCORE, "New geo risk score",
+                        "Raw risk score used when the optional geography header differs from recent successful login history.",
+                        AdaptiveAuthPolicy.DEFAULT_NEW_GEO_RISK_SCORE),
+                integer(AdaptiveAuthPolicy.HISTORY_LOOKBACK_LIMIT, "History lookback limit",
+                        "Maximum number of recent login events to inspect for history-based strategies.",
+                        AdaptiveAuthPolicy.DEFAULT_HISTORY_LOOKBACK_LIMIT));
+    }
+
+    private static ProviderConfigProperty integer(String name, String label, String helpText, int defaultValue) {
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setName(name);
+        property.setLabel(label);
+        property.setHelpText(helpText);
+        property.setType(ProviderConfigProperty.INTEGER_TYPE);
+        property.setDefaultValue(Integer.toString(defaultValue));
+        return property;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/context/LoginContext.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/context/LoginContext.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.context;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
+
+public final class LoginContext {
+
+    private final String realmId;
+    private final String userId;
+    private final String username;
+    private final String remoteAddress;
+    private final String userAgent;
+    private final String acceptLanguage;
+    private final String geoSignal;
+    private final Instant loginTime;
+    private final int recentFailedAttempts;
+    private final Set<String> recentSuccessfulLoginIps;
+    private final Set<String> recentDeviceFingerprints;
+    private final Set<String> recentGeoSignals;
+    private final boolean historyAvailable;
+
+    public LoginContext(String realmId, String userId, String username, String remoteAddress, String userAgent,
+            String acceptLanguage, String geoSignal, Instant loginTime, int recentFailedAttempts,
+            Set<String> recentSuccessfulLoginIps, Set<String> recentDeviceFingerprints, Set<String> recentGeoSignals,
+            boolean historyAvailable) {
+        this.realmId = realmId;
+        this.userId = userId;
+        this.username = username;
+        this.remoteAddress = remoteAddress;
+        this.userAgent = userAgent;
+        this.acceptLanguage = acceptLanguage;
+        this.geoSignal = geoSignal;
+        this.loginTime = loginTime == null ? Instant.now() : loginTime;
+        this.recentFailedAttempts = Math.max(0, recentFailedAttempts);
+        this.recentSuccessfulLoginIps = immutableSet(recentSuccessfulLoginIps);
+        this.recentDeviceFingerprints = immutableSet(recentDeviceFingerprints);
+        this.recentGeoSignals = immutableSet(recentGeoSignals);
+        this.historyAvailable = historyAvailable;
+    }
+
+    private static Set<String> immutableSet(Set<String> values) {
+        return values == null ? Collections.emptySet() : Set.copyOf(values);
+    }
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
+    public String getAcceptLanguage() {
+        return acceptLanguage;
+    }
+
+    public String getGeoSignal() {
+        return geoSignal;
+    }
+
+    public Instant getLoginTime() {
+        return loginTime;
+    }
+
+    public int getRecentFailedAttempts() {
+        return recentFailedAttempts;
+    }
+
+    public Set<String> getRecentSuccessfulLoginIps() {
+        return recentSuccessfulLoginIps;
+    }
+
+    public Set<String> getRecentDeviceFingerprints() {
+        return recentDeviceFingerprints;
+    }
+
+    public Set<String> getRecentGeoSignals() {
+        return recentGeoSignals;
+    }
+
+    public boolean isHistoryAvailable() {
+        return historyAvailable;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/context/LoginContextCollector.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/context/LoginContextCollector.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.context;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.DeviceRiskStrategy;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventStoreProvider;
+import org.keycloak.events.EventType;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserLoginFailureModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.utils.StringUtil;
+
+public class LoginContextCollector {
+
+    public static final String HEADER_CF_IP_COUNTRY = "CF-IPCountry";
+    public static final String HEADER_CLOUDFRONT_VIEWER_COUNTRY = "CloudFront-Viewer-Country";
+    public static final String HEADER_X_FORWARDED_COUNTRY = "X-Forwarded-Country";
+    public static final String EVENT_DETAIL_DEVICE = "risk_device";
+    public static final String EVENT_DETAIL_GEO = "risk_geo";
+
+    public LoginContext collect(AuthenticationFlowContext context, AdaptiveAuthPolicy policy) {
+        RealmModel realm = context.getRealm();
+        UserModel user = context.getUser();
+        MultivaluedMap<String, String> headers = requestHeaders(context);
+        String userAgent = firstHeader(headers, HttpHeaders.USER_AGENT);
+        String acceptLanguage = firstHeader(headers, HttpHeaders.ACCEPT_LANGUAGE);
+        String geoSignal = geoSignalFromHeaders(headers);
+        String userId = user == null ? null : user.getId();
+        History history = collectHistory(context, realm, userId, policy.getHistoryLookbackLimit());
+
+        return new LoginContext(
+                realm == null ? null : realm.getId(),
+                userId,
+                user == null ? null : user.getUsername(),
+                context.getConnection() == null ? null : context.getConnection().getRemoteAddr(),
+                userAgent,
+                acceptLanguage,
+                geoSignal,
+                Instant.now(),
+                recentFailedAttempts(context, realm, userId),
+                history.ips,
+                history.devices,
+                history.geos,
+                history.available);
+    }
+
+    private static MultivaluedMap<String, String> requestHeaders(AuthenticationFlowContext context) {
+        HttpRequest request = context.getHttpRequest();
+        if (request == null || request.getHttpHeaders() == null || request.getHttpHeaders().getRequestHeaders() == null) {
+            return new MultivaluedHashMap<>();
+        }
+        return request.getHttpHeaders().getRequestHeaders();
+    }
+
+    static String geoSignalFromHeaders(MultivaluedMap<String, String> headers) {
+        String value = firstHeader(headers, HEADER_CF_IP_COUNTRY);
+        if (!StringUtil.isBlank(value)) {
+            return normalizeGeo(value);
+        }
+
+        value = firstHeader(headers, HEADER_CLOUDFRONT_VIEWER_COUNTRY);
+        if (!StringUtil.isBlank(value)) {
+            return normalizeGeo(value);
+        }
+
+        value = firstHeader(headers, HEADER_X_FORWARDED_COUNTRY);
+        return StringUtil.isBlank(value) ? null : normalizeGeo(value);
+    }
+
+    static String firstHeader(MultivaluedMap<String, String> headers, String name) {
+        if (headers == null || StringUtil.isBlank(name)) {
+            return null;
+        }
+
+        String direct = headers.getFirst(name);
+        if (!StringUtil.isBlank(direct)) {
+            return direct;
+        }
+
+        for (Map.Entry<String, java.util.List<String>> entry : headers.entrySet()) {
+            if (name.equalsIgnoreCase(entry.getKey()) && entry.getValue() != null && !entry.getValue().isEmpty()) {
+                return entry.getValue().get(0);
+            }
+        }
+
+        return null;
+    }
+
+    private static String normalizeGeo(String value) {
+        return value == null ? null : value.trim().toUpperCase();
+    }
+
+    private int recentFailedAttempts(AuthenticationFlowContext context, RealmModel realm, String userId) {
+        if (realm == null || userId == null) {
+            return 0;
+        }
+
+        try {
+            UserLoginFailureModel failure = context.getSession().loginFailures().getUserLoginFailure(realm, userId);
+            return failure == null ? 0 : Math.max(0, failure.getNumFailures());
+        } catch (RuntimeException e) {
+            return 0;
+        }
+    }
+
+    private History collectHistory(AuthenticationFlowContext context, RealmModel realm, String userId, int limit) {
+        if (realm == null || userId == null || limit <= 0) {
+            return History.unavailable();
+        }
+
+        EventStoreProvider eventStore;
+        try {
+            eventStore = context.getSession().getProvider(EventStoreProvider.class);
+        } catch (RuntimeException e) {
+            return History.unavailable();
+        }
+
+        if (eventStore == null) {
+            return History.unavailable();
+        }
+
+        try {
+            History history = new History(true);
+            eventStore.createQuery()
+                    .realm(realm.getId())
+                    .user(userId)
+                    .type(EventType.LOGIN)
+                    .orderByDescTime()
+                    .maxResults(limit)
+                    .getResultStream()
+                    .forEach(event -> addEvent(history, event));
+            return history;
+        } catch (RuntimeException e) {
+            return History.unavailable();
+        }
+    }
+
+    private static void addEvent(History history, Event event) {
+        if (!StringUtil.isBlank(event.getIpAddress())) {
+            history.ips.add(event.getIpAddress().trim());
+        }
+
+        Map<String, String> details = event.getDetails();
+        if (details == null) {
+            return;
+        }
+
+        String device = details.get(EVENT_DETAIL_DEVICE);
+        if (!StringUtil.isBlank(device)) {
+            history.devices.add(device);
+        }
+
+        String geo = details.get(EVENT_DETAIL_GEO);
+        if (!StringUtil.isBlank(geo)) {
+            history.geos.add(normalizeGeo(geo));
+        }
+    }
+
+    public static String currentDeviceFingerprint(String userAgent, String acceptLanguage) {
+        return DeviceRiskStrategy.fingerprint(userAgent, acceptLanguage);
+    }
+
+    private static final class History {
+        private final Set<String> ips = new HashSet<>();
+        private final Set<String> devices = new HashSet<>();
+        private final Set<String> geos = new HashSet<>();
+        private final boolean available;
+
+        private History(boolean available) {
+            this.available = available;
+        }
+
+        private static History unavailable() {
+            return new History(false);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthDecisionService.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthDecisionService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.decision;
+
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskScore;
+
+public class AdaptiveAuthDecisionService {
+
+    public AuthAction decide(RiskScore score, AdaptiveAuthPolicy policy) {
+        if (score.getValue() >= policy.getHighRiskThreshold()) {
+            return AuthAction.BLOCK;
+        }
+        if (score.getValue() >= policy.getLowRiskThreshold()) {
+            return AuthAction.STEP_UP_MFA;
+        }
+        return AuthAction.ALLOW;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthPolicy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthPolicy.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.decision;
+
+import java.util.Collections;
+import java.util.Map;
+
+public final class AdaptiveAuthPolicy {
+
+    public static final String LOW_RISK_THRESHOLD = "lowRiskThreshold";
+    public static final String HIGH_RISK_THRESHOLD = "highRiskThreshold";
+    public static final String FAILED_ATTEMPTS_WEIGHT = "failedAttemptsWeight";
+    public static final String IP_RISK_WEIGHT = "ipRiskWeight";
+    public static final String DEVICE_RISK_WEIGHT = "deviceRiskWeight";
+    public static final String BEHAVIOR_RISK_WEIGHT = "behaviorRiskWeight";
+    public static final String GEO_RISK_WEIGHT = "geoRiskWeight";
+    public static final String FAILED_ATTEMPTS_THRESHOLD = "failedAttemptsThreshold";
+    public static final String NEW_IP_RISK_SCORE = "newIpRiskScore";
+    public static final String NEW_DEVICE_RISK_SCORE = "newDeviceRiskScore";
+    public static final String UNUSUAL_LOGIN_START_HOUR = "unusualLoginStartHour";
+    public static final String UNUSUAL_LOGIN_END_HOUR = "unusualLoginEndHour";
+    public static final String UNUSUAL_LOGIN_RISK_SCORE = "unusualLoginRiskScore";
+    public static final String NEW_GEO_RISK_SCORE = "newGeoRiskScore";
+    public static final String HISTORY_LOOKBACK_LIMIT = "historyLookbackLimit";
+
+    public static final int DEFAULT_LOW_RISK_THRESHOLD = 30;
+    public static final int DEFAULT_HIGH_RISK_THRESHOLD = 70;
+    public static final int DEFAULT_FAILED_ATTEMPTS_WEIGHT = 35;
+    public static final int DEFAULT_IP_RISK_WEIGHT = 20;
+    public static final int DEFAULT_DEVICE_RISK_WEIGHT = 20;
+    public static final int DEFAULT_BEHAVIOR_RISK_WEIGHT = 15;
+    public static final int DEFAULT_GEO_RISK_WEIGHT = 10;
+    public static final int DEFAULT_FAILED_ATTEMPTS_THRESHOLD = 3;
+    public static final int DEFAULT_NEW_IP_RISK_SCORE = 60;
+    public static final int DEFAULT_NEW_DEVICE_RISK_SCORE = 60;
+    public static final int DEFAULT_UNUSUAL_LOGIN_START_HOUR = 0;
+    public static final int DEFAULT_UNUSUAL_LOGIN_END_HOUR = 5;
+    public static final int DEFAULT_UNUSUAL_LOGIN_RISK_SCORE = 50;
+    public static final int DEFAULT_NEW_GEO_RISK_SCORE = 50;
+    public static final int DEFAULT_HISTORY_LOOKBACK_LIMIT = 10;
+
+    private final int lowRiskThreshold;
+    private final int highRiskThreshold;
+    private final int failedAttemptsWeight;
+    private final int ipRiskWeight;
+    private final int deviceRiskWeight;
+    private final int behaviorRiskWeight;
+    private final int geoRiskWeight;
+    private final int failedAttemptsThreshold;
+    private final int newIpRiskScore;
+    private final int newDeviceRiskScore;
+    private final int unusualLoginStartHour;
+    private final int unusualLoginEndHour;
+    private final int unusualLoginRiskScore;
+    private final int newGeoRiskScore;
+    private final int historyLookbackLimit;
+
+    private AdaptiveAuthPolicy(int lowRiskThreshold, int highRiskThreshold, int failedAttemptsWeight, int ipRiskWeight,
+            int deviceRiskWeight, int behaviorRiskWeight, int geoRiskWeight, int failedAttemptsThreshold,
+            int newIpRiskScore, int newDeviceRiskScore, int unusualLoginStartHour, int unusualLoginEndHour,
+            int unusualLoginRiskScore, int newGeoRiskScore, int historyLookbackLimit) {
+        this.lowRiskThreshold = lowRiskThreshold;
+        this.highRiskThreshold = highRiskThreshold;
+        this.failedAttemptsWeight = failedAttemptsWeight;
+        this.ipRiskWeight = ipRiskWeight;
+        this.deviceRiskWeight = deviceRiskWeight;
+        this.behaviorRiskWeight = behaviorRiskWeight;
+        this.geoRiskWeight = geoRiskWeight;
+        this.failedAttemptsThreshold = failedAttemptsThreshold;
+        this.newIpRiskScore = newIpRiskScore;
+        this.newDeviceRiskScore = newDeviceRiskScore;
+        this.unusualLoginStartHour = unusualLoginStartHour;
+        this.unusualLoginEndHour = unusualLoginEndHour;
+        this.unusualLoginRiskScore = unusualLoginRiskScore;
+        this.newGeoRiskScore = newGeoRiskScore;
+        this.historyLookbackLimit = historyLookbackLimit;
+    }
+
+    public static AdaptiveAuthPolicy defaults() {
+        return fromConfig(Collections.emptyMap());
+    }
+
+    public static AdaptiveAuthPolicy fromConfig(Map<String, String> config) {
+        Map<String, String> safeConfig = config == null ? Collections.emptyMap() : config;
+
+        int low = parseBounded(safeConfig, LOW_RISK_THRESHOLD, DEFAULT_LOW_RISK_THRESHOLD, 0, 100);
+        int high = parseBounded(safeConfig, HIGH_RISK_THRESHOLD, DEFAULT_HIGH_RISK_THRESHOLD, 0, 100);
+
+        if (high < low) {
+            low = DEFAULT_LOW_RISK_THRESHOLD;
+            high = DEFAULT_HIGH_RISK_THRESHOLD;
+        }
+
+        return new AdaptiveAuthPolicy(
+                low,
+                high,
+                parseBounded(safeConfig, FAILED_ATTEMPTS_WEIGHT, DEFAULT_FAILED_ATTEMPTS_WEIGHT, 0, 100),
+                parseBounded(safeConfig, IP_RISK_WEIGHT, DEFAULT_IP_RISK_WEIGHT, 0, 100),
+                parseBounded(safeConfig, DEVICE_RISK_WEIGHT, DEFAULT_DEVICE_RISK_WEIGHT, 0, 100),
+                parseBounded(safeConfig, BEHAVIOR_RISK_WEIGHT, DEFAULT_BEHAVIOR_RISK_WEIGHT, 0, 100),
+                parseBounded(safeConfig, GEO_RISK_WEIGHT, DEFAULT_GEO_RISK_WEIGHT, 0, 100),
+                parseBounded(safeConfig, FAILED_ATTEMPTS_THRESHOLD, DEFAULT_FAILED_ATTEMPTS_THRESHOLD, 1, 100),
+                parseBounded(safeConfig, NEW_IP_RISK_SCORE, DEFAULT_NEW_IP_RISK_SCORE, 0, 100),
+                parseBounded(safeConfig, NEW_DEVICE_RISK_SCORE, DEFAULT_NEW_DEVICE_RISK_SCORE, 0, 100),
+                parseBounded(safeConfig, UNUSUAL_LOGIN_START_HOUR, DEFAULT_UNUSUAL_LOGIN_START_HOUR, 0, 23),
+                parseBounded(safeConfig, UNUSUAL_LOGIN_END_HOUR, DEFAULT_UNUSUAL_LOGIN_END_HOUR, 0, 23),
+                parseBounded(safeConfig, UNUSUAL_LOGIN_RISK_SCORE, DEFAULT_UNUSUAL_LOGIN_RISK_SCORE, 0, 100),
+                parseBounded(safeConfig, NEW_GEO_RISK_SCORE, DEFAULT_NEW_GEO_RISK_SCORE, 0, 100),
+                parseBounded(safeConfig, HISTORY_LOOKBACK_LIMIT, DEFAULT_HISTORY_LOOKBACK_LIMIT, 0, 100));
+    }
+
+    private static int parseBounded(Map<String, String> config, String key, int defaultValue, int min, int max) {
+        String value = config.get(key);
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed < min || parsed > max) {
+                return defaultValue;
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    public int getLowRiskThreshold() {
+        return lowRiskThreshold;
+    }
+
+    public int getHighRiskThreshold() {
+        return highRiskThreshold;
+    }
+
+    public int getFailedAttemptsWeight() {
+        return failedAttemptsWeight;
+    }
+
+    public int getIpRiskWeight() {
+        return ipRiskWeight;
+    }
+
+    public int getDeviceRiskWeight() {
+        return deviceRiskWeight;
+    }
+
+    public int getBehaviorRiskWeight() {
+        return behaviorRiskWeight;
+    }
+
+    public int getGeoRiskWeight() {
+        return geoRiskWeight;
+    }
+
+    public int getFailedAttemptsThreshold() {
+        return failedAttemptsThreshold;
+    }
+
+    public int getNewIpRiskScore() {
+        return newIpRiskScore;
+    }
+
+    public int getNewDeviceRiskScore() {
+        return newDeviceRiskScore;
+    }
+
+    public int getUnusualLoginStartHour() {
+        return unusualLoginStartHour;
+    }
+
+    public int getUnusualLoginEndHour() {
+        return unusualLoginEndHour;
+    }
+
+    public int getUnusualLoginRiskScore() {
+        return unusualLoginRiskScore;
+    }
+
+    public int getNewGeoRiskScore() {
+        return newGeoRiskScore;
+    }
+
+    public int getHistoryLookbackLimit() {
+        return historyLookbackLimit;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/decision/AuthAction.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/decision/AuthAction.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.decision;
+
+public enum AuthAction {
+    ALLOW,
+    STEP_UP_MFA,
+    CHALLENGE,
+    BLOCK
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskFactorResult.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskFactorResult.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.scoring;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class RiskFactorResult {
+
+    private final String factor;
+    private final int rawScore;
+    private final int weightedScore;
+    private final Map<String, String> details;
+
+    public RiskFactorResult(String factor, int rawScore, int weightedScore, Map<String, String> details) {
+        this.factor = factor;
+        this.rawScore = clamp(rawScore);
+        this.weightedScore = Math.max(0, weightedScore);
+        this.details = details == null ? Collections.emptyMap() :
+                Collections.unmodifiableMap(new LinkedHashMap<>(details));
+    }
+
+    public static RiskFactorResult raw(String factor, int rawScore, Map<String, String> details) {
+        return new RiskFactorResult(factor, rawScore, 0, details);
+    }
+
+    public RiskFactorResult withWeightedScore(int weightedScore) {
+        return new RiskFactorResult(factor, rawScore, weightedScore, details);
+    }
+
+    private static int clamp(int value) {
+        return Math.max(0, Math.min(100, value));
+    }
+
+    public String getFactor() {
+        return factor;
+    }
+
+    public int getRawScore() {
+        return rawScore;
+    }
+
+    public int getWeightedScore() {
+        return weightedScore;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskLevel.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskLevel.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.scoring;
+
+public enum RiskLevel {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskScore.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskScore.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.scoring;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class RiskScore {
+
+    private final int value;
+    private final RiskLevel level;
+    private final List<RiskFactorResult> factors;
+
+    public RiskScore(int value, RiskLevel level, List<RiskFactorResult> factors) {
+        this.value = Math.max(0, Math.min(100, value));
+        this.level = level;
+        this.factors = factors == null ? Collections.emptyList() : List.copyOf(factors);
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public RiskLevel getLevel() {
+        return level;
+    }
+
+    public List<RiskFactorResult> getFactors() {
+        return factors;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskScoringService.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskScoringService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.scoring;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.BehaviorRiskStrategy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.DeviceRiskStrategy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.FailedAttemptRiskStrategy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.GeoLocationRiskStrategy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.IPRiskStrategy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.RiskStrategy;
+
+public class RiskScoringService {
+
+    private final List<RiskStrategy> strategies;
+
+    public RiskScoringService() {
+        this(List.of(
+                new FailedAttemptRiskStrategy(),
+                new IPRiskStrategy(),
+                new DeviceRiskStrategy(),
+                new BehaviorRiskStrategy(),
+                new GeoLocationRiskStrategy()));
+    }
+
+    public RiskScoringService(List<RiskStrategy> strategies) {
+        this.strategies = List.copyOf(strategies);
+    }
+
+    public RiskScore score(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+        List<RiskFactorResult> factors = new ArrayList<>();
+        int total = 0;
+
+        for (RiskStrategy strategy : strategies) {
+            RiskFactorResult result = strategy.evaluate(loginContext, policy);
+            int weighted = (result.getRawScore() * weightFor(strategy.getName(), policy)) / 100;
+            RiskFactorResult weightedResult = result.withWeightedScore(weighted);
+            factors.add(weightedResult);
+            total += weighted;
+        }
+
+        int value = Math.max(0, Math.min(100, total));
+        return new RiskScore(value, levelFor(value, policy), factors);
+    }
+
+    private static int weightFor(String factor, AdaptiveAuthPolicy policy) {
+        return switch (factor) {
+            case FailedAttemptRiskStrategy.NAME -> policy.getFailedAttemptsWeight();
+            case IPRiskStrategy.NAME -> policy.getIpRiskWeight();
+            case DeviceRiskStrategy.NAME -> policy.getDeviceRiskWeight();
+            case BehaviorRiskStrategy.NAME -> policy.getBehaviorRiskWeight();
+            case GeoLocationRiskStrategy.NAME -> policy.getGeoRiskWeight();
+            default -> 0;
+        };
+    }
+
+    private static RiskLevel levelFor(int value, AdaptiveAuthPolicy policy) {
+        if (value >= policy.getHighRiskThreshold()) {
+            return RiskLevel.HIGH;
+        }
+        if (value >= policy.getLowRiskThreshold()) {
+            return RiskLevel.MEDIUM;
+        }
+        return RiskLevel.LOW;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/BehaviorRiskStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/BehaviorRiskStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+
+public class BehaviorRiskStrategy implements RiskStrategy {
+
+    public static final String NAME = "behavior";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+        int hour = loginContext.getLoginTime().atZone(ZoneOffset.UTC).getHour();
+        boolean unusual = isInsideWindow(hour, policy.getUnusualLoginStartHour(), policy.getUnusualLoginEndHour());
+
+        return RiskFactorResult.raw(getName(), unusual ? policy.getUnusualLoginRiskScore() : 0, Map.of(
+                "hour", Integer.toString(hour),
+                "unusual", Boolean.toString(unusual)));
+    }
+
+    static boolean isInsideWindow(int hour, int start, int end) {
+        if (start == end) {
+            return hour == start;
+        }
+        if (start < end) {
+            return hour >= start && hour <= end;
+        }
+        return hour >= start || hour <= end;
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/DeviceRiskStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/DeviceRiskStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+import org.keycloak.utils.StringUtil;
+
+public class DeviceRiskStrategy implements RiskStrategy {
+
+    public static final String NAME = "device";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+        String fingerprint = fingerprint(loginContext.getUserAgent(), loginContext.getAcceptLanguage());
+
+        if (fingerprint == null) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "missing_user_agent"));
+        }
+
+        if (!loginContext.isHistoryAvailable()) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "history_unavailable"));
+        }
+
+        if (loginContext.getRecentDeviceFingerprints().isEmpty()) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "no_device_history"));
+        }
+
+        if (loginContext.getRecentDeviceFingerprints().contains(fingerprint)) {
+            return RiskFactorResult.raw(getName(), 0, Map.of("reason", "known_device"));
+        }
+
+        return RiskFactorResult.raw(getName(), policy.getNewDeviceRiskScore(), Map.of("reason", "new_device"));
+    }
+
+    public static String fingerprint(String userAgent, String acceptLanguage) {
+        if (StringUtil.isBlank(userAgent)) {
+            return null;
+        }
+
+        String normalized = userAgent.trim().toLowerCase(Locale.ROOT) + "|"
+                + (acceptLanguage == null ? "" : acceptLanguage.trim().toLowerCase(Locale.ROOT));
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(normalized.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 must be available", e);
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/FailedAttemptRiskStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/FailedAttemptRiskStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.util.Map;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+
+public class FailedAttemptRiskStrategy implements RiskStrategy {
+
+    public static final String NAME = "failed_attempts";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+        int threshold = Math.max(1, policy.getFailedAttemptsThreshold());
+        int failures = Math.max(0, loginContext.getRecentFailedAttempts());
+        int raw = Math.min(100, (failures * 100) / threshold);
+
+        return RiskFactorResult.raw(getName(), raw, Map.of(
+                "failures", Integer.toString(failures),
+                "threshold", Integer.toString(threshold)));
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/GeoLocationRiskStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/GeoLocationRiskStrategy.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+import org.keycloak.utils.StringUtil;
+
+public class GeoLocationRiskStrategy implements RiskStrategy {
+
+    public static final String NAME = "geo";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+        String geoSignal = normalize(loginContext.getGeoSignal());
+
+        if (geoSignal == null) {
+            return RiskFactorResult.raw(getName(), 0, Map.of("reason", "missing_geo_signal"));
+        }
+
+        if (!loginContext.isHistoryAvailable()) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "history_unavailable"));
+        }
+
+        if (loginContext.getRecentGeoSignals().isEmpty()) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "no_geo_history"));
+        }
+
+        if (loginContext.getRecentGeoSignals().contains(geoSignal)) {
+            return RiskFactorResult.raw(getName(), 0, Map.of("reason", "known_geo"));
+        }
+
+        return RiskFactorResult.raw(getName(), policy.getNewGeoRiskScore(), Map.of("reason", "new_geo"));
+    }
+
+    static String normalize(String value) {
+        if (StringUtil.isBlank(value)) {
+            return null;
+        }
+        return value.trim().toUpperCase(Locale.ROOT);
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/IPRiskStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/IPRiskStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.util.Map;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+import org.keycloak.utils.StringUtil;
+
+public class IPRiskStrategy implements RiskStrategy {
+
+    public static final String NAME = "ip";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+        String remoteAddress = normalize(loginContext.getRemoteAddress());
+
+        if (remoteAddress == null) {
+            return RiskFactorResult.raw(getName(), 0, Map.of("reason", "missing_ip"));
+        }
+
+        if (!loginContext.isHistoryAvailable()) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "history_unavailable"));
+        }
+
+        if (loginContext.getRecentSuccessfulLoginIps().isEmpty()) {
+            return RiskFactorResult.raw(getName(), 10, Map.of("reason", "no_ip_history"));
+        }
+
+        if (loginContext.getRecentSuccessfulLoginIps().contains(remoteAddress)) {
+            return RiskFactorResult.raw(getName(), 0, Map.of("reason", "known_ip"));
+        }
+
+        return RiskFactorResult.raw(getName(), policy.getNewIpRiskScore(), Map.of("reason", "new_ip"));
+    }
+
+    private static String normalize(String value) {
+        if (StringUtil.isBlank(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/RiskStrategy.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/risk/strategy/RiskStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+
+public interface RiskStrategy {
+
+    String getName();
+
+    RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy);
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.authentication.AuthenticatorFactory
@@ -58,3 +58,4 @@ org.keycloak.authentication.authenticators.sessionlimits.UserSessionLimitsAuthen
 org.keycloak.authentication.authenticators.browser.RecoveryAuthnCodesFormAuthenticatorFactory
 org.keycloak.organization.authentication.authenticators.browser.OrganizationAuthenticatorFactory
 org.keycloak.authentication.authenticators.browser.PasskeysConditionalUIAuthenticatorFactory
+org.keycloak.authentication.authenticators.browser.risk.authn.RiskScoreAuthenticatorFactory

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticatorFactoryTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticatorFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.authn;
+
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RiskScoreAuthenticatorFactoryTest {
+
+    @Test
+    public void exposesExpectedConfigurationProperties() {
+        RiskScoreAuthenticatorFactory factory = new RiskScoreAuthenticatorFactory();
+
+        assertThat(factory.getId(), equalTo("risk-score-authenticator"));
+        assertThat(factory.isConfigurable(), equalTo(true));
+        assertThat(factory.getConfigProperties().stream().map(property -> property.getName()).collect(Collectors.toList()),
+                contains(
+                        AdaptiveAuthPolicy.LOW_RISK_THRESHOLD,
+                        AdaptiveAuthPolicy.HIGH_RISK_THRESHOLD,
+                        AdaptiveAuthPolicy.FAILED_ATTEMPTS_WEIGHT,
+                        AdaptiveAuthPolicy.IP_RISK_WEIGHT,
+                        AdaptiveAuthPolicy.DEVICE_RISK_WEIGHT,
+                        AdaptiveAuthPolicy.BEHAVIOR_RISK_WEIGHT,
+                        AdaptiveAuthPolicy.GEO_RISK_WEIGHT,
+                        AdaptiveAuthPolicy.FAILED_ATTEMPTS_THRESHOLD,
+                        AdaptiveAuthPolicy.NEW_IP_RISK_SCORE,
+                        AdaptiveAuthPolicy.NEW_DEVICE_RISK_SCORE,
+                        AdaptiveAuthPolicy.UNUSUAL_LOGIN_START_HOUR,
+                        AdaptiveAuthPolicy.UNUSUAL_LOGIN_END_HOUR,
+                        AdaptiveAuthPolicy.UNUSUAL_LOGIN_RISK_SCORE,
+                        AdaptiveAuthPolicy.NEW_GEO_RISK_SCORE,
+                        AdaptiveAuthPolicy.HISTORY_LOOKBACK_LIMIT));
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticatorTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/authn/RiskScoreAuthenticatorTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.authn;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import jakarta.ws.rs.core.Response;
+
+import org.junit.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.authenticators.browser.OTPFormAuthenticator;
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContextCollector;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthDecisionService;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AuthAction;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskFactorResult;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskLevel;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskScore;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskScoringService;
+import org.keycloak.common.ClientConnection;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.tracing.TracingProvider;
+
+import io.opentelemetry.api.trace.Span;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class RiskScoreAuthenticatorTest {
+
+    @Test
+    public void lowRiskAddsEventDetailsAndSucceeds() {
+        TestContext context = new TestContext(user("user-1"));
+        RiskScore score = score(12, RiskLevel.LOW, List.of(
+                RiskFactorResult.raw("failed_attempts", 0, Map.of()),
+                RiskFactorResult.raw("ip", 10, Map.of())));
+
+        authenticator(loginContext(context.user), score, AuthAction.ALLOW, new TestOtpAuthenticator()).authenticate(context.proxy);
+
+        assertThat(context.success, equalTo(true));
+        assertThat(context.event.getEvent().getDetails().get(RiskScoreAuthenticator.EVENT_RISK_SCORE), equalTo("12"));
+        assertThat(context.event.getEvent().getDetails().get(RiskScoreAuthenticator.EVENT_RISK_LEVEL), equalTo("LOW"));
+        assertThat(context.event.getEvent().getDetails().get(RiskScoreAuthenticator.EVENT_RISK_ACTION), equalTo("ALLOW"));
+        assertThat(context.event.getEvent().getDetails().get(RiskScoreAuthenticator.EVENT_RISK_FACTORS),
+                equalTo("failed_attempts:0,ip:10"));
+        assertThat(context.event.getEvent().getDetails().get(LoginContextCollector.EVENT_DETAIL_DEVICE), notNullValue());
+        assertThat(context.event.getEvent().getDetails().get(LoginContextCollector.EVENT_DETAIL_GEO), equalTo("US"));
+    }
+
+    @Test
+    public void mediumRiskSetsNotesAndChallengesForOtp() {
+        TestContext context = new TestContext(user("user-1"));
+        TestOtpAuthenticator otp = new TestOtpAuthenticator();
+
+        authenticator(loginContext(context.user), score(40, RiskLevel.MEDIUM, List.of()), AuthAction.STEP_UP_MFA, otp)
+                .authenticate(context.proxy);
+
+        assertThat(otp.authenticateCalled, equalTo(true));
+        assertThat(context.authNotes.get(RiskScoreAuthenticator.RISK_STEP_UP), equalTo("true"));
+        assertThat(context.authNotes.get(RiskScoreAuthenticator.RISK_LEVEL), equalTo("MEDIUM"));
+        assertThat(context.authNotes.get(RiskScoreAuthenticator.RISK_SCORE), equalTo("40"));
+    }
+
+    @Test
+    public void mediumRiskWithoutUserBlocksInsteadOfCrashing() {
+        TestContext context = new TestContext(null);
+
+        authenticator(loginContext(null), score(40, RiskLevel.MEDIUM, List.of()), AuthAction.STEP_UP_MFA,
+                new TestOtpAuthenticator()).authenticate(context.proxy);
+
+        assertThat(context.failureError, equalTo(AuthenticationFlowError.ACCESS_DENIED));
+        assertThat(context.failureResponse.getStatus(), equalTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+    }
+
+    @Test
+    public void mediumRiskWithoutConfiguredOtpBlocksInsteadOfBypassingStepUp() {
+        TestContext context = new TestContext(user("user-1"));
+        TestOtpAuthenticator otp = new TestOtpAuthenticator(false);
+
+        authenticator(loginContext(context.user), score(40, RiskLevel.MEDIUM, List.of()), AuthAction.STEP_UP_MFA, otp)
+                .authenticate(context.proxy);
+
+        assertThat(otp.authenticateCalled, equalTo(false));
+        assertThat(context.failureError, equalTo(AuthenticationFlowError.ACCESS_DENIED));
+        assertThat(context.failureResponse.getStatus(), equalTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+    }
+
+    @Test
+    public void mediumRiskActionDelegatesToOtpValidation() {
+        TestContext context = new TestContext(user("user-1"));
+        context.authNotes.put(RiskScoreAuthenticator.RISK_STEP_UP, "true");
+        TestOtpAuthenticator otp = new TestOtpAuthenticator();
+
+        authenticator(loginContext(context.user), score(40, RiskLevel.MEDIUM, List.of()), AuthAction.STEP_UP_MFA, otp)
+                .action(context.proxy);
+
+        assertThat(otp.actionCalled, equalTo(true));
+    }
+
+    @Test
+    public void highRiskBlocksWithBrowserChallenge() {
+        TestContext context = new TestContext(user("user-1"));
+
+        authenticator(loginContext(context.user), score(90, RiskLevel.HIGH, List.of()), AuthAction.BLOCK,
+                new TestOtpAuthenticator()).authenticate(context.proxy);
+
+        assertThat(context.failureError, equalTo(AuthenticationFlowError.ACCESS_DENIED));
+        assertThat(context.failureResponse.getStatus(), equalTo(Response.Status.UNAUTHORIZED.getStatusCode()));
+        assertThat(context.event.getEvent().getError(), equalTo(Errors.ACCESS_DENIED));
+    }
+
+    @Test
+    public void missingUserDoesNotCrashLowRiskEvaluation() {
+        TestContext context = new TestContext(null);
+
+        authenticator(loginContext(null), score(0, RiskLevel.LOW, List.of()), AuthAction.ALLOW, new TestOtpAuthenticator())
+                .authenticate(context.proxy);
+
+        assertThat(new RiskScoreAuthenticator().requiresUser(), equalTo(false));
+        assertThat(context.success, equalTo(true));
+    }
+
+    private static RiskScoreAuthenticator authenticator(LoginContext loginContext, RiskScore score, AuthAction action,
+            OTPFormAuthenticator otpAuthenticator) {
+        return new RiskScoreAuthenticator(new TestLoginContextCollector(loginContext), new TestRiskScoringService(score),
+                new TestDecisionService(action), otpAuthenticator);
+    }
+
+    private static RiskScore score(int value, RiskLevel level, List<RiskFactorResult> factors) {
+        return new RiskScore(value, level, factors);
+    }
+
+    private static LoginContext loginContext(UserModel user) {
+        String userId = user == null ? null : user.getId();
+        String username = user == null ? null : user.getUsername();
+        return new LoginContext("realm", userId, username, "127.0.0.1", "Browser", "en-US", "US", Instant.EPOCH, 0,
+                Set.of(), Set.of(), Set.of(), false);
+    }
+
+    private static UserModel user(String id) {
+        return proxy(UserModel.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getId" -> id;
+            case "getUsername" -> "alice";
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    private static EventBuilder eventBuilder(RealmModel realm, KeycloakSession session) {
+        return new EventBuilder(realm, session, connection()).storeImmediately(false);
+    }
+
+    private static ClientConnection connection() {
+        return proxy(ClientConnection.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getRemoteAddr", "getRemoteHost" -> "127.0.0.1";
+            case "getRemotePort", "getLocalPort" -> 0;
+            case "getLocalAddr" -> "127.0.0.1";
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    private static RealmModel realm() {
+        return proxy(RealmModel.class, (proxy, method, args) -> switch (method.getName()) {
+            case "getId", "getName" -> "realm";
+            case "isEventsEnabled" -> false;
+            case "getEventsListenersStream" -> Stream.<String>empty();
+            case "getEnabledEventTypesStream" -> Stream.<String>empty();
+            default -> defaultValue(method.getReturnType());
+        });
+    }
+
+    private static KeycloakSession session() {
+        KeycloakSessionFactory factory = proxy(KeycloakSessionFactory.class, (proxy, method, args) -> {
+            if ("getProviderFactoriesStream".equals(method.getName())) {
+                return Stream.<ProviderFactory<EventListenerProvider>>empty();
+            }
+            return defaultValue(method.getReturnType());
+        });
+
+        TracingProvider tracing = proxy(TracingProvider.class, (proxy, method, args) -> {
+            if ("getCurrentSpan".equals(method.getName())) {
+                return Span.getInvalid();
+            }
+            return defaultValue(method.getReturnType());
+        });
+
+        return proxy(KeycloakSession.class, (proxy, method, args) -> {
+            if ("getKeycloakSessionFactory".equals(method.getName())) {
+                return factory;
+            }
+            if ("getProvider".equals(method.getName()) && args != null && args.length > 0 && args[0] == TracingProvider.class) {
+                return tracing;
+            }
+            if ("getProvider".equals(method.getName())) {
+                return null;
+            }
+            return defaultValue(method.getReturnType());
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] { type }, (proxy, method, args) -> {
+            if (method.getDeclaringClass() == Object.class) {
+                return switch (method.getName()) {
+                    case "toString" -> type.getSimpleName() + "Proxy";
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == args[0];
+                    default -> null;
+                };
+            }
+            return handler.invoke(proxy, method, args);
+        });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == void.class) {
+            return null;
+        }
+        return 0;
+    }
+
+    private static final class TestContext {
+        private final RealmModel realm = realm();
+        private final KeycloakSession session = session();
+        private final EventBuilder event = eventBuilder(realm, session);
+        private final Map<String, String> authNotes = new HashMap<>();
+        private final UserModel user;
+        private final AuthenticationFlowContext proxy;
+        private boolean success;
+        private AuthenticationFlowError failureError;
+        private Response failureResponse;
+
+        private TestContext(UserModel user) {
+            this.user = user;
+            AuthenticationSessionModel authSession = proxy(AuthenticationSessionModel.class, (proxy, method, args) -> {
+                if ("setAuthNote".equals(method.getName())) {
+                    authNotes.put((String) args[0], (String) args[1]);
+                    return null;
+                }
+                if ("getAuthNote".equals(method.getName())) {
+                    return authNotes.get(args[0]);
+                }
+                return defaultValue(method.getReturnType());
+            });
+            LoginFormsProvider form = proxy(LoginFormsProvider.class, (proxy, method, args) -> {
+                if ("setError".equals(method.getName())) {
+                    return proxy;
+                }
+                if ("createErrorPage".equals(method.getName())) {
+                    return Response.status((Response.Status) args[0]).build();
+                }
+                return defaultValue(method.getReturnType());
+            });
+
+            this.proxy = proxy(AuthenticationFlowContext.class, (proxy, method, args) -> switch (method.getName()) {
+                case "getEvent" -> event;
+                case "getRealm" -> realm;
+                case "getSession" -> session;
+                case "getUser" -> user;
+                case "getConnection" -> connection();
+                case "getAuthenticationSession" -> authSession;
+                case "form" -> form;
+                case "success" -> {
+                    success = true;
+                    yield null;
+                }
+                case "failure" -> {
+                    failureError = (AuthenticationFlowError) args[0];
+                    failureResponse = args.length > 1 ? (Response) args[1] : null;
+                    yield null;
+                }
+                default -> defaultValue(method.getReturnType());
+            });
+        }
+    }
+
+    private static final class TestLoginContextCollector extends LoginContextCollector {
+        private final LoginContext loginContext;
+
+        private TestLoginContextCollector(LoginContext loginContext) {
+            this.loginContext = loginContext;
+        }
+
+        @Override
+        public LoginContext collect(AuthenticationFlowContext context, AdaptiveAuthPolicy policy) {
+            return loginContext;
+        }
+    }
+
+    private static final class TestRiskScoringService extends RiskScoringService {
+        private final RiskScore score;
+
+        private TestRiskScoringService(RiskScore score) {
+            this.score = score;
+        }
+
+        @Override
+        public RiskScore score(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+            return score;
+        }
+    }
+
+    private static final class TestDecisionService extends AdaptiveAuthDecisionService {
+        private final AuthAction action;
+
+        private TestDecisionService(AuthAction action) {
+            this.action = action;
+        }
+
+        @Override
+        public AuthAction decide(RiskScore score, AdaptiveAuthPolicy policy) {
+            return action;
+        }
+    }
+
+    private static final class TestOtpAuthenticator extends OTPFormAuthenticator {
+        private boolean authenticateCalled;
+        private boolean actionCalled;
+        private final boolean configured;
+
+        private TestOtpAuthenticator() {
+            this(true);
+        }
+
+        private TestOtpAuthenticator(boolean configured) {
+            this.configured = configured;
+        }
+
+        @Override
+        public void authenticate(AuthenticationFlowContext context) {
+            authenticateCalled = true;
+        }
+
+        @Override
+        public void action(AuthenticationFlowContext context) {
+            actionCalled = true;
+        }
+
+        @Override
+        public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
+            return configured;
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/context/LoginContextCollectorTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/context/LoginContextCollectorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.context;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class LoginContextCollectorTest {
+
+    @Test
+    public void geoSignalPrefersConfiguredHeaders() {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add(LoginContextCollector.HEADER_X_FORWARDED_COUNTRY, "ca");
+        headers.add(LoginContextCollector.HEADER_CLOUDFRONT_VIEWER_COUNTRY, "gb");
+        headers.add(LoginContextCollector.HEADER_CF_IP_COUNTRY, "us");
+
+        assertThat(LoginContextCollector.geoSignalFromHeaders(headers), equalTo("US"));
+    }
+
+    @Test
+    public void headerLookupIsCaseInsensitive() {
+        MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+        headers.add("user-agent", "browser");
+
+        assertThat(LoginContextCollector.firstHeader(headers, "User-Agent"), equalTo("browser"));
+    }
+
+    @Test
+    public void missingHeadersDoNotCrash() {
+        assertThat(LoginContextCollector.geoSignalFromHeaders(new MultivaluedHashMap<>()), nullValue());
+        assertThat(LoginContextCollector.firstHeader(null, "User-Agent"), nullValue());
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthDecisionServiceTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthDecisionServiceTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.decision;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskLevel;
+import org.keycloak.authentication.authenticators.browser.risk.scoring.RiskScore;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AdaptiveAuthDecisionServiceTest {
+
+    private final AdaptiveAuthDecisionService service = new AdaptiveAuthDecisionService();
+    private final AdaptiveAuthPolicy policy = AdaptiveAuthPolicy.defaults();
+
+    @Test
+    public void scoreBelowLowThresholdAllows() {
+        assertThat(service.decide(score(29), policy), equalTo(AuthAction.ALLOW));
+    }
+
+    @Test
+    public void scoreBetweenThresholdsStepsUp() {
+        assertThat(service.decide(score(30), policy), equalTo(AuthAction.STEP_UP_MFA));
+    }
+
+    @Test
+    public void scoreAboveHighThresholdBlocks() {
+        assertThat(service.decide(score(70), policy), equalTo(AuthAction.BLOCK));
+    }
+
+    private static RiskScore score(int value) {
+        return new RiskScore(value, RiskLevel.LOW, List.of());
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthPolicyTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/decision/AdaptiveAuthPolicyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.decision;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AdaptiveAuthPolicyTest {
+
+    @Test
+    public void defaultConfigLoadsCorrectly() {
+        AdaptiveAuthPolicy policy = AdaptiveAuthPolicy.defaults();
+
+        assertThat(policy.getLowRiskThreshold(), equalTo(30));
+        assertThat(policy.getHighRiskThreshold(), equalTo(70));
+        assertThat(policy.getFailedAttemptsWeight(), equalTo(35));
+        assertThat(policy.getHistoryLookbackLimit(), equalTo(10));
+    }
+
+    @Test
+    public void customConfigLoadsCorrectly() {
+        AdaptiveAuthPolicy policy = AdaptiveAuthPolicy.fromConfig(Map.of(
+                AdaptiveAuthPolicy.LOW_RISK_THRESHOLD, "20",
+                AdaptiveAuthPolicy.HIGH_RISK_THRESHOLD, "80",
+                AdaptiveAuthPolicy.NEW_IP_RISK_SCORE, "75",
+                AdaptiveAuthPolicy.UNUSUAL_LOGIN_START_HOUR, "22",
+                AdaptiveAuthPolicy.UNUSUAL_LOGIN_END_HOUR, "6"));
+
+        assertThat(policy.getLowRiskThreshold(), equalTo(20));
+        assertThat(policy.getHighRiskThreshold(), equalTo(80));
+        assertThat(policy.getNewIpRiskScore(), equalTo(75));
+        assertThat(policy.getUnusualLoginStartHour(), equalTo(22));
+        assertThat(policy.getUnusualLoginEndHour(), equalTo(6));
+    }
+
+    @Test
+    public void invalidConfigFallsBackSafely() {
+        AdaptiveAuthPolicy policy = AdaptiveAuthPolicy.fromConfig(Map.of(
+                AdaptiveAuthPolicy.LOW_RISK_THRESHOLD, "90",
+                AdaptiveAuthPolicy.HIGH_RISK_THRESHOLD, "10",
+                AdaptiveAuthPolicy.FAILED_ATTEMPTS_WEIGHT, "-10",
+                AdaptiveAuthPolicy.HISTORY_LOOKBACK_LIMIT, "not-a-number"));
+
+        assertThat(policy.getLowRiskThreshold(), equalTo(30));
+        assertThat(policy.getHighRiskThreshold(), equalTo(70));
+        assertThat(policy.getFailedAttemptsWeight(), equalTo(35));
+        assertThat(policy.getHistoryLookbackLimit(), equalTo(10));
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskScoringServiceTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/scoring/RiskScoringServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.scoring;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+import org.keycloak.authentication.authenticators.browser.risk.strategy.RiskStrategy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RiskScoringServiceTest {
+
+    private final LoginContext context = new LoginContext("realm", "user", "alice", "127.0.0.1", "ua", "en", null,
+            Instant.EPOCH, 0, Set.of(), Set.of(), Set.of(), false);
+
+    @Test
+    public void weightedScoresAggregateCorrectly() {
+        RiskScoringService service = new RiskScoringService(List.of(
+                fixed("failed_attempts", 100),
+                fixed("ip", 50),
+                fixed("device", 25),
+                fixed("behavior", 0),
+                fixed("geo", 10)));
+
+        RiskScore score = service.score(context, AdaptiveAuthPolicy.defaults());
+
+        assertThat(score.getValue(), equalTo(51));
+        assertThat(score.getLevel(), equalTo(RiskLevel.MEDIUM));
+        assertThat(score.getFactors().get(0).getWeightedScore(), equalTo(35));
+        assertThat(score.getFactors().get(4).getRawScore(), equalTo(10));
+    }
+
+    @Test
+    public void finalScoreClampsTo100() {
+        RiskScoringService service = new RiskScoringService(List.of(
+                fixed("failed_attempts", 100),
+                fixed("ip", 100),
+                fixed("device", 100),
+                fixed("behavior", 100),
+                fixed("geo", 100)));
+
+        RiskScore score = service.score(context, AdaptiveAuthPolicy.fromConfig(Map.of(
+                AdaptiveAuthPolicy.FAILED_ATTEMPTS_WEIGHT, "100",
+                AdaptiveAuthPolicy.IP_RISK_WEIGHT, "100",
+                AdaptiveAuthPolicy.DEVICE_RISK_WEIGHT, "100",
+                AdaptiveAuthPolicy.BEHAVIOR_RISK_WEIGHT, "100",
+                AdaptiveAuthPolicy.GEO_RISK_WEIGHT, "100")));
+
+        assertThat(score.getValue(), equalTo(100));
+        assertThat(score.getLevel(), equalTo(RiskLevel.HIGH));
+    }
+
+    @Test
+    public void scoreNeverGoesBelowZeroAndKeepsFactorBreakdown() {
+        RiskScoringService service = new RiskScoringService(List.of(fixed("unknown", -10)));
+
+        RiskScore score = service.score(context, AdaptiveAuthPolicy.defaults());
+
+        assertThat(score.getValue(), equalTo(0));
+        assertThat(score.getLevel(), equalTo(RiskLevel.LOW));
+        assertThat(score.getFactors().size(), equalTo(1));
+        assertThat(score.getFactors().get(0).getRawScore(), equalTo(0));
+    }
+
+    private static RiskStrategy fixed(String name, int rawScore) {
+        return new RiskStrategy() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public RiskFactorResult evaluate(LoginContext loginContext, AdaptiveAuthPolicy policy) {
+                return RiskFactorResult.raw(name, rawScore, Map.of("fixed", "true"));
+            }
+        };
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/BehaviorRiskStrategyTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/BehaviorRiskStrategyTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class BehaviorRiskStrategyTest {
+
+    private final BehaviorRiskStrategy strategy = new BehaviorRiskStrategy();
+
+    @Test
+    public void unusualLoginHourGivesBehaviorRisk() {
+        assertThat(strategy.evaluate(context("2026-06-09T02:00:00Z"), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(50));
+    }
+
+    @Test
+    public void normalLoginHourGivesLowRisk() {
+        assertThat(strategy.evaluate(context("2026-06-09T12:00:00Z"), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(0));
+    }
+
+    @Test
+    public void wraparoundWindowIsHandled() {
+        assertThat(BehaviorRiskStrategy.isInsideWindow(23, 22, 5), equalTo(true));
+        assertThat(BehaviorRiskStrategy.isInsideWindow(4, 22, 5), equalTo(true));
+        assertThat(BehaviorRiskStrategy.isInsideWindow(12, 22, 5), equalTo(false));
+    }
+
+    private static org.keycloak.authentication.authenticators.browser.risk.context.LoginContext context(String instant) {
+        return LoginContextTestUtils.context(0, "127.0.0.1", "ua", "en", null, Instant.parse(instant), Set.of(),
+                Set.of(), Set.of(), false);
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/DeviceRiskStrategyTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/DeviceRiskStrategyTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+public class DeviceRiskStrategyTest {
+
+    private final DeviceRiskStrategy strategy = new DeviceRiskStrategy();
+
+    @Test
+    public void knownDeviceGivesLowRisk() {
+        String fingerprint = DeviceRiskStrategy.fingerprint("UA", "en");
+
+        assertThat(strategy.evaluate(context("UA", "en", Set.of(fingerprint), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(0));
+    }
+
+    @Test
+    public void newDeviceGivesConfiguredRisk() {
+        assertThat(strategy.evaluate(context("UA2", "en", Set.of(DeviceRiskStrategy.fingerprint("UA1", "en")), true),
+                AdaptiveAuthPolicy.defaults()).getRawScore(), equalTo(60));
+    }
+
+    @Test
+    public void missingUserAgentGivesLowNeutralRisk() {
+        assertThat(DeviceRiskStrategy.fingerprint(null, "en"), nullValue());
+        assertThat(strategy.evaluate(context(null, "en", Set.of(), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(10));
+    }
+
+    @Test
+    public void fingerprintIsHashed() {
+        assertThat(DeviceRiskStrategy.fingerprint("UA", "en"), not(equalTo("ua|en")));
+    }
+
+    private static org.keycloak.authentication.authenticators.browser.risk.context.LoginContext context(String userAgent,
+            String acceptLanguage, Set<String> devices, boolean historyAvailable) {
+        return LoginContextTestUtils.context(0, "127.0.0.1", userAgent, acceptLanguage, null, Instant.EPOCH, Set.of(),
+                devices, Set.of(), historyAvailable);
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/FailedAttemptRiskStrategyTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/FailedAttemptRiskStrategyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class FailedAttemptRiskStrategyTest {
+
+    private final FailedAttemptRiskStrategy strategy = new FailedAttemptRiskStrategy();
+
+    @Test
+    public void failedAttemptsProduceProportionalRisk() {
+        assertThat(strategy.evaluate(context(0), AdaptiveAuthPolicy.defaults()).getRawScore(), equalTo(0));
+        assertThat(strategy.evaluate(context(1), AdaptiveAuthPolicy.defaults()).getRawScore(), equalTo(33));
+        assertThat(strategy.evaluate(context(3), AdaptiveAuthPolicy.defaults()).getRawScore(), equalTo(100));
+        assertThat(strategy.evaluate(context(6), AdaptiveAuthPolicy.defaults()).getRawScore(), equalTo(100));
+    }
+
+    private static org.keycloak.authentication.authenticators.browser.risk.context.LoginContext context(int failures) {
+        return LoginContextTestUtils.context(failures, "127.0.0.1", "ua", "en", null, Instant.EPOCH, Set.of(), Set.of(),
+                Set.of(), false);
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/GeoLocationRiskStrategyTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/GeoLocationRiskStrategyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class GeoLocationRiskStrategyTest {
+
+    private final GeoLocationRiskStrategy strategy = new GeoLocationRiskStrategy();
+
+    @Test
+    public void missingGeoSignalGivesNeutralRisk() {
+        assertThat(strategy.evaluate(context(null, Set.of("US"), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(0));
+    }
+
+    @Test
+    public void sameGeoSignalGivesLowRisk() {
+        assertThat(strategy.evaluate(context("us", Set.of("US"), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(0));
+    }
+
+    @Test
+    public void changedGeoSignalGivesConfiguredRisk() {
+        assertThat(strategy.evaluate(context("CA", Set.of("US"), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(50));
+    }
+
+    @Test
+    public void missingHistoryReturnsNeutralRisk() {
+        assertThat(strategy.evaluate(context("US", Set.of(), false), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(10));
+        assertThat(strategy.evaluate(context("US", Set.of(), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(10));
+    }
+
+    private static org.keycloak.authentication.authenticators.browser.risk.context.LoginContext context(String geo,
+            Set<String> geos, boolean historyAvailable) {
+        return LoginContextTestUtils.context(0, "127.0.0.1", "ua", "en", geo, Instant.EPOCH, Set.of(), Set.of(),
+                geos, historyAvailable);
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/IPRiskStrategyTest.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/IPRiskStrategyTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.Test;
+import org.keycloak.authentication.authenticators.browser.risk.decision.AdaptiveAuthPolicy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IPRiskStrategyTest {
+
+    private final IPRiskStrategy strategy = new IPRiskStrategy();
+
+    @Test
+    public void knownIpGivesLowRisk() {
+        assertThat(strategy.evaluate(context("10.0.0.1", Set.of("10.0.0.1"), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(0));
+    }
+
+    @Test
+    public void newIpGivesConfiguredRisk() {
+        assertThat(strategy.evaluate(context("10.0.0.2", Set.of("10.0.0.1"), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(60));
+    }
+
+    @Test
+    public void missingHistoryReturnsNeutralRisk() {
+        assertThat(strategy.evaluate(context("10.0.0.2", Set.of(), false), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(10));
+        assertThat(strategy.evaluate(context("10.0.0.2", Set.of(), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(10));
+    }
+
+    @Test
+    public void missingIpReturnsNeutralRisk() {
+        assertThat(strategy.evaluate(context(null, Set.of("10.0.0.1"), true), AdaptiveAuthPolicy.defaults()).getRawScore(),
+                equalTo(0));
+    }
+
+    private static org.keycloak.authentication.authenticators.browser.risk.context.LoginContext context(String ip, Set<String> ips,
+            boolean historyAvailable) {
+        return LoginContextTestUtils.context(0, ip, "ua", "en", null, Instant.EPOCH, ips, Set.of(), Set.of(),
+                historyAvailable);
+    }
+}

--- a/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/LoginContextTestUtils.java
+++ b/services/src/test/java/org/keycloak/authentication/authenticators/browser/risk/strategy/LoginContextTestUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.authentication.authenticators.browser.risk.strategy;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.keycloak.authentication.authenticators.browser.risk.context.LoginContext;
+
+final class LoginContextTestUtils {
+
+    private LoginContextTestUtils() {
+    }
+
+    static LoginContext context(int failures, String ip, String userAgent, String acceptLanguage, String geo,
+            Instant loginTime, Set<String> ips, Set<String> devices, Set<String> geos, boolean historyAvailable) {
+        return new LoginContext("realm", "user", "alice", ip, userAgent, acceptLanguage, geo, loginTime, failures, ips,
+                devices, geos, historyAvailable);
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in browser authenticator that performs adaptive login risk scoring during the browser authentication flow. The authenticator collects a lightweight login context from the current request, user failure state, and available event history, then evaluates failed-attempt, IP, device, behavior, and geo-location signals without external APIs or new database tables.

Low-risk logins continue normally. Medium-risk logins delegate to the existing OTP form authenticator when OTP is configured for the user, providing step-up MFA through the existing Keycloak flow machinery. High-risk logins are blocked with an access-denied browser challenge.

## Cause and effect

Keycloak browser flows can currently be configured with fixed requirements, but the requested feature needs per-login risk evaluation so suspicious attempts can receive stronger treatment than familiar attempts. Without this authenticator, administrators cannot insert a configurable risk decision point into a browser flow without custom provider code.

This change introduces that decision point as a normal authenticator provider. Realms can add the authenticator to browser flows, configure weights and thresholds, and receive audit details such as risk score, level, action, and factor breakdown on login events.

## Implementation

- Registers `risk-score-authenticator` as a configurable browser authenticator.
- Adds immutable login context collection with null-safe request/header handling and neutral fallback behavior when event history is unavailable.
- Adds weighted risk scoring strategies for failed attempts, new IP, new device fingerprint, unusual login time, and geo changes.
- Adds threshold-based adaptive decisions for allow, step-up MFA, and block.
- Records `risk_score`, `risk_level`, `risk_action`, and `risk_factors` event details, plus internal device/geo details used for future correlation.
- Uses existing OTP flow behavior for medium-risk step-up and blocks conservatively when OTP cannot be performed.

## Review follow-up

Reviewer agents checked the implementation and the feedback was applied before this PR. Fixes included replacing the original medium-risk no-op with OTP delegation, returning a browser challenge on blocked attempts, using integer provider config properties, making missing-user handling safe, falling back to default config values for invalid settings, and blocking medium-risk attempts when OTP is unavailable rather than silently allowing them.

## Testing

```bash
./mvnw -pl services -am -Dtest='org.keycloak.authentication.authenticators.browser.risk.**.*Test' test
```

Passed: 36 tests, 0 failures, 0 errors.

Also ran `git diff --check` and a trailing-whitespace scan for the new Java files.
