### PR TITLE
Enforce path containment in FolderTheme.getTemplate()

### DIFF
--- a/services/src/main/java/org/keycloak/theme/FolderTheme.java
+++ b/services/src/main/java/org/keycloak/theme/FolderTheme.java
@@ -84,8 +84,8 @@ public class FolderTheme extends FileBasedTheme {
 
     @Override
     public URL getTemplate(String name) throws IOException {
-        File file = new File(themeDir, name);
-        return file.isFile() ? file.toURI().toURL() : null;
+        File file = ResourceLoader.getFile(themeDir, name);
+        return file != null && file.isFile() ? file.toURI().toURL() : null;
     }
 
     @Override

--- a/services/src/test/java/org/keycloak/theme/FolderThemeTest.java
+++ b/services/src/test/java/org/keycloak/theme/FolderThemeTest.java
@@ -18,16 +18,28 @@
 package org.keycloak.theme;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.Set;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.keycloak.theme.Theme.Type.LOGIN;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class FolderThemeTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String NONE = "../";
 
     private final Set<String> someValidISOLocaleCodes = Set.of("de", "de-DE", "de-x-informal");
 
@@ -39,5 +51,33 @@ public class FolderThemeTest {
             Locale locale = Locale.forLanguageTag(localeCode);
             assertNotNull(theme.getMessages("base", locale));
         }
+    }
+
+    @Test
+    public void testGetTemplatePathContainment() throws Exception {
+        File tempDirectory = temporaryFolder.newFolder();
+        File themeDir = new File(tempDirectory, "login");
+        assertTrue("Failed to create theme directory: " + themeDir, themeDir.mkdirs());
+        assertTrue("Failed to create theme subdirectory", new File(themeDir, "one").mkdir());
+
+        Files.createFile(themeDir.toPath().resolve("login.ftl"));
+        Files.createFile(tempDirectory.toPath().resolve("forbidden.ftl"));
+
+        FolderTheme theme = new FolderTheme(themeDir, "name", LOGIN);
+
+        assertGetTemplate(theme, themeDir, "login.ftl", true);
+        assertGetTemplate(theme, themeDir, NONE + "forbidden.ftl", false);
+        assertGetTemplate(theme, themeDir, "one/" + NONE + NONE + "forbidden.ftl", false);
+    }
+
+    private void assertGetTemplate(FolderTheme theme, File themeDir, String name, boolean expectValid) throws IOException {
+        URL template = theme.getTemplate(name);
+        if (expectValid) {
+            assertNotNull(template);
+        } else {
+            assertNull(template);
+        }
+
+        assertTrue(new File(themeDir, name).getCanonicalFile().isFile());
     }
 }


### PR DESCRIPTION
## Summary
- Route `FolderTheme.getTemplate()` through `ResourceLoader.getFile()` for parity with `getResourceAsStream()`
- Reject template names containing `../` or encoded traversal sequences that escape `themeDir`
- Add `testGetTemplatePathContainment` covering valid and traversal paths
## Test plan
- [x] `mvn test -Dtest=FolderThemeTest,ResourceLoaderTest` in `services` module
- [ ] Custom folder theme still loads templates normally (e.g. `login.ftl`)
Closes #49961