### PR TITLE
Add sort parameters to Client Admin API v2

### DIFF
--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -96,6 +96,10 @@
           }
         }
       },
+      "ClientField" : {
+        "type" : "string",
+        "enum" : [ "clientId", "displayName", "description", "protocol", "enabled", "appUrl" ]
+      },
       "Flow" : {
         "type" : "string",
         "enum" : [ "STANDARD", "IMPLICIT", "DIRECT_GRANT", "SERVICE_ACCOUNT", "TOKEN_EXCHANGE", "DEVICE", "CIBA" ]
@@ -213,6 +217,10 @@
       "SignatureAlgorithm" : {
         "type" : "string",
         "enum" : [ "RSA_SHA1", "RSA_SHA256", "RSA_SHA256_MGF1", "RSA_SHA512", "RSA_SHA512_MGF1", "DSA_SHA1" ]
+      },
+      "SortOrder" : {
+        "type" : "string",
+        "enum" : [ "asc", "desc" ]
       }
     },
     "securitySchemes" : {
@@ -269,6 +277,25 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "description" : "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId). Allowed values: clientId, displayName, description, protocol, enabled, appUrl. Defaults to clientId when omitted.",
+          "explode" : false,
+          "name" : "sortBy",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ClientField"
+            }
+          },
+          "style" : "form",
+          "in" : "query"
+        }, {
+          "description" : "Sort direction. Allowed values: asc (default), desc.",
+          "schema" : {
+            "$ref" : "#/components/schemas/SortOrder"
+          },
+          "name" : "sortOrder",
+          "in" : "query"
         } ],
         "responses" : {
           "200" : {
@@ -283,6 +310,9 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "Invalid sort parameter"
           }
         }
       },

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -96,10 +96,6 @@
           }
         }
       },
-      "ClientField" : {
-        "type" : "string",
-        "enum" : [ "clientId", "displayName", "description", "protocol", "enabled", "appUrl" ]
-      },
       "Flow" : {
         "type" : "string",
         "enum" : [ "STANDARD", "IMPLICIT", "DIRECT_GRANT", "SERVICE_ACCOUNT", "TOKEN_EXCHANGE", "DEVICE", "CIBA" ]
@@ -217,10 +213,6 @@
       "SignatureAlgorithm" : {
         "type" : "string",
         "enum" : [ "RSA_SHA1", "RSA_SHA256", "RSA_SHA256_MGF1", "RSA_SHA512", "RSA_SHA512_MGF1", "DSA_SHA1" ]
-      },
-      "SortOrder" : {
-        "type" : "string",
-        "enum" : [ "asc", "desc" ]
       }
     },
     "securitySchemes" : {
@@ -278,7 +270,7 @@
             "type" : "string"
           }
         }, {
-          "description" : "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc.",
+          "description" : "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc. Allowed fields: clientId, displayName, description, protocol, enabled, appUrl.",
           "schema" : {
             "type" : "string",
             "default" : "clientId"

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -293,6 +293,8 @@
         }, {
           "description" : "Sort direction. Allowed values: asc, desc.",
           "schema" : {
+            "type" : "string",
+            "enum" : [ "asc", "desc" ],
             "default" : "asc"
           },
           "name" : "sortOrder",

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -278,26 +278,12 @@
             "type" : "string"
           }
         }, {
-          "description" : "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId).",
-          "explode" : false,
-          "name" : "sortBy",
-          "schema" : {
-            "type" : "array",
-            "default" : "clientId",
-            "items" : {
-              "$ref" : "#/components/schemas/ClientField"
-            }
-          },
-          "style" : "form",
-          "in" : "query"
-        }, {
-          "description" : "Sort direction. Allowed values: asc, desc.",
+          "description" : "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc.",
           "schema" : {
             "type" : "string",
-            "enum" : [ "asc", "desc" ],
-            "default" : "asc"
+            "default" : "clientId"
           },
-          "name" : "sortOrder",
+          "name" : "sort",
           "in" : "query"
         } ],
         "responses" : {

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -291,11 +291,11 @@
           "in" : "query"
         }, {
           "description" : "Sort direction. Allowed values: asc (default), desc.",
+          "name" : "sortOrder",
+          "in" : "query",
           "schema" : {
             "$ref" : "#/components/schemas/SortOrder"
-          },
-          "name" : "sortOrder",
-          "in" : "query"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -278,11 +278,12 @@
             "type" : "string"
           }
         }, {
-          "description" : "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId). Allowed values: clientId, displayName, description, protocol, enabled, appUrl. Defaults to clientId when omitted.",
+          "description" : "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId).",
           "explode" : false,
           "name" : "sortBy",
           "schema" : {
             "type" : "array",
+            "default" : "clientId",
             "items" : {
               "$ref" : "#/components/schemas/ClientField"
             }
@@ -290,12 +291,12 @@
           "style" : "form",
           "in" : "query"
         }, {
-          "description" : "Sort direction. Allowed values: asc (default), desc.",
-          "name" : "sortOrder",
-          "in" : "query",
+          "description" : "Sort direction. Allowed values: asc, desc.",
           "schema" : {
-            "$ref" : "#/components/schemas/SortOrder"
-          }
+            "default" : "asc"
+          },
+          "name" : "sortOrder",
+          "in" : "query"
         } ],
         "responses" : {
           "200" : {

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
@@ -3,6 +3,7 @@ package org.keycloak.admin.api;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
@@ -45,6 +46,10 @@ public enum ClientField {
 
     public static Optional<ClientField> fromApiName(String apiName) {
         return Stream.of(values()).filter(field -> field.apiName.equals(apiName)).findFirst();
+    }
+
+    public static String allowedApiNames() {
+        return Stream.of(values()).map(ClientField::getApiName).collect(Collectors.joining(", "));
     }
 
     private static ComparatorFactory stringKey(Function<BaseClientRepresentation, String> getter) {

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
@@ -16,15 +16,15 @@ public enum ClientField {
     DISPLAY_NAME("displayName", stringKey(BaseClientRepresentation::getDisplayName)),
     DESCRIPTION("description", stringKey(BaseClientRepresentation::getDescription)),
     PROTOCOL("protocol", stringKey(BaseClientRepresentation::getProtocol)),
-    ENABLED("enabled", Comparator.comparing(BaseClientRepresentation::getEnabled, Comparator.nullsLast(Boolean::compareTo))),
+    ENABLED("enabled", booleanKey(BaseClientRepresentation::getEnabled)),
     APP_URL("appUrl", stringKey(BaseClientRepresentation::getAppUrl));
 
     private final String apiName;
-    private final Comparator<BaseClientRepresentation> comparator;
+    private final ComparatorFactory comparatorFactory;
 
-    ClientField(String apiName, Comparator<BaseClientRepresentation> comparator) {
+    ClientField(String apiName, ComparatorFactory comparatorFactory) {
         this.apiName = apiName;
-        this.comparator = comparator;
+        this.comparatorFactory = comparatorFactory;
     }
 
     public String getApiName() {
@@ -36,7 +36,7 @@ public enum ClientField {
     }
 
     public Comparator<BaseClientRepresentation> comparator(boolean ascending) {
-        return ascending ? comparator : comparator.reversed();
+        return comparatorFactory.comparator(ascending);
     }
 
     public static ClientField defaultField() {
@@ -47,7 +47,18 @@ public enum ClientField {
         return Stream.of(values()).filter(field -> field.apiName.equals(apiName)).findFirst();
     }
 
-    private static Comparator<BaseClientRepresentation> stringKey(Function<BaseClientRepresentation, String> getter) {
-        return Comparator.comparing(getter, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+    private static ComparatorFactory stringKey(Function<BaseClientRepresentation, String> getter) {
+        return ascending -> Comparator.comparing(getter, Comparator.nullsLast(
+                ascending ? String.CASE_INSENSITIVE_ORDER : String.CASE_INSENSITIVE_ORDER.reversed()));
+    }
+
+    private static ComparatorFactory booleanKey(Function<BaseClientRepresentation, Boolean> getter) {
+        return ascending -> Comparator.comparing(getter, Comparator.nullsLast(
+                ascending ? Boolean::compareTo : Comparator.<Boolean>reverseOrder()));
+    }
+
+    @FunctionalInterface
+    private interface ComparatorFactory {
+        Comparator<BaseClientRepresentation> comparator(boolean ascending);
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
@@ -7,13 +7,10 @@ import java.util.stream.Stream;
 
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-
 /**
  * Sortable fields for Client Admin API v2 list queries ({@code sort}).
  * API names map to scalar {@code CLIENT} table columns.
  */
-@Schema(enumeration = {"clientId", "displayName", "description", "protocol", "enabled", "appUrl"})
 public enum ClientField {
     CLIENT_ID("clientId", stringKey(BaseClientRepresentation::getClientId)),
     DISPLAY_NAME("displayName", stringKey(BaseClientRepresentation::getDisplayName)),

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
@@ -10,7 +10,7 @@ import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
- * Sortable fields for Client Admin API v2 list queries ({@code sortBy} / {@code sortOrder}).
+ * Sortable fields for Client Admin API v2 list queries ({@code sort}).
  * API names map to scalar {@code CLIENT} table columns.
  */
 @Schema(enumeration = {"clientId", "displayName", "description", "protocol", "enabled", "appUrl"})

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
@@ -1,0 +1,66 @@
+package org.keycloak.admin.api;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.keycloak.representations.admin.v2.BaseClientRepresentation;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Sortable fields for Client Admin API v2 list queries ({@code sortBy} / {@code sortOrder}).
+ * API names map to scalar {@code CLIENT} table columns.
+ */
+@Schema(enumeration = {"clientId", "displayName", "description", "protocol", "enabled", "appUrl"})
+public enum ClientField {
+    CLIENT_ID("clientId", stringKey(BaseClientRepresentation::getClientId)),
+    DISPLAY_NAME("displayName", stringKey(BaseClientRepresentation::getDisplayName)),
+    DESCRIPTION("description", stringKey(BaseClientRepresentation::getDescription)),
+    PROTOCOL("protocol", stringKey(BaseClientRepresentation::getProtocol)),
+    ENABLED("enabled", Comparator.comparing(BaseClientRepresentation::getEnabled, Comparator.nullsLast(Boolean::compareTo))),
+    APP_URL("appUrl", stringKey(BaseClientRepresentation::getAppUrl));
+
+    private final String apiName;
+    private final Comparator<BaseClientRepresentation> comparator;
+
+    ClientField(String apiName, Comparator<BaseClientRepresentation> comparator) {
+        this.apiName = apiName;
+        this.comparator = comparator;
+    }
+
+    public String getApiName() {
+        return apiName;
+    }
+
+    public String toQueryValue() {
+        return apiName;
+    }
+
+    public Comparator<BaseClientRepresentation> comparator(boolean ascending) {
+        return ascending ? comparator : comparator.reversed();
+    }
+
+    public static ClientField defaultField() {
+        return CLIENT_ID;
+    }
+
+    public static Optional<ClientField> fromApiName(String apiName) {
+        return Stream.of(values()).filter(field -> field.apiName.equals(apiName)).findFirst();
+    }
+
+    public static Optional<String> validateApiName(String field) {
+        if (field == null) {
+            return Optional.empty();
+        }
+        if (fromApiName(field).isEmpty()) {
+            return Optional.of(String.format("%s is not a sortable field", field));
+        }
+        return Optional.empty();
+    }
+
+    private static Comparator<BaseClientRepresentation> stringKey(Function<BaseClientRepresentation, String> getter) {
+        return Comparator.comparing(getter, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ClientField.java
@@ -50,16 +50,6 @@ public enum ClientField {
         return Stream.of(values()).filter(field -> field.apiName.equals(apiName)).findFirst();
     }
 
-    public static Optional<String> validateApiName(String field) {
-        if (field == null) {
-            return Optional.empty();
-        }
-        if (fromApiName(field).isEmpty()) {
-            return Optional.of(String.format("%s is not a sortable field", field));
-        }
-        return Optional.empty();
-    }
-
     private static Comparator<BaseClientRepresentation> stringKey(Function<BaseClientRepresentation, String> getter) {
         return Comparator.comparing(getter, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER));
     }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -10,6 +10,8 @@ import jakarta.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
 public class ListOptions {
@@ -18,6 +20,18 @@ public class ListOptions {
             explode = Explode.FALSE, schema = @Schema(type = SchemaType.ARRAY, uniqueItems = true, implementation = String.class))
     @QueryParam("fields")
     protected String fields;
+
+    @Parameter(name = "sortBy",
+               description = "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId). Allowed values: clientId, displayName, description, protocol, enabled, appUrl. Defaults to clientId when omitted.",
+               style = ParameterStyle.FORM,
+               explode = Explode.FALSE,
+               schema = @Schema(type = SchemaType.ARRAY, implementation = ClientField.class))
+    @QueryParam("sortBy")
+    protected String sortBy;
+
+    @Parameter(description = "Sort direction. Allowed values: asc (default), desc.", schema = @Schema(implementation = SortOrder.class))
+    @QueryParam("sortOrder")
+    protected SortOrder sortOrder;
 
     @Parameter(description = "Filter expression using SCIM-like syntax, e.g. clientId eq \"my-app\" and enabled eq true")
     @QueryParam("q")
@@ -89,4 +103,32 @@ public class ListOptions {
         this.offset = offset;
     }
     
+    public String getSortBy() {
+        return sortBy;
+    }
+
+    public void setSortBy(String sortBy) {
+        this.sortBy = sortBy;
+    }
+
+    public void setSortBy(ClientField sortBy) {
+        this.sortBy = sortBy == null ? null : sortBy.toQueryValue();
+    }
+
+    public void setSortBy(List<ClientField> sortBy) {
+        this.sortBy = parseSortBy(sortBy);
+    }
+
+    public SortOrder getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(SortOrder sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    private String parseSortBy(List<ClientField> list) {
+        return list == null || list.isEmpty() ? null :
+                 list.stream().map(ClientField::toQueryValue).collect(Collectors.joining(","));
+    }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -20,7 +20,7 @@ public class ListOptions {
     @QueryParam("fields")
     protected String fields;
 
-    @Parameter(description = "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc. Allowed fields: clientId, displayName, description, protocol, enabled, appUrl.",
+    @Parameter(description = "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc.",
             schema = @Schema(type = SchemaType.STRING, defaultValue = "clientId"))
     @QueryParam("sort")
     protected String sort;

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -19,7 +19,7 @@ public class ListOptions {
     @QueryParam("fields")
     protected String fields;
 
-    @Parameter(description = "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc.",
+    @Parameter(description = "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc. Allowed fields: clientId, displayName, description, protocol, enabled, appUrl.",
             schema = @Schema(type = SchemaType.STRING, defaultValue = "clientId"))
     @QueryParam("sort")
     protected String sort;

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -23,14 +23,15 @@ public class ListOptions {
 
     // TODO: this name is a temporary solution until we have a fix from smallrye-openapi
     @Parameter(name = "sortBy",
-               description = "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId). Allowed values: clientId, displayName, description, protocol, enabled, appUrl. Defaults to clientId when omitted.",
+               description = "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId).",
                style = ParameterStyle.FORM,
                explode = Explode.FALSE,
-               schema = @Schema(type = SchemaType.ARRAY, implementation = ClientField.class))
+               schema = @Schema(type = SchemaType.ARRAY, implementation = ClientField.class,
+               defaultValue = "clientId"))
     @QueryParam("sortBy")
     protected String sortBy;
 
-    @Parameter(description = "Sort direction. Allowed values: asc (default), desc.")
+    @Parameter(description = "Sort direction. Allowed values: asc, desc.", schema = @Schema(defaultValue = "asc"))
     @QueryParam("sortOrder")
     protected SortOrder sortOrder;
 
@@ -117,7 +118,7 @@ public class ListOptions {
     }
 
     public void setSortBy(List<ClientField> sortBy) {
-        this.sortBy = parseSortBy(sortBy);
+        this.sortBy = stringify(sortBy);
     }
 
     public SortOrder getSortOrder() {
@@ -128,7 +129,7 @@ public class ListOptions {
         this.sortOrder = sortOrder;
     }
 
-    private String parseSortBy(List<ClientField> list) {
+    private String stringify(List<ClientField> list) {
         return list == null || list.isEmpty() ? null :
                  list.stream().map(ClientField::toQueryValue).collect(Collectors.joining(","));
     }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -21,6 +21,7 @@ public class ListOptions {
     @QueryParam("fields")
     protected String fields;
 
+    // TODO: this name is a temporary solution until we have a fix from smallrye-openapi
     @Parameter(name = "sortBy",
                description = "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId). Allowed values: clientId, displayName, description, protocol, enabled, appUrl. Defaults to clientId when omitted.",
                style = ParameterStyle.FORM,
@@ -29,7 +30,7 @@ public class ListOptions {
     @QueryParam("sortBy")
     protected String sortBy;
 
-    @Parameter(description = "Sort direction. Allowed values: asc (default), desc.", schema = @Schema(implementation = SortOrder.class))
+    @Parameter(description = "Sort direction. Allowed values: asc (default), desc.")
     @QueryParam("sortOrder")
     protected SortOrder sortOrder;
 

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -21,7 +21,7 @@ public class ListOptions {
     @QueryParam("fields")
     protected String fields;
 
-    // TODO: this name is a temporary solution until we have a fix from smallrye-openapi
+    // TODO: this name is a temporary solution until we have a fix from smallrye-openapi https://github.com/smallrye/smallrye-open-api/issues/2585
     @Parameter(name = "sortBy",
                description = "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId).",
                style = ParameterStyle.FORM,

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -10,8 +10,6 @@ import jakarta.ws.rs.QueryParam;
 import org.eclipse.microprofile.openapi.annotations.enums.Explode;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.eclipse.microprofile.openapi.annotations.enums.ParameterStyle;
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
 public class ListOptions {
@@ -21,19 +19,10 @@ public class ListOptions {
     @QueryParam("fields")
     protected String fields;
 
-    // TODO: this name is a temporary solution until we have a fix from smallrye-openapi https://github.com/smallrye/smallrye-open-api/issues/2585
-    @Parameter(name = "sortBy",
-               description = "Field(s) to sort by, comma-separated for multi-field sort (e.g. displayName,clientId).",
-               style = ParameterStyle.FORM,
-               explode = Explode.FALSE,
-               schema = @Schema(type = SchemaType.ARRAY, implementation = ClientField.class,
-               defaultValue = "clientId"))
-    @QueryParam("sortBy")
-    protected String sortBy;
-
-    @Parameter(description = "Sort direction. Allowed values: asc, desc.", schema = @Schema(implementation = SortOrder.class, defaultValue = "asc"))
-    @QueryParam("sortOrder")
-    protected SortOrder sortOrder;
+    @Parameter(description = "Sort expression. Comma-separated fields with optional direction per field using | (e.g. displayName|desc,clientId). Default direction is asc.",
+            schema = @Schema(type = SchemaType.STRING, defaultValue = "clientId"))
+    @QueryParam("sort")
+    protected String sort;
 
     @Parameter(description = "Filter expression using SCIM-like syntax, e.g. clientId eq \"my-app\" and enabled eq true")
     @QueryParam("q")
@@ -104,33 +93,17 @@ public class ListOptions {
     public void setOffset(Integer offset) {
         this.offset = offset;
     }
-    
-    public String getSortBy() {
-        return sortBy;
+
+    public String getSort() {
+        return sort;
     }
 
-    public void setSortBy(String sortBy) {
-        this.sortBy = sortBy;
+    public void setSort(String sort) {
+        this.sort = sort;
     }
 
-    public void setSortBy(ClientField sortBy) {
-        this.sortBy = sortBy == null ? null : sortBy.toQueryValue();
-    }
-
-    public void setSortBy(List<ClientField> sortBy) {
-        this.sortBy = stringify(sortBy);
-    }
-
-    public SortOrder getSortOrder() {
-        return sortOrder;
-    }
-
-    public void setSortOrder(SortOrder sortOrder) {
-        this.sortOrder = sortOrder;
-    }
-
-    private String stringify(List<ClientField> list) {
-        return list == null || list.isEmpty() ? null :
-                 list.stream().map(ClientField::toQueryValue).collect(Collectors.joining(","));
+    public void setSort(List<SortOption> sort) {
+        this.sort = sort == null || sort.isEmpty() ? null :
+                sort.stream().map(SortOption::toQuerySegment).collect(Collectors.joining(","));
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -31,7 +31,7 @@ public class ListOptions {
     @QueryParam("sortBy")
     protected String sortBy;
 
-    @Parameter(description = "Sort direction. Allowed values: asc, desc.", schema = @Schema(defaultValue = "asc"))
+    @Parameter(description = "Sort direction. Allowed values: asc, desc.", schema = @Schema(implementation = SortOrder.class, defaultValue = "asc"))
     @QueryParam("sortOrder")
     protected SortOrder sortOrder;
 

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -1,5 +1,6 @@
 package org.keycloak.admin.api;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -51,6 +52,11 @@ public class ListOptions {
         return this;
     }
 
+    public ListOptions sort(List<SortOption> sort) {
+        this.setSort(sort);
+        return this;
+    }
+
     public ListOptions offset(int offset) {
         this.setOffset(offset);
         return this;
@@ -94,16 +100,55 @@ public class ListOptions {
         this.offset = offset;
     }
 
-    public String getSort() {
-        return sort;
-    }
-
-    public void setSort(String sort) {
-        this.sort = sort;
+    public List<SortOption> getSort() {
+        if (sort == null) {
+            return null;
+        }
+        if (sort.isEmpty()) {
+            return List.of();
+        }
+        List<SortOption> options = Arrays.stream(sort.split(","))
+                .map(String::trim)
+                .filter(segment -> !segment.isEmpty())
+                .map(ListOptions::parseSortSegment)
+                .collect(Collectors.toList());
+        if (options.isEmpty()) {
+            throw new IllegalArgumentException("sort must specify at least one field");
+        }
+        return options;
     }
 
     public void setSort(List<SortOption> sort) {
-        this.sort = sort == null || sort.isEmpty() ? null :
-                sort.stream().map(SortOption::toQuerySegment).collect(Collectors.joining(","));
+        if (sort == null) {
+            this.sort = null;
+        } else if (sort.isEmpty()) {
+            this.sort = "";
+        } else {
+            this.sort = sort.stream().map(SortOption::toQuerySegment).collect(Collectors.joining(","));
+        }
+    }
+
+    private static SortOption parseSortSegment(String segment) {
+        String[] parts = segment.split("\\|", 2);
+        String fieldName = parts[0].trim();
+        if (fieldName.isEmpty()) {
+            throw new IllegalArgumentException("sort must specify at least one field");
+        }
+        ClientField field = ClientField.fromApiName(fieldName).orElseThrow(() ->
+                new IllegalArgumentException(String.format("%s is not a sortable field", fieldName)));
+        SortOrder order = parts.length == 1 ? SortOrder.ASC : parseSortOrder(parts[1].trim());
+        return SortOption.of(field, order);
+    }
+
+    private static SortOrder parseSortOrder(String value) {
+        if (value.isEmpty()) {
+            return SortOrder.ASC;
+        }
+        for (SortOrder order : SortOrder.values()) {
+            if (order.name().equalsIgnoreCase(value)) {
+                return order;
+            }
+        }
+        throw new IllegalArgumentException("sort direction must be asc or desc");
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOption.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOption.java
@@ -38,4 +38,21 @@ public final class SortOption {
         }
         return field.toQueryValue() + "|" + order.name().toLowerCase();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof SortOption)) {
+            return false;
+        }
+        SortOption other = (SortOption) obj;
+        return field == other.field && order == other.order;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field, order);
+    }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOption.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOption.java
@@ -1,0 +1,41 @@
+package org.keycloak.admin.api;
+
+import java.util.Objects;
+
+public final class SortOption {
+
+    private final ClientField field;
+    private final SortOrder order;
+
+    private SortOption(ClientField field, SortOrder order) {
+        this.field = Objects.requireNonNull(field, "field cannot be null");
+        this.order = order == null ? SortOrder.ASC : order;
+    }
+
+    public static SortOption of(ClientField field) {
+        return new SortOption(field, SortOrder.ASC);
+    }
+
+    public static SortOption of(ClientField field, SortOrder order) {
+        return new SortOption(field, order);
+    }
+
+    public ClientField field() {
+        return field;
+    }
+
+    public SortOrder order() {
+        return order;
+    }
+
+    public boolean isAscending() {
+        return order.isAscending();
+    }
+
+    public String toQuerySegment() {
+        if (order == SortOrder.ASC) {
+            return field.toQueryValue();
+        }
+        return field.toQueryValue() + "|" + order.name().toLowerCase();
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOrder.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOrder.java
@@ -1,0 +1,28 @@
+package org.keycloak.admin.api;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(enumeration = {"asc", "desc"})
+public enum SortOrder {
+    ASC,
+    DESC;
+
+    public boolean isAscending() {
+        return this == ASC;
+    }
+
+    public static SortOrder fromString(String value) {
+        if (value == null || value.isBlank()) {
+            return ASC;
+        }
+        for (SortOrder order : values()) {
+            if (order.name().equalsIgnoreCase(value)) {
+                return order;
+            }
+        }
+        throw new WebApplicationException("sortOrder must be asc or desc", Response.Status.BAD_REQUEST);
+    }
+}

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOrder.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOrder.java
@@ -23,6 +23,6 @@ public enum SortOrder {
                 return order;
             }
         }
-        throw new WebApplicationException("sortOrder must be asc or desc", Response.Status.BAD_REQUEST);
+        throw new WebApplicationException("sort direction must be asc or desc", Response.Status.BAD_REQUEST);
     }
 }

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOrder.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/SortOrder.java
@@ -3,9 +3,6 @@ package org.keycloak.admin.api;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-import org.eclipse.microprofile.openapi.annotations.media.Schema;
-
-@Schema(enumeration = {"asc", "desc"})
 public enum SortOrder {
     ASC,
     DESC;

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/client/ClientsApi.java
@@ -36,7 +36,8 @@ public interface ClientsApi {
     @Operation(summary = "Get all clients", description = "Returns a list of clients in the realm, optionally filtered by a query expression. "
             + "Results are paginated using offset (0-based, default 0) and limit (default 100).")
     @APIResponses(value = {
-            @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = BaseClientRepresentation.class)))
+            @APIResponse(responseCode = "200", content = @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = BaseClientRepresentation.class))),
+            @APIResponse(responseCode = "400", description = "Invalid sort parameter")
     })
     Stream<BaseClientRepresentation> getClients(@BeanParam ListOptions params);
 

--- a/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
+++ b/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
@@ -1,10 +1,12 @@
 package org.keycloak.admin.api;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ListOptionsTest {
 
@@ -21,6 +23,47 @@ public class ListOptionsTest {
         ListOptions options = new ListOptions();
         options.fields = "a,b";
         assertEquals(Set.of("a", "b"), options.getFields());
+    }
+
+    @Test
+    void testGetSortEmpty() {
+        ListOptions options = new ListOptions();
+        options.setSort(List.of());
+        assertEquals("", options.sort);
+        assertEquals(List.of(), options.getSort());
+    }
+
+    @Test
+    void testGetSort() {
+        ListOptions options = new ListOptions();
+        options.sort = "displayName|desc,clientId";
+        assertEquals(List.of(SortOption.of(ClientField.DISPLAY_NAME, SortOrder.DESC), SortOption.of(ClientField.CLIENT_ID)),
+                options.getSort());
+    }
+
+    @Test
+    void testSetSort() {
+        ListOptions options = new ListOptions();
+        options.setSort(List.of(SortOption.of(ClientField.CLIENT_ID, SortOrder.DESC)));
+        assertEquals("clientId|desc", options.sort);
+    }
+
+    @Test
+    void invalidSortFieldThrowsBadRequest() {
+        ListOptions options = new ListOptions();
+        options.sort = "unknown";
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, options::getSort);
+        assertEquals("unknown is not a sortable field", exception.getMessage());
+    }
+
+    @Test
+    void invalidSortDirectionThrowsBadRequest() {
+        ListOptions options = new ListOptions();
+        options.sort = "clientId|what";
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, options::getSort);
+        assertEquals("sort direction must be asc or desc", exception.getMessage());
     }
 
 }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/OASModelFilter.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/OASModelFilter.java
@@ -12,6 +12,8 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.keycloak.admin.api.ClientField;
+
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -21,6 +23,7 @@ import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.media.Discriminator;
 import org.eclipse.microprofile.openapi.models.media.Schema;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter;
 import org.eclipse.microprofile.openapi.models.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.models.security.SecurityScheme;
 import org.jboss.jandex.AnnotationInstance;
@@ -33,6 +36,9 @@ import org.jboss.logging.Logger;
 import static org.keycloak.utils.StringUtil.isNullOrEmpty;
 
 public class OASModelFilter implements OASFilter {
+
+    private static final String SORT_PARAMETER_NAME = "sort";
+    private static final String ALLOWED_FIELDS_MARKER = " Allowed fields: ";
 
     private final Logger log = Logger.getLogger(OASModelFilter.class);
     private final IndexView indexView;
@@ -49,6 +55,14 @@ public class OASModelFilter implements OASFilter {
         indexView.getKnownClasses().forEach(classInfo -> {
             simpleNameToClassInfoMap.put(classInfo.simpleName(), classInfo);
         });
+    }
+
+    @Override
+    public Parameter filterParameter(Parameter parameter) {
+        if (parameter != null && SORT_PARAMETER_NAME.equals(parameter.getName())) {
+            parameter.setDescription(enhanceSortParameterDescription(parameter.getDescription()));
+        }
+        return parameter;
     }
 
     @Override
@@ -407,6 +421,25 @@ public class OASModelFilter implements OASFilter {
 
     private void addJavaExampleExtensions(OpenAPI openAPI) {
         new JavaDocExampleGenerator(indexView).generate(openAPI);
+    }
+
+    private static String enhanceSortParameterDescription(String description) {
+        String base = stripAllowedFieldsSuffix(description);
+        if (isNullOrEmpty(base)) {
+            return "Allowed fields: " + ClientField.allowedApiNames() + ".";
+        }
+        return base + ALLOWED_FIELDS_MARKER + ClientField.allowedApiNames() + ".";
+    }
+
+    private static String stripAllowedFieldsSuffix(String description) {
+        if (isNullOrEmpty(description)) {
+            return description;
+        }
+        int idx = description.indexOf(ALLOWED_FIELDS_MARKER);
+        if (idx >= 0) {
+            return description.substring(0, idx);
+        }
+        return description;
     }
 
 }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/client/DefaultClientsApi.java
@@ -49,9 +49,9 @@ public class DefaultClientsApi implements ClientsApi {
     public Stream<BaseClientRepresentation> getClients(ListOptions params) {
         try {
             var searchOptions = params.getQuery() != null ? new ClientService.ClientSearchOptions(params.getQuery()) : null;
-            var sortAndSliceOptions = ClientService.normalizePagination(params.getOffset(), params.getLimit());
             return clientService.getClients(realm, new ClientProjectionOptions(params.getFields()), searchOptions,
                     ClientSortAndSliceOptions.fromQuery(params));
+        } catch (ClientQueryException e) {
             throw new BadRequestException(e.getMessage());
         }
     }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/client/DefaultClientsApi.java
@@ -20,8 +20,10 @@ import org.keycloak.admin.api.client.ClientsApi;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
+import org.keycloak.services.ServiceException;
 import org.keycloak.services.client.ClientService;
 import org.keycloak.services.client.ClientService.ClientProjectionOptions;
+import org.keycloak.services.client.ClientService.ClientSortAndSliceOptions;
 import org.keycloak.services.client.DefaultClientService;
 import org.keycloak.services.client.query.ClientQueryException;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
@@ -50,8 +52,7 @@ public class DefaultClientsApi implements ClientsApi {
             var searchOptions = params.getQuery() != null ? new ClientService.ClientSearchOptions(params.getQuery()) : null;
             var sortAndSliceOptions = ClientService.normalizePagination(params.getOffset(), params.getLimit());
             return clientService.getClients(realm, new ClientProjectionOptions(params.getFields()), searchOptions,
-                    sortAndSliceOptions);
-        } catch (ClientQueryException e) {
+                    ClientSortAndSliceOptions.fromQuery(params));
             throw new BadRequestException(e.getMessage());
         }
     }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/client/DefaultClientsApi.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/rest/admin/api/client/DefaultClientsApi.java
@@ -20,7 +20,6 @@ import org.keycloak.admin.api.client.ClientsApi;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
-import org.keycloak.services.ServiceException;
 import org.keycloak.services.client.ClientService;
 import org.keycloak.services.client.ClientService.ClientProjectionOptions;
 import org.keycloak.services.client.ClientService.ClientSortAndSliceOptions;

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -1,14 +1,12 @@
 package org.keycloak.services.client;
 
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.Response;
@@ -17,7 +15,6 @@ import org.keycloak.models.Constants;
 import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.SortOption;
-import org.keycloak.admin.api.SortOrder;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.services.PatchType;
@@ -50,46 +47,15 @@ public interface ClientService extends Service {
         }
 
         public static ClientSortAndSliceOptions fromQuery(ListOptions listOptions) {
-            List<SortOption> options = listOptions.getSort() == null || listOptions.getSort().isEmpty()
-                    ? List.of(SortOption.of(ClientField.defaultField()))
-                    : parseSort(listOptions.getSort());
+            List<SortOption> options;
+            try {
+                options = listOptions.getSort() == null || listOptions.getSort().isEmpty()
+                        ? List.of(SortOption.of(ClientField.defaultField()))
+                        : listOptions.getSort();
+            } catch (IllegalArgumentException e) {
+                throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);
+            }
             return new ClientSortAndSliceOptions(options);
-        }
-
-        private static List<SortOption> parseSort(String sort) {
-            List<SortOption> options = Arrays.stream(sort.split(","))
-                    .map(String::trim)
-                    .filter(segment -> !segment.isEmpty())
-                    .map(ClientSortAndSliceOptions::parseSortSegment)
-                    .collect(Collectors.toList());
-            if (options.isEmpty()) {
-                throw new ServiceException("sort must specify at least one field", Response.Status.BAD_REQUEST);
-            }
-            return options;
-        }
-
-        private static SortOption parseSortSegment(String segment) {
-            String[] parts = segment.split("\\|", 2);
-            String fieldName = parts[0].trim();
-            if (fieldName.isEmpty()) {
-                throw new ServiceException("sort must specify at least one field", Response.Status.BAD_REQUEST);
-            }
-            ClientField field = ClientField.fromApiName(fieldName).orElseThrow(() ->
-                    new ServiceException(String.format("%s is not a sortable field", fieldName), Response.Status.BAD_REQUEST));
-            SortOrder order = parts.length == 1 ? SortOrder.ASC : parseSortOrder(parts[1].trim());
-            return SortOption.of(field, order);
-        }
-
-        private static SortOrder parseSortOrder(String value) {
-            if (value.isEmpty()) {
-                return SortOrder.ASC;
-            }
-            for (SortOrder order : SortOrder.values()) {
-                if (order.name().equalsIgnoreCase(value)) {
-                    return order;
-                }
-            }
-            throw new ServiceException("sort direction must be asc or desc", Response.Status.BAD_REQUEST);
         }
 
         public Comparator<BaseClientRepresentation> getSortComparator() {

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -54,7 +54,7 @@ public interface ClientService extends Service {
             List<ClientField> fields = listOptions.getSortBy() == null || listOptions.getSortBy().isEmpty()
                     ? List.of(ClientField.defaultField())
                     : parseSortBy(listOptions.getSortBy());
-            return new ClientSortAndSliceOptions(fields, resolveSortOrder(listOptions.getSortOrder()));
+            return new ClientSortAndSliceOptions(fields, isSortOrderAscending(listOptions.getSortOrder()));
         }
 
         private static List<ClientField> parseSortBy(String sortBy) {
@@ -75,7 +75,7 @@ public interface ClientService extends Service {
             });
         }
 
-        private static boolean resolveSortOrder(SortOrder sortOrder) {
+        private static boolean isSortOrderAscending(SortOrder sortOrder) {
             return sortOrder == null ? true : sortOrder.isAscending();
         }
 

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -70,10 +70,9 @@ public interface ClientService extends Service {
         }
 
         private static ClientField parseSortField(String field) {
-            ClientField.validateApiName(field).ifPresent(msg -> {
-                throw new ServiceException(msg, Response.Status.BAD_REQUEST);
+            return ClientField.fromApiName(field).orElseThrow(() -> {
+                throw new ServiceException(String.format("%s is not a sortable field"),  Response.Status.BAD_REQUEST);
             });
-            return ClientField.fromApiName(field).orElseThrow();
         }
 
         private static boolean resolveSortOrder(SortOrder sortOrder) {

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.Response;
 import org.keycloak.models.Constants;
 import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
+import org.keycloak.admin.api.SortOption;
 import org.keycloak.admin.api.SortOrder;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
@@ -42,46 +43,58 @@ public interface ClientService extends Service {
     }
 
     class ClientSortAndSliceOptions {
-        private final List<ClientField> sortFields;
-        private final boolean ascending;
+        private final List<SortOption> sortOptions;
 
-        private ClientSortAndSliceOptions(List<ClientField> sortFields, boolean ascending) {
-            this.sortFields = List.copyOf(sortFields);
-            this.ascending = ascending;
+        private ClientSortAndSliceOptions(List<SortOption> sortOptions) {
+            this.sortOptions = List.copyOf(sortOptions);
         }
 
         public static ClientSortAndSliceOptions fromQuery(ListOptions listOptions) {
-            List<ClientField> fields = listOptions.getSortBy() == null || listOptions.getSortBy().isEmpty()
-                    ? List.of(ClientField.defaultField())
-                    : parseSortBy(listOptions.getSortBy());
-            return new ClientSortAndSliceOptions(fields, isSortOrderAscending(listOptions.getSortOrder()));
+            List<SortOption> options = listOptions.getSort() == null || listOptions.getSort().isEmpty()
+                    ? List.of(SortOption.of(ClientField.defaultField()))
+                    : parseSort(listOptions.getSort());
+            return new ClientSortAndSliceOptions(options);
         }
 
-        private static List<ClientField> parseSortBy(String sortBy) {
-            List<ClientField> fields = Arrays.stream(sortBy.split(","))
+        private static List<SortOption> parseSort(String sort) {
+            List<SortOption> options = Arrays.stream(sort.split(","))
                     .map(String::trim)
-                    .filter(field -> !field.isEmpty())
-                    .map(ClientSortAndSliceOptions::parseSortField)
+                    .filter(segment -> !segment.isEmpty())
+                    .map(ClientSortAndSliceOptions::parseSortSegment)
                     .collect(Collectors.toList());
-            if (fields.isEmpty()) {
-                throw new ServiceException("sortBy must specify at least one field", Response.Status.BAD_REQUEST);
+            if (options.isEmpty()) {
+                throw new ServiceException("sort must specify at least one field", Response.Status.BAD_REQUEST);
             }
-            return fields;
+            return options;
         }
 
-        private static ClientField parseSortField(String field) {
-            return ClientField.fromApiName(field).orElseThrow(() -> {
-                return new ServiceException(String.format("%s is not a sortable field", field),  Response.Status.BAD_REQUEST);
-            });
+        private static SortOption parseSortSegment(String segment) {
+            String[] parts = segment.split("\\|", 2);
+            String fieldName = parts[0].trim();
+            if (fieldName.isEmpty()) {
+                throw new ServiceException("sort must specify at least one field", Response.Status.BAD_REQUEST);
+            }
+            ClientField field = ClientField.fromApiName(fieldName).orElseThrow(() ->
+                    new ServiceException(String.format("%s is not a sortable field", fieldName), Response.Status.BAD_REQUEST));
+            SortOrder order = parts.length == 1 ? SortOrder.ASC : parseSortOrder(parts[1].trim());
+            return SortOption.of(field, order);
         }
 
-        private static boolean isSortOrderAscending(SortOrder sortOrder) {
-            return sortOrder == null ? true : sortOrder.isAscending();
+        private static SortOrder parseSortOrder(String value) {
+            if (value.isEmpty()) {
+                return SortOrder.ASC;
+            }
+            for (SortOrder order : SortOrder.values()) {
+                if (order.name().equalsIgnoreCase(value)) {
+                    return order;
+                }
+            }
+            throw new ServiceException("sort direction must be asc or desc", Response.Status.BAD_REQUEST);
         }
 
         public Comparator<BaseClientRepresentation> getSortComparator() {
-            return sortFields.stream()
-                    .map(field -> field.comparator(ascending))
+            return sortOptions.stream()
+                    .map(option -> option.field().comparator(option.isAscending()))
                     .reduce(Comparator::thenComparing)
                     .orElseThrow();
         }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -11,10 +11,10 @@ import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.models.Constants;
 import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.SortOption;
+import org.keycloak.models.Constants;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.services.PatchType;
@@ -40,22 +40,47 @@ public interface ClientService extends Service {
     }
 
     class ClientSortAndSliceOptions {
-        private final List<SortOption> sortOptions;
+        private List<SortOption> sortOptions;
+        private int offset;
+        private int limit;
 
-        private ClientSortAndSliceOptions(List<SortOption> sortOptions) {
+        private ClientSortAndSliceOptions(List<SortOption> sortOptions, int offset, int limit) {
+            this.offset = offset;
+            this.limit = limit;
             this.sortOptions = List.copyOf(sortOptions);
+        }
+
+        public int limit() {
+            return this.limit;
+        }
+
+        public int offset() {
+            return this.offset;
         }
 
         public static ClientSortAndSliceOptions fromQuery(ListOptions listOptions) {
             List<SortOption> options;
+            int normalizedOffset;
+            int normalizedLimit;
             try {
                 options = listOptions.getSort() == null || listOptions.getSort().isEmpty()
                         ? List.of(SortOption.of(ClientField.defaultField()))
                         : listOptions.getSort();
+
+                Integer offset = listOptions.getOffset();
+                Integer limit = listOptions.getLimit();
+                if (offset != null && offset < 0) {
+                    throw new ServiceException("offset must be greater than or equal to 0", Response.Status.BAD_REQUEST);
+                }
+                if (limit != null && limit < 1) {
+                    throw new ServiceException("limit must be greater than or equal to 1", Response.Status.BAD_REQUEST);
+                }
+                normalizedOffset = offset != null ? offset : 0;
+                normalizedLimit = limit != null ? limit : Constants.DEFAULT_MAX_RESULTS;
             } catch (IllegalArgumentException e) {
                 throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);
             }
-            return new ClientSortAndSliceOptions(options);
+            return new ClientSortAndSliceOptions(options, normalizedOffset, normalizedLimit);
         }
 
         public Comparator<BaseClientRepresentation> getSortComparator() {
@@ -64,6 +89,7 @@ public interface ClientService extends Service {
                     .reduce(Comparator::thenComparing)
                     .orElseThrow();
         }
+    }
 
     record CreateOrUpdateResult(BaseClientRepresentation representation, boolean created) {}
 
@@ -81,15 +107,4 @@ public interface ClientService extends Service {
 
     BaseClientRepresentation patchClient(RealmModel realm, String clientId, PatchType patchType, InputStream patch) throws ServiceException;
 
-    public static ClientSortAndSliceOptions normalizePagination(Integer offset, Integer limit) throws ServiceException {
-        if (offset != null && offset < 0) {
-            throw new ServiceException("offset must be greater than or equal to 0", Response.Status.BAD_REQUEST);
-        }
-        if (limit != null && limit < 1) {
-            throw new ServiceException("limit must be greater than or equal to 1", Response.Status.BAD_REQUEST);
-        }
-        int normalizedOffset = offset != null ? offset : 0;
-        int normalizedLimit = limit != null ? limit : Constants.DEFAULT_MAX_RESULTS;
-        return new ClientSortAndSliceOptions(normalizedOffset, normalizedLimit);
-    }
 }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -71,7 +71,7 @@ public interface ClientService extends Service {
 
         private static ClientField parseSortField(String field) {
             return ClientField.fromApiName(field).orElseThrow(() -> {
-                throw new ServiceException(String.format("%s is not a sortable field"),  Response.Status.BAD_REQUEST);
+                return new ServiceException(String.format("%s is not a sortable field", field),  Response.Status.BAD_REQUEST);
             });
         }
 
@@ -85,8 +85,6 @@ public interface ClientService extends Service {
                     .reduce(Comparator::thenComparing)
                     .orElseThrow();
         }
-
-        // offset / limit — #48289
 
     record CreateOrUpdateResult(BaseClientRepresentation representation, boolean created) {}
 

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/ClientService.java
@@ -1,15 +1,22 @@
 package org.keycloak.services.client;
 
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.models.Constants;
+import org.keycloak.admin.api.ClientField;
+import org.keycloak.admin.api.ListOptions;
+import org.keycloak.admin.api.SortOrder;
 import org.keycloak.models.RealmModel;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.services.PatchType;
@@ -34,7 +41,53 @@ public interface ClientService extends Service {
         }
     }
 
-    record ClientSortAndSliceOptions(int offset, int limit) {}
+    class ClientSortAndSliceOptions {
+        private final List<ClientField> sortFields;
+        private final boolean ascending;
+
+        private ClientSortAndSliceOptions(List<ClientField> sortFields, boolean ascending) {
+            this.sortFields = List.copyOf(sortFields);
+            this.ascending = ascending;
+        }
+
+        public static ClientSortAndSliceOptions fromQuery(ListOptions listOptions) {
+            List<ClientField> fields = listOptions.getSortBy() == null || listOptions.getSortBy().isEmpty()
+                    ? List.of(ClientField.defaultField())
+                    : parseSortBy(listOptions.getSortBy());
+            return new ClientSortAndSliceOptions(fields, resolveSortOrder(listOptions.getSortOrder()));
+        }
+
+        private static List<ClientField> parseSortBy(String sortBy) {
+            List<ClientField> fields = Arrays.stream(sortBy.split(","))
+                    .map(String::trim)
+                    .filter(field -> !field.isEmpty())
+                    .map(ClientSortAndSliceOptions::parseSortField)
+                    .collect(Collectors.toList());
+            if (fields.isEmpty()) {
+                throw new ServiceException("sortBy must specify at least one field", Response.Status.BAD_REQUEST);
+            }
+            return fields;
+        }
+
+        private static ClientField parseSortField(String field) {
+            ClientField.validateApiName(field).ifPresent(msg -> {
+                throw new ServiceException(msg, Response.Status.BAD_REQUEST);
+            });
+            return ClientField.fromApiName(field).orElseThrow();
+        }
+
+        private static boolean resolveSortOrder(SortOrder sortOrder) {
+            return sortOrder == null ? true : sortOrder.isAscending();
+        }
+
+        public Comparator<BaseClientRepresentation> getSortComparator() {
+            return sortFields.stream()
+                    .map(field -> field.comparator(ascending))
+                    .reduce(Comparator::thenComparing)
+                    .orElseThrow();
+        }
+
+        // offset / limit — #48289
 
     record CreateOrUpdateResult(BaseClientRepresentation representation, boolean created) {}
 

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -154,11 +154,11 @@ public class DefaultClientService implements ClientService {
                     .map(client -> getMapper(client.getProtocol()).fromModel(client))
                     .filter(Objects::nonNull);
 
-            stream = applySearchFilter(stream, searchOptions);
-            return applyProjection(stream.sorted(sortComparator), projectionOptions);
+            stream = applySearchFilter(stream, searchOptions).sorted(sortComparator);
             if (!useJpaPagination) {
                 stream = paginatedStream(stream, offset, limit);
             }
+            return applyProjection(stream, projectionOptions);
 
         } catch (ModelException e) {
             throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.validation.groups.Default;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.admin.api.ListOptions;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
@@ -140,6 +142,10 @@ public class DefaultClientService implements ClientService {
         boolean useJpaPagination = canView && !hasQuery;
         int offset = sortAndSliceOptions.offset();
         int limit = sortAndSliceOptions.limit();
+        ClientSortAndSliceOptions sortOptions = sortAndSliceOptions != null
+                ? sortAndSliceOptions
+                : ClientSortAndSliceOptions.fromQuery(new ListOptions());
+        Comparator<BaseClientRepresentation> sortComparator = sortOptions.getSortComparator();
 
         try {
             Stream<ClientModel> clientModels = useJpaPagination
@@ -158,7 +164,7 @@ public class DefaultClientService implements ClientService {
                 stream = paginatedStream(stream, offset, limit);
             }
 
-            return applyProjection(stream, projectionOptions);
+            return applyProjection(stream, projectionOptions).sorted(sortComparator);
         } catch (ModelException e) {
             throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);
         }

--- a/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/services/client/DefaultClientService.java
@@ -17,7 +17,6 @@ import jakarta.annotation.Nonnull;
 import jakarta.validation.groups.Default;
 import jakarta.ws.rs.core.Response;
 
-import org.keycloak.admin.api.ListOptions;
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
@@ -119,9 +118,9 @@ public class DefaultClientService implements ClientService {
 
     @Override
     public Stream<BaseClientRepresentation> getClients(@Nonnull RealmModel realm,
-                                                       ClientProjectionOptions projectionOptions,
+                                                       @Nonnull ClientProjectionOptions projectionOptions,
                                                        ClientSearchOptions searchOptions,
-                                                       ClientSortAndSliceOptions sortAndSliceOptions) {
+                                                       @Nonnull ClientSortAndSliceOptions sortAndSliceOptions) {
         permissions.clients().requireList();
 
         // TODO: this check is weak
@@ -142,11 +141,8 @@ public class DefaultClientService implements ClientService {
         boolean useJpaPagination = canView && !hasQuery;
         int offset = sortAndSliceOptions.offset();
         int limit = sortAndSliceOptions.limit();
-        ClientSortAndSliceOptions sortOptions = sortAndSliceOptions != null
-                ? sortAndSliceOptions
-                : ClientSortAndSliceOptions.fromQuery(new ListOptions());
-        Comparator<BaseClientRepresentation> sortComparator = sortOptions.getSortComparator();
 
+        Comparator<BaseClientRepresentation> sortComparator = sortAndSliceOptions.getSortComparator();
         try {
             Stream<ClientModel> clientModels = useJpaPagination
                     ? realm.getClientsStream(offset, limit)
@@ -159,12 +155,11 @@ public class DefaultClientService implements ClientService {
                     .filter(Objects::nonNull);
 
             stream = applySearchFilter(stream, searchOptions);
-
+            return applyProjection(stream.sorted(sortComparator), projectionOptions);
             if (!useJpaPagination) {
                 stream = paginatedStream(stream, offset, limit);
             }
 
-            return applyProjection(stream, projectionOptions).sorted(sortComparator);
         } catch (ModelException e) {
             throw new ServiceException(e.getMessage(), Response.Status.BAD_REQUEST);
         }

--- a/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortByParameterTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortByParameterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.admin.internal.openapi;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenApiSortByParameterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void sortByParameterIsArrayOfClientSortField() throws Exception {
+        Path openApiFile = Path.of("target/openapi.json");
+        assertTrue(Files.exists(openApiFile), "OpenAPI spec must be generated before running this test");
+
+        JsonNode spec = MAPPER.readTree(openApiFile.toFile());
+        JsonNode params = spec.at("/paths/~1admin~1api~1{realmName}~1clients~1v2/get/parameters");
+        JsonNode sortByParam = StreamSupport.stream(params.spliterator(), false)
+                .filter(parameter -> "sortBy".equals(parameter.path("name").asText()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(sortByParam, "sortBy parameter must exist in the spec");
+        assertEquals("array", sortByParam.at("/schema/type").asText(),
+                "sortBy schema type must be 'array' to support multi-field sort");
+        assertEquals("#/components/schemas/ClientField", sortByParam.at("/schema/items/$ref").asText(),
+                "sortBy array items must reference ClientField");
+    }
+}

--- a/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortParameterTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortParameterTest.java
@@ -21,6 +21,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.StreamSupport;
 
+import org.keycloak.admin.api.ClientField;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
@@ -48,5 +50,7 @@ class OpenApiSortParameterTest {
         assertNotNull(sortParam, "sort parameter must exist in the spec");
         assertEquals("string", sortParam.at("/schema/type").asText(),
                 "sort schema type must be 'string' to support per-field sort directions");
+        assertTrue(sortParam.path("description").asText().contains("Allowed fields: " + ClientField.allowedApiNames()),
+                "sort parameter description must list allowed fields from ClientField metadata");
     }
 }

--- a/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortParameterTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/admin/internal/openapi/OpenApiSortParameterTest.java
@@ -29,26 +29,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class OpenApiSortByParameterTest {
+class OpenApiSortParameterTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Test
-    void sortByParameterIsArrayOfClientSortField() throws Exception {
+    void sortParameterIsString() throws Exception {
         Path openApiFile = Path.of("target/openapi.json");
         assertTrue(Files.exists(openApiFile), "OpenAPI spec must be generated before running this test");
 
         JsonNode spec = MAPPER.readTree(openApiFile.toFile());
         JsonNode params = spec.at("/paths/~1admin~1api~1{realmName}~1clients~1v2/get/parameters");
-        JsonNode sortByParam = StreamSupport.stream(params.spliterator(), false)
-                .filter(parameter -> "sortBy".equals(parameter.path("name").asText()))
+        JsonNode sortParam = StreamSupport.stream(params.spliterator(), false)
+                .filter(parameter -> "sort".equals(parameter.path("name").asText()))
                 .findFirst()
                 .orElse(null);
 
-        assertNotNull(sortByParam, "sortBy parameter must exist in the spec");
-        assertEquals("array", sortByParam.at("/schema/type").asText(),
-                "sortBy schema type must be 'array' to support multi-field sort");
-        assertEquals("#/components/schemas/ClientField", sortByParam.at("/schema/items/$ref").asText(),
-                "sortBy array items must reference ClientField");
+        assertNotNull(sortParam, "sort parameter must exist in the spec");
+        assertEquals("string", sortParam.at("/schema/type").asText(),
+                "sort schema type must be 'string' to support per-field sort directions");
     }
 }

--- a/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
@@ -1,0 +1,90 @@
+package org.keycloak.services.client;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.keycloak.admin.api.ClientField;
+import org.keycloak.admin.api.ListOptions;
+import org.keycloak.admin.api.SortOption;
+import org.keycloak.admin.api.SortOrder;
+import org.keycloak.representations.admin.v2.BaseClientRepresentation;
+import org.keycloak.services.ServiceException;
+import org.keycloak.services.client.ClientService.ClientSortAndSliceOptions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ClientSortAndSliceOptionsTest {
+
+    @Test
+    void defaultSortUsesClientIdAscending() {
+        Comparator<BaseClientRepresentation> comparator = ClientSortAndSliceOptions.fromQuery(new ListOptions()).getSortComparator();
+
+        BaseClientRepresentation a = client("a");
+        BaseClientRepresentation b = client("b");
+
+        assertEquals(-1, comparator.compare(a, b));
+        assertEquals(1, comparator.compare(b, a));
+    }
+
+    @Test
+    void parseSortWithPerFieldDirections() {
+        ListOptions options = new ListOptions();
+        options.setSort("displayName|desc,clientId|asc");
+
+        Comparator<BaseClientRepresentation> comparator = ClientSortAndSliceOptions.fromQuery(options).getSortComparator();
+
+        BaseClientRepresentation first = client("sort-a", "A");
+        BaseClientRepresentation second = client("sort-b", "A");
+        BaseClientRepresentation third = client("sort-c", "B");
+
+        assertEquals(-1, comparator.compare(third, first));
+        assertEquals(-1, comparator.compare(first, second));
+    }
+
+    @Test
+    void parseSortUsesDefaultDirectionWhenOmitted() {
+        ListOptions options = new ListOptions();
+        options.setSort(List.of(SortOption.of(ClientField.DISPLAY_NAME), SortOption.of(ClientField.CLIENT_ID, SortOrder.DESC)));
+
+        Comparator<BaseClientRepresentation> comparator = ClientSortAndSliceOptions.fromQuery(options).getSortComparator();
+
+        BaseClientRepresentation first = client("sort-a", "A");
+        BaseClientRepresentation second = client("sort-b", "A");
+        BaseClientRepresentation third = client("sort-c", "B");
+
+        assertEquals(1, comparator.compare(first, second));
+        assertEquals(1, comparator.compare(third, first));
+    }
+
+    @Test
+    void invalidSortFieldThrowsBadRequest() {
+        ListOptions options = new ListOptions();
+        options.setSort("unknown");
+
+        ServiceException exception = assertThrows(ServiceException.class, () -> ClientSortAndSliceOptions.fromQuery(options));
+        assertEquals("unknown is not a sortable field", exception.getMessage());
+    }
+
+    @Test
+    void invalidSortDirectionThrowsBadRequest() {
+        ListOptions options = new ListOptions();
+        options.setSort("clientId|what");
+
+        ServiceException exception = assertThrows(ServiceException.class, () -> ClientSortAndSliceOptions.fromQuery(options));
+        assertEquals("sort direction must be asc or desc", exception.getMessage());
+    }
+
+    private static BaseClientRepresentation client(String clientId) {
+        return client(clientId, clientId);
+    }
+
+    private static BaseClientRepresentation client(String clientId, String displayName) {
+        BaseClientRepresentation client = new BaseClientRepresentation();
+        client.setClientId(clientId);
+        client.setDisplayName(displayName);
+        return client;
+    }
+}

--- a/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
@@ -1,5 +1,6 @@
 package org.keycloak.services.client;
 
+import java.lang.reflect.Field;
 import java.util.Comparator;
 import java.util.List;
 
@@ -32,7 +33,9 @@ class ClientSortAndSliceOptionsTest {
     @Test
     void parseSortWithPerFieldDirections() {
         ListOptions options = new ListOptions();
-        options.setSort("displayName|desc,clientId|asc");
+        options.setSort(List.of(
+                SortOption.of(ClientField.DISPLAY_NAME, SortOrder.DESC),
+                SortOption.of(ClientField.CLIENT_ID, SortOrder.ASC)));
 
         Comparator<BaseClientRepresentation> comparator = ClientSortAndSliceOptions.fromQuery(options).getSortComparator();
 
@@ -61,8 +64,7 @@ class ClientSortAndSliceOptionsTest {
 
     @Test
     void invalidSortFieldThrowsBadRequest() {
-        ListOptions options = new ListOptions();
-        options.setSort("unknown");
+        ListOptions options = withSortQuery("unknown");
 
         ServiceException exception = assertThrows(ServiceException.class, () -> ClientSortAndSliceOptions.fromQuery(options));
         assertEquals("unknown is not a sortable field", exception.getMessage());
@@ -81,11 +83,22 @@ class ClientSortAndSliceOptionsTest {
 
     @Test
     void invalidSortDirectionThrowsBadRequest() {
-        ListOptions options = new ListOptions();
-        options.setSort("clientId|what");
+        ListOptions options = withSortQuery("clientId|what");
 
         ServiceException exception = assertThrows(ServiceException.class, () -> ClientSortAndSliceOptions.fromQuery(options));
         assertEquals("sort direction must be asc or desc", exception.getMessage());
+    }
+
+    private static ListOptions withSortQuery(String sort) {
+        ListOptions options = new ListOptions();
+        try {
+            Field field = ListOptions.class.getDeclaredField("sort");
+            field.setAccessible(true);
+            field.set(options, sort);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+        return options;
     }
 
     private static BaseClientRepresentation client(String clientId) {

--- a/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/services/client/ClientSortAndSliceOptionsTest.java
@@ -69,6 +69,17 @@ class ClientSortAndSliceOptionsTest {
     }
 
     @Test
+    void descendingSortKeepsNullValuesLast() {
+        Comparator<BaseClientRepresentation> comparator = ClientField.DISPLAY_NAME.comparator(false);
+
+        BaseClientRepresentation withDisplayName = client("with-name", "Beta");
+        BaseClientRepresentation withoutDisplayName = client("without-name", null);
+
+        assertEquals(1, comparator.compare(withoutDisplayName, withDisplayName));
+        assertEquals(-1, comparator.compare(withDisplayName, withoutDisplayName));
+    }
+
+    @Test
     void invalidSortDirectionThrowsBadRequest() {
         ListOptions options = new ListOptions();
         options.setSort("clientId|what");

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -19,6 +19,8 @@ package org.keycloak.tests.admin.client.v2;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,6 +36,7 @@ import jakarta.ws.rs.core.MediaType;
 import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.PatchTypeNames;
+import org.keycloak.admin.api.SortOption;
 import org.keycloak.admin.api.SortOrder;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
@@ -62,6 +65,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpOptions;
 import org.apache.http.client.methods.HttpPatch;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
@@ -382,7 +386,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
 
         ListOptions listOptions = new ListOptions();
         listOptions.setFields(Set.of("clientId", "displayName"));
-        listOptions.setSortBy(List.of(ClientField.DISPLAY_NAME, ClientField.CLIENT_ID));
+        listOptions.setSort(List.of(SortOption.of(ClientField.DISPLAY_NAME), SortOption.of(ClientField.CLIENT_ID)));
 
         try (Stream<BaseClientRepresentation> clients = getClientsApi().getClients(listOptions)) {
             List<String> sortTestClientIds = clients
@@ -401,8 +405,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
 
         ListOptions listOptions = new ListOptions();
         listOptions.setFields(Set.of("clientId", "displayName"));
-        listOptions.setSortBy(List.of(ClientField.DISPLAY_NAME, ClientField.CLIENT_ID));
-        listOptions.setSortOrder(SortOrder.DESC);
+        listOptions.setSort(List.of(SortOption.of(ClientField.DISPLAY_NAME, SortOrder.DESC), SortOption.of(ClientField.CLIENT_ID, SortOrder.DESC)));
 
         try (Stream<BaseClientRepresentation> clients = getClientsApi().getClients(listOptions)) {
             List<String> sortTestClientIds = clients
@@ -414,8 +417,10 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
     }
 
     @Test
-    public void getClientsSortByInvalidField() throws IOException {
-        HttpGet request = new HttpGet(getClientsApiUrl() + "?fields=clientId&sortBy=displayName,unknown");
+    public void getClientsSortByInvalidField() throws IOException, URISyntaxException {
+        URI uri = new URIBuilder(getClientsApiUrl()).addParameter("fields", "clientId")
+                .addParameter("sort", "displayName|desc,unknown").build();
+        HttpGet request = new HttpGet(uri);
         setAuthHeader(request);
         try (var response = client.execute(request)) {
             assertEquals(400, response.getStatusLine().getStatusCode());
@@ -429,7 +434,7 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         createSortTestClient("sort-a", "A", "alpha");
         createSortTestClient("sort-c", "A", "gamma");
 
-        HttpGet request = new HttpGet(getClientsApiUrl() + "?fields=clientId&fields=displayName&sortBy=displayName,clientId");
+        HttpGet request = new HttpGet(getClientsApiUrl() + "?fields=clientId,displayName&sort=displayName,clientId");
         setAuthHeader(request);
         try (var response = client.execute(request)) {
             String responseBody = EntityUtils.toString(response.getEntity());
@@ -446,12 +451,14 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
     }
 
     @Test
-    public void getClientsInvalidSortOrderReturns400() throws IOException {
-        HttpGet request = new HttpGet(getClientsApiUrl() + "?sortOrder=what");
+    public void getClientsInvalidSortDirectionReturns400() throws IOException, URISyntaxException {
+        URI uri = new URIBuilder(getClientsApiUrl()).addParameter("sort", "clientId|what").build();
+
+        HttpGet request = new HttpGet(uri);
         setAuthHeader(request);
         try (var response = client.execute(request)) {
             assertEquals(400, response.getStatusLine().getStatusCode());
-            assertThat(EntityUtils.toString(response.getEntity()), containsString("sortOrder must be asc or desc"));
+            assertThat(EntityUtils.toString(response.getEntity()), containsString("sort direction must be asc or desc"));
         }
     }
 

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -31,8 +31,10 @@ import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 
+import org.keycloak.admin.api.ClientField;
 import org.keycloak.admin.api.ListOptions;
 import org.keycloak.admin.api.PatchTypeNames;
+import org.keycloak.admin.api.SortOrder;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator;
 import org.keycloak.authentication.authenticators.client.JWTClientAuthenticator;
@@ -370,6 +372,100 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         // ensure that multiple fields are interpreted correctly
         e = assertThrows(BadRequestException.class, () -> getClientsApi().getClients(new ListOptions().fields(new LinkedHashSet<>(List.of("clientId","unknown!")))));
         assertEquals("{\"error\":\"unknown! is an unknown field\"}", e.getResponse().readEntity(String.class));
+    }
+
+    @Test
+    public void getClientsSortByMultipleFields() {
+        createSortTestClient("sort-b", "B", "beta");
+        createSortTestClient("sort-a", "A", "alpha");
+        createSortTestClient("sort-c", "A", "gamma");
+
+        ListOptions listOptions = new ListOptions();
+        listOptions.setFields(Set.of("clientId", "displayName"));
+        listOptions.setSortBy(List.of(ClientField.DISPLAY_NAME, ClientField.CLIENT_ID));
+
+        try (Stream<BaseClientRepresentation> clients = getClientsApi().getClients(listOptions)) {
+            List<String> sortTestClientIds = clients
+                    .map(BaseClientRepresentation::getClientId)
+                    .filter(id -> id.startsWith("sort-"))
+                    .toList();
+            assertThat(sortTestClientIds, is(List.of("sort-a", "sort-c", "sort-b")));
+        }
+    }
+
+    @Test
+    public void getClientsSortByMultipleFieldsDesc() {
+        createSortTestClient("sort-b", "B", "beta");
+        createSortTestClient("sort-a", "A", "alpha");
+        createSortTestClient("sort-c", "A", "gamma");
+
+        ListOptions listOptions = new ListOptions();
+        listOptions.setFields(Set.of("clientId", "displayName"));
+        listOptions.setSortBy(List.of(ClientField.DISPLAY_NAME, ClientField.CLIENT_ID));
+        listOptions.setSortOrder(SortOrder.DESC);
+
+        try (Stream<BaseClientRepresentation> clients = getClientsApi().getClients(listOptions)) {
+            List<String> sortTestClientIds = clients
+                    .map(BaseClientRepresentation::getClientId)
+                    .filter(id -> id.startsWith("sort-"))
+                    .toList();
+            assertThat(sortTestClientIds, is(List.of("sort-b", "sort-c", "sort-a")));
+        }
+    }
+
+    @Test
+    public void getClientsSortByInvalidField() throws IOException {
+        HttpGet request = new HttpGet(getClientsApiUrl() + "?fields=clientId&sortBy=displayName,unknown");
+        setAuthHeader(request);
+        try (var response = client.execute(request)) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+            assertThat(EntityUtils.toString(response.getEntity()), containsString("unknown is not a sortable field"));
+        }
+    }
+
+    @Test
+    public void getClientsSortByMultipleFieldsViaHttp() throws IOException {
+        createSortTestClient("sort-b", "B", "beta");
+        createSortTestClient("sort-a", "A", "alpha");
+        createSortTestClient("sort-c", "A", "gamma");
+
+        HttpGet request = new HttpGet(getClientsApiUrl() + "?fields=clientId&fields=displayName&sortBy=displayName,clientId");
+        setAuthHeader(request);
+        try (var response = client.execute(request)) {
+            String responseBody = EntityUtils.toString(response.getEntity());
+            assertEquals(200, response.getStatusLine().getStatusCode(), "Response body: " + responseBody);
+            List<BaseClientRepresentation> clients = mapper.readValue(
+                    responseBody,
+                    mapper.getTypeFactory().constructCollectionType(List.class, BaseClientRepresentation.class));
+            List<String> sortTestClientIds = clients.stream()
+                    .map(BaseClientRepresentation::getClientId)
+                    .filter(id -> id.startsWith("sort-"))
+                    .toList();
+            assertThat(sortTestClientIds, is(List.of("sort-a", "sort-c", "sort-b")));
+        }
+    }
+
+    @Test
+    public void getClientsInvalidSortOrderReturns400() throws IOException {
+        HttpGet request = new HttpGet(getClientsApiUrl() + "?sortOrder=what");
+        setAuthHeader(request);
+        try (var response = client.execute(request)) {
+            assertEquals(400, response.getStatusLine().getStatusCode());
+            assertThat(EntityUtils.toString(response.getEntity()), containsString("sortOrder must be asc or desc"));
+        }
+    }
+
+    private void createSortTestClient(String clientId, String displayName, String description) {
+        OIDCClientRepresentation rep = new OIDCClientRepresentation();
+        rep.setEnabled(true);
+        rep.setClientId(clientId);
+        rep.setDisplayName(displayName);
+        rep.setDescription(description);
+        try (var response = getClientsApi().createClient(rep)) {
+            assertEquals(201, response.getStatus());
+            BaseClientRepresentation created = response.readEntity(BaseClientRepresentation.class);
+            testRealm.cleanup().add(realm -> realm.clients().delete(created.getUuid()));
+        }
     }
 
     @Test


### PR DESCRIPTION
Introduce sortBy and sortOrder query parameters for client list
queries without changing the existing fields parameter behavior.

Closes #49171

Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
