### PR TITLE
Binding authentication flow leads to 'flow.undefined' showing in admin UI

### DIFF
--- a/js/apps/admin-ui/src/authentication/AuthenticationSection.tsx
+++ b/js/apps/admin-ui/src/authentication/AuthenticationSection.tsx
@@ -15,7 +15,7 @@ import {
   ToolbarItem,
 } from "@patternfly/react-core";
 import { sortBy } from "lodash-es";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useAdminClient } from "../admin-client";
@@ -66,7 +66,11 @@ const AliasRenderer = ({ id, alias, usedBy, builtIn }: AuthenticationType) => {
 export default function AuthenticationSection() {
   const { adminClient } = useAdminClient();
   const { t } = useTranslation();
-  const { realm: realmName } = useRealm();
+  const { realm: realmName, refresh: refreshRealm } = useRealm();
+
+  useEffect(() => {
+    refreshRealm();
+  }, []);
   const [key, setKey] = useState(0);
   const refresh = () => setKey(key + 1);
   const { addAlert, addError } = useAlerts();


### PR DESCRIPTION
- Closes #50014
- The browser flow name is just trying to get the info from the stale realm object - we can just fetch the realm again when accessing the Authentication section
- No refetching when flows are updated, etc. 
- There should not be any performance issues as it targets admins
- I was able to reproduce it and it fixes the issue

@rmartinc @edewit Could you review this small PR? Thanks!


<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
