### PR TITLE
[SSF] Protect push delivery secret on stream admin endpoint

### DIFF
--- a/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
+++ b/ssf/services/src/main/java/org/keycloak/ssf/services/admin/SsfAdminResource.java
@@ -61,6 +61,7 @@ import org.keycloak.ssf.transmitter.outbox.SsfOutboxKinds;
 import org.keycloak.ssf.transmitter.stream.DuplicateStreamConfigException;
 import org.keycloak.ssf.transmitter.stream.StreamConfig;
 import org.keycloak.ssf.transmitter.stream.StreamConfigInputRepresentation;
+import org.keycloak.ssf.transmitter.stream.StreamDeliveryConfig;
 import org.keycloak.ssf.transmitter.stream.StreamVerificationRequest;
 import org.keycloak.ssf.transmitter.stream.storage.SsfStreamStore;
 import org.keycloak.ssf.transmitter.stream.storage.client.ClientStreamStore;
@@ -303,12 +304,19 @@ public class SsfAdminResource {
             @Parameter(description = "OAuth client_id of the receiver")
             @PathParam("clientId") String clientId) {
 
-        auth.realm().requireViewRealm();
-
         ClientModel client = realm.getClientByClientId(clientId);
         if (client == null) {
             throw new NotFoundException("Client not found");
         }
+
+        // Client-level view check rather than a realm-wide view-realm gate:
+        // the stream is scoped to this receiver client, so reading it must
+        // require authorization over that client — matching the other admin
+        // SSF endpoints (create/update use requireManage, checkSubject uses
+        // requireView). A realm-level check would let an admin without
+        // permission over this client read its stream, including the
+        // receiver's push delivery credential.
+        auth.clients().requireView(client);
 
         StreamConfig streamConfig = streamStore().getStreamForClient(client);
         if (streamConfig == null) {
@@ -394,7 +402,7 @@ public class SsfAdminResource {
         }
         rep.setStatusReason(streamConfig.getStatusReason());
         rep.setAudience(streamConfig.getAudience());
-        rep.setDelivery(streamConfig.getDelivery());
+        rep.setDelivery(redactDeliverySecret(streamConfig.getDelivery()));
         rep.setEventsSupported(toEventAliases(transmitter, streamConfig.getEventsSupported()));
         rep.setEventsRequested(toEventAliases(transmitter, streamConfig.getEventsRequested()));
         rep.setEventsDelivered(toEventAliases(transmitter, streamConfig.getEventsDelivered()));
@@ -411,6 +419,29 @@ public class SsfAdminResource {
             }
         }
         return rep;
+    }
+
+    /**
+     * Returns a copy of the delivery config with the push
+     * {@code authorization_header} stripped, so the receiver-supplied
+     * delivery credential is never echoed back in an admin response.
+     *
+     * <p>The header is a live credential for the receiver's delivery
+     * endpoint and may be a vault-resolved secret (the store resolves
+     * {@code ${vault.x}} references at read time, see
+     * {@link ClientStreamStore}). It is therefore write-only — accepted on
+     * create/update but redacted from every response — mirroring how client
+     * secrets are handled elsewhere. We copy rather than mutate so the
+     * stored {@link StreamConfig} instance keeps the value for actual
+     * delivery.
+     */
+    protected StreamDeliveryConfig redactDeliverySecret(StreamDeliveryConfig delivery) {
+        if (delivery == null) {
+            return null;
+        }
+        StreamDeliveryConfig redacted = new StreamDeliveryConfig(delivery);
+        redacted.setAuthorizationHeader(null);
+        return redacted;
     }
 
     /**

--- a/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterStreamManagementTests.java
+++ b/ssf/tests/base/src/test/java/org/keycloak/tests/ssf/transmitter/SsfTransmitterStreamManagementTests.java
@@ -387,6 +387,46 @@ public class SsfTransmitterStreamManagementTests {
     }
 
     @Test
+    public void testAdminStreamResponseRedactsPushAuthorizationHeader() throws IOException {
+
+        // Security regression (issue #50074): the push delivery
+        // authorization_header is a live credential for the receiver's
+        // delivery endpoint and must never be echoed back in an admin
+        // response — it is write-only (accepted on create/update, redacted
+        // on read), mirroring how client secrets are handled. We assert it
+        // is stripped from both the create (POST) response and the admin GET,
+        // while the non-secret delivery fields (method, endpoint_url) survive.
+        String adminToken = adminClient.tokenManager().getAccessTokenString();
+        String adminStreamUrl = keycloakUrls.getAdmin() + "/realms/" + realm.getName()
+                + "/ssf/clients/" + RECEIVER_RW + "/stream";
+
+        // buildPushStreamRequest sets delivery.authorization_header = DUMMY_PUSH_AUTH_HEADER.
+        StreamConfigUpdateRepresentation createBody = buildPushStreamRequest(Set.of(CaepCredentialChange.TYPE));
+
+        try (SimpleHttpResponse response = http.doPost(adminStreamUrl)
+                .json(createBody)
+                .auth(adminToken)
+                .acceptJson()
+                .asResponse()) {
+            Assertions.assertEquals(201, response.getStatus(), "admin stream create should succeed");
+            SsfClientStreamRepresentation created = response.asJson(SsfClientStreamRepresentation.class);
+            Assertions.assertNotNull(created.getDelivery());
+            Assertions.assertNull(created.getDelivery().getAuthorizationHeader(),
+                    "create response must not echo the push authorization_header");
+            Assertions.assertEquals(DUMMY_PUSH_ENDPOINT, created.getDelivery().getEndpointUrl(),
+                    "non-secret delivery fields must still be returned");
+        }
+
+        // Same on the read path — this is the endpoint the issue flagged.
+        SsfClientStreamRepresentation fetched = fetchAdminStreamRepresentation(RECEIVER_RW);
+        Assertions.assertNotNull(fetched.getDelivery());
+        Assertions.assertNull(fetched.getDelivery().getAuthorizationHeader(),
+                "admin GET must not return the push authorization_header");
+        Assertions.assertEquals(DUMMY_PUSH_ENDPOINT, fetched.getDelivery().getEndpointUrl(),
+                "non-secret delivery fields must still be returned on read");
+    }
+
+    @Test
     public void testAdminCreateStreamValidationErrorReturnsReadable400() throws IOException {
 
         // Regression: a validation failure on the admin create endpoint must


### PR DESCRIPTION
Fixes #50074

Assisted-by: claude-opus-4-8