### PR TITLE
Add conformance tests to CI

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,47 @@
+name: Conformance Tests
+
+on:
+  workflow_dispatch:
+
+env:
+  MAVEN_ARGS: "-B -nsu -Daether.connector.http.connectionMaxTtl=25"
+
+concurrency:
+  group: conformance-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Build Keycloak
+        uses: ./.github/actions/build-keycloak
+
+  conformance-tests:
+    name: Conformance Tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - id: integration-test-setup
+        name: Integration test setup
+        uses: ./.github/actions/integration-test-setup
+
+      - name: Build tar keycloak-quarkus-dist
+        run: ./mvnw package -pl quarkus/server/,quarkus/dist/
+
+      - name: Run conformance tests
+        run: ./mvnw package -f tests/conformance/pom.xml

--- a/.github/workflows/schedule-nightly.yml
+++ b/.github/workflows/schedule-nightly.yml
@@ -39,6 +39,7 @@ jobs:
         - js-ci.yml
         - operator-ci.yml
         - codeql-analysis.yml
+        - conformance.yml
 
     steps:
       - name: Run workflow

--- a/tests/conformance/pom.xml
+++ b/tests/conformance/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2026 Red Hat, Inc. and/or its affiliates
+  ~ and other contributors as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>keycloak-tests-parent</artifactId>
+        <groupId>org.keycloak.tests</groupId>
+        <version>999.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>keycloak-tests-conformance</artifactId>
+    <name>Keycloak Conformance Tests</name>
+    <packaging>jar</packaging>
+    <description>Keycloak Conformance Tests</description>
+
+    <properties>
+        <keycloak.conformance.imageTag>release-v5.1.44</keycloak.conformance.imageTag>
+        <keycloak.conformance.mongoImageTag>6.0.13</keycloak.conformance.mongoImageTag>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.keycloak.testframework</groupId>
+                <artifactId>keycloak-test-framework-bom</artifactId>
+                <version>${project.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-services</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-crypto-default</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client-tests</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-junit5-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-remote</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-test-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <keycloak.conformance.imageTag>${keycloak.conformance.imageTag}</keycloak.conformance.imageTag>
+                        <keycloak.conformance.mongoImageTag>${keycloak.conformance.mongoImageTag}</keycloak.conformance.mongoImageTag>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/AbstractConformanceTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/AbstractConformanceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.https.CertificatesConfig;
+import org.keycloak.testframework.https.CertificatesConfigBuilder;
+import org.keycloak.testframework.https.InjectCertificates;
+import org.keycloak.testframework.https.ManagedCertificates;
+import org.keycloak.tests.conformance.containers.InjectConformanceSuite;
+import org.keycloak.tests.conformance.containers.OpenIdConformanceSuite;
+import org.keycloak.tests.conformance.runner.BrowserInteraction;
+import org.keycloak.tests.conformance.runner.ConformanceModuleResult;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+import org.keycloak.tests.conformance.runner.ConformanceResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Base class for all conformance areas. Test classes inject a realm and implement {@link #moduleVariants()},
+ * either listing the variants explicitly or using {@link #discoverModuleVariants}.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class AbstractConformanceTest {
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractConformanceTest.class);
+
+    // Not used directly, but required to start the Keycloak server with TLS enabled
+    @InjectCertificates(config = TlsCertificates.class)
+    ManagedCertificates certificates;
+
+    @InjectConformanceSuite
+    protected OpenIdConformanceSuite suite;
+
+    protected abstract Stream<ConformanceModuleVariant> moduleVariants();
+
+    protected abstract JsonNode suiteConfig(ConformanceModuleVariant moduleVariant);
+
+    /**
+     * Discovers all variant combinations of a module from the plan. Runs while tests are collected, before the
+     * test framework injects the suite, hence the singleton access.
+     */
+    protected Stream<ConformanceModuleVariant> discoverModuleVariants(String plan, Map<String, String> planVariant, String name) {
+        return discoverModuleVariants(plan, planVariant, name, ConformanceResult.PASSED, BrowserInteraction.NONE);
+    }
+
+    protected Stream<ConformanceModuleVariant> discoverModuleVariants(String plan, Map<String, String> planVariant,
+            String name, ConformanceResult expectedResult, BrowserInteraction browserInteraction) {
+        ConformanceModuleVariant template = new ConformanceModuleVariant(plan, planVariant, name, Map.of(),
+                expectedResult, browserInteraction);
+        return OpenIdConformanceSuite.instance().client()
+                .discoverModuleVariants(plan, planVariant, name, suiteConfig(template))
+                .map(moduleVariant -> new ConformanceModuleVariant(plan, planVariant, name, moduleVariant,
+                        expectedResult, browserInteraction));
+    }
+
+    @ParameterizedTest
+    @MethodSource("moduleVariants")
+    public void conformance(ConformanceModuleVariant moduleVariant) {
+        ConformanceModuleResult result = suite.client().run(moduleVariant, suiteConfig(moduleVariant));
+        if (!result.finishedWith(moduleVariant.expectedResult())) {
+            LOGGER.errorf("Full logs of failed conformance module %s:%n%s", result.module(), result.logs().toPrettyString());
+            Assertions.fail(result.failureSummary());
+        }
+    }
+
+    public static class TlsCertificates implements CertificatesConfig {
+
+        @Override
+        public CertificatesConfigBuilder configure(CertificatesConfigBuilder config) {
+            return config.tlsEnabled(true);
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/ConformanceTestFrameworkExtension.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/ConformanceTestFrameworkExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.containers;
+
+import java.util.List;
+
+import org.keycloak.testframework.TestFrameworkExtension;
+import org.keycloak.testframework.injection.Supplier;
+
+public class ConformanceTestFrameworkExtension implements TestFrameworkExtension {
+
+    @Override
+    public List<Supplier<?, ?>> suppliers() {
+        return List.of(new OpenIdConformanceSuiteSupplier());
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/InjectConformanceSuite.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/InjectConformanceSuite.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.containers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InjectConformanceSuite {
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/OpenIdConformanceSuite.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/OpenIdConformanceSuite.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.containers;
+
+import java.net.URI;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.List;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.keycloak.tests.conformance.runner.ConformanceApiClient;
+
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+public final class OpenIdConformanceSuite implements AutoCloseable {
+
+    public static final String IMAGE_TAG_PROPERTY = "keycloak.conformance.imageTag";
+    public static final String MONGO_IMAGE_TAG_PROPERTY = "keycloak.conformance.mongoImageTag";
+
+    // The suite URL within the container network, to be used by Keycloak redirect URIs and web origins
+    public static final URI INTERNAL_BASE_URI = URI.create("https://nginx:8443");
+
+    // The URL at which the suite containers reach Keycloak, which must be set as the Keycloak 'hostname' option
+    public static final URI KEYCLOAK_BASE_URI = URI.create("https://host.testcontainers.internal:8443");
+
+    // Fallbacks for running outside Maven, where the defaults are set by the pom properties of the same name
+    private static final String DEFAULT_IMAGE_TAG = "release-v5.1.44";
+    private static final String DEFAULT_MONGO_IMAGE_TAG = "6.0.13";
+    private static final String NGINX_CERTIFICATE_PATH = "/etc/ssl/certs/nginx-selfsigned.crt";
+
+    private static OpenIdConformanceSuite instance;
+
+    private final Network network;
+    private final GenericContainer<?> mongo;
+    private final GenericContainer<?> server;
+    private final GenericContainer<?> nginx;
+    private final ConformanceApiClient client;
+
+    private OpenIdConformanceSuite(Network network, GenericContainer<?> mongo, GenericContainer<?> server,
+            GenericContainer<?> nginx, URI baseUri, SSLContext sslContext) {
+        this.network = network;
+        this.mongo = mongo;
+        this.server = server;
+        this.nginx = nginx;
+        this.client = new ConformanceApiClient(baseUri, sslContext);
+    }
+
+    /**
+     * The suite is a singleton as it is also used to discover module variants while tests are collected, before
+     * the test framework injects it.
+     */
+    public static synchronized OpenIdConformanceSuite instance() {
+        if (instance == null) {
+            // Must be exposed before the containers start so they can reach Keycloak on the Docker host
+            Testcontainers.exposeHostPorts(KEYCLOAK_BASE_URI.getPort());
+            instance = start();
+        }
+        return instance;
+    }
+
+    private static OpenIdConformanceSuite start() {
+        String imageTag = System.getProperty(IMAGE_TAG_PROPERTY, DEFAULT_IMAGE_TAG);
+        String mongoImageTag = System.getProperty(MONGO_IMAGE_TAG_PROPERTY, DEFAULT_MONGO_IMAGE_TAG);
+        Network network = Network.newNetwork();
+
+        GenericContainer<?> mongo = new GenericContainer<>(DockerImageName.parse("mongo:" + mongoImageTag))
+                .withNetwork(network)
+                .withNetworkAliases("mongodb")
+                .withExposedPorts(27017)
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(2)));
+
+        GenericContainer<?> server = new GenericContainer<>(
+                DockerImageName.parse("registry.gitlab.com/openid/conformance-suite:" + imageTag))
+                .withNetwork(network)
+                .withNetworkAliases("server")
+                .withExposedPorts(8080)
+                .withEnv("BASE_URL", INTERNAL_BASE_URI.toString())
+                .withEnv("MONGODB_HOST", "mongodb")
+                .withEnv("SPRING_PROFILES_ACTIVE", "dev")
+                .withEnv("OIDC_GOOGLE_CLIENTID", "google-client")
+                .withEnv("OIDC_GOOGLE_SECRET", "google-secret")
+                .withEnv("OIDC_GITLAB_CLIENTID", "gitlab-client")
+                .withEnv("OIDC_GITLAB_SECRET", "gitlab-secret")
+                .dependsOn(mongo)
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(4)));
+
+        GenericContainer<?> nginx = new GenericContainer<>(
+                DockerImageName.parse("registry.gitlab.com/openid/conformance-suite/nginx:" + imageTag))
+                .withExposedPorts(8443)
+                .withNetwork(network)
+                .withNetworkAliases("nginx")
+                .dependsOn(server)
+                .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofMinutes(2)));
+
+        try {
+            mongo.start();
+            server.start();
+            nginx.start();
+
+            URI baseUri = URI.create("https://" + nginx.getHost() + ":" + nginx.getMappedPort(8443));
+            SSLContext sslContext = sslContextTrusting(nginxCertificate(nginx));
+            OpenIdConformanceSuite suite = new OpenIdConformanceSuite(network, mongo, server, nginx, baseUri, sslContext);
+            suite.client().waitUntilAvailable(Duration.ofMinutes(4));
+            return suite;
+        } catch (RuntimeException e) {
+            List.of(nginx, server, mongo).forEach(GenericContainer::stop);
+            network.close();
+            throw e;
+        }
+    }
+
+    public ConformanceApiClient client() {
+        return client;
+    }
+
+    @Override
+    public void close() {
+        List.of(nginx, server, mongo).forEach(GenericContainer::stop);
+        network.close();
+        synchronized (OpenIdConformanceSuite.class) {
+            if (instance == this) {
+                instance = null;
+            }
+        }
+    }
+
+    private static X509Certificate nginxCertificate(GenericContainer<?> nginx) {
+        try {
+            return nginx.copyFileFromContainer(NGINX_CERTIFICATE_PATH,
+                    input -> (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(input));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read the conformance suite TLS certificate from " + NGINX_CERTIFICATE_PATH, e);
+        }
+    }
+
+    private static SSLContext sslContextTrusting(X509Certificate certificate) {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("conformance-nginx", certificate);
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            SSLContext context = SSLContext.getInstance("TLS");
+            context.init(null, trustManagerFactory.getTrustManagers(), null);
+            return context;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create SSL context trusting the conformance suite certificate", e);
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/OpenIdConformanceSuiteSupplier.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/containers/OpenIdConformanceSuiteSupplier.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.containers;
+
+import java.net.URI;
+import java.util.List;
+
+import org.keycloak.testframework.injection.DependenciesBuilder;
+import org.keycloak.testframework.injection.Dependency;
+import org.keycloak.testframework.injection.InstanceContext;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.injection.RequestedInstance;
+import org.keycloak.testframework.injection.Supplier;
+import org.keycloak.testframework.server.KeycloakServer;
+
+
+public class OpenIdConformanceSuiteSupplier implements Supplier<OpenIdConformanceSuite, InjectConformanceSuite> {
+
+    @Override
+    public OpenIdConformanceSuite getValue(InstanceContext<OpenIdConformanceSuite, InjectConformanceSuite> instanceContext) {
+        // The KeycloakServer dependency ensures Keycloak is running before the suite containers connect to it
+        KeycloakServer server = instanceContext.getDependency(KeycloakServer.class);
+        URI serverUri = URI.create(server.getBaseUrl());
+        if (serverUri.getPort() != OpenIdConformanceSuite.KEYCLOAK_BASE_URI.getPort()) {
+            throw new IllegalStateException("Keycloak server port " + serverUri.getPort()
+                    + " does not match the port the conformance suite is configured to reach it at: "
+                    + OpenIdConformanceSuite.KEYCLOAK_BASE_URI);
+        }
+        return OpenIdConformanceSuite.instance();
+    }
+
+    @Override
+    public LifeCycle getDefaultLifecycle() {
+        return LifeCycle.GLOBAL;
+    }
+
+    @Override
+    public boolean compatible(InstanceContext<OpenIdConformanceSuite, InjectConformanceSuite> a,
+            RequestedInstance<OpenIdConformanceSuite, InjectConformanceSuite> b) {
+        return true;
+    }
+
+    @Override
+    public List<Dependency> getDependencies(RequestedInstance<OpenIdConformanceSuite, InjectConformanceSuite> instanceContext) {
+        return DependenciesBuilder.create(KeycloakServer.class).build();
+    }
+
+    @Override
+    public void close(InstanceContext<OpenIdConformanceSuite, InjectConformanceSuite> instanceContext) {
+        instanceContext.getValue().close();
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/BrowserFlow.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/BrowserFlow.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+import java.util.List;
+
+public record BrowserFlow(String match, List<BrowserTask> tasks) {
+
+    public record BrowserTask(String task, String match, List<List<Object>> commands) {
+        public static final String TEXT = "text";
+        public static final String CLICK = "click";
+        public static final String WAIT = "wait";
+        // Predefined action of the wait command that snapshots the page into the screenshot placeholder
+        public static final String UPDATE_IMAGE_PLACEHOLDER = "update-image-placeholder";
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/BrowserInteraction.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/BrowserInteraction.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+import java.util.List;
+
+import org.keycloak.tests.conformance.runner.BrowserFlow.BrowserTask;
+
+public interface BrowserInteraction {
+
+    BrowserInteraction NONE = new None();
+    BrowserInteraction LOGIN = new Login();
+
+    static BrowserInteraction errorPage(String messageRegexp) {
+        return new ErrorPage(messageRegexp);
+    }
+
+    List<BrowserFlow> browserFlows(BrowserContext context);
+
+    record BrowserContext(String realm, String username, String password, String callbackUrl) {
+
+        String authorizationEndpoint() {
+            return "https://*/realms/" + realm + "/protocol/openid-connect/auth*";
+        }
+
+        String loginPage() {
+            return "https://*/realms/" + realm + "/login-actions/authenticate*";
+        }
+    }
+
+    record None() implements BrowserInteraction {
+
+        @Override
+        public List<BrowserFlow> browserFlows(BrowserContext context) {
+            return List.of();
+        }
+    }
+
+    record Login() implements BrowserInteraction {
+
+        @Override
+        public List<BrowserFlow> browserFlows(BrowserContext context) {
+            return List.of(new BrowserFlow(context.authorizationEndpoint(), List.of(
+                    new BrowserFlow.BrowserTask(
+                            "Keycloak Login",
+                            context.loginPage(),
+                            List.of(
+                                    // command, element selector type, element selector, value to enter
+                                    List.of(BrowserTask.TEXT, "id", "username", context.username()),
+                                    List.of(BrowserTask.TEXT, "id", "password", context.password()),
+                                    // command, element selector type, element selector
+                                    List.of(BrowserTask.CLICK, "id", "kc-login"))),
+                    new BrowserFlow.BrowserTask(
+                            "Verify Complete",
+                            context.callbackUrl() + "*",
+                            // command, element selector type, element selector, timeout in seconds
+                            List.of(List.of(BrowserTask.WAIT, "id", "submission_complete", 10))))));
+        }
+    }
+
+    record ErrorPage(String messageRegexp) implements BrowserInteraction {
+
+        @Override
+        public List<BrowserFlow> browserFlows(BrowserContext context) {
+            return List.of(new BrowserFlow(context.authorizationEndpoint(), List.of(
+                    new BrowserFlow.BrowserTask(
+                            "Keycloak Error Page",
+                            context.authorizationEndpoint(),
+                            // command, element selector type, element selector, timeout in seconds, element text regexp, action
+                            List.of(List.of(BrowserTask.WAIT, "id", "kc-error-message", 10, messageRegexp,
+                                    BrowserTask.UPDATE_IMAGE_PLACEHOLDER))))));
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceApiClient.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceApiClient.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLContext;
+
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+
+public final class ConformanceApiClient {
+
+    private final URI baseUri;
+    private final HttpClient httpClient;
+
+    public ConformanceApiClient(URI baseUri, SSLContext sslContext) {
+        this.baseUri = baseUri;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(20))
+                .sslContext(sslContext)
+                .build();
+    }
+
+    public void waitUntilAvailable(Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        RuntimeException lastFailure = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                HttpResponse<String> response = send(request("/api/runner/available").GET().build());
+                if (response.statusCode() == 200) {
+                    return;
+                }
+                lastFailure = new IllegalStateException("Conformance server returned HTTP " + response.statusCode());
+            } catch (RuntimeException e) {
+                lastFailure = e;
+            }
+            sleep(Duration.ofSeconds(2));
+        }
+        throw new IllegalStateException("Conformance server did not become available at " + baseUri, lastFailure);
+    }
+
+    /**
+     * Discovers all variant combinations of a module from a created plan.
+     */
+    public Stream<Map<String, String>> discoverModuleVariants(String planName, Map<String, String> planVariant,
+            String moduleName, JsonNode suiteConfig) {
+        JsonNode plan = createPlan(planName, suiteConfig, planVariant);
+        List<Map<String, String>> variants = new ArrayList<>();
+        for (JsonNode entry : plan.path("modules")) {
+            if (moduleName.equals(entry.path("testModule").asText())) {
+                variants.add(variantMap(entry.path("variant")));
+            }
+        }
+        if (variants.isEmpty()) {
+            throw new IllegalStateException("Plan contains no module named '" + moduleName + "': " + plan);
+        }
+        return variants.stream();
+    }
+
+    private static Map<String, String> variantMap(JsonNode variant) {
+        Map<String, String> map = new LinkedHashMap<>();
+        variant.fields().forEachRemaining(field -> map.put(field.getKey(), field.getValue().asText()));
+        return map;
+    }
+
+    public ConformanceModuleResult run(ConformanceModuleVariant module, JsonNode suiteConfig) {
+        JsonNode plan = createPlan(module.plan(), suiteConfig, module.planVariant());
+        String planId = requiredText(plan, "id");
+
+        JsonNode moduleNode = createModule(planId, module.name(), module.moduleVariant());
+        String moduleId = requiredText(moduleNode, "id");
+        JsonNode info = waitForRunnableOrFinished(planId, moduleId);
+        if ("CONFIGURED".equals(info.path("status").asText())) {
+            startModule(planId, moduleId);
+        }
+        info = waitForFinished(planId, moduleId);
+        JsonNode logs = getLogs(planId, moduleId);
+
+        return new ConformanceModuleResult(module.plan(), module.planVariant(), module.name(), module.moduleVariant(),
+                planId, moduleId, info.path("status").asText(), info.path("result").asText("UNKNOWN"), logs);
+    }
+
+    private JsonNode createPlan(String planName, JsonNode suiteConfig, Map<String, String> variants) {
+        StringBuilder path = new StringBuilder("/api/plan?planName=").append(URLEncoder.encode(planName, StandardCharsets.UTF_8));
+        if (variants != null && !variants.isEmpty()) {
+            path.append("&variant=").append(URLEncoder.encode(JsonSerialization.valueAsString(variants), StandardCharsets.UTF_8));
+        }
+        HttpRequest request = request(path.toString())
+                .POST(HttpRequest.BodyPublishers.ofString(suiteConfig.toString()))
+                .header("Content-Type", "application/json")
+                .build();
+        return expectJson(request, 201);
+    }
+
+    private JsonNode createModule(String planId, String module, Map<String, String> variants) {
+        StringBuilder path = new StringBuilder("/api/runner?test=")
+                .append(URLEncoder.encode(module, StandardCharsets.UTF_8))
+                .append("&plan=")
+                .append(URLEncoder.encode(planId, StandardCharsets.UTF_8));
+        if (variants != null && !variants.isEmpty()) {
+            path.append("&variant=").append(URLEncoder.encode(JsonSerialization.valueAsString(variants), StandardCharsets.UTF_8));
+        }
+        return expectJson(request(path.toString()).POST(HttpRequest.BodyPublishers.noBody()).build(), 201);
+    }
+
+    private void startModule(String planId, String moduleId) {
+        expectJson(request("/api/runner/" + moduleId).POST(HttpRequest.BodyPublishers.noBody()).build(), 200, planId, moduleId);
+    }
+
+    private JsonNode waitForRunnableOrFinished(String planId, String moduleId) {
+        return waitForState(planId, moduleId, List.of("CONFIGURED", "WAITING", "FINISHED"), Duration.ofMinutes(4));
+    }
+
+    private JsonNode waitForFinished(String planId, String moduleId) {
+        return waitForState(planId, moduleId, List.of("FINISHED"), Duration.ofMinutes(8));
+    }
+
+    private JsonNode waitForState(String planId, String moduleId, List<String> states, Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        JsonNode lastInfo = null;
+        RuntimeException lastFailure = null;
+        while (System.nanoTime() < deadline) {
+            try {
+                lastInfo = getInfo(planId, moduleId);
+                String status = lastInfo.path("status").asText();
+                // INTERRUPTED is a terminal state too and surfaces as a normal assertion failure downstream
+                if (states.contains(status) || "INTERRUPTED".equals(status)) {
+                    return lastInfo;
+                }
+            } catch (RuntimeException e) {
+                // Transient failures are tolerated until the deadline
+                lastFailure = e;
+            }
+            sleep(Duration.ofSeconds(1));
+        }
+        throw new IllegalStateException("Timed out waiting for conformance module (planId=" + planId
+                + ", moduleId=" + moduleId + ") to reach " + states + "; last info: " + lastInfo, lastFailure);
+    }
+
+    private JsonNode getInfo(String planId, String moduleId) {
+        return expectJson(request("/api/info/" + moduleId).GET().build(), 200, planId, moduleId);
+    }
+
+    private JsonNode getLogs(String planId, String moduleId) {
+        return expectJson(request("/api/log/" + moduleId).GET().build(), 200, planId, moduleId);
+    }
+
+    private JsonNode expectJson(HttpRequest request, int expectedStatus) {
+        return expectJson(request, expectedStatus, "");
+    }
+
+    private JsonNode expectJson(HttpRequest request, int expectedStatus, String planId, String moduleId) {
+        // The plan and module ids help cross-reference the failure with the OIDF suite UI
+        return expectJson(request, expectedStatus, " (planId=" + planId + ", moduleId=" + moduleId + ")");
+    }
+
+    private JsonNode expectJson(HttpRequest request, int expectedStatus, String idContext) {
+        HttpResponse<String> response = send(request);
+        if (response.statusCode() != expectedStatus) {
+            throw new IllegalStateException("Conformance API " + request.method() + " " + request.uri()
+                    + idContext + " returned HTTP " + response.statusCode() + ": " + response.body());
+        }
+        return JsonSerialization.valueFromString(response.body(), JsonNode.class);
+    }
+
+    private HttpResponse<String> send(HttpRequest request) {
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new RuntimeException("Conformance API request failed: " + request.uri(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while calling conformance API: " + request.uri(), e);
+        }
+    }
+
+    private HttpRequest.Builder request(String path) {
+        return HttpRequest.newBuilder(baseUri.resolve(path))
+                .timeout(Duration.ofMinutes(2))
+                .header("Accept", "application/json");
+    }
+
+    private static String requiredText(JsonNode node, String field) {
+        String value = node.path(field).asText(null);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Conformance API response missing '" + field + "': " + node);
+        }
+        return value;
+    }
+
+    private static void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceModuleResult.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceModuleResult.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public record ConformanceModuleResult(
+        String plan,
+        Map<String, String> planVariant,
+        String module,
+        Map<String, String> moduleVariant,
+        String planId,
+        String moduleId,
+        String status,
+        String result,
+        JsonNode logs) {
+
+    public boolean finishedWith(ConformanceResult expectedResult) {
+        return "FINISHED".equals(status) && expectedResult.name().equals(result);
+    }
+
+    public String failureSummary() {
+        return "Conformance module failed"
+                + "\n  plan=" + plan
+                + "\n  planVariant=" + planVariant
+                + "\n  module=" + module
+                + "\n  moduleVariant=" + moduleVariant
+                + "\n  planId=" + planId
+                + "\n  moduleId=" + moduleId
+                + "\n  status=" + status
+                + "\n  result=" + result
+                + "\n  logExcerpt=" + failureLogExcerpt();
+    }
+
+    private String failureLogExcerpt() {
+        if (logs == null || !logs.isArray()) {
+            return "<no logs>";
+        }
+        String excerpt = StreamSupport.stream(logs.spliterator(), false)
+                .filter(log -> "FAILURE".equals(log.path("result").asText())
+                        || "WARNING".equals(log.path("result").asText()))
+                .limit(20)
+                .map(this::formatLog)
+                .collect(Collectors.joining(" | "));
+        return excerpt.isBlank() ? "<no failure or warning log entries>" : excerpt;
+    }
+
+    private String formatLog(JsonNode log) {
+        String source = log.path("src").asText(log.path("condition").asText(""));
+        String message = log.path("msg").asText(log.path("message").asText(log.path("error").asText("")));
+        StringBuilder formatted = new StringBuilder(log.path("result").asText() + ":" + source + " " + message);
+        for (String detail : new String[] {"url", "match", "detail"}) {
+            if (log.hasNonNull(detail)) {
+                formatted.append(" ").append(detail).append("=").append(log.get(detail).asText());
+            }
+        }
+        return formatted.toString();
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceModuleVariant.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceModuleVariant.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+import java.util.Map;
+
+/**
+ * A conformance suite test module to run in one variant combination. The plan variant selects the plan wide
+ * variant when the plan is created, while the module variant selects which combination of the module to run, as
+ * a plan can contain the same module in several variant combinations.
+ */
+public record ConformanceModuleVariant(
+        String plan,
+        Map<String, String> planVariant,
+        String name,
+        Map<String, String> moduleVariant,
+        ConformanceResult expectedResult,
+        BrowserInteraction browserInteraction) {
+
+    public ConformanceModuleVariant(String plan, Map<String, String> planVariant,
+            String name, Map<String, String> moduleVariant) {
+        this(plan, planVariant, name, moduleVariant, ConformanceResult.PASSED, BrowserInteraction.NONE);
+    }
+
+    // Display name for the parameterized test, including the module variant to keep combinations distinguishable
+    @Override
+    public String toString() {
+        return moduleVariant.isEmpty() ? plan + " " + name : plan + " " + name + " " + moduleVariant;
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceResult.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/runner/ConformanceResult.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.runner;
+
+/**
+ * Terminal results a module can finish with. Modules that capture an error page snapshot finish with REVIEW.
+ */
+public enum ConformanceResult {
+    PASSED,
+    WARNING,
+    FAILED,
+    REVIEW,
+    SKIPPED,
+    UNKNOWN
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/AbstractVciConformanceTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/AbstractVciConformanceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import org.keycloak.tests.conformance.AbstractConformanceTest;
+import org.keycloak.tests.conformance.containers.OpenIdConformanceSuite;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Baseline for OID4VCI conformance tests. Test classes inject a realm with {@link VciConformanceRealmConfig} or
+ * a subclass of it for additional configuration.
+ */
+abstract class AbstractVciConformanceTest extends AbstractConformanceTest {
+
+    @Override
+    protected JsonNode suiteConfig(ConformanceModuleVariant module) {
+        return VciSuiteConfig.create(
+                OpenIdConformanceSuite.KEYCLOAK_BASE_URI,
+                VciConformanceRealmConfig.attesterJwks(),
+                VciTestSigningKey.caCertificatePem(),
+                module.browserInteraction()).toJson();
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerExpiredRequestUriTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerExpiredRequestUriTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.models.ParConfig;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.tests.conformance.runner.BrowserInteraction;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+import org.keycloak.tests.conformance.runner.ConformanceResult;
+
+@KeycloakIntegrationTest(config = VciConformanceRealmConfig.ServerConfig.class)
+public class IssuerExpiredRequestUriTest extends AbstractVciConformanceTest {
+
+    @InjectRealm(config = ShortParRequestUriLifespanRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vci-1_0-issuer-haip-test-plan",
+                Map.of(
+                        "credential_format", "sd_jwt_vc",
+                        "vci_authorization_code_flow_variant", "wallet_initiated"),
+                "fapi2-security-profile-final-par-attempt-to-use-expired-request_uri",
+                ConformanceResult.REVIEW,
+                BrowserInteraction.errorPage("Invalid Request"));
+    }
+
+    public static class ShortParRequestUriLifespanRealmConfig extends VciConformanceRealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return super.configure(realm).attribute(ParConfig.PAR_REQUEST_URI_LIFESPAN, "15");
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerHappyFlowTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerHappyFlowTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.BrowserInteraction;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+import org.keycloak.tests.conformance.runner.ConformanceResult;
+
+@KeycloakIntegrationTest(config = VciConformanceRealmConfig.ServerConfig.class)
+public class IssuerHappyFlowTest extends AbstractVciConformanceTest {
+
+    @InjectRealm(config = VciConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        // The plan variant pins every dimension but vci_credential_encryption, leaving the plain and encrypted variants
+        return discoverModuleVariants(
+                "oid4vci-1_0-issuer-haip-test-plan",
+                Map.of(
+                        "credential_format", "sd_jwt_vc",
+                        "vci_authorization_code_flow_variant", "wallet_initiated"),
+                "oid4vci-1_0-issuer-happy-flow",
+                ConformanceResult.PASSED,
+                BrowserInteraction.LOGIN);
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerKeyAttestationTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerKeyAttestationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.tests.conformance.runner.BrowserInteraction;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+import org.keycloak.tests.conformance.runner.ConformanceResult;
+
+/**
+ * Issues a credential whose configuration requires key attestations, so the suite includes a valid key attestation
+ * that Keycloak must accept.
+ */
+@KeycloakIntegrationTest(config = IssuerKeyAttestationTest.KeyAttestationServerConfig.class)
+public class IssuerKeyAttestationTest extends AbstractVciConformanceTest {
+
+    @InjectRealm(config = KeyAttestationRequiredRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vci-1_0-issuer-haip-test-plan",
+                Map.of(
+                        "credential_format", "sd_jwt_vc",
+                        "vci_authorization_code_flow_variant", "wallet_initiated"),
+                "oid4vci-1_0-issuer-happy-flow",
+                ConformanceResult.PASSED,
+                BrowserInteraction.LOGIN);
+    }
+
+    public static class KeyAttestationServerConfig extends VciConformanceRealmConfig.ServerConfig {
+
+        // TODO Drop this truststore path once Keycloak trusts key attestation keys via a trust material identity
+        // provider instead of validating the x5c chain against the server truststore.
+        private static final String ATTESTER_CA_PATH = writeAttesterCaCertificate();
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return super.configure(config).option("truststore-paths", ATTESTER_CA_PATH);
+        }
+
+        private static String writeAttesterCaCertificate() {
+            try {
+                Path caPath = Files.createTempFile("oid4vci-conformance-attester-ca", ".pem");
+                Files.writeString(caPath, VciAttesterKey.caCertificatePem(), StandardCharsets.UTF_8);
+                caPath.toFile().deleteOnExit();
+                return caPath.toString();
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to write the attester CA certificate for the truststore", e);
+            }
+        }
+    }
+
+    public static class KeyAttestationRequiredRealmConfig extends VciConformanceRealmConfig {
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return super.configure(realm).update(rep -> rep.getClientScopes().stream()
+                    .filter(scope -> SD_JWT_SCOPE.equals(scope.getName()))
+                    .forEach(scope -> scope.getAttributes().put(CredentialScopeModel.VC_KEY_ATTESTATION_REQUIRED, "true")));
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerSignedMetadataTest.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/IssuerSignedMetadataTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.tests.conformance.runner.BrowserInteraction;
+import org.keycloak.tests.conformance.runner.ConformanceModuleVariant;
+import org.keycloak.tests.conformance.runner.ConformanceResult;
+
+@KeycloakIntegrationTest(config = VciConformanceRealmConfig.ServerConfig.class)
+public class IssuerSignedMetadataTest extends AbstractVciConformanceTest {
+
+    @InjectRealm(config = VciConformanceRealmConfig.class, lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @Override
+    protected Stream<ConformanceModuleVariant> moduleVariants() {
+        return discoverModuleVariants(
+                "oid4vci-1_0-issuer-haip-test-plan",
+                Map.of(
+                        "credential_format", "sd_jwt_vc",
+                        "vci_authorization_code_flow_variant", "wallet_initiated"),
+                "oid4vci-1_0-issuer-metadata-test-signed",
+                ConformanceResult.PASSED,
+                BrowserInteraction.NONE);
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciAttesterKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciAttesterKey.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.List;
+
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.util.Base64Url;
+import org.keycloak.common.util.CertificateUtils;
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.def.DefaultCryptoProvider;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jwk.JWKUtil;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * The attester key, generated at runtime so no private key material is committed to the repository. It is signed
+ * by a CA so it serves both client attestation (verified against the trusted public JWKS) and key attestation
+ * (which validates the x5c chain against the CA). The private JWKS is handed to the conformance suite to sign
+ * attestations, while Keycloak trusts only the public JWKS and the CA certificate.
+ */
+final class VciAttesterKey {
+
+    static final String KID = "ct_client_attester_key";
+
+    private static final JsonNode PRIVATE_JWKS;
+    private static final JsonNode PUBLIC_JWKS;
+    private static final String CA_CERTIFICATE_PEM;
+
+    static {
+        try {
+            if (!CryptoIntegration.isInitialised()) {
+                CryptoIntegration.setProvider(new DefaultCryptoProvider());
+            }
+
+            KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("EC");
+            keyGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair caKeyPair = keyGenerator.generateKeyPair();
+            KeyPair attesterKeyPair = keyGenerator.generateKeyPair();
+
+            X509Certificate caCertificate = CertificateUtils.generateV1SelfSignedCertificate(caKeyPair,
+                    "OID4VCI Conformance Attester CA");
+            X509Certificate attesterCertificate = CertificateUtils.generateV3Certificate(attesterKeyPair,
+                    caKeyPair.getPrivate(), caCertificate, "OID4VCI Conformance Attester");
+
+            PUBLIC_JWKS = jwks(publicJwk(attesterKeyPair, attesterCertificate));
+
+            JWK privateJwk = publicJwk(attesterKeyPair, attesterCertificate);
+            ECPrivateKey privateKey = (ECPrivateKey) attesterKeyPair.getPrivate();
+            int fieldSize = privateKey.getParams().getCurve().getField().getFieldSize();
+            privateJwk.setOtherClaims("d", Base64Url.encode(JWKUtil.toIntegerBytes(privateKey.getS(), fieldSize)));
+            PRIVATE_JWKS = jwks(privateJwk);
+
+            CA_CERTIFICATE_PEM = PemUtils.addCertificateBeginEnd(PemUtils.encodeCertificate(caCertificate));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create OID4VCI conformance attester key", e);
+        }
+    }
+
+    private VciAttesterKey() {
+    }
+
+    static JsonNode privateJwks() {
+        return PRIVATE_JWKS;
+    }
+
+    static JsonNode publicJwks() {
+        return PUBLIC_JWKS;
+    }
+
+    static String caCertificatePem() {
+        return CA_CERTIFICATE_PEM;
+    }
+
+    private static JWK publicJwk(KeyPair keyPair, X509Certificate certificate) {
+        return JWKBuilder.create().kid(KID).algorithm(Algorithm.ES256)
+                .ec(keyPair.getPublic(), List.of(certificate), KeyUse.SIG);
+    }
+
+    private static JsonNode jwks(JWK key) {
+        JSONWebKeySet keySet = new JSONWebKeySet();
+        keySet.setKeys(new JWK[] { key });
+        return JsonSerialization.writeValueAsNode(keySet);
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciConformanceRealmConfig.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.keycloak.OID4VCConstants;
+import org.keycloak.VCFormat;
+import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator;
+import org.keycloak.broker.trust.DefaultTrustIdentityProviderConfig;
+import org.keycloak.broker.trust.DefaultTrustIdentityProviderFactory;
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.constants.OID4VCIConstants;
+import org.keycloak.crypto.Algorithm;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.keys.Attributes;
+import org.keycloak.keys.GeneratedEcdhKeyProviderFactory;
+import org.keycloak.keys.JavaKeystoreKeyProviderFactory;
+import org.keycloak.keys.KeyProvider;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCGeneratedIdMapper;
+import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCIssuedAtTimeClaimMapper;
+import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.protocol.oid4vc.model.DisplayObject;
+import org.keycloak.representations.idm.ComponentExportRepresentation;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.tests.conformance.containers.OpenIdConformanceSuite;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.keycloak.OID4VCConstants.OID4VCI_ENABLED_ATTRIBUTE_KEY;
+import static org.keycloak.models.Constants.CREATE_DEFAULT_CLIENT_SCOPES;
+import static org.keycloak.models.Constants.DEFAULT_ROLES_ROLE_PREFIX;
+
+public class VciConformanceRealmConfig implements RealmConfig {
+
+    public static final String REALM = "oid4vci";
+    public static final String HOLDER = "alice";
+    public static final String PASSWORD = "password";
+    public static final String CLIENT = "oid4vci-client";
+    public static final String CLIENT2 = "oid4vci-client2";
+    public static final String SD_JWT_SCOPE = "conformance_sd_jwt_vc";
+    public static final String CREDENTIAL_CONFIGURATION_ID = "conformance_sd_jwt_vc";
+    public static final String CONFORMANCE_CALLBACK = OpenIdConformanceSuite.INTERNAL_BASE_URI + "/test/a/keycloak/callback";
+    public static final String TRUST_IDP_ALIAS = "conformance-client-attester";
+
+    @Override
+    public RealmBuilder configure(RealmBuilder realm) {
+        realm.name(REALM)
+                .eventsEnabled(true)
+                .eventsListeners("jboss-logging")
+                .verifiableCredentialsEnabled(true)
+                .attribute(CREATE_DEFAULT_CLIENT_SCOPES, "true")
+                // The conformance suite wallet requests DEF-compressed encrypted credential responses
+                .attribute(OID4VCIssuerWellKnownProvider.ATTR_REQUEST_ZIP_ALGS, "DEF")
+                .defaultSignatureAlgorithm(Algorithm.ES256)
+                .clientScopes(createSdJwtCredentialScope())
+                .users(UserBuilder.create()
+                        .username(HOLDER)
+                        .enabled(true)
+                        .email("alice@example.test")
+                        .emailVerified(true)
+                        .firstName("Alice")
+                        .lastName("Wonderland")
+                        .password(PASSWORD)
+                        .attribute("did", "did:key:alice")
+                        .attribute("address_street_address", "221B Baker Street")
+                        .attribute("address_locality", "London")
+                        .realmRoles(DEFAULT_ROLES_ROLE_PREFIX + "-" + REALM)
+                        .verifiableCredential(SD_JWT_SCOPE)
+                        .build())
+                .clients(conformanceClient(CLIENT, false), conformanceClient(CLIENT2, true))
+                .update(rep -> {
+                    MultivaluedHashMap<String, ComponentExportRepresentation> components = rep.getComponents();
+                    if (components == null) {
+                        components = new MultivaluedHashMap<>();
+                        rep.setComponents(components);
+                    }
+                    components.add(KeyProvider.class.getName(), conformanceSigningKeyProvider());
+                    components.add(KeyProvider.class.getName(), conformanceEcdhEncryptionKeyProvider());
+                    rep.setIdentityProviders(List.of(attesterTrustIdentityProvider()));
+                });
+        return realm;
+    }
+
+    public static JsonNode attesterJwks() {
+        return VciAttesterKey.privateJwks();
+    }
+
+    private IdentityProviderRepresentation attesterTrustIdentityProvider() {
+        IdentityProviderRepresentation trust = new IdentityProviderRepresentation();
+        trust.setAlias(TRUST_IDP_ALIAS);
+        trust.setProviderId(DefaultTrustIdentityProviderFactory.PROVIDER_ID);
+        trust.setEnabled(true);
+        trust.setConfig(Map.of(DefaultTrustIdentityProviderConfig.TRUSTED_JWKS, VciAttesterKey.publicJwks().toString()));
+        return trust;
+    }
+
+    private ClientBuilder conformanceClient(String clientId, boolean wildcardRedirect) {
+        return ClientBuilder.create(clientId)
+                .serviceAccountsEnabled(false)
+                .directAccessGrantsEnabled(false)
+                .authenticatorType(AttestationBasedClientAuthenticator.PROVIDER_ID)
+                .attribute(AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS, TRUST_IDP_ALIAS)
+                .attribute(OID4VCIConstants.OID4VCI_ATTESTER_TRUST_IDPS_ATTR, TRUST_IDP_ALIAS)
+                .defaultClientScopes("basic", "profile", "roles")
+                .optionalClientScopes(SD_JWT_SCOPE, "email")
+                .attribute(OID4VCI_ENABLED_ATTRIBUTE_KEY, "true")
+                .redirectUris(CONFORMANCE_CALLBACK + (wildcardRedirect ? "*" : ""))
+                .webOrigins(OpenIdConformanceSuite.INTERNAL_BASE_URI.toString());
+    }
+
+    private CredentialScopeRepresentation createSdJwtCredentialScope() {
+        CredentialScopeRepresentation scope = new CredentialScopeRepresentation(SD_JWT_SCOPE)
+                .setIncludeInTokenScope(true)
+                .setExpiryInSeconds(300)
+                .setCredentialConfigurationId(CREDENTIAL_CONFIGURATION_ID)
+                .setCredentialIdentifier(CREDENTIAL_CONFIGURATION_ID)
+                .setFormat(VCFormat.SD_JWT_VC)
+                .setSigningAlg(Algorithm.ES256)
+                .setVct("https://credentials.example.com/SD-JWT-Credential");
+
+        scope.setDisplay(JsonSerialization.valueAsString(List.of(new DisplayObject().setName(CREDENTIAL_CONFIGURATION_ID).setLocale("en-EN"))));
+        scope.setProtocolMappers(protocolMappers(SD_JWT_SCOPE));
+
+        Map<String, String> attributes = Optional.ofNullable(scope.getAttributes()).orElseGet(HashMap::new);
+        attributes.put(CredentialScopeModel.VC_BINDING_REQUIRED, "true");
+        attributes.put(CredentialScopeModel.VC_BINDING_REQUIRED_PROOF_TYPES, "jwt");
+        attributes.put(CredentialScopeModel.VC_CRYPTOGRAPHIC_BINDING_METHODS, CredentialScopeModel.CRYPTOGRAPHIC_BINDING_METHODS_DEFAULT);
+        scope.setAttributes(attributes);
+        return scope;
+    }
+
+    private ComponentExportRepresentation conformanceSigningKeyProvider() {
+        ComponentExportRepresentation keyProvider = new ComponentExportRepresentation();
+        keyProvider.setName("oid4vci-conformance-signing-key");
+        keyProvider.setId(UUID.randomUUID().toString());
+        keyProvider.setProviderId(JavaKeystoreKeyProviderFactory.ID);
+        keyProvider.setConfig(new MultivaluedHashMap<>(Map.of(
+                Attributes.PRIORITY_KEY, List.of("0"),
+                Attributes.ENABLED_KEY, List.of("true"),
+                Attributes.ACTIVE_KEY, List.of("true"),
+                Attributes.ALGORITHM_KEY, List.of(Algorithm.ES256),
+                Attributes.KEY_USE, List.of(KeyUse.SIG.name()),
+                JavaKeystoreKeyProviderFactory.KEYSTORE_KEY, List.of(VciTestSigningKey.keyStorePath()),
+                JavaKeystoreKeyProviderFactory.KEYSTORE_PASSWORD_KEY, List.of(VciTestSigningKey.PASSWORD),
+                JavaKeystoreKeyProviderFactory.KEYSTORE_TYPE_KEY, List.of("PKCS12"),
+                JavaKeystoreKeyProviderFactory.KEY_ALIAS_KEY, List.of(VciTestSigningKey.KEY_ALIAS),
+                JavaKeystoreKeyProviderFactory.KEY_PASSWORD_KEY, List.of(VciTestSigningKey.PASSWORD))));
+        return keyProvider;
+    }
+
+    // The conformance suite wallet requests ECDH-ES encrypted credential responses
+    private ComponentExportRepresentation conformanceEcdhEncryptionKeyProvider() {
+        ComponentExportRepresentation keyProvider = new ComponentExportRepresentation();
+        keyProvider.setName("oid4vci-conformance-ecdh-encryption-key");
+        keyProvider.setId(UUID.randomUUID().toString());
+        keyProvider.setProviderId(GeneratedEcdhKeyProviderFactory.ID);
+        keyProvider.setConfig(new MultivaluedHashMap<>(Map.of(
+                Attributes.PRIORITY_KEY, List.of("0"),
+                Attributes.ENABLED_KEY, List.of("true"),
+                Attributes.ACTIVE_KEY, List.of("true"),
+                GeneratedEcdhKeyProviderFactory.ECDH_ALGORITHM_KEY, List.of(Algorithm.ECDH_ES),
+                GeneratedEcdhKeyProviderFactory.ECDH_ELLIPTIC_CURVE_KEY, List.of("P-256"))));
+        return keyProvider;
+    }
+
+    private List<ProtocolMapperRepresentation> protocolMappers(String scopeName) {
+        return List.of(
+                mapper("did-mapper", "oid4vc-subject-id-mapper", Map.of("claim.name", OID4VCConstants.CLAIM_NAME_SUBJECT_ID, "userAttribute", "did")),
+                mapper("email-mapper", "oid4vc-user-attribute-mapper", Map.of("claim.name", "email", "userAttribute", "email")),
+                mapper("first-name-mapper", "oid4vc-user-attribute-mapper", Map.of("claim.name", "firstName", "userAttribute", "firstName")),
+                mapper("last-name-mapper", "oid4vc-user-attribute-mapper", Map.of("claim.name", "lastName", "userAttribute", "lastName")),
+                mapper("address-street-mapper", "oid4vc-user-attribute-mapper",
+                        Map.of("claim.name", "address.street_address", "userAttribute", "address_street_address")),
+                mapper("address-locality-mapper", "oid4vc-user-attribute-mapper",
+                        Map.of("claim.name", "address.locality", "userAttribute", "address_locality")),
+                mapper("generated-id-mapper", "oid4vc-generated-id-mapper", Map.of(OID4VCGeneratedIdMapper.CLAIM_NAME, "jti")),
+                mapper("static-scope-mapper", "oid4vc-static-claim-mapper", Map.of("claim.name", "scope-name", "staticValue", scopeName)),
+                mapper("issued-at-mapper", "oid4vc-issued-at-time-claim-mapper", Map.of(
+                        OID4VCIssuedAtTimeClaimMapper.CLAIM_NAME, "iat",
+                        OID4VCIssuedAtTimeClaimMapper.TRUNCATE_TO_TIME_UNIT_KEY, "HOURS",
+                        OID4VCIssuedAtTimeClaimMapper.VALUE_SOURCE, "COMPUTE")),
+                mapper("not-before-mapper", "oid4vc-issued-at-time-claim-mapper", Map.of(
+                        OID4VCIssuedAtTimeClaimMapper.CLAIM_NAME, "nbf",
+                        OID4VCIssuedAtTimeClaimMapper.VALUE_SOURCE, "COMPUTE")));
+    }
+
+    private ProtocolMapperRepresentation mapper(String name, String type, Map<String, String> config) {
+        ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+        mapper.setName(name);
+        mapper.setId(UUID.randomUUID().toString());
+        mapper.setProtocol(OID4VCIConstants.OID4VC_PROTOCOL);
+        mapper.setProtocolMapper(type);
+        mapper.setConfig(config);
+        return mapper;
+    }
+
+    public static class ServerConfig implements KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.OID4VC_VCI, Profile.Feature.CLIENT_AUTH_ABCA)
+                    .option("hostname", OpenIdConformanceSuite.KEYCLOAK_BASE_URI.toString());
+        }
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciSuiteConfig.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciSuiteConfig.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.net.URI;
+import java.util.List;
+
+import org.keycloak.tests.conformance.runner.BrowserFlow;
+import org.keycloak.tests.conformance.runner.BrowserInteraction;
+import org.keycloak.util.JsonSerialization;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+
+/**
+ * The test configuration uploaded to the conformance suite. The structure is defined by the suite and issuer
+ * plans require two clients, of which the second is only used by "multiple clients" modules.
+ */
+record VciSuiteConfig(
+        String alias,
+        Vci vci,
+        Credential credential,
+        Client client,
+        Client client2,
+        List<BrowserFlow> browser) {
+
+    static VciSuiteConfig create(URI keycloakBaseUri, JsonNode attesterJwks, String trustAnchorPem,
+            BrowserInteraction browserInteraction) {
+        return new VciSuiteConfig(
+                "keycloak",
+                new Vci(keycloakBaseUri + "/realms/" + VciConformanceRealmConfig.REALM,
+                        VciConformanceRealmConfig.CREDENTIAL_CONFIGURATION_ID,
+                        "https://example.com/client-attester",
+                        attesterJwks,
+                        attesterJwks),
+                new Credential(trustAnchorPem, trustAnchorPem),
+                new Client(VciConformanceRealmConfig.CLIENT),
+                new Client(VciConformanceRealmConfig.CLIENT2),
+                browserInteraction.browserFlows(new BrowserInteraction.BrowserContext(
+                        VciConformanceRealmConfig.REALM,
+                        VciConformanceRealmConfig.HOLDER,
+                        VciConformanceRealmConfig.PASSWORD,
+                        VciConformanceRealmConfig.CONFORMANCE_CALLBACK)));
+    }
+
+    JsonNode toJson() {
+        return JsonSerialization.writeValueAsNode(this);
+    }
+
+    record Vci(
+            @JsonProperty("credential_issuer_url") String credentialIssuerUrl,
+            @JsonProperty("credential_configuration_id") String credentialConfigurationId,
+            @JsonProperty("client_attestation_issuer") String clientAttestationIssuer,
+            @JsonProperty("client_attester_keys_jwks") JsonNode clientAttesterKeysJwks,
+            @JsonProperty("key_attestation_jwks") JsonNode keyAttestationJwks) {
+    }
+
+    record Credential(
+            @JsonProperty("trust_anchor_pem") String trustAnchorPem,
+            @JsonProperty("status_list_trust_anchor_pem") String statusListTrustAnchorPem) {
+    }
+
+    record Client(@JsonProperty("client_id") String clientId) {
+    }
+}

--- a/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciTestSigningKey.java
+++ b/tests/conformance/src/test/java/org/keycloak/tests/conformance/vci/VciTestSigningKey.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.conformance.vci;
+
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.util.PemUtils;
+import org.keycloak.crypto.def.DefaultCryptoProvider;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+// Not using org.keycloak.common.util.CertificateUtils as its leaf certificates are CA capable, which strict
+// trust chain validation rejects for an issuer signing certificate
+final class VciTestSigningKey {
+
+    static final String KEY_ALIAS = "oid4vci-conformance-signing";
+    static final String PASSWORD = "password";
+
+    private static final String KEY_STORE_PATH;
+    private static final String CA_CERTIFICATE_PEM;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    static {
+        try {
+            if (!CryptoIntegration.isInitialised()) {
+                CryptoIntegration.setProvider(new DefaultCryptoProvider());
+            }
+
+            KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("EC");
+            keyGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+            KeyPair caKeyPair = keyGenerator.generateKeyPair();
+            KeyPair leafKeyPair = keyGenerator.generateKeyPair();
+
+            X509Certificate caCertificate = generateCaCertificate(caKeyPair);
+            X509Certificate leafCertificate = generateLeafCertificate(leafKeyPair, caKeyPair, caCertificate);
+
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            keyStore.load(null, null);
+            keyStore.setKeyEntry(KEY_ALIAS, leafKeyPair.getPrivate(), PASSWORD.toCharArray(),
+                    new Certificate[] { leafCertificate, caCertificate });
+
+            Path keyStorePath = Files.createTempFile("keycloak-oid4vci-conformance-signing", ".p12");
+            try (OutputStream output = Files.newOutputStream(keyStorePath)) {
+                keyStore.store(output, PASSWORD.toCharArray());
+            }
+            keyStorePath.toFile().deleteOnExit();
+
+            KEY_STORE_PATH = keyStorePath.toString();
+            CA_CERTIFICATE_PEM = PemUtils.addCertificateBeginEnd(PemUtils.encodeCertificate(caCertificate));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create OID4VCI conformance signing key", e);
+        }
+    }
+
+    private VciTestSigningKey() {
+    }
+
+    static String keyStorePath() {
+        return KEY_STORE_PATH;
+    }
+
+    static String caCertificatePem() {
+        return CA_CERTIFICATE_PEM;
+    }
+
+    private static X509Certificate generateCaCertificate(KeyPair caKeyPair) throws Exception {
+        X500Name caName = new X500Name("CN=OID4VCI Conformance CA");
+        X509v3CertificateBuilder builder = certificateBuilder(caName, caName, caKeyPair);
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        return sign(builder, caKeyPair);
+    }
+
+    private static X509Certificate generateLeafCertificate(KeyPair leafKeyPair, KeyPair caKeyPair,
+            X509Certificate caCertificate) throws Exception {
+        X500Name caName = new X500Name(caCertificate.getSubjectX500Principal().getName());
+        X500Name leafName = new X500Name("CN=OID4VCI Conformance Issuer");
+        X509v3CertificateBuilder builder = certificateBuilder(caName, leafName, leafKeyPair);
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature));
+        return sign(builder, caKeyPair);
+    }
+
+    private static X509v3CertificateBuilder certificateBuilder(X500Name issuer, X500Name subject, KeyPair keyPair) {
+        Instant now = Instant.now();
+        return new X509v3CertificateBuilder(
+                issuer,
+                new BigInteger(160, RANDOM),
+                Date.from(now.minus(1, ChronoUnit.DAYS)),
+                Date.from(now.plus(365, ChronoUnit.DAYS)),
+                subject,
+                SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()));
+    }
+
+    private static X509Certificate sign(X509v3CertificateBuilder builder, KeyPair signingKeyPair) throws Exception {
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withECDSA").build(signingKeyPair.getPrivate());
+        return new JcaX509CertificateConverter().getCertificate(builder.build(signer));
+    }
+}

--- a/tests/conformance/src/test/resources/META-INF/services/org.keycloak.testframework.TestFrameworkExtension
+++ b/tests/conformance/src/test/resources/META-INF/services/org.keycloak.testframework.TestFrameworkExtension
@@ -1,0 +1,1 @@
+org.keycloak.tests.conformance.containers.ConformanceTestFrameworkExtension

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -40,6 +40,7 @@
         <module>custom-scripts</module>
         <module>clustering</module>
         <module>webauthn</module>
+        <module>conformance</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Closes #49947

@mposolda @tnorimat @thomasdarimont @tdiesler  Could you please review?
Goal of this PR is to provide the infrastructure, so it just implements some example tests.

Example output from failing test:
```
Conformance module failed
  plan=oid4vci-1_0-issuer-haip-test-plan
  planVariant=sd-jwt-wallet-initiated
  module=oid4vci-1_0-issuer-happy-flow
  moduleVariant=haip-client-attestation-dpop
  planId=kGTMl2ETRZTRK
  moduleId=2ZDvmh1A692qhJg
  status=INTERRUPTED
  result=FAILED
  logExcerpt=FAILURE:CheckPAREndpointResponse201WithNoError Invalid pushed authorization
             request endpoint response http status code ==> expected: <true> but was: <false>
```

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
