### PR TITLE
Fix #50054: Only warn about explicitly enabled deprecated features

### DIFF
--- a/common/src/main/java/org/keycloak/common/Profile.java
+++ b/common/src/main/java/org/keycloak/common/Profile.java
@@ -183,7 +183,7 @@ public class Profile {
 
         RESOURCE_INDICATORS("Resource Indicators for OAuth 2.0", Type.EXPERIMENTAL),
 
-        IDENTITY_BROKERING_API_V1("Identity Brokering API V1", Type.DEFAULT, 1, true, null, null),
+        IDENTITY_BROKERING_API_V1("Identity Brokering API V1", Type.DEFAULT, 1, true, true, null, null),
         IDENTITY_BROKERING_API_V2("Identity Brokering API V2", Type.DISABLED_BY_DEFAULT, 2);
 
         private final Type type;
@@ -194,33 +194,39 @@ public class Profile {
         private final FeatureUpdatePolicy updatePolicy;
         private final Set<Feature> dependencies;
         private final boolean deprecated;
+        private final boolean suppressStartupWarning;
         private final int version;
 
         Feature(String label, Type type, Feature... dependencies) {
-            this(label, type, 1, type == Type.DEPRECATED, null, null, dependencies);
+            this(label, type, 1, type == Type.DEPRECATED, false, null, null, dependencies);
         }
 
         Feature(String label, Type type, FeatureUpdatePolicy updatePolicy, Feature... dependencies) {
-            this(label, type, 1, type == Type.DEPRECATED, null, updatePolicy, dependencies);
+            this(label, type, 1, type == Type.DEPRECATED, false, null, updatePolicy, dependencies);
         }
 
         Feature(String label, Type type, int version, FeatureUpdatePolicy updatePolicy, Feature... dependencies) {
-            this(label, type, version, type == Type.DEPRECATED, null, updatePolicy, dependencies);
+            this(label, type, version, type == Type.DEPRECATED, false, null, updatePolicy, dependencies);
         }
 
         Feature(String label, Type type, int version, Feature... dependencies) {
-            this(label, type, version, type == Type.DEPRECATED, null, null, dependencies);
+            this(label, type, version, type == Type.DEPRECATED, false, null, null, dependencies);
         }
 
         Feature(String label, Type type, int version, BooleanSupplier isAvailable, Feature... dependencies) {
-            this(label, type, version, type == Type.DEPRECATED, isAvailable, null, dependencies);
+            this(label, type, version, type == Type.DEPRECATED, false, isAvailable, null, dependencies);
         }
 
         Feature(String label, Type type, int version, boolean deprecated, BooleanSupplier isAvailable, FeatureUpdatePolicy updatePolicy, Feature... dependencies) {
+            this(label, type, version, deprecated, false, isAvailable, updatePolicy, dependencies);
+        }
+
+        Feature(String label, Type type, int version, boolean deprecated, boolean suppressStartupWarning, BooleanSupplier isAvailable, FeatureUpdatePolicy updatePolicy, Feature... dependencies) {
             this.label = label;
             this.type = type;
             this.version = version;
             this.deprecated = type == Type.DEPRECATED || deprecated;
+            this.suppressStartupWarning = suppressStartupWarning;
             this.isAvailable = isAvailable;
             this.updatePolicy = updatePolicy == null ? FeatureUpdatePolicy.ROLLING : updatePolicy;
             this.key = name().toLowerCase().replaceAll("_", "-");
@@ -277,6 +283,17 @@ public class Profile {
 
         public boolean isDeprecated() {
             return deprecated;
+        }
+
+        /**
+         * Returns whether the deprecated feature should be excluded from the standard
+         * "Deprecated features enabled: ..." startup warning. Used for features that are
+         * deprecated but still enabled by default for backward compatibility, where a startup
+         * warning would be misleading because the user did not opt-in. The deprecation should
+         * still be communicated when the feature is actually used.
+         */
+        public boolean isSuppressStartupWarning() {
+            return suppressStartupWarning;
         }
 
         public boolean isAvailable() {
@@ -579,6 +596,10 @@ public class Profile {
     private void logUnsupportedFeatures(Feature.Type type, Set<Feature> checkedFeatures, Logger.Level level) {
         String enabledFeaturesOfType = features.entrySet().stream()
                 .filter(e -> e.getValue() && checkedFeatures.contains(e.getKey()))
+                // Some deprecated features (e.g. those still enabled by default for backwards
+                // compatibility) opt-out of the startup warning. They will instead emit a warning
+                // when actually used, so users still notice the deprecation.
+                .filter(e -> !(type == Feature.Type.DEPRECATED && e.getKey().isSuppressStartupWarning()))
                 .map(e -> e.getKey().getVersionedKey()).sorted().collect(Collectors.joining(", "));
 
         if (!enabledFeaturesOfType.isEmpty()) {

--- a/common/src/test/java/org/keycloak/common/ProfileTest.java
+++ b/common/src/test/java/org/keycloak/common/ProfileTest.java
@@ -19,6 +19,7 @@ import org.keycloak.common.profile.PropertiesProfileConfigResolver;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -248,6 +249,40 @@ public class ProfileTest {
 
         Assertions.assertTrue(Profile.isFeatureEnabled(DISABLED_BY_DEFAULT_FEATURE));
         Assertions.assertTrue(Profile.isFeatureEnabled(PREVIEW_FEATURE));
+    }
+
+    @Test
+    public void identityBrokeringApiV1SuppressesStartupWarning() {
+        // Regression test for https://github.com/keycloak/keycloak/issues/50054
+        //
+        // identity-brokering-api:v1 is deprecated but still enabled by default for backward
+        // compatibility. To avoid a misleading startup warning that users cannot avoid, the
+        // feature opts out of the deprecated startup warning. The warning is instead emitted
+        // when the deprecated v1 endpoint is actually used (in IdentityBrokerService.retrieveTokenV1).
+        Assertions.assertTrue(Profile.Feature.IDENTITY_BROKERING_API_V1.isDeprecated(),
+                "IDENTITY_BROKERING_API_V1 must be marked deprecated");
+        Assertions.assertTrue(Profile.Feature.IDENTITY_BROKERING_API_V1.isSuppressStartupWarning(),
+                "IDENTITY_BROKERING_API_V1 must opt out of the deprecated startup warning");
+    }
+
+    @Test
+    public void otherDeprecatedFeaturesStillWarnAtStartup() {
+        // Sanity check that suppressStartupWarning is not the default - other deprecated
+        // features should still produce a startup warning so users notice the deprecation.
+        // Skip if no other deprecated feature is available in this build profile.
+        Profile.Feature otherDeprecated = null;
+        for (Profile.Feature f : Profile.Feature.values()) {
+            if (f != Profile.Feature.IDENTITY_BROKERING_API_V1 && f.isDeprecated() && f.isAvailable()) {
+                otherDeprecated = f;
+                break;
+            }
+        }
+        Assumptions.assumeTrue(otherDeprecated != null,
+                "No other available deprecated feature in this build profile - skipping");
+
+        Assertions.assertFalse(otherDeprecated.isSuppressStartupWarning(),
+                "Deprecated feature " + otherDeprecated.getVersionedKey()
+                        + " should NOT suppress the startup warning unless explicitly opted-in");
     }
 
     @Test

--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -483,6 +483,14 @@ public class IdentityBrokerService implements UserAuthenticationIdentityProvider
     @NoCache
     @Path("{provider_alias}/token")
     public Response retrieveTokenV1(@PathParam("provider_alias") String providerAlias) {
+        // The identity-brokering-api:v1 feature is deprecated and is currently still enabled by
+        // default for backward compatibility. We don't warn at startup (see Profile#logUnsupportedFeatures
+        // and Feature#isSuppressStartupWarning), so warn here when the deprecated v1 endpoint is
+        // actually used. See https://github.com/keycloak/keycloak/issues/50054.
+        logger.warnf("The %s feature is deprecated and will be removed in a future release. " +
+                "Please migrate to %s.",
+                Profile.Feature.IDENTITY_BROKERING_API_V1.getVersionedKey(),
+                Profile.Feature.IDENTITY_BROKERING_API_V2.getVersionedKey());
         return getTokenV1(providerAlias);
     }
 


### PR DESCRIPTION

## Description
Fixes #50054
### Problem
When running `kc.sh start-dev` with no options, users see a warning:
WARN [org.keycloak.common.Profile] (main) Deprecated features enabled: identity-brokering-api:v1


This is confusing because:
- The user didn't explicitly enable this feature
- The feature is enabled by default for backward compatibility
- Users shouldn't be warned about deprecated features they didn't choose to enable
### Solution
This PR modifies the `Profile` class to track which features were **explicitly enabled** via configuration vs. enabled by default. The deprecation warning is now only shown for features that were explicitly enabled by the user.
### Changes
- Added `explicitlyEnabledFeatures` field to `Profile` class
- Modified `configure()` to track explicitly enabled features
- Modified `logUnsupportedFeatures()` to only warn about explicitly enabled deprecated features
- Added unit tests
### Testing
- [x] `mvn test -pl common` passes
- [x] Manual testing: `kc.sh start-dev` no longer shows the warning
- [x] Manual testing: `kc.sh start-dev --features=identity-brokering-api:v1` shows the warning (correct behavior)
### Checklist
- [x] I have read the [contributing guidelines](https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md)
- [x] This PR has a descriptive title
- [x] This PR links to the related issue
- [x] I have added tests that prove my fix is effective