### PR TITLE
Identity brokering API: v2 supported and v1 deprecated

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -183,8 +183,8 @@ public class Profile {
 
         RESOURCE_INDICATORS("Resource Indicators for OAuth 2.0", Type.EXPERIMENTAL),
 
-        IDENTITY_BROKERING_API_V1("Identity Brokering API V1", Type.DEFAULT, 1),
-        IDENTITY_BROKERING_API_V2("Identity Brokering API V2", Type.PREVIEW, 2);
+        IDENTITY_BROKERING_API_V1("Identity Brokering API V1", Type.DEFAULT, 1, true, null, null),
+        IDENTITY_BROKERING_API_V2("Identity Brokering API V2", Type.DISABLED_BY_DEFAULT, 2);
 
         private final Type type;
         private final String label;

--- a/docs/documentation/release_notes/topics/26_7_0.adoc
+++ b/docs/documentation/release_notes/topics/26_7_0.adoc
@@ -3,6 +3,16 @@
 
 This release features new capabilities for users and administrators of {project_name}. The highlights of this release are:
 
+= Security and Standards
+
+== Identity Brokering API: V2 promoted to supported, V1 deprecated
+
+The Identity Brokering API, which allows applications to retrieve tokens from external identity providers, now has V2 *supported but disabled by default* and V1 *deprecated but still enabled by default* for backward compatibility.
+
+In a future release, V1 will be removed and V2 will become the default. Users are encouraged to migrate to V2 now.
+
+For more information, see the link:{developerguide_link}#_identity-brokering-apis[Identity Brokering APIs] chapter in the {developerguide_name}.
+
 = Administration
 
 == Delegated administration for organizations
@@ -67,3 +77,4 @@ NIST is going to fully https://www.nist.gov/news-events/news/2022/12/nist-retire
 ====
 Consider SHA1 hashing retired in all uses within {project_name}. Users should configure other secure hashing functions as soon as possible (for example SHA2, SHA3).
 ====
+

--- a/docs/documentation/server_development/topics/identity-brokering/tokens.adoc
+++ b/docs/documentation/server_development/topics/identity-brokering/tokens.adoc
@@ -6,7 +6,9 @@
 
 ==== Identity brokering API V1
 
-Version 1 or V1 is the old feature and enabled by default. In a future {project_name} release V1 will be deprecated and substituted by V2.
+WARNING: Identity Brokering API V1 is *deprecated* and will be removed in a future version. Users should migrate to V2.
+
+Version 1 or V1 is the old feature and still enabled by default for backward compatibility.
 
 You can use the `Store Tokens` configuration option in the `Advanced settings` section of the IDP's settings page. Once this option is enabled, when a user authenticates using a external Identity provider, the returned token will be stored inside the database for each user and IDP.
 
@@ -31,11 +33,14 @@ These external tokens can be re-established by either logging in again through t
 
 ==== Identity brokering API V2
 
-:tech_feature_name: Identity Brokering API V2
-:tech_feature_id: identity-brokering-api:v2
-include::../templates/techpreview.adoc[]
+[NOTE]
+====
+Identity Brokering API V2 is *supported* and disabled by default.
 
-Version 2 or V2 is the new feature that is now in preview status. The new feature manages two different configuration options in the same Identity Provider page.
+To enable, start the server with `--features=identity-brokering-api:v2`.
+====
+
+Version 2 or V2 is the new feature that replaces V1. The new feature manages two different configuration options in the same Identity Provider page.
 
 * **Store token in session**: New option that stores the returned token in the user session associated to the login.
 * **Store tokens**: Same option used in V1 and with the same meaning. The store token returned by the external provider is stored in the database after a successful login.

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -163,6 +163,10 @@ This improves security by ensuring that only trusted, pre-registered hosts can b
 
 The following sections provide details on deprecated features.
 
+=== Identity Brokering API V1 is deprecated
+
+The Identity Brokering API V1 is now deprecated but remains enabled by default for backward compatibility. See the link:{releasenotes_link}[Release Notes] for more details.
+
 === Option Allow regex pattern comparison is deprecated for the X509 client authenticator
 
 The option **Allow regex pattern comparison** is deprecated for the X509 client authenticator. This option allows to configure a Java regular expression instead of the exact DN for the client certificate subject DN. As previously commented in the breaking changes section, this option is now deprecated and it will be removed in a future version. The certificate for the client should be unambiguously identified because of security reasons.


### PR DESCRIPTION
Closes #47339
Closes #47478

Addressed both issues with the same PR.

V2 has now type DISABLED_BY_DEFAULT, which means supported but disabled.
V1 is  has still type DEFAULT but is marked as deprecated, a waring is showed when the server starts.
Added also the release notes, but nothing in the upgrading guide as v1 is still enabled by default so no upgrade is needed.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
