### PR TITLE
Combine search query param with other filters in users endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/UsersResource.java
@@ -303,73 +303,66 @@ public class UsersResource {
                 ? Collections.emptyMap()
                 : SearchQueryUtils.getFields(searchQuery);
 
-        Stream<UserModel> userModels = Stream.empty();
         if (search != null) {
             SearchQueryUtils.UserSearchPrefix prefix = SearchQueryUtils.UserSearchPrefix.matching(search);
             if (prefix != null) {
-                userModels = Arrays.stream(prefix.splitTerms(search))
+                Stream<UserModel> userModels = Arrays.stream(prefix.splitTerms(search))
                         .map(term -> prefix.lookup(session.users(), realm, term))
                         .filter(Objects::nonNull);
                 if (AdminPermissionsSchema.SCHEMA.isAdminPermissionsEnabled(realm)) {
                     userModels = userModels.filter(userPermissionEvaluator::canView);
                 }
-            } else {
-                Map<String, String> attributes = new HashMap<>();
-                attributes.put(UserModel.SEARCH, search.trim());
-                if (enabled != null) {
-                    attributes.put(UserModel.ENABLED, enabled.toString());
-                }
-                if (emailVerified != null) {
-                    attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
-                }
-                addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
-
-                return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                        maxResults, false);
+                return toRepresentation(realm, userPermissionEvaluator, briefRepresentation, userModels);
             }
-        } else if (last != null || first != null || email != null || username != null || emailVerified != null
+        }
+
+        if (search != null || last != null || first != null || email != null || username != null || emailVerified != null
                 || idpAlias != null || idpUserId != null || enabled != null || exact != null || !searchAttributes.isEmpty()
                 || createdAfter != null || createdBefore != null) {
-                    Map<String, String> attributes = new HashMap<>();
-                    if (last != null) {
-                        attributes.put(UserModel.LAST_NAME, last);
-                    }
-                    if (first != null) {
-                        attributes.put(UserModel.FIRST_NAME, first);
-                    }
-                    if (email != null) {
-                        attributes.put(UserModel.EMAIL, email);
-                    }
-                    if (username != null) {
-                        attributes.put(UserModel.USERNAME, username);
-                    }
-                    if (emailVerified != null) {
-                        attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
-                    }
-                    if (idpAlias != null) {
-                        attributes.put(UserModel.IDP_ALIAS, idpAlias);
-                    }
-                    if (idpUserId != null) {
-                        attributes.put(UserModel.IDP_USER_ID, idpUserId);
-                    }
-                    if (enabled != null) {
-                        attributes.put(UserModel.ENABLED, enabled.toString());
-                    }
-                    if (exact != null) {
-                        attributes.put(UserModel.EXACT, exact.toString());
-                    }
-                    addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
+            Map<String, String> attributes = new HashMap<>();
+            if (search != null) {
+                attributes.put(UserModel.SEARCH, search.trim());
+            }
+            if (last != null) {
+                attributes.put(UserModel.LAST_NAME, last);
+            }
+            if (first != null) {
+                attributes.put(UserModel.FIRST_NAME, first);
+            }
+            if (email != null) {
+                attributes.put(UserModel.EMAIL, email);
+            }
+            if (username != null) {
+                attributes.put(UserModel.USERNAME, username);
+            }
+            if (emailVerified != null) {
+                attributes.put(UserModel.EMAIL_VERIFIED, emailVerified.toString());
+            }
+            if (idpAlias != null) {
+                attributes.put(UserModel.IDP_ALIAS, idpAlias);
+            }
+            if (idpUserId != null) {
+                attributes.put(UserModel.IDP_USER_ID, idpUserId);
+            }
+            if (enabled != null) {
+                attributes.put(UserModel.ENABLED, enabled.toString());
+            }
+            if (exact != null) {
+                attributes.put(UserModel.EXACT, exact.toString());
+            }
+            addCreatedTimestampConditions(attributes, createdAfter, createdBefore);
 
-                    attributes.putAll(searchAttributes);
+            attributes.putAll(searchAttributes);
 
-                    return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
-                            maxResults, true);
-                } else {
-                    return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
-                            firstResult, maxResults, false);
-                }
+            // Service accounts are excluded from full-text search, but included when filtering by explicit attributes.
+            boolean includeServiceAccounts = search == null;
 
-        return toRepresentation(realm, userPermissionEvaluator, briefRepresentation, userModels);
+            return searchForUser(attributes, realm, userPermissionEvaluator, briefRepresentation, firstResult,
+                    maxResults, includeServiceAccounts);
+        } else {
+            return searchForUser(new HashMap<>(), realm, userPermissionEvaluator, briefRepresentation,
+                    firstResult, maxResults, false);
+        }
     }
 
     /**

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -351,6 +351,46 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
+    @DatabaseTest
+    public void searchStacksWithOtherFilters() {
+        // The 'search' query param must combine with the other filters instead of overriding them, see
+        // https://github.com/keycloak/keycloak/issues/49995
+        UserRepresentation alice = new UserRepresentation();
+        alice.setUsername("stackalice");
+        alice.setEmail("alice@stackbug.test");
+        alice.setFirstName("Alice");
+        alice.setLastName("Stackbugcommon");
+        alice.setEmailVerified(true);
+        alice.setRequiredActions(Collections.emptyList());
+        alice.setEnabled(true);
+        createUser(alice);
+
+        UserRepresentation bob = new UserRepresentation();
+        bob.setUsername("stackbob");
+        bob.setEmail("bob@stackbug.test");
+        bob.setFirstName("Bob");
+        bob.setLastName("Stackbugcommon");
+        bob.setEmailVerified(true);
+        bob.setRequiredActions(Collections.emptyList());
+        bob.setEnabled(true);
+        createUser(bob);
+
+        // sanity check: the search term on its own matches both users via their last name
+        List<UserRepresentation> bySearchOnly = managedRealm.admin().users().search("Stackbugcommon", null, null, null, true, null, null, null);
+        assertThat(bySearchOnly, hasSize(2));
+
+        // search combined with username must narrow down to a single user, not ignore the username filter
+        List<UserRepresentation> bySearchAndUsername = managedRealm.admin().users().search("Stackbugcommon", null, null, null, true, "stackalice", null, null);
+        assertThat(bySearchAndUsername, hasSize(1));
+        assertEquals("stackalice", bySearchAndUsername.get(0).getUsername());
+
+        // search combined with email must narrow down as well
+        List<UserRepresentation> bySearchAndEmail = managedRealm.admin().users().search("Stackbugcommon", null, null, "bob@stackbug.test", true, null, null, null);
+        assertThat(bySearchAndEmail, hasSize(1));
+        assertEquals("stackbob", bySearchAndEmail.get(0).getUsername());
+    }
+
+    @Test
     public void searchWithFilterAndEnabledAttribute() {
         createUser();
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/UserSearchTest.java
@@ -344,6 +344,46 @@ public class UserSearchTest extends AbstractUserTest {
     }
 
     @Test
+    @DatabaseTest
+    public void searchStacksWithOtherFilters() {
+        // The 'search' query param must combine with the other filters instead of overriding them, see
+        // https://github.com/keycloak/keycloak/issues/49995
+        UserRepresentation alice = new UserRepresentation();
+        alice.setUsername("stackalice");
+        alice.setEmail("alice@stackbug.test");
+        alice.setFirstName("Alice");
+        alice.setLastName("Stackbugcommon");
+        alice.setEmailVerified(true);
+        alice.setRequiredActions(Collections.emptyList());
+        alice.setEnabled(true);
+        createUser(alice);
+
+        UserRepresentation bob = new UserRepresentation();
+        bob.setUsername("stackbob");
+        bob.setEmail("bob@stackbug.test");
+        bob.setFirstName("Bob");
+        bob.setLastName("Stackbugcommon");
+        bob.setEmailVerified(true);
+        bob.setRequiredActions(Collections.emptyList());
+        bob.setEnabled(true);
+        createUser(bob);
+
+        // sanity check: the search term on its own matches both users via their last name
+        List<UserRepresentation> bySearchOnly = managedRealm.admin().users().search("Stackbugcommon", null, null, null, true, null, null, null);
+        assertThat(bySearchOnly, hasSize(2));
+
+        // search combined with username must narrow down to a single user, not ignore the username filter
+        List<UserRepresentation> bySearchAndUsername = managedRealm.admin().users().search("Stackbugcommon", null, null, null, true, "stackalice", null, null);
+        assertThat(bySearchAndUsername, hasSize(1));
+        assertEquals("stackalice", bySearchAndUsername.get(0).getUsername());
+
+        // search combined with email must narrow down as well
+        List<UserRepresentation> bySearchAndEmail = managedRealm.admin().users().search("Stackbugcommon", null, null, "bob@stackbug.test", true, null, null, null);
+        assertThat(bySearchAndEmail, hasSize(1));
+        assertEquals("stackbob", bySearchAndEmail.get(0).getUsername());
+    }
+
+    @Test
     public void searchWithFilterAndEnabledAttribute() {
         createUser();
 


### PR DESCRIPTION
Closes #49995

## Problem

On `GET /admin/realms/{realm}/users`, the `search` query param overrode the other attribute filters instead of stacking with them. A request like:

GET /admin/realms/my-realm/users?email=foo@bar&username=baz&search=bam

ignored `email` and `username` and only applied the full-text `search`, so it returned every user matching `bam` in username, first/last name or email. The same happened with `idpAlias`, `idpUserId`, `firstName`, `lastName`, `exact` and `q`.

## Cause

In `UsersResource#getUsers`, the logic was an `if (search != null) … else if (other filters) … else …` chain. When `search` was present, the branch that handles all the other filters was never reached, and the `search` branch built
an attribute map containing only `SEARCH` (plus `enabled` / `emailVerified` / created timestamps) before returning early.

## Fix

The branching is reworked so that all provided filters are collected into a single attribute map and applied together, letting `search` stack with the other filters. The special prefix lookups (`id:` / `username:` / `email:`) keep their dedicated path and short-circuit as before. The `includeServiceAccounts` behaviour is preserved: service accounts are excluded when `search` is used and included for plain attribute filtering.

The underlying store layer (`JpaUserProvider#predicates`) already supports combining `SEARCH` with the individual field predicates, so no model changes were needed.

## Testing

Added `UserSearchTest#searchStacksWithOtherFilters`, which creates two users sharing a common last name and verifies that combining `search` with `username` / `email` narrows the result to the matching user instead of returning both.