### PR TITLE
fix(login): apply kc_locale on every action token request

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
+++ b/services/src/main/java/org/keycloak/services/resources/LoginActionsService.java
@@ -684,9 +684,9 @@ public class LoginActionsService {
 
                 authSession = handler.startFreshAuthenticationSession(token, tokenContext);
                 tokenContext.setAuthenticationSession(authSession, true);
-
-                processLocaleParam(authSession);
             }
+
+            processLocaleParam(authSession);
 
             sessionContext.setAuthenticationSession(authSession);
             initLoginEvent(authSession);


### PR DESCRIPTION
When a user opens a page through an email action link (e.g. email verification via First Broker Login) and uses the locale selector, the `kc_locale` query parameter was ignored on the first request. The page reloaded but the content stayed in the previous language, and only a second selection worked. The cause was that `processLocaleParam` was only invoked when the authentication session was just created, not when it was already present.

This commit moves the `processLocaleParam` call out of the `startFreshAuthenticationSession` branch so it runs for every request handled by `LoginActionsService`, regardless of whether the session is fresh or resumed.

Resolves #46931

### Changes
- Move the `processLocaleParam(authSession)` call in `LoginActionsService` so it executes unconditionally for each action token request, not only when a new authentication session is started.
- Ensures the locale selected on the first attempt is applied when navigating to an action token URL with `kc_locale` set.