### PR TITLE
Set default Kubernetes identity provider issuer

### DIFF
--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesConstants.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesConstants.java
@@ -2,6 +2,7 @@ package org.keycloak.broker.kubernetes;
 
 public interface KubernetesConstants {
 
+    String DEFAULT_KUBERNETES_ISSUER_URL = "https://kubernetes.default.svc.cluster.local";
     String KUBERNETES_SERVICE_HOST_KEY = "KUBERNETES_SERVICE_HOST";
     String KUBERNETES_SERVICE_PORT_HTTPS_KEY = "KUBERNETES_SERVICE_PORT_HTTPS";
     String SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";

--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java
@@ -5,6 +5,9 @@ import org.keycloak.broker.oidc.IssuerValidation;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.IdentityProviderType;
 import org.keycloak.models.RealmModel;
+import org.keycloak.util.Strings;
+
+import static org.keycloak.broker.kubernetes.KubernetesConstants.DEFAULT_KUBERNETES_ISSUER_URL;
 
 
 public class KubernetesIdentityProviderConfig extends IdentityProviderModel implements IssuerValidation {
@@ -17,7 +20,12 @@ public class KubernetesIdentityProviderConfig extends IdentityProviderModel impl
     }
 
     public String getIssuer() {
-        return getConfig().get(ISSUER);
+        String issuer = getConfig().get(ISSUER);
+        if (Strings.isEmpty(issuer)) {
+            return DEFAULT_KUBERNETES_ISSUER_URL;
+        }
+
+        return issuer;
     }
 
     public int getAllowedClockSkew() {
@@ -41,6 +49,7 @@ public class KubernetesIdentityProviderConfig extends IdentityProviderModel impl
     @Override
     public void validate(RealmModel realm) {
         super.validate(realm);
+        getConfig().put(ISSUER, getIssuer());
         validateIssuer(realm, IdentityProviderType.CLIENT_ASSERTION);
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderKubernetesTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderKubernetesTest.java
@@ -36,6 +36,59 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @KeycloakIntegrationTest(config = IdentityProviderKubernetesTest.TestServerConfig.class)
 public class IdentityProviderKubernetesTest extends AbstractIdentityProviderTest {
 
+    private static final String DEFAULT_KUBERNETES_ISSUER = "https://kubernetes.default.svc.cluster.local";
+
+    @Test
+    public void testCreateIdentityProviderUsesDefaultIssuer() {
+        IdentityProviderRepresentation identityProvider = createRep("kubernetes", "kubernetes");
+        identityProvider.getConfig().remove("issuer");
+
+        try (Response response = managedRealm.admin().identityProviders().create(identityProvider)) {
+            assertEquals(201, response.getStatus(), () -> response.readEntity(String.class));
+        }
+        managedRealm.cleanup().add(r -> r.identityProviders().get("kubernetes").remove());
+
+        IdentityProviderRepresentation created = managedRealm.admin().identityProviders().get("kubernetes").toRepresentation();
+        assertEquals(DEFAULT_KUBERNETES_ISSUER, created.getConfig().get("issuer"));
+    }
+
+    @Test
+    public void testUpdateIdentityProviderUsesDefaultIssuer() {
+        IdentityProviderRepresentation identityProvider = createRep("kubernetes", "kubernetes");
+        identityProvider.getConfig().put("issuer", "https://localhost");
+
+        try (Response response = managedRealm.admin().identityProviders().create(identityProvider)) {
+            assertEquals(201, response.getStatus(), () -> response.readEntity(String.class));
+        }
+        managedRealm.cleanup().add(r -> r.identityProviders().get("kubernetes").remove());
+
+        IdentityProviderResource idpResource = managedRealm.admin().identityProviders().get("kubernetes");
+        identityProvider = idpResource.toRepresentation();
+        identityProvider.getConfig().remove("issuer");
+        idpResource.update(identityProvider);
+
+        IdentityProviderRepresentation updated = idpResource.toRepresentation();
+        assertEquals(DEFAULT_KUBERNETES_ISSUER, updated.getConfig().get("issuer"));
+    }
+
+    @Test
+    public void testCreateIdentityProviderWithDuplicateDefaultIssuer() {
+        IdentityProviderRepresentation identityProvider = createRep("kubernetes1", "kubernetes");
+        identityProvider.getConfig().remove("issuer");
+
+        try (Response response = managedRealm.admin().identityProviders().create(identityProvider)) {
+            assertEquals(201, response.getStatus(), () -> response.readEntity(String.class));
+        }
+        managedRealm.cleanup().add(r -> r.identityProviders().get("kubernetes1").remove());
+
+        identityProvider.setAlias("kubernetes2");
+        try (Response response = managedRealm.admin().identityProviders().create(identityProvider)) {
+            Assertions.assertEquals(400, response.getStatus());
+            ErrorRepresentation error = response.readEntity(ErrorRepresentation.class);
+            assertEquals("Issuer URL already used for IDP 'kubernetes1', Issuer must be unique if the idp supports JWT Authorization Grant or Federated Client Authentication", error.getErrorMessage());
+        }
+    }
+
     @Test
     public void testCreateIdentityProviderWithDuplicateIssuer() {
         IdentityProviderRepresentation identityProvider = createRep("kubernetes1", "kubernetes");


### PR DESCRIPTION
Fixes #49978 
Related to #49039

The Kubernetes identity provider documentation states that the default issuer URL is `https://kubernetes.default.svc.cluster.local`, but the provider currently requires the issuer to be set explicitly.

This change applies the documented default issuer server-side when a Kubernetes identity provider is created or updated without an issuer. The default is persisted before issuer validation, so REST and Admin UI saves behave consistently and issuer uniqueness validation still applies.

This PR intentionally only fixes the default issuer bug. Automatic issuer discovery for managed Kubernetes clusters will be handled separately.

Documentation:
- Existing documentation already states the default issuer URL. No documentation changes are needed.

Testing:
- `./mvnw -pl services,tests/base -DspotlessFiles=services/src/main/java/org/keycloak/broker/kubernetes/KubernetesConstants.java,services/src/main/java/org/keycloak/broker/kubernetes/KubernetesIdentityProviderConfig.java,tests/base/src/test/java/org/keycloak/tests/admin/identityprovider/IdentityProviderKubernetesTest.java spotless:check`
- `git diff --check`
- `./mvnw -pl services -am -DskipTests install`
- `./mvnw -pl tests/base -am -DskipTests install`
- `JAVA_TOOL_OPTIONS='-Djava.net.preferIPv4Stack=true' ./mvnw -pl tests/base -Dtest=org.keycloak.tests.admin.identityprovider.IdentityProviderKubernetesTest test`
- `JAVA_TOOL_OPTIONS='-Djava.net.preferIPv4Stack=true' ./mvnw -pl tests/base -Dtest=org.keycloak.tests.client.authentication.external.KubernetesClientAuthTest test`




AI disclosure:
- I used AI assistance to inspect and understand the existing implementation and draft the plan for these changes.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
