### PR TITLE
fix(account-ui): url-encode clientId when revoking consent

### DIFF
--- a/js/apps/account-ui/src/api/methods.ts
+++ b/js/apps/account-ui/src/api/methods.ts
@@ -91,7 +91,9 @@ export async function deleteConsent(
   context: KeycloakContext<BaseEnvironment>,
   id: string,
 ) {
-  return request(`/applications/${id}/consent`, context, { method: "DELETE" });
+  return request(`/applications/${encodeURIComponent(id)}/consent`, context, {
+    method: "DELETE",
+  });
 }
 
 export async function deleteSession(


### PR DESCRIPTION
The `deleteConsent` function in the Account Console v3 API client was building the request path with the raw `clientId`, which broke for clients whose IDs contain special characters such as `https://test-app`. The unencoded slashes and colons produced a malformed path that the backend rejected, so removing access silently failed and the consent remained visible after a refresh.

This change updates the path construction to use `encodeURIComponent` on the clientId, mirroring the fix that was previously applied to Account Console v2 in #19515.

Resolves #48456

### Changes
n- `js/apps/account-ui/src/api/methods.ts`: encode the `id` segment in the `deleteConsent` path via `encodeURIComponent` so clients with URL-based or special-character IDs are addressed correctly.