### PR TITLE
[OID4VCI] Make sure single issued-credential persisted during user VC…

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -882,8 +882,8 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     @Override
-    public void addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc) {
-        getDelegate().addIssuedVerifiableCredential(issuedVc);
+    public IssuedVerifiableCredentialModel addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc) {
+        return getDelegate().addIssuedVerifiableCredential(issuedVc);
     }
 
     @Override

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -1124,7 +1124,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     }
 
     @Override
-    public void addIssuedVerifiableCredential(IssuedVerifiableCredentialModel model) {
+    public IssuedVerifiableCredentialModel addIssuedVerifiableCredential(IssuedVerifiableCredentialModel model) {
 
         String revision;
         if (model.getRevision() != null) {
@@ -1140,7 +1140,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
 
         IssuedVerifiableCredentialEntity issuedVerifiableCredentialEntity = new IssuedVerifiableCredentialEntity();
 
-        issuedVerifiableCredentialEntity.setId(KeycloakModelUtils.generateId());
+        issuedVerifiableCredentialEntity.setId(SecretGenerator.getInstance().generateSecureID());
         issuedVerifiableCredentialEntity.setUser(em.getReference(UserEntity.class, model.getUserId()));
         issuedVerifiableCredentialEntity.setCredentialType(model.getCredentialType());
         issuedVerifiableCredentialEntity.setClientId(model.getClientId());
@@ -1153,6 +1153,8 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
 
         em.persist(issuedVerifiableCredentialEntity);
         em.flush();
+
+        return toIssuedVcModel(issuedVerifiableCredentialEntity);
     }
 
     @Override

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -969,9 +969,9 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     }
 
     @Override
-    public void addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc) {
+    public IssuedVerifiableCredentialModel addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc) {
         if (StorageId.isLocalStorage(issuedVc.getUserId())) {
-            localStorage().addIssuedVerifiableCredential(issuedVc);
+            return localStorage().addIssuedVerifiableCredential(issuedVc);
         } else {
             throw new UnsupportedOperationException("Issued verifiable credential operations not yet supported on federated users");
         }

--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
@@ -93,6 +93,17 @@ public interface AuthorizationDetailsProcessor<ADR extends AuthorizationDetailsJ
                                           AuthorizationDetailsJSONRepresentation storedAuthDetailsMember) throws InvalidAuthorizationDetailsException;
 
     /**
+     * Hook method called after authorization_details are processed and before the token response is created.
+     * This allows authorization details processors to perform post-processing actions (e.g., creating state objects).
+     *
+     * @param userSession      the user session
+     * @param clientSessionCtx the client session context
+     * @param authorizationDetailsResponse The response object of the proper type, which is supposed to be processed by this processor.
+     */
+    void afterAuthorizationDetailsProcessed(UserSessionModel userSession, ClientSessionContext clientSessionCtx,
+                                            ADR authorizationDetailsResponse);
+
+    /**
      * @param authzDetailsResponse all the authorizationDetails. May contain also authorizationDetails entries, with different "type" than the type understandable by this processor
      * @return sublist of the list provided by "authDetailsResponse" parameter, which will contain just the authorizationDetails of the corresponding type of this processor.
      */

--- a/server-spi/src/main/java/org/keycloak/models/UserProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserProvider.java
@@ -344,9 +344,9 @@ public interface UserProvider extends Provider,
      * Record that a verifiable credential was issued to a user.
      *
      * @param issuedVc model with userId, clientId, credentialType set
-     *
+     * @return issuedVerifiableCredentialModel with all the fields set (including ID)
      */
-    void addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc);
+    IssuedVerifiableCredentialModel addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc);
 
     /**
      * Get all issued verifiable credentials for a specific user.

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsParser.java
@@ -14,6 +14,7 @@ import static org.keycloak.protocol.oid4vc.model.ClaimsDescription.MANDATORY;
 import static org.keycloak.protocol.oid4vc.model.ClaimsDescription.PATH;
 import static org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail.CLAIMS;
 import static org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail.CREDENTIALS_OFFER_ID;
+import static org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail.ISSUED_CREDENTIAL_ID;
 
 public class OID4VCAuthorizationDetailsParser implements AuthorizationDetailsParser {
 
@@ -38,6 +39,7 @@ public class OID4VCAuthorizationDetailsParser implements AuthorizationDetailsPar
         outDetail.setCredentialConfigurationId((String) inDetail.getCustomData().get(CREDENTIAL_CONFIGURATION_ID));
         outDetail.setCredentialIdentifiers((List<String>) inDetail.getCustomData().get(CREDENTIAL_IDENTIFIERS));
         outDetail.setCredentialsOfferId((String) inDetail.getCustomData().get(CREDENTIALS_OFFER_ID));
+        outDetail.setIssuedCredentialId((String) inDetail.getCustomData().get(ISSUED_CREDENTIAL_ID));
         outDetail.setClaims(parseClaims((List<Map>) inDetail.getCustomData().get(CLAIMS)));
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -24,8 +24,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.keycloak.common.Profile;
+import org.keycloak.common.util.Time;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.Constants;
+import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
@@ -52,6 +58,7 @@ import static org.keycloak.OAuth2Constants.ISSUER_STATE;
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONFIGURATION_ID;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIALS_OFFER_ID_ATTR;
+import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
 import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByConfigurationId;
 import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByName;
 import static org.keycloak.protocol.oidc.endpoints.AuthorizationEndpoint.LOGIN_SESSION_NOTE_ADDITIONAL_REQ_PARAMS_PREFIX;
@@ -128,6 +135,12 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
             // we also reject an empty array of credential identifiers
             logger.warnf("Property credential_identifiers not allowed in authorization_details");
             throw getInvalidRequestException("credential_identifiers not allowed");
+        }
+
+        // Issued credential ID not allowed
+        if (requestAuthDetail.getIssuedCredentialId() != null) {
+            logger.warnf("Property '%s' not allowed in authorization_details", OID4VCAuthorizationDetail.ISSUED_CREDENTIAL_ID);
+            throw getInvalidRequestException("Issued credential ID not allowed in authorization details");
         }
 
         // Validate credential_configuration_id
@@ -303,6 +316,26 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
     }
 
     @Override
+    public void afterAuthorizationDetailsProcessed(UserSessionModel userSession, ClientSessionContext clientSessionCtx, OID4VCAuthorizationDetail oid4vcAuthzDetailResponse) {
+        String credentialConfigId = oid4vcAuthzDetailResponse.getCredentialConfigurationId();
+        CredentialScopeModel credentialScope = findCredentialScopeModelByConfigurationId(session.getContext().getRealm(), clientSessionCtx::getClientScopesStream, credentialConfigId);
+
+        if (credentialScope == null && Profile.isFeatureEnabled(Profile.Feature.OID4VC_VCI_PREAUTH_CODE) && PRE_AUTH_GRANT_TYPE.equals(clientSessionCtx.getAttribute(Constants.GRANT_TYPE, String.class))) {
+            // For now, for pre-authorized grant we allow fallback to all client scopes of the realm, but this needs to be double-check before pre-authorization grant
+            // is going to be supported feature. Details: https://github.com/keycloak/keycloak/issues/49965
+            credentialScope = findCredentialScopeModelByConfigurationId(session.getContext().getRealm(), session.getContext().getRealm()::getClientScopesStream, credentialConfigId);
+        }
+
+        if (credentialScope == null) {
+            throw new InvalidAuthorizationDetailsException("Cannot find credential scope for credential configuration ID: " + credentialConfigId);
+        }
+
+        // Create issued-credential and set it's ID in authorization_details
+        IssuedVerifiableCredentialModel issuedCredential = createIssuedVerifiableCredential(userSession.getUser(), clientSessionCtx.getClientSession().getClient(), credentialScope);
+        oid4vcAuthzDetailResponse.setIssuedCredentialId(issuedCredential.getId());
+    }
+
+    @Override
     public void close() {
         // No cleanup needed
     }
@@ -333,6 +366,24 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
         authDetail.setCredentialIdentifiers(List.of(credIdentifier));
 
         return authDetail;
+    }
+
+
+    protected IssuedVerifiableCredentialModel createIssuedVerifiableCredential(UserModel userModel, ClientModel clientModel, CredentialScopeModel credentialScope) {
+        String credentialScopeName = credentialScope.getName();
+        try {
+            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userModel.getId(), credentialScopeName, clientModel.getId());
+
+            long issuedAt = Time.currentTimeMillis();
+            model.setIssuedAt(issuedAt);
+            model.setExpiresAt(issuedAt + (credentialScope.getExpiryInSeconds() * 1000));
+
+            logger.debugf("Created VC issuance: user=%s, client=%s, type=%s", userModel.getUsername(), clientModel.getClientId(), credentialScopeName);
+
+            return session.users().addIssuedVerifiableCredential(model);
+        } catch (Exception e) {
+            throw new ModelException(String.format("Failed to create VC issuance for user=%s, client=%s, type=%s", userModel.getUsername(), clientModel.getClientId(), credentialScopeName), e);
+        }
     }
 
     // Private ---------------------------------------------------------------------------------------------------------

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -53,7 +53,6 @@ import org.keycloak.OID4VCConstants;
 import org.keycloak.VCFormat;
 import org.keycloak.common.Profile;
 import org.keycloak.common.VerificationException;
-import org.keycloak.common.util.Time;
 import org.keycloak.crypto.KeyUse;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.events.Details;
@@ -70,7 +69,6 @@ import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.Constants;
-import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeyManager;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.KeycloakSessionFactory;
@@ -740,6 +738,21 @@ public class OID4VCIssuerEndpoint {
         }
     }
 
+    private void checkUserHasIssuedVerifiableCredential(UserModel user, CredentialScopeModel requestedCredential, String issuedCredentialId, ClientModel client, EventBuilder event) {
+        try {
+            OID4VCUtil.checkIssuedVerifiableCredential(session, user, issuedCredentialId, requestedCredential, client);
+        } catch (IllegalStateException ise) {
+            String errorMessage = String.format("User '%s' does not have valid requested issued verifiable credential with ID '%s'. Details: %s",
+                    user.getUsername(), issuedCredentialId, ise.getMessage());
+            LOGGER.debugf(errorMessage);
+            event.detail(Details.REASON, errorMessage).error(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue());
+            throw new CorsErrorResponseException(cors,
+                    ErrorType.INVALID_CREDENTIAL_REQUEST.getValue(),
+                    errorMessage,
+                    Response.Status.BAD_REQUEST);
+        }
+    }
+
     /**
      * Returns a verifiable credential
      */
@@ -977,6 +990,7 @@ public class OID4VCIssuerEndpoint {
 
         checkScope(authorizedCredentialScope);
         checkUserHasVerifiableCredential(userModel, authorizedCredentialScope, eventBuilder);
+        checkUserHasIssuedVerifiableCredential(userModel, authorizedCredentialScope, tokenAuthDetail.getIssuedCredentialId(), clientModel, eventBuilder);
 
         SupportedCredentialConfiguration supportedCredential =
                 OID4VCIssuerWellKnownProvider.toSupportedCredentialConfiguration(session, authorizedCredentialScope);
@@ -1030,8 +1044,6 @@ public class OID4VCIssuerEndpoint {
                 .detail(Details.VERIFIABLE_CREDENTIAL_FORMAT, supportedCredential.getFormat())
                 .detail(Details.VERIFIABLE_CREDENTIALS_ISSUED, String.valueOf(responseVO.getCredentials().size()));
 
-        recordIssuedVerifiableCredentials(userModel, clientModel, authorizedCredentialScope, responseVO.getCredentials().size());
-
         eventBuilder.success();
 
         // Clean up offer state after successful credential issuance
@@ -1042,24 +1054,6 @@ public class OID4VCIssuerEndpoint {
         }
 
         return response;
-    }
-
-    private void recordIssuedVerifiableCredentials(UserModel userModel, ClientModel clientModel, CredentialScopeModel credentialScope, int count) {
-        String credentialScopeName = credentialScope.getName();
-        try {
-            if (count > 0) {
-                IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userModel.getId(), credentialScopeName, clientModel.getId());
-
-                long issuedAt = Time.currentTimeMillis();
-                model.setIssuedAt(issuedAt);
-                model.setExpiresAt(issuedAt + (credentialScope.getExpiryInSeconds() * 1000));
-
-                session.users().addIssuedVerifiableCredential(model);
-                LOGGER.debugf("Recorded VC issuance: user=%s, client=%s, type=%s, credentials=%d", userModel.getUsername(), clientModel.getClientId(), credentialScopeName, count);
-            }
-        } catch (Exception e) {
-            LOGGER.warnf(e, "Failed to record VC issuance for user=%s, client=%s, type=%s", userModel.getUsername(), clientModel.getClientId(), credentialScopeName);
-        }
     }
 
     private List<OID4VCAuthorizationDetail> getAuthorizationDetailsResponse(AccessToken accessToken) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/OID4VCAuthorizationDetail.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/OID4VCAuthorizationDetail.java
@@ -37,6 +37,12 @@ public class OID4VCAuthorizationDetail extends AuthorizationDetailsJSONRepresent
     public static final String CLAIMS = "claims";
     public static final String CREDENTIALS_OFFER_ID = "credentials_offer_id";
 
+    /**
+     * Access token (and refresh token) claim with reference to the issued-credential ID. Can be used to link issued-credential
+     * with token to be able to check at credential-request (or refresh-token request) if particular issued-credential still exists
+     */
+    public static final String ISSUED_CREDENTIAL_ID = "iss_cred_id";
+
     @JsonProperty(CREDENTIAL_CONFIGURATION_ID)
     private String credentialConfigurationId;
 
@@ -56,6 +62,9 @@ public class OID4VCAuthorizationDetail extends AuthorizationDetailsJSONRepresent
 
     @JsonProperty(CREDENTIALS_OFFER_ID)
     private String credentialsOfferId;
+
+    @JsonProperty(ISSUED_CREDENTIAL_ID)
+    private String issuedCredentialId;
 
     public String getCredentialConfigurationId() {
         return credentialConfigurationId;
@@ -79,6 +88,14 @@ public class OID4VCAuthorizationDetail extends AuthorizationDetailsJSONRepresent
 
     public void setCredentialsOfferId(String credentialsOfferId) {
         this.credentialsOfferId = credentialsOfferId;
+    }
+
+    public String getIssuedCredentialId() {
+        return issuedCredentialId;
+    }
+
+    public void setIssuedCredentialId(String issuedCredentialId) {
+        this.issuedCredentialId = issuedCredentialId;
     }
 
     public List<ClaimsDescription> getClaims() {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
@@ -3,6 +3,7 @@ package org.keycloak.protocol.oid4vc.utils;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 
 import org.keycloak.common.util.KeycloakUriBuilder;
 import org.keycloak.models.ClientModel;
@@ -41,6 +42,36 @@ public class OID4VCUtil {
     public static boolean hasVerifiableCredential(KeycloakSession session, UserModel user, CredentialScopeModel credentialScope) {
         return session.users().getVerifiableCredentialsByUser(user.getId())
                 .anyMatch(credential -> credential.getCredentialScopeName().equals(credentialScope.getName()));
+    }
+
+    /**
+     * Check issued-credential present on the user with expected ID and expected issued-credential-id and credential-scope
+     *
+     * @param session kc session
+     * @param user user
+     * @param issuedCredentialId issued credential ID
+     * @param expectedCredentialScope expected credential scope
+     * @param expectedClient expected client
+     * @throws IllegalStateException in case that issued-credential not present or does not match with user, client or clientScope
+     */
+    public static void checkIssuedVerifiableCredential(KeycloakSession session, UserModel user, String issuedCredentialId, CredentialScopeModel expectedCredentialScope, ClientModel expectedClient) {
+        if (issuedCredentialId == null) {
+            throw new IllegalStateException("Issued credential ID not present");
+        }
+
+        // TODO: For performance, it will be good to lookup issued-credential by ID directly
+        Optional<IssuedVerifiableCredentialModel> issuedCred = session.users().getIssuedVerifiableCredentialsStreamByUser(user.getId())
+                .filter(issuedCredential -> issuedCredential.getId().equals(issuedCredentialId))
+                .findFirst();
+        if (issuedCred.isEmpty()) {
+            throw new IllegalStateException("Verifiable credential not found");
+        }
+        if (!expectedClient.getId().equals(issuedCred.get().getClientId())) {
+            throw new IllegalStateException("Different client sent credential request than client from issued-credential");
+        }
+        if (!expectedCredentialScope.getName().equals(issuedCred.get().getCredentialType())) {
+            throw new IllegalStateException("Different client scope than client scope from issued-credential");
+        }
     }
 
     public static List<IssuedVerifiableCredentialModel> getIssuedVerifiableCredentialsByUserAndClient(KeycloakSession session, UserModel user, ClientModel client) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -296,7 +296,6 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
      * Hook method called after authorization_details are processed and before the token response is created.
      * This allows authorization details processors to perform post-processing actions (e.g., creating state objects).
      * Processors can store information in session notes during processing, and this hook allows them to act on it.
-     * Default implementation does nothing.
      *
      * @param userSession                  the user session
      * @param clientSessionCtx             the client session context
@@ -304,8 +303,10 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
      */
     protected void afterAuthorizationDetailsProcessed(UserSessionModel userSession, ClientSessionContext clientSessionCtx,
                                                       List<AuthorizationDetailsJSONRepresentation> authorizationDetailsResponse) {
-        // Default: do nothing
-        // Subclasses or processors can override/extend this to perform post-processing
+        if (authorizationDetailsResponse != null && !authorizationDetailsResponse.isEmpty()) {
+            new AuthorizationDetailsProcessorManager(session)
+                    .afterAuthorizationDetailsProcessed(userSession, clientSessionCtx, authorizationDetailsResponse);
+        }
     }
 
     /**

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -204,6 +204,9 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
                     errorMessage, Response.Status.BAD_REQUEST);
         }
+
+        afterAuthorizationDetailsProcessed(userSession, sessionContext, authorizationDetailsResponses);
+
         OID4VCAuthorizationDetail authDetails = (OID4VCAuthorizationDetail) authorizationDetailsResponses.get(0);
 
         AccessToken accessToken = tokenManager.createClientAccessToken(session,

--- a/services/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessorManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessorManager.java
@@ -59,6 +59,17 @@ public class AuthorizationDetailsProcessorManager {
         return processAuthorizationDetailsInternal(authorizationDetailsParam, AuthorizationDetailsProcessor::validateAuthorizationDetail);
     }
 
+    @SuppressWarnings("unchecked")
+    public void afterAuthorizationDetailsProcessed(UserSessionModel userSession,
+                                                   ClientSessionContext clientSessionCtx,
+                                                   List<AuthorizationDetailsJSONRepresentation> authorizationDetailsResponse) throws InvalidAuthorizationDetailsException {
+        Map<String, AuthorizationDetailsProcessor<?>> processors = getAuthorizationDetailsProcessorMap();
+        for (AuthorizationDetailsJSONRepresentation authzDetailResponse : authorizationDetailsResponse) {
+            AuthorizationDetailsProcessor processor = findProcessorForAuthorizationDetails(processors, authzDetailResponse);
+            processor.afterAuthorizationDetailsProcessed(userSession, clientSessionCtx, authzDetailResponse.asSubtype(processor.getSupportedResponseJavaType()));
+        }
+    }
+
     // Private ---------------------------------------------------------------------------------------------------------
 
     private Map<String, AuthorizationDetailsProcessor<?>> getAuthorizationDetailsProcessorMap() {
@@ -79,16 +90,7 @@ public class AuthorizationDetailsProcessorManager {
 
         List<AuthorizationDetailsJSONRepresentation> authzResponses = new ArrayList<>();
         for (AuthorizationDetailsJSONRepresentation authzDetail : authzDetails) {
-            if (authzDetail.getType() == null) {
-                throw new InvalidAuthorizationDetailsException("Authorization_Details parameter provided without type: " + authorizationDetailsParam);
-            }
-            AuthorizationDetailsProcessor<?> processor = processors.get(authzDetail.getType());
-            if (processor == null) {
-                String errorDetails = String.format("Unsupported type '%s' of authorization_details parameter supplied in the request. Supported values: %s",
-                        authzDetail.getType(), processors.keySet());
-                logger.warn(errorDetails);
-                throw new InvalidAuthorizationDetailsException(errorDetails);
-            }
+            AuthorizationDetailsProcessor<?> processor = findProcessorForAuthorizationDetails(processors, authzDetail);
             AuthorizationDetailsJSONRepresentation response = function.apply(processor, authzDetail);
             if (response != null) {
                 authzResponses.add(response);
@@ -98,6 +100,20 @@ public class AuthorizationDetailsProcessorManager {
         }
 
         return authzResponses;
+    }
+
+    private AuthorizationDetailsProcessor<?> findProcessorForAuthorizationDetails(Map<String, AuthorizationDetailsProcessor<?>> processors, AuthorizationDetailsJSONRepresentation authzDetail) {
+        if (authzDetail.getType() == null) {
+            throw new InvalidAuthorizationDetailsException("Authorization_Details parameter provided without type: " + authzDetail);
+        }
+        AuthorizationDetailsProcessor<?> processor = processors.get(authzDetail.getType());
+        if (processor == null) {
+            String errorDetails = String.format("Unsupported type '%s' of authorization_details parameter supplied in the request. Supported values: %s",
+                    authzDetail.getType(), processors.keySet());
+            logger.warn(errorDetails);
+            throw new InvalidAuthorizationDetailsException(errorDetails);
+        }
+        return processor;
     }
 
     private List<AuthorizationDetailsJSONRepresentation> parseAuthorizationDetails(String authorizationDetailsParam) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -51,6 +51,7 @@ import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.oauth.LoginUrlBuilder;
 import org.keycloak.testsuite.util.oauth.PkceGenerator;
+import org.keycloak.testsuite.util.oauth.RefreshRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriRequest;
@@ -322,6 +323,21 @@ public class OID4VCBasicWallet {
 
     public AccessTokenRequest accessTokenRequest(OID4VCTestContext ctx, String authCode) {
         AccessTokenRequest request = new AccessTokenRequest(oauth, authCode) {
+            public AccessTokenResponse send() {
+                AccessTokenResponse response = super.send();
+                ctx.putAttachment(ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY, response);
+                return response;
+            }
+        };
+        return request;
+    }
+
+    public RefreshRequest refreshRequest(OID4VCTestContext ctx) {
+        String refreshToken = ctx.getAccessTokenResponse().getRefreshToken();
+        if (refreshToken == null) {
+            fail("Refresh token not available");
+        }
+        RefreshRequest request = new RefreshRequest(refreshToken, oauth) {
             public AccessTokenResponse send() {
                 AccessTokenResponse response = super.send();
                 ctx.putAttachment(ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY, response);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuedCredentialsAdminAPITest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuedCredentialsAdminAPITest.java
@@ -6,12 +6,15 @@ import org.keycloak.admin.client.resource.UserVerifiableCredentialResource;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.ErrorType;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialResponse;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
@@ -23,15 +26,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerWithRestCredentialOfferEnabled.class)
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
 public class OID4VCIssuedCredentialsAdminAPITest extends OID4VCIssuerEndpointTest {
+
+    private String userId;
+
+    @BeforeEach
+    void beforeEach() {
+        userId = testRealm.admin().users().search("john").get(0).getId();
+        testRealm.admin().users().get(userId).logout();
+    }
 
     @Test
     public void testIssuedCredentialsArePersistedAndRetrievableViaAdminAPI() {
         String scopeName = jwtTypeCredentialScope.getName();
         String credConfigId = jwtTypeCredentialScope.getAttributes().get(CredentialScopeModel.VC_CONFIGURATION_ID);
-
-        String userId = testRealm.admin().users().search("john").get(0).getId();
 
         UserVerifiableCredentialResource userVerifiableCredentialResource = testRealm.admin().users().get(userId).verifiableCredentials();
 
@@ -82,6 +91,12 @@ public class OID4VCIssuedCredentialsAdminAPITest extends OID4VCIssuerEndpointTes
                 () -> assertNotNull(issuedCred.getClientId(), "ClientId should be set")
         );
 
+        // Verify expiration for both issued credentials
+        assertEquals(issuedCred.getIssuedAt() + (CREDENTIALS_EXPIRATION_IN_SECONDS * 1000), issuedCred.getExpiresAt());
+
+        // Move time a bit before sending another credential request
+        timeOffSet.set(10);
+
         String cNonce2 = oauth.oid4vc().doNonceRequest().getNonce();
         Proofs proofs2 = jwtProofs(credentialIssuer.getCredentialIssuer(), cNonce2);
 
@@ -95,17 +110,52 @@ public class OID4VCIssuedCredentialsAdminAPITest extends OID4VCIssuerEndpointTes
 
         assertNotNull(credentialResponseVO2, "Second credential should have been issued");
 
-        List<IssuedVerifiableCredentialRepresentation> multipleIssuedCreds = testRealm.admin().users().get(userId).verifiableCredentials().getIssuedCredentials();
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds2 = testRealm.admin().users().get(userId).verifiableCredentials().getIssuedCredentials();
 
-        assertEquals(2, multipleIssuedCreds.size(), "Two issued credentials should be stored");
+        assertEquals(1, issuedCreds2.size(), "Single issued credential should be stored");
+        IssuedVerifiableCredentialRepresentation issuedCred2 = issuedCreds2.get(0);
 
-        // Verify sorting (newest first - DESC by issuedAt)
-        assertTrue(multipleIssuedCreds.get(0).getIssuedAt() >= multipleIssuedCreds.get(1).getIssuedAt(),
-                "Issued credentials should be sorted by issuedAt DESC (newest first)");
+        // Verify issuedAt and expiresAt did not change for the stored issued-credential
+        assertEquals(issuedCred.getIssuedAt(), issuedCred2.getIssuedAt());
+        assertEquals(issuedCred.getExpiresAt(), issuedCred2.getExpiresAt());
+        assertEquals(issuedCred.getRevision(), issuedCred2.getRevision());
 
-        // Verify expiration for both issued credentials
-        for (IssuedVerifiableCredentialRepresentation issuedCredential : multipleIssuedCreds) {
-            assertEquals(issuedCredential.getIssuedAt() + (CREDENTIALS_EXPIRATION_IN_SECONDS * 1000), issuedCredential.getExpiresAt());
-        }
+        // Verify ID from access-token authorization_details matches with ID of issued-credential
+        assertEquals(issuedCred.getId(), issuedCred2.getId());
+        assertEquals(authDetailsResponse.get(0).getIssuedCredentialId(), issuedCred.getId());
+    }
+
+    @Test
+    public void testCredentialRequestNotAllowedWhenIssuedCredentialRevoked() {
+        String scopeName = jwtTypeCredentialScope.getName();
+
+        String authCode = getAuthorizationCode(oauth, client, "john", scopeName);
+        AccessTokenResponse tokenResponse = getBearerToken(oauth, authCode);
+        List<OID4VCAuthorizationDetail> authDetailsResponse = tokenResponse.getOID4VCAuthorizationDetails();
+        String credentialIdentifier = authDetailsResponse.get(0).getCredentialIdentifiers().get(0);
+
+        // Right now, the single issued-verifiable credential should exists
+        UserVerifiableCredentialResource vcResource = testRealm.admin().users().get(userId).verifiableCredentials();
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds = vcResource.getIssuedCredentials();
+        assertEquals(1, issuedCreds.size(), "Exactly one issued credential should be stored");
+        IssuedVerifiableCredentialRepresentation issuedCred = issuedCreds.get(0);
+
+        // Revoke issued credential and assert not present anymore
+        vcResource.revokeIssuedCredential(issuedCred.getId());
+        issuedCreds = vcResource.getIssuedCredentials();
+        assertEquals(0, issuedCreds.size(), "No issued credentials should be stored");
+
+        // Credential request should fail due the issued-credential was revoked
+        String cNonce = oauth.oid4vc().nonceRequest().send().getNonce();
+        Proofs proofs = jwtProofs(getCredentialIssuerMetadata().getCredentialIssuer(), cNonce);
+        Oid4vcCredentialResponse credentialResponse = oauth.oid4vc()
+                .credentialRequest()
+                .bearerToken(tokenResponse.getAccessToken())
+                .credentialIdentifier(credentialIdentifier)
+                .proofs(proofs)
+                .send();
+        assertEquals(400, credentialResponse.getStatusCode());
+        assertEquals(ErrorType.INVALID_CREDENTIAL_REQUEST.getValue(), credentialResponse.getError());
+        assertTrue(credentialResponse.getErrorDescription().contains("Verifiable credential not found"));
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
@@ -1,0 +1,125 @@
+package org.keycloak.tests.oid4vc;
+
+import java.util.List;
+
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
+import org.keycloak.sdjwt.IssuerSignedJWT;
+import org.keycloak.sdjwt.vp.SdJwtVP;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Testing scenarios related to refresh credentials and refresh requests
+ *
+ * @see <a href="https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-14.5">OID4VCI specification section about credential refresh</a>
+ */
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
+
+    @InjectUser(config = OID4VCActionTest.OID4VCTestUserConfig.class)
+    ManagedUser user;
+
+    OID4VCTestContext ctx;
+
+    @BeforeEach
+    void beforeEach() {
+        ctx = new OID4VCTestContext(client, minimalJwtTypeCredentialScope);
+        user.admin().logout();
+    }
+
+    /**
+     * Obtain authorization-code flow and obtain VC with access token.
+     *
+     * Then refresh token. After refreshing the token the new access-token must still be usable for a credential request
+     * and there should be single issued-verifiable-credential instance
+     *
+     **/
+    @Test
+    public void testRefreshTokenSingleCredentialIssued() throws Exception {
+        // Login
+        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
+        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+
+        // Obtain credential
+        String accessToken1 = tokenResponse.getAccessToken();
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, accessToken1)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+        assertSuccessfulCredentialResponse(credResponse);
+
+        // Single issued-credential should be present
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds1 = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, issuedCreds1.size(), "Single issued credential should be stored");
+        IssuedVerifiableCredentialRepresentation issuedCred1 = issuedCreds1.get(0);
+
+        // Assert issued-credential ID matches
+        OID4VCAuthorizationDetail authzDetailResponse1 = ctx.getAuthorizationDetail();
+        assertEquals(issuedCred1.getId(), authzDetailResponse1.getIssuedCredentialId());
+
+        // Move time a bit before refresh token
+        timeOffSet.set(10);
+
+        // Refresh token
+        AccessTokenResponse refreshed = wallet.refreshRequest(ctx).send();
+        assertEquals(200, refreshed.getStatusCode(), "Refresh token exchange should succeed");
+        String accessToken2 = refreshed.getAccessToken();
+
+        // Obtain another VC
+        credResponse = wallet.credentialRequest(ctx, accessToken2)
+                .credentialIdentifier(credentialIdentifier)
+                .send().getCredentialResponse();
+        assertSuccessfulCredentialResponse(credResponse);
+
+        List<IssuedVerifiableCredentialRepresentation> issuedCreds2 = testRealm.admin().users().get(user.getId()).verifiableCredentials().getIssuedCredentials();
+        assertEquals(1, issuedCreds2.size(), "Single issued credential should be stored");
+        IssuedVerifiableCredentialRepresentation issuedCred2 = issuedCreds2.get(0);
+
+        // Verify issuedAt and expiresAt did not changed for the stored issued-credential after refresh-token and obtain another VC
+        assertEquals(issuedCred1.getId(), issuedCred2.getId());
+        assertEquals(issuedCred1.getIssuedAt(), issuedCred2.getIssuedAt());
+        assertEquals(issuedCred1.getExpiresAt(), issuedCred2.getExpiresAt());
+        assertEquals(issuedCred1.getRevision(), issuedCred2.getRevision());
+
+        // Assert issued-credential ID matches and did not changed
+        OID4VCAuthorizationDetail authzDetailResponse2 = ctx.getAuthorizationDetail();
+        assertEquals(issuedCred2.getId(), authzDetailResponse2.getIssuedCredentialId());
+    }
+
+
+    protected AccessTokenResponse authzCodeFlow(CredentialIssuer issuer) throws Exception {
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .scope(ctx.getScope())
+                .send(user.getUsername(), TEST_PASSWORD);
+        String code = authResponse.getCode();
+        assertNotNull(code, "Authorization code should not be null");
+
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, code).send();
+        String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
+        assertNotNull(accessToken, "No accessToken");
+        return tokenResponse;
+    }
+
+    protected void assertSuccessfulCredentialResponse(CredentialResponse credentialResponse) {
+        CredentialResponse.Credential credentialObj = credentialResponse.getCredentials().get(0);
+        assertNotNull(credentialObj, "The first credential in the array should not be null");
+        IssuerSignedJWT issuerSignedJWT = SdJwtVP.of(credentialObj.getCredential().toString()).getIssuerSignedJWT();
+        assertEquals(minimalJwtTypeCredentialScopeName, issuerSignedJWT.getPayload().get(CLAIM_NAME_VCT).asText());
+    }
+
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RefreshRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/RefreshRequest.java
@@ -11,7 +11,7 @@ public class RefreshRequest extends AbstractHttpPostRequest<RefreshRequest, Acce
 
     private final String refreshToken;
 
-    RefreshRequest(String refreshToken, AbstractOAuthClient<?> client) {
+    public RefreshRequest(String refreshToken, AbstractOAuthClient<?> client) {
         super(client);
         this.refreshToken = refreshToken;
     }


### PR DESCRIPTION
… session

closes #49948

Besides what is mentioned in the description on the issue, the other updates in this PR, which worth mention:

- Update of `UserProvider.addIssuedVerifiableCredential` to return `IssuedVerifiableCredentialModel` to return with filled generated ID from DB

- Adding `AuthorizationDetailsProcessor.afterAuthorizationDetailsProcessed` as a callback method invoked at the end of token request (for authorization-code or pre-authorized code grants right now) , which is now used to persist issued-credential-model and add the ID of the generated issued-credential model to the `authorization_Details` so that access-token and refresh-token has reference to the issued-credential model

- Added workaround in `OID4VCAuthorizationDetailsProcessor.afterAuthorizationDetailsProcessed` for pre-authorized grant to consider all client scopes of the realm. This is not ideal, so I've added follow-up issue to remove this before we make pre-authorized code grant supported feature: https://github.com/keycloak/keycloak/issues/49965
