### PR TITLE
fix: switching to a string for the fields

### DIFF
--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -225,13 +225,6 @@ public class Keycloak implements AutoCloseable {
     }
     
     /**
-     * @return the {@link WebTarget} used to create proxies relative to server URL
-     */
-    public WebTarget getWebTarget() {
-        return target;
-    }
-
-    /**
      * Closes the underlying client. After calling this method, this <code>Keycloak</code> instance cannot be reused.
      */
     @Override

--- a/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
+++ b/integration/admin-client/src/main/java/org/keycloak/admin/client/Keycloak.java
@@ -218,10 +218,17 @@ public class Keycloak implements AutoCloseable {
     }
     
     /**
-     * Create a secure proxy with endpoints targetting the server
+     * Create a secure proxy with endpoints targeting the server
      */
     public <T> T proxy(Class<T> proxyClass) {
         return CLIENT_PROVIDER.targetProxy(target, proxyClass);
+    }
+    
+    /**
+     * @return the {@link WebTarget} used to create proxies relative to server URL
+     */
+    public WebTarget getWebTarget() {
+        return target;
     }
 
     /**

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -236,15 +236,16 @@
         "tags" : [ "Clients (v2)" ],
         "parameters" : [ {
           "description" : "Set of fields to include in the response. Must be top-level fields. If omitted or empty, all fields will be populated.",
-          "name" : "fields",
-          "in" : "query",
+          "explode" : false,
           "schema" : {
             "type" : "array",
             "uniqueItems" : true,
             "items" : {
               "type" : "string"
             }
-          }
+          },
+          "name" : "fields",
+          "in" : "query"
         }, {
           "description" : "Filter expression using SCIM-like syntax, e.g. clientId eq \"my-app\" and enabled eq true",
           "name" : "q",

--- a/rest/admin-v2/api/pom.xml
+++ b/rest/admin-v2/api/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>hibernate-validator</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/admin/api/ListOptions.java
@@ -1,16 +1,23 @@
 package org.keycloak.admin.api;
 
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.ws.rs.QueryParam;
 
+import org.eclipse.microprofile.openapi.annotations.enums.Explode;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 
 public class ListOptions {
 
-    @Parameter(description = "Set of fields to include in the response. Must be top-level fields. If omitted or empty, all fields will be populated.")
+    @Parameter(description = "Set of fields to include in the response. Must be top-level fields. If omitted or empty, all fields will be populated.", 
+            explode = Explode.FALSE, schema = @Schema(type = SchemaType.ARRAY, uniqueItems = true, implementation = String.class))
     @QueryParam("fields")
-    protected Set<String> fields;
+    protected String fields;
 
     @Parameter(description = "Filter expression using SCIM-like syntax, e.g. clientId eq \"my-app\" and enabled eq true")
     @QueryParam("q")
@@ -27,11 +34,17 @@ public class ListOptions {
     }
 
     public Set<String> getFields() {
-        return fields;
+        if (fields == null) {
+            return null;
+        }
+        if (fields.isEmpty()) {
+            return Set.of();
+        }
+        return new LinkedHashSet<>(List.of(fields.split(",")));
     }
 
     public void setFields(Set<String> fields) {
-        this.fields = fields;
+        this.fields = fields == null ? null : fields.stream().collect(Collectors.joining(","));
     }
 
     public String getQuery() {
@@ -41,5 +54,5 @@ public class ListOptions {
     public void setQuery(String query) {
         this.query = query;
     }
-
+    
 }

--- a/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
+++ b/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
@@ -1,0 +1,27 @@
+package org.keycloak.admin.api;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ListOptionsTest {
+
+    @Test
+    void testGetFieldsEmpty() {
+        ListOptions options = new ListOptions();
+        options.setFields(Set.of());
+        assertEquals("", options.fields);
+        assertTrue(options.getFields().isEmpty());
+    }
+    
+    @Test
+    void testGetFields() {
+        ListOptions options = new ListOptions();
+        options.fields = "a,b";
+        assertTrue(options.getFields().equals(Set.of("a", "b")));
+    }
+
+}

--- a/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
+++ b/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ListOptionsTest {
 
@@ -14,7 +13,7 @@ public class ListOptionsTest {
         ListOptions options = new ListOptions();
         options.setFields(Set.of());
         assertEquals("", options.fields);
-        assertTrue(options.getFields().isEmpty());
+        assertEquals(Set.of(), options.getFields());
     }
     
     @Test

--- a/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
+++ b/rest/admin-v2/api/src/test/java/org/keycloak/admin/api/ListOptionsTest.java
@@ -21,7 +21,7 @@ public class ListOptionsTest {
     void testGetFields() {
         ListOptions options = new ListOptions();
         options.fields = "a,b";
-        assertTrue(options.getFields().equals(Set.of("a", "b")));
+        assertEquals(Set.of("a", "b"), options.getFields());
     }
 
 }

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
@@ -1,9 +1,5 @@
 package org.keycloak.tests.admin.client.v2;
 
-import java.io.IOException;
-
-import jakarta.ws.rs.client.ClientRequestContext;
-import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import org.keycloak.admin.api.AdminRootV2;
@@ -14,41 +10,10 @@ import org.keycloak.testframework.annotations.InjectAdminClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpMessage;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractClientApiV2Test {
-
-    public static class LastClientRequestFilter implements ClientRequestFilter {
-        
-        ClientRequestContext lastRequest;
-        
-        @Override
-        public void filter(ClientRequestContext requestContext) throws IOException {
-            this.lastRequest = requestContext;
-        }
-    }
-    
     protected static ObjectMapper mapper;
-    protected static LastClientRequestFilter filter = new LastClientRequestFilter();
-    
-    protected ClientRequestContext getLastRequest() {
-        return filter.lastRequest;
-    }
-    
-    @BeforeEach
-    public void before() {
-        var target = adminClient.getWebTarget();
-        if (!target.getConfiguration().isRegistered(filter)) {
-            target.register(filter);
-        }
-    }
-    
-    @AfterEach
-    public void after() {
-        filter.lastRequest = null;
-    }
 
     @InjectAdminClient
     protected Keycloak adminClient;

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
@@ -1,5 +1,9 @@
 package org.keycloak.tests.admin.client.v2;
 
+import java.io.IOException;
+
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.core.HttpHeaders;
 
 import org.keycloak.admin.api.AdminRootV2;
@@ -10,10 +14,38 @@ import org.keycloak.testframework.annotations.InjectAdminClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpMessage;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractClientApiV2Test {
+
+    public static class LastClientRequestFilter implements ClientRequestFilter {
+        
+        ClientRequestContext lastRequest;
+        
+        @Override
+        public void filter(ClientRequestContext requestContext) throws IOException {
+            this.lastRequest = requestContext;
+        }
+    }
+    
     protected static ObjectMapper mapper;
+    protected static LastClientRequestFilter filter = new LastClientRequestFilter();
+    
+    protected ClientRequestContext getLastRequest() {
+        return filter.lastRequest;
+    }
+    
+    @BeforeEach
+    public void before() {
+        adminClient.getWebTarget().register(filter);
+    }
+    
+    @AfterEach
+    public void after() {
+        filter.lastRequest = null;
+    }
 
     @InjectAdminClient
     protected Keycloak adminClient;

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/AbstractClientApiV2Test.java
@@ -39,7 +39,10 @@ public abstract class AbstractClientApiV2Test {
     
     @BeforeEach
     public void before() {
-        adminClient.getWebTarget().register(filter);
+        var target = adminClient.getWebTarget();
+        if (!target.getConfiguration().isRegistered(filter)) {
+            target.register(filter);
+        }
     }
     
     @AfterEach

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -20,6 +20,7 @@ package org.keycloak.tests.admin.client.v2;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -365,6 +366,11 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
     public void invalidFieldProjection() {
         BadRequestException e = assertThrows(BadRequestException.class, () -> getClientsApi().getClients(new ListOptions().fields(Set.of("unknown!"))));
         assertEquals("{\"error\":\"unknown! is an unknown field\"}", e.getResponse().readEntity(String.class));
+        
+        // ensure that multiple fields are interpreted correctly
+        e = assertThrows(BadRequestException.class, () -> getClientsApi().getClients(new ListOptions().fields(new LinkedHashSet<>(List.of("clientId","unknown!")))));
+        assertEquals("{\"error\":\"unknown! is an unknown field\"}", e.getResponse().readEntity(String.class));
+        assertEquals("fields=clientId,unknown!", getLastRequest().getUri().getQuery());
     }
 
     @Test

--- a/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
+++ b/rest/admin-v2/tests/src/test/java/org/keycloak/tests/admin/client/v2/ClientApiV2Test.java
@@ -370,7 +370,6 @@ public class ClientApiV2Test extends AbstractClientApiV2Test{
         // ensure that multiple fields are interpreted correctly
         e = assertThrows(BadRequestException.class, () -> getClientsApi().getClients(new ListOptions().fields(new LinkedHashSet<>(List.of("clientId","unknown!")))));
         assertEquals("{\"error\":\"unknown! is an unknown field\"}", e.getResponse().readEntity(String.class));
-        assertEquals("fields=clientId,unknown!", getLastRequest().getUri().getQuery());
     }
 
     @Test


### PR DESCRIPTION
Targeting the initial implementation issue, rather than opening an additional one.

Quarkus requires the use of an Separator annotation to handle a non-exploded option - even if the openapi metadata is inferred correctly. However that currently only works correctly with a BeanParam and Resteasy Reactive - https://github.com/quarkusio/quarkus/issues/31050

Resteasy Classic only understands its Separator annotation if it's used on a parameter - it can't be used on a field. So the easiest thing to do is roll our own support for now.

Also adding a way to programtically verify the last request - as it was not initially clear for me just from the json schema that the Set was being sent exploded. The cleanest way to do this seems to be by exposing the WebTarget used by the admin client - but this can be removed if it doesn't seem like there is enough value.

closes: #48734

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
