### PR TITLE
Built-in cross-site failover health check (STONITH)

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -99,6 +99,21 @@ Resources with malformed URI templates should be corrected before upgrading.
 After the upgrade, existing resources with malformed templates will continue to be stored, but they may not match request URIs as intended.
 Any update to such a resource will require fixing the URI template at the same time, as the stricter validation applies to all create and update operations.
 
+=== Built-in cross-site health check available for multi-site deployments
+
+When the `multi-site` feature is enabled, {project_name} provides a built-in cross-site health check algorithm that coordinates failover between sites using a database-backed state machine.
+This algorithm controls which site receives traffic by manipulating the `/lb-check` health endpoint.
+
+For backwards compatibility, the built-in health check is **disabled by default**. If you want to use the new algorithm, you must explicitly enable it:
+
+[source]
+----
+--spi-connections-infinispan--default--site-health-enabled=true
+----
+
+If you are using the AWS Lambda-based fencing mechanism to manage failover via AWS Global Accelerator, keep the built-in health check disabled (the default).
+Running both mechanisms simultaneously is not supported, as each may independently reach a different conclusion about which site is active, leading to split-brain or downtime.
+
 === Organization invitation filters use exact matching
 
 The `email`, `firstName`, and `lastName` query parameters on the organization invitations list endpoint (`+GET /admin/realms/{realm}/orgs/{orgId}/invitations+`) now use case-insensitive exact matching instead of substring matching.

--- a/docs/guides/high-availability/multi-cluster/building-blocks.adoc
+++ b/docs/guides/high-availability/multi-cluster/building-blocks.adoc
@@ -1,5 +1,6 @@
 <#import "/templates/guide.adoc" as tmpl>
 <#import "/templates/links.adoc" as links>
+<#import "/templates/profile.adoc" as profile>
 
 <@tmpl.guide
 title="Building blocks multi-cluster deployments"
@@ -57,10 +58,20 @@ A clustered deployment of {project_name} in each site, connected to an external 
 
 *Blueprint:* <@links.ha id="multi-cluster-deploy-keycloak-kubernetes" /> that includes connecting to the Aurora database and the {jdgserver_name} server.
 
-</@tmpl.guide>
-
 == Load balancer
 
 A load balancer which checks the `/lb-check` URL of the {project_name} deployment in each site, plus an automation to detect {jdgserver_name} connectivity problems between the two sites.
 
-*Blueprint:* <@links.ha id="multi-cluster-deploy-aws-accelerator-loadbalancer"/> together with  <@links.ha id="multi-cluster-deploy-aws-accelerator-fencing-lambda"/>.
+*Blueprint:* <@links.ha id="multi-cluster-deploy-aws-accelerator-loadbalancer"/> together with <@links.ha id="multi-cluster-deploy-aws-accelerator-fencing-lambda"/>.
+
+<@profile.ifCommunity>
+
+[NOTE]
+====
+The AWS Lambda is no longer required because {project_name} has a built-in split-brain algorithm, which manipulates the `/lb-check` health endpoint to control traffic routing.
+It still requires the load balancer to check the `/lb-check` URL of the {project_name} deployment in each site.
+====
+
+</@profile.ifCommunity>
+
+</@tmpl.guide>

--- a/docs/guides/high-availability/multi-cluster/introduction.adoc
+++ b/docs/guides/high-availability/multi-cluster/introduction.adoc
@@ -122,7 +122,8 @@ Additional performance tuning and security hardening are still recommended when 
 * <@links.ha id="multi-cluster-deploy-infinispan-kubernetes-crossdc" />
 * <@links.ha id="multi-cluster-deploy-keycloak-kubernetes" />
 * <@links.ha id="multi-cluster-deploy-aws-accelerator-loadbalancer" />
-* <@links.ha id="multi-cluster-deploy-aws-accelerator-fencing-lambda" />
+* <@links.ha id="multi-cluster-deploy-aws-accelerator-fencing-lambda" /> (Optional, see <@links.ha id="multi-cluster-site-health-checks" />)
+* <@links.ha id="multi-cluster-site-health-checks" />
 
 == Operational procedures
 

--- a/docs/guides/high-availability/multi-cluster/site-health-checks.adoc
+++ b/docs/guides/high-availability/multi-cluster/site-health-checks.adoc
@@ -1,0 +1,203 @@
+<#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/links.adoc" as links>
+
+<@tmpl.guide
+title="Cross-site automatic failover algorithm"
+summary="Understand the STONITH algorithm that automatically detects site failures and coordinates failover."
+tileVisible="false" >
+
+include::../partials/infinispan/infinispan-attributes.adoc[]
+
+{project_name} includes a built-in cross-site health check that runs periodically on every node.
+It uses a database-backed state machine to coordinate failover between two sites without requiring an external orchestrator.
+The algorithm is sometimes referred to as STONITH (Shoot The Other Node In The Head) because the surviving site disconnects the failed site to prevent split-brain data corruption.
+
+This mechanism is an alternative to the <@links.ha id="multi-cluster-deploy-aws-accelerator-fencing-lambda" /> approach.
+Unlike the AWS Lambda-based fencing, this algorithm is cloud-agnostic and works with any cloud vendor or on-premises deployment.
+It relies on the external load balancer checking the `/lb-check` endpoint to detect which site is active and route traffic accordingly.
+
+[IMPORTANT]
+====
+For backwards compatibility, the built-in site health check is **disabled by default**.
+To use this algorithm, you must explicitly enable it:
+
+[source]
+----
+--spi-connections-infinispan--default--site-health-enabled=true
+----
+
+If you are using the AWS Lambda-based fencing mechanism, keep the built-in health check disabled (the default).
+Running both mechanisms simultaneously is not supported.
+The Lambda directly reconfigures the AWS Global Accelerator load balancer to remove the failed site, while the built-in algorithm controls traffic via the `/lb-check` endpoint.
+Each mechanism may independently reach a different conclusion about which site is active, leading to split-brain or downtime.
+====
+
+== State machine
+
+The health check maintains a single shared state in the database.
+Both sites read and update this state using compare-and-set (CAS) operations, which guarantees that only one site can transition the state at a time.
+
+The state machine has four statuses:
+
+HEALTHY:: All sites are reachable and replication is functioning normally.
+Both sites serve traffic.
+SUSPECTING:: A site has detected that one or more remote sites are unreachable.
+A one-round delay is applied before taking action to avoid reacting to transient network issues.
+UNHEALTHY:: The remote site is confirmed unreachable.
+The active site has disconnected replication and is serving traffic alone.
+The non-active site marks itself as unhealthy and stops serving traffic.
+RECOVERING:: The remote site has come back online.
+The active site verifies stable connectivity before transitioning back to HEALTHY.
+
+== State transition diagram
+
+The following diagram shows the state transitions and the conditions that trigger them.
+
+image::high-availability/site-health-state-machine.svg[]
+
+== Algorithm details
+
+=== HEALTHY state
+
+Every node checks whether all remote sites are present in the Infinispan cluster view.
+If all sites are reachable, no action is taken.
+If any site is missing, the detecting node performs a CAS to transition to SUSPECTING, recording itself as the active site.
+
+=== SUSPECTING state
+
+Both sites remain healthy (serve traffic) during this state.
+
+Active site behavior::
+The active site waits one full health-check round before making a decision.
+On the first round, it records the current state.
+On the second round:
+* If all sites have recovered, it transitions back to HEALTHY.
+* If sites are still unreachable, it transitions to UNHEALTHY and disconnects replication.
+
+Non-active site behavior (steal)::
+The non-active site monitors whether the active site is making progress.
+If the state has not changed after one full round, the non-active site assumes the active site has crashed and steals the SUSPECTING state by performing a CAS that replaces the active site with itself.
+This prevents the system from getting stuck when the site that first detected the failure crashes before completing the transition.
+
+=== UNHEALTHY state
+
+The active site continues serving traffic and monitoring for recovery.
+The non-active site marks itself as unhealthy and stops serving traffic.
+
+When all remote sites reappear in the cluster view and their replication status is `online`, the active site transitions to RECOVERING.
+If sites that were marked offline come back partially, the active site re-disconnects them.
+
+=== RECOVERING state
+
+Only the active site can drive recovery.
+The non-active site remains unhealthy.
+
+The active site waits one full round (same pattern as SUSPECTING) to confirm that connectivity is stable.
+If all sites remain online after the delay, it transitions to HEALTHY.
+If connectivity is lost again during recovery, it falls back to UNHEALTHY.
+
+== Expected downtime windows
+
+This algorithm minimizes downtime, but cannot eliminate it entirely in all scenarios:
+
+JGroups failure detection::
+The Infinispan cluster uses JGroups for network communication, which relies on heartbeat-based failure detection with a default interval of 30 seconds.
+When a site fails, JGroups may take up to 60 seconds (two heartbeat intervals) to detect the failure and remove the site from the cluster view.
+All cross-site requests will fail during this window.
+
+Detection delay::
+After JGroups detects the failure, the health check state machine requires up to two additional health-check rounds to transition through SUSPECTING to UNHEALTHY.
+Until the transition completes, the surviving site has not yet updated `/lb-check` to reflect the failure, so the load balancer continues routing traffic to both sites.
+
+Active site crash during UNHEALTHY or RECOVERING::
+If the active site crashes while the state is UNHEALTHY or RECOVERING, the non-active site *cannot* take over.
+In these states the non-active site may have stale or incomplete data (replication was disconnected), so promoting it would risk data corruption.
+Manual intervention is required to restore the active site or reset the state.
+
+NOTE: The non-active site can only steal the SUSPECTING state, because at that point replication has not yet been disconnected and both sites still have consistent data.
+
+== Metrics
+
+{project_name} exposes the cross-site status as a Micrometer gauge when metrics are enabled.
+
+Metric name:: `keycloak.site.status`
+Description:: Cross-site health status.
+Type:: Gauge (integer value updated on every health-check round).
+
+The gauge value maps to the state machine statuses:
+
+[%autowidth]
+|===
+| Value | Status | Meaning
+
+| 0 | HEALTHY | All sites reachable, replication is normal.
+| 1 | SUSPECTING | Failure detected, waiting for one round before acting.
+| 2 | UNHEALTHY | The remote site confirmed unreachable, replication disconnected.
+| 3 | RECOVERING | Remote site back online, verifying stable connectivity.
+|===
+
+Use this metric to set up alerts.
+For example, alert when the value is >= 2 for longer than two health-check intervals, which indicates a confirmed outage requiring operator attention.
+
+== Recovery procedures
+
+This section describes the manual steps required to restore a healthy multi-cluster deployment after a failover.
+
+=== Recovering from UNHEALTHY state
+
+When the state machine reaches UNHEALTHY, the active site is serving traffic alone and replication to the inactive site has been disconnected.
+The inactive site has stale data in both its {project_name} and {jdgserver_name} caches and must not receive traffic until it is resynchronized.
+
+To restore the inactive site:
+
+. *Shut down {project_name} on the inactive site.*
+This clears all {project_name} caches and prevents stale data from being served.
++
+When deploying {project_name} using the {project_name} Operator, set the number of {project_name} instances in the {project_name} Custom Resource to 0.
+
+. *Resynchronize the {jdgserver_name} clusters.*
+Follow the steps described in <@links.ha id="multi-cluster-operate-synchronize" /> to clear the caches on the inactive site and transfer state from the active site.
++
+[WARNING]
+====
+Do not start {project_name} on the inactive site until the state transfer has fully completed.
+The active {project_name} is not aware of the synchronization in progress, and starting too early may result in the inactive site serving partially transferred data.
+====
+
+. *Start {project_name} on the inactive site.*
+Once the state transfer has completed, start {project_name} on the inactive site.
++
+When deploying {project_name} using the {project_name} Operator, set the number of {project_name} instances in the {project_name} Custom Resource back to its original value.
+
+. *Wait for automatic recovery.*
+After the state transfer restores connectivity between the {jdgserver_name} clusters, the active site will detect the remote site as reachable again.
+The state machine will transition automatically from `UNHEALTHY` to `RECOVERING` and then to `HEALTHY`.
+No further manual action is needed once synchronization is complete.
+
+=== Recovering when the active site is down
+
+If the active site crashes while the state is UNHEALTHY or RECOVERING, the state machine is stuck: only the active site can drive the transition, and the inactive site cannot safely take over because its data is stale.
+
+==== Option 1: Restore the active site
+
+If the active site can be brought back, it will resume the state machine from where it left off and eventually transition back to `HEALTHY`.
+No manual state changes are needed.
+
+==== Option 2: Reset the state machine manually
+
+If the active site cannot be restored, follow these steps:
+
+. *Delete the site state row from the database.*
++
+[source,sql]
+----
+DELETE FROM SERVER_CONFIG WHERE SERVER_CONFIG_KEY = 'site.state';
+----
++
+When the row is missing, the next {project_name} node to start will initialize the state as `HEALTHY`.
+
+. *Resynchronize before accepting traffic.*
+After resetting the state, the surviving site has stale {jdgserver_name} data from before the failure.
+Follow the <@links.ha id="multi-cluster-operate-synchronize" /> procedure to ensure data consistency before routing traffic to both sites.
+
+</@tmpl.guide>

--- a/docs/guides/high-availability/pinned-guides
+++ b/docs/guides/high-availability/pinned-guides
@@ -28,6 +28,7 @@ multi-cluster/operate-site-offline
 multi-cluster/operate-site-online
 multi-cluster/operate-synchronize
 multi-cluster/health-checks
+multi-cluster/site-health-checks
 multi-cluster/upgrades
 multi-cluster-v2/introduction
 multi-cluster-v2/concepts

--- a/docs/guides/images/high-availability/site-health-state-machine.svg
+++ b/docs/guides/images/high-availability/site-health-state-machine.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 520" font-family="Arial, Helvetica, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#555"/>
+    </marker>
+    <marker id="arrow-red" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#c0392b"/>
+    </marker>
+  </defs>
+
+  <!-- HEALTHY box -->
+  <rect x="260" y="30" width="180" height="54" rx="10" fill="#27ae60" stroke="#1e8449" stroke-width="2"/>
+  <text x="350" y="55" text-anchor="middle" fill="white" font-weight="bold" font-size="15">HEALTHY</text>
+  <text x="350" y="72" text-anchor="middle" fill="white" font-size="11">both sites serve traffic</text>
+
+  <!-- SUSPECTING box -->
+  <rect x="260" y="180" width="180" height="54" rx="10" fill="#f39c12" stroke="#d68910" stroke-width="2"/>
+  <text x="350" y="205" text-anchor="middle" fill="white" font-weight="bold" font-size="15">SUSPECTING</text>
+  <text x="350" y="222" text-anchor="middle" fill="white" font-size="11">both sites serve traffic</text>
+
+  <!-- UNHEALTHY box -->
+  <rect x="260" y="340" width="180" height="54" rx="10" fill="#c0392b" stroke="#a93226" stroke-width="2"/>
+  <text x="350" y="365" text-anchor="middle" fill="white" font-weight="bold" font-size="15">UNHEALTHY</text>
+  <text x="350" y="382" text-anchor="middle" fill="white" font-size="11">only active site serves</text>
+
+  <!-- RECOVERING box -->
+  <rect x="530" y="340" width="180" height="54" rx="10" fill="#2980b9" stroke="#2471a3" stroke-width="2"/>
+  <text x="620" y="365" text-anchor="middle" fill="white" font-weight="bold" font-size="15">RECOVERING</text>
+  <text x="620" y="382" text-anchor="middle" fill="white" font-size="11">only active site serves</text>
+
+  <!-- HEALTHY -> SUSPECTING -->
+  <line x1="350" y1="84" x2="350" y2="175" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="355" y="108" width="155" height="36" rx="4" fill="white" stroke="#ccc" stroke-width="1"/>
+  <text x="432" y="122" text-anchor="middle" fill="#333" font-size="11">site(s) unreachable</text>
+  <text x="432" y="137" text-anchor="middle" fill="#888" font-size="10">CAS to SUSPECTING</text>
+
+  <!-- SUSPECTING -> HEALTHY (recovered quickly) -->
+  <line x1="260" y1="195" x2="165" y2="195" stroke="#555" stroke-width="1.5" stroke-dasharray="none"/>
+  <line x1="165" y1="195" x2="165" y2="57" stroke="#555" stroke-width="1.5"/>
+  <line x1="165" y1="57" x2="255" y2="57" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="40" y="103" width="120" height="36" rx="4" fill="white" stroke="#ccc" stroke-width="1"/>
+  <text x="100" y="117" text-anchor="middle" fill="#333" font-size="11">sites recovered</text>
+  <text x="100" y="132" text-anchor="middle" fill="#888" font-size="10">CAS to HEALTHY</text>
+
+  <!-- SUSPECTING -> UNHEALTHY -->
+  <line x1="350" y1="234" x2="350" y2="335" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="355" y="263" width="175" height="36" rx="4" fill="white" stroke="#ccc" stroke-width="1"/>
+  <text x="442" y="277" text-anchor="middle" fill="#333" font-size="11">still unreachable (1 round)</text>
+  <text x="442" y="292" text-anchor="middle" fill="#888" font-size="10">CAS to UNHEALTHY + disconnect</text>
+
+  <!-- UNHEALTHY -> RECOVERING -->
+  <line x1="440" y1="367" x2="525" y2="367" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="442" y="405" width="138" height="36" rx="4" fill="white" stroke="#ccc" stroke-width="1"/>
+  <text x="511" y="419" text-anchor="middle" fill="#333" font-size="11">sites back online</text>
+  <text x="511" y="434" text-anchor="middle" fill="#888" font-size="10">CAS to RECOVERING</text>
+
+  <!-- RECOVERING -> HEALTHY -->
+  <line x1="620" y1="340" x2="620" y2="57" stroke="#555" stroke-width="1.5"/>
+  <line x1="620" y1="57" x2="445" y2="57" stroke="#555" stroke-width="2" marker-end="url(#arrow)"/>
+  <rect x="625" y="170" width="90" height="36" rx="4" fill="white" stroke="#ccc" stroke-width="1"/>
+  <text x="670" y="184" text-anchor="middle" fill="#333" font-size="11">all online</text>
+  <text x="670" y="199" text-anchor="middle" fill="#888" font-size="10">CAS to HEALTHY</text>
+
+  <!-- RECOVERING -> UNHEALTHY (failure during recovery) -->
+  <line x1="530" y1="382" x2="445" y2="382" stroke="#c0392b" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-red)"/>
+  <rect x="442" y="450" width="138" height="36" rx="4" fill="white" stroke="#e6b0aa" stroke-width="1"/>
+  <text x="511" y="464" text-anchor="middle" fill="#c0392b" font-size="11">sites lost again</text>
+  <text x="511" y="479" text-anchor="middle" fill="#c0392b" font-size="10">CAS to UNHEALTHY</text>
+
+  <!-- Steal annotation -->
+  <rect x="10" y="230" width="220" height="52" rx="6" fill="#fef9e7" stroke="#f39c12" stroke-width="1.5"/>
+  <text x="120" y="249" text-anchor="middle" fill="#7d6608" font-size="11" font-weight="bold">Non-active site can steal</text>
+  <text x="120" y="266" text-anchor="middle" fill="#7d6608" font-size="11">if active site stops progressing</text>
+  <line x1="230" y1="256" x2="258" y2="220" stroke="#f39c12" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+</svg>

--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-cachestore-remote</artifactId>
         </dependency>
         <dependency>

--- a/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/DatabaseAwareClusterProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/DatabaseAwareClusterProviderFactory.java
@@ -98,6 +98,7 @@ public class DatabaseAwareClusterProviderFactory extends InfinispanClusterProvid
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
+        super.postInit(factory);
         KeycloakModelUtils.runJobInTransaction(factory, session -> {
             InfinispanConnectionProvider ispnConnections = session.getProvider(InfinispanConnectionProvider.class);
             nodeInfo = ispnConnections.getNodeInfo();

--- a/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/InfinispanClusterProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/cluster/infinispan/InfinispanClusterProviderFactory.java
@@ -19,6 +19,7 @@ package org.keycloak.cluster.infinispan;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,13 +32,13 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.util.Time;
 import org.keycloak.connections.infinispan.DefaultInfinispanConnectionProviderFactory;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.connections.infinispan.InvalidateLocalCachesEvent;
 import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 
 import org.infinispan.Cache;
-import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.context.Flag;
 import org.infinispan.lifecycle.ComponentStatus;
 import org.infinispan.notifications.Listener;
@@ -61,6 +62,7 @@ public class InfinispanClusterProviderFactory implements ClusterProviderFactory,
 
     private volatile Cache<String, Object> workCache;
     private volatile ClusterProvider clusterProvider;
+    private KeycloakSessionFactory keycloakSessionFactory;
 
     private final ExecutorService localExecutor = Executors.newCachedThreadPool(r -> {
         Thread thread = Executors.defaultThreadFactory().newThread(r);
@@ -132,6 +134,7 @@ public class InfinispanClusterProviderFactory implements ClusterProviderFactory,
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
+        this.keycloakSessionFactory = factory;
     }
 
 
@@ -165,12 +168,7 @@ public class InfinispanClusterProviderFactory implements ClusterProviderFactory,
             // During split-brain only Keycloak instances contained within the same partition will receive updates via
             // the work cache. On split-brain healing, it's necessary for us to clear all local caches so that potentially
             // stale values are invalidated and subsequent requests are forced to read from the DB.
-            localExecutor.execute(() ->
-                    Arrays.stream(InfinispanConnectionProvider.LOCAL_CACHE_NAMES)
-                            .map(name -> workCache.getCacheManager().getCache(name))
-                            .filter(cache -> cache.getCacheConfiguration().clustering().cacheMode() == CacheMode.LOCAL)
-                            .forEach(Cache::clear)
-            );
+            localExecutor.execute(this::triggerInvalidationEvent);
 
             if (Profile.isFeatureEnabled(Profile.Feature.PERSISTENT_USER_SESSIONS)) {
                 // If persistent user sessions are enabled, the reasoning from above is true for the user and client sessions as well.
@@ -217,6 +215,10 @@ public class InfinispanClusterProviderFactory implements ClusterProviderFactory,
 
         private Set<String> convertAddresses(Collection<Address> addresses) {
             return addresses.stream().map(Object::toString).collect(Collectors.toSet());
+        }
+
+        private void triggerInvalidationEvent() {
+            Optional.ofNullable(keycloakSessionFactory).ifPresent(f -> f.publish(InvalidateLocalCachesEvent.INSTANCE));
         }
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -24,6 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -75,10 +76,12 @@ import org.keycloak.spi.infinispan.impl.embedded.CacheConfigurator;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
+import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.commons.configuration.io.ConfigurationWriter;
 import org.infinispan.commons.io.StringBuilderWriter;
 import org.infinispan.commons.util.Version;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
@@ -119,6 +122,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
     private static final String REMOTE_HEALTH_ENABLED = "remoteHealthEnabled";
 
     private Config.Scope config;
+    private KeycloakSessionFactory keycloakSessionFactory;
 
     private volatile EmbeddedCacheManager cacheManager;
     private volatile RemoteCacheManager remoteCacheManager;
@@ -192,6 +196,7 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
+        keycloakSessionFactory = factory;
         factory.register(this);
     }
 
@@ -286,7 +291,12 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                     .register(Metrics.globalRegistry);
         }
         return SiteHealthImpl.create(factory, remoteCacheManager, connectionProvider.getExecutor("site-health"),
-                status -> siteStatus.set(status.getValue()));
+                status -> siteStatus.set(status.getValue()),
+                this::triggerInvalidationEvent);
+    }
+
+    private void triggerInvalidationEvent() {
+        Optional.ofNullable(keycloakSessionFactory).ifPresent(f -> f.publish(InvalidateLocalCachesEvent.INSTANCE));
     }
 
     private Duration getShutdownTimeout() {
@@ -439,6 +449,12 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
             KeycloakModelUtils.runJobInTransaction(pme.getFactory(), this::registerSystemWideListeners);
         } else if (event instanceof ShutdownDelayInitiatedEvent se) {
             Optional.ofNullable(shutdownManager).ifPresent(sm -> sm.onShutdownStarted(se.timestamp()));
+        } else if (event instanceof InvalidateLocalCachesEvent) {
+            Arrays.stream(InfinispanConnectionProvider.LOCAL_CACHE_NAMES)
+                    .map(name -> cacheManager.getCache(name, false))
+                    .filter(Objects::nonNull)
+                    .filter(cache -> cache.getCacheConfiguration().clustering().cacheMode() == CacheMode.LOCAL)
+                    .forEach(Cache::clear);
         }
     }
 

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/DefaultInfinispanConnectionProviderFactory.java
@@ -18,6 +18,7 @@
 package org.keycloak.connections.infinispan;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -41,6 +43,10 @@ import org.keycloak.connections.infinispan.remote.RemoteInfinispanConnectionProv
 import org.keycloak.connections.infinispan.shutdown.ShutdownManager;
 import org.keycloak.connections.infinispan.shutdown.TopologyChangeCacheListener;
 import org.keycloak.infinispan.health.ClusterHealth;
+import org.keycloak.infinispan.health.CompositeClusterHealth;
+import org.keycloak.infinispan.health.embedded.EmbeddedCacheHealthImpl;
+import org.keycloak.infinispan.health.remote.RemoteCacheHealthImpl;
+import org.keycloak.infinispan.health.site.SiteHealthImpl;
 import org.keycloak.infinispan.util.InfinispanUtils;
 import org.keycloak.marshalling.KeycloakIndexSchemaUtil;
 import org.keycloak.marshalling.KeycloakModelSchema;
@@ -57,6 +63,8 @@ import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.PostMigrationEvent;
 import org.keycloak.provider.InvalidationHandler.ObjectType;
 import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
 import org.keycloak.provider.ProviderEvent;
 import org.keycloak.provider.ProviderEventListener;
 import org.keycloak.provider.ServerInfoAwareProviderFactory;
@@ -65,6 +73,8 @@ import org.keycloak.spi.infinispan.CacheEmbeddedConfigProvider;
 import org.keycloak.spi.infinispan.CacheRemoteConfigProvider;
 import org.keycloak.spi.infinispan.impl.embedded.CacheConfigurator;
 
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Metrics;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.commons.configuration.io.ConfigurationWriter;
 import org.infinispan.commons.io.StringBuilderWriter;
@@ -102,6 +112,11 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
     private static final ReadWriteLock READ_WRITE_LOCK = new ReentrantReadWriteLock();
     private static final Logger logger = Logger.getLogger(DefaultInfinispanConnectionProviderFactory.class);
     private static final String SHUTDOWN_TIMEOUT = "shutdownTimeout";
+
+    private static final String SITE_HEALTH_ENABLED = "siteHealthEnabled";
+    private static final String JGROUPS_HEALTH_ENABLED = "jgroupsHealthEnabled";
+    private static final String EMBEDDED_HEALTH_ENABLED = "embeddedHealthEnabled";
+    private static final String REMOTE_HEALTH_ENABLED = "remoteHealthEnabled";
 
     private Config.Scope config;
 
@@ -145,6 +160,10 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
     @Override
     public void close() {
         logger.debug("Closing provider");
+        if (clusterHealth != null) {
+            clusterHealth.close();
+            clusterHealth = null;
+        }
         if (shutdownManager != null) {
             shutdownManager.onShutdown();
             shutdownManager = null;
@@ -198,7 +217,9 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
                     new RemoteInfinispanConnectionProvider(cacheManager, remoteCacheManager, topologyInfo, nodeInfo) :
                     new DefaultInfinispanConnectionProvider(cacheManager, topologyInfo, nodeInfo);
 
-            clusterHealth = GlobalComponentRegistry.componentOf(cacheManager, ClusterHealth.class);
+            clusterHealth = InfinispanUtils.isRemoteInfinispan() ?
+                    createClusterHealthWithRemote(keycloakSession.getKeycloakSessionFactory()) :
+                    createClusterHealthWithEmbedded();
             return connectionProvider;
         }
     }
@@ -230,6 +251,42 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
             sm.addListener(listener);
         }
         shutdownManager = sm;
+    }
+
+    private ClusterHealth createClusterHealthWithRemote(KeycloakSessionFactory factory) {
+        var healths = new ArrayList<ClusterHealth>(3);
+        if (config.getBoolean(EMBEDDED_HEALTH_ENABLED, Boolean.TRUE)) {
+            healths.add(new EmbeddedCacheHealthImpl(cacheManager));
+        }
+        if (config.getBoolean(REMOTE_HEALTH_ENABLED, Boolean.TRUE)) {
+            healths.add(new RemoteCacheHealthImpl(remoteCacheManager, connectionProvider.getExecutor("remote-health")));
+        }
+        if (config.getBoolean(SITE_HEALTH_ENABLED, false)) {
+            healths.add(createSiteHealth(factory));
+        }
+        return new CompositeClusterHealth(healths);
+    }
+
+    private ClusterHealth createClusterHealthWithEmbedded() {
+        var healths = new ArrayList<ClusterHealth>(2);
+        if (config.getBoolean(EMBEDDED_HEALTH_ENABLED, Boolean.TRUE)) {
+            healths.add(new EmbeddedCacheHealthImpl(cacheManager));
+        }
+        if (config.getBoolean(JGROUPS_HEALTH_ENABLED, Boolean.TRUE)) {
+            healths.add(GlobalComponentRegistry.componentOf(cacheManager, ClusterHealth.class));
+        }
+        return new CompositeClusterHealth(healths);
+    }
+
+    private SiteHealthImpl createSiteHealth(KeycloakSessionFactory factory) {
+        var siteStatus = new AtomicInteger(0);
+        if (cacheManager.getCacheManagerConfiguration().metrics().enabled()) {
+            Gauge.builder("keycloak.site.status", siteStatus, AtomicInteger::doubleValue)
+                    .description("Cross-site health status (0=healthy, 1=suspecting, 2=unhealthy, 3=recovering)")
+                    .register(Metrics.globalRegistry);
+        }
+        return SiteHealthImpl.create(factory, remoteCacheManager, connectionProvider.getExecutor("site-health"),
+                status -> siteStatus.set(status.getValue()));
     }
 
     private Duration getShutdownTimeout() {
@@ -405,8 +462,26 @@ public class DefaultInfinispanConnectionProviderFactory implements InfinispanCon
     }
 
     @Override
+    public boolean isSiteActive() {
+        clusterHealth.triggerClusterHealthCheck();
+        return clusterHealth.isSiteActive();
+    }
+
+    @Override
     public boolean isClusterHealthSupported() {
         return clusterHealth.isSupported();
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        var builder = ProviderConfigurationBuilder.create();
+        builder.property()
+                .name(SITE_HEALTH_ENABLED)
+                .helpText("Enables the site health check, for " + Profile.Feature.MULTI_SITE.getKey() + " feature.")
+                .type(ProviderConfigProperty.BOOLEAN_TYPE)
+                .defaultValue(Boolean.FALSE)
+                .add();
+        return builder.build();
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/InfinispanConnectionProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/InfinispanConnectionProviderFactory.java
@@ -70,4 +70,13 @@ public interface InfinispanConnectionProviderFactory extends ProviderFactory<Inf
         return false;
     }
 
+    /**
+     * Checks if this site is the active site in a cross-site deployment.
+     *
+     * @return {@code true} if this site is active or if cross-site is not configured.
+     */
+    default boolean isSiteActive() {
+        return true;
+    }
+
 }

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/InvalidateLocalCachesEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/InvalidateLocalCachesEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.connections.infinispan;
+
+import org.keycloak.provider.ProviderEvent;
+
+/**
+ * A {@link ProviderEvent} that clears all local caches to prevent stale cached data.
+ * <p>
+ * This event should be triggered when there is a risk of missing invalidation events, for example after a split-brain
+ * scenario where some cache invalidations may have been lost. Unlike most provider events, this event does not carry a
+ * {@link org.keycloak.models.KeycloakSessionFactory} reference and the listeners must obtain it through other means.
+ */
+public enum InvalidateLocalCachesEvent implements ProviderEvent {
+    INSTANCE;
+}

--- a/model/infinispan/src/main/java/org/keycloak/connections/infinispan/remote/RemoteLoadBalancerCheckProviderFactory.java
+++ b/model/infinispan/src/main/java/org/keycloak/connections/infinispan/remote/RemoteLoadBalancerCheckProviderFactory.java
@@ -17,20 +17,12 @@
 
 package org.keycloak.connections.infinispan.remote;
 
-import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 import org.keycloak.Config;
 import org.keycloak.common.util.MultiSiteUtils;
 import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
+import org.keycloak.connections.infinispan.InfinispanConnectionProviderFactory;
 import org.keycloak.health.LoadBalancerCheckProvider;
 import org.keycloak.health.LoadBalancerCheckProviderFactory;
 import org.keycloak.infinispan.util.InfinispanUtils;
@@ -38,32 +30,10 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.Provider;
-import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.provider.ProviderConfigurationBuilder;
 
-import org.infinispan.client.hotrod.impl.InternalRemoteCache;
-import org.infinispan.client.hotrod.impl.operations.PingResponse;
-import org.infinispan.commons.util.concurrent.CompletableFutures;
-import org.infinispan.factories.ComponentRegistry;
-import org.infinispan.persistence.manager.PersistenceManager;
-import org.infinispan.util.concurrent.ActionSequencer;
-import org.jboss.logging.Logger;
+public class RemoteLoadBalancerCheckProviderFactory implements LoadBalancerCheckProviderFactory, LoadBalancerCheckProvider, EnvironmentDependentProviderFactory {
 
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NAMES;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.LOCAL_CACHE_NAMES;
-import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.skipSessionsCacheIfRequired;
-
-public class RemoteLoadBalancerCheckProviderFactory implements LoadBalancerCheckProviderFactory, EnvironmentDependentProviderFactory {
-
-    private static final int DEFAULT_POLL_INTERVAL = 5000;
-    private static final LoadBalancerCheckProvider ALWAYS_HEALTHY = () -> false;
-    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
-
-    private volatile int pollIntervalMillis;
-    private volatile LoadBalancerCheckProvider provider;
-    private InfinispanConnectionProvider connectionProvider;
-    private ScheduledFuture<?> availabilityFuture;
-    private RemoteCacheCheckList remoteCacheCheckList;
+    private volatile InfinispanConnectionProviderFactory connectionProviderFactory;
 
     @Override
     public boolean isSupported(Config.Scope config) {
@@ -72,46 +42,25 @@ public class RemoteLoadBalancerCheckProviderFactory implements LoadBalancerCheck
 
     @Override
     public LoadBalancerCheckProvider create(KeycloakSession session) {
-        return provider;
+        return this;
     }
 
     @Override
     public void init(Config.Scope config) {
-        pollIntervalMillis = config.getInt("poll-interval", DEFAULT_POLL_INTERVAL);
     }
 
     @Override
     public void postInit(KeycloakSessionFactory factory) {
-        try (var session = factory.create()) {
-            var provider = session.getProvider(InfinispanConnectionProvider.class);
-            if (provider == null) {
-                logger.warn("InfinispanConnectionProvider is not available. Load balancer check will be always healthy for Infinispan.");
-                this.provider = ALWAYS_HEALTHY;
-                return;
-            }
-            this.connectionProvider = provider;
+        connectionProviderFactory = (InfinispanConnectionProviderFactory) factory.getProviderFactory(InfinispanConnectionProvider.class);
+    }
 
-            var remoteCacheChecks = skipSessionsCacheIfRequired(Arrays.stream(CLUSTERED_CACHE_NAMES))
-                    .map(s -> new RemoteCacheCheck(s, provider))
-                    .collect(Collectors.toList());
-            var sequencer = new ActionSequencer(connectionProvider.getExecutor("load-balancer-check"), false, null);
-
-            this.remoteCacheCheckList = new RemoteCacheCheckList(remoteCacheChecks, sequencer);
-            this.availabilityFuture = provider.getScheduledExecutor()
-                    .scheduleAtFixedRate(remoteCacheCheckList, pollIntervalMillis, pollIntervalMillis, TimeUnit.MILLISECONDS);
-
-            this.provider = this::isAnyCacheDown;
-        }
+    @Override
+    public boolean isDown() {
+        return connectionProviderFactory != null && !connectionProviderFactory.isSiteActive();
     }
 
     @Override
     public void close() {
-        if (availabilityFuture != null) {
-            availabilityFuture.cancel(true);
-            availabilityFuture = null;
-        }
-        provider = null;
-        remoteCacheCheckList = null;
     }
 
     @Override
@@ -128,96 +77,4 @@ public class RemoteLoadBalancerCheckProviderFactory implements LoadBalancerCheck
    public Set<Class<? extends Provider>> dependsOn() {
       return Set.of(InfinispanConnectionProvider.class);
    }
-
-   @Override
-    public List<ProviderConfigProperty> getConfigMetadata() {
-        return ProviderConfigurationBuilder.create()
-                .property()
-                .name("poll-interval")
-                .type("int")
-                .helpText("The Remote caches poll interval, in milliseconds, for connection availability")
-                .defaultValue(DEFAULT_POLL_INTERVAL)
-                .add()
-                .build();
-    }
-
-    private boolean isAnyCacheDown() {
-        return isEmbeddedCachesDown() || remoteCacheCheckList.isDown();
-    }
-
-    private boolean isEmbeddedCachesDown() {
-        for (var name : LOCAL_CACHE_NAMES) {
-            var cache = connectionProvider.getCache(name, false);
-
-            // check if cache is started
-            if (cache == null || !cache.getStatus().allowInvocations()) {
-                logger.debugf("Cache '%s' is not started yet.", name);
-                return true; // no need to check other caches
-            }
-
-            var persistenceManager = ComponentRegistry.componentOf(cache, PersistenceManager.class);
-            if (persistenceManager != null && !persistenceManager.isAvailable()) {
-                logger.debugf("Persistence for embedded cache '%s' is down.", name);
-                return true; // no need to check other caches
-            }
-        }
-        return false;
-    }
-
-    private record RemoteCacheCheckList(List<RemoteCacheCheck> list, ActionSequencer sequencer) implements Runnable {
-        @Override
-        public void run() {
-            list.forEach(remoteCacheCheck -> sequencer.orderOnKey(remoteCacheCheck.name(), remoteCacheCheck));
-        }
-
-        public boolean isDown() {
-            return list.stream().anyMatch(RemoteCacheCheck::isDown);
-        }
-    }
-
-    private static class RemoteCacheCheck implements Callable<CompletionStage<Void>>, BiFunction<PingResponse, Throwable, Void> {
-
-        private final String name;
-        private final InfinispanConnectionProvider provider;
-        private volatile boolean isDown;
-
-        private RemoteCacheCheck(String name, InfinispanConnectionProvider provider) {
-            this.name = name;
-            this.provider = provider;
-        }
-
-        String name() {
-            return name;
-        }
-
-        boolean isDown() {
-            return isDown;
-        }
-
-        @Override
-        public CompletionStage<Void> call() {
-            try {
-                var cache = provider.getRemoteCache(name);
-                if (cache instanceof InternalRemoteCache<Object, Object>) {
-                    return ((InternalRemoteCache<Object, Object>) cache).ping()
-                            .handle(this);
-                }
-                isDown = false;
-            } catch (Exception e) {
-                if (!isDown) {
-                    logger.warnf("Remote cache '%' is down.", name);
-                }
-                isDown = true;
-            }
-            return CompletableFutures.completedNull();
-        }
-
-        @Override
-        public Void apply(PingResponse response, Throwable throwable) {
-            var successPing = response != null && response.isSuccess();
-            logger.debugf("Received Ping response for cache '%s'. Success=%s, Throwable=%s", name, successPing, throwable);
-            isDown = throwable != null || !successPing;
-            return null;
-        }
-    }
 }

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/ClusterHealth.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/ClusterHealth.java
@@ -49,4 +49,21 @@ public interface ClusterHealth {
      */
     boolean isSupported();
 
+    /**
+     * Checks if this site is the active site in a cross-site deployment.
+     * <p>
+     * In a multi-cluster setup, only the active site should serve traffic. The non-active site should reject requests
+     * to prevent serving stale data.
+     *
+     * @return {@code true} if this site is active or if cross-site is not configured, {@code false} if this site
+     * should stop serving traffic.
+     */
+    default boolean isSiteActive() {
+        return true;
+    }
+
+    default void close() {
+        //no-op
+    }
+
 }

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/CompositeClusterHealth.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/CompositeClusterHealth.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Aggregates multiple {@link ClusterHealth} implementations into a single health check. The composite is healthy only
+ * if all delegates are healthy.
+ */
+public class CompositeClusterHealth implements ClusterHealth {
+
+    private final List<ClusterHealth> clusterHealth;
+
+    public CompositeClusterHealth(List<ClusterHealth> clusterHealth) {
+        this.clusterHealth = Objects.requireNonNullElse(clusterHealth, List.<ClusterHealth>of())
+                .stream()
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return clusterHealth.stream().allMatch(ClusterHealth::isHealthy);
+    }
+
+    @Override
+    public boolean isSiteActive() {
+        return clusterHealth.stream().allMatch(ClusterHealth::isSiteActive);
+    }
+
+    @Override
+    public void triggerClusterHealthCheck() {
+        clusterHealth.forEach(ClusterHealth::triggerClusterHealthCheck);
+    }
+
+    @Override
+    public boolean isSupported() {
+        return clusterHealth.stream().anyMatch(ClusterHealth::isSupported);
+    }
+
+    @Override
+    public void close() {
+        clusterHealth.forEach(ClusterHealth::close);
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/embedded/EmbeddedCacheHealthImpl.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/embedded/EmbeddedCacheHealthImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.embedded;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+
+import org.keycloak.infinispan.health.ClusterHealth;
+
+import org.infinispan.factories.ComponentRegistry;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.manager.PersistenceManager;
+import org.jboss.logging.Logger;
+
+/**
+ * Health check for the embedded Infinispan cache manager, verifying that all caches allow invocations.
+ */
+public class EmbeddedCacheHealthImpl implements ClusterHealth {
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final EmbeddedCacheManager cacheManager;
+    private volatile boolean healthy = false;
+
+    public EmbeddedCacheHealthImpl(EmbeddedCacheManager cacheManager) {
+        this.cacheManager = Objects.requireNonNull(cacheManager);
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return healthy;
+    }
+
+    @Override
+    public void triggerClusterHealthCheck() {
+        checkHealth();
+    }
+
+    @Override
+    public boolean isSupported() {
+        return true;
+    }
+
+    private void checkHealth() {
+        var cacheNames = cacheManager.getCacheNames();
+        for (var name : cacheNames) {
+            try {
+                var cache = cacheManager.getCache(name, false);
+                if (cache == null || !cache.getStatus().allowInvocations()) {
+                    logger.debugf("Embedded cache '%s' is not ready", name);
+                    healthy = false;
+                    return;
+                }
+
+                var persistenceManager = ComponentRegistry.componentOf(cache, PersistenceManager.class);
+                if (persistenceManager != null && !persistenceManager.isAvailable()) {
+                    logger.debugf("Persistence for embedded cache '%s' is down.", name);
+                    healthy = false;
+                    return;
+                }
+            } catch (Exception e) {
+                logger.debugf(e, "Failed to check embedded cache '%s'", name);
+                healthy = false;
+                return;
+            }
+        }
+        healthy = true;
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/remote/RemoteCacheHealthImpl.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/remote/RemoteCacheHealthImpl.java
@@ -18,8 +18,8 @@
 package org.keycloak.infinispan.health.remote;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -28,6 +28,9 @@ import org.keycloak.infinispan.health.ClusterHealth;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.impl.InternalRemoteCache;
 import org.jboss.logging.Logger;
+
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.CLUSTERED_CACHE_NAMES;
+import static org.keycloak.connections.infinispan.InfinispanConnectionProvider.skipSessionsCacheIfRequired;
 
 /**
  * Health check for the external Infinispan cluster, verifying connectivity by pinging each remote cache.
@@ -67,15 +70,9 @@ public class RemoteCacheHealthImpl implements ClusterHealth {
             return;
         }
         try {
-            Set<String> cacheNames;
-            try {
-                cacheNames = remoteCacheManager.getCacheNames();
-            } catch (Exception e) {
-                logger.debugf(e, "Failed to retrieve remote cache names");
-                healthy = false;
-                return;
-            }
-            for (var name : cacheNames) {
+            var it = skipSessionsCacheIfRequired(Arrays.stream(CLUSTERED_CACHE_NAMES)).iterator();
+            while (it.hasNext()) {
+                var name = it.next();
                 try {
                     var cache = remoteCacheManager.getCache(name);
                     if (cache instanceof InternalRemoteCache<?, ?> internalCache) {

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/remote/RemoteCacheHealthImpl.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/remote/RemoteCacheHealthImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.remote;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.keycloak.infinispan.health.ClusterHealth;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.impl.InternalRemoteCache;
+import org.jboss.logging.Logger;
+
+/**
+ * Health check for the external Infinispan cluster, verifying connectivity by pinging each remote cache.
+ */
+public class RemoteCacheHealthImpl implements ClusterHealth {
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final RemoteCacheManager remoteCacheManager;
+    private final Executor executor;
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+    private volatile boolean healthy = false;
+
+    public RemoteCacheHealthImpl(RemoteCacheManager remoteCacheManager, Executor executor) {
+        this.remoteCacheManager = Objects.requireNonNull(remoteCacheManager);
+        this.executor = Objects.requireNonNull(executor);
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return healthy;
+    }
+
+    @Override
+    public void triggerClusterHealthCheck() {
+        executor.execute(this::checkHealth);
+    }
+
+    @Override
+    public boolean isSupported() {
+        return true;
+    }
+
+    private void checkHealth() {
+        if (!inProgress.compareAndSet(false, true)) {
+            logger.debug("A thread is running. Ignoring health check request");
+            return;
+        }
+        try {
+            Set<String> cacheNames;
+            try {
+                cacheNames = remoteCacheManager.getCacheNames();
+            } catch (Exception e) {
+                logger.debugf(e, "Failed to retrieve remote cache names");
+                healthy = false;
+                return;
+            }
+            for (var name : cacheNames) {
+                try {
+                    var cache = remoteCacheManager.getCache(name);
+                    if (cache instanceof InternalRemoteCache<?, ?> internalCache) {
+                        var response = internalCache.ping().toCompletableFuture().join();
+                        if (response == null || !response.isSuccess()) {
+                            logger.warnf("Ping failed for remote cache '%s'", name);
+                            healthy = false;
+                            return;
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.debugf(e, "Failed to ping remote cache '%s'", name);
+                    healthy = false;
+                    return;
+                }
+            }
+            healthy = true;
+        } finally {
+            inProgress.set(false);
+        }
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/InfinispanManagement.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/InfinispanManagement.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Abstraction over the Infinispan server management API used to query and control cross-site replication state.
+ */
+public interface InfinispanManagement extends AutoCloseable {
+
+    /**
+     * Returns the backup site statuses for all cross-site replicated caches.
+     * <p>
+     * The returned map keys are site names and the values are their replication status (e.g. {@code "online"},
+     * {@code "offline"}).
+     *
+     * @return A map of site name to replication status.
+     */
+    Map<String, String> siteStatus() throws ExecutionException, InterruptedException;
+
+    /**
+     * Returns the local site identity and the set of sites currently visible in the cluster view.
+     *
+     * @return The {@link SiteConnection} for this node.
+     */
+    SiteConnection siteConnection() throws ExecutionException, InterruptedException;
+
+    /**
+     * Disconnects (takes offline) the given remote sites for all cross-site replicated caches.
+     *
+     * @param remoteSites The site names to disconnect.
+     */
+    void disconnect(Collection<String> remoteSites) throws ExecutionException, InterruptedException;
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/JpaSiteStorage.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/JpaSiteStorage.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.ModelException;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.storage.configuration.ServerConfigStorageProvider;
+import org.keycloak.util.JsonSerialization;
+
+/**
+ * {@link SiteStorage} implementation backed by the {@link ServerConfigStorageProvider}, which stores the
+ * {@link SiteState} as a JSON-serialized row in the {@code SERVER_CONFIG} table. Each read and write runs in its own
+ * transaction to ensure atomicity of compare-and-set operations across sites sharing the same database.
+ */
+public class JpaSiteStorage implements SiteStorage {
+
+    private static final String STORAGE_KEY = "site.state";
+    private final KeycloakSessionFactory factory;
+
+    public JpaSiteStorage(KeycloakSessionFactory factory) {
+        this.factory = Objects.requireNonNull(factory);
+    }
+
+    @Override
+    public SiteState get() {
+        return KeycloakModelUtils.runJobInTransactionWithResult(factory, session -> {
+            var jsonState = storage(session).loadOrCreate(STORAGE_KEY, JpaSiteStorage::initialState);
+            assert jsonState != null;
+            return fromJson(jsonState);
+        });
+    }
+
+    @Override
+    public boolean compareAndSet(SiteState expectedState, SiteState newState) {
+        return KeycloakModelUtils.runJobInTransactionWithResult(factory,
+                session -> storage(session).replace(STORAGE_KEY, toJson(expectedState), toJson(newState)));
+    }
+
+    private static ServerConfigStorageProvider storage(KeycloakSession session) {
+        return session.getProvider(ServerConfigStorageProvider.class);
+    }
+
+    private static String initialState() {
+        return toJson(SiteState.healthy());
+    }
+
+    private static String toJson(SiteState state) {
+        try {
+            return JsonSerialization.writeValueAsString(state);
+        } catch (IOException e) {
+            throw new ModelException("Unable to convert site state to json", e);
+        }
+    }
+
+    private static SiteState fromJson(String json) {
+        try {
+            return JsonSerialization.readValue(json, SiteState.class);
+        } catch (IOException e) {
+            throw new ModelException("Unable to convert site state from json", e);
+        }
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/RestInfinispanManagement.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/RestInfinispanManagement.java
@@ -102,9 +102,12 @@ public class RestInfinispanManagement implements InfinispanManagement {
         }
         var container = restClient.container();
         var stage = CompletionStages.aggregateCompletionStage();
+        // the rest response is not important.
+        // keycloak will try to take offline in each round.
         remoteSites.stream()
                 .distinct()
                 .map(container::takeOffline)
+                .peek(rsp -> rsp.thenAccept(RestResponse::close))
                 .forEach(stage::dependsOn);
         CompletionStages.await(stage.freeze());
     }
@@ -124,8 +127,7 @@ public class RestInfinispanManagement implements InfinispanManagement {
     }
 
     private static void copyHostName(org.infinispan.client.hotrod.configuration.Configuration from, RestClientConfigurationBuilder to) {
-        var server = from.servers().get(0);
-        to.addServer().host(server.host()).port(server.port());
+        from.servers().forEach(server -> to.addServer().host(server.host()).port(server.port()));
     }
 
     private static void copyAuthentication(org.infinispan.client.hotrod.configuration.Configuration from, RestClientConfigurationBuilder to) {

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/RestInfinispanManagement.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/RestInfinispanManagement.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import org.keycloak.models.ModelException;
+
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.security.BasicCallbackHandler;
+import org.infinispan.client.hotrod.security.TokenCallbackHandler;
+import org.infinispan.client.rest.RestClient;
+import org.infinispan.client.rest.RestResponse;
+import org.infinispan.client.rest.RestResponseInfo;
+import org.infinispan.client.rest.configuration.RestClientConfigurationBuilder;
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.infinispan.commons.util.concurrent.CompletionStages;
+
+/**
+ * {@link InfinispanManagement} implementation that uses the Infinispan REST API to query and control cross-site
+ * replication state.
+ * <p>
+ * The {@link #fromRemoteCacheManager(RemoteCacheManager)} factory method creates a REST client by copying the
+ * connection configuration (host, authentication, and TLS) from an existing Hot Rod client, so that no additional
+ * server coordinates need to be configured.
+ */
+public class RestInfinispanManagement implements InfinispanManagement {
+
+    private final RestClient restClient;
+
+    public static RestInfinispanManagement fromRemoteCacheManager(RemoteCacheManager remoteCacheManager) {
+        var restConfigBuilder = new RestClientConfigurationBuilder();
+        var hotRodConfig = remoteCacheManager.getConfiguration();
+        restConfigBuilder.pingOnCreate(false)
+                .followRedirects(true)
+                .tcpKeepAlive(false)
+                .socketTimeout(hotRodConfig.socketTimeout());
+        copyHostName(hotRodConfig, restConfigBuilder);
+        copyAuthentication(hotRodConfig, restConfigBuilder);
+        copySsl(hotRodConfig, restConfigBuilder);
+        var restClient = RestClient.forConfiguration(restConfigBuilder.build());
+        return new RestInfinispanManagement(restClient);
+    }
+
+    public RestInfinispanManagement(RestClient restClient) {
+        this.restClient = Objects.requireNonNull(restClient);
+    }
+
+    @Override
+    public Map<String, String> siteStatus() throws ExecutionException, InterruptedException {
+        CompletionStage<Map<String, String>> stage = restClient.container().backupStatuses()
+                .thenApply(restResponse -> {
+                    checkResponse(restResponse);
+                    var data = Json.read(restResponse.body()).asMap();
+                    if (data.isEmpty()) {
+                        return Map.of();
+                    }
+                    return data.entrySet().stream()
+                            .collect(Collectors.toMap(Map.Entry::getKey,
+                                    entry -> Json.make(entry.getValue()).at("status").asString()));
+                });
+        return CompletionStages.await(stage);
+    }
+
+    @Override
+    public SiteConnection siteConnection() throws ExecutionException, InterruptedException {
+        var stage = restClient.container().info()
+                .thenApply(restResponse -> {
+                    checkResponse(restResponse);
+                    var data = Json.read(restResponse.body());
+                    var localSite = data.at("local_site").isNull() ? null : data.at("local_site").asString();
+                    var sites = data.at("sites_view").asJsonList().stream().map(Json::asString).collect(Collectors.toSet());
+                    return new SiteConnection(localSite, sites);
+                });
+        return CompletionStages.await(stage);
+    }
+
+    @Override
+    public void disconnect(Collection<String> remoteSites) throws ExecutionException, InterruptedException {
+        if (remoteSites.isEmpty()) {
+            return;
+        }
+        var container = restClient.container();
+        var stage = CompletionStages.aggregateCompletionStage();
+        remoteSites.stream()
+                .distinct()
+                .map(container::takeOffline)
+                .forEach(stage::dependsOn);
+        CompletionStages.await(stage.freeze());
+    }
+
+    @Override
+    public void close() throws Exception {
+        restClient.close();
+    }
+
+    private static void checkResponse(RestResponse response) {
+        if (response == null) {
+            throw new IllegalStateException("Null response received from external Infinispan cluster");
+        }
+        if (response.status() != RestResponseInfo.OK) {
+            throw new ModelException("Unexpected http response status. Expected %s but got %s", RestResponseInfo.OK, response.status());
+        }
+    }
+
+    private static void copyHostName(org.infinispan.client.hotrod.configuration.Configuration from, RestClientConfigurationBuilder to) {
+        var server = from.servers().get(0);
+        to.addServer().host(server.host()).port(server.port());
+    }
+
+    private static void copyAuthentication(org.infinispan.client.hotrod.configuration.Configuration from, RestClientConfigurationBuilder to) {
+        var authn = from.security().authentication();
+        if (!authn.enabled()) {
+            return;
+        }
+        to.security().authentication().enable()
+                .clientSubject(authn.clientSubject())
+                .mechanism("AUTO");
+        var callback = authn.callbackHandler();
+        if (callback instanceof BasicCallbackHandler bch) {
+            to.security().authentication()
+                    .username(bch.getUsername())
+                    .password(bch.getPassword())
+                    .realm(bch.getRealm());
+        } else if (callback instanceof TokenCallbackHandler tch) {
+            to.security().authentication().username(tch.getToken());
+        }
+    }
+
+    private static void copySsl(org.infinispan.client.hotrod.configuration.Configuration from, RestClientConfigurationBuilder to) {
+        var ssl = from.security().ssl();
+        if (!ssl.enabled()) {
+            return;
+        }
+        to.security().ssl()
+                .enable()
+                .sslContext(ssl.sslContext())
+                .sniHostName(ssl.sniHostName());
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/RestInfinispanManagement.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/RestInfinispanManagement.java
@@ -70,14 +70,20 @@ public class RestInfinispanManagement implements InfinispanManagement {
     public Map<String, String> siteStatus() throws ExecutionException, InterruptedException {
         CompletionStage<Map<String, String>> stage = restClient.container().backupStatuses()
                 .thenApply(restResponse -> {
-                    checkResponse(restResponse);
-                    var data = Json.read(restResponse.body()).asMap();
-                    if (data.isEmpty()) {
-                        return Map.of();
+                    try {
+                        checkResponse(restResponse);
+                        var data = Json.read(restResponse.body()).asMap();
+                        if (data.isEmpty()) {
+                            return Map.of();
+                        }
+                        return data.entrySet().stream()
+                                .collect(Collectors.toMap(Map.Entry::getKey,
+                                        entry -> Json.make(entry.getValue()).at("status").asString()));
+                    } finally {
+                        if (restResponse != null) {
+                            restResponse.close();
+                        }
                     }
-                    return data.entrySet().stream()
-                            .collect(Collectors.toMap(Map.Entry::getKey,
-                                    entry -> Json.make(entry.getValue()).at("status").asString()));
                 });
         return CompletionStages.await(stage);
     }
@@ -86,11 +92,17 @@ public class RestInfinispanManagement implements InfinispanManagement {
     public SiteConnection siteConnection() throws ExecutionException, InterruptedException {
         var stage = restClient.container().info()
                 .thenApply(restResponse -> {
-                    checkResponse(restResponse);
-                    var data = Json.read(restResponse.body());
-                    var localSite = data.at("local_site").isNull() ? null : data.at("local_site").asString();
-                    var sites = data.at("sites_view").asJsonList().stream().map(Json::asString).collect(Collectors.toSet());
-                    return new SiteConnection(localSite, sites);
+                    try {
+                        checkResponse(restResponse);
+                        var data = Json.read(restResponse.body());
+                        var localSite = data.at("local_site").isNull() ? null : data.at("local_site").asString();
+                        var sites = data.at("sites_view").asJsonList().stream().map(Json::asString).collect(Collectors.toSet());
+                        return new SiteConnection(localSite, sites);
+                    } finally {
+                        if (restResponse != null) {
+                            restResponse.close();
+                        }
+                    }
                 });
         return CompletionStages.await(stage);
     }
@@ -102,12 +114,18 @@ public class RestInfinispanManagement implements InfinispanManagement {
         }
         var container = restClient.container();
         var stage = CompletionStages.aggregateCompletionStage();
-        // the rest response is not important.
-        // keycloak will try to take offline in each round.
         remoteSites.stream()
                 .distinct()
                 .map(container::takeOffline)
-                .peek(rsp -> rsp.thenAccept(RestResponse::close))
+                .map(responseStage -> responseStage.thenAccept(response -> {
+                    try {
+                        checkResponse(response);
+                    } finally {
+                        if (response != null) {
+                            response.close();
+                        }
+                    }
+                }))
                 .forEach(stage::dependsOn);
         CompletionStages.await(stage.freeze());
     }

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteConnection.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteConnection.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.util.Set;
+
+/**
+ * The local site identity and the set of remote sites currently visible in the Infinispan cluster view.
+ *
+ * @param localSite   The name of this site, or {@code null} if cross-site is not configured.
+ * @param onlineSites The site names that are currently reachable in the cluster view.
+ */
+public record SiteConnection(String localSite, Set<String> onlineSites) {
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthCheckEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthCheckEvent.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+/**
+ * JFR event emitted during each cross-site health check, capturing the site statuses, cluster view, and current
+ * state from the database.
+ */
+@Name("org.keycloak.SiteHealthCheck")
+@Label("Site Health Check")
+@Description("Periodic cross-site health check")
+@Category({"Keycloak", "Health"})
+public class SiteHealthCheckEvent extends Event {
+
+    @Label("Site Statuses")
+    @Description("Backup site statuses in key=value format")
+    public String sites;
+
+    @Label("Local Site")
+    @Description("The local site name")
+    public String localSite;
+
+    @Label("Online Sites")
+    @Description("Sites visible in the cluster view")
+    public String onlineSites;
+
+    @Label("Status")
+    @Description("Current site state status from the database")
+    public String status;
+
+    @Label("Active Site")
+    @Description("The site currently owning the state transition")
+    public String activeSite;
+
+    public void set(Map<String, String> sites, SiteConnection connection, SiteState siteState) {
+        this.sites = sites.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(", "));
+        this.localSite = connection.localSite();
+        this.onlineSites = String.join(", ", connection.onlineSites());
+        this.status = siteState.status().name();
+        this.activeSite = siteState.activeSite();
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthImpl.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthImpl.java
@@ -123,7 +123,7 @@ public class SiteHealthImpl implements ClusterHealth {
                 return;
             }
             if (sites.isEmpty()) {
-                logger.debug("No caches are replicated to the remove sites. Is this a mistake?");
+                logger.debug("No caches are replicated to the remote sites. Is this a mistake?");
                 healthy = true;
                 return;
             }
@@ -132,7 +132,7 @@ public class SiteHealthImpl implements ClusterHealth {
             statusConsumer.accept(siteState.status());
             SiteHealthCheckEvent event = null;
             if (JFR_HEALTH_CHECK.isEnabled()) {
-                // a recording is progress, let's track it.
+                // a recording is in progress, let's track it.
                 event = new SiteHealthCheckEvent();
                 event.begin();
             }
@@ -213,7 +213,7 @@ public class SiteHealthImpl implements ClusterHealth {
         }
 
         logger.debugf("Some site(s) is(are) not reachable. Keeping 'unhealthy' state");
-        if (!allOnline && sites.values().stream().allMatch("offline"::equals)) {
+        if (!allOnline && sites.values().stream().allMatch("online"::equals)) {
             takeOffline(sites.keySet());
         }
     }
@@ -294,7 +294,7 @@ public class SiteHealthImpl implements ClusterHealth {
         // do not throw an exception, it will change the health to false
         SiteStateChangeEvent event = null;
         if (JFR_STATE_CHANGE.isEnabled()) {
-            // a recording is progress, let's track it.
+            // a recording is in progress, let's track it.
             event = new SiteStateChangeEvent();
             event.begin();
         }

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthImpl.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthImpl.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import org.keycloak.infinispan.health.ClusterHealth;
+import org.keycloak.models.KeycloakSessionFactory;
+
+import jdk.jfr.EventType;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.jboss.logging.Logger;
+
+/**
+ * Cross-site STONITH health check implementation.
+ * <p>
+ * Uses a database-backed state machine ({@link SiteStorage}) and the Infinispan management API
+ * ({@link InfinispanManagement}) to detect site failures and coordinate failover between two sites. The state machine
+ * follows the lifecycle {@code HEALTHY → SUSPECTING → UNHEALTHY → RECOVERING → HEALTHY}, with a one-round delay in the
+ * {@code SUSPECTING} state to avoid reacting to transient failures.
+ */
+public class SiteHealthImpl implements ClusterHealth {
+
+    private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
+    private static final EventType JFR_HEALTH_CHECK = EventType.getEventType(SiteHealthCheckEvent.class);
+    private static final EventType JFR_STATE_CHANGE = EventType.getEventType(SiteStateChangeEvent.class);
+
+    private final InfinispanManagement management;
+    private final SiteStorage storage;
+    private final Executor executor;
+    private final Consumer<Status> statusConsumer;
+    private final AtomicBoolean inProgress = new AtomicBoolean(false);
+    private volatile boolean healthy = false;
+    private volatile SiteState transitionState;
+
+    public SiteHealthImpl(SiteStorage storage, InfinispanManagement management, Executor executor, Consumer<Status> statusConsumer) {
+        this.management = Objects.requireNonNull(management);
+        this.storage = Objects.requireNonNull(storage);
+        this.executor = Objects.requireNonNull(executor);
+        this.statusConsumer = Objects.requireNonNullElse(statusConsumer, status -> {
+        });
+    }
+
+    public static SiteHealthImpl create(KeycloakSessionFactory factory, RemoteCacheManager remoteCacheManager, Executor executor, Consumer<Status> statusConsumer) {
+        return new SiteHealthImpl(new JpaSiteStorage(factory), RestInfinispanManagement.fromRemoteCacheManager(remoteCacheManager), executor, statusConsumer);
+    }
+
+    @Override
+    public boolean isHealthy() {
+        return healthy;
+    }
+
+    @Override
+    public boolean isSiteActive() {
+        return healthy;
+    }
+
+    @Override
+    public void triggerClusterHealthCheck() {
+        executor.execute(() -> {
+            try {
+                checkHealth();
+            } catch (ExecutionException | RuntimeException e) {
+                healthy = false;
+                logger.warn("Failed to check cross-site state. Marking instance as unhealthy", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+    }
+
+    @Override
+    public boolean isSupported() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        try {
+            management.close();
+        } catch (Exception e) {
+            logger.debug("Exception while closing the Infinispan connection. Ignored.", e);
+        }
+    }
+
+    private void checkHealth() throws ExecutionException, InterruptedException {
+        if (!inProgress.compareAndSet(false, true)) {
+            logger.debug("A thread is running. Ignoring health check request");
+            return;
+        }
+        try {
+            var sites = management.siteStatus();
+            var connection = management.siteConnection();
+
+            if (connection.localSite() == null) {
+                logger.debug("Cross-site disabled in Infinispan cluster.");
+                healthy = true;
+                return;
+            }
+            if (sites.isEmpty()) {
+                logger.debug("No caches are replicated to the remove sites. Is this a mistake?");
+                healthy = true;
+                return;
+            }
+
+            var siteState = storage.get();
+            statusConsumer.accept(siteState.status());
+            SiteHealthCheckEvent event = null;
+            if (JFR_HEALTH_CHECK.isEnabled()) {
+                // a recording is progress, let's track it.
+                event = new SiteHealthCheckEvent();
+                event.begin();
+            }
+            try {
+                computeState(siteState, sites, connection);
+            } finally {
+                if (event != null) {
+                    event.end();
+                    if (event.shouldCommit()) {
+                        // returns true if the duration is within the configured threshold (if configured)
+                        event.set(sites, connection, siteState);
+                        event.commit();
+                    }
+                }
+            }
+        } finally {
+            inProgress.set(false);
+        }
+    }
+
+    private void computeState(SiteState siteState, Map<String, String> sites, SiteConnection connection) {
+        switch (siteState.status()) {
+            case HEALTHY -> onHealthy(siteState, sites, connection);
+            case RECOVERING -> onRecovering(siteState, sites, connection);
+            case UNHEALTHY -> onUnhealthy(siteState, sites, connection);
+            case SUSPECTING -> onSuspecting(siteState, sites, connection);
+        }
+    }
+
+    private void onSuspecting(SiteState siteState, Map<String, String> sites, SiteConnection connection) {
+        logger.debugf("Checking 'suspecting' state. State=%s, Connection=%s", siteState, connection);
+        healthy = true;
+        if (!Objects.equals(siteState.activeSite(), connection.localSite())) {
+            tryStealSuspect(siteState, connection);
+            return;
+        }
+
+        if (!Objects.equals(siteState, transitionState)) {
+            logger.debugf("Current state does not match our last state, skipping. Last=%s, Current=%s", transitionState, siteState);
+            transitionState = siteState;
+            return;
+        }
+
+        if (connection.onlineSites().containsAll(sites.keySet())) {
+            logger.debugf("All sites are online (in the view). Setting 'healthy' state");
+            if (advanceState(siteState, SiteState.healthy())) {
+                transitionState = null;
+            }
+            return;
+        }
+
+        logger.warnf("Some site(s) is(are) not reachable. Setting 'unhealthy' state");
+        if (advanceState(siteState, SiteState.unhealthy(connection.localSite()))) {
+            // db updated - disconnect all sites
+            takeOffline(sites.keySet());
+            transitionState = null;
+        }
+    }
+
+    private void onUnhealthy(SiteState siteState, Map<String, String> sites, SiteConnection connection) {
+        logger.debugf("Checking 'unhealthy' state. State=%s, Connection=%s", siteState, connection);
+        if (!Objects.equals(connection.localSite(), siteState.activeSite())) {
+            logger.debug("Not the active site; mark unhealthy");
+            healthy = false;
+            transitionState = null;
+            return;
+        }
+        logger.debug("Active site; keep healthy");
+        healthy = true;
+        var allOnline = connection.onlineSites().containsAll(sites.keySet());
+        if (allOnline && sites.values().stream().allMatch("online"::equals)) {
+            logger.debug("All sites are online, setting 'recovering' state");
+            var recovering = SiteState.recovering(connection.localSite());
+            if (advanceState(siteState, recovering)) {
+                transitionState = recovering;
+            }
+            return;
+        }
+
+        logger.debugf("Some site(s) is(are) not reachable. Keeping 'unhealthy' state");
+        if (!allOnline && sites.values().stream().allMatch("offline"::equals)) {
+            takeOffline(sites.keySet());
+        }
+    }
+
+    private void onRecovering(SiteState siteState, Map<String, String> sites, SiteConnection connection) {
+        logger.debugf("Checking 'recovering' state. State=%s, Connection=%s", siteState, connection);
+        if (!Objects.equals(connection.localSite(), siteState.activeSite())) {
+            // only active site can recover
+            // we can get stuck here if it fails, and we don't know what does the other site sees
+            logger.debug("Not the active site; keep unhealthy");
+            healthy = false;
+            return;
+        }
+        logger.debug("Active site; keep healthy");
+        healthy = true;
+        if (!Objects.equals(siteState, transitionState)) {
+            logger.debugf("Current state does not match our last state, skipping. Last=%s, Current=%s", transitionState, siteState);
+            transitionState = siteState;
+            return;
+        }
+        if (connection.onlineSites().containsAll(sites.keySet()) && sites.values().stream().allMatch("online"::equals)) {
+            logger.debug("All sites are online, setting 'healthy' state");
+            if (advanceState(siteState, SiteState.healthy())) {
+                transitionState = null;
+            }
+        } else {
+            // connection is broken or cache state is not online (needs admin to change it)
+            logger.debugf("Some site(s) is(are) not reachable. Setting 'unhealthy' state");
+            if (advanceState(siteState, SiteState.unhealthy(connection.localSite()))) {
+                transitionState = null;
+            }
+        }
+    }
+
+    private void onHealthy(SiteState siteState, Map<String, String> sites, SiteConnection connection) {
+        logger.debugf("Checking 'healthy' state. State=%s, Connection=%s", siteState, connection);
+        healthy = true;
+        if (connection.onlineSites().containsAll(sites.keySet())) {
+            logger.debug("All sites are online, keeping 'healthy' state");
+            return;
+        }
+        logger.debugf("Some site(s) is(are) not reachable. Setting 'suspecting' state");
+        var newState = SiteState.suspecting(connection.localSite());
+        if (advanceState(siteState, newState)) {
+            transitionState = newState;
+        }
+    }
+
+    private void tryStealSuspect(SiteState siteState, SiteConnection connection) {
+        if (!Objects.equals(siteState, transitionState)) {
+            // first round, wait to see if active site makes progress
+            transitionState = siteState;
+            return;
+        }
+        // active site didn't progress (may have crashed), steal the suspect state
+        logger.debug("Stealing 'suspecting' state from other site. No progress has been made yet.");
+        var stolen = SiteState.suspecting(connection.localSite());
+        if (advanceState(siteState, stolen)) {
+            transitionState = stolen;
+        }
+    }
+
+    private void takeOffline(Collection<String> sites) {
+        // do not throw an exception, it will change the health to false
+        try {
+            management.disconnect(sites);
+        } catch (ExecutionException e) {
+            logger.debugf(e, "Failed to take sites offline: %s", sites);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private boolean advanceState(SiteState expectedState, SiteState newState) {
+        // do not throw an exception, it will change the health to false
+        SiteStateChangeEvent event = null;
+        if (JFR_STATE_CHANGE.isEnabled()) {
+            // a recording is progress, let's track it.
+            event = new SiteStateChangeEvent();
+            event.begin();
+        }
+        var success = false;
+        try {
+            success = storage.compareAndSet(expectedState, newState);
+        } catch (Exception e) {
+            logger.debugf(e, "Failed to advance state %s to state %s", expectedState, newState);
+        } finally {
+            if (event != null) {
+                event.end();
+                if (event.shouldCommit()) {
+                    event.set(expectedState, newState, success);
+                    event.commit();
+                }
+            }
+        }
+        return success;
+    }
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthImpl.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteHealthImpl.java
@@ -51,20 +51,23 @@ public class SiteHealthImpl implements ClusterHealth {
     private final SiteStorage storage;
     private final Executor executor;
     private final Consumer<Status> statusConsumer;
+    private final Runnable onBecameHealthy;
     private final AtomicBoolean inProgress = new AtomicBoolean(false);
     private volatile boolean healthy = false;
     private volatile SiteState transitionState;
 
-    public SiteHealthImpl(SiteStorage storage, InfinispanManagement management, Executor executor, Consumer<Status> statusConsumer) {
+    public SiteHealthImpl(SiteStorage storage, InfinispanManagement management, Executor executor, Consumer<Status> statusConsumer, Runnable onBecameHealthy) {
         this.management = Objects.requireNonNull(management);
         this.storage = Objects.requireNonNull(storage);
         this.executor = Objects.requireNonNull(executor);
         this.statusConsumer = Objects.requireNonNullElse(statusConsumer, status -> {
         });
+        this.onBecameHealthy = Objects.requireNonNullElse(onBecameHealthy, () -> {
+        });
     }
 
-    public static SiteHealthImpl create(KeycloakSessionFactory factory, RemoteCacheManager remoteCacheManager, Executor executor, Consumer<Status> statusConsumer) {
-        return new SiteHealthImpl(new JpaSiteStorage(factory), RestInfinispanManagement.fromRemoteCacheManager(remoteCacheManager), executor, statusConsumer);
+    public static SiteHealthImpl create(KeycloakSessionFactory factory, RemoteCacheManager remoteCacheManager, Executor executor, Consumer<Status> statusConsumer, Runnable onBecameHealthy) {
+        return new SiteHealthImpl(new JpaSiteStorage(factory), RestInfinispanManagement.fromRemoteCacheManager(remoteCacheManager), executor, statusConsumer, onBecameHealthy);
     }
 
     @Override
@@ -247,7 +250,10 @@ public class SiteHealthImpl implements ClusterHealth {
 
     private void onHealthy(SiteState siteState, Map<String, String> sites, SiteConnection connection) {
         logger.debugf("Checking 'healthy' state. State=%s, Connection=%s", siteState, connection);
-        healthy = true;
+        if (!healthy) {
+            healthy = true;
+            onBecameHealthy.run();
+        }
         if (connection.onlineSites().containsAll(sites.keySet())) {
             logger.debug("All sites are online, keeping 'healthy' state");
             return;

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteState.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteState.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Immutable snapshot of the cross-site state stored in the database, consisting of the current {@link Status}, the
+ * site that owns the ongoing state transition ({@code activeSite}), and a random {@code revision} used for
+ * compare-and-set identity.
+ */
+public record SiteState(Status status, String activeSite, UUID revision) {
+
+    private static final SiteState HEALTHY = new SiteState(Status.HEALTHY, null, null);
+
+    public SiteState {
+        Objects.requireNonNull(status);
+    }
+
+    // Helpers
+    public static SiteState healthy() {
+        return HEALTHY;
+    }
+
+    public static SiteState suspecting(String activeSite) {
+        return new  SiteState(Status.SUSPECTING, activeSite, UUID.randomUUID());
+    }
+
+    public static SiteState recovering(String activeSite) {
+        return new  SiteState(Status.RECOVERING, activeSite, UUID.randomUUID());
+    }
+
+    public static SiteState unhealthy(String activeSite) {
+        return new  SiteState(Status.UNHEALTHY, activeSite, null);
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteStateChangeEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteStateChangeEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+
+/**
+ * JFR event emitted when a cross-site state transition is attempted via {@link SiteStorage#compareAndSet}.
+ */
+@Name("org.keycloak.SiteStateChange")
+@Label("Site State Change")
+@Description("Cross-site state transition attempt")
+@Category({"Keycloak", "Health"})
+public class SiteStateChangeEvent extends Event {
+
+    @Label("Expected Status")
+    @Description("The status expected in the database before the transition")
+    public String expectedStatus;
+
+    @Label("New Status")
+    @Description("The target status of the transition")
+    public String newStatus;
+
+    @Label("Expected Active Site")
+    @Description("The active site in the expected state")
+    public String expectedActiveSite;
+
+    @Label("New Active Site")
+    @Description("The active site in the new state")
+    public String newActiveSite;
+
+    @Label("Success")
+    @Description("Whether the compare-and-set succeeded")
+    public boolean success;
+
+    public void set(SiteState expectedState, SiteState newState, boolean success) {
+        this.expectedStatus = expectedState.status().name();
+        this.newStatus = newState.status().name();
+        this.expectedActiveSite = expectedState.activeSite();
+        this.newActiveSite = newState.activeSite();
+        this.success = success;
+    }
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteStorage.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/SiteStorage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+/**
+ * Persistent storage for the cross-site state, backed by a single database row used as a consensus mechanism between
+ * sites.
+ * <p>
+ * Implementations must provide atomic compare-and-set semantics so that only one site can transition the state at a
+ * time.
+ */
+public interface SiteStorage {
+
+    /**
+     * @return The current {@link SiteState} from the persistent store.
+     */
+    SiteState get();
+
+    /**
+     * Atomically updates the site state if the current value matches the expected state.
+     *
+     * @param expectedState The state expected to be in the store.
+     * @param newState      The new state to write.
+     * @return {@code true} if the update succeeded, {@code false} if the current state no longer matches
+     * {@code expectedState}.
+     */
+    boolean compareAndSet(SiteState expectedState, SiteState newState);
+
+}

--- a/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/Status.java
+++ b/model/infinispan/src/main/java/org/keycloak/infinispan/health/site/Status.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+/**
+ * The cross-site state machine statuses.
+ * <p>
+ * The normal lifecycle is: {@code HEALTHY → SUSPECTING → UNHEALTHY → RECOVERING → HEALTHY}.
+ */
+public enum Status {
+    /**
+     * All sites are reachable and replication is functioning normally.
+     */
+    HEALTHY(0),
+    /**
+     * A site has detected that one or more remote sites are unreachable. A one-round delay is applied before
+     * transitioning to {@link #UNHEALTHY} to avoid reacting to transient failures.
+     */
+    SUSPECTING(1),
+    /**
+     * Sites have come back online after a failure. The active site verifies connectivity before transitioning back
+     * to {@link #HEALTHY}.
+     */
+    RECOVERING(3),
+    /**
+     * One or more remote sites are confirmed unreachable. The active site has disconnected replication and is
+     * serving traffic alone.
+     */
+    UNHEALTHY(2);
+
+    private final int value;
+
+    Status(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/model/infinispan/src/test/java/org/keycloak/infinispan/health/site/SiteHealthImplTest.java
+++ b/model/infinispan/src/test/java/org/keycloak/infinispan/health/site/SiteHealthImplTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +44,11 @@ public class SiteHealthImplTest {
     }
 
     private SiteHealthImpl createSite(StubInfinispanManagement management) {
-        return new SiteHealthImpl(storage, management, Runnable::run, s -> {});
+        return createSite(management, null);
+    }
+
+    private SiteHealthImpl createSite(StubInfinispanManagement management, Runnable onBecameHealthy) {
+        return new SiteHealthImpl(storage, management, Runnable::run, s -> {}, onBecameHealthy);
     }
 
     // --- Initial state ---
@@ -668,6 +673,59 @@ public class SiteHealthImplTest {
         siteB.triggerClusterHealthCheck();
         assertFalse(siteB.isHealthy());
         assertTrue(siteA.isHealthy());
+    }
+
+    // --- onBecameHealthy callback tests ---
+
+    @Test
+    public void testOnBecameHealthyInvokedWhenHealthySwitchesFromFalseToTrue() {
+        var counter = new AtomicInteger(0);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management, counter::incrementAndGet);
+
+        assertFalse(site.isHealthy());
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testOnBecameHealthyNotInvokedWhenAlreadyHealthy() {
+        var counter = new AtomicInteger(0);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management, counter::incrementAndGet);
+
+        site.triggerClusterHealthCheck();
+        assertEquals(1, counter.get());
+
+        // second check: already healthy, should not invoke again
+        site.triggerClusterHealthCheck();
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    public void testOnBecameHealthyInvokedAgainAfterHealthyBecomeFalse() {
+        var counter = new AtomicInteger(0);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management, counter::incrementAndGet);
+
+        // become healthy
+        site.triggerClusterHealthCheck();
+        assertTrue(site.isHealthy());
+        assertEquals(1, counter.get());
+
+        // site goes down, trigger failure
+        management.throwOnSiteStatus = true;
+        site.triggerClusterHealthCheck();
+        assertFalse(site.isHealthy());
+
+        // site comes back, healthy again
+        management.throwOnSiteStatus = false;
+        site.triggerClusterHealthCheck();
+        assertTrue(site.isHealthy());
+        assertEquals(2, counter.get());
     }
 
     // --- Stubs ---

--- a/model/infinispan/src/test/java/org/keycloak/infinispan/health/site/SiteHealthImplTest.java
+++ b/model/infinispan/src/test/java/org/keycloak/infinispan/health/site/SiteHealthImplTest.java
@@ -1,0 +1,737 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.infinispan.health.site;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SiteHealthImplTest {
+
+    private static final String SITE_A = "site-a";
+    private static final String SITE_B = "site-b";
+
+    private StubSiteStorage storage;
+
+    @Before
+    public void setUp() {
+        storage = new StubSiteStorage();
+    }
+
+    private SiteHealthImpl createSite(StubInfinispanManagement management) {
+        return new SiteHealthImpl(storage, management, Runnable::run, s -> {});
+    }
+
+    // --- Initial state ---
+
+    @Test
+    public void testInitialStateIsDown() {
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        assertFalse(site.isHealthy());
+    }
+
+    // --- HEALTHY state tests ---
+
+    @Test
+    public void testHealthyAllSitesReachableStaysHealthy() {
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+        assertEquals(Status.HEALTHY, storage.state.status());
+    }
+
+    @Test
+    public void testHealthyRemoteSiteUnreachableTransitionsToSuspecting() {
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+    }
+
+    @Test
+    public void testHealthyCasFailureStaysHealthy() {
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        storage.casFailure = true;
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+        assertEquals(Status.HEALTHY, storage.state.status());
+    }
+
+    // --- SUSPECTING state tests (non-active site) ---
+
+    @Test
+    public void testSuspectingNonActiveSiteFirstRoundWaitsForActiveSite() {
+        storage.state = SiteState.suspecting(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_B, storage.state.activeSite());
+    }
+
+    @Test
+    public void testSuspectingNonActiveSiteActiveSiteProgressedNoSteal() {
+        storage.state = SiteState.suspecting(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+        assertEquals(SITE_B, storage.state.activeSite());
+
+        // active site (SITE_B) progressed to UNHEALTHY between rounds
+        storage.state = SiteState.unhealthy(SITE_B);
+
+        // round 2: state changed, goes to onUnhealthy, not stealing
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertEquals(SITE_B, storage.state.activeSite());
+        assertFalse(site.isHealthy());
+    }
+
+    @Test
+    public void testSuspectingNonActiveSiteActiveSiteCrashedSteals() {
+        storage.state = SiteState.suspecting(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+        assertEquals(SITE_B, storage.state.activeSite());
+
+        // round 2: state unchanged (active site crashed), steal
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+    }
+
+    @Test
+    public void testSuspectingNonActiveSiteStealsAndProceeds() {
+        storage.state = SiteState.suspecting(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+
+        // round 2: steal
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+
+        // round 3: now active site, transitionState matches, proceeds to UNHEALTHY
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+        assertTrue(management.disconnectedSites.contains(SITE_B));
+    }
+
+    @Test
+    public void testSuspectingNonActiveSiteStealCasFailsNoChange() {
+        storage.state = SiteState.suspecting(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+
+        // round 2: steal attempt but CAS fails
+        storage.casFailure = true;
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_B, storage.state.activeSite());
+    }
+
+    // --- SUSPECTING state tests (active site) ---
+
+    @Test
+    public void testSuspectingActiveSiteFirstRoundWaitsForNextRound() {
+        storage.state = SiteState.suspecting(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertTrue(site.isHealthy());
+    }
+
+    @Test
+    public void testSuspectingActiveSiteSecondRoundSitesRecoveredBackToHealthy() {
+        storage.state = SiteState.suspecting(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+
+        // round 2: sites are now reachable
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A, SITE_B));
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.HEALTHY, storage.state.status());
+        assertTrue(site.isHealthy());
+    }
+
+    @Test
+    public void testSuspectingActiveSiteSecondRoundStillUnreachableTransitionsToUnhealthy() {
+        storage.state = SiteState.suspecting(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+
+        // round 2: still unreachable
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+        assertTrue(management.disconnectedSites.contains(SITE_B));
+    }
+
+    @Test
+    public void testSuspectingActiveSiteCasToUnhealthyFailsNoDisconnect() {
+        storage.state = SiteState.suspecting(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1
+        site.triggerClusterHealthCheck();
+
+        // round 2 with CAS failure
+        storage.casFailure = true;
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertTrue(management.disconnectedSites.isEmpty());
+    }
+
+    // --- UNHEALTHY state tests ---
+
+    @Test
+    public void testUnhealthyNonActiveSiteMarkedDown() {
+        storage.state = SiteState.unhealthy(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertFalse(site.isHealthy());
+    }
+
+    @Test
+    public void testUnhealthyActiveSiteSitesStillUnreachableStaysUnhealthy() {
+        storage.state = SiteState.unhealthy(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        management.siteStatuses = Map.of(SITE_B, "offline");
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertTrue(site.isHealthy());
+    }
+
+    @Test
+    public void testUnhealthyActiveSiteSitesReachableButMixedStaysUnhealthy() {
+        storage.state = SiteState.unhealthy(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.siteStatuses = Map.of(SITE_B, "mixed");
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+    }
+
+    @Test
+    public void testUnhealthyActiveSiteSitesReachableAndOnlineTransitionsToRecovery() {
+        storage.state = SiteState.unhealthy(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.RECOVERING, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+    }
+
+    @Test
+    public void testUnhealthyActiveSiteCasToRecoveryFailsStaysUnhealthy() {
+        storage.state = SiteState.unhealthy(SITE_A);
+        storage.casFailure = true;
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+    }
+
+    // --- RECOVERY state tests ---
+
+    @Test
+    public void testRecoveryNonActiveSiteMarkedDown() {
+        storage.state = SiteState.recovering(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertFalse(site.isHealthy());
+    }
+
+    @Test
+    public void testRecoveryActiveSiteFirstRoundWaitsForNextRound() {
+        storage.state = SiteState.recovering(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.RECOVERING, storage.state.status());
+    }
+
+    @Test
+    public void testRecoveryActiveSiteSecondRoundAllOnlineTransitionsToHealthy() {
+        storage.state = SiteState.recovering(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        // round 1
+        site.triggerClusterHealthCheck();
+        // round 2
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.HEALTHY, storage.state.status());
+    }
+
+    @Test
+    public void testRecoveryActiveSiteSecondRoundConnectionBrokenFallsBackToUnhealthy() {
+        storage.state = SiteState.recovering(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        // round 1
+        site.triggerClusterHealthCheck();
+
+        // round 2: site became unreachable again
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+    }
+
+    @Test
+    public void testRecoveryActiveSiteSecondRoundCachesNotOnlineFallsBackToUnhealthy() {
+        storage.state = SiteState.recovering(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        // round 1
+        site.triggerClusterHealthCheck();
+
+        // round 2: caches went to mixed
+        management.siteStatuses = Map.of(SITE_B, "mixed");
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+    }
+
+    @Test
+    public void testRecoveryCasToHealthyFailsStaysInRecovery() {
+        storage.state = SiteState.recovering(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        // round 1
+        site.triggerClusterHealthCheck();
+
+        // round 2 with CAS failure
+        storage.casFailure = true;
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.RECOVERING, storage.state.status());
+    }
+
+    @Test
+    public void testRecoveryCasToUnhealthyFailsStaysInRecovery() {
+        storage.state = SiteState.recovering(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        // round 1
+        site.triggerClusterHealthCheck();
+
+        // round 2: connection broken but CAS fails
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        storage.casFailure = true;
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.RECOVERING, storage.state.status());
+    }
+
+    // --- Cross-site disabled / no replication ---
+
+    @Test
+    public void testCrossSiteDisabledAlwaysHealthy() {
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(null, Set.of());
+        management.siteStatuses = Map.of();
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+    }
+
+    @Test
+    public void testNoCachesReplicatingAlwaysHealthy() {
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        management.siteStatuses = Map.of();
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertTrue(site.isHealthy());
+    }
+
+    // --- Exception handling ---
+
+    @Test
+    public void testInfinispanConnectionFailureMarkedDown() {
+        var management = new StubInfinispanManagement(SITE_A);
+        management.throwOnSiteStatus = true;
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertFalse(site.isHealthy());
+    }
+
+    // --- Full lifecycle tests ---
+
+    @Test
+    public void testFullLifecycleHealthySuspectUnhealthyRecoveryHealthy() {
+        var management = new StubInfinispanManagement(SITE_A);
+        var site = createSite(management);
+
+        // start healthy, all reachable
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.HEALTHY, storage.state.status());
+        assertTrue(site.isHealthy());
+
+        // site B goes down
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertTrue(site.isHealthy());
+
+        // still down after one round
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertTrue(site.isHealthy());
+        assertFalse(management.disconnectedSites.isEmpty());
+
+        // site B comes back, caches online
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A, SITE_B));
+        management.siteStatuses = Map.of(SITE_B, "online");
+
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.RECOVERING, storage.state.status());
+
+        // second round of recovery
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.HEALTHY, storage.state.status());
+        assertTrue(site.isHealthy());
+    }
+
+    @Test
+    public void testFullLifecycleSuspectingRecoversQuickly() {
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: HEALTHY → SUSPECTING
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+
+        // site recovers before second check
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A, SITE_B));
+
+        // round 2: SUSPECTING → HEALTHY (quick recovery, no disconnect)
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.HEALTHY, storage.state.status());
+        assertTrue(management.disconnectedSites.isEmpty());
+    }
+
+    @Test
+    public void testNonActiveSiteFullLifecycle() {
+        // SITE_B won the CAS to SUSPECTING
+        storage.state = SiteState.suspecting(SITE_B);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: non-active site waits
+        site.triggerClusterHealthCheck();
+        assertTrue(site.isHealthy());
+
+        // SITE_B transitions to UNHEALTHY before SITE_A can steal
+        storage.state = SiteState.unhealthy(SITE_B);
+
+        site.triggerClusterHealthCheck();
+        assertFalse(site.isHealthy());
+
+        // SITE_B starts recovery
+        storage.state = SiteState.recovering(SITE_B);
+
+        site.triggerClusterHealthCheck();
+        assertFalse(site.isHealthy());
+
+        // SITE_B completes recovery
+        storage.state = SiteState.healthy();
+
+        site.triggerClusterHealthCheck();
+        assertTrue(site.isHealthy());
+    }
+
+    @Test
+    public void testMultipleSiteStatusesPartialOffline() {
+        storage.state = SiteState.unhealthy(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.siteStatuses = Map.of(SITE_B, "online", "site-c", "offline");
+        var site = createSite(management);
+
+        site.triggerClusterHealthCheck();
+
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+    }
+
+    @Test
+    public void testSuspectingDbStateChangedExternallyWaitsAnotherRound() {
+        storage.state = SiteState.suspecting(SITE_A);
+        var management = new StubInfinispanManagement(SITE_A);
+        management.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var site = createSite(management);
+
+        // round 1: records transitionState
+        site.triggerClusterHealthCheck();
+
+        // external update: someone else changed the DB state (new revision)
+        storage.state = SiteState.suspecting(SITE_A);
+
+        // round 2: siteState != transitionState (different revision), waits again
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+
+        // round 3: now transitionState matches, will proceed
+        site.triggerClusterHealthCheck();
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+    }
+
+    // --- Two-site tests ---
+
+    @Test
+    public void testTwoSitesBothDetectFailureOnlyOneWinsSuspecting() {
+        var mgmtA = new StubInfinispanManagement(SITE_A);
+        mgmtA.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var siteA = createSite(mgmtA);
+
+        var mgmtB = new StubInfinispanManagement(SITE_B);
+        mgmtB.connection = new SiteConnection(SITE_B, Set.of(SITE_B));
+        var siteB = createSite(mgmtB);
+
+        // SITE_A detects failure first and wins CAS
+        siteA.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+
+        // SITE_B tries but CAS fails (expected HEALTHY, actual SUSPECTING)
+        siteB.triggerClusterHealthCheck();
+        // SITE_B sees SUSPECTING(activeSite=A), enters non-active path, waits
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_A, storage.state.activeSite());
+        assertTrue(siteA.isHealthy());
+        assertTrue(siteB.isHealthy());
+    }
+
+    @Test
+    public void testTwoSitesActiveSiteCrashesLoserStealsAndTakesOver() {
+        var mgmtA = new StubInfinispanManagement(SITE_A);
+        mgmtA.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var siteA = createSite(mgmtA);
+
+        var mgmtB = new StubInfinispanManagement(SITE_B);
+        mgmtB.connection = new SiteConnection(SITE_B, Set.of(SITE_B));
+        var siteB = createSite(mgmtB);
+
+        // SITE_A detects failure first
+        siteA.triggerClusterHealthCheck();
+        assertEquals(SITE_A, storage.state.activeSite());
+
+        // SITE_B sees SUSPECTING(A), round 1: waits
+        siteB.triggerClusterHealthCheck();
+
+        // SITE_A crashes (no more checks from A)
+
+        // SITE_B round 2: state unchanged, steals
+        siteB.triggerClusterHealthCheck();
+        assertEquals(Status.SUSPECTING, storage.state.status());
+        assertEquals(SITE_B, storage.state.activeSite());
+
+        // SITE_B round 3: now active, proceeds to UNHEALTHY
+        siteB.triggerClusterHealthCheck();
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+        assertEquals(SITE_B, storage.state.activeSite());
+        assertFalse(mgmtB.disconnectedSites.isEmpty());
+    }
+
+    @Test
+    public void testTwoSitesActiveSiteProgressesLoserDoesNotSteal() {
+        var mgmtA = new StubInfinispanManagement(SITE_A);
+        mgmtA.connection = new SiteConnection(SITE_A, Set.of(SITE_A));
+        var siteA = createSite(mgmtA);
+
+        var mgmtB = new StubInfinispanManagement(SITE_B);
+        mgmtB.connection = new SiteConnection(SITE_B, Set.of(SITE_B));
+        var siteB = createSite(mgmtB);
+
+        // SITE_A detects and wins CAS to SUSPECTING
+        siteA.triggerClusterHealthCheck();
+
+        // SITE_B round 1: waits
+        siteB.triggerClusterHealthCheck();
+        assertEquals(SITE_A, storage.state.activeSite());
+
+        // SITE_A progresses to UNHEALTHY
+        siteA.triggerClusterHealthCheck();
+        assertEquals(Status.UNHEALTHY, storage.state.status());
+
+        // SITE_B round 2: state changed (now UNHEALTHY), no steal, goes down
+        siteB.triggerClusterHealthCheck();
+        assertFalse(siteB.isHealthy());
+        assertTrue(siteA.isHealthy());
+    }
+
+    // --- Stubs ---
+
+    private static class StubInfinispanManagement implements InfinispanManagement {
+        SiteConnection connection;
+        Map<String, String> siteStatuses;
+        List<String> disconnectedSites = new ArrayList<>();
+        boolean throwOnSiteStatus = false;
+
+        StubInfinispanManagement(String localSite) {
+            var remoteSite = SITE_A.equals(localSite) ? SITE_B : SITE_A;
+            connection = new SiteConnection(localSite, Set.of(SITE_A, SITE_B));
+            siteStatuses = Map.of(remoteSite, "online");
+        }
+
+        @Override
+        public Map<String, String> siteStatus() throws ExecutionException {
+            if (throwOnSiteStatus) {
+                throw new ExecutionException("simulated failure", new RuntimeException());
+            }
+            return siteStatuses;
+        }
+
+        @Override
+        public SiteConnection siteConnection() {
+            return connection;
+        }
+
+        @Override
+        public void disconnect(Collection<String> remoteSites) {
+            disconnectedSites.addAll(remoteSites);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    private static class StubSiteStorage implements SiteStorage {
+        SiteState state = SiteState.healthy();
+        boolean casFailure = false;
+
+        @Override
+        public SiteState get() {
+            return state;
+        }
+
+        @Override
+        public boolean compareAndSet(SiteState expectedState, SiteState newState) {
+            if (casFailure) {
+                return false;
+            }
+            if (state.equals(expectedState)) {
+                state = newState;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    private static class ExecutionException extends java.util.concurrent.ExecutionException {
+        ExecutionException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -729,6 +729,10 @@
             <artifactId>infinispan-cachestore-remote</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-rest</artifactId>
+        </dependency>
+        <dependency>
             <!-- adding to avoid warning during compilation about "unknown enum constant org.infinispan.jmx.annotations.DataType.TRAIT" and others -->
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-component-annotations</artifactId>

--- a/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/ExternalInfinispanTest.java
+++ b/quarkus/tests/integration/src/test/java/org/keycloak/it/storage/database/ExternalInfinispanTest.java
@@ -17,11 +17,8 @@
 
 package org.keycloak.it.storage.database;
 
-import org.keycloak.common.util.Retry;
-import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.it.junit5.extension.CLIResult;
 import org.keycloak.it.junit5.extension.DistributionTest;
-import org.keycloak.it.junit5.extension.InfinispanContainer;
 import org.keycloak.it.junit5.extension.StopServer.Mode;
 import org.keycloak.it.junit5.extension.WithExternalInfinispan;
 
@@ -29,60 +26,10 @@ import io.quarkus.test.junit.main.Launch;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static io.restassured.RestAssured.when;
-
 @DistributionTest(stopServer = Mode.MANUAL)
 @WithExternalInfinispan
 @Tag(DistributionTest.STORAGE)
 public class ExternalInfinispanTest {
-
-    @Test
-    @Launch({
-            "start-dev",
-            "--features=multi-site",
-            "--cache=ispn",
-            "--cache-remote-host=127.0.0.1",
-            "--cache-remote-username=keycloak",
-            "--cache-remote-password=Password1!",
-            "--cache-remote-tls-enabled=false",
-            "--spi-cache-embedded-default-site-name=ISPN",
-            "--spi-load-balancer-check-remote-poll-interval=500",
-            "--verbose"
-    })
-    void testLoadBalancerCheckFailureWithMultiSite() {
-        runLoadBalancerCheckFailureTest();
-    }
-
-    @Test
-    @Launch({
-            "start-dev",
-            "--features=multi-site,clusterless",
-            "--cache=ispn",
-            "--cache-remote-host=127.0.0.1",
-            "--cache-remote-username=keycloak",
-            "--cache-remote-password=Password1!",
-            "--cache-remote-tls-enabled=false",
-            "--spi-cache-embedded-default-site-name=ISPN",
-            "--spi-load-balancer-check-remote-poll-interval=500",
-            "--verbose"
-    })
-    void testLoadBalancerCheckFailureWithRemoteOnlyCaches() {
-        runLoadBalancerCheckFailureTest();
-    }
-
-    private void runLoadBalancerCheckFailureTest() {
-        when().get("/lb-check").then()
-                .statusCode(200);
-
-        InfinispanContainer.removeCache(InfinispanConnectionProvider.WORK_CACHE_NAME);
-
-        // The `lb-check` relies on the Infinispan's persistence check status. By default, Infinispan checks in the background every second that the remote store is available.
-        // So we'll wait on average about one second here for the check to switch its state.
-        Retry.execute(() -> {
-            when().get("/lb-check").then()
-                    .statusCode(503);
-        }, 10, 200);
-    }
 
     @Test
     @Launch({


### PR DESCRIPTION
Closes #49923

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This code has been a "PoC" for quite some months already, and I finally cleaned it up a bit. 
I need to review the AI-generated changes before making it ready.

- [x] Javadoc
- [x] Documentation
- [x] Unit Test

I need to test it locally too to make sure I didn't break anything since the cleanup and code refactoring. 

# What's new? 
`ClusterHealth` has been split into multiple implementations

**EmbeddedCacheHealthImpl**: enabled in all modes (previously only runs with multi-site). It checks if all local caches can handle requests.
**RemoteCacheHealthImpl**: enabled in clusterless and multi-site (previously only with multi-site). It checks connectivity with the external Infinispan cluster. 
**JdbcPingClusterHealthImpl**: enabled in embedded. No changes, and it checks for split-brain scenarios. 
**SiteHealthImpl**: the core of this change, enabled only with multi-site

# Notes

* Undocumented SPI options as a safeguard that allows users to disable any of these implementations, in case of problems
* `SiteHealthImpl` includes JFR events to help debug reported issues. Those are recorded by default.
* `SiteHealthImpl` includes metrics so users can do their own alerts.
* The `/lb-check` endpoint only includes `SiteHealthImpl` logic.
* The `RemoteCacheHealthImpl` logic was moved from `/lb-check` to the instance readiness probe (it makes more sense as the DB connection checks are only in the readiness probe too)