### PR TITLE
Stop cookie-based SSO re-auth from resetting brute-force counter (26.6)

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/services/managers/BruteForceProtector.java
+++ b/server-spi-private/src/main/java/org/keycloak/services/managers/BruteForceProtector.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.services.managers;
 
+import java.util.Set;
+
 import jakarta.ws.rs.core.UriInfo;
 
 import org.keycloak.common.ClientConnection;
@@ -32,9 +34,9 @@ import org.keycloak.provider.Provider;
 public interface BruteForceProtector extends Provider {
     String DISABLED_BY_PERMANENT_LOCKOUT = "permanentLockout";
 
-    void failedLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, String authenticationCategory);
+    void failedLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, Set<String> authenticationCategory);
 
-    void successfulLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, String authenticationCategory);
+    void successfulLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, Set<String> authenticationCategories);
 
     boolean isTemporarilyDisabled(KeycloakSession session, RealmModel realm, UserModel user);
 

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -19,9 +19,11 @@ package org.keycloak.authentication;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -768,7 +770,9 @@ public class AuthenticationProcessor {
         if (realm.isBruteForceProtected()) {
             UserModel user = AuthenticationManager.lookupUserForBruteForceLog(session, realm, authenticationSession);
             if (user != null) {
-                getBruteForceProtector().failedLogin(realm, user, connection, session.getContext().getHttpRequest().getUri(), AuthenticationManager.getAuthenticationCategory(session, executionId));
+                getBruteForceProtector().failedLogin(realm, user, connection, session.getContext().getHttpRequest().getUri(),
+                        Optional.ofNullable(AuthenticationManager.getAuthenticationCategory(session, executionId))
+                                .map(Collections::singleton).orElse(null));
             }
         }
     }

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetPassword.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetPassword.java
@@ -37,7 +37,8 @@ public class ResetPassword extends AbstractSetRequiredActionAuthenticator {
                         configuredFor(context))) {
             context.getAuthenticationSession().addRequiredAction(UserModel.RequiredAction.UPDATE_PASSWORD);
         }
-        context.success();
+        // send password category to force brute-force reset for temporary lockout
+        context.success(PasswordCredentialModel.TYPE);
     }
 
     protected boolean configuredFor(AuthenticationFlowContext context) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -91,7 +91,6 @@ import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
-import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.utils.DefaultRequiredActions;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.SessionExpirationUtils;
@@ -987,7 +986,6 @@ public class AuthenticationManager {
         logSuccess(session, authSession);
 
         return protocol.authenticated(authSession, userSession, clientSessionCtx);
-
     }
 
     /**
@@ -1739,7 +1737,7 @@ public class AuthenticationManager {
                         user,
                         session.getContext().getConnection(),
                         session.getContext().getHttpRequest().getUri(),
-                        AuthenticatorUtil.getAuthnCredentials(authSession).contains(OTPCredentialModel.TYPE) ? OTPCredentialModel.TYPE : null
+                        Set.copyOf(AuthenticatorUtil.getAuthnCredentials(authSession))
                 );
             }
         }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBlockingBruteForceProtector.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.ws.rs.core.UriInfo;
@@ -135,23 +136,23 @@ public class DefaultBlockingBruteForceProtector extends DefaultBruteForceProtect
     }
 
     @Override
-    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success, String category) {
+    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success, Set<String> categories) {
         // mark the off-thread is started for this request
         loginAttempts.computeIfPresent(user.getId(), (k, v) -> v + OFF_THREAD_STARTED);
-        super.processLogin(realm, user, clientConnection, uriInfo, success, category);
+        super.processLogin(realm, user, clientConnection, uriInfo, success, categories);
     }
 
     @Override
-    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, String category) {
+    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
         // remove the user from concurrent login attemps once it's processed
         enlistRemoval(session, userId);
-        super.failure(session, realm, userId, remoteAddr, failureTime, category);
+        super.failure(session, realm, userId, remoteAddr, failureTime, categories);
     }
 
     @Override
-    protected void success(KeycloakSession session, RealmModel realm, String userId, String category) {
+    protected void success(KeycloakSession session, RealmModel realm, String userId, Set<String> categories) {
         // remove the user from concurrent login attempts once it's processed
         enlistRemoval(session, userId);
-        super.success(session, realm, userId, category);
+        super.success(session, realm, userId, categories);
     }
 }

--- a/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
+++ b/services/src/main/java/org/keycloak/services/managers/DefaultBruteForceProtector.java
@@ -21,8 +21,8 @@ import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import jakarta.ws.rs.core.HttpHeaders;
@@ -65,12 +65,10 @@ import static org.keycloak.models.UserModel.DISABLED_REASON;
 public class DefaultBruteForceProtector implements BruteForceProtector {
     private static final Logger logger = Logger.getLogger(DefaultBruteForceProtector.class);
 
-    public static final List<String> ALLOWED_AUTHENTICATION_CATEGORIES = new ArrayList<>(
-            List.of(
-                PasswordCredentialModel.TYPE,
-                OTPCredentialModel.TYPE,
-                RecoveryAuthnCodesCredentialModel.TYPE
-            )
+    public static final Set<String> ALLOWED_AUTHENTICATION_CATEGORIES = Set.of(
+            PasswordCredentialModel.TYPE,
+            OTPCredentialModel.TYPE,
+            RecoveryAuthnCodesCredentialModel.TYPE
     );
 
     public static final String OTP_CATEGORY = OTPCredentialModel.TYPE;
@@ -82,10 +80,7 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
         this.factory = factory;
     }
 
-    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, String category) {
-        logger.debugf("failure (category=%s)", category);
-        if (category != null && !ALLOWED_AUTHENTICATION_CATEGORIES.contains(category)) return;
-
+    protected void failure(KeycloakSession session, RealmModel realm, String userId, String remoteAddr, long failureTime, Set<String> categories) {
         UserLoginFailureModel userLoginFailure = getUserFailureModel(session, realm, userId);
         if (userLoginFailure == null) {
             userLoginFailure = session.loginFailures().addUserLoginFailure(realm, userId);
@@ -144,7 +139,7 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
             }
         }
 
-        if (OTP_CATEGORY.equals(category)) {
+        if (categories != null && categories.contains(OTP_CATEGORY)) {
             int maxSecondaryAuthFailures = realm.getMaxSecondaryAuthFailures();
             boolean lockoutEnabled = maxSecondaryAuthFailures > 0;
             userLoginFailure.incrementSecondaryAuthFailures();
@@ -209,14 +204,14 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
 
     public void shutdown() {}
 
-    protected void success(KeycloakSession session, RealmModel realm, String userId, String category) {
+    protected void success(KeycloakSession session, RealmModel realm, String userId, Set<String> categories) {
         UserLoginFailureModel userLoginFailure = getUserFailureModel(session, realm, userId);
         if(userLoginFailure == null) return;
         if (logger.isDebugEnabled()) {
             UserModel model = session.users().getUserById(realm, userId);
             logger.debugv("user {0} successfully logged in:", model.getUsername());
         }
-        if (OTP_CATEGORY.equals(category)) {
+        if (categories != null && categories.contains(OTP_CATEGORY)) {
             logger.debug("clearing primary and secondary (OTP) failures");
             userLoginFailure.clearPrimaryAndSecondaryAuthFailures();
         } else {
@@ -226,12 +221,12 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
     }
 
     @Override
-    public void failedLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, String authenticationCategory) {
-        if (authenticationCategory != null && !ALLOWED_AUTHENTICATION_CATEGORIES.contains(authenticationCategory)) {
-            logger.debugf("'%s' authentication category not allowed for brute force", authenticationCategory);
+    public void failedLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, Set<String> authenticationCategories) {
+        if (authenticationCategories != null && Collections.disjoint(ALLOWED_AUTHENTICATION_CATEGORIES, authenticationCategories)) {
+            logger.debugf("'%s' authentication category not allowed for brute force", authenticationCategories);
             return;
         }
-        processLogin(realm, user, clientConnection, uriInfo, false, authenticationCategory);
+        processLogin(realm, user, clientConnection, uriInfo, false, authenticationCategories);
         // wait a minimum of seconds for type to process so that a hacker
         // cannot flood with failed logins and overwhelm the queue and not have notBefore updated to block next requests
         // todo failure HTTP responses should be queued via async HTTP
@@ -240,16 +235,16 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
     }
 
     @Override
-    public void successfulLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, String authenticationCategory) {
-        if (authenticationCategory != null && !ALLOWED_AUTHENTICATION_CATEGORIES.contains(authenticationCategory)) {
-            logger.debugf("'%s' authentication category not allowed for brute force", authenticationCategory);
+    public void successfulLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, Set<String> authenticationCategories) {
+        if (authenticationCategories == null || Collections.disjoint(ALLOWED_AUTHENTICATION_CATEGORIES, authenticationCategories)) {
+            logger.debugf("'%s' authentication category not allowed for brute force", authenticationCategories);
             return;
         }
-        processLogin(realm, user, clientConnection, uriInfo, true, authenticationCategory);
+        processLogin(realm, user, clientConnection, uriInfo, true, authenticationCategories);
         logger.trace("sent success event");
     }
 
-    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success, String category) {
+    protected void processLogin(RealmModel realm, UserModel user, ClientConnection clientConnection, UriInfo uriInfo, boolean success, Set<String> categories) {
         ExecutorService executor = KeycloakModelUtils.runJobInTransactionWithResult(factory, session -> {
             ExecutorsProvider provider = session.getProvider(ExecutorsProvider.class);
             return provider.getExecutor("bruteforce");
@@ -261,9 +256,9 @@ public class DefaultBruteForceProtector implements BruteForceProtector {
             s.getContext().setHttpRequest(bruteForceHttpRequest);
             s.getContext().setHttpResponse(bruteForceHttpResponse);
             if (success) {
-                success(s, realm, user.getId(), category);
+                success(s, realm, user.getId(), categories);
             } else {
-                failure(s, realm, user.getId(), clientConnection.getRemoteHost(), Time.currentTimeMillis(), category);
+                failure(s, realm, user.getId(), clientConnection.getRemoteHost(), Time.currentTimeMillis(), categories);
             }
         }));
     }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/BruteForceTest.java
@@ -1102,6 +1102,36 @@ public class BruteForceTest extends AbstractChangeImportedUserPasswordsTest {
         }
     }
 
+    // https://github.com/keycloak/keycloak/issues/49960
+    @Test
+    public void testCookieSsoReauthenticationDoesNotResetLockout() {
+        String totpSecret = totp.generateTOTP("totpSecret");
+
+        oauth.openLoginForm();
+        loginPage.login("test-user@localhost", getPassword("test-user@localhost"));
+        loginTotpPage.assertCurrent();
+        loginTotpPage.login(totpSecret);
+        Assert.assertEquals(RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        String sessionId = events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent().getSessionId();
+
+        getTestToken("wrongpass", totpSecret);
+        getTestToken("wrongpass", totpSecret);
+
+        AccessTokenResponse shouldBeLocked = getTestToken(getPassword("test-user@localhost"), totpSecret);
+        Assert.assertNull(shouldBeLocked.getAccessToken());
+        events.clear();
+
+        oauth.openLoginForm();
+        Assert.assertEquals("Expected SSO cookie re-authentication to skip the login form", RequestType.AUTH_RESPONSE, appPage.getRequestType());
+        EventRepresentation ssoLogin = events.expectLogin().detail(Details.USERNAME, "test-user@localhost").assertEvent();
+        Assert.assertEquals("SSO re-auth must reuse the existing user session", sessionId, ssoLogin.getSessionId());
+
+        AccessTokenResponse shouldStillBeLocked = getTestToken(getPassword("test-user@localhost"), totpSecret);
+        Assert.assertNull("User should still be locked after cookie-based SSO re-authentication", shouldStillBeLocked.getAccessToken());
+
+        events.clear();
+    }
+
     @Test
     public void testRaceAttackPermanentLockout() throws Exception {
         RealmRepresentation realm = testRealm().toRepresentation();


### PR DESCRIPTION
Closes #49960

PR:             https://github.com/keycloak/keycloak/pull/49996
Commit:         https://github.com/keycloak/keycloak/commit/ed270d9bdb1786757679a4e59c4e39d93fae44b8
PR branch:      backport-49996-26.6
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.6


