### PR TITLE
Fixes #50128 - ensure DL_DIR exists

### DIFF
--- a/misc/scripts/kcw
+++ b/misc/scripts/kcw
@@ -106,6 +106,7 @@ if [ "$INSTALL" != "" ]; then
 		echo "Installing"
 		echo "-------------------------------------------------------------------------------------------"
 
+        mkdir -p "$DL_DIR"
         cd $DL_DIR
         
         if [ -f keycloak-$VERSION.zip ]; then


### PR DESCRIPTION
fix #50128
'./kcw: line 109: cd: /home/myuser/Downloads: No such file or directory'