### PR TITLE
Improvements for webauthn registration and validation

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/browser/WebAuthnAuthenticator.java
@@ -171,7 +171,11 @@ public class WebAuthnAuthenticator implements Authenticator, CredentialValidator
         String rpId = getRpID(context);
 
         Origin origin = new Origin(baseUrl);
-        Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
+        final String challengeNote = context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE);
+        if (challengeNote != null) {
+            context.getAuthenticationSession().removeAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE);
+        }
+        Challenge challenge = new DefaultChallenge(challengeNote);
         ServerProperty server = new ServerProperty(origin, rpId, challenge);
 
         byte[] credentialId = Base64Url.decode(params.getFirst(WebAuthnConstants.CREDENTIAL_ID));

--- a/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
+++ b/services/src/main/java/org/keycloak/authentication/requiredactions/WebAuthnRegister.java
@@ -252,7 +252,11 @@ public class WebAuthnRegister implements RequiredActionProvider, CredentialRegis
                 .map(Origin::new)
                 .collect(Collectors.toSet());
         allOrigins.add(origin);
-        Challenge challenge = new DefaultChallenge(context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE));
+        final String challengeNote = context.getAuthenticationSession().getAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE);
+        if (challengeNote != null) {
+            context.getAuthenticationSession().removeAuthNote(WebAuthnConstants.AUTH_CHALLENGE_NOTE);
+        }
+        Challenge challenge = new DefaultChallenge(challengeNote);
         ServerProperty serverProperty = new ServerProperty(allOrigins, rpId, challenge);
         // check User Verification by considering a malicious user might modify the result of calling WebAuthn API
         boolean isUserVerificationRequired = policy.getUserVerificationRequirement().equals(Constants.WEBAUTHN_POLICY_OPTION_REQUIRED);

--- a/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
+++ b/services/src/main/java/org/keycloak/credential/WebAuthnCredentialProvider.java
@@ -227,6 +227,7 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
 
                     // parse
                     authenticationData = webAuthnAuthenticationManager.parse(context.getAuthenticationRequest());
+
                     // validate
                     AuthenticationParameters authenticationParameters = new AuthenticationParameters(
                             context.getAuthenticationParameters().getServerProperty(),
@@ -244,9 +245,15 @@ public class WebAuthnCredentialProvider implements CredentialProvider<WebAuthnCr
                     // update authenticator counter
                     // counters are an optional feature of the spec - if an authenticator does not support them, it
                     // will always send zero. MacOS/iOS does this for keys stored in the secure enclave (TouchID/FaceID)
-                    long count = auth.getCount();
-                    if (count > 0) {
-                        webAuthnCredModel.updateCounter(count + 1);
+                    final long storedCounter = auth.getCount();
+                    final long clientCounter = authenticationData.getAuthenticatorData().getSignCount();
+                    if (storedCounter > 0 || clientCounter > 0) {
+                        if (clientCounter <= storedCounter) {
+                            logger.debugf("Invalid client counter, authenticator may have been cloned");
+                            return false;
+                        }
+
+                        webAuthnCredModel.updateCounter(clientCounter);
                         user.credentialManager().updateStoredCredential(webAuthnCredModel);
                     }
 

--- a/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnRegisterAndLoginTest.java
+++ b/tests/webauthn/src/test/java/org/keycloak/tests/webauthn/WebAuthnRegisterAndLoginTest.java
@@ -142,7 +142,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
 
         // confirm user registered
         assertUserRegistered(userId, username.toLowerCase(), email.toLowerCase());
-        assertRegisteredCredentials(userId, ALL_ZERO_AAGUID, "none");
+        assertRegisteredCredentials(userId, ALL_ZERO_AAGUID, "none", 1);
 
         events.clear();
 
@@ -170,6 +170,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
                 .details(Details.REDIRECT_URI, testApp.getRedirectionUri())
                 .details(WebAuthnConstants.PUBKEY_CRED_ID_ATTR, regPubKeyCredentialId2)
                 .details(WebAuthnConstants.USER_VERIFICATION_CHECKED, Boolean.FALSE.toString());
+        assertRegisteredCredentials(userId, ALL_ZERO_AAGUID, "none", 2);
 
         events.clear();
         // logout by user
@@ -446,7 +447,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
         assertThat(user.getLastName(), is("lastName"));
     }
 
-    private void assertRegisteredCredentials(String userId, String aaguid, String attestationStatementFormat) {
+    private void assertRegisteredCredentials(String userId, String aaguid, String attestationStatementFormat, long expectedCounter) {
         List<CredentialRepresentation> credentials = getCredentials(userId);
         credentials.forEach(i -> {
             if (WebAuthnCredentialModel.TYPE_TWOFACTOR.equals(i.getType())) {
@@ -454,6 +455,7 @@ public class WebAuthnRegisterAndLoginTest extends AbstractWebAuthnVirtualTest {
                     WebAuthnCredentialData data = JsonSerialization.readValue(i.getCredentialData(), WebAuthnCredentialData.class);
                     assertThat(data.getAaguid(), is(aaguid));
                     assertThat(data.getAttestationStatementFormat(), is(attestationStatementFormat));
+                    assertThat(data.getCounter(), is(expectedCounter));
                 } catch (IOException e) {
                     Assertions.fail();
                 }


### PR DESCRIPTION
Closes #49920
Closes #49921

Adding the two little changes suggested in the issues:

* The auth note for the webauthn challenge is removed after getting it from the auth session.
* The counter returned by the webauth4j is used instead. Besides if the counter is less or equals to the one set in the credential and error is returned because that means that the couter went backwards (which means it was cloned or similar).

Just checked that the counter is updated correctly in one of the tests.
