### PR TITLE
Reduce tightly coupling between ClientAccessTypeCondition and contexts

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/condition/ClientAccessTypeCondition.java
@@ -29,8 +29,11 @@ import org.keycloak.services.clientpolicy.ClientPolicyContext;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
 import org.keycloak.services.clientpolicy.ClientPolicyVote;
 import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
+import org.keycloak.services.clientpolicy.context.ClientModelContext;
 
 import org.jboss.logging.Logger;
+
+import static org.keycloak.services.clientpolicy.ClientPolicyEvent.REGISTER;
 
 /**
  * @author <a href="mailto:takashi.norimatsu.ws@hitachi.com">Takashi Norimatsu</a>
@@ -68,36 +71,19 @@ public class ClientAccessTypeCondition extends AbstractClientPolicyConditionProv
 
     @Override
     public ClientPolicyVote applyPolicy(ClientPolicyContext context) throws ClientPolicyException {
-        switch (context.getEvent()) {
-            case AUTHORIZATION_REQUEST:
-            case RESOURCE_OWNER_PASSWORD_CREDENTIALS_REQUEST:
-            case TOKEN_REQUEST:
-            case TOKEN_RESPONSE:
-            case SERVICE_ACCOUNT_TOKEN_REQUEST:
-            case SERVICE_ACCOUNT_TOKEN_RESPONSE:
-            case TOKEN_REFRESH:
-            case TOKEN_REFRESH_RESPONSE:
-            case TOKEN_REVOKE:
-            case TOKEN_INTROSPECT:
-            case USERINFO_REQUEST:
-            case LOGOUT_REQUEST:
-            case UPDATE:
-            case UPDATED:
-            case REGISTERED:
-            case TOKEN_EXCHANGE_REQUEST:
-            case JWT_AUTHORIZATION_GRANT:
-                if (isClientAccessTypeMatched()) return ClientPolicyVote.YES;
-                return ClientPolicyVote.NO;
-            case REGISTER:
-                if (isProposedClientAccessTypeMatched((ClientCRUDContext)context)) return ClientPolicyVote.YES;
-                return ClientPolicyVote.NO;
-            default:
-                return ClientPolicyVote.ABSTAIN;
+        if (context instanceof ClientModelContext) {
+            ClientModel client = ((ClientModelContext) context).getClient();
+            if (isClientAccessTypeMatched(client)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else if (context.getEvent() == REGISTER) {
+            if (isProposedClientAccessTypeMatched((ClientCRUDContext)context)) return ClientPolicyVote.YES;
+            return ClientPolicyVote.NO;
+        } else {
+            return ClientPolicyVote.ABSTAIN;
         }
     }
 
-    private String getClientAccessType() {
-        ClientModel client = session.getContext().getClient();
+    private String getClientAccessType(ClientModel client) {
         if (client == null) return null;
         return getClientAccessType(client.isPublicClient(), client.isBearerOnly());
     }
@@ -115,8 +101,8 @@ public class ClientAccessTypeCondition extends AbstractClientPolicyConditionProv
         else return ClientAccessTypeConditionFactory.TYPE_CONFIDENTIAL;
     }
 
-    private boolean isClientAccessTypeMatched() {
-        return isClientAccessTypeMatched(getClientAccessType());
+    private boolean isClientAccessTypeMatched(ClientModel client) {
+        return isClientAccessTypeMatched(getClientAccessType(client));
     }
 
     private boolean isProposedClientAccessTypeMatched(ClientCRUDContext context) {


### PR DESCRIPTION
closes #50081

Refactoring of `ClientAccessTypeCondition` to avoid explicit listing of all the contexts, which the condition need to handle on (See parent issue https://github.com/keycloak/keycloak/issues/49666 for more details and motivation behind this).

All contexts, which were listed in `ClientAccessTypeCondition` (with the exception of `REGISTER`, which is still listed as "Special case") already implements `ClientModelContext`, so no changes were needed on any context classes.
