### PR TITLE
Use versioned FreeMarker Configuration defaults

### DIFF
--- a/services/src/main/java/org/keycloak/theme/freemarker/DefaultFreeMarkerProvider.java
+++ b/services/src/main/java/org/keycloak/theme/freemarker/DefaultFreeMarkerProvider.java
@@ -56,7 +56,7 @@ public class DefaultFreeMarkerProvider implements FreeMarkerProvider {
     }
 
     private Template getTemplate(String templateName, Theme theme) throws IOException {
-        Configuration cfg = new Configuration();
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_32);
 
         // Assume *.ftl files are html.  This lets freemarker know how to
         // sanitize and prevent XSS attacks.


### PR DESCRIPTION
Summary

- Replace deprecated `new Configuration() `with `new Configuration(Configuration.VERSION_2_3_32)` in `DefaultFreeMarkerProvider`.
- Avoid legacy FreeMarker 2.3.0 defaults and opt into the bundled FreeMarker version’s security/correctness improvements.

Fix #49922