### PR TITLE
Add federated users support for user verifiable credentials

### DIFF
--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -41,7 +41,6 @@ import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
-import jakarta.ws.rs.BadRequestException;
 
 import org.keycloak.authorization.fgap.AdminPermissionsSchema;
 import org.keycloak.common.util.SecretGenerator;
@@ -395,7 +394,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     @Override
     public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel verifCredentialModel) {
         if (verifCredentialModel.getClientScopeId() == null) {
-            throw new BadRequestException("Credential scope not specified");
+            throw new ModelException("Credential scope not specified");
         }
 
         UserVerifiableCredentialEntity vcEntity = new UserVerifiableCredentialEntity();

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -1116,4 +1116,12 @@ public class JpaUserFederatedStorageProvider implements
                 .map(this::toModel)
                 .sorted(Comparator.comparing(UserVerifiableCredentialModel::getClientScopeId));
     }
+
+    @Override
+    public UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId) {
+        return getFederatedVerifiableCredentialEntitiesByUser(userId)
+                .filter(federatedUserVerifiableCredentialEntity -> federatedUserVerifiableCredentialEntity.getClientScopeId().equals(clientScopeId))
+                .map(this::toModel)
+                .findFirst().orElse(null);
+    }
 }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -692,7 +692,7 @@ public class JpaUserFederatedStorageProvider implements
     }
 
     private UserVerifiableCredentialModel toModel(FederatedUserVerifiableCredentialEntity entity) {
-        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(entity.getCredentialScopeName());
+        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(entity.getId(), entity.getClientScopeId());
         model.setRevision(entity.getRevision());
         model.setCreatedDate(entity.getCreatedDate());
         model.setUpdatedDate(entity.getUpdatedDate());
@@ -908,13 +908,11 @@ public class JpaUserFederatedStorageProvider implements
 
     @Override
     public void preRemove(ClientScopeModel clientScope) {
-        RealmModel realm = session.getContext().getRealm();
         em.createNamedQuery("deleteFederatedUserConsentClientScopesByClientScope")
                 .setParameter("scopeId", clientScope.getId())
                 .executeUpdate();
         em.createNamedQuery("deleteFederatedVerifiableCredentialsByClientScope")
-                .setParameter("realmId", realm.getId())
-                .setParameter("scopeName", clientScope.getName())
+                .setParameter("scopeId", clientScope.getId())
                 .executeUpdate();
     }
 
@@ -1032,7 +1030,7 @@ public class JpaUserFederatedStorageProvider implements
                 createdDate : credentialModel.getUpdatedDate();
         entity.setUpdatedDate(updatedDate);
 
-        entity.setCredentialScopeName(credentialModel.getCredentialScopeName());
+        entity.setClientScopeId(credentialModel.getClientScopeId());
 
         Map<String, List<String>> userAttributes;
         if (credentialModel.getUserAttributes() != null) {
@@ -1061,14 +1059,14 @@ public class JpaUserFederatedStorageProvider implements
     }
 
     @Override
-    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName) {
+    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String clientScopeId) {
         RealmModel realm = session.getContext().getRealm();
 
         FederatedUserVerifiableCredentialEntity entity = getFederatedVerifiableCredentialEntitiesByUser(userId)
-                .filter(vc -> credentialScopeName.equals(vc.getCredentialScopeName()))
+                .filter(vc -> clientScopeId.equals(vc.getClientScopeId()))
                 .findFirst()
                 .orElseThrow(() -> new ModelException(
-                        "Verifiable credential not found: " + credentialScopeName));
+                        "Verifiable credential not found: " + clientScopeId));
         UserModel user = session.users().getUserById(realm, userId);
         if(user !=null) {
             try {
@@ -1098,9 +1096,9 @@ public class JpaUserFederatedStorageProvider implements
     }
 
     @Override
-    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+    public boolean removeVerifiableCredential(String userId, String clientScopeId) {
         FederatedUserVerifiableCredentialEntity found = getFederatedVerifiableCredentialEntitiesByUser(userId)
-                .filter(vcEnt -> vcEnt.getCredentialScopeName().equals(credentialScopeName))
+                .filter(vcEnt -> vcEnt.getClientScopeId().equals(clientScopeId))
                 .findFirst()
                 .orElse(null);
 
@@ -1116,6 +1114,6 @@ public class JpaUserFederatedStorageProvider implements
     public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
         return getFederatedVerifiableCredentialEntitiesByUser(userId)
                 .map(this::toModel)
-                .sorted(Comparator.comparing(UserVerifiableCredentialModel::getCredentialScopeName));
+                .sorted(Comparator.comparing(UserVerifiableCredentialModel::getClientScopeId));
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -1112,7 +1112,7 @@ public class JpaUserFederatedStorageProvider implements
     }
 
     @Override
-    public Stream<UserVerifiableCredentialModel> getVerifiableCredential(String userId) {
+    public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
         return getFederatedVerifiableCredentialEntitiesByUser(userId)
                 .map(this::toModel)
                 .sorted(Comparator.comparing(UserVerifiableCredentialModel::getCredentialScopeName));

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -1010,6 +1010,9 @@ public class JpaUserFederatedStorageProvider implements
     @Override
     public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel) {
         RealmModel realm = session.getContext().getRealm();
+        if (credentialModel.getClientScopeId() == null) {
+            throw new ModelException("Credential scope not specified");
+        }
         createIndex(realm, userId);
 
         FederatedUserVerifiableCredentialEntity entity = new FederatedUserVerifiableCredentialEntity();
@@ -1068,7 +1071,7 @@ public class JpaUserFederatedStorageProvider implements
                 .orElseThrow(() -> new ModelException(
                         "Verifiable credential not found: " + clientScopeId));
         UserModel user = session.users().getUserById(realm, userId);
-        if(user !=null) {
+        if (user != null) {
             try {
                 UserProfileProvider profileProvider = session.getProvider(UserProfileProvider.class);
                 UserProfile profile = profileProvider.create(UserProfileContext.USER_API, user);
@@ -1123,5 +1126,11 @@ public class JpaUserFederatedStorageProvider implements
                 .filter(federatedUserVerifiableCredentialEntity -> federatedUserVerifiableCredentialEntity.getClientScopeId().equals(clientScopeId))
                 .map(this::toModel)
                 .findFirst().orElse(null);
+    }
+
+    @Override
+    public UserVerifiableCredentialModel getVerifiableCredentialById(String id) {
+        FederatedUserVerifiableCredentialEntity entity = em.find(FederatedUserVerifiableCredentialEntity.class, id);
+        return entity != null ? toModel(entity) : null;
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -1105,7 +1105,7 @@ public class JpaUserFederatedStorageProvider implements
         if (found == null) return false;
 
         em.remove(found);
-        //Remove associated issued credentials
+        // No issued VC records to delete here (issued VCs are linked to USER_VER_CREDENTIAL/USER_ENTITY only).
         em.flush();
         return true;
     }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -908,10 +908,12 @@ public class JpaUserFederatedStorageProvider implements
 
     @Override
     public void preRemove(ClientScopeModel clientScope) {
+        RealmModel realm = session.getContext().getRealm();
         em.createNamedQuery("deleteFederatedUserConsentClientScopesByClientScope")
                 .setParameter("scopeId", clientScope.getId())
                 .executeUpdate();
         em.createNamedQuery("deleteFederatedVerifiableCredentialsByClientScope")
+                .setParameter("realmId", realm.getId())
                 .setParameter("scopeName", clientScope.getName())
                 .executeUpdate();
     }
@@ -1042,6 +1044,7 @@ public class JpaUserFederatedStorageProvider implements
                 UserProfile profile = profileProvider.create(UserProfileContext.USER_API, user);
                 userAttributes = profile.getAttributes().getReadable();
             } else {
+                logger.debugf("User %s not found when adding verifiable credential, storing empty attributes", userId);
                 userAttributes = new java.util.HashMap<>();
             }
         }
@@ -1096,8 +1099,6 @@ public class JpaUserFederatedStorageProvider implements
 
     @Override
     public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
-        session.getContext().getRealm();
-
         FederatedUserVerifiableCredentialEntity found = getFederatedVerifiableCredentialEntitiesByUser(userId)
                 .filter(vcEnt -> vcEnt.getCredentialScopeName().equals(credentialScopeName))
                 .findFirst()
@@ -1106,7 +1107,7 @@ public class JpaUserFederatedStorageProvider implements
         if (found == null) return false;
 
         em.remove(found);
-        //TODO Also remove associated issued credentials
+        //Remove associated issued credentials
         em.flush();
         return true;
     }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/JpaUserFederatedStorageProvider.java
@@ -16,19 +16,24 @@
  */
 package org.keycloak.storage.jpa;
 
+import java.io.IOException;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
+import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.TypedQuery;
 
 import org.keycloak.common.util.MultivaluedHashMap;
+import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.credential.CredentialModel;
@@ -46,6 +51,7 @@ import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserConsentModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.jpa.JpaUserCredentialStore;
 import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.storage.StorageId;
@@ -62,7 +68,13 @@ import org.keycloak.storage.jpa.entity.FederatedUserGroupMembershipEntity;
 import org.keycloak.storage.jpa.entity.FederatedUserRequiredActionEntity;
 import org.keycloak.storage.jpa.entity.FederatedUserRequiredActionEntity.Key;
 import org.keycloak.storage.jpa.entity.FederatedUserRoleMappingEntity;
+import org.keycloak.storage.jpa.entity.FederatedUserVerifiableCredentialEntity;
+import org.keycloak.userprofile.UserProfile;
+import org.keycloak.userprofile.UserProfileContext;
+import org.keycloak.userprofile.UserProfileProvider;
+import org.keycloak.util.JsonSerialization;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.models.jpa.PaginationUtils.paginateQuery;
@@ -679,6 +691,32 @@ public class JpaUserFederatedStorageProvider implements
         return model;
     }
 
+    private UserVerifiableCredentialModel toModel(FederatedUserVerifiableCredentialEntity entity) {
+        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(entity.getCredentialScopeName());
+        model.setRevision(entity.getRevision());
+        model.setCreatedDate(entity.getCreatedDate());
+        model.setUpdatedDate(entity.getUpdatedDate());
+
+        if (entity.getUserAttributes() != null) {
+            try {
+                TypeReference<Map<String, List<String>>> typeRef = new TypeReference<>() {};
+                Map<String, List<String>> attrs = JsonSerialization.readValue(entity.getUserAttributes(), typeRef);
+                model.setUserAttributes(attrs);
+            } catch (IOException e) {
+                throw new ModelException("Failed to deserialize user attributes", e);
+            }
+        }
+        return model;
+    }
+
+    private Stream<FederatedUserVerifiableCredentialEntity> getFederatedVerifiableCredentialEntitiesByUser(String userId) {
+        TypedQuery<FederatedUserVerifiableCredentialEntity> query =
+                em.createNamedQuery("federatedVerifiableCredentialsByUser", FederatedUserVerifiableCredentialEntity.class);
+        query.setParameter("userId", userId);
+        return closing(query.getResultStream());
+    }
+
+
     @Override
     public Stream<CredentialModel> getStoredCredentialsStream(RealmModel realm, String userId) {
         return this.getStoredCredentialEntitiesStream(userId).map(this::toModel);
@@ -830,6 +868,8 @@ public class JpaUserFederatedStorageProvider implements
                 .setParameter("realmId", realm.getId()).executeUpdate();
         num = em.createNamedQuery("deleteFederatedUsersByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
+        num = em.createNamedQuery("deleteFederatedVerifiableCredentialsByRealm")
+                .setParameter("realmId", realm.getId()).executeUpdate();
     }
 
     @Override
@@ -871,6 +911,9 @@ public class JpaUserFederatedStorageProvider implements
         em.createNamedQuery("deleteFederatedUserConsentClientScopesByClientScope")
                 .setParameter("scopeId", clientScope.getId())
                 .executeUpdate();
+        em.createNamedQuery("deleteFederatedVerifiableCredentialsByClientScope")
+                .setParameter("scopeName", clientScope.getName())
+                .executeUpdate();
     }
 
     @Override
@@ -911,6 +954,10 @@ public class JpaUserFederatedStorageProvider implements
                 .setParameter("userId", user.getId())
                 .setParameter("realmId", realm.getId())
                 .executeUpdate();
+        em.createNamedQuery("deleteFederatedVerifiableCredentialsByUser")
+                .setParameter("userId", user.getId())
+                .setParameter("realmId", realm.getId())
+                .executeUpdate();
 
     }
 
@@ -945,6 +992,9 @@ public class JpaUserFederatedStorageProvider implements
             em.createNamedQuery("deleteFederatedUsersByStorageProvider")
                     .setParameter("storageProviderId", model.getId())
                     .executeUpdate();
+            em.createNamedQuery("deleteFederatedVerifiableCredentialsByStorageProvider")
+                    .setParameter("storageProviderId", model.getId())
+                    .executeUpdate();
         } else if (model.getProviderType().equals(ClientStorageProvider.class.getName())) {
             em.createNamedQuery("deleteFederatedUserConsentClientScopesByClientStorageProvider")
                     .setParameter("clientStorageProvider",  model.getId())
@@ -955,5 +1005,116 @@ public class JpaUserFederatedStorageProvider implements
 
         }
 
+    }
+
+    @Override
+    public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel) {
+        RealmModel realm = session.getContext().getRealm();
+        createIndex(realm, userId);
+
+        FederatedUserVerifiableCredentialEntity entity = new FederatedUserVerifiableCredentialEntity();
+        entity.setId(KeycloakModelUtils.generateId());
+        entity.setUserId(userId);
+        entity.setRealmId(realm.getId());
+        entity.setStorageProviderId(new StorageId(userId).getProviderId());
+
+        String revision = credentialModel.getRevision() == null ?
+                SecretGenerator.getInstance().generateSecureID() : credentialModel.getRevision();
+        entity.setRevision(revision);
+
+        long createdDate = credentialModel.getCreatedDate() == null ?
+                Time.currentTimeMillis() : credentialModel.getCreatedDate();
+        entity.setCreatedDate(createdDate);
+
+        long updatedDate = credentialModel.getUpdatedDate() == null ?
+                createdDate : credentialModel.getUpdatedDate();
+        entity.setUpdatedDate(updatedDate);
+
+        entity.setCredentialScopeName(credentialModel.getCredentialScopeName());
+
+        Map<String, List<String>> userAttributes;
+        if (credentialModel.getUserAttributes() != null) {
+            userAttributes = credentialModel.getUserAttributes();
+        } else {
+            UserModel user = session.users().getUserById(realm, userId);
+            if (user != null) {
+                UserProfileProvider profileProvider = session.getProvider(UserProfileProvider.class);
+                UserProfile profile = profileProvider.create(UserProfileContext.USER_API, user);
+                userAttributes = profile.getAttributes().getReadable();
+            } else {
+                userAttributes = new java.util.HashMap<>();
+            }
+        }
+
+        try {
+            String attributesJson = JsonSerialization.writeValueAsString(userAttributes);
+            entity.setUserAttributes(attributesJson);
+        } catch (IOException e) {
+            throw new ModelException("Failed to serialize user attributes", e);
+        }
+        em.persist(entity);
+        em.flush();
+        return toModel(entity);
+    }
+
+    @Override
+    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName) {
+        RealmModel realm = session.getContext().getRealm();
+
+        FederatedUserVerifiableCredentialEntity entity = getFederatedVerifiableCredentialEntitiesByUser(userId)
+                .filter(vc -> credentialScopeName.equals(vc.getCredentialScopeName()))
+                .findFirst()
+                .orElseThrow(() -> new ModelException(
+                        "Verifiable credential not found: " + credentialScopeName));
+        UserModel user = session.users().getUserById(realm, userId);
+        if(user !=null) {
+            try {
+                UserProfileProvider profileProvider = session.getProvider(UserProfileProvider.class);
+                UserProfile profile = profileProvider.create(UserProfileContext.USER_API, user);
+                Map<String, List<String>> userAttributes = profile.getAttributes().getReadable();
+                String attributesJson = JsonSerialization.writeValueAsString(userAttributes);
+                entity.setUserAttributes(attributesJson);
+            } catch (IOException e) {
+                throw new ModelException("Failed to serialize user attributes", e);
+            }
+        } else {
+            logger.warnf("Could not retrieve user %s for updating verifiable credential attributes. " +
+                    "Keeping existing attributes.", userId);
+        }
+        String newRevision = SecretGenerator.getInstance().generateSecureID();
+        entity.setRevision(newRevision);
+        entity.setUpdatedDate(Time.currentTimeMillis());
+
+        try {
+            FederatedUserVerifiableCredentialEntity mergedEntity = em.merge(entity);
+            em.flush();
+            return toModel(mergedEntity);
+        } catch (OptimisticLockException e) {
+            throw new ModelException("Verifiable credential was concurrently modified. Please retry the operation.", e);
+        }
+    }
+
+    @Override
+    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+        session.getContext().getRealm();
+
+        FederatedUserVerifiableCredentialEntity found = getFederatedVerifiableCredentialEntitiesByUser(userId)
+                .filter(vcEnt -> vcEnt.getCredentialScopeName().equals(credentialScopeName))
+                .findFirst()
+                .orElse(null);
+
+        if (found == null) return false;
+
+        em.remove(found);
+        //TODO Also remove associated issued credentials
+        em.flush();
+        return true;
+    }
+
+    @Override
+    public Stream<UserVerifiableCredentialModel> getVerifiableCredential(String userId) {
+        return getFederatedVerifiableCredentialEntitiesByUser(userId)
+                .map(this::toModel)
+                .sorted(Comparator.comparing(UserVerifiableCredentialModel::getCredentialScopeName));
     }
 }

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.keycloak.storage.jpa.entity;
 
 import jakarta.persistence.Access;

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
@@ -1,0 +1,156 @@
+package org.keycloak.storage.jpa.entity;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+
+
+@Entity
+@Table(name="FED_USER_VER_CREDENTIAL", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"USER_ID", "CREDENTIAL_SCOPE_ID"})
+})
+@NamedQueries({
+        @NamedQuery(name="federatedVerifiableCredentialsByUser", query="select vc from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId"),
+        @NamedQuery(name="deleteFederatedVerifiableCredentialsByRealm", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.realmId = :realmId"),
+        @NamedQuery(name="deleteFederatedVerifiableCredentialsByClientScope", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.credentialScopeName = :scopeName"),
+        @NamedQuery(name="deleteFederatedVerifiableCredentialsByUser", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId and vc.realmId = :realmId"),
+        @NamedQuery(name="deleteFederatedVerifiableCredentialsByStorageProvider", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.storageProviderId = :storageProviderId"),
+})
+public class FederatedUserVerifiableCredentialEntity {
+
+    @Id
+    @Column(name="ID", length = 36)
+    @Access(AccessType.PROPERTY)
+    protected String id;
+
+    @Column(name="USER_ID")
+    protected String userId;
+
+    @Column(name="REALM_ID")
+    protected String realmId;
+
+    @Column(name="STORAGE_PROVIDER_ID")
+    protected String storageProviderId;
+
+    @Column(name="CREDENTIAL_SCOPE_NAME")
+    protected String credentialScopeName;
+
+    @Column(name="REVISION")
+    protected String revision;
+
+    @Column(name="USER_ATTRIBUTES", length = 4000)
+    protected String userAttributes;
+
+    @Column(name="CREATED_DATE")
+    private Long createdDate;
+
+    @Column(name="UPDATED_DATE")
+    private Long updatedDate;
+
+    @Version
+    @Column(name="VERSION")
+    private int version;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getRealmId() {
+        return realmId;
+    }
+
+    public void setRealmId(String realmId) {
+        this.realmId = realmId;
+    }
+
+    public String getStorageProviderId() {
+        return storageProviderId;
+    }
+
+    public void setStorageProviderId(String storageProviderId) {
+        this.storageProviderId = storageProviderId;
+    }
+
+    public String getCredentialScopeName() {
+        return credentialScopeName;
+    }
+
+    public void setCredentialScopeName(String credentialScopeName) {
+        this.credentialScopeName = credentialScopeName;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
+    }
+
+    public String getUserAttributes() {
+        return userAttributes;
+    }
+
+    public void setUserAttributes(String userAttributes) {
+        this.userAttributes = userAttributes;
+    }
+
+    public Long getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(Long createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public Long getUpdatedDate() {
+        return updatedDate;
+    }
+
+    public void setUpdatedDate(Long updatedDate) {
+        this.updatedDate = updatedDate;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null) return false;
+        if (!(o instanceof FederatedUserVerifiableCredentialEntity that)) return false;
+
+        if (!id.equals(that.getId())) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
@@ -14,12 +14,12 @@ import jakarta.persistence.Version;
 
 @Entity
 @Table(name="FED_USER_VER_CREDENTIAL", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"USER_ID", "REALM_ID", "CREDENTIAL_SCOPE_NAME"})
+        @UniqueConstraint(columnNames = {"USER_ID", "CLIENT_SCOPE_ID"})
 })
 @NamedQueries({
         @NamedQuery(name="federatedVerifiableCredentialsByUser", query="select vc from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId"),
         @NamedQuery(name="deleteFederatedVerifiableCredentialsByRealm", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.realmId = :realmId"),
-        @NamedQuery(name="deleteFederatedVerifiableCredentialsByClientScope", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.realmId = :realmId and vc.credentialScopeName = :scopeName"),
+        @NamedQuery(name="deleteFederatedVerifiableCredentialsByClientScope", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.clientScopeId = :scopeId"),
         @NamedQuery(name="deleteFederatedVerifiableCredentialsByUser", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId and vc.realmId = :realmId"),
         @NamedQuery(name="deleteFederatedVerifiableCredentialsByStorageProvider", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.storageProviderId = :storageProviderId"),
 })
@@ -39,8 +39,8 @@ public class FederatedUserVerifiableCredentialEntity {
     @Column(name="STORAGE_PROVIDER_ID", length = 36)
     protected String storageProviderId;
 
-    @Column(name="CREDENTIAL_SCOPE_NAME")
-    protected String credentialScopeName;
+    @Column(name="CLIENT_SCOPE_ID")
+    protected String clientScopeId;
 
     @Column(name="REVISION")
     protected String revision;
@@ -90,12 +90,12 @@ public class FederatedUserVerifiableCredentialEntity {
         this.storageProviderId = storageProviderId;
     }
 
-    public String getCredentialScopeName() {
-        return credentialScopeName;
+    public String getClientScopeId() {
+        return clientScopeId;
     }
 
-    public void setCredentialScopeName(String credentialScopeName) {
-        this.credentialScopeName = credentialScopeName;
+    public void setClientScopeId(String clientScopeId) {
+        this.clientScopeId = clientScopeId;
     }
 
     public String getRevision() {

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
@@ -14,12 +14,12 @@ import jakarta.persistence.Version;
 
 @Entity
 @Table(name="FED_USER_VER_CREDENTIAL", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"USER_ID", "CREDENTIAL_SCOPE_NAME"})
+        @UniqueConstraint(columnNames = {"USER_ID", "REALM_ID", "CREDENTIAL_SCOPE_NAME"})
 })
 @NamedQueries({
         @NamedQuery(name="federatedVerifiableCredentialsByUser", query="select vc from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId"),
         @NamedQuery(name="deleteFederatedVerifiableCredentialsByRealm", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.realmId = :realmId"),
-        @NamedQuery(name="deleteFederatedVerifiableCredentialsByClientScope", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.credentialScopeName = :scopeName"),
+        @NamedQuery(name="deleteFederatedVerifiableCredentialsByClientScope", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.realmId = :realmId and vc.credentialScopeName = :scopeName"),
         @NamedQuery(name="deleteFederatedVerifiableCredentialsByUser", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId and vc.realmId = :realmId"),
         @NamedQuery(name="deleteFederatedVerifiableCredentialsByStorageProvider", query="delete from FederatedUserVerifiableCredentialEntity vc where vc.storageProviderId = :storageProviderId"),
 })
@@ -36,7 +36,7 @@ public class FederatedUserVerifiableCredentialEntity {
     @Column(name="REALM_ID")
     protected String realmId;
 
-    @Column(name="STORAGE_PROVIDER_ID")
+    @Column(name="STORAGE_PROVIDER_ID", length = 36)
     protected String storageProviderId;
 
     @Column(name="CREDENTIAL_SCOPE_NAME")

--- a/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/storage/jpa/entity/FederatedUserVerifiableCredentialEntity.java
@@ -14,7 +14,7 @@ import jakarta.persistence.Version;
 
 @Entity
 @Table(name="FED_USER_VER_CREDENTIAL", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"USER_ID", "CREDENTIAL_SCOPE_ID"})
+        @UniqueConstraint(columnNames = {"USER_ID", "CREDENTIAL_SCOPE_NAME"})
 })
 @NamedQueries({
         @NamedQuery(name="federatedVerifiableCredentialsByUser", query="select vc from FederatedUserVerifiableCredentialEntity vc where vc.userId = :userId"),
@@ -45,7 +45,7 @@ public class FederatedUserVerifiableCredentialEntity {
     @Column(name="REVISION")
     protected String revision;
 
-    @Column(name="USER_ATTRIBUTES", length = 4000)
+    @Column(name="USER_ATTRIBUTES")
     protected String userAttributes;
 
     @Column(name="CREATED_DATE")

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -74,7 +74,7 @@
     <changeSet author="keycloak" id="26.7.0-federated-verifiable-credentials-1">
         <createTable tableName="FED_USER_VER_CREDENTIAL">
             <column name="ID" type="VARCHAR(36)">
-                <constraints primaryKey="true" nullable="false"/>
+                <constraints primaryKey="true" nullable="false" primaryKeyName="PK_FED_USER_VER_CREDENTIAL"/>
             </column>
             <column name="USER_ID" type="VARCHAR(255)">
                 <constraints nullable="false"/>

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -83,7 +83,7 @@
                 <constraints nullable="false"/>
             </column>
             <column name="STORAGE_PROVIDER_ID" type="VARCHAR(36)"/>
-            <column name="CREDENTIAL_SCOPE_NAME" type="VARCHAR(255)">
+            <column name="CLIENT_SCOPE_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="REVISION" type="VARCHAR(36)">
@@ -98,7 +98,7 @@
         </createTable>
 
         <addUniqueConstraint tableName="FED_USER_VER_CREDENTIAL"
-                             columnNames="REALM_ID, USER_ID, CREDENTIAL_SCOPE_NAME"
+                             columnNames="USER_ID, CLIENT_SCOPE_ID"
                              constraintName="UK_FED_USER_VC"/>
 
         <createIndex tableName="FED_USER_VER_CREDENTIAL" indexName="IDX_FED_USER_VC_USER">

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -98,7 +98,7 @@
         </createTable>
 
         <addUniqueConstraint tableName="FED_USER_VER_CREDENTIAL"
-                             columnNames="USER_ID, CREDENTIAL_SCOPE_NAME"
+                             columnNames="REALM_ID, USER_ID, CREDENTIAL_SCOPE_NAME"
                              constraintName="UK_FED_USER_VC"/>
 
         <createIndex tableName="FED_USER_VER_CREDENTIAL" indexName="IDX_FED_USER_VC_USER">

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -71,6 +71,41 @@
         <addUniqueConstraint columnNames="USER_ID, CLIENT_SCOPE_ID" constraintName="UK_KKUWUVD67ONTGSUGOGM8UEWRE" tableName="USER_VER_CREDENTIAL"/>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.7.0-federated-verifiable-credentials-1">
+        <createTable tableName="FED_USER_VER_CREDENTIAL">
+            <column name="ID" type="VARCHAR(36)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="USER_ID" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REALM_ID" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="STORAGE_PROVIDER_ID" type="VARCHAR(36)"/>
+            <column name="CREDENTIAL_SCOPE_NAME" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="REVISION" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="USER_ATTRIBUTES" type="TEXT"/>
+            <column name="CREATED_DATE" type="BIGINT"/>
+            <column name="UPDATED_DATE" type="BIGINT"/>
+            <column name="VERSION" type="INT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addUniqueConstraint tableName="FED_USER_VER_CREDENTIAL"
+                             columnNames="USER_ID, CREDENTIAL_SCOPE_NAME"
+                             constraintName="UK_FED_USER_VC"/>
+
+        <createIndex tableName="FED_USER_VER_CREDENTIAL" indexName="IDX_FED_USER_VC_USER">
+            <column name="USER_ID"/>
+        </createIndex>
+    </changeSet>
+
     <changeSet author="keycloak" id="26.7.0-outbox">
 
     <!--

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -101,7 +101,8 @@
                              columnNames="USER_ID, CLIENT_SCOPE_ID"
                              constraintName="UK_FED_USER_VC"/>
 
-        <createIndex tableName="FED_USER_VER_CREDENTIAL" indexName="IDX_FED_USER_VC_USER">
+        <createIndex tableName="FED_USER_VER_CREDENTIAL" indexName="IDX_FED_USER_VC_REALM_USER">
+            <column name="REALM_ID"/>
             <column name="USER_ID"/>
         </createIndex>
     </changeSet>

--- a/model/jpa/src/main/resources/default-persistence.xml
+++ b/model/jpa/src/main/resources/default-persistence.xml
@@ -95,6 +95,7 @@
         <class>org.keycloak.storage.jpa.entity.FederatedUserGroupMembershipEntity</class>
         <class>org.keycloak.storage.jpa.entity.FederatedUserRequiredActionEntity</class>
         <class>org.keycloak.storage.jpa.entity.FederatedUserRoleMappingEntity</class>
+        <class>org.keycloak.storage.jpa.entity.FederatedUserVerifiableCredentialEntity</class>
 
         <!-- Organization -->
         <class>org.keycloak.models.jpa.entities.OrganizationEntity</class>

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -946,7 +946,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().updateVerifiableCredential(userId, clientScopeId);
         } else {
-            return getFederatedStorage().updateVerifiableCredential(userId, credentialScopeName);
+            return getFederatedStorage().updateVerifiableCredential(userId, clientScopeId);
         }
     }
 
@@ -955,7 +955,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().removeVerifiableCredential(userId, clientScopeId);
         } else {
-            return getFederatedStorage().removeVerifiableCredential(userId, credentialScopeName);
+            return getFederatedStorage().removeVerifiableCredential(userId, clientScopeId);
         }
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -937,7 +937,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().addVerifiableCredential(userId, credentialModel);
         } else {
-            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+            return getFederatedStorage().addVerifiableCredential(userId, credentialModel);
         }
     }
 
@@ -946,7 +946,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().updateVerifiableCredential(userId, clientScopeId);
         } else {
-            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+            return getFederatedStorage().updateVerifiableCredential(userId, credentialScopeName);
         }
     }
 
@@ -955,7 +955,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().removeVerifiableCredential(userId, clientScopeId);
         } else {
-            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+            return getFederatedStorage().removeVerifiableCredential(userId, credentialScopeName);
         }
     }
 
@@ -964,7 +964,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().getVerifiableCredentialsByUser(userId);
         } else {
-            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+            return getFederatedStorage().getVerifiableCredential(userId);
         }
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -978,7 +978,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().getVerifiableCredentialByClientScope(userId, clientScopeId);
         } else {
-            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+            return getFederatedStorage().getVerifiableCredentialByClientScope(userId, clientScopeId);
         }
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -964,7 +964,7 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().getVerifiableCredentialsByUser(userId);
         } else {
-            return getFederatedStorage().getVerifiableCredential(userId);
+            return getFederatedStorage().getVerifiableCredentialsByUser(userId);
         }
     }
 

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -970,7 +970,11 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
 
     @Override
     public UserVerifiableCredentialModel getVerifiableCredentialById(String id) {
-        return localStorage().getVerifiableCredentialById(id);
+        UserVerifiableCredentialModel credentialModel = localStorage().getVerifiableCredentialById(id);
+        if (credentialModel == null) {
+            return getFederatedStorage().getVerifiableCredentialById(id);
+        }
+        return credentialModel;
     }
 
     @Override

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserFederatedStorageProvider.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserFederatedStorageProvider.java
@@ -41,7 +41,8 @@ public interface UserFederatedStorageProvider extends Provider,
         UserGroupMembershipFederatedStorage,
         UserRequiredActionsFederatedStorage,
         UserRoleMappingsFederatedStorage,
-        UserFederatedUserCredentialStore {
+        UserFederatedUserCredentialStore,
+        UserVerifiableCredentialFederatedStorage{
 
     /**
      * Obtains the ids of all federated users in the realm.

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserFederatedStorageProvider.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserFederatedStorageProvider.java
@@ -42,7 +42,7 @@ public interface UserFederatedStorageProvider extends Provider,
         UserRequiredActionsFederatedStorage,
         UserRoleMappingsFederatedStorage,
         UserFederatedUserCredentialStore,
-        UserVerifiableCredentialFederatedStorage{
+        UserVerifiableCredentialFederatedStorage {
 
     /**
      * Obtains the ids of all federated users in the realm.

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
@@ -57,4 +57,13 @@ public interface UserVerifiableCredentialFederatedStorage {
      */
     Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId);
 
+    /**
+     * Gets a verifiable credential for a federated user and client scope.
+     *
+     * @param userId the federated user ID
+     * @param clientScopeId the clien scope ID
+     * @return stream of verifiable credentials
+     */
+    UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId);
+
 }

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
@@ -35,19 +35,19 @@ public interface UserVerifiableCredentialFederatedStorage {
      * Updates a verifiable credential for a federated user.
      *
      * @param userId the federated user ID
-     * @param credentialScopeName the credential scope name
+     * @param clientScopeId the client scope ID
      * @return the updated credential
      */
-    UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName);
+    UserVerifiableCredentialModel updateVerifiableCredential(String userId, String clientScopeId);
 
     /**
      * Removes a verifiable credential for a federated user.
      *
      * @param userId the federated user ID
-     * @param credentialScopeName the credential scope name to remove
+     * @param clientScopeId the client scope ID to remove
      * @return true if removed, false if not found
      */
-    boolean removeVerifiableCredential(String userId, String credentialScopeName);
+    boolean removeVerifiableCredential(String userId, String clientScopeId);
 
     /**
      * Gets all verifiable credentials for a federated user.

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
@@ -55,6 +55,6 @@ public interface UserVerifiableCredentialFederatedStorage {
      * @param userId the federated user ID
      * @return stream of verifiable credentials
      */
-    Stream<UserVerifiableCredentialModel> getVerifiableCredential(String userId);
+    Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId);
 
 }

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.storage.federated;
+
+import java.util.stream.Stream;
+
+import org.keycloak.models.UserVerifiableCredentialModel;
+
+public interface UserVerifiableCredentialFederatedStorage {
+
+    /**
+     * Adds a verifiable credential for a federated user.
+     *
+     * @param userId the federated user ID
+     * @param credentialModel the credential to add
+     * @return the added credential with generated fields populated
+     */
+    UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel);
+
+    /**
+     * Updates a verifiable credential for a federated user.
+     *
+     * @param userId the federated user ID
+     * @param credentialScopeName the credential scope name
+     * @return the updated credential
+     */
+    UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName);
+
+    /**
+     * Removes a verifiable credential for a federated user.
+     *
+     * @param userId the federated user ID
+     * @param credentialScopeName the credential scope name to remove
+     * @return true if removed, false if not found
+     */
+    boolean removeVerifiableCredential(String userId, String credentialScopeName);
+
+    /**
+     * Gets all verifiable credentials for a federated user.
+     *
+     * @param userId the federated user ID
+     * @return stream of verifiable credentials
+     */
+    Stream<UserVerifiableCredentialModel> getVerifiableCredential(String userId);
+
+}

--- a/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
+++ b/model/storage/src/main/java/org/keycloak/storage/federated/UserVerifiableCredentialFederatedStorage.java
@@ -61,9 +61,17 @@ public interface UserVerifiableCredentialFederatedStorage {
      * Gets a verifiable credential for a federated user and client scope.
      *
      * @param userId the federated user ID
-     * @param clientScopeId the clien scope ID
-     * @return stream of verifiable credentials
+     * @param clientScopeId the client scope ID
+     * @return the verifiable credential model, or {@code null} if not found
      */
     UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId);
+
+    /**
+     * Gets a verifiable credential by its ID.
+     *
+     * @param id the ID of the verifiable credential
+     * @return the verifiable credential model, or {@code null} if not found
+     */
+    UserVerifiableCredentialModel getVerifiableCredentialById(String id);
 
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
@@ -153,10 +153,11 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
         scopeRep.setName("test-scope-to-delete");
         scopeRep.setProtocol("oid4vc");
-        Response resp = managedRealm.admin().clientScopes().create(scopeRep);
-        assertNotNull(resp);
-        String scopeId = ApiUtil.getCreatedId(resp);
-        resp.close();
+        String scopeId;
+        try(Response resp = managedRealm.admin().clientScopes().create(scopeRep)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), resp.getStatus());
+            scopeId = ApiUtil.getCreatedId(resp);
+        }
         adminEvents.clear();
 
         runOnServer.run(session -> session.users().addVerifiableCredential(federatedUserId,
@@ -205,6 +206,37 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         });
     }
 
+    @Test
+    public void testGetVerifiableCredentialById() {
+        String federatedUserId = createFederatedUser("fed-user-get-verify-fields-by-id");
+        String scopeId = resolveScopeId(CLIENT_SCOPE_NAME_1);
+
+        String verCredId = runOnServer.fetchString(session -> {
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel("vc-with-fields", scopeId);
+            vcModel.setRevision("rev-456");
+            vcModel.setUserAttributes(Map.of(
+                    "firstName", List.of("Max"),
+                    "lastName", List.of("Mustermann")
+            ));
+
+            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(federatedUserId, vcModel);
+            return added.getId();
+        });
+
+        runOnServer.run(session -> {
+            UserVerifiableCredentialModel retrieved = session.users().getVerifiableCredentialById(verCredId);
+
+            assertNotNull(retrieved);
+            assertNotNull(retrieved.getId());
+            assertEquals(scopeId, retrieved.getClientScopeId());
+            assertEquals("rev-456", retrieved.getRevision());
+            assertNotNull(retrieved.getCreatedDate());
+            assertNotNull(retrieved.getUserAttributes());
+            assertEquals(List.of("Max"), retrieved.getUserAttributes().get("firstName"));
+            assertEquals(List.of("Mustermann"), retrieved.getUserAttributes().get("lastName"));
+        });
+    }
+
     public static class FederatedVcTestRealmConfig implements RealmConfig {
         public static final String TEST_REALM_NAME = "test";
 
@@ -247,7 +279,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
 
     private String createFederatedUser(String username, String firstName, String lastName, String email) {
         return runOnServer.fetchString(session -> {
-            String providerId = "test-provider";
+            String providerId = "00000000-0000-0000-0000-000000000001";
             // Create federated user ID: f:<providerId>:<externalId>
             String federatedUserId = "f:" + providerId + ":" + username;
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
@@ -3,6 +3,8 @@ package org.keycloak.tests.admin.user;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
@@ -49,7 +51,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
             assertNotNull(added);
             assertNotNull(added.getRevision());
             assertNotNull(added.getCreatedDate());
-            assertEquals(CREDENTIAL_TYPE_1, added.getCredentialScopeName());
+            assertNotNull(added.getCredentialScopeName());
         });
 
         runOnServer.run(session -> {
@@ -58,7 +60,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
                     .collect(Collectors.toList());
 
             assertEquals(1, vcs.size());
-            assertEquals(CREDENTIAL_TYPE_1, vcs.get(0).getCredentialScopeName());
+            assertNotNull(vcs.get(0).getCredentialScopeName());
         });
     }
 
@@ -112,6 +114,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         String localUserId = createUser("local-user", "local@test.com");
         String federatedUserId = createFederatedUser("fed-user-isolated");
 
+
         runOnServer.run(session -> {
             session.users().addVerifiableCredential(localUserId, new UserVerifiableCredentialModel("local-cert"));
             session.users().addVerifiableCredential(federatedUserId, new UserVerifiableCredentialModel("federated-cert"));
@@ -143,7 +146,8 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
         scopeRep.setName("test-scope-to-delete");
         scopeRep.setProtocol("oid4vc");
-        jakarta.ws.rs.core.Response resp = managedRealm.admin().clientScopes().create(scopeRep);
+        Response resp = managedRealm.admin().clientScopes().create(scopeRep);
+        assertNotNull(resp);
         String scopeId = ApiUtil.getCreatedId(resp);
         resp.close();
         adminEvents.clear();
@@ -162,22 +166,6 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
             long count = session.users().getVerifiableCredentialsByUser(federatedUserId).count();
             assertEquals(0, count);
         });
-    }
-
-    @Test
-    @DatabaseTest
-    public void testUpdateVerifiableCredentialForFederatedUser() {
-        String federatedUserId = createFederatedUser("fed-user-update");
-
-        String originalRevision = runOnServer.fetchString(session -> {
-            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
-            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(federatedUserId, vcModel);
-            return added.getRevision();
-        });
-
-        // Note: Update requires actual user model - skip for now as it needs UserProfile
-        // This test validates the basic structure works
-        assertNotNull(originalRevision);
     }
 
     public static class FederatedVcTestRealmConfig implements RealmConfig {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
@@ -1,6 +1,7 @@
 package org.keycloak.tests.admin.user;
 
 import java.util.List;
+import java.util.Map;
 
 import jakarta.ws.rs.core.Response;
 
@@ -171,6 +172,36 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         runOnServer.run(session -> {
             long count = session.users().getVerifiableCredentialsByUser(federatedUserId).count();
             assertEquals(0, count);
+        });
+    }
+
+    @Test
+    public void testGetVerifiableCredentialByClientScope() {
+        String federatedUserId = createFederatedUser("fed-user-get-verify-fields");
+        String scopeId = resolveScopeId(CLIENT_SCOPE_NAME_1);
+
+        runOnServer.run(session -> {
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel("vc-with-fields", scopeId);
+            vcModel.setRevision("rev-123");
+            vcModel.setUserAttributes(Map.of(
+                    "firstName", List.of("John"),
+                    "lastName", List.of("Doe")
+            ));
+
+            session.users().addVerifiableCredential(federatedUserId, vcModel);
+        });
+
+        runOnServer.run(session -> {
+            UserVerifiableCredentialModel retrieved = session.users().getVerifiableCredentialByClientScope(federatedUserId, scopeId);
+
+            assertNotNull(retrieved);
+            assertNotNull(retrieved.getId());
+            assertEquals(scopeId, retrieved.getClientScopeId());
+            assertEquals("rev-123", retrieved.getRevision());
+            assertNotNull(retrieved.getCreatedDate());
+            assertNotNull(retrieved.getUserAttributes());
+            assertEquals(List.of("John"), retrieved.getUserAttributes().get("firstName"));
+            assertEquals(List.of("Doe"), retrieved.getUserAttributes().get("lastName"));
         });
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
@@ -1,0 +1,216 @@
+package org.keycloak.tests.admin.user;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.connections.jpa.JpaConnectionProvider;
+import org.keycloak.models.UserVerifiableCredentialModel;
+import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.storage.UserStorageUtil;
+import org.keycloak.storage.federated.UserFederatedStorageProvider;
+import org.keycloak.storage.jpa.entity.FederatedUser;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
+import org.keycloak.tests.suites.DatabaseTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.jwtTypeNaturalPersonScopeName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@KeycloakIntegrationTest(config = OID4VCIssuerTestBase.VCTestServerConfig.class)
+@DatabaseTest
+public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
+
+    private static final String CREDENTIAL_TYPE_1 = jwtTypeNaturalPersonScopeName;
+    private static final String CREDENTIAL_TYPE_2 = "education-cert";
+
+    @InjectRealm(config = FederatedVcTestRealmConfig.class)
+    protected ManagedRealm testRealm;
+
+    @Test
+    public void testAddVerifiableCredentialForFederatedUser() {
+        String federatedUserId = createFederatedUser("fed-user-1");
+
+        runOnServer.run(session -> {
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
+            vcModel.setRevision("rev-001");
+
+            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(federatedUserId, vcModel);
+            assertNotNull(added);
+            assertNotNull(added.getRevision());
+            assertNotNull(added.getCreatedDate());
+            assertEquals(CREDENTIAL_TYPE_1, added.getCredentialScopeName());
+        });
+
+        runOnServer.run(session -> {
+            List<UserVerifiableCredentialModel> vcs = session.users()
+                    .getVerifiableCredentialsByUser(federatedUserId)
+                    .collect(Collectors.toList());
+
+            assertEquals(1, vcs.size());
+            assertEquals(CREDENTIAL_TYPE_1, vcs.get(0).getCredentialScopeName());
+        });
+    }
+
+    @Test
+    public void testGetVerifiableCredentialsForFederatedUser_EmptyList() {
+        String federatedUserId = createFederatedUser("fed-user-empty");
+
+        runOnServer.run(session -> {
+            List<UserVerifiableCredentialModel> vcs = session.users()
+                    .getVerifiableCredentialsByUser(federatedUserId)
+                    .collect(Collectors.toList());
+
+            assertNotNull(vcs);
+            assertTrue(vcs.isEmpty());
+        });
+    }
+
+    @Test
+    public void testRemoveVerifiableCredentialForFederatedUser() {
+        String federatedUserId = createFederatedUser("fed-user-remove");
+
+        runOnServer.run(session -> {
+            session.users().addVerifiableCredential(federatedUserId,
+                    new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1));
+            session.users().addVerifiableCredential(federatedUserId,
+                    new UserVerifiableCredentialModel(CREDENTIAL_TYPE_2));
+        });
+
+        runOnServer.run(session -> {
+            long count = session.users().getVerifiableCredentialsByUser(federatedUserId).count();
+            assertEquals(2, count);
+        });
+
+        runOnServer.run(session ->  {
+                boolean removed = session.users().removeVerifiableCredential(federatedUserId, CREDENTIAL_TYPE_1);
+            assertTrue(removed);
+        });
+
+        runOnServer.run(session -> {
+            List<UserVerifiableCredentialModel> remaining = session.users()
+                    .getVerifiableCredentialsByUser(federatedUserId)
+                    .toList();
+
+            assertEquals(1, remaining.size());
+            assertEquals(CREDENTIAL_TYPE_2, remaining.get(0).getCredentialScopeName());
+        });
+    }
+
+    @Test
+    public void testFederatedAndLocalUsersAreIsolated() {
+        String localUserId = createUser("local-user", "local@test.com");
+        String federatedUserId = createFederatedUser("fed-user-isolated");
+
+        runOnServer.run(session -> {
+            session.users().addVerifiableCredential(localUserId, new UserVerifiableCredentialModel("local-cert"));
+            session.users().addVerifiableCredential(federatedUserId, new UserVerifiableCredentialModel("federated-cert"));
+        });
+
+        runOnServer.run(session -> {
+            List<UserVerifiableCredentialModel> localVcs = session.users()
+                    .getVerifiableCredentialsByUser(localUserId)
+                    .collect(Collectors.toList());
+
+            assertEquals(1, localVcs.size());
+            assertEquals("local-cert", localVcs.get(0).getCredentialScopeName());
+        });
+
+        runOnServer.run(session -> {
+            List<UserVerifiableCredentialModel> fedVcs = session.users()
+                    .getVerifiableCredentialsByUser(federatedUserId)
+                    .collect(Collectors.toList());
+
+            assertEquals(1, fedVcs.size());
+            assertEquals("federated-cert", fedVcs.get(0).getCredentialScopeName());
+        });
+    }
+
+    @Test
+    public void testCredentialsDeletedWhenClientScopeDeleted() {
+        String federatedUserId = createFederatedUser("fed-user-scope-delete");
+
+        ClientScopeRepresentation scopeRep = new ClientScopeRepresentation();
+        scopeRep.setName("test-scope-to-delete");
+        scopeRep.setProtocol("oid4vc");
+        jakarta.ws.rs.core.Response resp = managedRealm.admin().clientScopes().create(scopeRep);
+        String scopeId = ApiUtil.getCreatedId(resp);
+        resp.close();
+        adminEvents.clear();
+
+        runOnServer.run(session -> session.users().addVerifiableCredential(federatedUserId,
+                new UserVerifiableCredentialModel("test-scope-to-delete")));
+
+        runOnServer.run(session -> {
+            long count = session.users().getVerifiableCredentialsByUser(federatedUserId).count();
+            assertEquals(1, count);
+        });
+
+        managedRealm.admin().clientScopes().get(scopeId).remove();
+
+        runOnServer.run(session -> {
+            long count = session.users().getVerifiableCredentialsByUser(federatedUserId).count();
+            assertEquals(0, count);
+        });
+    }
+
+    public static class FederatedVcTestRealmConfig implements RealmConfig {
+        public static final String TEST_REALM_NAME = "test";
+
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm
+                    .name(TEST_REALM_NAME)
+                    .eventsEnabled(true)
+                    .eventsListeners("jboss-logging")
+                    .verifiableCredentialsEnabled(true)
+                    .clientScopes(
+                            createCredentialScope(CREDENTIAL_TYPE_1),
+                            createCredentialScope(CREDENTIAL_TYPE_2)
+                    );
+        }
+
+
+        private static CredentialScopeRepresentation createCredentialScope(String scopeName) {
+            return new CredentialScopeRepresentation(scopeName)
+                    .setIncludeInTokenScope(true)
+                    .setCredentialConfigurationId(scopeName);
+        }
+
+    }
+
+    private String createFederatedUser(String username) {
+        return createFederatedUser(username, "John", "Doe", username + "@example.com");
+    }
+
+    private String createFederatedUser(String username, String firstName, String lastName, String email) {
+        return runOnServer.fetchString(session -> {
+            String providerId = "test-provider";
+            // Create federated user ID: f:<providerId>:<externalId>
+            String federatedUserId = "f:" + providerId + ":" + username;
+
+            FederatedUser fedUser = new FederatedUser();
+            fedUser.setId(federatedUserId);
+            fedUser.setRealmId(session.getContext().getRealm().getId());
+            fedUser.setStorageProviderId(providerId);
+            session.getProvider(JpaConnectionProvider.class).getEntityManager().persist(fedUser);
+
+            UserFederatedStorageProvider federatedStorage = UserStorageUtil.userFederatedStorage(session);
+            federatedStorage.setSingleAttribute(session.getContext().getRealm(), federatedUserId, "username", username);
+            federatedStorage.setSingleAttribute(session.getContext().getRealm(), federatedUserId, "firstName", firstName);
+            federatedStorage.setSingleAttribute(session.getContext().getRealm(), federatedUserId, "lastName", lastName);
+            federatedStorage.setSingleAttribute(session.getContext().getRealm(), federatedUserId, "email", email);
+            return federatedUserId;
+        });
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
@@ -164,6 +164,22 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         });
     }
 
+    @Test
+    @DatabaseTest
+    public void testUpdateVerifiableCredentialForFederatedUser() {
+        String federatedUserId = createFederatedUser("fed-user-update");
+
+        String originalRevision = runOnServer.fetchString(session -> {
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
+            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(federatedUserId, vcModel);
+            return added.getRevision();
+        });
+
+        // Note: Update requires actual user model - skip for now as it needs UserProfile
+        // This test validates the basic structure works
+        assertNotNull(originalRevision);
+    }
+
     public static class FederatedVcTestRealmConfig implements RealmConfig {
         public static final String TEST_REALM_NAME = "test";
 

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/FederatedUserVerifiableCredentialTest.java
@@ -1,7 +1,6 @@
 package org.keycloak.tests.admin.user;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import jakarta.ws.rs.core.Response;
 
@@ -23,8 +22,6 @@ import org.keycloak.tests.suites.DatabaseTest;
 
 import org.junit.jupiter.api.Test;
 
-import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.jwtTypeNaturalPersonScopeName;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,8 +30,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DatabaseTest
 public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
 
-    private static final String CREDENTIAL_TYPE_1 = jwtTypeNaturalPersonScopeName;
-    private static final String CREDENTIAL_TYPE_2 = "education-cert";
+    private static final String CLIENT_SCOPE_NAME_1 = "driving-license-cert";
+    private static final String CLIENT_SCOPE_NAME_2 = "education-cert";
 
     @InjectRealm(config = FederatedVcTestRealmConfig.class)
     protected ManagedRealm testRealm;
@@ -42,25 +39,26 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
     @Test
     public void testAddVerifiableCredentialForFederatedUser() {
         String federatedUserId = createFederatedUser("fed-user-1");
+        String expectedScopeId = resolveScopeId(CLIENT_SCOPE_NAME_1);
 
         runOnServer.run(session -> {
-            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel("vc-1", expectedScopeId);
             vcModel.setRevision("rev-001");
 
             UserVerifiableCredentialModel added = session.users().addVerifiableCredential(federatedUserId, vcModel);
             assertNotNull(added);
             assertNotNull(added.getRevision());
             assertNotNull(added.getCreatedDate());
-            assertNotNull(added.getCredentialScopeName());
+            assertEquals(expectedScopeId, added.getClientScopeId());
         });
 
         runOnServer.run(session -> {
             List<UserVerifiableCredentialModel> vcs = session.users()
                     .getVerifiableCredentialsByUser(federatedUserId)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals(1, vcs.size());
-            assertNotNull(vcs.get(0).getCredentialScopeName());
+            assertEquals(expectedScopeId, vcs.get(0).getClientScopeId());
         });
     }
 
@@ -71,7 +69,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         runOnServer.run(session -> {
             List<UserVerifiableCredentialModel> vcs = session.users()
                     .getVerifiableCredentialsByUser(federatedUserId)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertNotNull(vcs);
             assertTrue(vcs.isEmpty());
@@ -82,11 +80,14 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
     public void testRemoveVerifiableCredentialForFederatedUser() {
         String federatedUserId = createFederatedUser("fed-user-remove");
 
+        String scopeId1 = resolveScopeId(CLIENT_SCOPE_NAME_1);
+        String scopeId2 = resolveScopeId(CLIENT_SCOPE_NAME_2);
+
         runOnServer.run(session -> {
             session.users().addVerifiableCredential(federatedUserId,
-                    new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1));
+                new UserVerifiableCredentialModel("vc-1", scopeId1));
             session.users().addVerifiableCredential(federatedUserId,
-                    new UserVerifiableCredentialModel(CREDENTIAL_TYPE_2));
+                new UserVerifiableCredentialModel("vc-2", scopeId2));
         });
 
         runOnServer.run(session -> {
@@ -94,8 +95,8 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
             assertEquals(2, count);
         });
 
-        runOnServer.run(session ->  {
-                boolean removed = session.users().removeVerifiableCredential(federatedUserId, CREDENTIAL_TYPE_1);
+        runOnServer.run(session -> {
+            boolean removed = session.users().removeVerifiableCredential(federatedUserId, scopeId1);
             assertTrue(removed);
         });
 
@@ -105,7 +106,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
                     .toList();
 
             assertEquals(1, remaining.size());
-            assertEquals(CREDENTIAL_TYPE_2, remaining.get(0).getCredentialScopeName());
+            assertEquals(scopeId2, remaining.get(0).getClientScopeId());
         });
     }
 
@@ -114,28 +115,33 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         String localUserId = createUser("local-user", "local@test.com");
         String federatedUserId = createFederatedUser("fed-user-isolated");
 
+        // Use existing test scopes - resolve both before adding credentials
+        String localScopeId = resolveScopeId(CLIENT_SCOPE_NAME_1);
+        String fedScopeId = resolveScopeId(CLIENT_SCOPE_NAME_2);
 
         runOnServer.run(session -> {
-            session.users().addVerifiableCredential(localUserId, new UserVerifiableCredentialModel("local-cert"));
-            session.users().addVerifiableCredential(federatedUserId, new UserVerifiableCredentialModel("federated-cert"));
+            session.users().addVerifiableCredential(localUserId,
+                new UserVerifiableCredentialModel("local-vc-01", localScopeId));
+            session.users().addVerifiableCredential(federatedUserId,
+                new UserVerifiableCredentialModel("fed-vc-02", fedScopeId));
         });
 
         runOnServer.run(session -> {
             List<UserVerifiableCredentialModel> localVcs = session.users()
                     .getVerifiableCredentialsByUser(localUserId)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals(1, localVcs.size());
-            assertEquals("local-cert", localVcs.get(0).getCredentialScopeName());
+            assertEquals(localScopeId, localVcs.get(0).getClientScopeId());
         });
 
         runOnServer.run(session -> {
             List<UserVerifiableCredentialModel> fedVcs = session.users()
                     .getVerifiableCredentialsByUser(federatedUserId)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals(1, fedVcs.size());
-            assertEquals("federated-cert", fedVcs.get(0).getCredentialScopeName());
+            assertEquals(fedScopeId, fedVcs.get(0).getClientScopeId());
         });
     }
 
@@ -153,7 +159,7 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
         adminEvents.clear();
 
         runOnServer.run(session -> session.users().addVerifiableCredential(federatedUserId,
-                new UserVerifiableCredentialModel("test-scope-to-delete")));
+                new UserVerifiableCredentialModel("vc_1", scopeId)));
 
         runOnServer.run(session -> {
             long count = session.users().getVerifiableCredentialsByUser(federatedUserId).count();
@@ -179,8 +185,8 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
                     .eventsListeners("jboss-logging")
                     .verifiableCredentialsEnabled(true)
                     .clientScopes(
-                            createCredentialScope(CREDENTIAL_TYPE_1),
-                            createCredentialScope(CREDENTIAL_TYPE_2)
+                            createCredentialScope(CLIENT_SCOPE_NAME_1),
+                            createCredentialScope(CLIENT_SCOPE_NAME_2)
                     );
         }
 
@@ -191,6 +197,17 @@ public class FederatedUserVerifiableCredentialTest extends AbstractUserTest {
                     .setCredentialConfigurationId(scopeName);
         }
 
+    }
+
+    private String resolveScopeId(String scopeName) {
+        return runOnServer.fetchString(session ->
+            session.clientScopes()
+                    .getClientScopesStream(session.getContext().getRealm())
+                    .filter(cs -> scopeName.equals(cs.getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Client scope not found: " + scopeName))
+                    .getId()
+        );
     }
 
     private String createFederatedUser(String username) {


### PR DESCRIPTION
 Adds support for verifiable credentials (VC) on federated users.
  
  ## Changes
  - Created federated storage entities for user verifiable credentials
  - Implemented `UserVerifiableCredentialFederatedStorage` interface in `JpaUserFederatedStorageProvider`
  - Updated `UserStorageManager` to delegate VC operations to federated storage when appropriate
  - Added database schema (Liquibase changesets) for federated VC tables
  - Added integration tests for federated user VC operations

Closes #48677

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
