### PR TITLE
SSF: Stop event delivery for disabled receiver clients (#50050)

### DIFF
--- a/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
+++ b/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
@@ -1123,6 +1123,10 @@ public class SsfAdminResource {
                 // (e.g. on a stream that was deleted between check and emit).
                 return invalidRequest(emitErrorCode, emitMessage,
                         "No SSF stream registered for client");
+            case RECEIVER_DISABLED:
+                // Receiver is configured but its client is disabled
+                return invalidRequest(emitErrorCode, emitMessage,
+                        "Receiver client is disabled");
             case NO_DELIVERY_CONFIG:
                 // Stream exists but is not deliverable
                 return invalidRequest(emitErrorCode, emitMessage,

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterClientDisabledTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterClientDisabledTests.java
@@ -43,7 +43,6 @@ import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
 import org.keycloak.testframework.server.KeycloakUrls;
 import org.keycloak.testframework.util.HttpServerUtil;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
@@ -203,6 +202,38 @@ public class SsfTransmitterClientDisabledTests {
         }
         Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
                 "event should reach the mock receiver again after re-enable — the stream survived the disable");
+    }
+
+    @Test
+    public void disabledReceiver_adminCanStillDeleteStream() throws Exception {
+        // Regression guard: the disable gate must NOT leak into admin-side
+        // stream management. Disabling the client and then deleting its
+        // stream as an admin must actually remove the stream (and cascade
+        // the outbox purge), not silently no-op behind a 204. The gate
+        // belongs on the delivery paths, not on the management lookup
+        // getStream() relies on.
+        setReceiverEnabled(false);
+
+        String deleteUrl = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/stream";
+        try (SimpleHttpResponse res = http.doDelete(deleteUrl)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .asResponse()) {
+            Assertions.assertEquals(204, res.getStatus(),
+                    "admin stream delete should succeed even when the receiver client is disabled");
+        }
+
+        // The stream must really be gone — admin GET reads the stream via
+        // the ungated getStreamForClient, so a 404 here proves the delete
+        // took effect rather than no-opping behind an idempotent 204.
+        String getUrl = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/stream";
+        try (SimpleHttpResponse res = http.doGet(getUrl)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .asResponse()) {
+            Assertions.assertEquals(404, res.getStatus(),
+                    "stream must actually be deleted for a disabled client, not left behind");
+        }
     }
 
     // --- helpers ---------------------------------------------------------

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterClientDisabledTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterClientDisabledTests.java
@@ -1,0 +1,382 @@
+package org.keycloak.tests.ssf.transmitter;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.ClientResource;
+import org.keycloak.common.Profile;
+import org.keycloak.http.simple.SimpleHttp;
+import org.keycloak.http.simple.SimpleHttpResponse;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.ssf.Ssf;
+import org.keycloak.ssf.event.caep.CaepCredentialChange;
+import org.keycloak.ssf.transmitter.DefaultSsfTransmitterProviderFactory;
+import org.keycloak.ssf.transmitter.SsfScopes;
+import org.keycloak.ssf.transmitter.SsfTransmitterConfig;
+import org.keycloak.ssf.transmitter.stream.StreamConfig;
+import org.keycloak.ssf.transmitter.stream.StreamDeliveryConfig;
+import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
+import org.keycloak.ssf.transmitter.support.SsfTransmitterUrls;
+import org.keycloak.testframework.annotations.InjectAdminClient;
+import org.keycloak.testframework.annotations.InjectHttpServer;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectSimpleHttp;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.server.DefaultKeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.testframework.util.HttpServerUtil;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for the per-client SSF disable gate
+ * (keycloak/keycloak#50050).
+ *
+ * <p>Disabling an SSF receiver client (the standard client on/off toggle)
+ * must take it off the air for event delivery — mirroring the realm-level
+ * transmitter disable — while leaving the stream configuration intact so
+ * re-enabling the client resumes delivery. The gate is implemented in
+ * {@link org.keycloak.ssf.transmitter.support.SsfUtil#isReceiverEnabled}
+ * and applied across the dispatch path, the synthetic-emit path, the
+ * receiver auth pipeline, and auto-notify-on-login.
+ *
+ * <p>These tests exercise the behaviour end-to-end through the synthetic
+ * emit endpoint and the async push pipeline, which is the path that gives
+ * a clean, observable signal: a configured receiver delivers while
+ * enabled, returns {@code receiver_disabled} (HTTP 400) with no push while
+ * disabled, and delivers again once re-enabled — proving the stream
+ * survived the disable.
+ *
+ * <p>The admin-caller path is used for emit (the {@code @InjectAdminClient}
+ * token has manage-clients), which bypasses the receiver's
+ * {@code allowEmitEvents}/role wiring and keeps the setup focused on the
+ * disable gate itself.
+ */
+@KeycloakIntegrationTest(config = SsfTransmitterClientDisabledTests.DisabledServerConfig.class)
+public class SsfTransmitterClientDisabledTests {
+
+    static final String RECEIVER = "ssf-receiver-disabled";
+    static final String RECEIVER_SECRET = "receiver-disabled-secret";
+
+    static final String TEST_USER = "disabled-tester";
+    static final String TEST_EMAIL = "disabled-tester@local.test";
+
+    static final String PUSH_CONTEXT_PATH = "/ssf/push-disabled";
+    static final String MOCK_PUSH_ENDPOINT = "http://127.0.0.1:8500" + PUSH_CONTEXT_PATH;
+    static final String PUSH_AUTH_HEADER = "Bearer dummy-disabled-receiver";
+
+    static final long PUSH_WAIT_SECONDS = 5;
+
+    @InjectRealm(config = DisabledRealm.class)
+    ManagedRealm realm;
+
+    @InjectSimpleHttp
+    SimpleHttp http;
+
+    @InjectAdminClient
+    Keycloak adminClient;
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectHttpServer
+    HttpServer mockReceiverServer;
+
+    private final BlockingQueue<String> pushes = new LinkedBlockingQueue<>();
+
+    @BeforeEach
+    public void setup() throws IOException {
+        pushes.clear();
+        mockReceiverServer.createContext(PUSH_CONTEXT_PATH, new HttpHandler() {
+            @Override
+            public void handle(HttpExchange exchange) throws IOException {
+                try (InputStream is = exchange.getRequestBody()) {
+                    pushes.add(new String(is.readAllBytes(), StandardCharsets.UTF_8));
+                }
+                HttpServerUtil.sendResponse(exchange, 202, Map.of());
+            }
+        });
+
+        // A previous test may have left the receiver disabled; restore a
+        // known-enabled state before (re)creating the stream, which needs
+        // a receiver token only an enabled client can obtain.
+        setReceiverEnabled(true);
+
+        assignOptionalClientScopes(RECEIVER, SsfScopes.SCOPE_SSF_READ, SsfScopes.SCOPE_SSF_MANAGE);
+        createPushStream();
+        subscribeTestUser();
+    }
+
+    @AfterEach
+    public void cleanup() {
+        // Re-enable first so the stream-delete (receiver-context) call and
+        // the next test's setup both run against an enabled client.
+        try {
+            setReceiverEnabled(true);
+        } catch (Exception ignored) {
+        }
+        bestEffortDeleteStream();
+        bestEffortRemoveNotify();
+        try {
+            mockReceiverServer.removeContext(PUSH_CONTEXT_PATH);
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
+    public void enabledReceiver_emitDispatchesAndPushes() throws Exception {
+        // Baseline: with the receiver enabled the emit endpoint dispatches
+        // and the SET reaches the mock receiver. Establishes that the rest
+        // of the wiring is sound, so the disabled-case assertions below
+        // can attribute the difference to the disable gate alone.
+        try (SimpleHttpResponse res = emitAsAdmin("CaepCredentialChange", TEST_EMAIL,
+                Map.of("credential_type", "password", "change_type", "update"))) {
+            Assertions.assertEquals(200, res.getStatus(),
+                    "emit should succeed while the receiver client is enabled");
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "status should be 'dispatched' when the receiver is enabled and all filters pass");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "dispatched event should reach the mock receiver while enabled");
+    }
+
+    @Test
+    public void disabledReceiver_emitReturnsReceiverDisabled_andNoPush() throws Exception {
+        setReceiverEnabled(false);
+
+        try (SimpleHttpResponse res = emitAsAdmin("CaepCredentialChange", TEST_EMAIL,
+                Map.of("credential_type", "password", "change_type", "update"))) {
+            Assertions.assertEquals(400, res.getStatus(),
+                    "emit against a disabled receiver client must not report success");
+            Assertions.assertEquals("receiver_disabled", res.asJson().get("error").asText(),
+                    "error code should name the disabled receiver so the caller can act on it");
+        }
+
+        Assertions.assertNull(pushes.poll(2, TimeUnit.SECONDS),
+                "a disabled receiver must not receive any push");
+    }
+
+    @Test
+    public void reEnablingReceiver_resumesDelivery() throws Exception {
+        // Disable → emit is gated → re-enable → emit delivers again. The
+        // stream is never re-created here, so a successful push after
+        // re-enable proves the disable did not discard the stream config.
+        setReceiverEnabled(false);
+        try (SimpleHttpResponse res = emitAsAdmin("CaepCredentialChange", TEST_EMAIL,
+                Map.of("credential_type", "password", "change_type", "update"))) {
+            Assertions.assertEquals(400, res.getStatus(), "disabled receiver should be gated");
+            Assertions.assertEquals("receiver_disabled", res.asJson().get("error").asText());
+        }
+        Assertions.assertNull(pushes.poll(1, TimeUnit.SECONDS), "no push while disabled");
+
+        setReceiverEnabled(true);
+        try (SimpleHttpResponse res = emitAsAdmin("CaepCredentialChange", TEST_EMAIL,
+                Map.of("credential_type", "password", "change_type", "update"))) {
+            Assertions.assertEquals(200, res.getStatus(),
+                    "re-enabling the client should resume SSF event delivery");
+            Assertions.assertEquals("dispatched", res.asJson().get("status").asText(),
+                    "delivery should resume against the surviving stream once the client is enabled again");
+        }
+        Assertions.assertNotNull(pushes.poll(PUSH_WAIT_SECONDS, TimeUnit.SECONDS),
+                "event should reach the mock receiver again after re-enable — the stream survived the disable");
+    }
+
+    // --- helpers ---------------------------------------------------------
+
+    protected String emitEndpointUrl() {
+        return keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/events/emit";
+    }
+
+    protected SimpleHttpResponse emitAsAdmin(String eventType, String userEmail,
+                                             Map<String, Object> event) throws IOException {
+        // Admin token has manage-clients on the receiver, so the emit auth
+        // pipeline takes the admin fast-path and we reach the dispatch
+        // filters (including the disable gate) without the role wiring.
+        return http.doPost(emitEndpointUrl())
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of(
+                        "eventType", eventType,
+                        "sub_id", Map.of("format", "email", "email", userEmail),
+                        "event", event))
+                .asResponse();
+    }
+
+    protected void setReceiverEnabled(boolean enabled) {
+        ClientResource clientResource = realm.admin().clients().get(findClientByClientId(RECEIVER).getId());
+        ClientRepresentation rep = clientResource.toRepresentation();
+        rep.setEnabled(enabled);
+        clientResource.update(rep);
+    }
+
+    protected void createPushStream() throws IOException {
+        StreamDeliveryConfig delivery = new StreamDeliveryConfig();
+        delivery.setMethod(Ssf.DELIVERY_METHOD_PUSH_URI);
+        delivery.setEndpointUrl(MOCK_PUSH_ENDPOINT);
+        delivery.setAuthorizationHeader(PUSH_AUTH_HEADER);
+
+        StreamConfig streamConfig = new StreamConfig();
+        streamConfig.setDelivery(delivery);
+        streamConfig.setEventsRequested(Set.of(CaepCredentialChange.TYPE));
+        streamConfig.setDescription("Client-disabled gate integration test");
+
+        String token = obtainReceiverManageToken();
+        try (SimpleHttpResponse response = http.doPost(SsfTransmitterUrls.getStreamsEndpointUrl(realm.getBaseUrl()))
+                .json(streamConfig)
+                .auth(token)
+                .acceptJson()
+                .asResponse()) {
+            Assertions.assertEquals(201, response.getStatus(),
+                    "stream creation should succeed in test setup");
+        }
+    }
+
+    protected String obtainReceiverManageToken() throws IOException {
+        String tokenUrl = realm.getBaseUrl() + "/protocol/openid-connect/token";
+        try (SimpleHttpResponse response = http.doPost(tokenUrl)
+                .authBasic(RECEIVER, RECEIVER_SECRET)
+                .param("grant_type", "client_credentials")
+                .param("scope", SsfScopes.SCOPE_SSF_MANAGE + " " + SsfScopes.SCOPE_SSF_READ)
+                .asResponse()) {
+            Assertions.assertEquals(200, response.getStatus());
+            return response.asJson().get("access_token").asText();
+        }
+    }
+
+    protected void subscribeTestUser() throws IOException {
+        String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER + "/subjects/add";
+        try (SimpleHttpResponse ignored = http.doPost(url)
+                .auth(adminClient.tokenManager().getAccessTokenString())
+                .json(Map.of("type", "user-email", "value", TEST_EMAIL))
+                .asResponse()) {
+        }
+    }
+
+    protected ClientRepresentation findClientByClientId(String clientId) {
+        List<ClientRepresentation> clients = realm.admin().clients().findByClientId(clientId);
+        Assertions.assertFalse(clients.isEmpty(),
+                () -> "expected client '" + clientId + "' to exist");
+        return clients.get(0);
+    }
+
+    protected void assignOptionalClientScopes(String clientId, String... scopeNames) {
+        ClientRepresentation client = findClientByClientId(clientId);
+        ClientResource clientResource = realm.admin().clients().get(client.getId());
+        Set<String> alreadyAssigned = clientResource.getOptionalClientScopes().stream()
+                .map(ClientScopeRepresentation::getName)
+                .collect(Collectors.toSet());
+        List<ClientScopeRepresentation> allScopes = realm.admin().clientScopes().findAll();
+        for (String scopeName : scopeNames) {
+            if (alreadyAssigned.contains(scopeName)) continue;
+            ClientScopeRepresentation scope = allScopes.stream()
+                    .filter(s -> scopeName.equals(s.getName()))
+                    .findFirst().orElse(null);
+            Assertions.assertNotNull(scope);
+            clientResource.addOptionalClientScope(scope.getId());
+        }
+    }
+
+    protected void bestEffortDeleteStream() {
+        try {
+            String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                    + "/ssf/clients/" + RECEIVER + "/stream";
+            http.doDelete(url).auth(adminClient.tokenManager().getAccessTokenString()).asResponse().close();
+        } catch (Exception ignored) {
+        }
+    }
+
+    protected void bestEffortRemoveNotify() {
+        try {
+            String url = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                    + "/ssf/clients/" + RECEIVER + "/subjects/remove";
+            http.doPost(url)
+                    .auth(adminClient.tokenManager().getAccessTokenString())
+                    .json(Map.of("type", "user-email", "value", TEST_EMAIL))
+                    .asResponse().close();
+        } catch (Exception ignored) {
+        }
+    }
+
+    // --- config ----------------------------------------------------------
+
+    public static class DisabledServerConfig extends DefaultKeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            KeycloakServerConfigBuilder configured = super.configure(config);
+            config.features(Profile.Feature.SSF);
+            config.log().categoryLevel("org.keycloak.ssf", "DEBUG");
+            // Async pushes flow through the outbox — without a fast drainer
+            // tick the happy-path push assertions time out.
+            config.spiOption("ssf-transmitter", "default",
+                    DefaultSsfTransmitterProviderFactory.CONFIG_OUTBOX_DRAINER_INTERVAL, "500ms");
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_MIN_VERIFICATION_INTERVAL_SECONDS, "0");
+            // Mock receiver lives on a loopback URL; relax the http-scheme +
+            // private-host SSRF gate. The per-client ssf.validPushUrls
+            // allow-list below remains the SSRF defence.
+            config.spiOption("ssf-transmitter", "default",
+                    SsfTransmitterConfig.CONFIG_ALLOW_INSECURE_PUSH_TARGETS, "true");
+            return configured;
+        }
+    }
+
+    public static class DisabledRealm implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            realm.name("ssf-transmitter-client-disabled");
+            realm.attribute(Ssf.SSF_TRANSMITTER_ENABLED_KEY, "true");
+
+            realm.eventsEnabled(true);
+            realm.adminEventsEnabled(true);
+            realm.eventsListeners("jboss-logging", "ssf-events");
+
+            realm.users(
+                    UserBuilder.create(TEST_USER)
+                            .email(TEST_EMAIL)
+                            .firstName("Disabled")
+                            .lastName("Tester")
+                            .enabled(true)
+                            .build()
+            );
+
+            realm.clients(
+                    ClientBuilder.create(RECEIVER)
+                            .secret(RECEIVER_SECRET)
+                            .serviceAccountsEnabled(true)
+                            .directAccessGrantsEnabled(false)
+                            .publicClient(false)
+                            .attribute(ClientStreamStore.SSF_ENABLED_KEY, "true")
+                            .attribute(ClientStreamStore.SSF_VALID_PUSH_URLS_KEY, "http://127.0.0.1:8500/*")
+                            .attribute(ClientStreamStore.SSF_DEFAULT_SUBJECTS_KEY, "NONE")
+                            .build()
+            );
+
+            return realm;
+        }
+    }
+}

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/SsfTransmitter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/SsfTransmitter.java
@@ -4,7 +4,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.ssf.SsfException;
-import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
+import org.keycloak.ssf.transmitter.support.SsfUtil;
 
 public final class SsfTransmitter {
 
@@ -21,20 +21,6 @@ public final class SsfTransmitter {
      */
     public static SsfTransmitterProvider of(KeycloakSession session) {
         return session.getProvider(SsfTransmitterProvider.class);
-    }
-
-    /**
-     * Returns {@code true} when the client carries the
-     * {@code ssf.enabled=true} attribute that marks it as an SSF Receiver.
-     * Returns {@code false} for {@code null} clients, regular OIDC apps,
-     * service accounts, or any client whose attribute is unset / explicitly
-     * {@code false}.
-     */
-    public static boolean isReceiverClient(ClientModel client) {
-        if (client == null) {
-            return false;
-        }
-        return Boolean.parseBoolean(client.getAttribute(ClientStreamStore.SSF_ENABLED_KEY));
     }
 
     /**
@@ -56,7 +42,14 @@ public final class SsfTransmitter {
             throw new SsfException("No client with clientId '" + clientClientId + "' in realm '"
                     + realm.getName() + "'");
         }
-        if (!isReceiverClient(client)) {
+        // Distinguish "disabled" from "not a receiver" so the emit caller
+        // gets an actionable message instead of being told to set an
+        // attribute that may already be present (see keycloak/keycloak#50050).
+        if (!client.isEnabled()) {
+            throw new SsfException("Client '" + clientClientId
+                    + "' is disabled — enable the client to resume SSF event delivery");
+        }
+        if (!SsfUtil.isReceiverClient(client)) {
             throw new SsfException("Client '" + clientClientId
                     + "' is not an SSF Receiver — set the ssf.enabled=true client attribute first");
         }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/SsfTransmitter.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/SsfTransmitter.java
@@ -42,16 +42,12 @@ public final class SsfTransmitter {
             throw new SsfException("No client with clientId '" + clientClientId + "' in realm '"
                     + realm.getName() + "'");
         }
-        // Distinguish "disabled" from "not a receiver" so the emit caller
-        // gets an actionable message instead of being told to set an
-        // attribute that may already be present (see keycloak/keycloak#50050).
-        if (!client.isEnabled()) {
-            throw new SsfException("Client '" + clientClientId
-                    + "' is disabled — enable the client to resume SSF event delivery");
-        }
+        // Confirm the client is a receiver before checking its on/off state
         if (!SsfUtil.isReceiverClient(client)) {
-            throw new SsfException("Client '" + clientClientId
-                    + "' is not an SSF Receiver — set the ssf.enabled=true client attribute first");
+            throw new SsfException("Client '" + clientClientId + "' is not an SSF Receiver");
+        }
+        if (!client.isEnabled()) {
+            throw new SsfException("Client '" + clientClientId + "' is disabled");
         }
         return client;
     }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventStatus.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EmitEventStatus.java
@@ -25,6 +25,15 @@ public enum EmitEventStatus {
     /** Receiver has no SSF stream registered yet. */
     STREAM_NOT_FOUND("stream_not_found"),
 
+    /**
+     * Receiver is a configured SSF receiver but its Keycloak client is
+     * currently disabled. The stream configuration is intact; re-enabling
+     * the client resumes delivery. Mirrors the dispatch-path gate so the
+     * synthetic emitter cannot deliver to a receiver the operator has
+     * switched off (keycloak/keycloak#50050).
+     */
+    RECEIVER_DISABLED("receiver_disabled"),
+
     /** The stream exists but has no delivery configuration. */
     NO_DELIVERY_CONFIG("no_delivery_config"),
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/emit/EventEmitterService.java
@@ -20,12 +20,12 @@ import org.keycloak.ssf.subject.ComplexSubjectId;
 import org.keycloak.ssf.subject.OpaqueSubjectId;
 import org.keycloak.ssf.subject.SubjectId;
 import org.keycloak.ssf.subject.SubjectUserLookup;
-import org.keycloak.ssf.transmitter.SsfTransmitter;
 import org.keycloak.ssf.transmitter.delivery.SecurityEventTokenDispatcher;
 import org.keycloak.ssf.transmitter.event.SecurityEventTokenMapper;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
 import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
 import org.keycloak.ssf.transmitter.subject.SsfSubjectInclusionResolver;
+import org.keycloak.ssf.transmitter.support.SsfUtil;
 import org.keycloak.util.JsonSerialization;
 
 import org.jboss.logging.Logger;
@@ -106,9 +106,16 @@ public class EventEmitterService {
         // routes through the same gate, so a request targeting a
         // non-SSF client surfaces this as a 500 with the message —
         // intentional: the caller's configuration is wrong.
-        if (!isSsfReceiverClient(receiverClient)) {
+        if (!SsfUtil.isReceiverClient(receiverClient)) {
             throw new SsfException("Client '" + receiverClient.getClientId()
                     + "' is not an SSF Receiver");
+        }
+        // A disabled receiver keeps its stream config but is off the air —
+        // mirror the dispatch-path gate (SsfUtil#isReceiverEnabled)
+        // so synthetic emit doesn't deliver to a client the operator has
+        // switched off. Re-enabling the client resumes delivery
+        if (!receiverClient.isEnabled()) {
+            return EmitEventResult.dropped(EmitEventStatus.RECEIVER_DISABLED);
         }
         if (eventTypeAliasOrUri == null || eventTypeAliasOrUri.isBlank()) {
             return EmitEventResult.dropped(EmitEventStatus.INVALID_REQUEST);
@@ -271,13 +278,6 @@ public class EventEmitterService {
             org = orgProvider.getById(opaque.getId());
         }
         return org;
-    }
-
-    protected boolean isSsfReceiverClient(ClientModel client) {
-        // Delegates to the public helper so anyone (REST callers,
-        // extensions, tests) shares one definition of "is this client
-        // an SSF Receiver."
-        return SsfTransmitter.isReceiverClient(client);
     }
 
     protected boolean isStreamEvent(String eventTypeUri) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListener.java
@@ -200,7 +200,10 @@ public class SsfTransmitterEventListener implements EventListenerProvider {
             return;
         }
 
-        if (!Boolean.parseBoolean(client.getAttribute(ClientStreamStore.SSF_ENABLED_KEY))) {
+        // Skip when the receiver is unconfigured or its client is disabled —
+        // no point tagging a user to receive events for a receiver that is
+        // off the air.
+        if (!SsfUtil.isReceiverEnabled(client)) {
             return;
         }
         if (!Boolean.parseBoolean(client.getAttribute(ClientStreamStore.SSF_AUTO_NOTIFY_ON_LOGIN_KEY))) {

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/SsfStreamStore.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/SsfStreamStore.java
@@ -54,15 +54,25 @@ public interface SsfStreamStore {
     List<StreamConfig> getAvailableStreams(ClientModel receiverClient);
 
     /**
-     * Returns every stream configuration attached to a client whose SSF
-     * receiver capability is enabled (i.e. the client carries the
-     * {@code ssf.enabled} attribute). This does <strong>not</strong> filter
-     * by per-stream {@code StreamStatusValue} — a stream registered against
-     * an SSF-enabled client is returned regardless of whether it is
-     * {@code enabled}, {@code paused}, or {@code disabled}; the dispatcher
-     * applies the per-stream status filter in
-     * {@code SecurityEventTokenDispatcher#dispatchEvent} before actually
-     * delivering an event.
+     * Returns every stream configuration eligible for event delivery —
+     * i.e. attached to a client that is an <em>enabled</em> SSF receiver.
+     * Implementations MUST exclude both clients that are not configured as
+     * SSF receivers and receivers whose client is disabled, so the
+     * transmitter stops delivering to a receiver the operator has switched
+     * off — the per-client counterpart to the realm-level transmitter
+     * disable.
+     *
+     * <p>This is the dispatch-enumeration entry point and is deliberately
+     * stricter than the management lookups ({@link #getStream} /
+     * {@link #getAvailableStreams}), which resolve a disabled client's
+     * stream so admin flows can still read and delete it.
+     *
+     * <p>This does <strong>not</strong> filter by per-stream
+     * {@code StreamStatusValue} — a stream owned by an eligible client is
+     * returned regardless of whether it is {@code enabled}, {@code paused},
+     * or {@code disabled}; the dispatcher applies the per-stream status
+     * filter in {@code SecurityEventTokenDispatcher#dispatchEvent} before
+     * actually delivering an event.
      *
      * <p>Used when there is no specific client context on the session, e.g.
      * when the event listener fans an event out to all receivers.

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
@@ -312,7 +312,10 @@ public class ClientStreamStore implements SsfStreamStore {
         if (streamConfig == null || !streamId.equals(streamConfig.getStreamId())) {
             return null;
         }
-        if (!SsfUtil.isReceiverEnabled(client)) {
+        // Config-only gate: admin flows (read, delete + outbox cascade) must
+        // still resolve a disabled client's stream — the delivery gate lives
+        // on findStreamsForSsfReceiverClients, not this shared lookup.
+        if (!SsfUtil.isReceiverClient(client)) {
             return null;
         }
         return streamConfig;
@@ -331,7 +334,9 @@ public class ClientStreamStore implements SsfStreamStore {
             return List.of();
         }
 
-        if (!SsfUtil.isReceiverEnabled(receiverClient)) {
+        // Config-only gate — see getStream; this lookup also backs management
+        // flows (e.g. the one-stream-per-receiver check at create time).
+        if (!SsfUtil.isReceiverClient(receiverClient)) {
             return List.of();
         }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/stream/storage/client/ClientStreamStore.java
@@ -27,6 +27,7 @@ import org.keycloak.ssf.transmitter.stream.StreamConfig;
 import org.keycloak.ssf.transmitter.stream.StreamDeliveryConfig;
 import org.keycloak.ssf.transmitter.stream.StreamVerificationConfig;
 import org.keycloak.ssf.transmitter.stream.storage.SsfStreamStore;
+import org.keycloak.ssf.transmitter.support.SsfUtil;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.vault.VaultStringSecret;
 
@@ -37,7 +38,7 @@ public class ClientStreamStore implements SsfStreamStore {
     protected static final Logger log = Logger.getLogger(ClientStreamStore.class);
 
     // ----- Receiver-level configuration (survives stream delete) -------------
-    public static final String SSF_ENABLED_KEY = "ssf.enabled";
+    public static final String SSF_ENABLED_KEY = SsfUtil.SSF_ENABLED_KEY;
     public static final String SSF_PROFILE_KEY = "ssf.profile";
     public static final String SSF_AUTO_VERIFY_STREAM_KEY = "ssf.autoVerifyStream";
     public static final String SSF_VERIFICATION_DELAY_MILLIS_KEY = "ssf.verificationDelayMillis";
@@ -311,7 +312,7 @@ public class ClientStreamStore implements SsfStreamStore {
         if (streamConfig == null || !streamId.equals(streamConfig.getStreamId())) {
             return null;
         }
-        if (!Boolean.parseBoolean(client.getAttribute(SSF_ENABLED_KEY))) {
+        if (!SsfUtil.isReceiverEnabled(client)) {
             return null;
         }
         return streamConfig;
@@ -330,7 +331,7 @@ public class ClientStreamStore implements SsfStreamStore {
             return List.of();
         }
 
-        if (!Boolean.parseBoolean(receiverClient.getAttribute("ssf.enabled"))) {
+        if (!SsfUtil.isReceiverEnabled(receiverClient)) {
             return List.of();
         }
 
@@ -343,6 +344,11 @@ public class ClientStreamStore implements SsfStreamStore {
         Map<String, String> attributes = Map.of(SSF_ENABLED_KEY, "true");
         return session.clients()
                 .searchClientsByAttributes(realm, attributes, null, null)
+                // The attribute search already matches ssf.enabled=true, but it
+                // cannot express the client on/off state — filter disabled
+                // receivers out here so the dispatcher and event listener never
+                // see their streams.
+                .filter(SsfUtil::isReceiverEnabled)
                 .map(this::extractStreamConfig)
                 .filter(Objects::nonNull)
                 .toList();

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfAuthUtil.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfAuthUtil.java
@@ -63,8 +63,8 @@ public class SsfAuthUtil {
 
         ClientModel client = authResult.client();
 
-        // 1. Client must have SSF enabled
-        if (!Boolean.parseBoolean(client.getAttribute(ClientStreamStore.SSF_ENABLED_KEY))) {
+        // 1. Client must be a configured SSF receiver AND an enabled client.
+        if (!SsfUtil.isReceiverEnabled(client)) {
             log.tracef("SSF auth denied: SSF receiver not enabled for client %s", client.getClientId());
             return false;
         }

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfAuthUtil.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfAuthUtil.java
@@ -62,10 +62,20 @@ public class SsfAuthUtil {
         }
 
         ClientModel client = authResult.client();
+        if (client == null) {
+            log.trace("SSF auth denied: authentication result carries no client");
+            return false;
+        }
 
-        // 1. Client must be a configured SSF receiver AND an enabled client.
-        if (!SsfUtil.isReceiverEnabled(client)) {
-            log.tracef("SSF auth denied: SSF receiver not enabled for client %s", client.getClientId());
+        // 1. Client must be configured as an SSF receiver.
+        if (!SsfUtil.isReceiverClient(client)) {
+            log.tracef("SSF auth denied: client %s is not configured as an SSF receiver", client.getClientId());
+            return false;
+        }
+
+        // ...and the client itself must be enabled.
+        if (!client.isEnabled()) {
+            log.tracef("SSF auth denied: SSF receiver client %s is disabled", client.getClientId());
             return false;
         }
 

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfUtil.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfUtil.java
@@ -118,13 +118,19 @@ public class SsfUtil {
     /**
      * Live-delivery receiver check: the client is both a configured SSF
      * Receiver ({@link #isReceiverClient}) <em>and</em> an enabled Keycloak
-     * client. Disabling the client (the standard client on/off toggle)
-     * takes its streams out of every lookup the dispatcher, event listener,
-     * and emit endpoint consult, so no further SSF events are delivered
-     * while it is off — the per-client counterpart to the realm-level
-     * transmitter disable ({@link org.keycloak.ssf.Ssf#isTransmitterEnabled}).
-     * The stream configuration itself survives, so re-enabling the client
-     * resumes delivery. See keycloak/keycloak#50050.
+     * client. Disabling the client (the standard client on/off toggle) takes
+     * its streams out of the lookups that drive <em>new</em> delivery
+     * decisions — stream enumeration ({@code findStreamsForSsfReceiverClients}),
+     * synthetic emit, and the receiver auth gate — so no new SSF events are
+     * queued or pushed while it is off. This is the per-client counterpart
+     * to the realm-level transmitter disable
+     * ({@link org.keycloak.ssf.Ssf#isTransmitterEnabled}).
+     *
+     * <p>It does <em>not</em> cancel events already queued in the outbox
+     * before the client was disabled: the drainer resolves those rows via
+     * {@code getStreamForClient} and may still push them. The stream
+     * configuration itself survives, so re-enabling the client resumes
+     * delivery. See keycloak/keycloak#50050.
      */
     public static boolean isReceiverEnabled(ClientModel client) {
         return isReceiverClient(client) && client.isEnabled();

--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfUtil.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfUtil.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.keycloak.Config;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -16,6 +17,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.jboss.logging.Logger;
 
 public class SsfUtil {
+
+    public static final String SSF_ENABLED_KEY = "ssf.enabled";
 
     private static final Logger log = Logger.getLogger(SsfUtil.class);
 
@@ -90,6 +93,41 @@ public class SsfUtil {
 
     public static Map<String, Object> treeToMap(JsonNode node) {
         return JsonSerialization.mapper.convertValue(node, new TypeReference<Map<String, Object>>() {});
+    }
+
+    /**
+     * Configuration-only receiver check: {@code true} when the client
+     * carries the {@code ssf.enabled=true} attribute that marks it as an
+     * SSF Receiver. Returns {@code false} for {@code null} clients, regular
+     * OIDC apps, service accounts, or any client whose attribute is unset /
+     * explicitly {@code false}.
+     *
+     * <p>This reflects <em>configuration</em> only — whether the client is
+     * set up as a receiver. It deliberately does <em>not</em> consider the
+     * client on/off state; a disabled-but-configured receiver still answers
+     * {@code true} here. Callers that care about live delivery use
+     * {@link #isReceiverEnabled} instead.
+     */
+    public static boolean isReceiverClient(ClientModel client) {
+        if (client == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(client.getAttribute(SSF_ENABLED_KEY));
+    }
+
+    /**
+     * Live-delivery receiver check: the client is both a configured SSF
+     * Receiver ({@link #isReceiverClient}) <em>and</em> an enabled Keycloak
+     * client. Disabling the client (the standard client on/off toggle)
+     * takes its streams out of every lookup the dispatcher, event listener,
+     * and emit endpoint consult, so no further SSF events are delivered
+     * while it is off — the per-client counterpart to the realm-level
+     * transmitter disable ({@link org.keycloak.ssf.Ssf#isTransmitterEnabled}).
+     * The stream configuration itself survives, so re-enabling the client
+     * resumes delivery. See keycloak/keycloak#50050.
+     */
+    public static boolean isReceiverEnabled(ClientModel client) {
+        return isReceiverClient(client) && client.isEnabled();
     }
 
     private static final String ADMIN_EVENT_USERS_PREFIX = "users/";

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/SsfTransmitterGetReceiverClientTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/SsfTransmitterGetReceiverClientTest.java
@@ -1,0 +1,118 @@
+package org.keycloak.ssf.transmitter;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.ssf.SsfException;
+import org.keycloak.ssf.transmitter.support.SsfUtil;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link SsfTransmitter#getReceiverClient}, which resolves a
+ * receiver client for programmatic emit callers and throws a descriptive
+ * {@link SsfException} for every rejection path.
+ *
+ * <p>Order matters: the receiver-capability check runs before the client
+ * on/off check, so a plain (non-receiver) client — even a disabled one —
+ * gets the accurate "not an SSF Receiver" diagnostic instead of being
+ * steered toward enabling a client that would still be rejected. Only an
+ * actual receiver that happens to be disabled gets the "is disabled"
+ * message.
+ */
+class SsfTransmitterGetReceiverClientTest {
+
+    private static final String CLIENT_ID = "my-receiver";
+    private static final String REALM_NAME = "test-realm";
+
+    private static KeycloakSession sessionWithClient(ClientModel client) {
+        RealmModel realm = mock(RealmModel.class);
+        when(realm.getName()).thenReturn(REALM_NAME);
+        when(realm.getClientByClientId(CLIENT_ID)).thenReturn(client);
+
+        KeycloakContext context = mock(KeycloakContext.class);
+        when(context.getRealm()).thenReturn(realm);
+
+        KeycloakSession session = mock(KeycloakSession.class);
+        when(session.getContext()).thenReturn(context);
+        return session;
+    }
+
+    private static ClientModel client(boolean ssfEnabled, boolean clientEnabled) {
+        ClientModel client = mock(ClientModel.class);
+        when(client.getClientId()).thenReturn(CLIENT_ID);
+        when(client.getAttribute(SsfUtil.SSF_ENABLED_KEY)).thenReturn(Boolean.toString(ssfEnabled));
+        when(client.isEnabled()).thenReturn(clientEnabled);
+        return client;
+    }
+
+    @Test
+    void noSuchClient_throwsNotFoundMessage() {
+        KeycloakSession session = sessionWithClient(null);
+
+        SsfException ex = assertThrows(SsfException.class,
+                () -> SsfTransmitter.getReceiverClient(session, CLIENT_ID));
+        assertTrue(ex.getMessage().contains("No client with clientId"),
+                () -> "unexpected message: " + ex.getMessage());
+    }
+
+    @Test
+    void notAReceiver_throwsNotAReceiverMessage() {
+        KeycloakSession session = sessionWithClient(client(false, true));
+
+        SsfException ex = assertThrows(SsfException.class,
+                () -> SsfTransmitter.getReceiverClient(session, CLIENT_ID));
+        assertTrue(ex.getMessage().contains("is not an SSF Receiver"),
+                () -> "unexpected message: " + ex.getMessage());
+    }
+
+    @Test
+    void disabledNonReceiver_reportsNotAReceiverNotDisabled() {
+        // The key ordering case: a disabled client that is ALSO not a
+        // receiver must report "not a receiver" — steering the caller to
+        // enable it would be misleading, since it would still be rejected.
+        KeycloakSession session = sessionWithClient(client(false, false));
+
+        SsfException ex = assertThrows(SsfException.class,
+                () -> SsfTransmitter.getReceiverClient(session, CLIENT_ID));
+        assertTrue(ex.getMessage().contains("is not an SSF Receiver"),
+                () -> "a disabled non-receiver should report not-a-receiver, not disabled: " + ex.getMessage());
+    }
+
+    @Test
+    void disabledReceiver_throwsDisabledMessage() {
+        KeycloakSession session = sessionWithClient(client(true, false));
+
+        SsfException ex = assertThrows(SsfException.class,
+                () -> SsfTransmitter.getReceiverClient(session, CLIENT_ID));
+        assertTrue(ex.getMessage().contains("is disabled"),
+                () -> "an actual receiver that is disabled should report disabled: " + ex.getMessage());
+    }
+
+    @Test
+    void enabledReceiver_returnsClient() {
+        ClientModel client = client(true, true);
+        KeycloakSession session = sessionWithClient(client);
+
+        assertSame(client, SsfTransmitter.getReceiverClient(session, CLIENT_ID),
+                "an enabled, configured receiver should be returned");
+    }
+
+    @Test
+    void noSuchClient_messageNamesTheRealm() {
+        KeycloakSession session = sessionWithClient(null);
+
+        SsfException ex = assertThrows(SsfException.class,
+                () -> SsfTransmitter.getReceiverClient(session, CLIENT_ID));
+        assertEquals("No client with clientId '" + CLIENT_ID + "' in realm '" + REALM_NAME + "'",
+                ex.getMessage());
+    }
+}

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/event/SsfTransmitterEventListenerTest.java
@@ -222,6 +222,7 @@ class SsfTransmitterEventListenerTest {
         when(context.getRealm()).thenReturn(realm);
         when(realm.getClientByClientId(RECEIVER_CLIENT_ID)).thenReturn(client);
         when(client.getAttribute(ClientStreamStore.SSF_ENABLED_KEY)).thenReturn("true");
+        when(client.isEnabled()).thenReturn(true);
         when(client.getAttribute(ClientStreamStore.SSF_AUTO_NOTIFY_ON_LOGIN_KEY)).thenReturn("true");
         // SSF_DEFAULT_SUBJECTS_KEY left unstubbed (null) → not broadcast (ALL).
         when(session.users()).thenReturn(users);

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/support/SsfUtilReceiverTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/support/SsfUtilReceiverTest.java
@@ -1,0 +1,100 @@
+package org.keycloak.ssf.transmitter.support;
+
+import org.keycloak.models.ClientModel;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the two receiver predicates in {@link SsfUtil}:
+ *
+ * <ul>
+ *     <li>{@link SsfUtil#isReceiverClient} — configuration only: does the
+ *         client carry {@code ssf.enabled=true}? Ignores the client on/off
+ *         state.</li>
+ *     <li>{@link SsfUtil#isReceiverEnabled} — live-delivery gate: configured
+ *         receiver <em>and</em> an enabled Keycloak client.</li>
+ * </ul>
+ *
+ * <p>The key behaviour under test (keycloak/keycloak#50050) is that a
+ * configured-but-disabled receiver is still a receiver
+ * ({@code isReceiverClient == true}) but is off the air for delivery
+ * ({@code isReceiverEnabled == false}), so disabling the client stops SSF
+ * event delivery without discarding the stream configuration.
+ */
+class SsfUtilReceiverTest {
+
+    private static ClientModel client(Boolean ssfEnabledAttr, boolean clientEnabled) {
+        ClientModel client = mock(ClientModel.class);
+        when(client.getAttribute(SsfUtil.SSF_ENABLED_KEY))
+                .thenReturn(ssfEnabledAttr == null ? null : ssfEnabledAttr.toString());
+        when(client.isEnabled()).thenReturn(clientEnabled);
+        return client;
+    }
+
+    // ----- isReceiverClient: configuration only -----------------------------
+
+    @Test
+    void isReceiverClient_nullClient_false() {
+        assertFalse(SsfUtil.isReceiverClient(null), "a null client is never a receiver");
+    }
+
+    @Test
+    void isReceiverClient_attributeUnset_false() {
+        assertFalse(SsfUtil.isReceiverClient(client(null, true)),
+                "absent ssf.enabled attribute means the client is not configured as a receiver");
+    }
+
+    @Test
+    void isReceiverClient_attributeFalse_false() {
+        assertFalse(SsfUtil.isReceiverClient(client(false, true)),
+                "ssf.enabled=false means the client is not a receiver");
+    }
+
+    @Test
+    void isReceiverClient_attributeTrue_true() {
+        assertTrue(SsfUtil.isReceiverClient(client(true, true)),
+                "ssf.enabled=true marks the client as a receiver");
+    }
+
+    @Test
+    void isReceiverClient_attributeTrueButClientDisabled_stillTrue() {
+        assertTrue(SsfUtil.isReceiverClient(client(true, false)),
+                "isReceiverClient reflects configuration only — a disabled client is still a configured receiver");
+    }
+
+    // ----- isReceiverEnabled: configuration AND client on/off ---------------
+
+    @Test
+    void isReceiverEnabled_nullClient_false() {
+        assertFalse(SsfUtil.isReceiverEnabled(null), "a null client is never a deliverable receiver");
+    }
+
+    @Test
+    void isReceiverEnabled_configuredAndEnabled_true() {
+        assertTrue(SsfUtil.isReceiverEnabled(client(true, true)),
+                "a configured receiver on an enabled client is live for delivery");
+    }
+
+    @Test
+    void isReceiverEnabled_configuredButDisabled_false() {
+        assertFalse(SsfUtil.isReceiverEnabled(client(true, false)),
+                "disabling the client takes a configured receiver off the air (keycloak/keycloak#50050)");
+    }
+
+    @Test
+    void isReceiverEnabled_notConfiguredButEnabled_false() {
+        assertFalse(SsfUtil.isReceiverEnabled(client(false, true)),
+                "an enabled client that is not configured as a receiver is not deliverable");
+    }
+
+    @Test
+    void isReceiverEnabled_notConfiguredAndDisabled_false() {
+        assertFalse(SsfUtil.isReceiverEnabled(client(false, false)),
+                "neither configured nor enabled is not deliverable");
+    }
+}


### PR DESCRIPTION
Disabling an SSF receiver client (the standard client on/off toggle) had no effect on SSF: streams stayed in every lookup and events kept being delivered to a client the operator had switched off. This defines the per-client counterpart to the realm-level transmitter disable.

A receiver's streams are now live only while the client is both a configured receiver (ssf.enabled=true) AND an enabled Keycloak client. The check is centralized in SsfUtil.isReceiverEnabled and applied at every delivery decision point:

- Dispatch / event listener: ClientStreamStore stream lookups (getStream, getAvailableStreams, findStreamsForSsfReceiverClients) exclude disabled receivers, so the dispatcher never sees their streams.
- Synthetic emit: EventEmitterService.emit returns the new EmitEventStatus.RECEIVER_DISABLED (mapped to HTTP 400 receiver_disabled), rather than reporting a misleading success or a 500.
- Receiver auth: SsfAuthUtil rejects stream-management calls from a disabled client — closes the window where an access token minted before the client was disabled would otherwise remain usable until expiry.
- Auto-notify-on-login: no longer tags users for an off-air receiver.

The stream configuration survives a disable (unlike client deletion, which purges it), so re-enabling the client resumes delivery.

Receiver predicates are consolidated in SsfUtil: isReceiverClient (configuration only) and isReceiverEnabled (configuration + client enabled). The SSF_ENABLED_KEY constant moves to SsfUtil; ClientStreamStore re-exports it for existing callers.

Tests:
- SsfTransmitterClientDisabledTests: end-to-end via the emit endpoint — delivers while enabled, returns receiver_disabled with no push while disabled, and resumes delivery (against the surviving stream) after re-enable.

Fixes #50050

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
