### PR TITLE
Ignore empty post-logout redirect URI values

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
@@ -236,8 +236,13 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
 
     private void verifyPostLogoutRedirectUriUpdate(ClientRepresentation client) throws ClientPolicyException {
         List<String> postLogoutRedirectUris = OIDCAdvancedConfigWrapper.fromClientRepresentation(client).getPostLogoutRedirectUris();
-        if (postLogoutRedirectUris == null || postLogoutRedirectUris.isEmpty()
-                || postLogoutRedirectUris.stream().allMatch(String::isEmpty)) {
+        if (postLogoutRedirectUris == null || postLogoutRedirectUris.isEmpty()) {
+            return;
+        }
+        postLogoutRedirectUris = postLogoutRedirectUris.stream()
+                .filter(uri -> uri != null && !uri.isBlank())
+                .toList();
+        if (postLogoutRedirectUris.isEmpty()) {
             return;
         }
         logger.tracef("Verifying post-logout redirect uris. Target client: %s, Effective post-logout uris: %s", client.getClientId(), postLogoutRedirectUris);

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
@@ -236,7 +236,8 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
 
     private void verifyPostLogoutRedirectUriUpdate(ClientRepresentation client) throws ClientPolicyException {
         List<String> postLogoutRedirectUris = OIDCAdvancedConfigWrapper.fromClientRepresentation(client).getPostLogoutRedirectUris();
-        if (postLogoutRedirectUris == null || postLogoutRedirectUris.isEmpty()) {
+        if (postLogoutRedirectUris == null || postLogoutRedirectUris.isEmpty()
+                || postLogoutRedirectUris.stream().allMatch(String::isEmpty)) {
             return;
         }
         logger.tracef("Verifying post-logout redirect uris. Target client: %s, Effective post-logout uris: %s", client.getClientId(), postLogoutRedirectUris);

--- a/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
@@ -20,6 +20,7 @@ package org.keycloak.services.clientpolicy.executor;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.keycloak.OAuthErrorException;
@@ -94,13 +95,30 @@ public class SecureRedirectUrisEnforcerExecutorTest {
     }
 
     @Test
-    public void emptyPostLogoutRedirectUriListValueIsIgnored() {
+    public void blankPostLogoutRedirectUriListValuesAreIgnored() {
         setupConfiguration(configuration);
 
         ClientRepresentation client = new ClientRepresentation();
         client.setClientId("test-client");
         client.setRedirectUris(Collections.singletonList("https://keycloak.org/callback"));
-        OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setPostLogoutRedirectUris(Collections.singletonList(""));
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setPostLogoutRedirectUris(List.of("", " "));
+
+        try {
+            executor.executeOnEvent(new AdminClientRegisterContext(client, null));
+        } catch (ClientPolicyException e) {
+            fail(e.getErrorDetail());
+        }
+    }
+
+    @Test
+    public void blankPostLogoutRedirectUriIsIgnoredAlongsideValidValue() {
+        setupConfiguration(configuration);
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("test-client");
+        client.setRedirectUris(Collections.singletonList("https://keycloak.org/callback"));
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setPostLogoutRedirectUris(
+                List.of("", "https://keycloak.org/post-logout"));
 
         try {
             executor.executeOnEvent(new AdminClientRegisterContext(client, null));

--- a/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
@@ -23,7 +23,10 @@ import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.keycloak.OAuthErrorException;
+import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.AdminClientRegisterContext;
 import org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutor.Configuration;
 import org.keycloak.services.clientpolicy.executor.SecureRedirectUrisEnforcerExecutor.UriValidation;
 import org.keycloak.util.JsonSerialization;
@@ -88,6 +91,22 @@ public class SecureRedirectUrisEnforcerExecutorTest {
     public void failUriSyntax() {
         checkFail("https://keycloak.org\n" ,false, SecureRedirectUrisEnforcerExecutor.ERR_GENERAL);
         checkFail("Collins'&1=1;--" ,false, SecureRedirectUrisEnforcerExecutor.ERR_GENERAL);
+    }
+
+    @Test
+    public void emptyPostLogoutRedirectUriListValueIsIgnored() {
+        setupConfiguration(configuration);
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("test-client");
+        client.setRedirectUris(Collections.singletonList("https://keycloak.org/callback"));
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setPostLogoutRedirectUris(Collections.singletonList(""));
+
+        try {
+            executor.executeOnEvent(new AdminClientRegisterContext(client, null));
+        } catch (ClientPolicyException e) {
+            fail(e.getErrorDetail());
+        }
     }
 
     @Test

--- a/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/services/src/test/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutorTest.java
@@ -128,6 +128,25 @@ public class SecureRedirectUrisEnforcerExecutorTest {
     }
 
     @Test
+    public void blankPostLogoutRedirectUriDoesNotSkipInvalidValue() {
+        setupConfiguration(configuration);
+
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("test-client");
+        client.setRedirectUris(Collections.singletonList("https://keycloak.org/callback"));
+        OIDCAdvancedConfigWrapper.fromClientRepresentation(client).setPostLogoutRedirectUris(
+                List.of("", "https://keycloak.org\n"));
+
+        try {
+            executor.executeOnEvent(new AdminClientRegisterContext(client, null));
+            fail("Expected the non-blank invalid redirect URI to be rejected");
+        } catch (ClientPolicyException e) {
+            assertEquals(OAuthErrorException.INVALID_REQUEST, e.getMessage());
+            assertEquals(SecureRedirectUrisEnforcerExecutor.ERR_GENERAL, e.getErrorDetail());
+        }
+    }
+
+    @Test
     public void failValidatePrivateUseUriScheme() {
         // default config
         checkFail("myapp:/oauth.redirect", false, SecureRedirectUrisEnforcerExecutor.ERR_PRIVATESCHEME);


### PR DESCRIPTION
Treat a post-logout redirect URI list containing only empty values the same as an unset list when the secure redirect URI client policy executor handles client registration.

This keeps the normal validation path for any non-empty post-logout redirect URI, while avoiding a registration failure for the empty list value described in #49911.

Closes #49911

Validation:
- `docker run --rm -v "$PWD":/work -v "$HOME/.m2":/root/.m2 -w /work eclipse-temurin:21 ./mvnw -pl services spotless:check`
- `docker run --rm -v "$PWD":/work -v "$HOME/.m2":/root/.m2 -w /work eclipse-temurin:21 ./mvnw -pl services -am -Dtest=SecureRedirectUrisEnforcerExecutorTest -Dsurefire.failIfNoSpecifiedTests=false test`
