### PR TITLE
Show total user count in admin UI user list

### DIFF
--- a/js/apps/admin-ui/src/components/users/UserDataTable.tsx
+++ b/js/apps/admin-ui/src/components/users/UserDataTable.tsx
@@ -191,6 +191,25 @@ export function UserDataTable() {
     }
   };
 
+  const countLoader = async (search?: string) => {
+    const params: { [name: string]: string | number | boolean } = {
+      q: query!,
+    };
+
+    const searchParam = search || searchUser || "";
+    if (searchParam) {
+      params.search = searchParam;
+    }
+
+    if (activeFilters.exact) params.exact = true;
+
+    if (!listUsers && !(params.search || params.q)) {
+      return 0;
+    }
+
+    return adminClient.users.count(params);
+  };
+
   const [toggleUnlockUsersDialog, UnlockUsersConfirm] = useConfirmDialog({
     titleKey: "unlockAllUsers",
     messageKey: "unlockUsersConfirm",
@@ -355,6 +374,7 @@ export function UserDataTable() {
         }
         key={key}
         loader={loader}
+        countLoader={countLoader}
         isPaginated
         ariaLabelKey="titleUsers"
         canSelectAll

--- a/js/apps/admin-ui/test/users/main.spec.ts
+++ b/js/apps/admin-ui/test/users/main.spec.ts
@@ -357,3 +357,30 @@ test.describe("Existing users", () => {
     await assertRowExists(page, "test-group");
   });
 });
+
+test.describe("Total user count", () => {
+  const placeHolder = "Search user";
+  const userA = "count-user-a";
+  const userB = "count-user-b";
+  const userC = "count-user-c";
+
+  const overrides: RealmRepresentation = {
+    users: [{ username: userA }, { username: userB }, { username: userC }],
+  };
+
+  test("shows total in pagination toggle", async ({ page }) => {
+    await using testBed = await createTestBed(overrides);
+
+    await login(page, { to: toUsers({ realm: testBed.realm }) });
+
+    // PatternFly's Pagination toggle button is identified by its rendered
+    // accessible name, which matches the visible "X - Y of Z" text.
+    const toggle = page.getByRole("button", { name: /\d+ - \d+ of/ }).first();
+
+    await expect(toggle).toContainText(/\d+ - \d+ of \d+/);
+
+    // Filter to a single user and assert the total updates.
+    await searchItem(page, placeHolder, userA);
+    await expect(toggle).toContainText("1 - 1 of 1");
+  });
+});

--- a/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
+++ b/js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx
@@ -319,6 +319,8 @@ export type LoaderFunction<T> = (
   search?: string,
 ) => Promise<T[]>;
 
+export type CountLoaderFunction = (search?: string) => Promise<number>;
+
 export type SignaledLoader<T> = {
   readonly signal: any;
   loader: LoaderFunction<T>;
@@ -329,6 +331,7 @@ export type DataListProps<T> = Omit<
   "rows" | "cells" | "onSelect"
 > & {
   loader: T[] | LoaderFunction<T> | SignaledLoader<T>;
+  countLoader?: CountLoaderFunction;
   onSelect?: (value: T[]) => void;
   canSelectAll?: boolean;
   detailColumns?: DetailField<T>[];
@@ -383,6 +386,7 @@ export function KeycloakDataTable<T>({
   detailColumns,
   isRowDisabled,
   loader,
+  countLoader,
   columns,
   actions,
   actionResolver,
@@ -399,6 +403,7 @@ export function KeycloakDataTable<T>({
   const [rows, setRows] = useState<(Row<T> | SubRow<T>)[]>();
   const [unPaginatedData, setUnPaginatedData] = useState<T[]>();
   const [loading, setLoading] = useState(false);
+  const [totalCount, setTotalCount] = useState<number | undefined>(undefined);
 
   const [defaultPageSize, setDefaultPageSize] = useStoredState(
     localStorage,
@@ -541,6 +546,28 @@ export function KeycloakDataTable<T>({
     ],
   );
 
+  useEffect(() => {
+    setTotalCount(undefined);
+  }, [search]);
+
+  useFetch(
+    async () => {
+      if (!countLoader) return undefined;
+      try {
+        return await countLoader(search);
+      } catch (error) {
+        console.error(error);
+        return undefined;
+      }
+    },
+    (count) => {
+      if (count !== undefined) {
+        setTotalCount(count);
+      }
+    },
+    [key, search],
+  );
+
   const convertAction = () =>
     actions &&
     cloneDeep(actions).map((action: Action<T>, index: number) => {
@@ -577,6 +604,7 @@ export function KeycloakDataTable<T>({
         <PaginatingTableToolbar
           id={id}
           count={rowLength}
+          totalCount={totalCount}
           first={first}
           max={max}
           onNextClick={setFirst}

--- a/js/libs/ui-shared/src/controls/table/PaginatingTableToolbar.tsx
+++ b/js/libs/ui-shared/src/controls/table/PaginatingTableToolbar.tsx
@@ -11,6 +11,7 @@ import { TableToolbar } from "./TableToolbar";
 type KeycloakPaginationProps = {
   id?: string;
   count: number;
+  totalCount?: number;
   first: number;
   max: number;
   onNextClick: (page: number) => void;
@@ -32,6 +33,7 @@ const KeycloakPagination = ({
   id,
   variant = "top",
   count,
+  totalCount,
   first,
   max,
   onNextClick,
@@ -40,6 +42,7 @@ const KeycloakPagination = ({
 }: KeycloakPaginationProps) => {
   const { t } = useTranslation();
   const page = Math.round(first / max);
+  const hasTotal = typeof totalCount === "number";
   return (
     <Pagination
       widgetId={id}
@@ -47,15 +50,16 @@ const KeycloakPagination = ({
         paginationAriaLabel: `${t("pagination")} ${variant} `,
       }}
       isCompact
-      toggleTemplate={({
-        firstIndex,
-        lastIndex,
-      }: PaginationToggleTemplateProps) => (
-        <b>
-          {firstIndex} - {lastIndex}
-        </b>
-      )}
-      itemCount={count + page * max}
+      toggleTemplate={
+        hasTotal
+          ? undefined
+          : ({ firstIndex, lastIndex }: PaginationToggleTemplateProps) => (
+              <b>
+                {firstIndex} - {lastIndex}
+              </b>
+            )
+      }
+      itemCount={hasTotal ? totalCount : count + page * max}
       page={page + 1}
       perPage={max}
       onNextClick={(_, p) => onNextClick((p - 1) * max)}
@@ -68,6 +72,7 @@ const KeycloakPagination = ({
 
 export const PaginatingTableToolbar = ({
   count,
+  totalCount,
   searchTypeComponent,
   toolbarItem,
   subToolbar,
@@ -84,7 +89,11 @@ export const PaginatingTableToolbar = ({
         <>
           {toolbarItem}
           <ToolbarItem variant="pagination">
-            <KeycloakPagination count={count} {...rest} />
+            <KeycloakPagination
+              count={count}
+              totalCount={totalCount}
+              {...rest}
+            />
           </ToolbarItem>
         </>
       }
@@ -92,7 +101,12 @@ export const PaginatingTableToolbar = ({
       toolbarItemFooter={
         count !== 0 ? (
           <ToolbarItem variant="pagination">
-            <KeycloakPagination count={count} variant="bottom" {...rest} />
+            <KeycloakPagination
+              count={count}
+              totalCount={totalCount}
+              variant="bottom"
+              {...rest}
+            />
           </ToolbarItem>
         ) : null
       }

--- a/js/libs/ui-shared/src/main.ts
+++ b/js/libs/ui-shared/src/main.ts
@@ -84,6 +84,7 @@ export type {
   Action,
   Field,
   DetailField,
+  CountLoaderFunction,
   LoaderFunction,
   SignaledLoader,
 } from "./controls/table/KeycloakDataTable";


### PR DESCRIPTION
Closes #10550

## Summary

Shows the true total in the admin UI user list pagination, so the toggle reads `"1 - 10 of 1320"` instead of the current `"1 - 10"`. The total is filter-aware: typing in the search box updates both the rows and the total.

## Approach

The shared `KeycloakDataTable` only sees one page of data at a time, so the existing `PaginatingTableToolbar` overrides PatternFly's default `toggleTemplate` to drop the total and fakes `itemCount` as `count + page * max`. This PR makes that opt-in:

- Adds an optional `countLoader?: (search?: string) => Promise<number>` prop to `KeycloakDataTable`.
- When provided, the table runs a second `useFetch` (keyed on `[key, search]` — deliberately not `first`/`max`, so paging doesn't refetch) and threads the result down through `PaginatingTableToolbar` as a new optional `totalCount` prop.
- When `totalCount` is provided, the toolbar drops its custom `toggleTemplate` so PatternFly's default `"X - Y of Z"` renders; `itemCount` becomes the real total.
- `UserDataTable` opts in by passing `(search) => adminClient.users.count({ q, search, exact })`, which mirrors the param construction used by the existing `loader`.
- Errors from the count fetch are swallowed (caught inside the async callback) so a transient `/users/count` failure doesn't crash the page via the error boundary; the pagination falls back to its current `"X - Y"` mode in that case.
- `totalCount` is reset to `undefined` on `search` change to avoid showing a stale total during a filter transition.

Backward compatible: every other paginated table in the admin UI (clients, groups, roles, sessions, …) does not pass `countLoader` and renders identically to today. Same pattern is now available to opt in any of those in follow-up PRs.

## Files

5 files, +101 / -11:

- `js/libs/ui-shared/src/controls/table/PaginatingTableToolbar.tsx` — accept optional `totalCount`; conditional `toggleTemplate` + `itemCount`.
- `js/libs/ui-shared/src/controls/table/KeycloakDataTable.tsx` — `CountLoaderFunction` type, optional `countLoader` prop, parallel `useFetch`, error swallowing, reset-on-search.
- `js/libs/ui-shared/src/main.ts` — export `CountLoaderFunction` alongside `LoaderFunction`.
- `js/apps/admin-ui/src/components/users/UserDataTable.tsx` — wire `countLoader` to `adminClient.users.count`.
- `js/apps/admin-ui/test/users/main.spec.ts` — Playwright integration test.

## Testing

**Playwright integration test** added in `js/apps/admin-ui/test/users/main.spec.ts`:

```
✓ Total user count › shows total in pagination toggle (3.8s)
```

The test creates a realm with 3 seeded users, asserts the toggle matches `/\d+ - \d+ of \d+/` on load, then searches for one user and asserts the toggle becomes `"1 - 1 of 1"`.

The full `users/main.spec.ts` suite continues to pass:

```
14 passed (20.3s)
```

**Verified locally:**
- `./mvnw spotless:check` — `BUILD SUCCESS`
- `./mvnw clean install -DskipTests` — `BUILD SUCCESS`
- `pnpm --filter @keycloak/keycloak-admin-ui run lint` — 0 errors (no new warnings)
- `pnpm --filter @keycloak/keycloak-admin-ui build` — clean
- Playwright suite against the built distribution (`kc.sh start-dev`) — green

## Documentation

This is a UI affordance change (the pagination toggle now includes the total); no user-facing documentation pages currently describe the pagination layout, so no docs changes are needed. Release notes for admin UI affordances are typically generated from the PR title/body.

## UI Preview
<img width="2552" height="606" alt="image" src="https://github.com/user-attachments/assets/9b610222-cd81-46d1-9296-1d1c2ee0c831" />


## AI agent disclosure

Per CONTRIBUTING.md, I'm disclosing that this PR was prepared with the assistance of an AI coding agent (Claude Code). I reviewed every change, ran the build, ran the test suite against a local Keycloak instance, and validated the behavior in the UI before pushing. I understand each line of the diff and will engage directly with review feedback.