### PR TITLE
fix(partial-import): recreate service account users on client overwrite

### DIFF
--- a/services/src/main/java/org/keycloak/partialimport/ClientsPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/ClientsPartialImport.java
@@ -34,6 +34,9 @@ import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.PartialImportRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.services.managers.ClientManager;
+import org.keycloak.services.managers.RealmManager;
 
 import org.jboss.logging.Logger;
 
@@ -47,6 +50,8 @@ public class ClientsPartialImport extends AbstractPartialImport<ClientRepresenta
     private static Set<String> INTERNAL_CLIENTS = Collections.unmodifiableSet(new HashSet(Constants.defaultClients));
 
     private static Logger logger = Logger.getLogger(ClientsPartialImport.class);
+
+    private final Set<String> serviceAccountsToRecreate = new HashSet<>();
 
     @Override
     public List<ClientRepresentation> getRepList(PartialImportRepresentation partialImportRep) {
@@ -94,6 +99,29 @@ public class ClientsPartialImport extends AbstractPartialImport<ClientRepresenta
     }
 
     @Override
+    public void prepare(PartialImportRepresentation partialImportRep, RealmModel realm, KeycloakSession session) {
+        super.prepare(partialImportRep, realm, session);
+
+        serviceAccountsToRecreate.clear();
+        for (ClientRepresentation clientRep : toOverwrite) {
+            if (Boolean.TRUE.equals(clientRep.isServiceAccountsEnabled())
+                    && !hasServiceAccountUser(partialImportRep, clientRep)) {
+                serviceAccountsToRecreate.add(clientRep.getClientId());
+            }
+        }
+    }
+
+    private boolean hasServiceAccountUser(PartialImportRepresentation partialImportRep, ClientRepresentation clientRep) {
+        List<UserRepresentation> users = partialImportRep.getUsers();
+        if (users == null) {
+            return false;
+        }
+
+        return users.stream()
+                .anyMatch(user -> clientRep.getClientId().equals(user.getServiceAccountClientId()));
+    }
+
+    @Override
     public void remove(RealmModel realm, KeycloakSession session, ClientRepresentation clientRep) {
         ClientModel clientModel = realm.getClientByClientId(getName(clientRep));
         // remove the associated service account if the account exists
@@ -120,6 +148,9 @@ public class ClientsPartialImport extends AbstractPartialImport<ClientRepresenta
         }
 
         ClientModel client = RepresentationToModel.createClient(session, realm, clientRep);
+        if (serviceAccountsToRecreate.contains(client.getClientId())) {
+            new ClientManager(new RealmManager(session)).enableServiceAccount(client);
+        }
         if(OIDCAdvancedConfigWrapper.fromClientModel(client).getPostLogoutRedirectUris() == null) {
             OIDCAdvancedConfigWrapper.fromClientModel(client).setPostLogoutRedirectUris(Collections.singletonList("+"));
         }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
@@ -184,6 +184,10 @@ public class PartialImportClientTest extends AbstractPartialImportTest {
 
         Assertions.assertEquals(1, doImport().getOverwritten());
 
+        List<UserRepresentation> serviceAccounts = managedRealm.admin().users().search(
+                ServiceAccountConstants.SERVICE_ACCOUNT_USER_PREFIX + CLIENT_SERVICE_ACCOUNT, true);
+        Assertions.assertEquals(1, serviceAccounts.size());
+
         ClientRepresentation client = managedRealm.admin().clients().findByClientId(CLIENT_SERVICE_ACCOUNT).get(0);
         Assertions.assertDoesNotThrow(() -> managedRealm.admin().clients().get(client.getId()).getServiceAccountUser());
     }


### PR DESCRIPTION
When a partial realm import overwrites a client whose service account user is not included in the import payload, the existing `service-account-<clientId>` user gets deleted, breaking client credentials grants. `ClientsPartialImport` now tracks clients that need their service account recreated and calls `ClientManager.enableServiceAccount` during creation when applicable.

Resolves #46674

Changes:
- Add a `prepare` step in `ClientsPartialImport` to detect clients with `serviceAccountsEnabled` whose service account user is not part of the partial import.
- In `create`, when an overwritten client is flagged, re-enable its service account user via `ClientManager`/`RealmManager`.
- Extend `PartialImportClientTest` to assert the service account user exists after an overwrite that does not include the user in the import payload.