### PR TITLE
[OID4VCI] Fix c_nonce replay protection

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -116,6 +116,7 @@ import org.keycloak.protocol.oidc.grants.PreAuthorizedCodeGrantType;
 import org.keycloak.protocol.oidc.rar.AuthorizationDetailsProcessor;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.AuthorizationDetailsJSONRepresentation;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.dpop.DPoP;
 import org.keycloak.saml.processing.api.util.DeflateUtil;
 import org.keycloak.services.CorsErrorResponseException;
@@ -998,19 +999,22 @@ public class OID4VCIssuerEndpoint {
                 OID4VCIssuerWellKnownProvider.toSupportedCredentialConfiguration(session, authorizedCredentialScope);
 
         enforceProofContractForCredential(supportedCredential, credentialRequest.getProofs());
+        Map<String, JsonWebToken> verifiedProofCNonces = new HashMap<>();
 
         // Get the list of all proofs (handles single proof, multiple proofs, or none)
         List<String> allProofs = getAllProofs(credentialRequest);
-        if (allProofs.stream().anyMatch(p -> p == null || p.isBlank()))
+        if (allProofs.stream().anyMatch(p -> p == null || p.isBlank())) {
             throw new BadRequestException(getErrorResponse(ErrorType.INVALID_PROOF, "Proof values must not be null or blank"));
+        }
 
-        // Generate credential response
-        CredentialResponse responseVO = new CredentialResponse();
+        // Prepare credential bodies and validate key binding proofs before consuming the nonce.
+        List<VCIssuanceContext> vcIssuanceContexts = new ArrayList<>();
 
         if (allProofs.isEmpty()) {
             // Single issuance without proof
-            Object theCredential = getCredential(authResult, supportedCredential, tokenAuthDetail, credentialRequest, eventBuilder);
-            responseVO.addCredential(theCredential);
+            VCIssuanceContext vcIssuanceContext = prepareCredential(authResult, supportedCredential, tokenAuthDetail, credentialRequest, eventBuilder);
+            vcIssuanceContexts.add(vcIssuanceContext);
+            verifiedProofCNonces.putAll(vcIssuanceContext.getVerifiedCNonces());
         } else {
             // Issue credentials for each proof
             Proofs originalProofs = credentialRequest.getProofs();
@@ -1027,14 +1031,28 @@ public class OID4VCIssuerEndpoint {
                 }
             }
 
-            for (String currentProof : allProofs) {
-                Proofs proofForIteration = Proofs.create(proofType, currentProof);
-                // Creating credential with keybinding to the current proof
-                credentialRequest.setProofs(proofForIteration);
-                Object theCredential = getCredential(authResult, supportedCredential, tokenAuthDetail, credentialRequest, eventBuilder);
-                responseVO.addCredential(theCredential);
+            try {
+                for (String currentProof : allProofs) {
+                    Proofs proofForIteration = Proofs.create(proofType, currentProof);
+                    // Creating credential with keybinding to the current proof
+                    credentialRequest.setProofs(proofForIteration);
+                    VCIssuanceContext vcIssuanceContext = prepareCredential(authResult, supportedCredential, tokenAuthDetail, credentialRequest, eventBuilder);
+                    vcIssuanceContexts.add(vcIssuanceContext);
+                    verifiedProofCNonces.putAll(vcIssuanceContext.getVerifiedCNonces());
+                }
+            } finally {
+                credentialRequest.setProofs(originalProofs);
             }
-            credentialRequest.setProofs(originalProofs);
+        }
+
+        // Fail-fast if any cnonce already consumed without consuming it
+        rejectConsumedProofCNonce(verifiedProofCNonces);
+
+        // Generate credential response before consuming the nonce, so server-side signing/encryption failures do not
+        // burn an otherwise valid proof nonce.
+        CredentialResponse responseVO = new CredentialResponse();
+        for (VCIssuanceContext vcIssuanceContext : vcIssuanceContexts) {
+            responseVO.addCredential(signCredential(supportedCredential, vcIssuanceContext, eventBuilder));
         }
 
         // Encrypt all responses if encryption parameters are provided, except for error credential responses
@@ -1052,6 +1070,9 @@ public class OID4VCIssuerEndpoint {
                     .entity(responseVO)
                     .build();
         }
+
+        // Consume cnonce to prevent replay
+        consumeProofCNonce(verifiedProofCNonces);
 
         // Mark event as successful
         eventBuilder.detail(Details.SCOPE, supportedCredential.getScope())
@@ -1349,6 +1370,52 @@ public class OID4VCIssuerEndpoint {
         return proofs.getAllProofs();
     }
 
+    private CNonceHandler getCNonceHandlerForProofValidation() {
+        CNonceHandler cNonceHandler = session.getProvider(CNonceHandler.class);
+
+        if (cNonceHandler == null) {
+            throw new ErrorResponseException(INVALID_PROOF.getValue(), "CNonce handler not configured", Response.Status.BAD_REQUEST);
+        }
+
+        if (!cNonceHandler.supportsCNonceConsumption()) {
+            throw new ErrorResponseException(INVALID_PROOF.getValue(), "CNonce handler does not support nonce consumption", Response.Status.BAD_REQUEST);
+        }
+
+        return  cNonceHandler;
+    }
+
+    private void rejectConsumedProofCNonce(Map<String, JsonWebToken> verifiedCNonces) {
+        if (verifiedCNonces.isEmpty()) {
+            return;
+        }
+
+        CNonceHandler cNonceHandler = getCNonceHandlerForProofValidation();
+
+        for (Map.Entry<String, JsonWebToken> cNonce : verifiedCNonces.entrySet()) {
+            try {
+                cNonceHandler.ensureCNonceNotYetConsumed(cNonce.getKey());
+            } catch (VerificationException e) {
+                throw new ErrorResponseException(INVALID_NONCE.getValue(), e.getMessage(), Response.Status.BAD_REQUEST);
+            }
+        }
+    }
+
+    private void consumeProofCNonce(Map<String, JsonWebToken> verifiedCNonces) {
+        if (verifiedCNonces.isEmpty()) {
+            return;
+        }
+
+        CNonceHandler cNonceHandler = getCNonceHandlerForProofValidation();
+
+        for (Map.Entry<String, JsonWebToken> cNonce : verifiedCNonces.entrySet()) {
+            try {
+                cNonceHandler.consumeCNonce(cNonce.getKey(), cNonce.getValue());
+            } catch (VerificationException e) {
+                throw new ErrorResponseException(INVALID_NONCE.getValue(), e.getMessage(), Response.Status.BAD_REQUEST);
+            }
+        }
+    }
+
     private void enforceProofContractForCredential(SupportedCredentialConfiguration credentialConfiguration, Proofs proofs) {
         boolean proofConfigured = credentialConfiguration != null
                 && credentialConfiguration.getProofTypesSupported() != null
@@ -1605,20 +1672,13 @@ public class OID4VCIssuerEndpoint {
     }
 
     /**
-     * Get a signed credential
-     *
-     * @param authResult          authResult containing the userSession to create the credential for
-     * @param credentialConfig    the supported credential configuration
-     * @param authDetail          Parsed OID4VC authorization_detail
-     * @param credentialRequestVO the credential request
-     * @param eventBuilder        the event builder for logging events
-     * @return the signed credential
+     * Prepare an unsigned credential and validate any key binding proof before signing.
      */
-    private Object getCredential(AuthenticationManager.AuthResult authResult,
-                                 SupportedCredentialConfiguration credentialConfig,
-                                 OID4VCAuthorizationDetail authDetail,
-                                 CredentialRequest credentialRequestVO,
-                                 EventBuilder eventBuilder
+    private VCIssuanceContext prepareCredential(AuthenticationManager.AuthResult authResult,
+                                                SupportedCredentialConfiguration credentialConfig,
+                                                OID4VCAuthorizationDetail authDetail,
+                                                CredentialRequest credentialRequestVO,
+                                                EventBuilder eventBuilder
     ) {
 
         // Get the client scope model from the credential configuration
@@ -1645,6 +1705,12 @@ public class OID4VCIssuerEndpoint {
         // Enforce key binding prior to signing if necessary
         enforceKeyBindingIfProofProvided(vcIssuanceContext);
 
+        return vcIssuanceContext;
+    }
+
+    private Object signCredential(SupportedCredentialConfiguration credentialConfig,
+                                  VCIssuanceContext vcIssuanceContext,
+                                  EventBuilder eventBuilder) {
         // Retrieve matching credential signer
         CredentialSigner<?> credentialSigner = session.getProvider(CredentialSigner.class,
                 credentialConfig.getFormat());

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/VCIssuanceContext.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/VCIssuanceContext.java
@@ -16,13 +16,17 @@
  */
 package org.keycloak.protocol.oid4vc.issuance;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.protocol.oid4vc.issuance.credentialbuilder.CredentialBody;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.services.managers.AuthenticationManager;
 
 /**
@@ -41,6 +45,8 @@ public class VCIssuanceContext {
     private AuthenticationManager.AuthResult authResult;
 
     private List<JWK> attestedKeys;
+
+    private Map<String, JsonWebToken> verifiedCNonces = new LinkedHashMap<>();
 
 
     public CredentialBody getCredentialBody() {
@@ -81,6 +87,15 @@ public class VCIssuanceContext {
 
     public VCIssuanceContext setAttestedKeys(List<JWK> attestedKeys) {
         this.attestedKeys = attestedKeys;
+        return this;
+    }
+
+    public Map<String, JsonWebToken> getVerifiedCNonces() {
+        return Collections.unmodifiableMap(verifiedCNonces);
+    }
+
+    public VCIssuanceContext addVerifiedCNonce(String cNonce, JsonWebToken cNonceToken) {
+        verifiedCNonces.put(cNonce, cNonceToken);
         return this;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationProofValidator.java
@@ -20,13 +20,8 @@ package org.keycloak.protocol.oid4vc.issuance.keybinding;
 import java.util.List;
 import java.util.Optional;
 
-import org.keycloak.common.util.Time;
-import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.jose.jwk.JWK;
-import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuanceContext;
 import org.keycloak.protocol.oid4vc.issuance.VCIssuerException;
 import org.keycloak.protocol.oid4vc.model.ErrorType;
@@ -34,10 +29,6 @@ import org.keycloak.protocol.oid4vc.model.KeyAttestationJwtBody;
 import org.keycloak.protocol.oid4vc.model.ProofType;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oid4vc.model.SupportedCredentialConfiguration;
-
-import org.apache.commons.codec.binary.Hex;
-
-import static org.keycloak.protocol.oid4vc.model.ErrorType.INVALID_NONCE;
 
 /**
  * Validates attestation proofs as per OID4VCI specification.
@@ -75,19 +66,6 @@ public class AttestationProofValidator extends AbstractProofValidator {
 
             if (attestationBody.getAttestedKeys() == null || attestationBody.getAttestedKeys().isEmpty()) {
                 throw new VCIssuerException(ErrorType.INVALID_PROOF, "No valid attested keys found in attestation proof");
-            }
-
-            // Nonce replay protection
-            //
-            String nonce = attestationBody.getNonce();
-            if (nonce != null) {
-                RealmModel realmModel = keycloakSession.getContext().getRealm();
-                SingleUseObjectProvider singleUseCache = keycloakSession.singleUseObjects();
-                String hashString = Hex.encodeHexString(HashUtils.hash("SHA1", nonce.getBytes()));
-                Long nonceLifetimeSeconds = realmModel.getAttribute(OID4VCIConstants.C_NONCE_LIFETIME_IN_SECONDS, 60L);
-                if (!singleUseCache.putIfAbsent(hashString, Time.currentTime() + 10 * nonceLifetimeSeconds)) {
-                    throw new VCIssuerException(INVALID_NONCE, "Nonce in proof has already been used");
-                }
             }
 
             return attestationBody.getAttestedKeys();

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/AttestationValidatorUtil.java
@@ -196,24 +196,29 @@ public class AttestationValidatorUtil {
 
         KeycloakContext keycloakContext = keycloakSession.getContext();
         CNonceHandler cNonceHandler = keycloakSession.getProvider(CNonceHandler.class);
+        if (cNonceHandler == null) {
+            throw new VCIssuerException(ErrorType.INVALID_PROOF, "CNonce handler not configured");
+        }
+        if (!cNonceHandler.supportsCNonceTokenRetrieval()) {
+            throw new VCIssuerException(ErrorType.INVALID_PROOF, "CNonce handler does not support token retrieval");
+        }
 
-        if (attestationBody.getNonce() == null) {
+        String nonce = attestationBody.getNonce();
+        if (nonce == null) {
             throw new VCIssuerException(ErrorType.INVALID_PROOF, "Missing 'nonce' in attestation");
         }
 
-        // Validate nonce if present. If provided, it must correspond to a nonce value provided by Keycloak.
-        if (attestationBody.getNonce() != null) {
-            try {
-                cNonceHandler.verifyCNonce(
-                        attestationBody.getNonce(),
-                        List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
-                        Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
-                                OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext))
-                );
-            } catch (VerificationException e) {
-                throw new VCIssuerException(ErrorType.INVALID_NONCE,
-                        "The key attestation uses an invalid nonce", e);
-            }
+        try {
+            vcIssuanceContext.addVerifiedCNonce(
+                    nonce,
+                    cNonceHandler.verifyCNonceAndGetToken(
+                            nonce,
+                            List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
+                            Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                                    OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext))));
+        } catch (VerificationException e) {
+            throw new VCIssuerException(ErrorType.INVALID_NONCE,
+                    "The key attestation uses an invalid nonce", e);
         }
 
         // Store attested keys in context for later use

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/CNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/CNonceHandler.java
@@ -25,6 +25,7 @@ import jakarta.annotation.Nullable;
 
 import org.keycloak.common.VerificationException;
 import org.keycloak.provider.Provider;
+import org.keycloak.representations.JsonWebToken;
 
 /**
  * @author Pascal Knüppel
@@ -49,8 +50,65 @@ public interface CNonceHandler extends Provider {
      * @param audiences         the expected audiences for jwt-based cNonces
      * @param additionalDetails additional attributes that might be required to build the cNonce and that are handler
      *                          specific
+     * @throws VerificationException if the cNonce cannot be verified
      */
     public void verifyCNonce(String cNonce, List<String> audiences, @Nullable Map<String, Object> additionalDetails) throws VerificationException;
+
+    /**
+     * Verifies the validity of a cNonce value and returns its verified token representation.
+     *
+     * @param cNonce            the cNonce to validate
+     * @param audiences         the expected audiences for jwt-based cNonces
+     * @param additionalDetails additional attributes that might be required to build the cNonce and that are handler
+     *                          specific
+     * @return the verified cNonce token representation
+     * @throws VerificationException if the cNonce cannot be verified
+     */
+    public default JsonWebToken verifyCNonceAndGetToken(String cNonce, List<String> audiences, @Nullable Map<String, Object> additionalDetails)
+            throws VerificationException {
+        throw new VerificationException("c_nonce token retrieval is not supported");
+    }
+
+    /**
+     * @return {@code true} if this handler can return the verified cNonce token representation.
+     */
+    public default boolean supportsCNonceTokenRetrieval() {
+        return false;
+    }
+
+    /**
+     * Marks a verified cNonce value as consumed.
+     *
+     * @param cNonce the cNonce to consume
+     */
+    public default void consumeCNonce(String cNonce) throws VerificationException {
+        throw new VerificationException("c_nonce consumption is not supported");
+    }
+
+    /**
+     * Marks a verified cNonce value as consumed.
+     *
+     * @param cNonce      the cNonce to consume
+     * @param cNonceToken the already verified cNonce token
+     */
+    public default void consumeCNonce(String cNonce, JsonWebToken cNonceToken) throws VerificationException {
+        consumeCNonce(cNonce);
+    }
+
+    /**
+     * @return {@code true} if this handler can mark cNonce values as consumed.
+     */
+    public default boolean supportsCNonceConsumption() {
+        return false;
+    }
+
+    /**
+     * Checks if {@code cNonce} is so far not yet consumed (without consuming it) for fail-fast purposes.
+     * @throws VerificationException if already consumed or check not supported.
+     */
+    default void ensureCNonceNotYetConsumed(String cNonce) throws VerificationException {
+        throw new VerificationException("c_nonce consumption check is not supported");
+    }
 
     @Override
     default void close() {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtCNonceHandler.java
@@ -18,11 +18,13 @@
 
 package org.keycloak.protocol.oid4vc.issuance.keybinding;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -41,9 +43,11 @@ import org.keycloak.crypto.SignatureProvider;
 import org.keycloak.crypto.SignatureSignerContext;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.jose.jws.crypto.HashUtils;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SingleUseObjectProvider;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
 import org.keycloak.protocol.oid4vc.model.JwtCNonce;
 import org.keycloak.representations.JsonWebToken;
@@ -61,6 +65,8 @@ public class JwtCNonceHandler implements CNonceHandler {
     public static final int NONCE_DEFAULT_LENGTH = 50;
 
     public static final int NONCE_LENGTH_RANDOM_OFFSET = 15;
+
+    private static final long CONSUMED_NONCE_CACHE_CLOCK_SKEW_SECONDS = 60;
 
     private static final Logger logger = Logger.getLogger(JwtCNonceHandler.class);
 
@@ -103,9 +109,19 @@ public class JwtCNonceHandler implements CNonceHandler {
     @Override
     public void verifyCNonce(String cNonce, List<String> audiences, @Nullable Map<String, Object> additionalDetails)
             throws VerificationException {
-        if (cNonce == null) {
+        verifyCNonceAndGetToken(cNonce, audiences, additionalDetails);
+    }
+
+    @Override
+    public JsonWebToken verifyCNonceAndGetToken(String cNonce, List<String> audiences, @Nullable Map<String, Object> additionalDetails)
+            throws VerificationException {
+        if (cNonce == null || cNonce.trim().isEmpty()) {
             throw new VerificationException("c_nonce is required");
         }
+
+        // Reject already consumed nonces
+        ensureCNonceNotYetConsumed(cNonce);
+
         TokenVerifier<JsonWebToken> verifier = TokenVerifier.create(cNonce, JsonWebToken.class);
         KeycloakContext keycloakContext = keycloakSession.getContext();
         List<TokenVerifier.Predicate<JsonWebToken>> verifiers = //
@@ -167,7 +183,83 @@ public class JwtCNonceHandler implements CNonceHandler {
                                                                                  signingKey.getAlgorithm())
                                                                     .verifier(signingKey);
         verifier.verifierContext(signatureVerifier);
-        verifier.verify(); // throws a VerificationException on failure
+        return verifier.verify().getToken();
+    }
+
+    @Override
+    public boolean supportsCNonceTokenRetrieval() {
+        return true;
+    }
+
+    @Override
+    public void ensureCNonceNotYetConsumed(String cNonce) throws VerificationException {
+        if (keycloakSession.singleUseObjects().contains(getCNonceSingleUseObjectKey(cNonce))) {
+            throw new VerificationException("c_nonce has already been used");
+        }
+    }
+
+    @Override
+    public void consumeCNonce(String cNonce) throws VerificationException {
+        if (cNonce == null || cNonce.trim().isEmpty()) {
+            throw new VerificationException("c_nonce is required");
+        }
+
+        try {
+            TokenVerifier<JsonWebToken> verifier = TokenVerifier.create(cNonce, JsonWebToken.class);
+            SignatureVerifierContext signatureVerifier = keycloakSession.getProvider(SignatureProvider.class,
+                                                                                     signingKey.getAlgorithm())
+                                                                        .verifier(signingKey);
+            verifier.verifierContext(signatureVerifier);
+            JsonWebToken cNonceToken = verifier.verify().getToken();
+            consumeCNonce(cNonce, cNonceToken);
+        } catch (VerificationException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new VerificationException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void consumeCNonce(String cNonce, JsonWebToken cNonceToken) throws VerificationException {
+        if (cNonce == null || cNonce.trim().isEmpty()) {
+            throw new VerificationException("c_nonce is required");
+        }
+        if (cNonceToken == null) {
+            throw new VerificationException("c_nonce token is required");
+        }
+
+        Long exp = cNonceToken.getExp();
+        if (exp == null) {
+            throw new VerificationException("c_nonce has no expiration time");
+        }
+
+        long now = Time.currentTime();
+        long expiresIn = exp - now + CONSUMED_NONCE_CACHE_CLOCK_SKEW_SECONDS;
+        if (expiresIn <= 0) {
+            String message = String.format(
+                    "c_nonce not valid: %s(exp) < %s(now)",
+                    exp,
+                    now);
+            throw new VerificationException(message);
+        }
+
+        SingleUseObjectProvider singleUseStore = keycloakSession.singleUseObjects();
+        String key = getCNonceSingleUseObjectKey(cNonce);
+        boolean firstInsertion = singleUseStore.putIfAbsent(key, expiresIn);
+        if (!firstInsertion) {
+            throw new VerificationException("c_nonce has already been used");
+        }
+    }
+
+    @Override
+    public boolean supportsCNonceConsumption() {
+        return true;
+    }
+
+    private static String getCNonceSingleUseObjectKey(String cNonce) {
+        String hash = HashUtils.sha256UrlEncodedHash(cNonce.trim(), StandardCharsets.UTF_8);
+        String fqcn = JwtCNonceHandler.class.getName().toLowerCase(Locale.ROOT);
+        return fqcn + "." + hash;
     }
 
     protected boolean checkAttributeEquality(String key, Object object, Object actualValue) throws VerificationException {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/keybinding/JwtProofValidator.java
@@ -456,11 +456,17 @@ public class JwtProofValidator extends AbstractProofValidator {
         if (cNonceHandler == null) {
             throw new VCIssuerException(ErrorType.INVALID_PROOF, "CNonce handler not configured");
         }
+        if (!cNonceHandler.supportsCNonceTokenRetrieval()) {
+            throw new VCIssuerException(ErrorType.INVALID_PROOF, "CNonce handler does not support token retrieval");
+        }
         try {
-            cNonceHandler.verifyCNonce(proofPayload.getNonce(),
-                    List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
-                    Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
-                            OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+            vcIssuanceContext.addVerifiedCNonce(
+                    proofPayload.getNonce(),
+                    cNonceHandler.verifyCNonceAndGetToken(
+                            proofPayload.getNonce(),
+                            List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
+                            Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                                    OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext))));
         } catch (VerificationException e) {
             throw new VCIssuerException(ErrorType.INVALID_NONCE, e.getMessage());
         }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/NonceEndpointTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/NonceEndpointTest.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.TokenVerifier;
+import org.keycloak.common.VerificationException;
 import org.keycloak.crypto.Algorithm;
 import org.keycloak.events.EventType;
 import org.keycloak.jose.jws.JWSHeader;
@@ -77,6 +78,29 @@ public class NonceEndpointTest extends OID4VCIssuerTestBase {
                     List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
                     Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
                             OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+        });
+    }
+
+    @Test
+    public void testCNonceCanOnlyBeConsumedOnce() throws Exception {
+        Oid4vcNonceResponse response = oauth.oid4vc().nonceRequest().send();
+        Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatusCode(),
+                "Nonce endpoint should return 200 OK");
+
+        String cNonce = response.getNonce();
+        Assertions.assertNotNull(cNonce);
+
+        runOnServer.run(session -> {
+            CNonceHandler cNonceHandler = session.getProvider(CNonceHandler.class);
+            var keycloakContext = session.getContext();
+
+            JsonWebToken verifiedToken = cNonceHandler.verifyCNonceAndGetToken(cNonce,
+                    List.of(OID4VCIssuerWellKnownProvider.getCredentialsEndpoint(keycloakContext)),
+                    Map.of(JwtCNonceHandler.SOURCE_ENDPOINT,
+                            OID4VCIssuerWellKnownProvider.getNonceEndpoint(keycloakContext)));
+            cNonceHandler.consumeCNonce(cNonce, verifiedToken);
+
+            Assertions.assertThrows(VerificationException.class, () -> cNonceHandler.consumeCNonce(cNonce));
         });
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/OID4VCAuthorizationCodeFlowTestBase.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/OID4VCAuthorizationCodeFlowTestBase.java
@@ -257,6 +257,35 @@ public abstract class OID4VCAuthorizationCodeFlowTestBase extends OID4VCIssuerTe
         assertSuccessfulCredentialResponse(credResponse);
     }
 
+    /**
+     * Replaying the same proof JWT in a second credential request must fail because the
+     * proof c_nonce is consumed after the first successful request.
+     */
+    @Test
+    public void testCredentialRequestRejectsReplayedProofCNonce() throws Exception {
+
+        CredentialIssuer issuer = wallet.getIssuerMetadata(ctx);
+        AccessTokenResponse tokenResponse = authzCodeFlow(issuer);
+        String credentialIdentifier = assertTokenResponse(tokenResponse);
+        Proofs proofs = newJwtProofs();
+
+        Oid4vcCredentialResponse firstResponse = oauth.oid4vc().credentialRequest()
+                .credentialIdentifier(credentialIdentifier)
+                .proofs(proofs)
+                .bearerToken(tokenResponse.getAccessToken())
+                .send();
+        assertSuccessfulCredentialResponse(firstResponse);
+
+        Oid4vcCredentialResponse replayResponse = oauth.oid4vc().credentialRequest()
+                .credentialIdentifier(credentialIdentifier)
+                .proofs(proofs)
+                .bearerToken(tokenResponse.getAccessToken())
+                .send();
+
+        assertEquals(400, replayResponse.getStatusCode());
+        assertEquals(ErrorType.INVALID_NONCE.getValue(), replayResponse.getError());
+    }
+
     /** After refreshing the token the new access-token must still be usable for a credential request. */
     @Test
     public void testCompleteFlowWithClaimsValidationAuthorizationCode_refreshToken() throws Exception {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCKeyAttestationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/issuance/signing/OID4VCKeyAttestationTest.java
@@ -755,6 +755,8 @@ public class OID4VCKeyAttestationTest extends OID4VCIssuerTestBase {
         List<JWK> attestedKeys = validator.validateProof(vcIssuanceContext);
         assertNotNull(attestedKeys);
         assertFalse(attestedKeys.isEmpty());
+        assertEquals(1, vcIssuanceContext.getVerifiedCNonces().size());
+        assertTrue(vcIssuanceContext.getVerifiedCNonces().containsKey(cNonce));
     }
 
     private static void runInvalidJwtProofWithKeyAttestationTest(KeycloakSession session) throws VCIssuerException {


### PR DESCRIPTION
Fixes OID4VCI `c_nonce` replay protection by marking verified proof nonces as consumed after successful credential request processing.

The nonce is stored in `SingleUseObjectProvider` using a hashed key, with the cache lifetime calculated from the remaining nonce validity plus clock skew. This prevents a captured proof JWT from being replayed within the nonce validity window.

## Details

- Add `CNonceHandler.consumeCNonce()` for explicit nonce consumption.
- Implement single-use storage in `JwtCNonceHandler` with `putIfAbsent()`.
- Calculate cache TTL as `exp - now + clockSkew`.
- Consume each distinct proof nonce once at the credential request boundary.
- Keep `verifyCNonce()` side-effect free so multi-proof and key-attestation flows can validate the same nonce during one request.
- Remove eager attestation nonce replay handling that used an incorrect TTL.
- Add regression coverage for single-use nonce consumption.

closes  https://github.com/keycloak/keycloak/issues/48043