### PR TITLE
Fix client secret length to always use HS512 entropy #49793

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/KeycloakModelUtils.java
@@ -59,7 +59,6 @@ import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
 import org.keycloak.constants.OID4VCIConstants;
-import org.keycloak.crypto.Algorithm;
 import org.keycloak.deployment.DeployedConfigurationsManager;
 import org.keycloak.models.AccountRoles;
 import org.keycloak.models.AuthenticationExecutionModel;
@@ -85,7 +84,6 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.ScopeContainerModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.organization.OrganizationProvider;
-import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.provider.Provider;
 import org.keycloak.provider.ProviderFactory;
 import org.keycloak.representations.idm.CertificateRepresentation;
@@ -253,11 +251,19 @@ public final class KeycloakModelUtils {
     }
 
     public static String generateSecret(ClientModel client) {
-        int secretLength = getSecretLengthByAuthenticationType(client.getClientAuthenticatorType(), client.getAttribute(OIDCConfigAttributes.TOKEN_ENDPOINT_AUTH_SIGNING_ALG));
+        int secretLength = getRequiredClientSecretLength();
         String secret = SecretGenerator.getInstance().randomString(secretLength);
         client.setSecret(secret);
         client.setAttribute(ClientSecretConstants.CLIENT_SECRET_CREATION_TIME, String.valueOf(Time.currentTime()));
         return secret;
+    }
+
+    /**
+     * Returns the required length for a client secret in alphanumeric characters.
+     * Always generated at HS512-level entropy to cover all HMAC signature use cases.
+     */
+    public static int getRequiredClientSecretLength() {
+        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_512_BITS, SecretGenerator.ALPHANUM.length);
     }
 
     public static String getDefaultClientAuthenticatorType() {
@@ -1305,22 +1311,12 @@ public final class KeycloakModelUtils {
     }
 
     /**
-     * @param clientAuthenticatorType
-     * @return secret size based on authentication type
+     * @param clientAuthenticatorType ignored, kept for backwards compatibility
+     * @param signingAlg ignored, kept for backwards compatibility
+     * @return secret size in alphanumeric characters with HS512-level entropy
      */
     public static int getSecretLengthByAuthenticationType(String clientAuthenticatorType, String signingAlg) {
-        if (clientAuthenticatorType != null)
-            switch (clientAuthenticatorType) {
-                case AUTH_TYPE_CLIENT_SECRET_JWT: {
-                    if (Algorithm.HS384.equals(signingAlg))
-                        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_384_BITS, SecretGenerator.ALPHANUM.length);
-                    else if (Algorithm.HS512.equals(signingAlg))
-                        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_512_BITS, SecretGenerator.ALPHANUM.length);
-                    else
-                        return SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_256_BITS, SecretGenerator.ALPHANUM.length);
-                }
-            }
-        return SecretGenerator.SECRET_LENGTH_256_BITS;
+        return getRequiredClientSecretLength();
     }
 
     /**

--- a/server-spi-private/src/test/java/org/keycloak/models/utils/KeycloakModelUtilsTest.java
+++ b/server-spi-private/src/test/java/org/keycloak/models/utils/KeycloakModelUtilsTest.java
@@ -21,6 +21,9 @@ import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.UUID;
 
+import org.keycloak.common.util.SecretGenerator;
+import org.keycloak.crypto.Algorithm;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,6 +40,21 @@ public class KeycloakModelUtilsTest {
         final String shortId = KeycloakModelUtils.generateShortId(UUID.fromString(id));
         final UUID uuid = fromShortId(shortId);
         Assert.assertEquals(id, uuid.toString());
+    }
+
+    @Test
+    public void testGetRequiredClientSecretLength() {
+        Assert.assertEquals(
+                SecretGenerator.equivalentEntropySize(SecretGenerator.SECRET_LENGTH_512_BITS, SecretGenerator.ALPHANUM.length),
+                KeycloakModelUtils.getRequiredClientSecretLength());
+    }
+
+    @Test
+    public void testGetSecretLengthByAuthenticationTypeAlwaysUsesHs512Entropy() {
+        int requiredLength = KeycloakModelUtils.getRequiredClientSecretLength();
+        Assert.assertEquals(requiredLength, KeycloakModelUtils.getSecretLengthByAuthenticationType("client-secret", null));
+        Assert.assertEquals(requiredLength, KeycloakModelUtils.getSecretLengthByAuthenticationType("client-secret-jwt", Algorithm.HS256));
+        Assert.assertEquals(requiredLength, KeycloakModelUtils.getSecretLengthByAuthenticationType("client-secret-jwt", Algorithm.HS512));
     }
 
     @Test

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
@@ -280,31 +280,61 @@ public class ClientAuthSecretSignedJWTTest extends AbstractKeycloakTest {
      */
     @Test
     public void authenticateWithValidClientSecretWhenRotationPolicyIsEnableForHS256() throws Exception {
-        processAuthenticateWithAlgorithm(Algorithm.HS256, SecretGenerator.SECRET_LENGTH_256_BITS);
+        processAuthenticateWithAlgorithm(Algorithm.HS256);
     }
 
     @Test
     public void authenticateWithValidClientSecretWhenRotationPolicyIsEnableForHS384() throws Exception {
-        processAuthenticateWithAlgorithm(Algorithm.HS384, SecretGenerator.SECRET_LENGTH_384_BITS);
+        processAuthenticateWithAlgorithm(Algorithm.HS384);
     }
 
     @Test
     public void authenticateWithValidClientSecretWhenRotationPolicyIsEnableForHS512() throws Exception {
-        processAuthenticateWithAlgorithm(Algorithm.HS512, SecretGenerator.SECRET_LENGTH_512_BITS);
+        processAuthenticateWithAlgorithm(Algorithm.HS512);
     }
 
-    private void processAuthenticateWithAlgorithm(String algorithm, Integer secretLength) throws Exception{
+    @Test
+    public void regenerateClientSecretForClientSecretBasicWithIdTokenHs512() throws Exception {
+        ClientRepresentation clientRep = new ClientRepresentation();
+        clientRep.setClientId("basic-hs512-client");
+        clientRep.setName("basic-hs512-client");
+        clientRep.setProtocol(OIDC);
+        clientRep.setBearerOnly(Boolean.FALSE);
+        clientRep.setPublicClient(Boolean.FALSE);
+        clientRep.setClientAuthenticatorType("client-secret");
+        clientRep.setStandardFlowEnabled(Boolean.TRUE);
+        clientRep.setAttributes(new HashMap<>());
+        clientRep.getAttributes().put(OIDCConfigAttributes.ID_TOKEN_SIGNED_RESPONSE_ALG, Algorithm.HS512);
+        clientRep.setRedirectUris(Collections.singletonList(
+                ServerURLs.getAuthServerContextRoot() + "/auth/realms/master/app/auth"));
+
+        Response resp = adminClient.realm(REALM_NAME).clients().create(clientRep);
+        assertEquals(Response.Status.CREATED.getStatusCode(), resp.getStatus());
+        String clientUuid = ApiUtil.getCreatedId(resp);
+        resp.close();
+        testContext.getOrCreateCleanup(REALM_NAME).addClientUuid(clientUuid);
+
+        ClientResource clientResource = adminClient.realm(REALM_NAME).clients().get(clientUuid);
+        String secret = clientResource.generateNewSecret().getValue();
+        assertThat(secret.length(), is(SecretGenerator.equivalentEntropySize(
+                SecretGenerator.SECRET_LENGTH_512_BITS, SecretGenerator.ALPHANUM.length)));
+    }
+
+    private void processAuthenticateWithAlgorithm(String algorithm) throws Exception{
         String cidConfidential= createClientByAdmin("jwt-client","jwt-client",CLIENT_SECRET,algorithm);
         ClientResource clientResource = adminClient.realm(REALM_NAME).clients().get(cidConfidential);
         configureDefaultProfileAndPolicy();
 
+        int requiredSecretLength = SecretGenerator.equivalentEntropySize(
+                SecretGenerator.SECRET_LENGTH_512_BITS, SecretGenerator.ALPHANUM.length);
+
         String firstSecret = clientResource.generateNewSecret().getValue(); //clientResource.getSecret().getValue();
-        assertThat(firstSecret.length(), is(SecretGenerator.equivalentEntropySize(secretLength, SecretGenerator.ALPHANUM.length)));
+        assertThat(firstSecret.length(), is(requiredSecretLength));
 
         //generate new secret, rotate the secret
         String newSecret = clientResource.generateNewSecret().getValue();
         assertThat(firstSecret, not(equalTo(newSecret)));
-        assertThat(newSecret.length(), is(SecretGenerator.equivalentEntropySize(secretLength, SecretGenerator.ALPHANUM.length)));
+        assertThat(newSecret.length(), is(requiredSecretLength));
 
         oauth.client("jwt-client");
         oauth.doLogin("test-user@localhost", "password");


### PR DESCRIPTION
**Summary**

Fixes #49793

When regenerating a client secret, Keycloak previously derived secret length only from the Token Endpoint Authentication Signing Algorithm (via PR #39637). Other HMAC-based settings were ignored:

- ID Token Signature Algorithm
- UserInfo Response Signature Algorithm
- Request Object Signature Algorithm
- Access Token Signature Algorithm
- Authorization Response / JARM Signature Algorithm

A client using `client_secret_basic `with ID Token Signature Algorithm = HS512 could receive a ~32-character secret insufficient for HS512.

This change follows Marek's suggestion: always generate secrets at HS512-level entropy (86 alphanumeric characters) on create and regenerate, regardless of authentication type or configured signing algorithms.

Changes

- `KeycloakModelUtils.generateSecret()` now uses` getRequiredClientSecretLength()` (86 chars / ~512 bits)
-` getSecretLengthByAuthenticationType()` is kept for backwards compatibility but delegates to the same fixed length
- Added unit tests in` KeycloakModelUtilsTest`
- Updated` ClientAuthSecretSignedJWTTest` to expect 86-character secrets and added coverage for regenerating with ID Token HS512 configured

