### PR TITLE
Document querying syntax

### DIFF
--- a/docs/documentation/server_admin/topics/scim/filtering-resources.adoc
+++ b/docs/documentation/server_admin/topics/scim/filtering-resources.adoc
@@ -1,6 +1,6 @@
 [id="scim-filtering-resources_{context}"]
 
-[[_scim_filtering_resources_]]
+[[_scim_filtering_resources]]
 = Filtering resources
 [role="_abstract"]
 

--- a/docs/documentation/server_admin/topics/scim/filtering-resources.adoc
+++ b/docs/documentation/server_admin/topics/scim/filtering-resources.adoc
@@ -90,7 +90,7 @@ Filters can be combined using logical operators:
 | At least one condition must be true.
 
 | `not`
-| Negates the following condition (must be enclosed in parentheses).
+| Negates the following expression. Parentheses are optional but recommended for clarity.
 |===
 
 === Examples

--- a/docs/documentation/server_admin/topics/scim/managing-groups.adoc
+++ b/docs/documentation/server_admin/topics/scim/managing-groups.adoc
@@ -72,7 +72,7 @@ curl http://localhost:8080/realms/myrealm/scim/v2/Groups \
   -H "Accept: application/scim+json"
 ----
 
-For filtering and pagination of results, see <<_scim_filtering_resources_,Filtering resources>>.
+For filtering and pagination of results, see <<_scim_filtering_resources,Filtering resources>>.
 
 == Updating a group
 

--- a/docs/documentation/server_admin/topics/scim/managing-users.adoc
+++ b/docs/documentation/server_admin/topics/scim/managing-users.adoc
@@ -147,7 +147,7 @@ The response uses the SCIM list format:
 }
 ----
 
-For filtering and pagination of results, see <<_scim_filtering_resources_,Filtering resources>>.
+For filtering and pagination of results, see <<_scim_filtering_resources,Filtering resources>>.
 
 == Selecting attributes
 

--- a/docs/documentation/server_admin/topics/scim/understanding-scim-endpoints.adoc
+++ b/docs/documentation/server_admin/topics/scim/understanding-scim-endpoints.adoc
@@ -92,7 +92,7 @@ are also accepted in the body of `POST /.search` requests.
 
 | `filter`
 | String
-| A SCIM filter expression to search for resources. See <<_scim_filtering_resources_,Filtering resources>>.
+| A SCIM filter expression to search for resources. See <<_scim_filtering_resources,Filtering resources>>.
 
 | `startIndex`
 | Integer

--- a/docs/guides/admin-api/admin-api-v2.adoc
+++ b/docs/guides/admin-api/admin-api-v2.adoc
@@ -1,9 +1,10 @@
 <#import "/templates/guide.adoc" as tmpl>
 <#import "/templates/kc.adoc" as kc>
 <#import "/templates/api.adoc" as api>
+<#import "/templates/links.adoc" as links>
 
 <@tmpl.guide
-title="Admin API v2"
+title="Admin API v2: Reference"
 summary="REST API for managing Keycloak resources. Experimental feature.">
 
 <#include "/templates/experimental-feature.adoc">
@@ -57,6 +58,8 @@ The Admin API v2 uses the same CLI tool described in the {adminguide_link}#admin
 <@kc.admin parameters="--v2 config credentials --server http://localhost:8080 --realm master --user admin"/>
 
 == Available Resources
+
+For details on filtering and projection, see <@links.adminapi id="querying" />.
 
 <#if ctx.adminApiV2.hasEndpoints()>
 <#list ctx.adminApiV2.categories as category>

--- a/docs/guides/admin-api/pinned-guides
+++ b/docs/guides/admin-api/pinned-guides
@@ -1,2 +1,3 @@
 protocol-mappers
 admin-api-v2
+querying

--- a/docs/guides/admin-api/querying.adoc
+++ b/docs/guides/admin-api/querying.adoc
@@ -1,7 +1,7 @@
 <#import "/templates/guide.adoc" as tmpl>
 
 <@tmpl.guide
-title="Filtering and Projection"
+title="Admin API v2: Filtering and Projection"
 summary="Filter and project client resources using the Admin API v2 query syntax.">
 
 <#include "/templates/experimental-feature.adoc">

--- a/docs/guides/admin-api/querying.adoc
+++ b/docs/guides/admin-api/querying.adoc
@@ -1,0 +1,288 @@
+<#import "/templates/guide.adoc" as tmpl>
+
+<@tmpl.guide
+title="Filtering and Projection"
+summary="Filter and project client resources using the Admin API v2 query syntax.">
+
+== Filtering and projecting clients with the Admin API v2
+
+<#include "/templates/experimental-feature.adoc">
+
+The Admin API v2 supports filtering clients using the `q` query parameter.
+The filter syntax is a subset of the link:{adminguide_link}#_scim_filtering_resources[SCIM filter syntax] defined in link:https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2[RFC 7644, Section 3.4.2.2].
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=<filter-expression>
+----
+
+String values must be enclosed in double quotes.
+Boolean values are unquoted.
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=clientId eq "my-app"
+GET /admin/api/{realm}/clients/v2?q=enabled eq true
+----
+
+=== Supported operators
+
+The following comparison operators are supported for client filtering:
+
+[cols="1,2,3",options="header"]
+|===
+|Operator |Meaning |Example
+
+|`eq`
+|Equal
+|`clientId eq "my-app"`
+
+|`ne`
+|Not equal
+|`protocol ne "saml"`
+
+|`co`
+|Contains (substring)
+|`description co "oauth"`
+
+|`sw`
+|Starts with
+|`clientId sw "query-"`
+
+|`ew`
+|Ends with
+|`clientId ew "-app"`
+
+|`pr`
+|Present (field is not null)
+|`description pr`
+|===
+
+Logical operators (`and`, `or`, `not`) and parentheses for grouping are supported.
+For the full syntax reference, including operator precedence and detailed examples, see the link:{adminguide_link}#_scim_filtering_resources[SCIM filtering] {section} in the {adminguide_name}.
+
+[NOTE]
+====
+The `gt`, `ge`, `lt`, and `le` operators supported by the SCIM API are not available for client filtering.
+====
+
+=== Queryable fields
+
+Only registered fields can be used in filter expressions.
+Using an unknown field returns HTTP 400.
+
+==== Common fields (all client types)
+
+[cols="1,1,3",options="header"]
+|===
+|Field |Type |Description
+
+|`clientId`
+|String
+|Client identifier
+
+|`displayName`
+|String
+|Display name shown in the UI
+
+|`description`
+|String
+|Client description
+
+|`enabled`
+|Boolean
+|Whether the client is enabled
+
+|`protocol`
+|String
+|Protocol type (`openid-connect` or `saml`)
+
+|`appUrl`
+|String
+|Application base URL
+
+|`redirectUris`
+|Set<String>
+|Registered redirect URIs
+
+|`roles`
+|Set<String>
+|Client role names
+|===
+
+==== OIDC-specific fields
+
+These fields are available only for `openid-connect` clients.
+They return `null` for SAML clients (no error, no match).
+
+[cols="1,1,3",options="header"]
+|===
+|Field |Type |Description
+
+|`loginFlows`
+|Set<Enum>
+|Enabled login flows (`STANDARD`, `IMPLICIT`, `DIRECT_GRANT`, `SERVICE_ACCOUNT`, `TOKEN_EXCHANGE`, `DEVICE`, `CIBA`)
+
+|`auth.method`
+|String
+|Client authentication method (e.g. `client-secret`, `client-secret-jwt`)
+
+|`webOrigins`
+|Set<String>
+|Allowed web origins
+
+|`serviceAccountRoles`
+|Set<String>
+|Roles assigned to the service account
+|===
+
+==== SAML-specific fields
+
+These fields are available only for `saml` clients.
+They return `null` for OIDC clients (no error, no match).
+
+[cols="1,1,3",options="header"]
+|===
+|Field |Type |Description
+
+|`nameIdFormat`
+|String
+|Name ID format (`username`, `email`, `persistent`, `transient`)
+
+|`forceNameIdFormat`
+|Boolean
+|Force the specified Name ID format
+
+|`includeAuthnStatement`
+|Boolean
+|Include AuthnStatement in the response
+
+|`signDocuments`
+|Boolean
+|Sign SAML documents on the server side
+
+|`signAssertions`
+|Boolean
+|Sign SAML assertions
+
+|`clientSignatureRequired`
+|Boolean
+|Require the client to sign requests
+
+|`signatureAlgorithm`
+|String
+|Signature algorithm (e.g. `RSA_SHA256`)
+
+|`signatureCanonicalizationMethod`
+|String
+|Canonicalization method for XML signatures
+
+|`signingCertificate`
+|String
+|X.509 certificate for signing (PEM format, without headers)
+
+|`forcePostBinding`
+|Boolean
+|Force POST binding for responses
+
+|`frontChannelLogout`
+|Boolean
+|Use front-channel logout (browser redirect)
+
+|`allowEcpFlow`
+|Boolean
+|Allow Enhanced Client or Proxy flow
+|===
+
+=== Collection field matching
+
+For fields that hold a collection of values (`redirectUris`, `roles`, `loginFlows`, `webOrigins`, `serviceAccountRoles`), the comparison operators match if *any* element in the collection satisfies the condition:
+
+[source]
+----
+q=roles eq "admin" // <1>
+q=redirectUris co "example.com" // <2>
+q=loginFlows eq "SERVICE_ACCOUNT" // <3>
+----
+<1> Matches clients that have a role named `admin`.
+<2> Matches clients with any redirect URI containing `example.com`.
+<3> Matches OIDC clients with the service account flow enabled.
+
+To match clients that have multiple values, combine conditions with `and`:
+
+[source]
+----
+q=roles eq "admin" and roles eq "user"
+----
+
+=== Examples
+
+Find all enabled OIDC clients:
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=protocol eq "openid-connect" and enabled eq true
+----
+
+Find clients with a description:
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=description pr
+----
+
+Find OIDC clients using client-secret authentication:
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=auth.method eq "client-secret"
+----
+
+Find SAML clients with document signing enabled:
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=signDocuments eq true
+----
+
+Find clients by display name prefix, excluding a specific protocol:
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=displayName sw "My" and protocol ne "saml"
+----
+
+=== Projection
+
+Use the `fields` query parameter to include only specific fields in the response.
+If omitted, all fields are returned.
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?fields=clientId,enabled,protocol
+----
+
+Filtering and projection can be combined.
+The filter evaluates against the full representation before projection is applied, so filtered fields do not need to be included in the projection:
+
+[source]
+----
+GET /admin/api/{realm}/clients/v2?q=enabled eq true&fields=clientId,displayName
+----
+
+=== Error handling
+
+The server returns HTTP 400 with a descriptive error message when:
+
+* The filter expression has a syntax error.
+* The filter references an unknown field.
+* The filter uses an unsupported operator (e.g. `gt`, `ge`, `lt`, `le`).
+
+[source,json]
+----
+{
+  "error": "Unknown query field: unknownField"
+}
+----
+
+</@tmpl.guide>

--- a/docs/guides/admin-api/querying.adoc
+++ b/docs/guides/admin-api/querying.adoc
@@ -67,7 +67,7 @@ The `gt`, `ge`, `lt`, and `le` operators supported by the SCIM API are not avail
 === Queryable fields
 
 Only registered fields can be used in filter expressions.
-Using an unknown field returns HTTP 400.
+Using an unknown field returns HTTP 400, unlike the SCIM API which silently ignores unrecognized attributes.
 
 ==== Common fields (all client types)
 
@@ -115,14 +115,15 @@ Using an unknown field returns HTTP 400.
 ==== OIDC-specific fields
 
 These fields are available only for `openid-connect` clients.
-They return `null` for SAML clients (no error, no match).
+They resolve to `null` for SAML clients, so value-based comparisons like `eq`, `co`, or `sw` will not match.
+However, `eq null` and `not ... pr` will match because the field is genuinely absent.
 
 [cols="1,1,3",options="header"]
 |===
 |Field |Type |Description
 
 |`loginFlows`
-|Set<Enum>
+|Set<String>
 |Enabled login flows (`STANDARD`, `IMPLICIT`, `DIRECT_GRANT`, `SERVICE_ACCOUNT`, `TOKEN_EXCHANGE`, `DEVICE`, `CIBA`)
 
 |`auth.method`
@@ -141,7 +142,8 @@ They return `null` for SAML clients (no error, no match).
 ==== SAML-specific fields
 
 These fields are available only for `saml` clients.
-They return `null` for OIDC clients (no error, no match).
+They resolve to `null` for OIDC clients, so value-based comparisons like `eq`, `co`, or `sw` will not match.
+However, `eq null` and `not ... pr` will match because the field is genuinely absent.
 
 [cols="1,1,3",options="header"]
 |===
@@ -198,11 +200,14 @@ They return `null` for OIDC clients (no error, no match).
 
 === Collection field matching
 
-For fields that hold a collection of values (`redirectUris`, `roles`, `loginFlows`, `webOrigins`, `serviceAccountRoles`), the comparison operators match if *any* element in the collection satisfies the condition:
+For fields that hold a collection of values (`redirectUris`, `roles`, `loginFlows`, `webOrigins`, `serviceAccountRoles`), the `eq`, `co`, `sw`, and `ew` operators match if *any* element in the collection satisfies the condition:
 
 * `roles eq "admin"` - matches clients that have a role named `admin`
 * `redirectUris co "example.com"` - matches clients with any redirect URI containing `example.com`
 * `loginFlows eq "SERVICE_ACCOUNT"` - matches OIDC clients with the service account flow enabled
+
+The `ne` operator is the logical negation of `eq`: it matches if *no* element in the collection equals the value.
+For example, `roles ne "admin"` matches clients that do not have a role named `admin`.
 
 To match clients that have multiple values, combine conditions with `and`:
 

--- a/docs/guides/admin-api/querying.adoc
+++ b/docs/guides/admin-api/querying.adoc
@@ -4,16 +4,14 @@
 title="Filtering and Projection"
 summary="Filter and project client resources using the Admin API v2 query syntax.">
 
-== Filtering and projecting clients with the Admin API v2
-
 <#include "/templates/experimental-feature.adoc">
 
 The Admin API v2 supports filtering clients using the `q` query parameter.
-The filter syntax is a subset of the link:{adminguide_link}#_scim_filtering_resources[SCIM filter syntax] defined in link:https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2[RFC 7644, Section 3.4.2.2].
+The filter syntax is a subset of the link:{adminguide_link}#_scim_filtering_resources[SCIM filter syntax] defined in link:https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2[RFC 7644, Section 3.4.2.2]. All string comparisons are case-sensitive.
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=<filter-expression>
+GET /admin/api/{realmName}/clients/v2?q=<filter-expression>
 ----
 
 String values must be enclosed in double quotes.
@@ -21,8 +19,8 @@ Boolean values are unquoted.
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=clientId eq "my-app"
-GET /admin/api/{realm}/clients/v2?q=enabled eq true
+GET /admin/api/{realmName}/clients/v2?q=clientId eq "my-app"
+GET /admin/api/{realmName}/clients/v2?q=enabled eq true
 ----
 
 === Supported operators
@@ -76,6 +74,10 @@ Using an unknown field returns HTTP 400.
 [cols="1,1,3",options="header"]
 |===
 |Field |Type |Description
+
+|`uuid`
+|String
+|Internal unique identifier
 
 |`clientId`
 |String
@@ -198,15 +200,9 @@ They return `null` for OIDC clients (no error, no match).
 
 For fields that hold a collection of values (`redirectUris`, `roles`, `loginFlows`, `webOrigins`, `serviceAccountRoles`), the comparison operators match if *any* element in the collection satisfies the condition:
 
-[source]
-----
-q=roles eq "admin" // <1>
-q=redirectUris co "example.com" // <2>
-q=loginFlows eq "SERVICE_ACCOUNT" // <3>
-----
-<1> Matches clients that have a role named `admin`.
-<2> Matches clients with any redirect URI containing `example.com`.
-<3> Matches OIDC clients with the service account flow enabled.
+* `roles eq "admin"` - matches clients that have a role named `admin`
+* `redirectUris co "example.com"` - matches clients with any redirect URI containing `example.com`
+* `loginFlows eq "SERVICE_ACCOUNT"` - matches OIDC clients with the service account flow enabled
 
 To match clients that have multiple values, combine conditions with `and`:
 
@@ -221,35 +217,35 @@ Find all enabled OIDC clients:
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=protocol eq "openid-connect" and enabled eq true
+GET /admin/api/{realmName}/clients/v2?q=protocol eq "openid-connect" and enabled eq true
 ----
 
 Find clients with a description:
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=description pr
+GET /admin/api/{realmName}/clients/v2?q=description pr
 ----
 
 Find OIDC clients using client-secret authentication:
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=auth.method eq "client-secret"
+GET /admin/api/{realmName}/clients/v2?q=auth.method eq "client-secret"
 ----
 
 Find SAML clients with document signing enabled:
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=signDocuments eq true
+GET /admin/api/{realmName}/clients/v2?q=signDocuments eq true
 ----
 
 Find clients by display name prefix, excluding a specific protocol:
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=displayName sw "My" and protocol ne "saml"
+GET /admin/api/{realmName}/clients/v2?q=displayName sw "My" and protocol ne "saml"
 ----
 
 === Projection
@@ -259,7 +255,7 @@ If omitted, all fields are returned.
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?fields=clientId,enabled,protocol
+GET /admin/api/{realmName}/clients/v2?fields=clientId,enabled,protocol
 ----
 
 Filtering and projection can be combined.
@@ -267,7 +263,7 @@ The filter evaluates against the full representation before projection is applie
 
 [source]
 ----
-GET /admin/api/{realm}/clients/v2?q=enabled eq true&fields=clientId,displayName
+GET /admin/api/{realmName}/clients/v2?q=enabled eq true&fields=clientId,displayName
 ----
 
 === Error handling

--- a/docs/guides/templates/links.adoc
+++ b/docs/guides/templates/links.adoc
@@ -5,3 +5,4 @@
 <#macro gettingstarted id anchor="">link:{links_getting-started_${id}_url}<#if anchor != "">#${anchor}</#if>[{links_getting-started_${id}_name}]</#macro>
 <#macro observability id anchor="">link:{links_observability_${id}_url}<#if anchor != "">#${anchor}</#if>[{links_observability_${id}_name}]</#macro>
 <#macro uicustomization id anchor="">link:{links_ui-customization_${id}_url}<#if anchor != "">#${anchor}</#if>[{links_ui-customization_${id}_name}]</#macro>
+<#macro adminapi id anchor="">link:{links_admin-api_${id}_url}<#if anchor != "">#${anchor}</#if>[{links_admin-api_${id}_name}]</#macro>

--- a/rest/admin-v2/services/src/test/java/org/keycloak/services/client/query/ClientQueryEvaluatorTest.java
+++ b/rest/admin-v2/services/src/test/java/org/keycloak/services/client/query/ClientQueryEvaluatorTest.java
@@ -188,6 +188,22 @@ class ClientQueryEvaluatorTest {
     }
 
     @Test
+    void notEqualOnCollection() {
+        var client = createClient("test", true);
+        client.setRoles(Set.of("admin", "user", "viewer"));
+        // ne is the logical negation of eq: matches if NO element equals the value
+        assertTrue(matches("roles ne \"superadmin\"", client));
+        assertFalse(matches("roles ne \"admin\"", client));
+    }
+
+    @Test
+    void notEqualOnEmptyCollection() {
+        var client = createClient("test", true);
+        client.setRoles(Set.of());
+        assertTrue(matches("roles ne \"admin\"", client));
+    }
+
+    @Test
     void containsOnCollection() {
         var client = createClient("test", true);
         client.setRoles(Set.of("admin-role", "user-role"));


### PR DESCRIPTION
Closes #49724

The filter syntax is a subset of the SCIM filter syntax already documented in the Server Administration Guide. This guide links to that section for operator/logical details and focuses on what's specific to the Admin API v2: the queryable fields, how collection fields match, how projection interacts with filtering and error responses.

Also, I renamed SCIM anchor to match server_admin convention (no trailing _). The old form broke cross-reference URLs via AsciiDoc italic rendering.