### PR TITLE
Add "none" to token_endpoint_auth_methods_supported when CIMD is enabled

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCWellKnownProvider.java
@@ -235,6 +235,16 @@ public class OIDCWellKnownProvider implements WellKnownProvider {
         // HAIP-1.0 does not want to see this property (don't set to false)
         if (Profile.isFeatureEnabled(Profile.Feature.CIMD)) {
             config.setClientIdMetadataDocumentSupported(true);
+
+            // CIMD clients authenticate as public clients at the token endpoint (RFC 7591 "none"),
+            // so advertise "none" as a supported token endpoint auth method (see #49730).
+            // Note: only the token endpoint is affected, not introspection/revocation, so a new
+            // list is used here instead of mutating the shared clientAuthMethodsSupported list.
+            List<String> tokenEndpointAuthMethods = new ArrayList<>(config.getTokenEndpointAuthMethodsSupported());
+            if (!tokenEndpointAuthMethods.contains("none")) {
+                tokenEndpointAuthMethods.add("none");
+                config.setTokenEndpointAuthMethodsSupported(tokenEndpointAuthMethods);
+            }
         }
 
         config = checkConfigOverride(config);

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientIdMetadataDocumentTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/ClientIdMetadataDocumentTest.java
@@ -16,6 +16,7 @@ import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.AbstractClientIdM
 import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutor;
 import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutorFactory;
 import org.keycloak.protocol.oauth2.cimd.clientpolicy.executor.ClientIdMetadataDocumentExecutorFactoryProviderConfig;
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
 import org.keycloak.protocol.oidc.mappers.AudienceProtocolMapper;
 import org.keycloak.representations.AccessToken;
@@ -97,6 +98,16 @@ public class ClientIdMetadataDocumentTest {
 
     @InjectPage
     protected OAuthGrantPage grantPage;
+
+    @Test
+    public void testTokenEndpointAuthMethodsIncludesNone() {
+        // With the CIMD feature enabled, public CIMD clients authenticate at the token endpoint
+        // with "none", so the discovery document must advertise it (see #49730).
+        OIDCConfigurationRepresentation oidcConfiguration = oauth.doWellKnownRequest();
+        Assertions.assertTrue(
+                oidcConfiguration.getTokenEndpointAuthMethodsSupported().contains("none"),
+                "token_endpoint_auth_methods_supported should include \"none\" when the CIMD feature is enabled");
+    }
 
     @Test
     public void testClientIdUriSchemeCondition() {


### PR DESCRIPTION
Closes #49730

## Problem

When Keycloak runs with `--features=cimd`, the OIDC discovery document already advertises `client_id_metadata_document_supported: true`, but `"none"` is missing from `token_endpoint_auth_methods_supported` — even though CIMD public clients authenticate at the token endpoint with `none`.

This blocks MCP clients such as Claude, which select CIMD over Dynamic Client Registration only when the authorization server metadata advertises **both** `client_id_metadata_document_supported: true` **and** `"none"` in `token_endpoint_auth_methods_supported`.

## Change

In `OIDCWellKnownProvider`, when `Profile.Feature.CIMD` is enabled, add `"none"` to `token_endpoint_auth_methods_supported`.

- Scoped to the **token endpoint only** — introspection/revocation share the same base list, so a new list is used here to avoid affecting them.
- Gated on the **CIMD feature**, matching the issue exactly and staying out of the broader "always advertise `none` for public clients" discussion (#10934).

The rationale for `"none"` being correct here is laid out thoroughly by @tnorimat in the issue (RFC 7591 §2 defines `none` for public clients; RFC 8414 / IANA OAuth parameters register it; RFC 9700 raises no security concern).

## Test

Added `testTokenEndpointAuthMethodsIncludesNone` to `ClientIdMetadataDocumentTest` (which runs with the CIMD feature enabled), asserting the discovery document includes `"none"`.

## Note

I wasn't able to run Keycloak's full multi-module build / integration tests locally. The change is small and uses existing APIs, and the test follows the established `oauth.doWellKnownRequest()` pattern — CI is the verification here.
