### PR TITLE
Test framework - deploy a single provider to the test server

### DIFF
--- a/test-framework/core/src/main/java/org/keycloak/testframework/FatalTestClassException.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/FatalTestClassException.java
@@ -11,4 +11,8 @@ public class FatalTestClassException extends RuntimeException {
         super(message);
     }
 
+    public FatalTestClassException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/DistributionKeycloakServer.java
@@ -69,7 +69,7 @@ public class DistributionKeycloakServer implements KeycloakServer {
                 killPreviousProcess();
             }
 
-            ProviderDeployer providerDeployer = new ProviderDeployer(log, keycloakHomeDir, keycloakServerConfigBuilder.toDependencies(), KeycloakServer.getDependencyHotDeployEnabled());
+            ProviderDeployer providerDeployer = new ProviderDeployer(log, keycloakHomeDir, keycloakServerConfigBuilder, KeycloakServer.getDependencyHotDeployEnabled());
 
             if (!installationCreated && reuse && ping()) {
                 checkRunning();
@@ -92,6 +92,8 @@ public class DistributionKeycloakServer implements KeycloakServer {
             } else {
                 providerDeployer.updateDependencies();
             }
+            // TODO manage updating the deployed jars
+            providerDeployer.deployProviderFactories();
 
             OutputHandler outputHandler = startKeycloak(args);
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/EmbeddedKeycloakServer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/EmbeddedKeycloakServer.java
@@ -18,6 +18,7 @@ public class EmbeddedKeycloakServer implements KeycloakServer {
 
     @Override
     public void start(KeycloakServerConfigBuilder keycloakServerConfigBuilder, boolean tlsEnabled) {
+        // TODO add support for keycloakServerConfigBuilder.toProviderFactories()
         Keycloak.Builder builder = Keycloak.builder().setVersion(Version.VERSION);
         this.tlsEnabled = tlsEnabled;
 

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/KeycloakServerConfigBuilder.java
@@ -25,6 +25,7 @@ public class KeycloakServerConfigBuilder {
     private final Set<String> featuresDisabled = new HashSet<>();
     private final LogBuilder log = new LogBuilder();
     private final Set<KeycloakDependency> dependencies = new HashSet<>();
+    private final Set<SingleTestProvider> providerFactories = new HashSet<>();
     private CacheType cacheType = CacheType.LOCAL;
     private boolean externalInfinispan = false;
     private String shutdownDelay = "0s";
@@ -187,10 +188,12 @@ public class KeycloakServerConfigBuilder {
         return dependency(groupId, artifactId, false, false);
     }
 
+    // TODO add JavaDoc
     public KeycloakServerConfigBuilder dependency(String groupId, String artifactId, boolean hotDeployable) {
         return dependency(groupId, artifactId, hotDeployable, false);
     }
 
+    // TODO add JavaDoc
     private KeycloakServerConfigBuilder dependency(String groupId, String artifactId, boolean hotDeployable, boolean dependencyCurrentProject) {
         dependencies.add(
                 new KeycloakDependency.Builder()
@@ -203,8 +206,26 @@ public class KeycloakServerConfigBuilder {
         return this;
     }
 
+    // TODO add JavaDoc
     public KeycloakServerConfigBuilder dependencyCurrentProject() {
         return dependency("", "", false, true);
+    }
+
+    /**
+     *
+     * @param providerFactory
+     * @param resources note that the service file for this factory is unnecessary
+     * @return
+     */
+    public KeycloakServerConfigBuilder deploy(Class<?> providerFactory, String... resources) {
+        this.providerFactories.add(new SingleTestProvider(providerFactory, null, resources));
+        return this;
+    }
+
+    // TODO add JavaDoc
+    public KeycloakServerConfigBuilder deploy(Class<?> providerFactory, Class<?> spi, String... resources) {
+        this.providerFactories.add(new SingleTestProvider(providerFactory, spi, resources));
+        return this;
     }
 
     public class LogBuilder {
@@ -325,6 +346,10 @@ public class KeycloakServerConfigBuilder {
 
     Set<KeycloakDependency> toDependencies() {
         return dependencies;
+    }
+
+    Set<SingleTestProvider> toProviderFactories() {
+        return providerFactories;
     }
 
     private Set<String> toFeatureStrings(Profile.Feature... features) {

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/ProviderDeployer.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/ProviderDeployer.java
@@ -2,16 +2,21 @@ package org.keycloak.testframework.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.keycloak.it.utils.Maven;
+import org.keycloak.testframework.FatalTestClassException;
 import org.keycloak.testframework.util.FileUtils;
 import org.keycloak.testframework.util.MavenProjectUtil;
 
@@ -24,12 +29,15 @@ final class ProviderDeployer {
     private final File providersDir;
     private final boolean hotDeployEnabled;
     private final Set<KeycloakDependency> requestedDependencies;
+    private final Set<SingleTestProvider> providerFactories;
+    private final String REL_SERVICES_PATH = "META-INF" + File.separator + "services" + File.separator;
 
-    ProviderDeployer(Logger log, File keycloakHomeDir, Set<KeycloakDependency> requestedDependencies, boolean hotDeployEnabled) {
+    ProviderDeployer(Logger log, File keycloakHomeDir, KeycloakServerConfigBuilder serverConfig, boolean hotDeployEnabled) {
         this.log = log;
         this.providersDir = new File(keycloakHomeDir, "providers");
-        this.requestedDependencies = requestedDependencies;
+        this.requestedDependencies = serverConfig.toDependencies();
         this.hotDeployEnabled = hotDeployEnabled;
+        this.providerFactories = serverConfig.toProviderFactories();
     }
 
     boolean updateDependencies() throws IOException {
@@ -136,6 +144,68 @@ final class ProviderDeployer {
                     .max()
                     .orElse(0);
         }
+    }
+
+    public void deployProviderFactories() {
+        for (SingleTestProvider testProvider : providerFactories) {
+            try {
+                Set<Class<?>> classesToDeploy = new HashSet<>();
+                List<String> resourceFiles = Arrays.stream(testProvider.resourceFiles()).toList();
+
+                Class<?> providerFactory = testProvider.providerFactory();
+                classesToDeploy.add(providerFactory);
+
+                List<Class<?>> providerFactoryIFaces = getAllIFaces(providerFactory);
+                classesToDeploy.addAll(providerFactoryIFaces);
+                Set<String> potentialServiceFiles = getPotentialServiceFiles(providerFactoryIFaces);
+
+                Class<?> provider = getProviderFromFactory(providerFactory);
+                try {
+                    classesToDeploy.add(provider.getDeclaredMethod("getResource").getReturnType());
+                } catch (NoSuchMethodException ignored) {}
+                classesToDeploy.add(provider);
+                classesToDeploy.addAll(getAllIFaces(provider));
+
+                if (testProvider.spi() != null) {
+                    classesToDeploy.add(testProvider.spi());
+                    potentialServiceFiles.add(REL_SERVICES_PATH + "org.keycloak.provider.Spi");
+                }
+
+                String jarName = provider.getSimpleName() + "-single-deploy.jar";
+                Path targetPath = providersDir.toPath().resolve(jarName);
+                Path classesDir = Path.of(providerFactory.getProtectionDomain().getCodeSource().getLocation().toURI());
+
+                MavenProjectUtil.buildJar(jarName, classesDir, classesToDeploy, potentialServiceFiles, resourceFiles, targetPath);
+            } catch (URISyntaxException e) {
+                throw new FatalTestClassException("Failed to deploy: " + testProvider.providerFactory(), e);
+            }
+        }
+    }
+
+    private List<Class<?>> getAllIFaces(Class<?> providerFactory) {
+        List<Class<?>> providerFactoryIFaces = List.of(providerFactory.getInterfaces());
+        List<Class<?>> classesToDeploy = new ArrayList<>(providerFactoryIFaces);
+        for (Class<?> iFace : providerFactoryIFaces) {
+            classesToDeploy.addAll(Arrays.asList(iFace.getInterfaces()));
+        }
+        return classesToDeploy;
+    }
+
+    private Set<String> getPotentialServiceFiles(List<Class<?>> providerFactoryIFaces) {
+        Set<String> potentialServiceFiles = new HashSet<>();
+        for (Class<?> iFace : providerFactoryIFaces) {
+            potentialServiceFiles.add(REL_SERVICES_PATH + iFace.getName());
+        }
+        return potentialServiceFiles;
+    }
+
+    private Class<?> getProviderFromFactory(Class<?> providerFactory) {
+        for (Method method : providerFactory.getDeclaredMethods()) {
+            if (method.getName().equals("create") && !method.isBridge()) {
+                return method.getReturnType();
+            }
+        }
+        throw new FatalTestClassException("Could not find provider of: " + providerFactory.getName() + ". ProviderFactory does not declare a create method"); // TODO prolly need a new exception
     }
 
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/server/SingleTestProvider.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/server/SingleTestProvider.java
@@ -1,0 +1,4 @@
+package org.keycloak.testframework.server;
+
+record SingleTestProvider(Class<?> providerFactory, Class<?> spi, String... resourceFiles) {
+}

--- a/test-framework/core/src/main/java/org/keycloak/testframework/util/MavenProjectUtil.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/util/MavenProjectUtil.java
@@ -5,10 +5,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.keycloak.it.utils.Maven;
+import org.keycloak.testframework.FatalTestClassException;
 import org.keycloak.testframework.server.KeycloakDependency;
 
 import io.quarkus.bootstrap.resolver.maven.BootstrapMavenContext;
@@ -100,7 +103,49 @@ public final class MavenProjectUtil {
                         }
                     });
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new FatalTestClassException("Could not build a JAR ", e);
+        }
+
+        providerJar.as(ZipExporter.class).exportTo(targetPath.toFile(), true);
+    }
+
+    /**
+     * TODO add JavaDoc
+     */
+    public static void buildJar(String jarName, Path classesPath, Set<Class<?>> classesToDeploy, Set<String> servicesFiles, List<String> resourceFiles, Path targetPath) {
+        JavaArchive providerJar = ShrinkWrap.create(JavaArchive.class, jarName);
+
+        try (Stream<Path> sourcePathStream = Files.walk(classesPath)) {
+            List<String> sources = sourcePathStream .filter(Files::isRegularFile)
+                    .map(p -> p.getFileName().toString())
+                    .filter(f -> f.endsWith(".class"))
+                    .map(s -> s.substring(0, s.lastIndexOf('.'))).toList();
+
+            for (Class<?> clazz : classesToDeploy) {
+                if (sources.contains(clazz.getSimpleName())) {
+                    providerJar.addClass(clazz);
+                }
+            }
+        } catch (IOException e) {
+            throw new FatalTestClassException("Could not build a JAR ", e);
+        }
+
+        // TODO when service file has multiple providers but not all are deployed Keycloak fails to start
+        for (String r : servicesFiles) {
+            Path serviceFilePath = classesPath.resolve(r);
+            File serviceFile = serviceFilePath.toFile();
+            if (serviceFile.exists() && serviceFile.isFile()) {
+                providerJar.addAsResource(serviceFile, r);
+            }
+        }
+
+        for (String resourceFile : resourceFiles) {
+            Path resourceFilePath = classesPath.resolve(resourceFile);
+            File serviceFile = resourceFilePath.toFile();
+            if (!serviceFile.exists() || !serviceFile.isFile()) {
+                throw new FatalTestClassException("Could not find \"" + resourceFile + "\" in: " + resourceFilePath);
+            }
+            providerJar.addAsResource(serviceFile, resourceFile);
         }
 
         providerJar.as(ZipExporter.class).exportTo(targetPath.toFile(), true);

--- a/test-framework/test-providers/pom.xml
+++ b/test-framework/test-providers/pom.xml
@@ -42,6 +42,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-remote</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiProvider.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiProvider.java
@@ -1,0 +1,7 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.provider.Provider;
+
+public interface ProviderAndSpiProvider extends Provider {
+
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiProviderFactory.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiProviderFactory.java
@@ -1,0 +1,6 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.component.ComponentFactory;
+
+public interface ProviderAndSpiProviderFactory<T extends ProviderAndSpiProvider> extends ComponentFactory<T, ProviderAndSpiProvider> {
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiProviderFactoryImpl.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiProviderFactoryImpl.java
@@ -1,0 +1,83 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.component.ComponentValidationException;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.models.RealmModel;
+import org.keycloak.provider.ConfigurationValidationHelper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import static org.keycloak.provider.ProviderConfigProperty.STRING_TYPE;
+
+public class ProviderAndSpiProviderFactoryImpl implements ProviderAndSpiProviderFactory {
+
+    final static String ID = "provider-and-spi";
+
+    private final List<ProviderConfigProperty> config = ProviderConfigurationBuilder.create()
+            .property("secret", "Secret", "A secret value", STRING_TYPE, null, null, true)
+            .property("number", "Number", "A number value", STRING_TYPE, null, null, false)
+            .property("required", "Required", "A required value", STRING_TYPE, null, null, false)
+            .property("val1", "Value 1", "Some more values", STRING_TYPE, null, null, false)
+            .property("val2", "Value 2", "Some more values", STRING_TYPE, null, null, false)
+            .property("val3", "Value 3", "Some more values", STRING_TYPE, null, null, false)
+            .build();
+
+    @Override
+    public ProviderAndSpiProviderImpl create(KeycloakSession session, ComponentModel model) {
+        return new ProviderAndSpiProviderImpl(model);
+    }
+
+    @Override
+    public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel model) throws ComponentValidationException {
+        ConfigurationValidationHelper.check(model)
+                .checkRequired("required", "Required")
+                .checkInt("number", "Number", false);
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Provider to test component storage";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return config;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    public static class ProviderAndSpiProviderImpl implements ProviderAndSpiProvider {
+
+        private ComponentModel model;
+
+        public ProviderAndSpiProviderImpl(ComponentModel model) {
+            this.model = model;
+        }
+
+        @Override
+        public void close() {
+        }
+
+    }
+
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiSpi.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiSpi.java
@@ -1,0 +1,30 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.provider.Spi;
+
+public class ProviderAndSpiSpi implements Spi {
+
+    final String ID = "provider-and-spi-spi";
+
+    @Override
+    public boolean isInternal() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return ID;
+    }
+
+    @Override
+    public Class<? extends Provider> getProviderClass() {
+        return ProviderAndSpiProvider.class;
+    }
+
+    @Override
+    public Class<? extends ProviderFactory> getProviderFactoryClass() {
+        return ProviderAndSpiProviderFactory.class;
+    }
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderIsAlsoProviderFactory.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderIsAlsoProviderFactory.java
@@ -1,0 +1,42 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+public class ProviderIsAlsoProviderFactory implements RealmResourceProviderFactory, RealmResourceProvider {
+
+    final static String ID =  "provider-is-also-provider-factory";
+
+    @Override
+    public ProviderIsAlsoProviderFactory create(KeycloakSession session) {
+        return this;
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public ProviderIsAlsoProviderFactory getResource() {
+        return this;
+    }
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesProvider.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesProvider.java
@@ -1,0 +1,26 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.services.resource.AccountResourceProvider;
+
+public class ProviderWithExtraResourcesProvider implements AccountResourceProvider {
+
+    @Override
+    public ProviderWithExtraResourcesProvider getResource() {
+        return this;
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public Response getMainPage() {
+        return Response.ok().entity("<html><head><title>Account</title></head><body><h1>Custom Account Console</h1></body></html>").build();
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesProviderFactory.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesProviderFactory.java
@@ -1,0 +1,34 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.AccountResourceProviderFactory;
+
+public class ProviderWithExtraResourcesProviderFactory implements AccountResourceProviderFactory {
+
+    final static String ID = "provider-with-extra-resources";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public ProviderWithExtraResourcesProvider create(KeycloakSession session) {
+        return new ProviderWithExtraResourcesProvider();
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceProvider.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceProvider.java
@@ -1,0 +1,17 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.services.resource.RealmResourceProvider;
+
+public class ProviderWithResourceProvider implements RealmResourceProvider {
+
+    @Override
+    public ProviderWithResourceResource getResource() {
+        return new ProviderWithResourceResource();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceProviderFactory.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceProviderFactory.java
@@ -1,0 +1,35 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+public class ProviderWithResourceProviderFactory implements RealmResourceProviderFactory {
+
+    static final String ID = "provider-with-resource";
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public ProviderWithResourceProvider create(KeycloakSession session) {
+        return new ProviderWithResourceProvider();
+    }
+
+    @Override
+    public void init(org.keycloak.Config.Scope config) {
+
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+
+    }
+
+    @Override
+    public void close() {
+
+    }
+}

--- a/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceResource.java
+++ b/test-framework/test-providers/src/main/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceResource.java
@@ -1,0 +1,4 @@
+package org.keycloak.testframework.tests.providers.single;
+
+public class ProviderWithResourceResource {
+}

--- a/test-framework/test-providers/src/main/resources/META-INF/keycloak-themes.json
+++ b/test-framework/test-providers/src/main/resources/META-INF/keycloak-themes.json
@@ -1,0 +1,10 @@
+{
+  "themes": [
+    {
+      "name": "provider-with-resources-theme",
+      "types": [
+        "account"
+      ]
+    }
+  ]
+}

--- a/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.provider.Spi
+++ b/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.provider.Spi
@@ -1,0 +1,1 @@
+org.keycloak.testframework.tests.providers.single.ProviderAndSpiSpi

--- a/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.services.resource.AccountResourceProviderFactory
+++ b/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.services.resource.AccountResourceProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.testframework.tests.providers.single.ProviderWithExtraResourcesProviderFactory

--- a/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
+++ b/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
@@ -1,1 +1,3 @@
 org.keycloak.testframework.tests.providers.MyCustomRealmResourceProviderFactory
+org.keycloak.testframework.tests.providers.single.ProviderWithResourceProviderFactory
+org.keycloak.testframework.tests.providers.single.ProviderIsAlsoProviderFactory

--- a/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.testframework.tests.providers.single.ProviderAndSpiProviderFactory
+++ b/test-framework/test-providers/src/main/resources/META-INF/services/org.keycloak.testframework.tests.providers.single.ProviderAndSpiProviderFactory
@@ -1,0 +1,1 @@
+org.keycloak.testframework.tests.providers.single.ProviderAndSpiProviderFactoryImpl

--- a/test-framework/test-providers/src/main/resources/theme/custom-account-provider/account/theme.properties
+++ b/test-framework/test-providers/src/main/resources/theme/custom-account-provider/account/theme.properties
@@ -1,0 +1,1 @@
+accountResourceProvider="provider-with-resources"

--- a/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/AbstractSingleProviderTest.java
+++ b/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/AbstractSingleProviderTest.java
@@ -1,0 +1,62 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest
+abstract class AbstractSingleProviderTest {
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @Test
+    void providerDeployedTest() {
+        ExpectedProvider expectedProvider = getExpectedProvider();
+        Class<? extends ProviderFactory> expectedProviderFactoryClass = expectedProvider.expectedProviderFactoryClass();
+        Class<? extends Provider> baseProviderClass = expectedProvider.baseProviderClass();
+        String expectedProviderId = expectedProvider.expectedProviderId();
+
+        runOnServer.run(session -> {
+            ProviderFactory providerFactory = session.getKeycloakSessionFactory().getProviderFactory(baseProviderClass, expectedProviderId);
+            assertNotNull(providerFactory);
+            assertInstanceOf(expectedProviderFactoryClass, providerFactory);
+        });
+    }
+
+    @Test
+    void providersIgnoredTest() {
+        Collection<ExpectedProvider> ignoredProviderClasses = getIgnoredProviderClasses();
+
+        runOnServer.run(session -> {
+            for (ExpectedProvider ignoredProvider : ignoredProviderClasses) {
+                Class<? extends Provider> baseProviderClass = ignoredProvider.baseProviderClass();
+                String ignoredProviderId = ignoredProvider.expectedProviderId();
+
+                ProviderFactory providerFactory = session.getKeycloakSessionFactory().getProviderFactory(baseProviderClass, ignoredProviderId);
+                assertNull(providerFactory);
+            }
+        });
+    }
+
+    abstract ExpectedProvider getExpectedProvider();
+
+    abstract Collection<ExpectedProvider> getIgnoredProviderClasses();
+
+    record ExpectedProvider(
+            Class<? extends Provider> baseProviderClass,
+            String expectedProviderId,
+            Class<? extends ProviderFactory> expectedProviderFactoryClass
+    ) implements Serializable {}
+}

--- a/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/AllProvidersDeployedTest.java
+++ b/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/AllProvidersDeployedTest.java
@@ -1,0 +1,61 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.util.List;
+
+import org.keycloak.provider.Provider;
+import org.keycloak.provider.ProviderFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.tests.providers.MyCustomRealmResourceProviderFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@KeycloakIntegrationTest(config = AllProvidersDeployedTest.KeycloakServerConfig.class)
+class AllProvidersDeployedTest {
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @Test
+    void allProvidersDeployedTest() {
+        List<AbstractSingleProviderTest.ExpectedProvider> allProviders = List.of(
+                new ProviderWithResourceTest().getExpectedProvider(),
+                new ProviderIsAlsoProviderFactoryTest().getExpectedProvider(),
+                new ProviderAndSpiTest().getExpectedProvider(),
+                new ProviderWithExtraResourcesTest().getExpectedProvider(),
+                new AbstractSingleProviderTest.ExpectedProvider(RealmResourceProvider.class, MyCustomRealmResourceProviderFactory.ID, MyCustomRealmResourceProviderFactory.class)
+        );
+
+        runOnServer.run(session -> {
+            for (AbstractSingleProviderTest.ExpectedProvider expectedProvider : allProviders) {
+                Class<? extends ProviderFactory> expectedProviderFactoryClass = expectedProvider.expectedProviderFactoryClass();
+                Class<? extends Provider> baseProviderClass = expectedProvider.baseProviderClass();
+                String expectedProviderId = expectedProvider.expectedProviderId();
+
+
+                ProviderFactory providerFactory = session.getKeycloakSessionFactory().getProviderFactory(baseProviderClass, expectedProviderId);
+                assertNotNull(providerFactory);
+                assertInstanceOf(expectedProviderFactoryClass, providerFactory);
+            }
+        });
+    }
+
+
+    final static class KeycloakServerConfig implements org.keycloak.testframework.server.KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config
+                    .deploy(ProviderWithResourceProviderFactory.class)
+                    .deploy(ProviderIsAlsoProviderFactory.class)
+                    .deploy(ProviderAndSpiProviderFactoryImpl.class, ProviderAndSpiSpi.class)
+                    .deploy(ProviderWithExtraResourcesProviderFactory.class, "META-INF/keycloak-themes.json", "theme/custom-account-provider/account/theme.properties")
+                    .deploy(MyCustomRealmResourceProviderFactory.class);
+        }
+    }
+}

--- a/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiTest.java
+++ b/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiTest.java
@@ -1,0 +1,32 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+@KeycloakIntegrationTest(config = ProviderAndSpiTest.KeycloakServerConfig.class)
+class ProviderAndSpiTest extends AbstractSingleProviderTest {
+
+    @Override
+    ExpectedProvider getExpectedProvider() {
+        return new ExpectedProvider(ProviderAndSpiProvider.class, ProviderAndSpiProviderFactoryImpl.ID, ProviderAndSpiProviderFactoryImpl.class);
+    }
+
+    @Override
+    Collection<ExpectedProvider> getIgnoredProviderClasses() {
+        return List.of(
+                new ProviderWithResourceTest().getExpectedProvider(),
+                new ProviderIsAlsoProviderFactoryTest().getExpectedProvider(),
+                new ProviderWithExtraResourcesTest().getExpectedProvider()
+        );
+    }
+
+    final static class KeycloakServerConfig implements org.keycloak.testframework.server.KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.deploy(ProviderAndSpiProviderFactoryImpl.class, ProviderAndSpiSpi.class);
+        }
+    }
+}

--- a/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderIsAlsoProviderFactoryTest.java
+++ b/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderIsAlsoProviderFactoryTest.java
@@ -1,0 +1,33 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+@KeycloakIntegrationTest(config = ProviderIsAlsoProviderFactoryTest.KeycloakServerConfig.class)
+class ProviderIsAlsoProviderFactoryTest extends AbstractSingleProviderTest {
+
+    @Override
+    ExpectedProvider getExpectedProvider() {
+        return new ExpectedProvider(RealmResourceProvider.class, ProviderIsAlsoProviderFactory.ID, ProviderIsAlsoProviderFactory.class);
+    }
+
+    @Override
+    Collection<ExpectedProvider> getIgnoredProviderClasses() {
+        return List.of(
+                new ProviderWithResourceTest().getExpectedProvider(),
+                new ProviderAndSpiTest().getExpectedProvider(),
+                new ProviderWithExtraResourcesTest().getExpectedProvider()
+        );
+    }
+
+    final static class KeycloakServerConfig implements org.keycloak.testframework.server.KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.deploy(ProviderIsAlsoProviderFactory.class);
+        }
+    }
+}

--- a/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesTest.java
+++ b/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesTest.java
@@ -1,0 +1,34 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.keycloak.services.resource.AccountResourceProvider;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+@KeycloakIntegrationTest(config = ProviderWithExtraResourcesTest.KeycloakServerConfig.class)
+class ProviderWithExtraResourcesTest extends AbstractSingleProviderTest {
+
+    @Override
+    ExpectedProvider getExpectedProvider() {
+        return new ExpectedProvider(AccountResourceProvider.class, ProviderWithExtraResourcesProviderFactory.ID, ProviderWithExtraResourcesProviderFactory.class);
+    }
+
+    @Override
+    Collection<ExpectedProvider> getIgnoredProviderClasses() {
+        return List.of(
+                new ProviderWithResourceTest().getExpectedProvider(),
+                new ProviderIsAlsoProviderFactoryTest().getExpectedProvider(),
+                new ProviderAndSpiTest().getExpectedProvider()
+        );
+    }
+
+    final static class KeycloakServerConfig implements org.keycloak.testframework.server.KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.deploy(ProviderWithExtraResourcesProviderFactory.class, "META-INF/keycloak-themes.json", "theme/custom-account-provider/account/theme.properties");
+        }
+
+    }
+}

--- a/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceTest.java
+++ b/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceTest.java
@@ -1,0 +1,34 @@
+package org.keycloak.testframework.tests.providers.single;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+@KeycloakIntegrationTest(config = ProviderWithResourceTest.KeycloakServerConfig.class)
+class ProviderWithResourceTest extends AbstractSingleProviderTest {
+
+    @Override
+    ExpectedProvider getExpectedProvider() {
+        return new ExpectedProvider(RealmResourceProvider.class, ProviderWithResourceProviderFactory.ID, ProviderWithResourceProviderFactory.class);
+    }
+
+    @Override
+    Collection<ExpectedProvider> getIgnoredProviderClasses() {
+        return List.of(
+                new ProviderAndSpiTest().getExpectedProvider(),
+                new ProviderIsAlsoProviderFactoryTest().getExpectedProvider(),
+                new ProviderWithExtraResourcesTest().getExpectedProvider()
+        );
+    }
+
+    final static class KeycloakServerConfig implements org.keycloak.testframework.server.KeycloakServerConfig {
+
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.deploy(ProviderWithResourceProviderFactory.class);
+        }
+    }
+}


### PR DESCRIPTION
- Closes #49498 

Check its usage in tests in [testframework/tests/providers/single](https://github.com/vaceksimon/keycloak/tree/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single). All example providers are taken from the current test suites.
- [AbstractSingleProviderTest](https://github.com/vaceksimon/keycloak/blob/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/AbstractSingleProviderTest.java) - has the actual test
- [ProviderIsAlsoProviderFactoryTest](https://github.com/vaceksimon/keycloak/blob/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderIsAlsoProviderFactoryTest.java) - the class implements both the ProviderFactory and Provider interfaces
- [ProviderWithResourceTest](https://github.com/vaceksimon/keycloak/blob/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderWithResourceTest.java) - the "most standard" provider with ProviderFactory, Provider and a resource class
- [ProviderWithExtraResourcesTest](https://github.com/vaceksimon/keycloak/blob/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderWithExtraResourcesTest.java) - a provider that requires extra files in the resource folder
- [ProviderAndSpiTest](https://github.com/vaceksimon/keycloak/blob/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/ProviderAndSpiTest.java) - a provider that also defines a custom Spi
- [AllProvidersDeployedTest](https://github.com/vaceksimon/keycloak/blob/49498-Ability-to-create-and-deploy-a-custom-provider-for-a-test/test-framework/test-providers/src/test/java/org/keycloak/testframework/tests/providers/single/AllProvidersDeployedTest.java) - demonstrates that multiple providers can be deployed this way at the same time

Checklist:
- Server modes supported:
  - [x] distribution
  - [ ] embedded
  - [ ] remote?
- [ ] Manage single deployed providers between server restarts (distribution server only)
- [ ] Handle service files with multiple entries in scenarios when only some of those providers are deployed