### PR TITLE
Fix unhandled duplicate-key error on concurrent first-broker-login

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -212,7 +212,11 @@ public class JpaUserFederatedStorageProvider implements
         entity.setBrokerUserName(link.getUserName());
         entity.setStorageProviderId(new StorageId(userId).getProviderId());
         em.persist(entity);
-
+        // Flush so a duplicate broker link is reported as ModelDuplicateException here
+        // at the call site instead of failing only at commit time, where it would bypass
+        // the catch (ModelDuplicateException) in IdentityBrokerService#afterFirstBrokerLogin
+        // under concurrent first-broker-login. Mirrors JpaUserProvider#addFederatedIdentity.
+        em.flush();
     }
 
     @Override

--- a/testsuite/model/src/test/java/org/keycloak/testsuite/model/FederatedIdentityModelTest.java
+++ b/testsuite/model/src/test/java/org/keycloak/testsuite/model/FederatedIdentityModelTest.java
@@ -18,6 +18,7 @@ package org.keycloak.testsuite.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.keycloak.broker.provider.IdentityProvider;
 import org.keycloak.broker.provider.IdentityProviderFactory;
@@ -25,9 +26,12 @@ import org.keycloak.models.Constants;
 import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.provider.ProviderEventListener;
+import org.keycloak.storage.UserStorageUtil;
+import org.keycloak.storage.federated.UserFederatedStorageProvider;
 import org.keycloak.testsuite.broker.oidc.TestKeycloakOidcIdentityProviderFactory;
 
 import org.junit.Test;
@@ -35,6 +39,7 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThrows;
 
 /**
  * @author Réda Housni Alaoui
@@ -44,6 +49,9 @@ public class FederatedIdentityModelTest extends KeycloakModelTest {
 
 	private static final String IDENTITY_PROVIDER_ALIAS = "idp-test";
 	private static final String USERNAME = "jdoe";
+	private static final String STORAGE_USER_ID = "f:test-storage:user-1";
+	private static final String BROKER_USER_ID = "broker-user-1";
+	private static final String BROKER_USERNAME = "jdoe-broker";
 	private String realmId;
 	private String userId;
 
@@ -131,6 +139,59 @@ public class FederatedIdentityModelTest extends KeycloakModelTest {
 		} finally {
 			getFactory().unregister(providerEventListener);
 		}
+	}
+
+	@Test
+	@RequireProvider(UserFederatedStorageProvider.class)
+	public void addExistingFederatedIdentityThrowsModelDuplicateException() {
+		FederatedIdentityModel link = new FederatedIdentityModel(IDENTITY_PROVIDER_ALIAS, BROKER_USER_ID, BROKER_USERNAME);
+
+		withRealm(realmId, (session, realm) -> {
+			UserStorageUtil.userFederatedStorage(session).addFederatedIdentity(realm, STORAGE_USER_ID, link);
+			return null;
+		});
+
+		withRealm(realmId, (session, realm) -> {
+			UserFederatedStorageProvider federatedStorage = UserStorageUtil.userFederatedStorage(session);
+			assertThrows(ModelDuplicateException.class,
+					() -> federatedStorage.addFederatedIdentity(realm, STORAGE_USER_ID, link));
+			return null;
+		});
+
+		withRealm(realmId, (session, realm) -> {
+			assertThat(UserStorageUtil.userFederatedStorage(session).getFederatedIdentitiesStream(STORAGE_USER_ID, realm).count(), equalTo(1L));
+			return null;
+		});
+	}
+
+	@Test
+	@RequireProvider(UserFederatedStorageProvider.class)
+	public void concurrentAddFederatedIdentityCreatesSingleLink() throws InterruptedException {
+		int numberOfThreads = 4;
+		AtomicInteger created = new AtomicInteger();
+		AtomicInteger duplicates = new AtomicInteger();
+		FederatedIdentityModel link = new FederatedIdentityModel(IDENTITY_PROVIDER_ALIAS, BROKER_USER_ID, BROKER_USERNAME);
+
+		inIndependentFactories(numberOfThreads, 60, () -> {
+			try {
+				inComittedTransaction(session -> {
+					RealmModel realm = session.realms().getRealm(realmId);
+					session.getContext().setRealm(realm);
+					UserStorageUtil.userFederatedStorage(session).addFederatedIdentity(realm, STORAGE_USER_ID, link);
+				});
+				created.incrementAndGet();
+			} catch (ModelDuplicateException e) {
+				duplicates.incrementAndGet();
+			}
+		});
+
+		assertThat(created.get(), equalTo(1));
+		assertThat(duplicates.get(), equalTo(numberOfThreads - 1));
+
+		withRealm(realmId, (session, realm) -> {
+			assertThat(UserStorageUtil.userFederatedStorage(session).getFederatedIdentitiesStream(STORAGE_USER_ID, realm).count(), equalTo(1L));
+			return null;
+		});
 	}
 
 }


### PR DESCRIPTION
Closes #49769

When two first-broker-login requests for the same brokered identity run concurrently, both pass the `getUserByFederatedIdentity` check and call `addFederatedIdentity`. For user-storage-backed users, `JpaUserFederatedStorageProvider#addFederatedIdentity` persisted the broker link without flushing, so the duplicate `(identity_provider, user_id)` only failed at commit time and bypassed the `catch (ModelDuplicateException)` in `IdentityBrokerService#afterFirstBrokerLogin` — resulting in an unhandled HTTP 500.

The fix flushes eagerly, mirroring `JpaUserProvider#addFederatedIdentity` for locally stored users, so the duplicate is reported at the call site and the existing handler returns the "already linked" conflict page instead of a 500. The `(identity_provider, user_id)` primary key is preserved — consistent with the discussion on #35059, where relaxing it was rejected.

Adds two `FederatedIdentityModelTest` cases: a direct duplicate regression and a concurrent-race test using independent session factories. Both run under the `jpa-federation*` model-test profiles in CI.


