### PR TITLE
Use credential config ID in account console UI 

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/oid4vc/UserVerifiableCredentialRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/oid4vc/UserVerifiableCredentialRepresentation.java
@@ -8,9 +8,18 @@ import java.util.Objects;
 public class UserVerifiableCredentialRepresentation {
 
     private String credentialScopeName;
+    private String credentialConfigurationId;
     private String revision;
     private Long createdDate;
     private Map<String, List<String>> userAttributes;
+
+    public String getCredentialConfigurationId() {
+        return credentialConfigurationId;
+    }
+
+    public void setCredentialConfigurationId(String credentialConfigurationId) {
+        this.credentialConfigurationId = credentialConfigurationId;
+    }
 
     public String getCredentialScopeName() {
         return credentialScopeName;

--- a/js/apps/account-ui/src/verifiable-credentials/CredentialRow.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/CredentialRow.tsx
@@ -112,7 +112,7 @@ export const CredentialRow = ({ credential, refresh }: CredentialRowProps) => {
     try {
       // Construct the AIA action parameter
       const config = {
-        credential_configuration_id: credential.credentialScopeName,
+        credential_configuration_id: credential.credentialConfigurationId,
         pre_authorized: false,
       };
 

--- a/js/apps/account-ui/src/verifiable-credentials/VerifiableCredentials.tsx
+++ b/js/apps/account-ui/src/verifiable-credentials/VerifiableCredentials.tsx
@@ -76,7 +76,7 @@ export const VerifiableCredentials = () => {
                       <strong>{t("credentialCreatedDate")}</strong>
                     </DataListCell>,
                     <DataListCell key="credential-attributes-header" width={2}>
-                      <strong>{t("User Attributes")}</strong>
+                      <strong>{t("credentialUserAttributes")}</strong>
                     </DataListCell>,
                   ]}
                 />

--- a/js/libs/keycloak-admin-client/src/defs/userVerifiableCredentialRepresentation.ts
+++ b/js/libs/keycloak-admin-client/src/defs/userVerifiableCredentialRepresentation.ts
@@ -3,6 +3,7 @@
  * */
 export default interface UserVerifiableCredentialRepresentation {
   credentialScopeName?: string;
+  credentialConfigurationId?: string;
   revision?: string;
   createdDate?: number;
   userAttributes?: Record<string, string[]>;

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -91,7 +91,6 @@ import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.WebAuthnPolicy;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.light.LightweightUserAdapter;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.account.CredentialMetadataRepresentation;
 import org.keycloak.representations.account.LocalizedMessage;
@@ -1064,20 +1063,6 @@ public class ModelToRepresentation {
         rep.setRevision(model.getRevision());
         rep.setCreatedDate(model.getCreatedDate());
         rep.setUserAttributes(model.getUserAttributes());
-        return rep;
-    }
-
-    public static UserVerifiableCredentialRepresentation toRepresentation(UserVerifiableCredentialModel model, RealmModel realm) {
-        UserVerifiableCredentialRepresentation rep = toRepresentation(model);
-        ClientScopeModel clientScopeModel =  realm.getClientScopesStream()
-                                                  .filter(scope -> scope.getName().equals(model.getCredentialScopeName()))
-                                                  .findFirst()
-                                                  .orElse(null);
-        if(clientScopeModel != null) {
-            CredentialScopeModel credentialScopeModel = new CredentialScopeModel(clientScopeModel);
-            String credentialConfigurationId =  credentialScopeModel.getCredentialConfigurationId();
-            rep.setCredentialConfigurationId(credentialConfigurationId);
-        }
         return rep;
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -91,6 +91,7 @@ import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.WebAuthnPolicy;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.account.CredentialMetadataRepresentation;
 import org.keycloak.representations.account.LocalizedMessage;
@@ -1063,6 +1064,20 @@ public class ModelToRepresentation {
         rep.setRevision(model.getRevision());
         rep.setCreatedDate(model.getCreatedDate());
         rep.setUserAttributes(model.getUserAttributes());
+        return rep;
+    }
+
+    public static UserVerifiableCredentialRepresentation toRepresentation(UserVerifiableCredentialModel model, RealmModel realm) {
+        UserVerifiableCredentialRepresentation rep = toRepresentation(model);
+        ClientScopeModel clientScopeModel =  realm.getClientScopesStream()
+                                                  .filter(scope -> scope.getName().equals(model.getCredentialScopeName()))
+                                                  .findFirst()
+                                                  .orElse(null);
+        if(clientScopeModel != null) {
+            CredentialScopeModel credentialScopeModel = new CredentialScopeModel(clientScopeModel);
+            String credentialConfigurationId =  credentialScopeModel.getCredentialConfigurationId();
+            rep.setCredentialConfigurationId(credentialConfigurationId);
+        }
         return rep;
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountVerifiableCredentialResource.java
@@ -32,7 +32,9 @@ import org.keycloak.models.AccountRoles;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils;
 import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.cors.Cors;
@@ -72,7 +74,14 @@ public class AccountVerifiableCredentialResource {
 
         List<UserVerifiableCredentialRepresentation> credentials = session.users()
                 .getVerifiableCredentialsByUser(user.getId())
-                .map(model -> ModelToRepresentation.toRepresentation(model, realm))
+                .map(model -> {
+                    UserVerifiableCredentialRepresentation userVerifiableCredentialRepresentation = ModelToRepresentation.toRepresentation(model);
+                    CredentialScopeModel credScope = CredentialScopeUtils.findCredentialScopeModelByName(realm, realm::getClientScopesStream, model.getCredentialScopeName());
+                    if(credScope != null){
+                         userVerifiableCredentialRepresentation.setCredentialConfigurationId(credScope.getCredentialConfigurationId());
+                    }
+                    return userVerifiableCredentialRepresentation;
+                })
                 .peek(rep -> rep.setUserAttributes(null))  // Do not expose attributes snapshot to users
                 .toList();
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountVerifiableCredentialResource.java
@@ -72,7 +72,7 @@ public class AccountVerifiableCredentialResource {
 
         List<UserVerifiableCredentialRepresentation> credentials = session.users()
                 .getVerifiableCredentialsByUser(user.getId())
-                .map(ModelToRepresentation::toRepresentation)
+                .map(model -> ModelToRepresentation.toRepresentation(model, realm))
                 .peek(rep -> rep.setUserAttributes(null))  // Do not expose attributes snapshot to users
                 .toList();
 


### PR DESCRIPTION
fix(oid4vc): use credential config ID in account console and fix column header

- Fixes a regression where the account console incorrectly passed the client scope name instead of the credential configuration ID when generating a credential offer, resulting in a 'unknown_credential_configuration' error.

- Updates the Verifiable Credentials data list column header to use the correct localized 'credentialUserAttributes' string.

Closes #49575

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
