### PR TITLE
Caching support for verifiable credentials

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/marshalling/KeycloakModelSchema.java
+++ b/model/infinispan/src/main/java/org/keycloak/marshalling/KeycloakModelSchema.java
@@ -63,6 +63,7 @@ import org.keycloak.models.cache.infinispan.events.UserFederationLinkRemovedEven
 import org.keycloak.models.cache.infinispan.events.UserFederationLinkUpdatedEvent;
 import org.keycloak.models.cache.infinispan.events.UserFullInvalidationEvent;
 import org.keycloak.models.cache.infinispan.events.UserUpdatedEvent;
+import org.keycloak.models.cache.infinispan.events.UserVerifiableCredentialsUpdatedEvent;
 import org.keycloak.models.cache.infinispan.stream.GroupListPredicate;
 import org.keycloak.models.cache.infinispan.stream.HasRolePredicate;
 import org.keycloak.models.cache.infinispan.stream.InClientPredicate;
@@ -208,6 +209,7 @@ import org.infinispan.protostream.types.java.CommonTypes;
                 UserFederationLinkUpdatedEvent.class,
                 UserFullInvalidationEvent.class,
                 UserUpdatedEvent.class,
+                UserVerifiableCredentialsUpdatedEvent.class,
 
                 // sessions.infinispan.entities package
                 AuthenticatedClientSessionStore.class,

--- a/model/infinispan/src/main/java/org/keycloak/marshalling/Marshalling.java
+++ b/model/infinispan/src/main/java/org/keycloak/marshalling/Marshalling.java
@@ -191,6 +191,7 @@ public final class Marshalling {
 
     /** see {@link org.keycloak.models.workflow.WorkflowScheduleClusterEvent} */
     public static final int WORKFLOW_SCHEDULE_CLUSTER_EVENT = 65621;
+    public static final int USER_VERIFIABLE_CREDENTIALS_UPDATED_EVENT = 65622;
 
     public static void configure(GlobalConfigurationBuilder builder) {
         getSchemas().forEach(builder.serialization()::addContextInitializer);

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheManager.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheManager.java
@@ -67,6 +67,9 @@ public class UserCacheManager extends CacheManager {
 
         // Consents
         invalidations.add(UserCacheSession.getConsentCacheKey(userId));
+
+        // Verifiable credentials
+        invalidations.add(UserCacheSession.getVerifiableCredentialsCacheKey(userId));
     }
 
     public void federatedIdentityLinkUpdatedInvalidation(String userId, Set<String> invalidations) {
@@ -82,6 +85,10 @@ public class UserCacheManager extends CacheManager {
 
     public void consentInvalidation(String userId, Set<String> invalidations) {
         invalidations.add(UserCacheSession.getConsentCacheKey(userId));
+    }
+
+    public void verifiableCredentialsInvalidation(String userId, Set<String> invalidations) {
+        invalidations.add(UserCacheSession.getVerifiableCredentialsCacheKey(userId));
     }
 
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -57,6 +57,8 @@ import org.keycloak.models.cache.infinispan.entities.CachedFederatedIdentityLink
 import org.keycloak.models.cache.infinispan.entities.CachedUser;
 import org.keycloak.models.cache.infinispan.entities.CachedUserConsent;
 import org.keycloak.models.cache.infinispan.entities.CachedUserConsents;
+import org.keycloak.models.cache.infinispan.entities.CachedUserVerifiableCredential;
+import org.keycloak.models.cache.infinispan.entities.CachedUserVerifiableCredentials;
 import org.keycloak.models.cache.infinispan.entities.UserListQuery;
 import org.keycloak.models.cache.infinispan.events.CacheKeyInvalidatedEvent;
 import org.keycloak.models.cache.infinispan.events.InvalidationEvent;
@@ -66,6 +68,7 @@ import org.keycloak.models.cache.infinispan.events.UserFederationLinkRemovedEven
 import org.keycloak.models.cache.infinispan.events.UserFederationLinkUpdatedEvent;
 import org.keycloak.models.cache.infinispan.events.UserFullInvalidationEvent;
 import org.keycloak.models.cache.infinispan.events.UserUpdatedEvent;
+import org.keycloak.models.cache.infinispan.events.UserVerifiableCredentialsUpdatedEvent;
 import org.keycloak.models.cache.infinispan.stream.InIdentityProviderPredicate;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ReadOnlyUserModelDelegate;
@@ -747,6 +750,9 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
         return userId + ".consents";
     }
 
+    static String getVerifiableCredentialsCacheKey(String userId) {
+        return userId + ".verifiableCredentials";
+    }
 
     @Override
     public void addConsent(RealmModel realm, String userId, UserConsentModel consent) {
@@ -863,21 +869,60 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
 
     @Override
     public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel) {
+        invalidateVerifiableCredentials(userId);
         return getDelegate().addVerifiableCredential(userId, credentialModel);
     }
 
     @Override
     public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+        invalidateVerifiableCredentials(userId);
         return getDelegate().removeVerifiableCredential(userId, credentialScopeName);
+    }
+
+    private void invalidateVerifiableCredentials(String userId) {
+        cache.verifiableCredentialsInvalidation(userId, invalidations);
+        invalidationEvents.add(UserVerifiableCredentialsUpdatedEvent.create(userId));
     }
 
     @Override
     public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
-        return getDelegate().getVerifiableCredentialsByUser(userId);
+        logger.tracev("getVerifiableCredentialsByUser: {0}", userId);
+
+        String cacheKey = getVerifiableCredentialsCacheKey(userId);
+        if (invalidations.contains(userId) || invalidations.contains(cacheKey)) {
+            return getDelegate().getVerifiableCredentialsByUser(userId);
+        }
+
+        CachedUserVerifiableCredentials cached = cache.get(cacheKey, CachedUserVerifiableCredentials.class);
+
+        if (cached != null && realmInvalidations.contains(cached.getRealm())) {
+            return getDelegate().getVerifiableCredentialsByUser(userId);
+        }
+
+        if (cached == null) {
+            long loaded = cache.getCurrentRevision(cacheKey);
+            List<UserVerifiableCredentialModel> credentials = getDelegate().getVerifiableCredentialsByUser(userId).toList();
+            RealmModel realm = session.getContext().getRealm();
+            cached = new CachedUserVerifiableCredentials(loaded, cacheKey, realm, credentials);
+            cache.addRevisioned(cached, startupRevision);
+            return credentials.stream();
+        } else {
+            return cached.getCredentials().stream()
+                    .map(this::toCredentialModel);
+        }
+    }
+
+    private UserVerifiableCredentialModel toCredentialModel(CachedUserVerifiableCredential cachedCredential) {
+        UserVerifiableCredentialModel credentialModel = new UserVerifiableCredentialModel(cachedCredential.getCredentialScopeName());
+        credentialModel.setRevision(cachedCredential.getRevision());
+        credentialModel.setCreatedDate(cachedCredential.getCreatedDate());
+        credentialModel.setUserAttributes(cachedCredential.getUserAttributes());
+        return credentialModel;
     }
 
     @Override
     public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName) {
+        invalidateVerifiableCredentials(userId);
         return getDelegate().updateVerifiableCredential(userId, credentialScopeName);
     }
 
@@ -1041,7 +1086,7 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
 
     @Override
     public void preRemove(ClientScopeModel clientScope) {
-        // Not needed to invalidate realm probably. Just consents are affected ATM and they are checked if they exists
+        addRealmInvalidation(clientScope.getRealm().getId());
         getDelegate().preRemove(clientScope);
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserVerifiableCredential.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserVerifiableCredential.java
@@ -1,0 +1,45 @@
+package org.keycloak.models.cache.infinispan.entities;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.models.UserVerifiableCredentialModel;
+
+public class CachedUserVerifiableCredential {
+
+    private final String credentialScopeName;
+    private final String revision;
+    private final Long createdDate;
+    private final MultivaluedHashMap<String, String> userAttributes;
+
+    public CachedUserVerifiableCredential(UserVerifiableCredentialModel credentialModel) {
+        this.credentialScopeName = credentialModel.getCredentialScopeName();
+        this.revision = credentialModel.getRevision();
+        this.createdDate = credentialModel.getCreatedDate();
+
+        this.userAttributes = new MultivaluedHashMap<>();
+        if (credentialModel.getUserAttributes() != null) {
+            for (Map.Entry<String, List<String>> entry : credentialModel.getUserAttributes().entrySet()) {
+                this.userAttributes.addAll(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    public String getCredentialScopeName() {
+        return credentialScopeName;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public Map<String, List<String>> getUserAttributes() {
+        return new HashMap<>(userAttributes);
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserVerifiableCredentials.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserVerifiableCredentials.java
@@ -1,0 +1,33 @@
+
+package org.keycloak.models.cache.infinispan.entities;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
+
+public class CachedUserVerifiableCredentials extends AbstractRevisioned implements InRealm {
+    private final List<CachedUserVerifiableCredential> credentials;
+    private final String realmId;
+
+    public CachedUserVerifiableCredentials(long revision, String id, RealmModel realm, List<UserVerifiableCredentialModel> credentials) {
+        super(revision, id);
+        this.realmId = realm.getId();
+        this.credentials = credentials != null
+            ? credentials.stream()
+                .map(CachedUserVerifiableCredential::new)
+                .collect(Collectors.toCollection(ArrayList::new))
+            : new ArrayList<>();
+    }
+
+    public List<CachedUserVerifiableCredential> getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public String getRealm() {
+        return realmId;
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserVerifiableCredentialsUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserVerifiableCredentialsUpdatedEvent.java
@@ -1,0 +1,37 @@
+
+package org.keycloak.models.cache.infinispan.events;
+
+import java.util.Set;
+
+import org.keycloak.marshalling.Marshalling;
+import org.keycloak.models.cache.infinispan.UserCacheManager;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoTypeId;
+
+/**
+ * Invalidation event for user verifiable credentials cache entries
+ */
+@ProtoTypeId(Marshalling.USER_VERIFIABLE_CREDENTIALS_UPDATED_EVENT)
+public class UserVerifiableCredentialsUpdatedEvent extends InvalidationEvent implements UserCacheInvalidationEvent {
+
+    private UserVerifiableCredentialsUpdatedEvent(String id) {
+        super(id);
+    }
+
+    @ProtoFactory
+    public static UserVerifiableCredentialsUpdatedEvent create(String id) {
+        return new UserVerifiableCredentialsUpdatedEvent(id);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("UserVerifiableCredentialsUpdatedEvent [ userId=%s ]", getId());
+    }
+
+    @Override
+    public void addInvalidations(UserCacheManager userCache, Set<String> invalidations) {
+        userCache.verifiableCredentialsInvalidation(getId(), invalidations);
+    }
+
+}


### PR DESCRIPTION
Closes #48676

I used option 2 from the proposed approach in the issue description: https://github.com/keycloak/keycloak/issues/48676 because verifiable credentials are part of `UserProvider`, not `UserModel`, and implementing it through CachedUser would have been more complicated. I followed the same approach as `CachedUserConsents`.

The tests should already be covered by the CRUD operations in `UserVerifiableCredentialsTest`.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
