### PR TITLE
[OID4VCI-FAPI2] Pass fapi2-security-profile-final-ensure-request-object-without-redirect-uri-fails

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -19,6 +19,7 @@ package org.keycloak.protocol.oidc.endpoints;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import jakarta.ws.rs.Consumes;
@@ -400,12 +401,17 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         this.event.event(EventType.LOGIN);
         authenticationSession.setAuthNote(Details.AUTH_TYPE, CODE_AUTH_TYPE);
 
-        // redirect if it is a PAR request because authentication can need a refresh (kerberos) and the single object is consumed now
-        final boolean redirectToAuthenticationIfParRequest = requestUriParam != null
-                && RequestUriType.PAR == AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUriParam);
+        RequestUriType requestUriType = Optional.ofNullable(requestUriParam)
+                .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
+                .orElse(null);
 
-        return handleBrowserAuthenticationRequest(authenticationSession, new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event),
-                TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE), redirectToAuthenticationIfParRequest);
+        // Redirect if it is a PAR request because authentication may need a refresh (kerberos) and the single object is consumed now
+        boolean redirectToAuthFlow = requestUriType == RequestUriType.PAR;
+
+        OIDCLoginProtocol loginProtocol = new OIDCLoginProtocol(session, realm, session.getContext().getUri(), headers, event);
+        boolean isPassive = TokenUtil.hasPrompt(request.getPrompt(), OIDCLoginProtocol.PROMPT_VALUE_NONE);
+        Response response = handleBrowserAuthenticationRequest(authenticationSession, loginProtocol, isPassive, redirectToAuthFlow);
+        return response;
     }
 
     private Response buildRegister() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -48,7 +48,6 @@ import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
-import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorManager;
 import org.keycloak.protocol.oidc.resourceindicators.ResourceIndicatorConstants;
@@ -72,6 +71,7 @@ import org.jboss.logging.Logger;
 import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 import static org.keycloak.OAuth2Constants.ISSUER_STATE;
 import static org.keycloak.protocol.oid4vc.clientpolicy.CredentialClientPolicies.VC_POLICY_CREDENTIAL_OFFER_REQUIRED;
+import static org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor.getRequestUriType;
 
 /**
  * Implements some checks typical for OIDC Authorization Endpoint. Useful to consolidate various checks on single place to avoid duplicated
@@ -160,22 +160,27 @@ public class AuthorizationEndpointChecker {
     }
 
     public void checkRedirectUri() throws AuthorizationCheckException {
-        String redirectUriParam = request.getRedirectUri();
-        boolean isOIDCRequest = TokenUtil.isOIDCRequest(request.getScope());
 
-        event.detail(Details.REDIRECT_URI, redirectUriParam);
+        String redirectUri = request.getRedirectUri();
+        String scope = request.getScope();
+
+        // The redirect_uri parameter is required for OIDC, but optional for OAuth2
+        boolean isOIDCRequest = TokenUtil.isOIDCRequest(scope);
+
+        event.detail(Details.REDIRECT_URI, redirectUri);
 
         // redirect_uri parameter is required per OpenID Connect, but optional per OAuth2
-        this.redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUriParam, client, isOIDCRequest);
-        if (redirectUri == null) {
+        this.redirectUri = RedirectUtils.verifyRedirectUri(session, redirectUri, client, isOIDCRequest);
+        if (this.redirectUri == null) {
             event.error(Errors.INVALID_REDIRECT_URI);
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, Messages.INVALID_PARAMETER, OIDCLoginProtocol.REDIRECT_URI_PARAM);
         }
     }
 
-
     public void checkResponseType() throws AuthorizationCheckException {
+
         String responseType = request.getResponseType();
+        String responseMode = request.getResponseMode();
 
         if (responseType == null) {
             ServicesLogger.LOGGER.missingParameter(OAuth2Constants.RESPONSE_TYPE);
@@ -188,16 +193,15 @@ public class AuthorizationEndpointChecker {
         event.detail(Details.RESPONSE_TYPE, responseType);
 
         try {
-            this.parsedResponseType = OIDCResponseType.parse(responseType);
+            parsedResponseType = OIDCResponseType.parse(responseType);
         } catch (IllegalArgumentException iae) {
             event.detail(Details.REASON, iae.getMessage());
             event.error(Errors.INVALID_REQUEST);
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE, null);
         }
 
-        OIDCResponseMode parsedResponseMode = null;
         try {
-            parsedResponseMode = OIDCResponseMode.parse(request.getResponseMode(), parsedResponseType);
+            parsedResponseMode = OIDCResponseMode.parse(responseMode, parsedResponseType);
         } catch (IllegalArgumentException iae) {
             ServicesLogger.LOGGER.invalidParameter(OIDCLoginProtocol.RESPONSE_MODE_PARAM);
             String errorMessage = "Invalid parameter: " + OIDCLoginProtocol.RESPONSE_MODE_PARAM;
@@ -205,8 +209,6 @@ public class AuthorizationEndpointChecker {
             event.error(Errors.INVALID_REQUEST);
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
-
-        event.detail(Details.RESPONSE_MODE, parsedResponseMode.toString().toLowerCase());
 
         // Disallowed by OIDC specs
         if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY) {
@@ -217,7 +219,7 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorMessage);
         }
 
-        this.parsedResponseMode = parsedResponseMode;
+        event.detail(Details.RESPONSE_MODE, parsedResponseMode.toString().toLowerCase());
 
         if (parsedResponseType.isImplicitOrHybridFlow() && parsedResponseMode == OIDCResponseMode.QUERY_JWT &&
                 (!StringUtil.isNotBlank(client.getAttribute(OIDCConfigAttributes.AUTHORIZATION_ENCRYPTED_RESPONSE_ALG)) ||
@@ -349,7 +351,7 @@ public class AuthorizationEndpointChecker {
             return;
         }
         String requestUriParam = params.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
-        if (requestUriParam != null && AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUriParam) == RequestUriType.PAR) {
+        if (requestUriParam != null && getRequestUriType(requestUriParam) == RequestUriType.PAR) {
             return;
         }
         ServicesLogger.LOGGER.missingParameter(OIDCLoginProtocol.REQUEST_URI_PARAM);

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/AbstractParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/AbstractParEndpoint.java
@@ -72,12 +72,12 @@ public abstract class AbstractParEndpoint {
             cors.checkAllowedOrigins(session, client);
 
             if (client == null) {
-                throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Client not allowed.", Response.Status.FORBIDDEN);
+                throw errorResponseException(OAuthErrorException.INVALID_REQUEST, "Client not allowed.", Response.Status.FORBIDDEN);
             }
         } catch (ForbiddenException e) {
             throw e;
         } catch (Exception e) {
-            throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Authentication failed.", Response.Status.UNAUTHORIZED);
+            throw errorResponseException(OAuthErrorException.INVALID_REQUEST, "Authentication failed.", Response.Status.UNAUTHORIZED);
         }
     }
 
@@ -93,7 +93,7 @@ public abstract class AbstractParEndpoint {
         return hash;
     }
 
-    protected CorsErrorResponseException throwErrorResponseException(String error, String detail, Response.Status status) {
+    protected CorsErrorResponseException errorResponseException(String error, String detail, Response.Status status) {
         this.event.detail("detail", detail).error(error);
         return new CorsErrorResponseException(cors, error, detail, status);
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -99,7 +99,7 @@ public class ParEndpoint extends AbstractParEndpoint {
         MultivaluedMap<String, String> decodedFormParameters = httpRequest.getDecodedFormParameters();
 
         if (decodedFormParameters.containsKey(REQUEST_URI_PARAM)) {
-            throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "It is not allowed to include request_uri to PAR.", Response.Status.BAD_REQUEST);
+            throw errorResponseException(OAuthErrorException.INVALID_REQUEST, "It is not allowed to include request_uri to PAR.", Response.Status.BAD_REQUEST);
         }
 
         // https://datatracker.ietf.org/doc/html/rfc9449#section-10.1
@@ -109,9 +109,9 @@ public class ParEndpoint extends AbstractParEndpoint {
             authorizationRequest = ParEndpointRequestParserProcessor.parseRequest(event, session, client, decodedFormParameters);
         } catch (Exception e) {
             if (!decodedFormParameters.containsKey(OIDCLoginProtocol.REQUEST_PARAM)) {
-                throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
+                throw errorResponseException(OAuthErrorException.INVALID_REQUEST, e.getMessage(), Response.Status.BAD_REQUEST);
             }
-            throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST_OBJECT, e.getMessage(), Response.Status.BAD_REQUEST);
+            throw errorResponseException(OAuthErrorException.INVALID_REQUEST_OBJECT, e.getMessage(), Response.Status.BAD_REQUEST);
         }
 
         AuthorizationEndpointChecker checker = new AuthorizationEndpointChecker()
@@ -124,14 +124,14 @@ public class ParEndpoint extends AbstractParEndpoint {
         try {
             checker.checkRedirectUri();
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
-            throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: redirect_uri", Response.Status.BAD_REQUEST);
+            throw errorResponseException(OAuthErrorException.INVALID_REQUEST, "Invalid parameter: redirect_uri", Response.Status.BAD_REQUEST);
         }
 
         try {
             checker.checkResponseType();
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
             if (ex.getError().equals(OAuthErrorException.UNSUPPORTED_RESPONSE_TYPE)) {
-                throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, "Unsupported response type", Response.Status.BAD_REQUEST);
+                throw errorResponseException(OAuthErrorException.INVALID_REQUEST, "Unsupported response type", Response.Status.BAD_REQUEST);
             } else {
                 checker.throwAsCorsErrorResponseException(cors, ex);
             }
@@ -141,7 +141,7 @@ public class ParEndpoint extends AbstractParEndpoint {
             checker.checkValidScope();
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
             // PAR throws this as "invalid_request" error
-            throw throwErrorResponseException(OAuthErrorException.INVALID_REQUEST, ex.getErrorDescription(), Response.Status.BAD_REQUEST);
+            throw errorResponseException(OAuthErrorException.INVALID_REQUEST, ex.getErrorDescription(), Response.Status.BAD_REQUEST);
         }
 
         try {
@@ -161,7 +161,7 @@ public class ParEndpoint extends AbstractParEndpoint {
             event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
             event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
             event.error(cpe.getError());
-            throw throwErrorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+            throw errorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
         }
 
         Map<String, String> params = new HashMap<>();

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureParContentsExecutor.java
@@ -36,6 +36,7 @@ import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestObjectParser;
 import org.keycloak.protocol.oidc.endpoints.request.AuthzEndpointRequestParser;
 import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
+import org.keycloak.protocol.oidc.par.clientpolicy.context.PushedAuthorizationRequestContext;
 import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyContext;
@@ -64,17 +65,28 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
     @Override
     public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
         switch (context.getEvent()) {
-            case PRE_AUTHORIZATION_REQUEST:
+            case PUSHED_AUTHORIZATION_REQUEST -> {
+                PushedAuthorizationRequestContext parAuthorizationRequestContext = (PushedAuthorizationRequestContext)context;
+                checkParAuthorizationRequest(parAuthorizationRequestContext);
+            }
+            case PRE_AUTHORIZATION_REQUEST -> {
                 PreAuthorizationRequestContext preAuthorizationRequestContext = (PreAuthorizationRequestContext)context;
-                checkValidParContents(preAuthorizationRequestContext);
-                break;
-            default:
-                return;
+                checkPreAuthorizationRequest(preAuthorizationRequestContext);
+            }
         }
     }
 
-    private void checkValidParContents(PreAuthorizationRequestContext preAuthorizationRequestContext) throws ClientPolicyException {
-        MultivaluedMap<String, String> requestParametersFromQuery = preAuthorizationRequestContext.getRequestParameters();
+    private void checkParAuthorizationRequest(PushedAuthorizationRequestContext context) throws ClientPolicyException {
+        // FAPI 2.0: For authorization-endpoint flows, ASs “shall require the redirect_uri parameter in pushed authorization requests”
+        // and clients must send only client_id and request_uri to the authorization endpoint afterward.
+        AuthorizationEndpointRequest request = context.getRequest();
+        if (request.getRedirectUri() == null) {
+            throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR is required to have a 'redirect_uri' parameter");
+        }
+    }
+
+    private void checkPreAuthorizationRequest(PreAuthorizationRequestContext context) throws ClientPolicyException {
+        MultivaluedMap<String, String> requestParametersFromQuery = context.getRequestParameters();
         String requestUri = requestParametersFromQuery.getFirst(OIDCLoginProtocol.REQUEST_URI_PARAM);
         if (requestUri == null || AuthorizationEndpointRequestParserProcessor.getRequestUriType(requestUri) != RequestUriType.PAR) {
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST, "PAR request_uri not included.");
@@ -85,22 +97,22 @@ public class SecureParContentsExecutor implements ClientPolicyExecutorProvider<C
             throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_URI, "PAR not found, not issued or used multiple times.");
         }
 
-        Set<String> requestParametersNameFromPAR;
+        Set<String> requestParameterKeysFromPAR;
         if (requestParametersFromPAR.containsKey(OIDCLoginProtocol.REQUEST_PARAM)) {
             // if PAR request includes request object (JAR), parsing the request is needed.
-            requestParametersNameFromPAR = getParRetrievedRequestParameters(requestParametersFromPAR, preAuthorizationRequestContext.getClientId());
+            requestParameterKeysFromPAR = getParRetrievedRequestParameters(requestParametersFromPAR, context.getClientId());
         } else {
-            requestParametersNameFromPAR = requestParametersFromPAR.keySet();
+            requestParameterKeysFromPAR = requestParametersFromPAR.keySet();
         }
 
-        List<String> queryKeys = requestParametersFromQuery.keySet().stream()
+        List<String> requestParameterKeysFromQuery = requestParametersFromQuery.keySet().stream()
                 .filter(it -> !it.equals(OIDCLoginProtocol.REQUEST_URI_PARAM))
                 .toList();
 
         // FAPI says only parameters inside the request object should be used
         //
-        for (String queryParam : queryKeys) {
-            if (!requestParametersNameFromPAR.contains(queryParam)) {
+        for (String queryParam : requestParameterKeysFromQuery) {
+            if (!requestParameterKeysFromPAR.contains(queryParam)) {
                 AuthzEndpointParParser.removeRequestObject(session, requestUri);
                 log.warnf("PAR request did not include query parameter: %s", queryParam);
                 throw new ClientPolicyException(OAuthErrorException.INVALID_REQUEST_OBJECT, "PAR request did not include query parameter");

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureSigningAlgorithmForSignedJwtExecutorFactory.java
@@ -17,8 +17,6 @@
 
 package org.keycloak.services.clientpolicy.executor;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.keycloak.Config.Scope;
@@ -66,7 +64,7 @@ public class SecureSigningAlgorithmForSignedJwtExecutorFactory implements Client
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return new ArrayList<>(Arrays.asList(REQUIRE_CLIENT_ASSERTION_PROPERTY));
+        return List.of(REQUIRE_CLIENT_ASSERTION_PROPERTY);
     }
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
@@ -1,4 +1,4 @@
-package org.keycloak.tests.oid4vc.haip;
+package org.keycloak.tests.oid4vc.abca;
 
 
 import java.util.Map;
@@ -24,9 +24,8 @@ import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.ErrorPage;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
-import org.keycloak.tests.oid4vc.abca.OIDCClientAttester;
-import org.keycloak.tests.oid4vc.abca.OIDCMockClientAttester;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.ParResponse;
 import org.keycloak.testsuite.util.oauth.PkceGenerator;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
@@ -42,7 +41,9 @@ import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Replicates various tests in oid4vci-1_0-issuer-haip-test-plan
@@ -168,11 +169,9 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
      * Uses a request object that does not contain state, but state is passed in the url parameters to the authorization endpoint
      * (hence state should be ignored, as FAPI says only parameters inside the request object should be used).
      * The expected result is a successful authentication that returns neither state nor s_hash.
-     *
-     * It is also permissible to return an error message: invalid_request, invalid_request_object or access_denied.
      */
     @Test
-    public void testOnlyParametersInsideRequestObjectAreUsed() throws Exception {
+    public void testOnlyParametersInsideRequestObjectAreUsed() {
 
         var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
         ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
@@ -197,16 +196,15 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
 
         // Send Authorization Request
         //
-        var success = wallet.authorizationRequest()
+        wallet.authorizationRequest()
                 .requestUri(requestUri)
                 .codeChallenge(pkce)
                 .state("123456")
                 .openLoginForm();
-
         errorPage.assertCurrent();
         assertEquals("PAR request did not include query parameter", errorPage.getError());
 
-        // When error on redirect_uri is configured, we'd need to assert the json response
+        // When error on redirect_uri is configured, we'd need to assert the JSON response
         //
         // assertFalse(authRequest.openLoginForm(), "Error expected");
         // AuthorizationEndpointResponse authResponse = authRequest.parseLoginResponse();
@@ -214,6 +212,47 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         // assertNull(authResponse.getCode(), "Expected no auth code");
         // assertEquals("invalid_request", authResponse.getError());
         // assertEquals("PAR request did not include query parameter", authResponse.getErrorDescription());
+    }
+
+    /**
+     * fapi2-security-profile-final-ensure-request-object-without-redirect-uri-fails
+     *
+     * This test should end with the authorization server showing an error message that the request object is invalid
+     * due to the missing redirect uri.
+     */
+    @Test
+    public void testRequestObjectWithoutRedirectUriFails() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var pkce = PkceGenerator.s256();
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper rsaKey = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, rsaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, rsaKey);
+
+        String redirectUri = oauth.config().getRedirectUri();
+        try {
+            oauth.config().redirectUri(null);
+
+            // Send PAR Request (without redirect_uri)
+            //
+            ParResponse parResponse = oauth.pushedAuthorizationRequest()
+                    .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                    .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                    .scopeParam(ctx.getScope())
+                    .codeChallenge(pkce)
+                    .send();
+            assertFalse(parResponse.isSuccess());
+            assertNull(parResponse.getRequestUri(), "Expected no request_uri");
+            assertEquals("invalid_request", parResponse.getError());
+            assertEquals("PAR is required to have a 'redirect_uri' parameter", parResponse.getErrorDescription());
+        } finally {
+            oauth.config().redirectUri(redirectUri);
+        }
     }
 
     // Private ---------------------------------------------------------------------------------------------------------

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/LoginUrlBuilder.java
@@ -121,11 +121,19 @@ public class LoginUrlBuilder extends AbstractUrlBuilder {
 
     @Override
     protected void initRequest() {
-        parameter(OAuth2Constants.RESPONSE_TYPE, client.config().getResponseType());
-        parameter(OIDCLoginProtocol.RESPONSE_MODE_PARAM, client.config().getResponseMode());
-        parameter(OAuth2Constants.CLIENT_ID, client.config().getClientId());
-        parameter(OAuth2Constants.REDIRECT_URI, client.config().getRedirectUri());
-        if (!params.containsKey(OAuth2Constants.SCOPE)) {
+        if (client.config().getResponseType() != null) {
+            parameter(OAuth2Constants.RESPONSE_TYPE, client.config().getResponseType());
+        }
+        if (client.config().getResponseMode() != null) {
+            parameter(OIDCLoginProtocol.RESPONSE_MODE_PARAM, client.config().getResponseMode());
+        }
+        if (client.config().getClientId() != null) {
+            parameter(OAuth2Constants.CLIENT_ID, client.config().getClientId());
+        }
+        if (client.config().getRedirectUri() != null) {
+            parameter(OAuth2Constants.REDIRECT_URI, client.config().getRedirectUri());
+        }
+        if (!params.containsKey(OAuth2Constants.SCOPE) && client.config().getScope() != null) {
             parameter(OAuth2Constants.SCOPE, client.config().getScope());
         }
     }


### PR DESCRIPTION
closes #48579

This PR ...

* Adds profile feature `--oid4vc-haip` and when enabled ...
  * Rejects PAR request without `redirect_uri`
  * Rejects authorization request with `response_type` other than `code`

