### PR TITLE
Review permission model to access the SCIM APIs

### DIFF
--- a/docs/documentation/server_admin/topics/scim/accessing-endpoints.adoc
+++ b/docs/documentation/server_admin/topics/scim/accessing-endpoints.adoc
@@ -70,12 +70,12 @@ The following table summarizes the permissions required for each type of SCIM op
 | Ability to list and filter group resources.
 
 | Access discovery endpoints
-| `view-realm`
-| Read access to `/ServiceProviderConfig`, `/ResourceTypes`, and `/Schemas`.
+| `query-users` or `query-groups`
+| Read access to `/ServiceProviderConfig`, `/ResourceTypes`, and `/Schemas`. Any role that implies `query-users` or `query-groups` (such as `view-users` or `manage-users`) also grants access.
 |===
 
-The minimum set of roles required for full access to the SCIM API is `manage-users` for user and group management
-operations, and `view-realm` for access to discovery endpoints.
+The minimum set of roles required for full access to the SCIM API is `manage-users`, which covers all user and group
+management operations as well as access to discovery endpoints.
 
 == Obtaining an access token
 

--- a/scim/core/src/main/java/org/keycloak/scim/resource/Scim.java
+++ b/scim/core/src/main/java/org/keycloak/scim/resource/Scim.java
@@ -1,5 +1,9 @@
 package org.keycloak.scim.resource;
 
+import org.keycloak.authorization.fgap.AdminPermissionsSchema;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.Permissions;
+
 public final class Scim {
 
     // Core Schemas
@@ -27,5 +31,12 @@ public final class Scim {
             case SCHEMA_RESOURCE_TYPE -> SCHEMA_CORE_SCHEMA;
             default -> throw new IllegalArgumentException("Unknown resource type " + resourceType);
         };
+    }
+
+    public static boolean hasDiscoveryEndpointPermission(KeycloakSession session) {
+        Permissions permissions = session.getContext().getPermissions();
+
+        return permissions.hasPermission(AdminPermissionsSchema.USERS_RESOURCE_TYPE, AdminPermissionsSchema.QUERY)
+                || permissions.hasPermission(AdminPermissionsSchema.GROUPS_RESOURCE_TYPE, AdminPermissionsSchema.QUERY);
     }
 }

--- a/scim/model/src/main/java/org/keycloak/scim/model/config/ServiceProviderConfigResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/config/ServiceProviderConfigResourceTypeProvider.java
@@ -3,7 +3,6 @@ package org.keycloak.scim.model.config;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.Model;
@@ -17,6 +16,8 @@ import org.keycloak.scim.resource.config.ServiceProviderConfig.Supported;
 import org.keycloak.scim.resource.schema.ModelSchema;
 import org.keycloak.scim.resource.spi.ScimResourceTypeProvider;
 import org.keycloak.scim.resource.spi.SingletonResourceTypeProvider;
+
+import static org.keycloak.scim.resource.Scim.hasDiscoveryEndpointPermission;
 
 public class ServiceProviderConfigResourceTypeProvider implements SingletonResourceTypeProvider<ServiceProviderConfig> {
 
@@ -66,10 +67,10 @@ public class ServiceProviderConfigResourceTypeProvider implements SingletonResou
 
     @Override
     public Stream<ServiceProviderConfig> getAll(SearchRequest searchRequest) {
-        if (!session.getContext().getPermissions().hasPermission(AdminPermissionsSchema.REALMS_RESOURCE_TYPE, AdminPermissionsSchema.VIEW)) {
-            throw new ForbiddenException();
+        if (hasDiscoveryEndpointPermission(session)) {
+            return Stream.of(getSingleton());
         }
-        return Stream.of(getSingleton());
+        throw new ForbiddenException();
     }
 
     @Override

--- a/scim/model/src/main/java/org/keycloak/scim/model/resourcetype/ResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/resourcetype/ResourceTypeProvider.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.Model;
 import org.keycloak.scim.protocol.ForbiddenException;
@@ -18,6 +17,8 @@ import org.keycloak.scim.resource.schema.ModelSchema;
 import org.keycloak.scim.resource.schema.Schema;
 import org.keycloak.scim.resource.spi.ScimResourceTypeProvider;
 import org.keycloak.scim.resource.spi.ScimResourceTypeProviderFactory;
+
+import static org.keycloak.scim.resource.Scim.hasDiscoveryEndpointPermission;
 
 public class ResourceTypeProvider implements ScimResourceTypeProvider<ResourceType> {
 
@@ -54,13 +55,13 @@ public class ResourceTypeProvider implements ScimResourceTypeProvider<ResourceTy
 
     @Override
     public Stream<ResourceType> getAll(SearchRequest searchRequest) {
-        if (!session.getContext().getPermissions().hasPermission(AdminPermissionsSchema.REALMS_RESOURCE_TYPE, AdminPermissionsSchema.VIEW)) {
-            throw new ForbiddenException();
+        if (hasDiscoveryEndpointPermission(session)) {
+            return session.getKeycloakSessionFactory().getProviderFactoriesStream(ScimResourceTypeProvider.class)
+                    .map(ScimResourceTypeProviderFactory.class::cast)
+                    .map(this::toRepresentation)
+                    .filter(Objects::nonNull);
         }
-        return session.getKeycloakSessionFactory().getProviderFactoriesStream(ScimResourceTypeProvider.class)
-                .map(ScimResourceTypeProviderFactory.class::cast)
-                .map(this::toRepresentation)
-                .filter(Objects::nonNull);
+        throw new ForbiddenException();
     }
 
     @Override

--- a/scim/model/src/main/java/org/keycloak/scim/model/schema/SchemaResourceTypeProvider.java
+++ b/scim/model/src/main/java/org/keycloak/scim/model/schema/SchemaResourceTypeProvider.java
@@ -22,6 +22,7 @@ import org.keycloak.scim.resource.schema.Schema;
 import org.keycloak.scim.resource.schema.Schema.Attribute;
 import org.keycloak.scim.resource.spi.ScimResourceTypeProvider;
 
+import static org.keycloak.scim.resource.Scim.hasDiscoveryEndpointPermission;
 
 /**
  * Provider for SCIM Schema resources. This provider exposes the supported SCIM schemas
@@ -210,13 +211,14 @@ public class SchemaResourceTypeProvider implements ScimResourceTypeProvider<Sche
 
     @Override
     public Stream<Schema> getAll(SearchRequest searchRequest) {
-        if (!session.getContext().getPermissions().hasPermission(AdminPermissionsSchema.REALMS_RESOURCE_TYPE, AdminPermissionsSchema.VIEW)) {
-            throw new ForbiddenException();
+        if (hasDiscoveryEndpointPermission(session)) {
+            // Per RFC 7644 Section 4, /Schemas is a discovery endpoint that SHALL return all schemas.
+            // Filtering, sorting, and pagination are not supported for discovery endpoints.
+            // The searchRequest parameter is ignored.
+            return schemas.values().stream();
         }
-        // Per RFC 7644 Section 4, /Schemas is a discovery endpoint that SHALL return all schemas.
-        // Filtering, sorting, and pagination are not supported for discovery endpoints.
-        // The searchRequest parameter is ignored.
-        return schemas.values().stream();
+
+        throw new ForbiddenException();
     }
 
     @Override

--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AuthorizationTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/AuthorizationTest.java
@@ -185,11 +185,14 @@ public class AuthorizationTest extends AbstractScimTest {
     }
 
     @Test
-    public void testDiscoveryEndpointsAccessIfViewRealmRoleGranted() {
-        grantAdminRole(AdminRoles.VIEW_REALM);
-        assertNotNull(noAccessClient.config().get());
-        assertNotNull(noAccessClient.schemas().getAll());
-        assertNotNull(noAccessClient.resourceTypes().getAll());
+    public void testDiscoveryEndpointsAccessIfGrantedAnySupportedAdminRole() {
+        for (String role : List.of(AdminRoles.QUERY_USERS, AdminRoles.VIEW_USERS, AdminRoles.MANAGE_USERS, AdminRoles.QUERY_GROUPS)) {
+            grantAdminRole(role);
+            assertNotNull(noAccessClient.config().get());
+            assertNotNull(noAccessClient.schemas().getAll());
+            assertNotNull(noAccessClient.resourceTypes().getAll());
+            revokeAdminRole(role);
+        }
     }
 
     @Test


### PR DESCRIPTION
- access to /ServiceProviderConfig, /ResourceTYpes and /Schemas now require only query-users or query-groups.

Closes #47820

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
