### PR TITLE
Allow external storage for service account users

### DIFF
--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -73,6 +73,7 @@ import org.keycloak.storage.user.UserLookupProvider;
 import org.keycloak.storage.user.UserQueryMethodsProvider;
 import org.keycloak.storage.user.UserQueryProvider;
 import org.keycloak.storage.user.UserRegistrationProvider;
+import org.keycloak.storage.user.UserServiceAccountProvider;
 import org.keycloak.tracing.TracingProvider;
 import org.keycloak.userprofile.AttributeMetadata;
 import org.keycloak.userprofile.UserProfileDecorator;
@@ -497,8 +498,11 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     @Override
     public UserModel addUser(RealmModel realm, String username) {
         if (username.startsWith(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX)) {
-            // Don't use federation for service account user
-            return localStorage().addUser(realm, username);
+            return getEnabledStorageProviders(realm, UserServiceAccountProvider.class)
+                    .map(provider -> provider.addServiceAccountUser(realm, username))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElseGet(() -> localStorage().addUser(realm, username));
         }
 
         return getEnabledStorageProviders(realm, UserRegistrationProvider.class)
@@ -510,13 +514,16 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
 
     @Override
     public boolean removeUser(RealmModel realm, UserModel user) {
-        if (getFederatedStorage() != null && user.getServiceAccountClientLink() == null) {
+        StorageId storageId = new StorageId(user.getId());
+        boolean isLocalServiceAccount = user.getServiceAccountClientLink() != null
+                && !user.isFederated()
+                && storageId.getProviderId() == null;
+
+        if (getFederatedStorage() != null && !isLocalServiceAccount) {
             getFederatedStorage().preRemove(realm, user);
         }
 
         publishUserPreRemovedEvent(realm, user);
-
-        StorageId storageId = new StorageId(user.getId());
 
         if (storageId.getProviderId() == null) {
             boolean linkRemoved = !user.isFederated() || Optional.ofNullable(
@@ -1027,7 +1034,13 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
 
     @Override
     public UserModel getServiceAccount(ClientModel client) {
-        return localStorage().getServiceAccount(client);
+        return getEnabledStorageProviders(client.getRealm(), UserServiceAccountProvider.class)
+                .map(provider -> provider.getServiceAccount(client))
+                .filter(Objects::nonNull)
+                .map(user -> validateUser(client.getRealm(), user))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElseGet(() -> localStorage().getServiceAccount(client));
     }
 
     @Override

--- a/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
+++ b/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapter.java
@@ -255,7 +255,8 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * This method should not be overridden
+     * Providers that store service account users can override this method to
+     * return the internal client id linked to this user.
      *
      * @return
      */
@@ -265,7 +266,8 @@ public abstract class AbstractUserAdapter extends UserModelDefaultMethods {
     }
 
     /**
-     * This method should not be overridden
+     * Providers that store service account users can override this method to
+     * persist the internal client id linked to this user.
      *
      * @return
      */

--- a/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/adapter/AbstractUserAdapterFederatedStorage.java
@@ -260,7 +260,8 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * This method should not be overridden
+     * Providers that store service account users can override this method to
+     * return the internal client id linked to this user.
      *
      * @return
      */
@@ -270,7 +271,8 @@ public abstract class AbstractUserAdapterFederatedStorage extends UserModelDefau
     }
 
     /**
-     * This method should not be overridden
+     * Providers that store service account users can override this method to
+     * persist the internal client id linked to this user.
      *
      * @return
      */

--- a/server-spi-private/src/main/java/org/keycloak/storage/user/UserServiceAccountProvider.java
+++ b/server-spi-private/src/main/java/org/keycloak/storage/user/UserServiceAccountProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.storage.user;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+/**
+ * Optional private capability for {@link org.keycloak.storage.UserStorageProvider}
+ * implementations that want to own service account users. This extends
+ * {@link UserRegistrationProvider} so provider-owned service accounts can be
+ * removed through the normal user removal path.
+ */
+public interface UserServiceAccountProvider extends UserRegistrationProvider {
+
+    /**
+     * Creates a service account user in this storage provider.
+     *
+     * If this provider does not want to handle the given service account user,
+     * it should return {@code null} so the next provider or local storage can be
+     * tried.
+     *
+     * @param realm a reference to the realm
+     * @param username service account username
+     * @return a model of the created service account user, or {@code null}
+     */
+    UserModel addServiceAccountUser(RealmModel realm, String username);
+
+    /**
+     * Returns the service account user for the client if this provider owns it.
+     *
+     * @param client the client model
+     * @return service account user, or {@code null}
+     */
+    UserModel getServiceAccount(ClientModel client);
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/ServiceAccountUserStorageProvider.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/ServiceAccountUserStorageProvider.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.federation;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.storage.StorageId;
+import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.adapter.AbstractUserAdapterFederatedStorage;
+import org.keycloak.storage.user.UserLookupProvider;
+import org.keycloak.storage.user.UserServiceAccountProvider;
+
+/**
+ * In-memory service account user storage used by integration tests.
+ */
+public class ServiceAccountUserStorageProvider implements UserStorageProvider, UserServiceAccountProvider, UserLookupProvider {
+
+    private final KeycloakSession session;
+    private final ComponentModel model;
+    private final ServiceAccountUserStorageProviderFactory.ProviderState state;
+
+    public ServiceAccountUserStorageProvider(KeycloakSession session, ComponentModel model,
+            ServiceAccountUserStorageProviderFactory.ProviderState state) {
+        this.session = session;
+        this.model = model;
+        this.state = state;
+    }
+
+    @Override
+    public UserModel addServiceAccountUser(RealmModel realm, String username) {
+        if (!username.startsWith(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX)) {
+            return null;
+        }
+
+        state.addUser(username);
+        return createUser(realm, username);
+    }
+
+    @Override
+    public UserModel addUser(RealmModel realm, String username) {
+        return null;
+    }
+
+    @Override
+    public boolean removeUser(RealmModel realm, UserModel user) {
+        return state.removeUser(user.getUsername());
+    }
+
+    @Override
+    public UserModel getServiceAccount(ClientModel client) {
+        String username = state.getUsernameByServiceAccountClientLink(client.getId());
+        return username == null ? null : createUser(client.getRealm(), username);
+    }
+
+    @Override
+    public UserModel getUserById(RealmModel realm, String id) {
+        StorageId storageId = new StorageId(id);
+        if (!Objects.equals(model.getId(), storageId.getProviderId())) {
+            return null;
+        }
+
+        String username = storageId.getExternalId();
+        return state.hasUser(username) ? createUser(realm, username) : null;
+    }
+
+    @Override
+    public UserModel getUserByUsername(RealmModel realm, String username) {
+        return state.hasUser(username) ? createUser(realm, username) : null;
+    }
+
+    @Override
+    public UserModel getUserByEmail(RealmModel realm, String email) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private UserModel createUser(RealmModel realm, String username) {
+        AtomicReference<String> usernameRef = new AtomicReference<>(username);
+
+        return new AbstractUserAdapterFederatedStorage.Streams(session, realm, model) {
+
+            @Override
+            public String getUsername() {
+                return state.getUsername(usernameRef.get());
+            }
+
+            @Override
+            public void setUsername(String newUsername) {
+                state.renameUser(usernameRef.get(), newUsername);
+                usernameRef.set(newUsername);
+            }
+
+            @Override
+            public boolean isEnabled() {
+                return state.isEnabled(usernameRef.get());
+            }
+
+            @Override
+            public void setEnabled(boolean enabled) {
+                state.setEnabled(usernameRef.get(), enabled);
+            }
+
+            @Override
+            public String getServiceAccountClientLink() {
+                return state.getServiceAccountClientLink(usernameRef.get());
+            }
+
+            @Override
+            public void setServiceAccountClientLink(String clientInternalId) {
+                state.setServiceAccountClientLink(usernameRef.get(), clientInternalId);
+            }
+        };
+    }
+
+    static String normalize(String username) {
+        return username == null ? null : username.toLowerCase(Locale.ROOT);
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/ServiceAccountUserStorageProviderFactory.java
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/java/org/keycloak/testsuite/federation/ServiceAccountUserStorageProviderFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.federation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.keycloak.Config;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.storage.UserStorageProviderFactory;
+
+public class ServiceAccountUserStorageProviderFactory implements UserStorageProviderFactory<ServiceAccountUserStorageProvider> {
+
+    public static final String PROVIDER_ID = "service-account-user-storage";
+
+    private final Map<String, ProviderState> states = new ConcurrentHashMap<>();
+
+    @Override
+    public ServiceAccountUserStorageProvider create(KeycloakSession session, ComponentModel model) {
+        return new ServiceAccountUserStorageProvider(session, model, getState(model.getId()));
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return List.of();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public ProviderState getState(String componentId) {
+        return states.computeIfAbsent(componentId, ignored -> new ProviderState());
+    }
+
+    public void clear() {
+        states.clear();
+    }
+
+    public static class ProviderState {
+
+        private final Map<String, StoredUser> users = new ConcurrentHashMap<>();
+
+        public void addUser(String username) {
+            users.put(ServiceAccountUserStorageProvider.normalize(username), new StoredUser(username));
+        }
+
+        public boolean removeUser(String username) {
+            return users.remove(ServiceAccountUserStorageProvider.normalize(username)) != null;
+        }
+
+        public boolean hasUser(String username) {
+            return users.containsKey(ServiceAccountUserStorageProvider.normalize(username));
+        }
+
+        public String getUsername(String username) {
+            StoredUser user = users.get(ServiceAccountUserStorageProvider.normalize(username));
+            return user == null ? null : user.username;
+        }
+
+        public void renameUser(String username, String newUsername) {
+            String oldKey = ServiceAccountUserStorageProvider.normalize(username);
+            StoredUser user = users.remove(oldKey);
+            if (user == null) {
+                return;
+            }
+
+            user.username = newUsername;
+            users.put(ServiceAccountUserStorageProvider.normalize(newUsername), user);
+        }
+
+        public boolean isEnabled(String username) {
+            StoredUser user = users.get(ServiceAccountUserStorageProvider.normalize(username));
+            return user != null && user.enabled;
+        }
+
+        public void setEnabled(String username, boolean enabled) {
+            StoredUser user = users.get(ServiceAccountUserStorageProvider.normalize(username));
+            if (user != null) {
+                user.enabled = enabled;
+            }
+        }
+
+        public String getServiceAccountClientLink(String username) {
+            StoredUser user = users.get(ServiceAccountUserStorageProvider.normalize(username));
+            return user == null ? null : user.serviceAccountClientLink;
+        }
+
+        public void setServiceAccountClientLink(String username, String clientInternalId) {
+            StoredUser user = users.get(ServiceAccountUserStorageProvider.normalize(username));
+            if (user != null) {
+                user.serviceAccountClientLink = clientInternalId;
+            }
+        }
+
+        public String getUsernameByServiceAccountClientLink(String clientInternalId) {
+            return users.values().stream()
+                    .filter(user -> clientInternalId.equals(user.serviceAccountClientLink))
+                    .map(user -> user.username)
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        public int size() {
+            return users.size();
+        }
+    }
+
+    private static class StoredUser {
+        private String username;
+        private boolean enabled;
+        private String serviceAccountClientLink;
+
+        private StoredUser(String username) {
+            this.username = username;
+        }
+    }
+}

--- a/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
+++ b/testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers/src/main/resources/META-INF/services/org.keycloak.storage.UserStorageProviderFactory
@@ -3,6 +3,7 @@ org.keycloak.testsuite.federation.DummyUserFederationProviderFactory
 org.keycloak.testsuite.federation.FailableHardcodedStorageProviderFactory
 org.keycloak.testsuite.federation.UserMapStorageFactory
 org.keycloak.testsuite.federation.UserPropertyFileStorageFactory
+org.keycloak.testsuite.federation.ServiceAccountUserStorageProviderFactory
 org.keycloak.testsuite.federation.PassThroughFederatedUserStorageProviderFactory
 org.keycloak.testsuite.federation.sync.SyncDummyUserFederationProviderFactory
 org.keycloak.testsuite.federation.sync.IgnoredDummyUserFederationProviderFactory

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ServiceAccountUserStorageTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/storage/ServiceAccountUserStorageTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.testsuite.federation.storage;
+
+import java.util.List;
+
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.common.constants.ServiceAccountConstants;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ComponentRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.storage.UserStoragePrivateUtil;
+import org.keycloak.storage.UserStorageProvider;
+import org.keycloak.storage.UserStorageUtil;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testsuite.AbstractKeycloakTest;
+import org.keycloak.testsuite.admin.ApiUtil;
+import org.keycloak.testsuite.federation.ServiceAccountUserStorageProviderFactory;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ServiceAccountUserStorageTest extends AbstractKeycloakTest {
+
+    private static final String REALM_NAME = "test";
+    private static final String CLIENT_SECRET = "secret";
+    private static final String DELETE_SERVICE_ACCOUNT_ROLE = "delete-service-account-role";
+
+    @Override
+    public void addTestRealms(List<RealmRepresentation> testRealms) {
+        testRealms.add(RealmBuilder.create().name(REALM_NAME).build());
+    }
+
+    @Before
+    public void clearProviderState() {
+        testingClient.server().run(session -> {
+            ServiceAccountUserStorageProviderFactory factory = (ServiceAccountUserStorageProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(UserStorageProvider.class, ServiceAccountUserStorageProviderFactory.PROVIDER_ID);
+            factory.clear();
+        });
+    }
+
+    @Test
+    public void serviceAccountUsesExternalProvider() {
+        String providerId = addServiceAccountProvider("service-account-provider", 0);
+        String clientUuid = createServiceAccountClient("external-service-account-client");
+
+        var serviceAccount = realm().clients().get(clientUuid).getServiceAccountUser();
+
+        assertEquals(ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + "external-service-account-client", serviceAccount.getUsername());
+        assertTrue(serviceAccount.getId().startsWith("f:" + providerId + ":"));
+
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName(REALM_NAME);
+            ClientModel client = realm.getClientByClientId("external-service-account-client");
+
+            assertNull(UserStoragePrivateUtil.userLocalStorage(session).getServiceAccount(client));
+
+            UserModel user = session.users().getServiceAccount(client);
+            assertNotNull(user);
+            assertEquals(providerId, user.getFederationLink());
+
+            ServiceAccountUserStorageProviderFactory factory = (ServiceAccountUserStorageProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(UserStorageProvider.class, ServiceAccountUserStorageProviderFactory.PROVIDER_ID);
+            assertEquals(1, factory.getState(providerId).size());
+        });
+    }
+
+    @Test
+    public void clientCredentialsGrantWorksWithExternalServiceAccount() {
+        addServiceAccountProvider("service-account-provider", 0);
+        createServiceAccountClient("external-client-credentials-client");
+
+        oauth.client("external-client-credentials-client", CLIENT_SECRET);
+        AccessTokenResponse response = oauth.doClientCredentialsGrantAccessTokenRequest();
+
+        assertEquals(200, response.getStatusCode());
+        assertNotNull(response.getAccessToken());
+    }
+
+    @Test
+    public void localStorageIsUsedWhenNoServiceAccountProviderExists() {
+        String clientUuid = createServiceAccountClient("local-service-account-client");
+
+        var serviceAccount = realm().clients().get(clientUuid).getServiceAccountUser();
+
+        assertFalse(serviceAccount.getId().startsWith("f:"));
+
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName(REALM_NAME);
+            ClientModel client = realm.getClientByClientId("local-service-account-client");
+
+            assertNotNull(UserStoragePrivateUtil.userLocalStorage(session).getServiceAccount(client));
+        });
+    }
+
+    @Test
+    public void serviceAccountProvidersAreConsultedInPriorityOrder() {
+        String lowPriorityProviderId = addServiceAccountProvider("low-priority-service-account-provider", 10);
+        String highPriorityProviderId = addServiceAccountProvider("high-priority-service-account-provider", 0);
+        String clientUuid = createServiceAccountClient("priority-service-account-client");
+
+        var serviceAccount = realm().clients().get(clientUuid).getServiceAccountUser();
+
+        assertTrue(serviceAccount.getId().startsWith("f:" + highPriorityProviderId + ":"));
+
+        testingClient.server().run(session -> {
+            ServiceAccountUserStorageProviderFactory factory = (ServiceAccountUserStorageProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(UserStorageProvider.class, ServiceAccountUserStorageProviderFactory.PROVIDER_ID);
+            assertEquals(1, factory.getState(highPriorityProviderId).size());
+            assertEquals(0, factory.getState(lowPriorityProviderId).size());
+        });
+    }
+
+    @Test
+    public void disablingServiceAccountRemovesExternalUser() {
+        String providerId = addServiceAccountProvider("service-account-provider", 0);
+        String clientUuid = createServiceAccountClient("disable-service-account-client");
+
+        assertNotNull(realm().clients().get(clientUuid).getServiceAccountUser());
+
+        ClientResource clientResource = realm().clients().get(clientUuid);
+        ClientRepresentation client = clientResource.toRepresentation();
+        client.setServiceAccountsEnabled(false);
+        clientResource.update(client);
+
+        testingClient.server().run(session -> {
+            ServiceAccountUserStorageProviderFactory factory = (ServiceAccountUserStorageProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(UserStorageProvider.class, ServiceAccountUserStorageProviderFactory.PROVIDER_ID);
+            assertEquals(0, factory.getState(providerId).size());
+        });
+    }
+
+    @Test
+    public void deletingClientRemovesExternalServiceAccountAndFederatedData() {
+        String providerId = addServiceAccountProvider("service-account-provider", 0);
+        String clientUuid = createServiceAccountClient("delete-service-account-client");
+
+        assertNotNull(realm().clients().get(clientUuid).getServiceAccountUser());
+
+        String userId = testingClient.server().fetchString(session -> {
+            RealmModel realm = session.realms().getRealmByName(REALM_NAME);
+            ClientModel client = realm.getClientByClientId("delete-service-account-client");
+            UserModel user = session.users().getServiceAccount(client);
+            RoleModel role = realm.addRole(DELETE_SERVICE_ACCOUNT_ROLE);
+
+            user.grantRole(role);
+            assertTrue(user.hasRole(role));
+
+            return user.getId();
+        });
+
+        realm().clients().get(clientUuid).remove();
+
+        testingClient.server().run(session -> {
+            RealmModel realm = session.realms().getRealmByName(REALM_NAME);
+
+            assertTrue(UserStorageUtil.userFederatedStorage(session).getRoleMappingsStream(realm, userId).findAny().isEmpty());
+
+            ServiceAccountUserStorageProviderFactory factory = (ServiceAccountUserStorageProviderFactory) session.getKeycloakSessionFactory()
+                    .getProviderFactory(UserStorageProvider.class, ServiceAccountUserStorageProviderFactory.PROVIDER_ID);
+            assertEquals(0, factory.getState(providerId).size());
+
+            RoleModel role = realm.getRole(DELETE_SERVICE_ACCOUNT_ROLE);
+            if (role != null) {
+                realm.removeRole(role);
+            }
+        });
+    }
+
+    private RealmResource realm() {
+        return adminClient.realm(REALM_NAME);
+    }
+
+    private String addServiceAccountProvider(String name, int priority) {
+        ComponentRepresentation provider = new ComponentRepresentation();
+        provider.setName(name);
+        provider.setProviderId(ServiceAccountUserStorageProviderFactory.PROVIDER_ID);
+        provider.setProviderType(UserStorageProvider.class.getName());
+        provider.setConfig(new MultivaluedHashMap<>());
+        provider.getConfig().putSingle("priority", Integer.toString(priority));
+
+        return UserStorageTest.addComponent(realm(), getCleanup(), provider);
+    }
+
+    private String createServiceAccountClient(String clientId) {
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId(clientId);
+        client.setName(clientId);
+        client.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        client.setPublicClient(false);
+        client.setSecret(CLIENT_SECRET);
+        client.setEnabled(true);
+        client.setServiceAccountsEnabled(true);
+
+        Response response = realm().clients().create(client);
+        String id = ApiUtil.getCreatedId(response);
+        response.close();
+
+        getCleanup().addClientUuid(id);
+
+        return id;
+    }
+}


### PR DESCRIPTION
## Summary
- add a private `UserServiceAccountProvider` capability for user storage providers that opt into owning service account users
- route service-account user creation and lookup through enabled providers in priority order, with local storage fallback
- allow external adapters to persist service-account client links and add testsuite coverage for external creation, client credentials, fallback, priority, and cleanup

Closes #49803

## Testing
- `./mvnw -pl server-spi-private,model/storage,model/storage-private -am -DskipTests -DskipProtoLock=true compile`
- `./mvnw -pl testsuite/integration-arquillian/servers/auth-server/services/testsuite-providers -DskipTests -DskipProtoLock=true compile`
- `./mvnw -pl testsuite/integration-arquillian/tests/base -DskipTests -DskipProtoLock=true test-compile`
- `./mvnw -pl testsuite/integration-arquillian/tests/base -Dtest=ServiceAccountUserStorageTest -DskipProtoLock=true test`
- `./mvnw -pl testsuite/integration-arquillian/tests/base -Dtest=ServiceAccountTest -DskipProtoLock=true test`
- `git diff --check`