### PR TITLE
[OID4VCI-FAPI2] Pass fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -253,6 +253,9 @@ public final class Constants {
     // Internal note for storing authorization details response in client session context
     public static final String AUTHORIZATION_DETAILS_RESPONSE = "authorization_details_response";
 
+    // Internal note for storing the authorization request uri
+    public static final String AUTHORIZATION_REQUEST_URI = "request_uri";
+
     // This attribute can be used in a realm import definition to signal that default client scopes should be created in addition to the client scopes defined by the realm import definition.
     // When this attribute is omitted or set to false, the default client scopes are not created if at least one other client scope is defined by the realm import definition.
     public static final String CREATE_DEFAULT_CLIENT_SCOPES = "CreateDefaultClientScopes";

--- a/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocol.java
+++ b/server-spi-private/src/main/java/org/keycloak/protocol/LoginProtocol.java
@@ -147,4 +147,10 @@ public interface LoginProtocol extends Provider {
         return false;
     }
 
+    /**
+     * Protocol specific handling of authentication completeness
+     */
+    default void authenticationComplete(AuthenticationSessionModel authSession) {
+        // do nothing
+    }
 }

--- a/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
+++ b/services/src/main/java/org/keycloak/authentication/AuthenticationProcessor.java
@@ -1243,10 +1243,17 @@ public class AuthenticationProcessor {
 
         String nextRequiredAction = nextRequiredAction();
         if (nextRequiredAction != null) {
-            return AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
+            Response response = AuthenticationManager.redirectToRequiredActions(session, realm, authenticationSession, uriInfo, nextRequiredAction);
+            return response;
         } else {
+
+            // Visit the LoginProtocol for authentication completeness
+            LoginProtocol loginProtocol = session.getProvider(LoginProtocol.class, authenticationSession.getProtocol());
+            loginProtocol.authenticationComplete(authenticationSession);
+
             event.detail(Details.CODE_ID, authenticationSession.getParentSession().getId());  // todo This should be set elsewhere.  find out why tests fail.  Don't know where this is supposed to be set
-            return AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+            Response response = AuthenticationManager.finishedRequiredActions(session, authenticationSession, userSession, connection, request, uriInfo, event);
+            return response;
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocol.java
@@ -28,6 +28,8 @@ import jakarta.ws.rs.core.UriInfo;
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.TokenIdGenerator;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.authentication.AuthenticationFlowException;
 import org.keycloak.authentication.AuthenticationProcessor;
 import org.keycloak.authentication.RequiredActionProvider;
 import org.keycloak.common.util.SecretGenerator;
@@ -48,6 +50,9 @@ import org.keycloak.protocol.ClientData;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.protocol.oidc.endpoints.AuthorizationEndpointChecker;
 import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequest;
+import org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor;
+import org.keycloak.protocol.oidc.endpoints.request.RequestUriType;
+import org.keycloak.protocol.oidc.par.endpoints.request.AuthzEndpointParParser;
 import org.keycloak.protocol.oidc.utils.LogoutUtil;
 import org.keycloak.protocol.oidc.utils.OAuth2Code;
 import org.keycloak.protocol.oidc.utils.OAuth2CodeParser;
@@ -576,7 +581,19 @@ public class OIDCLoginProtocol implements LoginProtocol {
     }
 
     @Override
-    public void close() {
+    public void authenticationComplete(AuthenticationSessionModel authSession) {
+        // Authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+        // not at the point of visiting the authorization endpoint
+        String requestUri = authSession.getAuthNote(Constants.AUTHORIZATION_REQUEST_URI);
+        RequestUriType requestUriType = Optional.ofNullable(requestUri)
+                .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
+                .orElse(null);
+        if (requestUriType == RequestUriType.PAR && AuthzEndpointParParser.removeRequestObject(session, requestUri) == null) {
+            throw new AuthenticationFlowException("PAR not found, not issued or used multiple times.", AuthenticationFlowError.INTERNAL_ERROR);
+        }
+    }
 
+    @Override
+    public void close() {
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpoint.java
@@ -401,11 +401,12 @@ public class AuthorizationEndpoint extends AuthorizationEndpointBase {
         }
     }
 
-    private Response buildAuthorizationCodeAuthorizationResponse(String requestUriParam) {
+    private Response buildAuthorizationCodeAuthorizationResponse(String requestUri) {
         this.event.event(EventType.LOGIN);
         authenticationSession.setAuthNote(Details.AUTH_TYPE, CODE_AUTH_TYPE);
+        authenticationSession.setAuthNote(Constants.AUTHORIZATION_REQUEST_URI, requestUri);
 
-        RequestUriType requestUriType = Optional.ofNullable(requestUriParam)
+        RequestUriType requestUriType = Optional.ofNullable(requestUri)
                 .map(AuthorizationEndpointRequestParserProcessor::getRequestUriType)
                 .orElse(null);
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/par/endpoints/request/AuthzEndpointParParser.java
@@ -52,9 +52,9 @@ public class AuthzEndpointParParser extends AuthzEndpointRequestParser {
         super(session);
         this.session = session;
         this.client = client;
-        Map<String, String> retrievedRequest = removeRequestObject(session, requestUri);
+        Map<String, String> retrievedRequest = getRequestObject(session, requestUri);
         if (retrievedRequest == null) {
-            throw new RuntimeException("PAR not found. not issued or used multiple times.");
+            throw new RuntimeException("PAR not found, not issued or used multiple times.");
         }
 
         RealmModel realm = session.getContext().getRealm();

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
@@ -29,9 +29,11 @@ import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.testframework.ui.annotations.InjectPage;
 import org.keycloak.testframework.ui.page.ErrorPage;
+import org.keycloak.tests.oid4vc.OID4VCBasicWallet.AuthorizationEndpointRequest;
 import org.keycloak.tests.oid4vc.OID4VCIssuerTestBase;
 import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
 import org.keycloak.testsuite.util.oauth.ParResponse;
 import org.keycloak.testsuite.util.oauth.PkceGenerator;
 import org.keycloak.util.JWKSUtils;
@@ -54,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Replicates various tests in oid4vci-1_0-issuer-haip-test-plan
@@ -468,6 +471,56 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         } finally {
             oauth.config().client(clientId);
         }
+    }
+
+    /**
+     * fapi2-security-profile-final-par-ensure-reused-request-uri-prior-to-auth-completion-succeeds
+     *
+     * This test checks that authorization servers that enforce one-time use of request_uri values do so at the point of authorization,
+     * not at the point of visiting the authorization endpoint.
+     */
+    @Test
+    public void testEnsureReusedRequestUriPriorToAuthCompletionSucceeds() throws Exception {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var pkce = PkceGenerator.s256();
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper rsaKey = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, rsaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, rsaKey);
+
+        // Send PAR Request
+        //
+        String requestUri = oauth.pushedAuthorizationRequest()
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .scopeParam(ctx.getScope())
+                .codeChallenge(pkce)
+                .send().getRequestUri();
+        assertNotNull(requestUri, "No requestUri");
+
+        // Open LoginForm and Cancel
+        // This should access the request_uri for the first time
+        //
+        AuthorizationEndpointRequest authRequest = wallet.authorizationRequest()
+                .requestUri(requestUri)
+                .codeChallenge(pkce);
+        assertTrue(authRequest.openLoginForm());
+
+        // Send Authorization Request
+        // This should access the request_uri for the second time
+        //
+        AuthorizationEndpointResponse authResponse = wallet.authorizationRequest()
+                .requestUri(requestUri)
+                .codeChallenge(pkce)
+                .send(ctx.getHolder(), TEST_PASSWORD);
+        assertTrue(authResponse.isSuccess());
+        String authCode = authResponse.getCode();
+        assertNotNull(authCode, "No auth code");
     }
 
     // Private ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
closes #48072

* Stop consuming/removing PAR request objects when first parsing request_uri at the authorization endpoint
* Defer PAR removal until authentication/authorization completes.
* Persist the request_uri in the authentication session so it can be consumed later.
* Add a new Details.REQUEST_URI constant for reuse as an auth-note key.