### PR TITLE
Filter options in typeahead search selects

### DIFF
--- a/js/apps/admin-ui/src/clients/scopes/EvaluateScopes.tsx
+++ b/js/apps/admin-ui/src/clients/scopes/EvaluateScopes.tsx
@@ -300,7 +300,7 @@ export const EvaluateScopes = ({ clientId, protocol }: EvaluateScopesProps) => {
                     toggleId="scopeParameter"
                     variant={SelectVariant.typeaheadMulti}
                     typeAheadAriaLabel={t("scopeParameter")}
-                    onToggle={() => setIsScopeOpen(!isScopeOpen)}
+                    onToggle={(isOpen) => setIsScopeOpen(isOpen)}
                     isOpen={isScopeOpen}
                     selections={selected}
                     onSelect={(value) => {

--- a/js/apps/admin-ui/test/events/list.spec.ts
+++ b/js/apps/admin-ui/test/events/list.spec.ts
@@ -1,4 +1,4 @@
-import { type Page, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 import { v4 as uuid } from "uuid";
 import adminClient from "../utils/AdminClient.ts";
 import { login, logout } from "../utils/login.ts";
@@ -111,6 +111,24 @@ test.describe.serial("Events tests", () => {
         page,
         eventsTestUser.eventsTestUserId,
       );
+    });
+
+    test("Filters the type select options while typing", async ({ page }) => {
+      await goToAdminEventsTab(page);
+      await clickSearchPanel(page);
+
+      const resourceTypeSelect = page.getByLabel("select-resourceTypes");
+      await resourceTypeSelect.click();
+      const optionCount = await page.getByRole("option").count();
+
+      await resourceTypeSelect.pressSequentially("user");
+
+      await expect(
+        page.getByRole("option", { name: "USER", exact: true }),
+      ).toBeVisible();
+      await expect
+        .poll(() => page.getByRole("option").count())
+        .toBeLessThan(optionCount);
     });
 
     test("Check accessibility on user events tab", async ({ page }) => {

--- a/js/libs/ui-shared/src/select/TypeaheadSelect.tsx
+++ b/js/libs/ui-shared/src/select/TypeaheadSelect.tsx
@@ -49,20 +49,30 @@ export const TypeaheadSelect = ({
     children,
   ) as React.ReactElement<SelectOptionProps>[];
 
+  const visibleChildren =
+    onFilter || !filterValue
+      ? childArray
+      : childArray.filter((child) => {
+          const { children: label, value } = child.props;
+          const text = typeof label === "string" ? label : String(value ?? "");
+          return text.toLowerCase().includes(filterValue.toLowerCase());
+        });
+
   const toggle = () => {
     onToggle(!rest.isOpen);
   };
 
   const onInputKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const focusedItem = childArray[focusedItemIndex];
+    const focusedItem = visibleChildren.at(focusedItemIndex);
     onToggle(true);
 
     switch (event.key) {
       case "Enter": {
         event.preventDefault();
+        if (!focusedItem) break;
 
         if (variant !== SelectVariant.typeaheadMulti) {
-          setFilterValue(focusedItem.props.value);
+          setFilterValue(String(focusedItem.props.value));
         } else {
           setFilterValue("");
         }
@@ -85,19 +95,20 @@ export const TypeaheadSelect = ({
       case "ArrowUp":
       case "ArrowDown": {
         event.preventDefault();
+        if (visibleChildren.length === 0) break;
 
         let indexToFocus = 0;
 
         if (event.key === "ArrowUp") {
           if (focusedItemIndex === 0) {
-            indexToFocus = childArray.length - 1;
+            indexToFocus = visibleChildren.length - 1;
           } else {
             indexToFocus = focusedItemIndex - 1;
           }
         }
 
         if (event.key === "ArrowDown") {
-          if (focusedItemIndex === childArray.length - 1) {
+          if (focusedItemIndex === visibleChildren.length - 1) {
             indexToFocus = 0;
           } else {
             indexToFocus = focusedItemIndex + 1;
@@ -145,6 +156,7 @@ export const TypeaheadSelect = ({
               onClick={toggle}
               onChange={(_, value) => {
                 setFilterValue(value);
+                setFocusedItemIndex(0);
                 onFilter?.(value);
               }}
               onKeyDown={(event) => onInputKeyDown(event)}
@@ -195,7 +207,7 @@ export const TypeaheadSelect = ({
         </MenuToggle>
       )}
     >
-      <SelectList>{children}</SelectList>
+      <SelectList>{visibleChildren}</SelectList>
       {footer && <MenuFooter>{footer}</MenuFooter>}
     </Select>
   );


### PR DESCRIPTION
Closes #50092

**What changed**

`TypeaheadSelect` (the component behind `KeycloakSelect` typeahead / typeaheadMulti) now filters its options by the typed text when the caller does not provide an `onFilter` handler. Previously it rendered every option regardless of input, so search only worked where the caller filtered manually.

This mirrors the filtering already done by the sibling `SelectControl` / `TypeaheadSelectControl` (which is where I took the approach from), so the two select components now behave consistently.

Also fixed `EvaluateScopes` "Scope parameter": its `onToggle` ignored the open state and toggled it on every keystroke, so the menu flickered open/closed while typing.

**Affected parts**

The issue was reported on the Events pages, but while fixing it I found the same typeahead component (`KeycloakSelect`) is reused across several other flows that all had the same broken search. 

All are fixed by the shared change:
- Events → User events → "Event saved type" (reported)
- Events → Admin events → "Resource types" / "Operation types" (reported)
- Clients → Client scopes → Evaluate → "Scope parameter"
- Clients → SSF → Stream → "Events Requested" / "Events Delivered"
- Users → Attribute search → attribute select
- Realm settings → User profile → Attribute → "Required/Enabled when" scopes
- Clients → Authorization → Evaluate → key/value selects

Files:
- `js/libs/ui-shared/src/select/TypeaheadSelect.tsx`
- `js/apps/admin-ui/src/clients/scopes/EvaluateScopes.tsx`
- `js/apps/admin-ui/test/events/list.spec.ts` (test)

**Video**

[select-fix.webm](https://github.com/user-attachments/assets/4874646f-e002-4c57-8e9f-6a2a0630dcd7)

> AI assisted with investigating the codebase for this change; I have implemented and tested all of it.