### PR TITLE
Automatic purge of expired issued verifiable credentials

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -942,6 +942,11 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     @Override
+    public void removeExpiredIssuedVerifiableCredentials() {
+        getDelegate().removeExpiredIssuedVerifiableCredentials();
+    }
+
+    @Override
     public void setNotBeforeForUser(RealmModel realm, UserModel user, int notBefore) {
         if (!isRegisteredForInvalidation(realm, user.getId())) {
             UserModel foundUser = getUserById(realm, user.getId());

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -1365,6 +1365,14 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
                 .where(predicates);
     }
 
+    @Override
+    public void removeExpiredIssuedVerifiableCredentials() {
+        long currentTimeMillis = Time.currentTimeMillis();
+        em.createNamedQuery("deleteExpiredIssuedVcs")
+            .setParameter("currentTime", currentTimeMillis)
+            .executeUpdate();
+    }
+
     private IssuedVerifiableCredentialModel toIssuedVcModel(IssuedVerifiableCredentialEntity entity) {
         IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel();
         model.setId(entity.getId());

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IssuedVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IssuedVerifiableCredentialEntity.java
@@ -21,6 +21,7 @@ import jakarta.persistence.Table;
         @NamedQuery(name="deleteIssuedVcsByClientScope", query="delete from IssuedVerifiableCredentialEntity vc where vc.credentialType = :scopeName"),
         @NamedQuery(name="deleteIssuedVcsByClient", query="delete from IssuedVerifiableCredentialEntity vc where vc.clientId = :clientId"),
         @NamedQuery(name="deleteIssuedVcsByUserAndType", query="delete from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId and vc.credentialType = :credentialType"),
+        @NamedQuery(name="deleteExpiredIssuedVcs", query="delete from IssuedVerifiableCredentialEntity vc where vc.expiresAt IS NOT NULL and vc.expiresAt < :currentTime"),
 })
 public class IssuedVerifiableCredentialEntity {
 

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -257,6 +257,12 @@
         </createIndex>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.7.0-issued-ver-credential-expires-at-index">
+        <createIndex tableName="ISSUED_VER_CREDENTIAL" indexName="IDX_ISSUED_VER_CREDENTIAL_EXPIRES_AT">
+            <column name="EXPIRES_AT"/>
+        </createIndex>
+    </changeSet>
+
     <changeSet author="keycloak" id="26.7.0-persistent-auth-session-root-table">
         <preConditions onFail="MARK_RAN" onSqlOutput="TEST">
             <not>

--- a/model/storage-private/src/main/java/org/keycloak/services/scheduled/ClearExpiredIssuedVerifiableCredentials.java
+++ b/model/storage-private/src/main/java/org/keycloak/services/scheduled/ClearExpiredIssuedVerifiableCredentials.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.scheduled;
+
+import org.keycloak.common.util.Time;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.timer.ScheduledTask;
+
+import org.jboss.logging.Logger;
+
+public class ClearExpiredIssuedVerifiableCredentials implements ScheduledTask {
+
+    protected static final Logger logger = Logger.getLogger(ClearExpiredIssuedVerifiableCredentials.class);
+
+    @Override
+    public void run(KeycloakSession session) {
+        long currentTimeMillis = Time.currentTimeMillis();
+
+        session.users().removeExpiredIssuedVerifiableCredentials();
+
+        long took = Time.currentTimeMillis() - currentTimeMillis;
+        logger.debugf("ClearExpiredIssuedVerifiableCredentials finished in %d ms", took);
+    }
+}

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -996,6 +996,11 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     }
 
     @Override
+    public void removeExpiredIssuedVerifiableCredentials() {
+        localStorage().removeExpiredIssuedVerifiableCredentials();
+    }
+
+    @Override
     public void setNotBeforeForUser(RealmModel realm, UserModel user, int notBefore) {
         if (StorageId.isLocalStorage(user.getId())) {
             localStorage().setNotBeforeForUser(realm, user, notBefore);

--- a/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProviderFactory.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/datastore/DefaultDatastoreProviderFactory.java
@@ -33,6 +33,7 @@ import org.keycloak.provider.ProviderEventListener;
 import org.keycloak.services.scheduled.ClearExpiredAdminEvents;
 import org.keycloak.services.scheduled.ClearExpiredClientInitialAccessTokens;
 import org.keycloak.services.scheduled.ClearExpiredEvents;
+import org.keycloak.services.scheduled.ClearExpiredIssuedVerifiableCredentials;
 import org.keycloak.services.scheduled.ClearExpiredRevokedTokens;
 import org.keycloak.services.scheduled.ClearExpiredUserSessions;
 import org.keycloak.services.scheduled.ClusterAwareScheduledTaskRunner;
@@ -145,7 +146,7 @@ public class DefaultDatastoreProviderFactory implements DatastoreProviderFactory
     }
 
     protected static List<ScheduledTask> getScheduledTasks() {
-        return Arrays.asList(new ClearExpiredEvents(), new ClearExpiredAdminEvents(), new ClearExpiredClientInitialAccessTokens(), new ClearExpiredUserSessions());
+        return Arrays.asList(new ClearExpiredEvents(), new ClearExpiredAdminEvents(), new ClearExpiredClientInitialAccessTokens(), new ClearExpiredUserSessions(), new ClearExpiredIssuedVerifiableCredentials());
     }
 
     protected static void scheduleTask(TimerProvider timer, KeycloakSessionFactory sessionFactory, ScheduledTask task, long interval) {

--- a/server-spi/src/main/java/org/keycloak/models/UserProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserProvider.java
@@ -364,4 +364,10 @@ public interface UserProvider extends Provider,
      */
     boolean removeIssuedVerifiableCredential(String credentialId);
 
+    /**
+     * Remove all expired issued verifiable credentials across all realms.
+     * This is called periodically by the scheduled cleanup task.
+     */
+    void removeExpiredIssuedVerifiableCredentials();
+
 }

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/IssuedVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/IssuedVerifiableCredentialTest.java
@@ -19,6 +19,8 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.realm.ManagedRealm;
 import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
+import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
 import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.suites.DatabaseTest;
@@ -47,6 +49,10 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
 
     @InjectRealm(config = IssuedVcTestRealmConfig.class)
     protected ManagedRealm testRealm;
+
+    @InjectTimeOffSet
+    protected TimeOffSet timeOffSet;
+
 
     @Test
     @DatabaseTest
@@ -300,6 +306,56 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
 
         // Verify IssuedVC deleted
         assertThat(userResource.verifiableCredentials().getIssuedCredentials(), empty());
+    }
+
+    @Test
+    @DatabaseTest
+    public void testRemoveExpiredIssuedVerifiableCredentials() {
+        String userId = createUser();
+        String clientId = createTestClient("wallet-client");
+
+        long now = Time.currentTimeMillis();
+        long oneHourInMs = 3600000L;
+        // Create two credentials, both expiring in 1 hour
+        runOnServer.run(session -> {
+            UserVerifiableCredentialModel vcModel1 = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
+            vcModel1.setRevision("rev-001");
+            session.users().addVerifiableCredential(userId, vcModel1);
+
+        });
+        runOnServer.run(session -> {
+            IssuedVerifiableCredentialModel model1 = new IssuedVerifiableCredentialModel(userId, CREDENTIAL_TYPE_1, clientId);
+            model1.setRevision("rev-001");
+            model1.setIssuedAt(now);
+            model1.setExpiresAt(now + oneHourInMs); // Expires in 1 hour
+            session.users().addIssuedVerifiableCredential(model1);
+
+            IssuedVerifiableCredentialModel model2 = new IssuedVerifiableCredentialModel(userId, CREDENTIAL_TYPE_1, clientId);
+            model2.setRevision("rev-002");
+            model2.setIssuedAt(now);
+            model2.setExpiresAt(now + oneHourInMs * 2); // Expires in 2 hour
+            session.users().addIssuedVerifiableCredential(model2);
+        });
+
+        UserResource userResource = managedRealm.admin().users().get(userId);
+        assertThat(userResource.verifiableCredentials().getIssuedCredentials(), hasSize(2));
+
+        // no expirations
+        runOnServer.run(session -> session.users().removeExpiredIssuedVerifiableCredentials());
+        List<IssuedVerifiableCredentialRepresentation> issuedCredentials = userResource.verifiableCredentials().getIssuedCredentials();
+        assertThat(issuedCredentials, hasSize(2));
+
+        //first expires
+        timeOffSet.set((int) (oneHourInMs / 1000));
+        runOnServer.run(session -> session.users().removeExpiredIssuedVerifiableCredentials());
+        issuedCredentials = userResource.verifiableCredentials().getIssuedCredentials();
+        assertThat(issuedCredentials, hasSize(1));
+
+        //all expired
+        timeOffSet.set((int) (2 * oneHourInMs / 1000));
+        runOnServer.run(session -> session.users().removeExpiredIssuedVerifiableCredentials());
+        issuedCredentials = userResource.verifiableCredentials().getIssuedCredentials();
+        assertThat(issuedCredentials, hasSize(0));
     }
 
     // Helper methods


### PR DESCRIPTION
Closes #49409

The test must call `removeExpiredIssuedVerifiableCredentials` to remove the expired issued credentials, I didn't find a way to run the scheduler in the testsuite. I tested manually the "auto-remove" with success.

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
