### PR TITLE
fix: set SCIM ServiceProviderConfig filter.maxResults default to 100

### DIFF
--- a/scim/model/src/main/java/org/keycloak/scim/model/config/ServiceProviderConfigResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/config/ServiceProviderConfigResourceTypeProvider.java
@@ -15,6 +15,7 @@ import org.keycloak.scim.resource.config.ServiceProviderConfig.BulkSupport;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.FilterSupport;
 import org.keycloak.scim.resource.config.ServiceProviderConfig.Supported;
 import org.keycloak.scim.resource.schema.ModelSchema;
+import org.keycloak.scim.resource.spi.ScimResourceTypeProvider;
 import org.keycloak.scim.resource.spi.SingletonResourceTypeProvider;
 
 public class ServiceProviderConfigResourceTypeProvider implements SingletonResourceTypeProvider<ServiceProviderConfig> {
@@ -47,6 +48,7 @@ public class ServiceProviderConfigResourceTypeProvider implements SingletonResou
         FilterSupport filter = new FilterSupport();
 
         filter.setSupported(true);
+        filter.setMaxResults(ScimResourceTypeProvider.DEFAULT_MAX_RESULTS);
 
         return filter;
     }


### PR DESCRIPTION
Fixes #49841

## Problem

The ServiceProviderConfig endpoint returns filter.maxResults: 0, but the actual enforced limit is 100 as defined by ScimResourceTypeProvider.DEFAULT_MAX_RESULTS.

## Root Cause

ServiceProviderConfigResourceTypeProvider.getFilterSupport() creates a FilterSupport object and sets supported to true, but never calls setMaxResults(). The FilterSupport class has a default maxResults of 0, so the response incorrectly reports 0.

## Fix

Added filter.setMaxResults(ScimResourceTypeProvider.DEFAULT_MAX_RESULTS) in getFilterSupport() so the response correctly reflects the enforced limit of 100.