### PR TITLE
Return HTTP 400 for malformed Content-Type header

### DIFF
--- a/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersProvider.java
+++ b/services/src/main/java/org/keycloak/headers/DefaultSecurityHeadersProvider.java
@@ -71,7 +71,7 @@ public class DefaultSecurityHeadersProvider implements SecurityHeadersProvider {
             return;
         }
 
-        MediaType requestType = requestContext.getMediaType();
+        MediaType requestType = safeGetRequestMediaType(requestContext);
         MediaType responseType = responseContext.getMediaType();
         MultivaluedMap<String, Object> headers = responseContext.getHeaders();
 
@@ -86,6 +86,15 @@ public class DefaultSecurityHeadersProvider implements SecurityHeadersProvider {
             addHtmlHeaders(headers);
         } else {
             addGenericHeaders(headers);
+        }
+    }
+
+    private MediaType safeGetRequestMediaType(ContainerRequestContext requestContext) {
+        try {
+            return requestContext.getMediaType();
+        } catch (IllegalArgumentException e) {
+            LOGGER.trace("Malformed Content-Type header");
+            return null;
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/filters/InvalidContentTypeHeaderFilter.java
+++ b/services/src/main/java/org/keycloak/services/filters/InvalidContentTypeHeaderFilter.java
@@ -1,0 +1,41 @@
+package org.keycloak.services.filters;
+
+import java.io.IOException;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
+
+import org.jboss.logging.Logger;
+
+@Provider
+@PreMatching
+@Priority(10)
+public class InvalidContentTypeHeaderFilter implements ContainerRequestFilter {
+
+    private static final Logger LOGGER = Logger.getLogger(InvalidContentTypeHeaderFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String contentType = requestContext.getHeaderString(HttpHeaders.CONTENT_TYPE);
+        if (contentType == null) {
+            return;
+        }
+
+        if (contentType.isBlank()) {
+            LOGGER.debugf("Request with invalid Content-Type header value is blocked");
+            throw new BadRequestException("Invalid Content-Type header");
+        }
+
+        try {
+            requestContext.getMediaType();
+        } catch (IllegalArgumentException e) {
+            LOGGER.debugf("Request with invalid Content-Type header value is blocked");
+            throw new BadRequestException("Invalid Content-Type header");
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
+++ b/services/src/test/java/org/keycloak/services/resteasy/ResteasyKeycloakApplication.java
@@ -31,6 +31,7 @@ import org.keycloak.services.DefaultKeycloakSessionFactory;
 import org.keycloak.services.error.KcUnrecognizedPropertyExceptionHandler;
 import org.keycloak.services.error.KeycloakErrorHandler;
 import org.keycloak.services.error.KeycloakMismatchedInputExceptionHandler;
+import org.keycloak.services.filters.InvalidContentTypeHeaderFilter;
 import org.keycloak.services.filters.InvalidQueryParameterFilter;
 import org.keycloak.services.filters.KeycloakSecurityHeadersFilter;
 import org.keycloak.services.resources.KeycloakApplication;
@@ -60,6 +61,7 @@ public class ResteasyKeycloakApplication extends KeycloakApplication {
         }
         classes.add(ThemeResource.class);
         classes.add(InvalidQueryParameterFilter.class);
+        classes.add(InvalidContentTypeHeaderFilter.class);
         classes.add(KeycloakSecurityHeadersFilter.class);
         classes.add(KeycloakErrorHandler.class);
         classes.add(KcUnrecognizedPropertyExceptionHandler.class);

--- a/tests/base/src/test/java/org/keycloak/tests/oidc/MalformedContentTypeHeaderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oidc/MalformedContentTypeHeaderTest.java
@@ -1,0 +1,86 @@
+package org.keycloak.tests.oidc;
+
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KeycloakIntegrationTest
+class MalformedContentTypeHeaderTest {
+
+    private static final String MALFORMED_CONTENT_TYPE = "application/jso@n";
+
+    @InjectHttpClient
+    HttpClient httpClient;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @Test
+    void malformedContentTypeOnUserInfoReturnsBadRequest() throws Exception {
+        HttpGet get = new HttpGet(oauth.getEndpoints().getUserInfo());
+        get.setHeader("Content-Type", MALFORMED_CONTENT_TYPE);
+
+        HttpResponse response = httpClient.execute(get);
+        try {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+        } finally {
+            if (response.getEntity() != null) {
+                response.getEntity().getContent().close();
+            }
+        }
+    }
+
+    @Test
+    void malformedContentTypeOnWellKnownReturnsBadRequest() throws Exception {
+        HttpGet get = new HttpGet(oauth.getEndpoints().getOpenIDConfiguration());
+        get.setHeader("Content-Type", MALFORMED_CONTENT_TYPE);
+
+        HttpResponse response = httpClient.execute(get);
+        try {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+        } finally {
+            if (response.getEntity() != null) {
+                response.getEntity().getContent().close();
+            }
+        }
+    }
+
+    @Test
+    void blankContentTypeOnUserInfoReturnsBadRequest() throws Exception {
+        HttpGet get = new HttpGet(oauth.getEndpoints().getUserInfo());
+        get.setHeader("Content-Type", "   ");
+
+        HttpResponse response = httpClient.execute(get);
+        try {
+            assertThat(response.getStatusLine().getStatusCode(), is(400));
+        } finally {
+            if (response.getEntity() != null) {
+                response.getEntity().getContent().close();
+            }
+        }
+    }
+
+    @Test
+    void validContentTypeOnUserInfoIsNotRejected() throws Exception {
+        HttpGet get = new HttpGet(oauth.getEndpoints().getUserInfo());
+        get.setHeader("Content-Type", "application/json");
+
+        HttpResponse response = httpClient.execute(get);
+        try {
+            assertThat(response.getStatusLine().getStatusCode(), is(401));
+        } finally {
+            if (response.getEntity() != null) {
+                response.getEntity().getContent().close();
+            }
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/suites/Base3TestSuite.java
+++ b/tests/base/src/test/java/org/keycloak/tests/suites/Base3TestSuite.java
@@ -7,6 +7,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectPackages({
         "org.keycloak.tests.model",
         "org.keycloak.tests.oauth",
+        "org.keycloak.tests.oidc",
         "org.keycloak.tests.organization",
         "org.keycloak.tests.oid4vc",
         "org.keycloak.tests.policy",


### PR DESCRIPTION
## Summary
- Reject syntactically invalid `Content-Type` headers with HTTP 400 via a new request filter
- Add defensive parsing in `DefaultSecurityHeadersProvider` to prevent `IllegalArgumentException` from becoming HTTP 500

Closes #49785
