### PR TITLE
Use exact match in InvitationManager.getByEmail()

### DIFF
--- a/server-spi/src/main/java/org/keycloak/organization/InvitationManager.java
+++ b/server-spi/src/main/java/org/keycloak/organization/InvitationManager.java
@@ -39,6 +39,7 @@ public interface InvitationManager {
      */
     default OrganizationInvitationModel getByEmail(OrganizationModel organization, String email) {
         return getAllStream(organization, Map.of(Filter.EMAIL, email), null, null)
+                .filter(inv -> inv.getEmail().equalsIgnoreCase(email))
                 .findFirst()
                 .orElse(null);
     }


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
Close: #50063

This PR adds an `equalsIgnoreCase()` filter to `getByEmail()` to ensure exact email matching.
`getAllStream()` is intentionally left unchanged to preserve the existing partial-match search behavior in the Admin UI.