### PR TITLE
[OID4VCI] Warning in conformance tests due to custom field in authorization_details

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessor.java
@@ -100,8 +100,21 @@ public interface AuthorizationDetailsProcessor<ADR extends AuthorizationDetailsJ
      * @param clientSessionCtx the client session context
      * @param authorizationDetailsResponse The response object of the proper type, which is supposed to be processed by this processor.
      */
-    void afterAuthorizationDetailsProcessed(UserSessionModel userSession, ClientSessionContext clientSessionCtx,
+    void afterAuthorizationDetailsProcessed(UserSessionModel userSession,
+                                            ClientSessionContext clientSessionCtx,
                                             ADR authorizationDetailsResponse);
+
+
+    /**
+     * Sanitize authorization details before they are sent as part of the Token Response
+     * https://github.com/keycloak/keycloak/issues/50079
+     *
+     * @param authzDetail The typed authorization detail
+     * @return A sanitized clone of the authorization detail
+     */
+    default ADR sanitizeBeforeSendingTokenResponse(ADR authzDetail) {
+        return authzDetail;
+    }
 
     /**
      * @param authzDetailsResponse all the authorizationDetails. May contain also authorizationDetails entries, with different "type" than the type understandable by this processor
@@ -116,5 +129,4 @@ public interface AuthorizationDetailsProcessor<ADR extends AuthorizationDetailsJ
                 .map(authDetailsResponse -> authDetailsResponse.asSubtype(getSupportedResponseJavaType()))
                 .toList();
     }
-
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -58,6 +58,7 @@ import static org.keycloak.OAuth2Constants.ISSUER_STATE;
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
 import static org.keycloak.models.oid4vci.CredentialScopeModel.VC_CONFIGURATION_ID;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerEndpoint.CREDENTIALS_OFFER_ID_ATTR;
+import static org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail.ISSUED_CREDENTIAL_ID;
 import static org.keycloak.protocol.oid4vc.model.PreAuthorizedCodeGrant.PRE_AUTH_GRANT_TYPE;
 import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByConfigurationId;
 import static org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils.findCredentialScopeModelByName;
@@ -139,7 +140,7 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
 
         // Issued credential ID not allowed
         if (requestAuthDetail.getIssuedCredentialId() != null) {
-            logger.warnf("Property '%s' not allowed in authorization_details", OID4VCAuthorizationDetail.ISSUED_CREDENTIAL_ID);
+            logger.warnf("Property '%s' not allowed in authorization_details", ISSUED_CREDENTIAL_ID);
             throw getInvalidRequestException("Issued credential ID not allowed in authorization details");
         }
 
@@ -156,6 +157,16 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
         }
 
         return requestAuthDetail;
+    }
+
+    @Override
+    public OID4VCAuthorizationDetail sanitizeBeforeSendingTokenResponse(OID4VCAuthorizationDetail authzDetail) {
+        // Remove non-standard properties before sending authorization_details in the Token Response
+        // https://github.com/keycloak/keycloak/pull/49958
+        OID4VCAuthorizationDetail cloned = authzDetail.clone();
+        cloned.setIssuedCredentialId(null);
+        cloned.setCredentialsOfferId(null);
+        return cloned;
     }
 
     // Private ---------------------------------------------------------------------------------------------------------
@@ -330,7 +341,7 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
             throw new InvalidAuthorizationDetailsException("Cannot find credential scope for credential configuration ID: " + credentialConfigId);
         }
 
-        // Create issued-credential and set it's ID in authorization_details
+        // Create issued-credential and set its ID in authorization_details
         IssuedVerifiableCredentialModel issuedCredential = createIssuedVerifiableCredential(userSession.getUser(), clientSessionCtx.getClientSession().getClient(), credentialScope);
         oid4vcAuthzDetailResponse.setIssuedCredentialId(issuedCredential.getId());
     }
@@ -368,7 +379,6 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
         return authDetail;
     }
 
-
     protected IssuedVerifiableCredentialModel createIssuedVerifiableCredential(UserModel userModel, ClientModel clientModel, CredentialScopeModel credentialScope) {
         String credentialScopeName = credentialScope.getName();
         try {
@@ -376,7 +386,7 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
 
             long issuedAt = Time.currentTimeMillis();
             model.setIssuedAt(issuedAt);
-            model.setExpiresAt(issuedAt + (credentialScope.getExpiryInSeconds() * 1000));
+            model.setExpiresAt(issuedAt + (credentialScope.getExpiryInSeconds() * 1000L));
 
             logger.debugf("Created VC issuance: user=%s, client=%s, type=%s", userModel.getUsername(), clientModel.getClientId(), credentialScopeName);
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -928,7 +928,7 @@ public class OID4VCIssuerEndpoint {
 
         // Validate that authorization_details from the token matches the offer state
         // This ensures the correct access token is being used for the credential request
-        if (offerState != null && !List.of(tokenAuthDetail).equals(offerState.getAuthorizationDetails())) {
+        if (offerState != null && !offerState.matchAuthorizationDetails(List.of(tokenAuthDetail))) {
             var errorMessage = "Authorization details in access token do not match the credential offer state. " +
                     "The access token may not be the one issued for this credential offer.";
             LOGGER.debug(errorMessage);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/credentialoffer/CredentialOfferState.java
@@ -16,7 +16,6 @@
  */
 package org.keycloak.protocol.oid4vc.issuance.credentialoffer;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -108,7 +107,9 @@ public class CredentialOfferState {
     }
 
     public List<OID4VCAuthorizationDetail> getAuthorizationDetails() {
-        return Collections.unmodifiableList(authDetails != null ? authDetails : List.of());
+        return Optional.ofNullable(authDetails).orElse(List.of()).stream()
+                .map(OID4VCAuthorizationDetail::clone)
+                .toList();
     }
 
     public OID4VCAuthorizationDetail getAuthorizationDetails(String credConfigId) {
@@ -117,6 +118,26 @@ public class CredentialOfferState {
                 .findFirst()
                 .map(OID4VCAuthorizationDetail::clone)
                 .orElse(null);
+    }
+
+    public boolean matchAuthorizationDetails(List<OID4VCAuthorizationDetail> otherAuthDetails) {
+        if (authDetails == null && otherAuthDetails == null) { return true; }
+        if (authDetails == null || otherAuthDetails == null) { return false; }
+        if (authDetails.size() != otherAuthDetails.size()) { return false; }
+        for (int i = 0; i < authDetails.size(); i++) {
+            var authDetail = authDetails.get(i);
+            var otherDetail = otherAuthDetails.get(i);
+            if (otherDetail.getIssuedCredentialId() != null) {
+                otherDetail = otherDetail.clone();
+                otherDetail.setIssuedCredentialId(null);
+            }
+            // Unexpected issued_credential_id in authorization_details
+            assert authDetail.getIssuedCredentialId() == null;
+            if (!authDetail.equals(otherDetail)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @JsonIgnore

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/OID4VCAuthorizationDetail.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/OID4VCAuthorizationDetail.java
@@ -41,7 +41,7 @@ public class OID4VCAuthorizationDetail extends AuthorizationDetailsJSONRepresent
      * Access token (and refresh token) claim with reference to the issued-credential ID. Can be used to link issued-credential
      * with token to be able to check at credential-request (or refresh-token request) if particular issued-credential still exists
      */
-    public static final String ISSUED_CREDENTIAL_ID = "iss_cred_id";
+    public static final String ISSUED_CREDENTIAL_ID = "issued_credential_id";
 
     @JsonProperty(CREDENTIAL_CONFIGURATION_ID)
     private String credentialConfigurationId;
@@ -120,12 +120,14 @@ public class OID4VCAuthorizationDetail extends AuthorizationDetailsJSONRepresent
         OID4VCAuthorizationDetail that = (OID4VCAuthorizationDetail) o;
         return Objects.equals(credentialConfigurationId, that.credentialConfigurationId)
                 && Objects.equals(credentialIdentifiers, that.credentialIdentifiers)
-                && Objects.equals(credentialsOfferId, that.credentialsOfferId);
+                && Objects.equals(credentialsOfferId, that.credentialsOfferId)
+                && Objects.equals(issuedCredentialId, that.issuedCredentialId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), credentialConfigurationId, credentialIdentifiers, credentialsOfferId);
+        return Objects.hash(super.hashCode(),
+                credentialConfigurationId, credentialIdentifiers, credentialsOfferId, issuedCredentialId);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -376,7 +376,7 @@ public class TokenManager {
         AccessTokenResponseBuilder responseBuilder = responseBuilder(realm, authorizedClient, event, session,
             validation.userSession, validation.clientSessionCtx).offlineToken( TokenUtil.TOKEN_TYPE_OFFLINE.equals(refreshToken.getType())).accessToken(validation.newToken);
 
-        // Copy authorization_details from refresh token to new access token and to acessTokenResponse (if present)
+        // Copy authorization_details from refresh token to new access token and to accessTokenResponse (if present)
         List<AuthorizationDetailsJSONRepresentation> authorizationDetails = refreshToken.getAuthorizationDetails();
         if (authorizationDetails != null) {
             validation.newToken.setAuthorizationDetails(authorizationDetails);

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenEndpoint.java
@@ -203,8 +203,6 @@ public class TokenEndpoint {
         if (client.isBearerOnly()) {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_CLIENT, "Bearer-only not allowed", Response.Status.BAD_REQUEST);
         }
-
-
     }
 
     private void checkGrantType() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/OAuth2GrantTypeBase.java
@@ -164,7 +164,7 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
     }
 
     protected Response createTokenResponse(TokenManager.AccessTokenResponseBuilder responseBuilder, ClientSessionContext clientSessionCtx, boolean code) {
-        AccessTokenResponse res = null;
+        AccessTokenResponse res;
         if (code) {
             try {
                 res = responseBuilder.build();
@@ -182,6 +182,10 @@ public abstract class OAuth2GrantTypeBase implements OAuth2GrantType {
 
         // Extension point for subclasses to add custom claims
         addCustomTokenResponseClaims(res, clientSessionCtx);
+
+        // Sanitize authorization details before they are sent as part of the Token Response
+        var authDetailsProcessor = new AuthorizationDetailsProcessorManager(session);
+        authDetailsProcessor.sanitizeBeforeSendingTokenResponse(res);
 
         event.success();
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/grants/RefreshTokenGrantType.java
@@ -31,6 +31,7 @@ import org.keycloak.events.EventType;
 import org.keycloak.models.AuthenticatedClientSessionModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.oidc.TokenManager;
+import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessorManager;
 import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.services.CorsErrorResponseException;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
@@ -76,7 +77,9 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
         AccessTokenResponse res;
         try {
             // KEYCLOAK-6771 Certificate Bound Token
-            TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.refreshAccessToken(session, session.getContext().getUri(), clientConnection, realm, client, refreshToken, event, headers, request, scopeParameter, resourceParameter);
+            TokenManager.AccessTokenResponseBuilder responseBuilder = tokenManager.refreshAccessToken(
+                    session, session.getContext().getUri(), clientConnection, realm, client, refreshToken,
+                    event, headers, request, scopeParameter, resourceParameter);
 
             checkAndBindMtlsHoKToken(responseBuilder, clientConfig.isUseRefreshToken());
 
@@ -110,6 +113,10 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
             throw new CorsErrorResponseException(cors, cpe.getError(), cpe.getErrorDetail(), cpe.getErrorStatus());
         }
 
+        // Sanitize authorization details before they are sent as part of the Token Response
+        var authDetailsProcessor = new AuthorizationDetailsProcessorManager(session);
+        authDetailsProcessor.sanitizeBeforeSendingTokenResponse(res);
+
         event.success();
 
         return cors.add(Response.ok(res, MediaType.APPLICATION_JSON_TYPE));
@@ -124,5 +131,4 @@ public class RefreshTokenGrantType extends OAuth2GrantTypeBase {
     public Set<String> getTokenParameterNames() {
         return Collections.emptySet();
     }
-
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessorManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/rar/AuthorizationDetailsProcessorManager.java
@@ -11,6 +11,7 @@ import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.provider.ProviderFactory;
+import org.keycloak.representations.AccessTokenResponse;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;
 import org.keycloak.util.JsonSerialization;
 
@@ -55,11 +56,11 @@ public class AuthorizationDetailsProcessorManager {
         return allAuthzDetails;
     }
 
-    public List<AuthorizationDetailsJSONRepresentation> validateAuthorizationDetail(String authorizationDetailsParam) {
-        return processAuthorizationDetailsInternal(authorizationDetailsParam, AuthorizationDetailsProcessor::validateAuthorizationDetail);
+    public void validateAuthorizationDetail(String authorizationDetailsParam) {
+        processAuthorizationDetailsInternal(authorizationDetailsParam, AuthorizationDetailsProcessor::validateAuthorizationDetail);
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public void afterAuthorizationDetailsProcessed(UserSessionModel userSession,
                                                    ClientSessionContext clientSessionCtx,
                                                    List<AuthorizationDetailsJSONRepresentation> authorizationDetailsResponse) throws InvalidAuthorizationDetailsException {
@@ -67,6 +68,24 @@ public class AuthorizationDetailsProcessorManager {
         for (AuthorizationDetailsJSONRepresentation authzDetailResponse : authorizationDetailsResponse) {
             AuthorizationDetailsProcessor processor = findProcessorForAuthorizationDetails(processors, authzDetailResponse);
             processor.afterAuthorizationDetailsProcessed(userSession, clientSessionCtx, authzDetailResponse.asSubtype(processor.getSupportedResponseJavaType()));
+        }
+    }
+
+    /**
+     * Sanitize authorization details before they are sent as part of the Token Response
+     * https://github.com/keycloak/keycloak/issues/50079
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void sanitizeBeforeSendingTokenResponse(AccessTokenResponse tokenResponse) {
+        if (tokenResponse.getAuthorizationDetails() != null) {
+            List<AuthorizationDetailsJSONRepresentation> outAuthzDetails = new ArrayList<>();
+            Map<String, AuthorizationDetailsProcessor<?>> processors = getAuthorizationDetailsProcessorMap();
+            for (AuthorizationDetailsJSONRepresentation authzDetail : tokenResponse.getAuthorizationDetails()) {
+                AuthorizationDetailsProcessor processor = findProcessorForAuthorizationDetails(processors, authzDetail);
+                AuthorizationDetailsJSONRepresentation subAuthzDetail = authzDetail.asSubtype(processor.getSupportedResponseJavaType());
+                outAuthzDetails.add(processor.sanitizeBeforeSendingTokenResponse(subAuthzDetail));
+            }
+            tokenResponse.setAuthorizationDetails(outAuthzDetails);
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAuthorizationDetailsUtil.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCAuthorizationDetailsUtil.java
@@ -1,0 +1,42 @@
+package org.keycloak.tests.oid4vc;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Optional;
+
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.jose.jws.JWSInputException;
+import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
+import org.keycloak.util.JsonSerialization;
+
+import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
+
+/**
+ * Utility access to OID4VCAuthorizationDetails
+ */
+public final class OID4VCAuthorizationDetailsUtil {
+
+    // Hide ctor
+    private OID4VCAuthorizationDetailsUtil() {}
+
+    /**
+     * Access AuthorizationDetails from the AccessToken JWT
+     * rather than from the Token endpoint response
+     */
+    public static List<OID4VCAuthorizationDetail> getAuthorizationDetailsFromAccessToken(String accessToken) {
+        String tokenContent;
+        try {
+            tokenContent = new JWSInput(accessToken).readContentAsString();
+        } catch (JWSInputException e) {
+            throw new IllegalArgumentException("Cannot parse access token", e);
+        }
+        LinkedHashMap<?, ?> contentMap = JsonSerialization.valueFromString(tokenContent, LinkedHashMap.class);
+        return Optional.ofNullable(contentMap.get(AUTHORIZATION_DETAILS))
+                .map(JsonSerialization::valueAsString)
+                .map(it -> JsonSerialization.valueFromString(it, OID4VCAuthorizationDetail[].class))
+                .map(Arrays::asList)
+                .orElse(Collections.emptyList());
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -64,10 +64,10 @@ import org.keycloak.util.DPoPGenerator;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
-import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
 import static org.keycloak.OAuth2Constants.DPOP_JWT_HEADER_TYPE;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_JWT_TYPE;
 import static org.keycloak.constants.OID4VCIConstants.CREDENTIAL_OFFER_CREATE;
+import static org.keycloak.tests.oid4vc.OID4VCAuthorizationDetailsUtil.getAuthorizationDetailsFromAccessToken;
 import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.TEST_PASSWORD;
 import static org.keycloak.tests.oid4vc.OID4VCIssuerTestBase.VCTestRealmConfig.TEST_REALM_NAME;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
@@ -563,22 +563,7 @@ public class OID4VCBasicWallet {
 
         // Extract authorization_details from AccessToken (JWT)
         //
-
-        JsonWebToken jwt;
-        try {
-            jwt = new JWSInput(tokenResponse.getAccessToken()).readJsonContent(JsonWebToken.class);
-        } catch (JWSInputException ex) {
-            throw new IllegalStateException(ex);
-        }
-
-        Object authDetailsClaim = jwt.getOtherClaims().get(AUTHORIZATION_DETAILS);
-        String authDetailsJson = Optional.ofNullable(authDetailsClaim)
-                .map(JsonSerialization::valueAsString)
-                .orElse(null);
-        List<OID4VCAuthorizationDetail> jwtAuthDetails = Optional.ofNullable(authDetailsJson)
-                .map(it -> JsonSerialization.valueFromString(it, OID4VCAuthorizationDetail[].class))
-                .map(Arrays::asList)
-                .orElse(null);
+        List<OID4VCAuthorizationDetail> jwtAuthDetails = getAuthorizationDetailsFromAccessToken(tokenResponse.getAccessToken());
         assertTrue(jwtAuthDetails != null && !jwtAuthDetails.isEmpty(), "No authorization_details in AccessTokenJWT");
 
         assertEquals(1, tokenAuthDetails.size(), "Expected one authorization_details entry");
@@ -588,7 +573,7 @@ public class OID4VCBasicWallet {
         var jwtAuthDetail = jwtAuthDetails.get(0);
 
         assertEquals(ctx.getCredentialConfigurationId(), tokenAuthDetail.getCredentialConfigurationId());
-        assertEquals(tokenAuthDetail, jwtAuthDetail);
+        assertEquals(ctx.getCredentialConfigurationId(), jwtAuthDetail.getCredentialConfigurationId());
 
         return accessToken;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuedCredentialsAdminAPITest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCIssuedCredentialsAdminAPITest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
+import static org.keycloak.tests.oid4vc.OID4VCAuthorizationDetailsUtil.getAuthorizationDetailsFromAccessToken;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.jwtProofs;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -56,8 +57,8 @@ public class OID4VCIssuedCredentialsAdminAPITest extends OID4VCIssuerEndpointTes
         String authCode = getAuthorizationCode(oauth, client, "john", scopeName);
         AccessTokenResponse tokenResponse = getBearerToken(oauth, authCode, authDetail);
 
-        String token = tokenResponse.getAccessToken();
-        List<OID4VCAuthorizationDetail> authDetailsResponse = tokenResponse.getOID4VCAuthorizationDetails();
+        String accessToken = tokenResponse.getAccessToken();
+        List<OID4VCAuthorizationDetail> authDetailsResponse = getAuthorizationDetailsFromAccessToken(accessToken);
         String credentialIdentifier = authDetailsResponse.get(0).getCredentialIdentifiers().get(0);
 
         String cNonce = oauth.oid4vc().nonceRequest().send().getNonce();
@@ -65,7 +66,7 @@ public class OID4VCIssuedCredentialsAdminAPITest extends OID4VCIssuerEndpointTes
 
         CredentialResponse credentialResponseVO = oauth.oid4vc()
                 .credentialRequest()
-                .bearerToken(token)
+                .bearerToken(accessToken)
                 .credentialIdentifier(credentialIdentifier)
                 .proofs(proofs)
                 .send()
@@ -102,7 +103,7 @@ public class OID4VCIssuedCredentialsAdminAPITest extends OID4VCIssuerEndpointTes
 
         CredentialResponse credentialResponseVO2 = oauth.oid4vc()
                 .credentialRequest()
-                .bearerToken(token)
+                .bearerToken(accessToken)
                 .credentialIdentifier(credentialIdentifier)
                 .proofs(proofs2)
                 .send()

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCRefreshCredentialTest.java
@@ -1,6 +1,8 @@
 package org.keycloak.tests.oid4vc;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
@@ -13,6 +15,7 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ManagedUser;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
+import org.keycloak.util.JsonSerialization;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +24,7 @@ import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing scenarios related to refresh credentials and refresh requests
@@ -34,6 +38,13 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
     ManagedUser user;
 
     OID4VCTestContext ctx;
+
+    // See OpenID Conformance - VCIWarnOnAuthorizationDetailsInTokenEndpointResponseConventions
+    private static final Set<String> KNOWN_AUTHORIZATION_DETAILS_FIELDS = Set.of(
+            // Defined for openid_credential by OID4VCI 1.0 Final §5.1.1 / §6.2
+            "type", "credential_configuration_id", "credential_identifiers", "claims",
+            // RFC 9396 §2.2 common authorization-details fields — any type MAY include these
+            "locations", "actions", "datatypes", "identifier", "privileges");
 
     @BeforeEach
     void beforeEach() {
@@ -53,6 +64,7 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         // Login
         CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
         AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+        assertTrue(tokenResponse.isSuccess(), "Access token exchange should succeed");
 
         // Obtain credential
         String accessToken1 = tokenResponse.getAccessToken();
@@ -69,16 +81,42 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         IssuedVerifiableCredentialRepresentation issuedCred1 = issuedCreds1.get(0);
 
         // Assert issued-credential ID matches
-        OID4VCAuthorizationDetail authzDetailResponse1 = ctx.getAuthorizationDetail();
+        OID4VCAuthorizationDetail authzDetailResponse1 = ctx.getAuthorizationDetailFromAccessToken();
         assertEquals(issuedCred1.getId(), authzDetailResponse1.getIssuedCredentialId());
+
+        // Verify that authorization_details on the token endpoint response have only known properties
+        //
+        for (OID4VCAuthorizationDetail authDetail : ctx.getAuthorizationDetails()) {
+            String json = JsonSerialization.valueAsString(authDetail);
+            Map<?, ?> authDetailMap = JsonSerialization.valueFromString(json, Map.class);
+            for (Map.Entry<?, ?> entry : authDetailMap.entrySet()) {
+                String key = String.valueOf(entry.getKey());
+                assertTrue(KNOWN_AUTHORIZATION_DETAILS_FIELDS.contains(key), "Unknown authorization detail: " + key);
+            }
+        }
 
         // Move time a bit before refresh token
         timeOffSet.set(10);
 
         // Refresh token
-        AccessTokenResponse refreshed = wallet.refreshRequest(ctx).send();
-        assertEquals(200, refreshed.getStatusCode(), "Refresh token exchange should succeed");
-        String accessToken2 = refreshed.getAccessToken();
+        AccessTokenResponse refreshResponse = wallet.refreshRequest(ctx).send();
+        assertTrue(refreshResponse.isSuccess(), "Refresh token exchange should succeed");
+        String accessToken2 = refreshResponse.getAccessToken();
+
+        // Assert issued-credential ID matches and has not changed
+        OID4VCAuthorizationDetail authzDetailResponse2 = ctx.getAuthorizationDetailFromAccessToken();
+        assertEquals(issuedCred1.getId(), authzDetailResponse2.getIssuedCredentialId());
+
+        // Verify that authorization_details on the token endpoint response have only known properties
+        //
+        for (OID4VCAuthorizationDetail authDetail : ctx.getAuthorizationDetails()) {
+            String json = JsonSerialization.valueAsString(authDetail);
+            Map<?, ?> authDetailMap = JsonSerialization.valueFromString(json, Map.class);
+            for (Map.Entry<?, ?> entry : authDetailMap.entrySet()) {
+                String key = String.valueOf(entry.getKey());
+                assertTrue(KNOWN_AUTHORIZATION_DETAILS_FIELDS.contains(key), "Unknown authorization detail: " + key);
+            }
+        }
 
         // Obtain another VC
         credResponse = wallet.credentialRequest(ctx, accessToken2)
@@ -95,10 +133,6 @@ public class OID4VCRefreshCredentialTest extends OID4VCIssuerTestBase {
         assertEquals(issuedCred1.getIssuedAt(), issuedCred2.getIssuedAt());
         assertEquals(issuedCred1.getExpiresAt(), issuedCred2.getExpiresAt());
         assertEquals(issuedCred1.getRevision(), issuedCred2.getRevision());
-
-        // Assert issued-credential ID matches and did not changed
-        OID4VCAuthorizationDetail authzDetailResponse2 = ctx.getAuthorizationDetail();
-        assertEquals(issuedCred2.getId(), authzDetailResponse2.getIssuedCredentialId());
     }
 
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCTestContext.java
@@ -89,13 +89,21 @@ public class OID4VCTestContext {
 
     public List<OID4VCAuthorizationDetail> getAuthorizationDetails() {
         AccessTokenResponse response = assertAttachment(ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY);
-        return Optional.ofNullable(response)
-                .map(AccessTokenResponse::getOID4VCAuthorizationDetails)
-                .orElse(Collections.emptyList());
+        return response.getOID4VCAuthorizationDetails();
     }
 
     public OID4VCAuthorizationDetail getAuthorizationDetail() {
         List<OID4VCAuthorizationDetail> tokenAuthDetails = getAuthorizationDetails();
+        return tokenAuthDetails.size() == 1 ? tokenAuthDetails.get(0) : null;
+    }
+
+    public List<OID4VCAuthorizationDetail> getAuthorizationDetailsFromAccessToken() {
+        AccessTokenResponse response = assertAttachment(ACCESS_TOKEN_RESPONSE_ATTACHMENT_KEY);
+        return OID4VCAuthorizationDetailsUtil.getAuthorizationDetailsFromAccessToken(response.getAccessToken());
+    }
+
+    public OID4VCAuthorizationDetail getAuthorizationDetailFromAccessToken()  {
+        List<OID4VCAuthorizationDetail> tokenAuthDetails = getAuthorizationDetailsFromAccessToken();
         return tokenAuthDetails.size() == 1 ? tokenAuthDetails.get(0) : null;
     }
 
@@ -180,7 +188,8 @@ public class OID4VCTestContext {
     }
 
     public <T> T assertAttachment(AttachmentKey<T> key) {
-        return Optional.of(getAttachment(key)).get();
+        return Optional.ofNullable(getAttachment(key))
+                .orElseThrow(() -> new IllegalStateException("No attachment for: " + key));
     }
 
     @SuppressWarnings("unchecked")

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccessTokenResponse.java
@@ -2,10 +2,10 @@ package org.keycloak.testsuite.util.oauth;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.protocol.oid4vc.model.OID4VCAuthorizationDetail;
@@ -136,10 +136,7 @@ public class AccessTokenResponse extends AbstractHttpResponse {
     }
 
     private <ADR extends AuthorizationDetailsJSONRepresentation> List<ADR> getAuthorizationDetails(Class<ADR> clazz) {
-        if (authorizationDetails == null) {
-            return Collections.emptyList();
-        }
-        return authorizationDetails.stream()
+        return Optional.ofNullable(authorizationDetails).orElse(List.of()).stream()
                 .map(authzResponse -> authzResponse.asSubtype(clazz))
                 .toList();
     }


### PR DESCRIPTION
closes #50079

Fixes regression described [here](https://github.com/keycloak/keycloak/pull/49958#issuecomment-4716994019)

* Add a shared helper (OID4VCAuthorizationDetails) to extract authorization_details from an access token JWT payload
* Update OID4VC tests to read authorization_details from the access token rather than the token endpoint response
* Sanitize token endpoint authorization_details in the authorization code grant response by removing the issued-credential id field


