### PR TITLE
feat(admin-ui): add reload button to OIDC client keys page

### DIFF
--- a/js/apps/admin-ui/src/clients/keys/Keys.tsx
+++ b/js/apps/admin-ui/src/clients/keys/Keys.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   TextContent,
 } from "@patternfly/react-core";
+import { SyncAltIcon } from "@patternfly/react-icons";
 import { saveAs } from "file-saver";
 import { useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
@@ -191,6 +192,14 @@ export const Keys = ({
                 isDisabled={useJwksUrl === "true"}
               >
                 {t("import")}
+              </Button>
+              <Button
+                data-testid="reload"
+                variant="secondary"
+                onClick={refresh}
+                isDisabled={useJwksUrl === "true"}
+              >
+                <SyncAltIcon /> {t("refresh")}
               </Button>
             </ActionGroup>
           </FormAccess>

--- a/js/apps/admin-ui/test/clients/keys.spec.ts
+++ b/js/apps/admin-ui/test/clients/keys.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+import { v4 as uuid } from "uuid";
+import adminClient from "../utils/AdminClient.ts";
+import { switchOff } from "../utils/form.ts";
+import { login } from "../utils/login.ts";
+import { goToClients, goToRealm } from "../utils/sidebar.ts";
+import { clickTableRowItem, searchItem } from "../utils/table.ts";
+
+test.describe.serial("Clients OIDC keys", () => {
+  const realmName = `clients-keys-realm-${uuid()}`;
+  const clientId = `client-keys-${uuid()}`;
+
+  test.beforeAll(async () => {
+    await adminClient.createRealm(realmName);
+    await adminClient.createClient({
+      clientId,
+      protocol: "openid-connect",
+      publicClient: false,
+      realm: realmName,
+      attributes: {
+        "use.jwks.url": "true",
+      },
+    });
+  });
+
+  test.afterAll(() => adminClient.deleteRealm(realmName));
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToRealm(page, realmName);
+    await goToClients(page);
+    await searchItem(page, "Search for client", clientId);
+    await clickTableRowItem(page, clientId);
+    await page.getByTestId("keysTab").click();
+  });
+
+  test("Should enable reload when JWKS URL is disabled", async ({ page }) => {
+    await expect(page.getByTestId("reload")).toBeVisible();
+    await expect(page.getByTestId("reload")).toBeDisabled();
+
+    await switchOff(page, page.getByTestId("attributes.use.jwks.url"));
+
+    await expect(page.getByTestId("reload")).toBeEnabled();
+  });
+});


### PR DESCRIPTION
The Keys tab in the OIDC client details view now exposes a Reload action alongside the existing Import button. The new button triggers the existing `refresh` handler and is disabled when the JWKS URL switch is enabled, matching the behavior of the Import button.

Resolves #17762

**Changes**
- Added a secondary-variant Refresh button to the `ActionGroup` in `js/apps/admin-ui/src/clients/keys/Keys.tsx`, placed after the Import button.
- Imported `SyncAltIcon` from `@patternfly/react-icons` and rendered it before the button label.
- Reused the existing `t('refresh')` translation key; no new strings were added.
- Applied `data-testid="reload"` to the button to align with the testid pattern used for the sibling Save/Generate/Import buttons.
- Disabled the button when `useJwksUrl === "true"` so it stays consistent with the Import button's enabled state.