### PR TITLE
Remove unused method and tag databaseTest to a method

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/concurrency/ConcurrentLoginTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/concurrency/ConcurrentLoginTest.java
@@ -258,6 +258,7 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
 
 
     @Test
+    @DatabaseTest
     public void concurrentCodeReuseShouldFail() throws Throwable {
         LOGGER.info("*********************************************");
         long start = System.currentTimeMillis();
@@ -494,14 +495,6 @@ public class ConcurrentLoginTest extends AbstractConcurrencyTest {
             if (userSessionId.get() == null) {
                 userSessionId.set(token.getSessionState());
             }
-        }
-
-        public int getRetryDelayMs() {
-            return retryDelayMs;
-        }
-
-        public int getRetryCount() {
-            return retryCount;
         }
 
         public Map<Integer, Integer> getHistogram() {


### PR DESCRIPTION
Removed both getRetryDelayMs() and getRetryCount() cause they were never called.

Add @databaseTest tag to concurrentCodeReuseShouldFail. this test take one login code and tries to use it many times, expect only one to succeed. Making sure only one pass is handled by the database, so I think it's worthy to run on all of them

Closes #48159

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
