### PR TITLE
fix: add content-type to SCIM 404 response

### DIFF
--- a/scim/services/src/main/java/org/keycloak/scim/services/ScimRealmResource.java
+++ b/scim/services/src/main/java/org/keycloak/scim/services/ScimRealmResource.java
@@ -2,6 +2,7 @@ package org.keycloak.scim.services;
 
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
@@ -27,7 +28,7 @@ public class ScimRealmResource {
         ScimResourceTypeProvider<?> provider = session.getProvider(ScimResourceTypeProvider.class, resourceType);// Ensure the provider is loaded
 
         if (provider == null) {
-            throw new ErrorResponseException(Response.status(Response.Status.NOT_FOUND).entity(new ErrorResponse("Resource type not found", Status.NOT_FOUND.getStatusCode())).build());
+            throw new ErrorResponseException(Response.status(Response.Status.NOT_FOUND).type(MediaType.APPLICATION_JSON).entity(new ErrorResponse("Resource type not found", Status.NOT_FOUND.getStatusCode())).build());
         }
 
         AdminEventBuilder adminEvent = createAdminEventBuilder();


### PR DESCRIPTION
Fixes #49847

**Problem:** The SCIM endpoint `ScimRealmResource.resourceType()` throws an `ErrorResponseException` with a 404 status when an unknown resource type is requested, but the response has no `MediaType` set. This causes `DefaultSecurityHeadersProvider.addHeaders()` to throw an `InternalServerErrorException`, overriding the original 404 with a 500.

**Fix:** Added `.type(MediaType.APPLICATION_JSON)` to the error response builder in the `resourceType()` method so the 404 response includes a proper content-type header.

**Reproduction:**
- Request: `GET /realms/{realm}/scim/v2/InvalidType`
- Before: 500 Internal Server Error
- After: 404 Not Found with SCIM error response body
