### PR TITLE
Handle missing UserInfo token algorithm

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/UserInfoEndpoint.java
@@ -51,7 +51,9 @@ import org.keycloak.jose.jwe.JWEException;
 import org.keycloak.jose.jwe.alg.JWEAlgorithmProvider;
 import org.keycloak.jose.jwe.enc.JWEEncryptionProvider;
 import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jws.Algorithm;
 import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.keys.loader.PublicKeyStorageManager;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.ClientModel;
@@ -189,7 +191,12 @@ public class UserInfoEndpoint {
 
             verifier = DPoPUtil.withDPoPVerifier(verifier, realm, new DPoPUtil.Validator(session).request(request).uriInfo(session.getContext().getUri()).accessToken(tokenForUserInfo.getToken()));
 
-            SignatureVerifierContext verifierContext = CryptoUtils.getSignatureProvider(session, verifier.getHeader().getAlgorithm().name()).verifier(verifier.getHeader().getKeyId());
+            JWSHeader header = verifier.getHeader();
+            Algorithm algorithm = header.getAlgorithm();
+            if (algorithm == null) {
+                throw new VerificationException("Missing token algorithm");
+            }
+            SignatureVerifierContext verifierContext = CryptoUtils.getSignatureProvider(session, algorithm.name()).verifier(header.getKeyId());
             verifier.verifierContext(verifierContext);
 
             token = verifier.verify().getToken();

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
@@ -35,6 +35,13 @@ public class TokenInputValidationTest {
     }
 
     @Test
+    public void userInfoRejectsTokensWithoutAlgorithmHeader() {
+        assertUserInfoRejectsInvalidToken("eyJhbGciOm51bGx9.eyJzdWIiOiJ0ZXN0In0.ZmFrZQ");
+        assertUserInfoRejectsInvalidToken("eyJ0eXAiOiJKV1QifQ.eyJzdWIiOiJ0ZXN0In0.ZmFrZQ");
+        assertUserInfoRejectsInvalidToken("e30.eyJzdWIiOiJ0ZXN0In0.ZmFrZQ");
+    }
+
+    @Test
     public void introspectionRejectsAlgNoneToken() throws IOException {
         String noneToken = new JWSBuilder().jsonContent(createDefaultToken()).none();
         IntrospectionResponse response = oauth.doIntrospectionAccessTokenRequest(noneToken);
@@ -51,6 +58,14 @@ public class TokenInputValidationTest {
         token.exp((long) (Time.currentTime() + 300));
         token.subject("attacker");
         return token;
+    }
+
+    private void assertUserInfoRejectsInvalidToken(String token) {
+        UserInfoResponse response = oauth.doUserInfoRequest(token);
+
+        assertEquals(401, response.getStatusCode());
+        assertFalse(response.isSuccess());
+        assertEquals(OAuthErrorException.INVALID_TOKEN, response.getError());
     }
 
 }


### PR DESCRIPTION
## Summary

- Reject UserInfo bearer JWTs with a missing or null JWS algorithm as invalid tokens instead of dereferencing the header algorithm
- Add regression coverage for null, missing, and empty JWT headers on the UserInfo endpoint

## Testing

- `./mvnw -pl tests/base -am -Dskip.pnpm=true -Dkc.test.server=embedded -Dkc.test.database=dev-mem -Dtest=TokenInputValidationTest#userInfoRejectsTokensWithoutAlgorithmHeader -DfailIfNoTests=false -DfailIfNoSpecifiedTests=false package`

Closes #49969
