### PR TITLE
Fix KcAdmV2EditCLITest.testEditNonExistentResource assertion when client is not found

### DIFF
--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2EditCLITest.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/cli/v2/KcAdmV2EditCLITest.java
@@ -91,7 +91,7 @@ public class KcAdmV2EditCLITest extends AbstractKcAdmV2CLITest {
         CommandResult result = kcAdmV2Cmd("client", "edit", "non-existent-id");
 
         assertThat("edit non-existent should fail", result.exitCode(), is(not(0)));
-        assertThat(result.err().trim(), is("Could not find client"));
+        assertThat(result.err().trim(), is("Cannot find the specified client"));
     }
 
     @Test


### PR DESCRIPTION
* Closes: https://github.com/keycloak/keycloak/issues/49869
