### PR TITLE
Change proto.lock URLs in model/infinispan/pom.xml to use tag references instead of branch references to prevent 404 err

### DIFF
--- a/model/infinispan/pom.xml
+++ b/model/infinispan/pom.xml
@@ -122,7 +122,7 @@
                     </execution>
                 </executions>
                 <configuration combine.self="append">
-                    <remoteLockFiles>https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.1/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.2/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/archive/release/26.3/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/heads/release/26.4/model/infinispan/proto.lock</remoteLockFiles>
+                    <remoteLockFiles>https://raw.githubusercontent.com/keycloak/keycloak/refs/tags/26.0.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/tags/26.1.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/tags/26.2.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/tags/26.3.0/model/infinispan/proto.lock,https://raw.githubusercontent.com/keycloak/keycloak/refs/tags/26.4.0/model/infinispan/proto.lock</remoteLockFiles>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Fixes #49928.

Change proto.lock URLs in model/infinispan/pom.xml to use tag references instead of branch references to prevent 404 errors when branches are renamed. The proto-schema-compatibility-maven-plugin fetches proto.lock files from GitHub using branch references (e.g., refs/heads/release/26.2). When maintainers rename branches to archive/release/X.Y, these URLs return 404, breaking builds of old releases. Using immutable tag references (e.g., refs/tags/26.2.0) ensures the files remain accessible indefinitely.

I ran the available static check for this change, but not the full project test suite locally.