### PR TITLE
[OID4VCI] Restore support for pre-auth tx_code

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -411,7 +411,7 @@ public class OID4VCIssuerEndpoint {
      * Creates a Credential Offer that is bound to a specific user.
      */
     public Response createCredentialOffer(String credConfigId, boolean preAuthorized, String targetUser) {
-        return createCredentialOffer(credConfigId, preAuthorized, targetUser, null, OfferResponseType.URI, 0, 0);
+        return createCredentialOffer(credConfigId, preAuthorized, false, targetUser, null, OfferResponseType.URI, 0, 0);
     }
 
     /**
@@ -467,6 +467,7 @@ public class OID4VCIssuerEndpoint {
      *
      * @param credentialConfigurationId  A valid credential configuration id
      * @param preAuthorized A flag whether the offer should be pre-authorized
+     * @param withTxCode    A flag whether a tx_code should be generated for a pre-auth offer
      * @param targetUser    The username that the offer is authorized for
      * @param expiresAt     The date/time when the offer expires (in Unix timestamp seconds)
      * @param responseType  The response type, which can be 'uri', 'qr' or 'uri+qr'
@@ -479,6 +480,7 @@ public class OID4VCIssuerEndpoint {
     public Response createCredentialOffer(
             @QueryParam("credential_configuration_id") String credentialConfigurationId,
             @QueryParam("pre_authorized") @DefaultValue("false") Boolean preAuthorized,
+            @QueryParam("tx_code") @DefaultValue("false") Boolean withTxCode,
             @QueryParam("target_user") String targetUser,
             @QueryParam("expire") Integer expiresAt,
             @QueryParam("type") @DefaultValue("uri") OfferResponseType responseType,
@@ -547,9 +549,10 @@ public class OID4VCIssuerEndpoint {
         CredentialOfferState offerState;
         try {
 
+            boolean generateTxCode = preAuthorized && withTxCode;
             CredentialOfferProvider offerProvider = session.getProvider(CredentialOfferProvider.class);
             offerState = offerProvider.createCredentialOffer(loginUserModel, grantType,
-                    credentialConfigurationIds, targetClientId, targetUser, expiresAt);
+                    credentialConfigurationIds, targetClientId, targetUser, generateTxCode, expiresAt);
 
         } catch (CredentialOfferException ex) {
             eventBuilder.detail(Details.REASON, ex.getMessage()).error(ex.getErrorType());
@@ -576,7 +579,8 @@ public class OID4VCIssuerEndpoint {
         CredentialsOffer credOffer = offerState.getCredentialsOffer();
         CredentialOfferURI credOfferURI = new CredentialOfferURI()
                 .setIssuer(credOffer.getCredentialIssuer() + "/protocol/" + OID4VC_PROTOCOL + "/" + CREDENTIAL_OFFER_PATH)
-                .setNonce(offerState.getNonce());
+                .setNonce(offerState.getNonce())
+                .setTxCode(offerState.getTxCode());
 
         // Respond with QR-Code as 'image/png'
         if (responseType == OfferResponseType.QR) {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferProvider.java
@@ -81,6 +81,7 @@ public interface CredentialOfferProvider extends Provider {
             List<String> credentialConfigurationIds,
             String targetClientId,
             String targetUserId,
+            Boolean withTxCode,
             Integer expireAt
     );
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
@@ -16,6 +16,7 @@
  */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -42,16 +43,21 @@ public class CredentialOfferState {
     private long expiresAt;
     private List<OID4VCAuthorizationDetail> authDetails;
 
+    private static final SecureRandom TX_CODE_RANDOM = new SecureRandom();
+    private static final char[] TX_CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+    private static final int TX_CODE_LENGTH = 6;
+
     /**
      * Create a new CredentialOfferState.
      * <p>
      * This should only be called from the configured  {@code CredentialOfferProvider}.
      * The constructor is public for testing purposes only.
      *
-     * @param credOffer   The credential offer
-     * @param clientId    The target client_id
-     * @param userId      The target user id
-     * @param expiresAt    The expiry date of the offer in seconds
+     * @param credOffer           The credential offer
+     * @param clientId            The target client_id
+     * @param userId              The target user id
+     * @param expiresAt           The expiry date of the offer in seconds
+     * @param withTxCode          A flag to indicate whether a tx_code should be generated
      * @param authDetailsProvider A provider function for authorization details, (optionally) one for each credential_configuration_id
      */
     public CredentialOfferState(
@@ -59,6 +65,7 @@ public class CredentialOfferState {
             String clientId,
             String userId,
             long expiresAt,
+            Boolean withTxCode,
             Function<String, List<OID4VCAuthorizationDetail>> authDetailsProvider
     ) {
         this.credentialsOfferId = Base64Url.encode(RandomSecret.createRandomSecret(64));
@@ -68,6 +75,9 @@ public class CredentialOfferState {
         this.expiresAt = expiresAt;
         String nonceSecret = Base64Url.encode(RandomSecret.createRandomSecret(64));
         this.nonce = CredentialOfferLookupKey.embed(nonceSecret, credentialsOfferId);
+        if (withTxCode == Boolean.TRUE) { // Allow null for authorization_code grant
+            this.txCode = generateTxCode();
+        }
         if (authDetailsProvider != null) {
             this.authDetails = authDetailsProvider.apply(credentialsOfferId);
         }
@@ -148,12 +158,22 @@ public class CredentialOfferState {
 
     // Private ---------------------------------------------------------------------------------------------------------
 
-    // For json serialization
+    // For JSON serialization
     private CredentialOfferState() {
     }
 
-    // For json serialization
+    // For JSON serialization
     private void setAuthorizationDetails(List<OID4VCAuthorizationDetail> authDetails) {
         this.authDetails = authDetails;
+    }
+
+    private String generateTxCode() {
+        int alphabetLength = TX_CODE_ALPHABET.length;
+        var sb = new StringBuilder(TX_CODE_LENGTH);
+        for (int i = 0; i < TX_CODE_LENGTH; i++) {
+            int idx = TX_CODE_RANDOM.nextInt(alphabetLength);
+            sb.append(TX_CODE_ALPHABET[idx]);
+        }
+        return sb.toString();
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/DefaultCredentialOfferProvider.java
@@ -65,6 +65,7 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
             List<String> credentialConfigurationIds,
             String targetClientId,
             String targetUsername,
+            Boolean withTxCode,
             Integer expireAt) {
 
         // Checks whether `--feature=oid4vc_vci_preauth_code` is enabled
@@ -103,7 +104,7 @@ class DefaultCredentialOfferProvider implements CredentialOfferProvider {
 
         // Create the CredentialOfferState
         //
-        CredentialOfferState offerState = new CredentialOfferState(credOffer, targetClientId, targetUserId, expireAt, credOffersId -> {
+        CredentialOfferState offerState = new CredentialOfferState(credOffer, targetClientId, targetUserId, expireAt, withTxCode, credOffersId -> {
             List<OID4VCAuthorizationDetail> authDetails = new ArrayList<>();
             for (String credConfigId : credentialConfigurationIds) {
                 CredentialScopeModel credScope = findCredentialScopeModelByConfigurationId(

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/VerifiableCredentialOfferAction.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/requiredactions/VerifiableCredentialOfferAction.java
@@ -177,7 +177,7 @@ public class VerifiableCredentialOfferAction implements RequiredActionProvider, 
         String clientId = actionConfig.getClientId();
         CredentialOfferProvider offerProvider = session.getProvider(CredentialOfferProvider.class);
         CredentialOfferState offerState = offerProvider.createCredentialOffer(user, grantType,
-                List.of(credentialConfigurationId), clientId, user.getUsername(), expiresAt);
+                List.of(credentialConfigurationId), clientId, user.getUsername(), false, expiresAt);
 
         CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
         offerStorage.putOfferState(offerState);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialOfferURI.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/CredentialOfferURI.java
@@ -35,6 +35,9 @@ public class CredentialOfferURI {
     private String issuer;
     private String nonce;
 
+    @JsonProperty("tx_code")
+    private String txCode;
+
     @JsonProperty("qr_code")
     private String qrCode;
 
@@ -53,6 +56,15 @@ public class CredentialOfferURI {
 
     public CredentialOfferURI setNonce(String nonce) {
         this.nonce = nonce;
+        return this;
+    }
+
+    public String getTxCode() {
+        return txCode;
+    }
+
+    public CredentialOfferURI setTxCode(String txCode) {
+        this.txCode = txCode;
         return this;
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/PreAuthorizedCodeGrantType.java
@@ -45,6 +45,7 @@ import org.keycloak.models.UserSessionModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
+import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.preauth.PreAuthCodeHandler;
 import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
@@ -91,8 +92,6 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         // Get token request parameters
         // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-token-request
         String preAuthCode = formParams.getFirst(PreAuthorizedCodeGrant.CODE_REQUEST_PARAM);
-        String txCode = formParams.getFirst(PreAuthorizedCodeGrant.TX_CODE_PARAM);
-
         if (preAuthCode == null) {
             // See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-token-request
             String errorMessage = "Missing parameter: " + PRE_AUTH_GRANT_TYPE;
@@ -103,39 +102,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         // Verify the pre-auth code and recover the public context associated with it.
         // The verification logic is delegated to the configured PreAuthCodeHandler provider.
-        PreAuthCodeCtx ctx = verifyPreAuthCode(preAuthCode);
-
-        // Recover matching credential offer state in storage
-        var offerStorage = session.getProvider(CredentialOfferStorage.class);
-        var offerState = offerStorage.getOfferStateById(ctx.getCredentialsOfferId());
-        if (offerState == null) {
-            var errorMessage = "No credential offer state for pre-auth code: " + preAuthCode;
-            event.detail(REASON, errorMessage).error(Errors.INVALID_CODE);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
-                    errorMessage, Response.Status.BAD_REQUEST);
-        }
-
-        if (offerState.isExpired()) {
-            event.error(Errors.EXPIRED_CODE);
-            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
-                    "Code is expired", Response.Status.BAD_REQUEST);
-        }
-
-        String expTxCode = offerState.getTxCode();
-        if (expTxCode != null) {
-            if (Strings.isEmpty(txCode)) {
-                event.error(Errors.MISSING_TX_CODE);
-                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
-                        "Missing TxCode", Response.Status.BAD_REQUEST);
-            }
-            // Prevent timing attacks - execution time does not depend on where the first difference occurs
-            if (!MessageDigest.isEqual(expTxCode.getBytes(), txCode.getBytes())) {
-                event.error(Errors.INVALID_TX_CODE);
-                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
-                        "Invalid TxCode", Response.Status.BAD_REQUEST);
-            }
-        }
-
+        CredentialOfferState offerState = verifyPreAuthCode(preAuthCode);
         CredentialsOffer credOffer = offerState.getCredentialsOffer();
 
         var targetUserId = offerState.getTargetUserId();
@@ -295,11 +262,14 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
         return audiences != null && audiences.length == 1 && expectedAudience.equals(audiences[0]);
     }
 
+    // Private ---------------------------------------------------------------------------------------------------------
+
     /**
      * Runs the pre-auth code verification logic using the configured PreAuthCodeHandler provider.
-     * A public, partial view of the CredentialOfferState is returned upon successful verification.
+     * @return CredentialOfferState upon successful verification
      */
-    private PreAuthCodeCtx verifyPreAuthCode(String code) {
+    private CredentialOfferState verifyPreAuthCode(String preAuthCode) {
+
         PreAuthCodeHandler preAuthCodeHandler = session.getProvider(PreAuthCodeHandler.class);
         if (preAuthCodeHandler == null) {
             throw new IllegalStateException("No PreAuthCodeHandler provider available");
@@ -307,7 +277,7 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
 
         PreAuthCodeCtx preAuthCodeCtx;
         try {
-            preAuthCodeCtx = preAuthCodeHandler.verifyPreAuthCode(code);
+            preAuthCodeCtx = preAuthCodeHandler.verifyPreAuthCode(preAuthCode);
         } catch (VerificationException e) {
             String errorType = Optional.ofNullable(e.getErrorType()).orElse(Errors.INVALID_CODE);
             String errorMessage = String.format("Pre-authorized code failed handler verification (%s)", errorType);
@@ -319,11 +289,44 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                             : OAuthErrorException.EXPIRED_TOKEN,
                     errorMessage, Response.Status.BAD_REQUEST);
         }
+        String credOfferId = preAuthCodeCtx.getCredentialsOfferId();
+
+        // Get matching credential offer state from storage
+        var offerStorage = session.getProvider(CredentialOfferStorage.class);
+        var offerState = offerStorage.getOfferStateById(credOfferId);
+        if (offerState == null) {
+            var errorMessage = "No credential offer state: " + credOfferId;
+            event.detail(REASON, errorMessage).error(Errors.INVALID_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST,
+                    errorMessage, Response.Status.BAD_REQUEST);
+        }
+
+        if (offerState.isExpired()) {
+            event.error(Errors.EXPIRED_CODE);
+            throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                    "Code is expired", Response.Status.BAD_REQUEST);
+        }
+        String txCode = formParams.getFirst(PreAuthorizedCodeGrant.TX_CODE_PARAM);
+
+        String expTxCode = offerState.getTxCode();
+        if (expTxCode != null) {
+            if (Strings.isEmpty(txCode)) {
+                event.error(Errors.MISSING_TX_CODE);
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                        "Missing TxCode", Response.Status.BAD_REQUEST);
+            }
+            // Prevent timing attacks - execution time does not depend on where the first difference occurs
+            if (!MessageDigest.isEqual(expTxCode.getBytes(StandardCharsets.UTF_8), txCode.getBytes(StandardCharsets.UTF_8))) {
+                event.error(Errors.INVALID_TX_CODE);
+                throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_GRANT,
+                        "Invalid TxCode", Response.Status.BAD_REQUEST);
+            }
+        }
 
         // Pre-auth code is valid, but let's prevent replay attacks (for the remaining validity period)
         SingleUseObjectProvider singleUseStore = session.singleUseObjects();
-        String key = getPreAuthCodeSingleObjectKey(code);
-        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTime();
+        String key = getPreAuthCodeSingleObjectKey(preAuthCode);
+        long expiresIn = preAuthCodeCtx.getExpiresAt() - Time.currentTimeSeconds();
         boolean firstInsertion = singleUseStore.putIfAbsent(key, expiresIn);
         if (!firstInsertion) {
             String errorMessage = "Pre-authorized code has already been used";
@@ -332,11 +335,11 @@ public class PreAuthorizedCodeGrantType extends OAuth2GrantTypeBase {
                     errorMessage, Response.Status.BAD_REQUEST);
         }
 
-        return preAuthCodeCtx;
+        return offerState;
     }
 
-    private static String getPreAuthCodeSingleObjectKey(String code) {
-        String hash = HashUtils.sha256UrlEncodedHash(code.trim(), StandardCharsets.UTF_8);
+    private static String getPreAuthCodeSingleObjectKey(String preAuthCode) {
+        String hash = HashUtils.sha256UrlEncodedHash(preAuthCode.trim(), StandardCharsets.UTF_8);
         String fqcn = PreAuthorizedCodeGrantType.class.getName().toLowerCase();
         return fqcn + "." + hash;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -77,6 +77,7 @@ import static org.keycloak.tests.oid4vc.OID4VCTestContext.AUTHORIZATION_SERVER_M
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.AttachmentKey;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CREDENTIALS_OFFER_RESPONSE_ATTACHMENT_KEY;
+import static org.keycloak.tests.oid4vc.OID4VCTestContext.CREDENTIALS_OFFER_URI_REQUEST_ATTACHMENT_KEY;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CREDENTIALS_OFFER_URI_RESPONSE_ATTACHMENT_KEY;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CREDENTIALS_RESPONSE_ATTACHMENT_KEY;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.ISSUER_METADATA_ATTACHMENT_KEY;
@@ -131,9 +132,9 @@ public class OID4VCBasicWallet {
         CredentialOfferUriResponse credOfferUriRes;
         try {
             String credConfigId = ctx.getCredentialConfigurationId();
-            var uriRequest = credentialOfferUriRequest(ctx, credConfigId);
-            consumer.accept(uriRequest.bearerToken(issToken));
-            credOfferUriRes = uriRequest.send();
+            var credOfferUriRequest = credentialOfferUriRequest(ctx, credConfigId);
+            consumer.accept(credOfferUriRequest.bearerToken(issToken));
+            credOfferUriRes = credOfferUriRequest.send();
         } finally {
             logout(ctx.getIssuer());
         }
@@ -149,6 +150,11 @@ public class OID4VCBasicWallet {
         // Create CredentialOfferURI
         //
         CredentialOfferURI credOfferUri = createCredentialOfferUri(ctx, consumer);
+
+        if (ctx.getAttachment(CREDENTIALS_OFFER_URI_REQUEST_ATTACHMENT_KEY).hasTxCode()) {
+            String txCode = credOfferUri.getTxCode();
+            assertNotNull(txCode, "No TxCode");
+        }
 
         // Fetch the CredentialsOffer
         //
@@ -355,13 +361,17 @@ public class OID4VCBasicWallet {
     }
 
     public PreAuthorizedCodeGrantRequest accessTokenRequestPreAuth(OID4VCTestContext ctx, String preAuthCode) {
+        return accessTokenRequestPreAuth(ctx, preAuthCode, null);
+    }
+
+    public PreAuthorizedCodeGrantRequest accessTokenRequestPreAuth(OID4VCTestContext ctx, String preAuthCode, String txCode) {
         PreAuthorizedCodeGrantRequest request = new PreAuthorizedCodeGrantRequest(oauth, preAuthCode) {
             public AccessTokenResponse send() {
                 AccessTokenResponse response = super.send();
                 ctx.putAttachment(ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY, response);
                 return response;
             }
-        };
+        }.txCode(txCode);
         return request;
     }
 
@@ -373,6 +383,7 @@ public class OID4VCBasicWallet {
                 return response;
             }
         };
+        ctx.putAttachment(CREDENTIALS_OFFER_URI_REQUEST_ATTACHMENT_KEY, request);
         return request;
     }
 
@@ -404,11 +415,15 @@ public class OID4VCBasicWallet {
     }
 
     public Oid4vcCredentialResponse fetchCredentialByOffer(OID4VCTestContext ctx, CredentialsOffer offer) {
+        return fetchCredentialByOffer(ctx, offer, null);
+    }
+
+    public Oid4vcCredentialResponse fetchCredentialByOffer(OID4VCTestContext ctx, CredentialsOffer offer, String txCode) {
 
         AccessTokenResponse tokenResponse;
         if (offer.hasPreAuthorizedGrant()) {
 
-            tokenResponse = accessTokenRequestPreAuth(ctx, offer.getPreAuthorizedCode()).send();
+            tokenResponse = accessTokenRequestPreAuth(ctx, offer.getPreAuthorizedCode(), txCode).send();
 
         } else {
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCCredentialOfferCorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCCredentialOfferCorsTest.java
@@ -290,10 +290,11 @@ public class OID4VCCredentialOfferCorsTest extends OID4VCIssuerEndpointTest {
                     .addGrant(new PreAuthorizedCodeGrant().setPreAuthorizedCode("test-code"))
                     .setCredentialConfigurationIds(List.of(jwtTypeCredentialConfigurationIdName));
 
-            CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
             // Create offer with expiration time just 1 second in the past
             // This ensures it's still findable in storage but marked as expired
-            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() - 1, null);
+            long expiresAt = Time.currentTimeSeconds() - 1;
+            CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
+            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, expiresAt, false, null);
             offerStorage.putOfferState(offerState);
             return offerState.getNonce();
         });

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCJWTIssuerEndpointTest.java
@@ -230,8 +230,9 @@ public class OID4VCJWTIssuerEndpointTest extends OID4VCIssuerEndpointTest {
                     .addGrant(new PreAuthorizedCodeGrant().setPreAuthorizedCode("the-code"))
                     .setCredentialConfigurationIds(List.of("credential-configuration-id"));
 
+            long expiresAt = Time.currentTimeSeconds() + 60;
             CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
-            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, Time.currentTime() + 60, null);
+            CredentialOfferState offerState = new CredentialOfferState(credOffer, null, null, expiresAt, false, null);
             offerStorage.putOfferState(offerState);
             return offerState.getNonce();
             // The cache transactions need to be committed

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
@@ -18,6 +18,7 @@ import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.tests.oid4vc.abca.OIDCClientAttester;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferResponse;
+import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriRequest;
 import org.keycloak.testsuite.util.oauth.oid4vc.CredentialOfferUriResponse;
 import org.keycloak.testsuite.util.oauth.oid4vc.Oid4vcCredentialResponse;
 
@@ -35,6 +36,7 @@ public class OID4VCTestContext {
     public static final AttachmentKey<OIDCConfigurationRepresentation> AUTHORIZATION_SERVER_METADATA_ATTACHMENT_KEY = new AttachmentKey<>(OIDCConfigurationRepresentation.class);
     public static final AttachmentKey<CredentialIssuer> ISSUER_METADATA_ATTACHMENT_KEY = new AttachmentKey<>(CredentialIssuer.class);
     public static final AttachmentKey<OIDCClientAttester> CLIENT_ATTESTER_ATTACHMENT_KEY = new AttachmentKey<>(OIDCClientAttester.class);
+    public static final AttachmentKey<CredentialOfferUriRequest> CREDENTIALS_OFFER_URI_REQUEST_ATTACHMENT_KEY = new AttachmentKey<>(CredentialOfferUriRequest.class);
     public static final AttachmentKey<CredentialOfferUriResponse> CREDENTIALS_OFFER_URI_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(CredentialOfferUriResponse.class);
     public static final AttachmentKey<CredentialOfferResponse> CREDENTIALS_OFFER_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(CredentialOfferResponse.class);
     public static final AttachmentKey<AccessTokenResponse> ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY = new AttachmentKey<>(AccessTokenResponse.class);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCredentialOfferAuthCodeTest.java
@@ -236,17 +236,25 @@ public class OID4VCredentialOfferAuthCodeTest extends OID4VCIssuerTestBase {
             req.targetUser(ctx.getHolder());
         });
 
+        CredentialOfferURI offerURI = ctx.getCredentialsOfferUri();
+        assertNotNull(offerURI, "No CredentialOfferURI");
+
         String issuerState = credOffer.getIssuerState();
         assertNotNull(issuerState, "No IssuerState");
 
+        // Fetch credential offer again
+        // https://github.com/keycloak/keycloak/issues/48014
+        credOffer = wallet.credentialsOfferRequest(ctx, offerURI).send().getCredentialsOffer();
+        assertNotNull(credOffer, "No credOffer");
+
         // Send AuthorizationRequest
         //
-        AuthorizationEndpointResponse authResponse = wallet
+        String authCode = wallet
                 .authorizationRequest()
                 .scope(ctx.getScope())
                 .issuerState(issuerState)
-                .send(ctx.getHolder(), TEST_PASSWORD);
-        String authCode = authResponse.getCode();
+                .send(ctx.getHolder(), TEST_PASSWORD)
+                .getCode();
         assertNotNull(authCode, "No authCode");
 
         // Build and send AccessTokenRequest

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCPublicClientPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCPublicClientPreAuthTest.java
@@ -64,7 +64,9 @@ public class OID4VCPublicClientPreAuthTest extends OID4VCIssuerTestBase {
             req.targetUser(ctx.getHolder());
             req.preAuthorized(true);
         });
+
         String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "No preAuthCode");
 
         // Redeem Pre-Authorized Code for AccessToken
         //

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/preauth/OID4VCredentialOfferPreAuthTest.java
@@ -81,7 +81,7 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
         });
 
         String preAuthCode = credOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthCode, "preAuthCode");
+        assertNotNull(preAuthCode, "No preAuthCode");
 
         // Disable the client
         ClientRepresentation clientRep = testRealm.admin().clients().get(ctx.getClient().getId()).toRepresentation();
@@ -116,6 +116,7 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
         });
 
         String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "No preAuthCode");
 
         // Redeem Pre-Authorized Code for AccessToken
         //
@@ -147,23 +148,27 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
         CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
             req.targetUser(ctx.getHolder());
             req.preAuthorized(true);
+            req.txCode(true);
         });
-
-        String preAuthCode = credOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthCode, "preAuthCode");
 
         CredentialOfferURI offerURI = ctx.getCredentialsOfferUri();
         assertNotNull(offerURI, "No CredentialOfferURI");
+
+        String txCode = offerURI.getTxCode();
+        assertNotNull(txCode, "No txCode");
+
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "No preAuthCode");
 
         // Fetch credential offer again
         // https://github.com/keycloak/keycloak/issues/48014
         credOffer = wallet.credentialsOfferRequest(ctx, offerURI).send().getCredentialsOffer();
         preAuthCode = credOffer.getPreAuthorizedCode();
-        assertNotNull(preAuthCode, "preAuthCode");
+        assertNotNull(preAuthCode, "No preAuthCode");
 
         // Redeem Pre-Authorized Code for AccessToken
         //
-        AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode, txCode).send();
         assertTrue(tokenResponse.isSuccess(), tokenResponse.getErrorDescription());
 
         String accessToken = wallet.validateHolderAccessToken(ctx, tokenResponse);
@@ -185,6 +190,51 @@ public class OID4VCredentialOfferPreAuthTest extends OID4VCIssuerTestBase {
         CredentialOfferResponse res = wallet.credentialsOfferRequest(ctx, offerURI).send();
         assertEquals("invalid_credential_offer_request", res.getError());
         assertEquals("Credential offer not found or already consumed", res.getErrorDescription());
+    }
+
+    @Test
+    public void testPreAuthOffer_Targeted_Invalid_TxCode() throws Exception {
+        var ctx = new OID4VCTestContext(client, jwtTypeCredentialScope);
+
+        // Create Pre-Authorized CredentialOffer
+        //
+        CredentialsOffer credOffer = wallet.createCredentialOffer(ctx, req -> {
+            req.targetUser(ctx.getHolder());
+            req.preAuthorized(true);
+            req.txCode(true);
+        });
+
+        CredentialOfferURI offerURI = ctx.getCredentialsOfferUri();
+        assertNotNull(offerURI, "No CredentialOfferURI");
+
+        String txCode = offerURI.getTxCode();
+        assertNotNull(txCode, "No txCode");
+
+        String preAuthCode = credOffer.getPreAuthorizedCode();
+        assertNotNull(preAuthCode, "No preAuthCode");
+
+        // Test missing TxCode
+        {
+            AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode).send();
+            assertFalse(tokenResponse.isSuccess());
+            assertEquals("invalid_grant", tokenResponse.getError());
+            assertEquals("Missing TxCode", tokenResponse.getErrorDescription());
+        }
+
+        // Test wrong TxCode
+        {
+            AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode, "wrong-code").send();
+            assertFalse(tokenResponse.isSuccess());
+            assertEquals("invalid_grant", tokenResponse.getError());
+            assertEquals("Invalid TxCode", tokenResponse.getErrorDescription());
+        }
+
+        // Test correct TxCode
+        {
+            AccessTokenResponse tokenResponse = wallet.accessTokenRequestPreAuth(ctx, preAuthCode, txCode).send();
+            assertTrue(tokenResponse.isSuccess());
+            assertNotNull(tokenResponse.getAccessToken(), "No accessToken");
+        }
     }
 
     // Private ---------------------------------------------------------------------------------------------------------

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/CredentialOfferUriRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/CredentialOfferUriRequest.java
@@ -15,6 +15,7 @@ public class CredentialOfferUriRequest extends AbstractHttpGetRequest<Credential
 
     private String credConfigId;
     private Boolean preAuthorized;
+    private Boolean txCode;
     private String targetUser;
     private Integer expireAt;
     private OfferResponseType responseType;
@@ -33,6 +34,15 @@ public class CredentialOfferUriRequest extends AbstractHttpGetRequest<Credential
     public CredentialOfferUriRequest preAuthorized(Boolean preAuthorized) {
         this.preAuthorized = preAuthorized;
         return this;
+    }
+
+    public CredentialOfferUriRequest txCode(Boolean txCode) {
+        this.txCode = txCode;
+        return this;
+    }
+
+    public boolean hasTxCode() {
+        return txCode == Boolean.TRUE;
     }
 
     public CredentialOfferUriRequest targetUser(String targetUser) {
@@ -65,6 +75,7 @@ public class CredentialOfferUriRequest extends AbstractHttpGetRequest<Credential
         UriBuilder builder = UriBuilder.fromUri(client.getEndpoints().getOid4vcCredentialOfferUri());
         if (!Strings.isEmpty(credConfigId)) builder.queryParam("credential_configuration_id", credConfigId);
         if (preAuthorized != null) builder.queryParam("pre_authorized", preAuthorized);
+        if (txCode != null) builder.queryParam("tx_code", txCode);
         if (!Strings.isEmpty(targetUser)) builder.queryParam("target_user", targetUser);
         if (expireAt != null) builder.queryParam("expire", expireAt);
         if (responseType != null) builder.queryParam("type", responseType.getValue());

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/PreAuthorizedCodeGrantRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/oid4vc/PreAuthorizedCodeGrantRequest.java
@@ -16,6 +16,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 public class PreAuthorizedCodeGrantRequest extends AbstractHttpPostRequest<PreAuthorizedCodeGrantRequest, AccessTokenResponse> {
 
     private final String preAuthCode;
+    private String txCode;
 
     public PreAuthorizedCodeGrantRequest(AbstractOAuthClient<?> client, String preAuthorizedCode) {
         super(client);
@@ -24,6 +25,11 @@ public class PreAuthorizedCodeGrantRequest extends AbstractHttpPostRequest<PreAu
 
     public PreAuthorizedCodeGrantRequest authorizationDetails(List<OID4VCAuthorizationDetail> authDetails) {
         parameter(OAuth2Constants.AUTHORIZATION_DETAILS, JsonSerialization.valueAsString(authDetails));
+        return this;
+    }
+
+    public PreAuthorizedCodeGrantRequest txCode(String txCode) {
+        this.txCode = txCode;
         return this;
     }
 
@@ -36,6 +42,7 @@ public class PreAuthorizedCodeGrantRequest extends AbstractHttpPostRequest<PreAu
     protected void initRequest() {
         parameter(OAuth2Constants.GRANT_TYPE, PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE);
         parameter(PreAuthorizedCodeGrant.CODE_REQUEST_PARAM, preAuthCode);
+        parameter(PreAuthorizedCodeGrant.TX_CODE_PARAM, txCode);
     }
 
     @Override


### PR DESCRIPTION
closes #47652

* Add optional tx_code generation to CredentialOfferState and surface it via CredentialOfferURI.
* Extend issuer endpoint and test utilities to request/transport tx_code, and validate it in the pre-auth token grant.
* Update OID4VC test wallet helpers and tests for the updated APIs and tx_code scenarios.
