### PR TITLE
[OID4VCI-FAPI2] Pass fapi2-security-profile-final-ensure-response-type-code-idtoken-fails

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -239,19 +239,19 @@ public class AuthorizationEndpointChecker {
             throw new AuthorizationCheckException(Response.Status.UNAUTHORIZED, OAuthErrorException.UNAUTHORIZED_CLIENT, errorMessage);
         }
 
-        if (parsedResponseType.isImplicitOrHybridFlow() && !client.isImplicitFlowEnabled()) {
-            ServicesLogger.LOGGER.flowNotAllowed("Implicit");
-            String errorMessage = "Client is not allowed to initiate browser login with given response_type. Implicit flow is disabled for the client.";
+        // DPoP is not supported for implicit nor hybrid flows
+        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
+        if (clientConfig.isUseDPoP() && parsedResponseType.isImplicitOrHybridFlow()) {
+            ServicesLogger.LOGGER.flowNotAllowed("Implicit/Hybrid with DPoP");
+            String errorMessage = "DPoP is not supported for implicit nor hybrid flows. Client requires DPoP bound access tokens.";
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.NOT_ALLOWED);
             throw new AuthorizationCheckException(Response.Status.UNAUTHORIZED, OAuthErrorException.UNAUTHORIZED_CLIENT, errorMessage);
         }
 
-        // DPoP is not supported for implicit and hybrid flows
-        OIDCAdvancedConfigWrapper clientConfig = OIDCAdvancedConfigWrapper.fromClientModel(client);
-        if (clientConfig.isUseDPoP() && parsedResponseType.isImplicitOrHybridFlow()) {
-            ServicesLogger.LOGGER.flowNotAllowed("Implicit/Hybrid with DPoP");
-            String errorMessage = "DPoP is not supported for implicit and hybrid flows. Client requires DPoP bound access tokens.";
+        if (parsedResponseType.isImplicitOrHybridFlow() && !client.isImplicitFlowEnabled()) {
+            ServicesLogger.LOGGER.flowNotAllowed("Implicit");
+            String errorMessage = "Client is not allowed to initiate browser login with given response_type. Implicit flow is disabled for the client.";
             event.detail(Details.REASON, errorMessage);
             event.error(Errors.NOT_ALLOWED);
             throw new AuthorizationCheckException(Response.Status.UNAUTHORIZED, OAuthErrorException.UNAUTHORIZED_CLIENT, errorMessage);

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/ParEndpoint.java
@@ -114,6 +114,16 @@ public class ParEndpoint extends AbstractParEndpoint {
             throw errorResponseException(OAuthErrorException.INVALID_REQUEST_OBJECT, e.getMessage(), Response.Status.BAD_REQUEST);
         }
 
+        try {
+            session.clientPolicy().triggerOnEvent(new PushedAuthorizationRequestContext(client, authorizationRequest, decodedFormParameters));
+        } catch (ClientPolicyException cpe) {
+            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
+            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
+            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
+            event.error(cpe.getError());
+            throw errorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
+        }
+
         AuthorizationEndpointChecker checker = new AuthorizationEndpointChecker()
                 .event(event)
                 .client(client)
@@ -152,16 +162,6 @@ public class ParEndpoint extends AbstractParEndpoint {
             checker.checkParDPoPParams();
         } catch (AuthorizationEndpointChecker.AuthorizationCheckException ex) {
             checker.throwAsCorsErrorResponseException(cors, ex);
-        }
-
-        try {
-            session.clientPolicy().triggerOnEvent(new PushedAuthorizationRequestContext(client, authorizationRequest, decodedFormParameters));
-        } catch (ClientPolicyException cpe) {
-            event.detail(Details.REASON, Details.CLIENT_POLICY_ERROR);
-            event.detail(Details.CLIENT_POLICY_ERROR, cpe.getError());
-            event.detail(Details.CLIENT_POLICY_ERROR_DETAIL, cpe.getErrorDetail());
-            event.error(cpe.getError());
-            throw errorResponseException(cpe.getError(), cpe.getErrorDetail(), Response.Status.BAD_REQUEST);
         }
 
         Map<String, String> params = new HashMap<>();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
@@ -255,6 +255,49 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         }
     }
 
+    /**
+     * fapi2-security-profile-final-ensure-response-type-code-idtoken-fails
+     *
+     * This test uses response_type=code+id_token in the authorization request, which is not permitted in FAPI2 Security Profile
+     * as it would return an id_token via the browser where it may be leaked. The authorization server should show an error message
+     * that the response type is unsupported or the request is invalid.
+     */
+    @Test
+    public void testRequestObjectWithHybridResponseTypeFails() {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var pkce = PkceGenerator.s256();
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper rsaKey = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, rsaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, rsaKey);
+
+        String responseType = oauth.config().getResponseType();
+        try {
+            oauth.config().responseType("code id_token");
+
+            // Send PAR Request (without redirect_uri)
+            //
+            ParResponse parResponse = oauth.pushedAuthorizationRequest()
+                    .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                    .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                    .scopeParam(ctx.getScope())
+                    .codeChallenge(pkce)
+                    .send();
+            assertFalse(parResponse.isSuccess());
+            assertNull(parResponse.getRequestUri(), "Expected no request_uri");
+            assertEquals("invalid_request", parResponse.getError());
+            String errorDescription = parResponse.getErrorDescription();
+            assertEquals("Implicit/Hybrid flow is prohibited.", errorDescription);
+        } finally {
+            oauth.config().responseType(responseType);
+        }
+    }
+
     // Private ---------------------------------------------------------------------------------------------------------
 
     private void verifyCredentialResponse(OID4VCTestContext ctx, CredentialResponse credResponse) throws Exception {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2DPoPTest.java
@@ -238,8 +238,8 @@ public class FAPI2DPoPTest extends AbstractFAPI2Test {
                 .nonce(nonce)
                 .send();
 
-        assertEquals(401, pResp.getStatusCode());
-        assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, pResp.getError());
+        assertEquals(400, pResp.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, pResp.getError());
 
         // an additional parameter in an authorization request that does not exist in a PAR request - should fail
         pResp = oauth

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/FAPI2Test.java
@@ -169,8 +169,8 @@ public class FAPI2Test extends AbstractFAPI2Test {
         // requiring hybrid request - should fail
         oauth.responseType(OIDCResponseType.CODE + " " + OIDCResponseType.ID_TOKEN + " " + OIDCResponseType.TOKEN);
         ParResponse pResp = oauth.pushedAuthorizationRequest().nonce("123456").codeChallenge(pkceGenerator).send();
-        assertEquals(401, pResp.getStatusCode());
-        assertEquals(OAuthErrorException.UNAUTHORIZED_CLIENT, pResp.getError());
+        assertEquals(400, pResp.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, pResp.getError());
 
         // authorization request does not match PAR request - should fail
         oauth.responseType(OIDCResponseType.CODE);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/DPoPTest.java
@@ -962,7 +962,7 @@ public class DPoPTest extends AbstractTestRealmKeycloakTest {
             clientRepresentation.setImplicitFlowEnabled(true);
         });
 
-        String errorMessage = "DPoP is not supported for implicit and hybrid flows. Client requires DPoP bound access tokens.";
+        String errorMessage = "DPoP is not supported for implicit nor hybrid flows. Client requires DPoP bound access tokens.";
 
         oauth.client(TEST_PUBLIC_CLIENT_ID);
 


### PR DESCRIPTION
closes #48067

* Reverses the order of Client Policy checks and AuthorizationEndpoint checker for PAR requests

In this way configurable checks have higher priority than generic checks