### PR TITLE
oidc: honor provided AuthorizationRequestContext in isValidScope overload

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -781,7 +781,7 @@ public class TokenManager {
      * @return
      */
     public static boolean isValidScope(KeycloakSession session, String scopes, AuthorizationRequestContext authorizationRequestContext, ClientModel client) {
-        return isValidScope(session, scopes, client, null);
+        return isValidScope(session, scopes, authorizationRequestContext, client, null);
     }
 
     public static boolean isValidScope(KeycloakSession session, String scopes, AuthorizationRequestContext authorizationRequestContext, ClientModel client, UserModel user) {

--- a/services/src/test/java/org/keycloak/protocol/oidc/TokenManagerTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/TokenManagerTest.java
@@ -1,0 +1,62 @@
+package org.keycloak.protocol.oidc;
+
+import java.util.List;
+
+import org.keycloak.common.Profile;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.common.profile.CommaSeparatedListProfileConfigResolver;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.rar.AuthorizationRequestContext;
+import org.keycloak.services.resteasy.ResteasyKeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class TokenManagerTest {
+
+    private static ResteasyKeycloakSessionFactory sessionFactory;
+    private static KeycloakSession session;
+
+    @BeforeAll
+    public static void beforeAll() {
+        Profile.configure();
+        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
+        sessionFactory = new ResteasyKeycloakSessionFactory();
+        sessionFactory.init();
+        session = new ResteasyKeycloakSession(sessionFactory);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (session != null) {
+            session.close();
+        }
+        if (sessionFactory != null) {
+            sessionFactory.close();
+        }
+    }
+
+    @AfterEach
+    public void resetProfile() {
+        Profile.reset();
+    }
+
+    @Test
+    public void shouldUseProvidedAuthorizationRequestContextWhenParameterizedScopesEnabled() {
+        Profile.configure(new CommaSeparatedListProfileConfigResolver(Profile.Feature.PARAMETERIZED_SCOPES.getVersionedKey(), ""));
+
+        AuthorizationRequestContext authorizationRequestContext = new AuthorizationRequestContext(List.of());
+
+        // If the provided authorizationRequestContext is honored, validation fails because it contains no scopes.
+        // Before the fix, this overload ignored the provided context and attempted to rebuild one from session/client.
+        boolean valid = TokenManager.isValidScope(session, "foo", authorizationRequestContext, null);
+
+        assertFalse(valid);
+    }
+}


### PR DESCRIPTION
## Summary

Fix `TokenManager.isValidScope(KeycloakSession, String, AuthorizationRequestContext, ClientModel)` to forward the provided `AuthorizationRequestContext` to the 5-argument variant instead of discarding it.

## Root Cause

The 4-argument overload introduced during the #49388 refactor delegates to the wrong overload:

```java
// Before fix — authorizationRequestContext is silently dropped
public static boolean isValidScope(KeycloakSession session, String scopes,
        AuthorizationRequestContext authorizationRequestContext, ClientModel client) {
    return isValidScope(session, scopes, client, null); // ← wrong overload
}
```

```java
// After fix — context is forwarded correctly
return isValidScope(session, scopes, authorizationRequestContext, client, null);
```

This was observed as part of investigation into token exchange returning `invalid_scope` when requesting an optional scope registered on the exchange client but not on the subject client. The overload bug was found while auditing the #49388 refactor area.

Full investigation and analysis: keycloak/keycloak#49952

## Changes

- `services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java` — one-line delegation fix
- `services/src/test/java/org/keycloak/protocol/oidc/TokenManagerTest.java` — new regression test

## Test

Added `TokenManagerTest#shouldUseProvidedAuthorizationRequestContextWhenParameterizedScopesEnabled`:
- enables `PARAMETERIZED_SCOPES`
- passes an explicit empty `AuthorizationRequestContext`
- asserts validation correctly returns `false` (context honored, not recomputed)

## Validation

```
mvn -f services/pom.xml -Dtest=TokenManagerTest test  →  PASS
mvn -f tests/base/pom.xml -Dtest=StandardBaseTokenExchangeWithParameterizedScopesTest#testScopeNotAllowed test  →  PASS
```

Closes #49952