### PR TITLE
Use the configurable admin realm name instead of hard-coded "master" in the admin console

### DIFF
--- a/js/apps/admin-ui/src/PageHeader.tsx
+++ b/js/apps/admin-ui/src/PageHeader.tsx
@@ -12,6 +12,7 @@ import { HelpHeader } from "./components/help-enabler/HelpHeader";
 import { useAccess } from "./context/access/Access";
 import { useRealm } from "./context/realm-context/RealmContext";
 import { toDashboard } from "./dashboard/routes/Dashboard";
+import type { Environment } from "./environment-types";
 import { usePreviewLogo } from "./realm-settings/themes/LogoContext";
 import { joinPath } from "./utils/joinPath";
 import { useIsFeatureDisabled, Feature } from "./utils/useIsFeatureEnabled";
@@ -97,7 +98,7 @@ const userDropdownItems = (isMasterRealm: boolean, isManager: boolean) => [
 ];
 
 export const Header = () => {
-  const { environment, keycloak } = useEnvironment();
+  const { environment, keycloak } = useEnvironment<Environment>();
   const { t } = useTranslation();
   const { realm } = useRealm();
   const { hasAccess } = useAccess();
@@ -105,7 +106,7 @@ export const Header = () => {
   const contextLogo = usePreviewLogo();
   const customLogo = contextLogo?.logo;
 
-  const isMasterRealm = realm === "master";
+  const isMasterRealm = realm === environment.masterRealm;
   const isManager = hasAccess("manage-realm");
 
   const logo = environment.logo || "/logo.svg";

--- a/js/apps/admin-ui/src/components/permission-tab/PermissionTab.tsx
+++ b/js/apps/admin-ui/src/components/permission-tab/PermissionTab.tsx
@@ -1,5 +1,9 @@
 import type { ManagementPermissionReference } from "@keycloak/keycloak-admin-client/lib/defs/managementPermissionReference";
-import { HelpItem, useFetch } from "@keycloak/keycloak-ui-shared";
+import {
+  HelpItem,
+  useEnvironment,
+  useFetch,
+} from "@keycloak/keycloak-ui-shared";
 import {
   Card,
   CardBody,
@@ -25,6 +29,7 @@ import { useAdminClient } from "../../admin-client";
 import { toPermissionDetails } from "../../clients/routes/PermissionDetails";
 import { KeycloakSpinner } from "@keycloak/keycloak-ui-shared";
 import { useRealm } from "../../context/realm-context/RealmContext";
+import type { Environment } from "../../environment-types";
 import useLocaleSort from "../../utils/useLocaleSort";
 import { useConfirmDialog } from "../confirm-dialog/ConfirmDialog";
 
@@ -48,6 +53,11 @@ export const PermissionsTab = ({ id, type }: PermissionsTabProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { realm } = useRealm();
+  const { environment } = useEnvironment<Environment>();
+  const realmManagementClientId =
+    realm === environment.masterRealm
+      ? `${environment.masterRealm}-realm`
+      : "realm-management";
   const [realmId, setRealmId] = useState("");
   const [permission, setPermission] = useState<ManagementPermissionReference>();
   const localeSort = useLocaleSort();
@@ -81,7 +91,7 @@ export const PermissionsTab = ({ id, type }: PermissionsTabProps) => {
       Promise.all([
         adminClient.clients.find({
           search: true,
-          clientId: realm === "master" ? "master-realm" : "realm-management",
+          clientId: realmManagementClientId,
         }),
         (() => {
           switch (type) {
@@ -106,7 +116,7 @@ export const PermissionsTab = ({ id, type }: PermissionsTabProps) => {
       setRealmId(clients[0]?.id!);
       setPermission(permission);
     },
-    [id],
+    [id, realm, realmManagementClientId, type],
   );
 
   const [toggleDisableDialog, DisableConfirm] = useConfirmDialog({
@@ -170,13 +180,7 @@ export const PermissionsTab = ({ id, type }: PermissionsTabProps) => {
             <CardBody>
               <Trans i18nKey="permissionsListIntro">
                 {" "}
-                <strong>
-                  {{
-                    realm:
-                      realm === "master" ? "master-realm" : "realm-management",
-                  }}
-                </strong>
-                .
+                <strong>{{ realm: realmManagementClientId }}</strong>.
               </Trans>
             </CardBody>
           </Card>

--- a/js/apps/admin-ui/src/context/RecentRealms.tsx
+++ b/js/apps/admin-ui/src/context/RecentRealms.tsx
@@ -1,12 +1,14 @@
 import type RealmRepresentation from "@keycloak/keycloak-admin-client/lib/defs/realmRepresentation";
 import {
   createNamedContext,
+  useEnvironment,
   useFetch,
   useRequiredContext,
   useStoredState,
 } from "@keycloak/keycloak-ui-shared";
 import { PropsWithChildren, useEffect } from "react";
 import { useAdminClient } from "../admin-client";
+import type { Environment } from "../environment-types";
 import { useRealm } from "./realm-context/RealmContext";
 import { fetchAdminUI } from "./auth/admin-ui-endpoint";
 
@@ -29,6 +31,7 @@ function convertRealmToNameRepresentation(
 
 export const RecentRealmsProvider = ({ children }: PropsWithChildren) => {
   const { realmRepresentation: realm } = useRealm();
+  const { environment } = useEnvironment<Environment>();
   const { adminClient } = useAdminClient();
 
   const [storedRealms, setStoredRealms] = useStoredState(
@@ -59,7 +62,7 @@ export const RecentRealmsProvider = ({ children }: PropsWithChildren) => {
         }),
       ),
     (realms) => setStoredRealms(realms.filter((r) => !!r)),
-    [realm.realm === "master"],
+    [realm.realm === environment.masterRealm],
   );
 
   useEffect(() => {

--- a/js/apps/admin-ui/src/dashboard/Dashboard.tsx
+++ b/js/apps/admin-ui/src/dashboard/Dashboard.tsx
@@ -40,6 +40,7 @@ import {
 } from "../components/routable-tabs/RoutableTabs";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useServerInfo } from "../context/server-info/ServerInfoProvider";
+import type { Environment } from "../environment-types";
 import helpUrls from "../help-urls";
 import { resolveDisplayName } from "../util";
 import useLocaleSort, { mapByKey } from "../utils/useLocaleSort";
@@ -354,7 +355,8 @@ const Dashboard = () => {
 
 export default function DashboardSection() {
   const { realm } = useRealm();
-  const isMasterRealm = realm === "master";
+  const { environment } = useEnvironment<Environment>();
+  const isMasterRealm = realm === environment.masterRealm;
   return (
     <>
       {!isMasterRealm && <EmptyDashboard />}

--- a/js/apps/admin-ui/src/realm/RealmSection.tsx
+++ b/js/apps/admin-ui/src/realm/RealmSection.tsx
@@ -1,5 +1,9 @@
 import { NetworkError } from "@keycloak/keycloak-admin-client";
-import { KeycloakDataTable, useAlerts } from "@keycloak/keycloak-ui-shared";
+import {
+  KeycloakDataTable,
+  useAlerts,
+  useEnvironment,
+} from "@keycloak/keycloak-ui-shared";
 import {
   AlertVariant,
   Badge,
@@ -24,6 +28,7 @@ import { fetchAdminUI } from "../context/auth/admin-ui-endpoint";
 import { useRealm } from "../context/realm-context/RealmContext";
 import { useRecentRealms } from "../context/RecentRealms";
 import { useWhoAmI } from "../context/whoami/WhoAmI";
+import type { Environment } from "../environment-types";
 import { resolveDisplayName } from "../util";
 import NewRealmForm from "./add/NewRealmForm";
 import { toRealm } from "./RealmRoutes";
@@ -120,6 +125,7 @@ export default function RealmSection() {
   const navigate = useNavigate();
   const { whoAmI } = useWhoAmI();
   const { realm } = useRealm();
+  const { environment } = useEnvironment<Environment>();
   const { adminClient } = useAdminClient();
   const { addAlert, addError } = useAlerts();
 
@@ -154,10 +160,12 @@ export default function RealmSection() {
     continueButtonLabel: "delete",
     onConfirm: async () => {
       try {
-        if (selected.filter(({ name }) => name === "master").length > 0) {
+        if (selected.some(({ name }) => name === environment.masterRealm)) {
           addAlert(t("cantDeleteMasterRealm"), AlertVariant.warning);
         }
-        const filtered = selected.filter(({ name }) => name !== "master");
+        const filtered = selected.filter(
+          ({ name }) => name !== environment.masterRealm,
+        );
         if (filtered.length === 0) return;
         await Promise.all(
           filtered.map(({ name: realmName }) =>
@@ -165,8 +173,8 @@ export default function RealmSection() {
           ),
         );
         addAlert(t("deletedSuccessRealmSetting"));
-        if (selected.filter(({ name }) => name === realm).length > 0) {
-          navigate(toRealm({ realm: "master" }));
+        if (selected.some(({ name }) => name === realm)) {
+          navigate(toRealm({ realm: environment.masterRealm }));
         }
         refresh();
         setSelected([]);


### PR DESCRIPTION
The admin UI contained several hard-coded checks against the literal realm name "master" and the client id "master-realm". When Keycloak is started with a custom admin realm name via `KC_SPI_ADMIN_REALM`, those checks silently failed and administrative features such as Server Info, Provider Info, Clear Caches, and the permissions tab disappeared.

This change replaces those hard-coded string comparisons with the configurable `environment.masterRealm` value (and the matching `${masterRealm}-realm` client id), so that whichever realm is configured as the initial admin realm is treated consistently throughout the admin UI.

Resolves #47523

Changes:
- `PageHeader.tsx`: compute `isMasterRealm` from `environment.masterRealm` instead of comparing to the literal `"master"`.
- `components/permission-tab/PermissionTab.tsx`: look up the realm management client id from `environment.masterRealm` (yielding `${masterRealm}-realm` for the admin realm, `realm-management` otherwise) and use it for both the client lookup and the rendered description.
- `context/RecentRealms.tsx`: base the "always include in recent realms" check on `environment.masterRealm`.
- `dashboard/Dashboard.tsx`: derive `isMasterRealm` from `environment.masterRealm` when deciding whether to render the empty dashboard.
- `realm/RealmSection.tsx`: protect the master realm from deletion, filter it out of bulk deletes, and fall back to the master realm navigation target using `environment.masterRealm`.