### PR TITLE
fix(client-registration): return 401 instead of 500 on invalid token (26.6)

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/oidc/OIDCClientRegistrationProvider.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.util.Time;
+import org.keycloak.events.EventType;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.ClientSecretConstants;
 import org.keycloak.models.KeycloakContext;
@@ -85,6 +86,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response createOIDC(OIDCClientRepresentation clientOIDC) {
+        event.event(EventType.CLIENT_REGISTER);
         Cors cors = cors();
         if (clientOIDC.getClientId() != null) {
             throw new ErrorResponseException(ErrorCodes.INVALID_CLIENT_METADATA, "Client Identifier included", Response.Status.BAD_REQUEST);
@@ -116,6 +118,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @Path("{clientId}")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getOIDC(@PathParam("clientId") String clientId) {
+        event.event(EventType.CLIENT_INFO);
         Cors cors = cors();
         ClientModel client = session.getContext().getRealm().getClientByClientId(clientId);
 
@@ -130,6 +133,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateOIDC(@PathParam("clientId") String clientId, OIDCClientRepresentation clientOIDC) {
+        event.event(EventType.CLIENT_UPDATE);
         Cors cors = cors();
         try {
             ClientRepresentation client = DescriptionConverter.toInternal(session, clientOIDC);
@@ -165,6 +169,7 @@ public class OIDCClientRegistrationProvider extends AbstractClientRegistrationPr
     @DELETE
     @Path("{clientId}")
     public Response deleteOIDC(@PathParam("clientId") String clientId) {
+        event.event(EventType.CLIENT_DELETE);
         Cors cors = cors();
         delete(clientId);
         return cors.add(Response.noContent());

--- a/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/ClientRegistrationAuthTest.java
@@ -2,16 +2,27 @@ package org.keycloak.tests.client;
 
 import java.io.IOException;
 
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response;
 
+import org.keycloak.OAuthErrorException;
+import org.keycloak.events.Errors;
+import org.keycloak.events.EventType;
 import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpRequest;
 import org.keycloak.http.simple.SimpleHttpResponse;
 import org.keycloak.representations.idm.ClientInitialAccessCreatePresentation;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.oidc.OIDCClientRepresentation;
+import org.keycloak.testframework.annotations.InjectEvents;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.InjectSimpleHttp;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.events.EventAssertion;
+import org.keycloak.testframework.events.Events;
 import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,8 +30,11 @@ import org.junit.jupiter.api.Test;
 @KeycloakIntegrationTest
 public class ClientRegistrationAuthTest {
 
-    @InjectRealm
+    @InjectRealm(config = ClientRegistrationAuthRealmConfig.class)
     ManagedRealm realm;
+
+    @InjectEvents
+    Events events;
 
     @InjectSimpleHttp
     SimpleHttp simpleHttp;
@@ -60,6 +74,26 @@ public class ClientRegistrationAuthTest {
         test("Bearer\t", false);
     }
 
+    @Test
+    public void testInvalidToken_Get() throws IOException {
+        testInvalidToken(HttpMethod.GET, EventType.CLIENT_INFO_ERROR);
+    }
+
+    @Test
+    public void testInvalidToken_Post() throws IOException {
+        testInvalidToken(HttpMethod.POST, EventType.CLIENT_REGISTER_ERROR);
+    }
+
+    @Test
+    public void testInvalidToken_Put() throws IOException {
+        testInvalidToken(HttpMethod.PUT, EventType.CLIENT_UPDATE_ERROR);
+    }
+
+    @Test
+    public void testInvalidToken_Delete() throws IOException {
+        testInvalidToken(HttpMethod.DELETE, EventType.CLIENT_DELETE_ERROR);
+    }
+
     private void test(String authPrefix, boolean success) throws IOException {
         String token = createInitialAccessToken();
         OIDCClientRepresentation client = new OIDCClientRepresentation();
@@ -82,6 +116,33 @@ public class ClientRegistrationAuthTest {
         }
     }
 
+    private void testInvalidToken(String method, EventType expectedEventType) throws IOException {
+        try (SimpleHttpResponse response = createInvalidTokenRequest(method)
+                .header("Authorization", "Bearer test")
+                .asResponse()) {
+            Assertions.assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+
+            OAuth2ErrorRepresentation error = response.asJson(OAuth2ErrorRepresentation.class);
+            Assertions.assertEquals(OAuthErrorException.INVALID_TOKEN, error.getError());
+            Assertions.assertNotNull(error.getErrorDescription());
+            Assertions.assertFalse(error.getErrorDescription().contains("IllegalStateException"));
+        }
+
+        EventAssertion.assertError(events.poll())
+                .type(expectedEventType)
+                .error(Errors.INVALID_TOKEN);
+    }
+
+    private SimpleHttpRequest createInvalidTokenRequest(String method) {
+        return switch (method) {
+            case HttpMethod.GET -> simpleHttp.doGet(getOidcUrl() + "/test-auth-client");
+            case HttpMethod.POST -> simpleHttp.doPost(getOidcUrl()).json(new OIDCClientRepresentation());
+            case HttpMethod.PUT -> simpleHttp.doPut(getOidcUrl() + "/test-auth-client").json(new OIDCClientRepresentation());
+            case HttpMethod.DELETE -> simpleHttp.doDelete(getOidcUrl() + "/test-auth-client");
+            default -> throw new IllegalArgumentException("Unsupported method: " + method);
+        };
+    }
+
     private String createInitialAccessToken() {
         ClientInitialAccessCreatePresentation initialAccessCreatePresentation = new ClientInitialAccessCreatePresentation(0, 100);
         return realm.admin().clientInitialAccess().create(initialAccessCreatePresentation).getToken();
@@ -89,5 +150,15 @@ public class ClientRegistrationAuthTest {
 
     private String getOidcUrl() {
         return realm.getBaseUrl() + "/clients-registrations/openid-connect";
+    }
+
+    private static class ClientRegistrationAuthRealmConfig implements RealmConfig {
+
+        @Override
+        public RealmConfigBuilder configure(RealmConfigBuilder realm) {
+            return realm.eventsEnabled(true)
+                    .enabledEventTypes(EventType.CLIENT_INFO_ERROR.name(), EventType.CLIENT_REGISTER_ERROR.name(),
+                            EventType.CLIENT_UPDATE_ERROR.name(), EventType.CLIENT_DELETE_ERROR.name());
+        }
     }
 }


### PR DESCRIPTION
Closes #49909

PR:             https://github.com/keycloak/keycloak/pull/49930
Commit:         https://github.com/keycloak/keycloak/commit/6a86e81bdeb12edd3d0f37c9845eda8a6b6b43ed
PR branch:      backport-49930-26.6
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.6

