### PR TITLE
Backport-26.6-Reject redirect URIs containing pre-loaded OIDC response parameters (#49959)

### DIFF
--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/OIDCRedirectUriBuilder.java
@@ -241,14 +241,14 @@ public abstract class OIDCRedirectUriBuilder {
         }
 
         private Response buildQueryResponse() {
-            uriBuilder.queryParam("response", session.tokens().encodeAndEncrypt(responseJWT));
+            uriBuilder.queryParam(OAuth2Constants.RESPONSE, session.tokens().encodeAndEncrypt(responseJWT));
             URI redirectUri = uriBuilder.build();
             Response.ResponseBuilder location = Response.status(302).location(redirectUri);
             return location.build();
         }
 
         private Response buildFragmentResponse() {
-            uriBuilder.encodedFragment("response=" + Encode.encodeQueryParamAsIs(session.tokens().encodeAndEncrypt(responseJWT)));
+            uriBuilder.encodedFragment(OAuth2Constants.RESPONSE + "=" + Encode.encodeQueryParamAsIs(session.tokens().encodeAndEncrypt(responseJWT)));
             URI redirectUri = uriBuilder.build();
             Response.ResponseBuilder location = Response.status(302).location(redirectUri);
             return location.build();
@@ -268,7 +268,9 @@ public abstract class OIDCRedirectUriBuilder {
                     .append(HtmlUtils.escapeAttribute(redirectUri.toString()))
                     .append("\">");
 
-            builder.append("  <INPUT TYPE=\"HIDDEN\" NAME=\"response\" VALUE=\"")
+            builder.append("  <INPUT TYPE=\"HIDDEN\" NAME=\"")
+                    .append(OAuth2Constants.RESPONSE)
+                    .append("\" VALUE=\"")
                     .append(HtmlUtils.escapeAttribute(session.tokens().encodeAndEncrypt(responseJWT)))
                     .append("\" />");
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/utils/RedirectUtils.java
@@ -23,11 +23,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
+import org.keycloak.OAuth2Constants;
 import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.UriUtils;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
@@ -45,6 +48,22 @@ import org.jboss.logging.Logger;
 public class RedirectUtils {
 
     public static final Set<String> LOOPBACK_INTERFACES = new HashSet<>(Arrays.asList("localhost", "127.0.0.1", "[::1]"));
+
+    private static final Set<String> FORBIDDEN_OIDC_PARAMS = Set.of(
+                                                                     OAuth2Constants.CODE,
+                                                                     OAuth2Constants.ID_TOKEN,
+                                                                     OAuth2Constants.ACCESS_TOKEN,
+                                                                     OAuth2Constants.TOKEN_TYPE,
+                                                                     OAuth2Constants.EXPIRES_IN,
+                                                                     OAuth2Constants.STATE,
+                                                                     OAuth2Constants.ISSUER,
+                                                                     OAuth2Constants.ERROR,
+                                                                     OAuth2Constants.ERROR_DESCRIPTION,
+                                                                     OAuth2Constants.SESSION_STATE,
+                                                                     OAuth2Constants.RESPONSE,
+                                                                     Constants.KC_ACTION,
+                                                                     Constants.KC_ACTION_STATUS
+                                                                   );
 
     private static final Logger logger = Logger.getLogger(RedirectUtils.class);
 
@@ -95,6 +114,11 @@ public class RedirectUtils {
                 return null;
             }
 
+            // Check for HTTP Parameter Pollution - forbidden OIDC response parameters in redirect URI
+            if (containsForbiddenOidcParameters(originalRedirect)){
+                return null;
+            }
+
             // check if the passed URI allows wildcards
             boolean allowWildcards = areWildcardsAllowed(originalRedirect);
 
@@ -133,6 +157,24 @@ public class RedirectUtils {
         } else {
             return redirectUri;
         }
+    }
+
+    private static boolean containsForbiddenOidcParameters(URI originalRedirect) {
+        String query = originalRedirect.getRawQuery();
+        if (query != null && !query.isEmpty()) {
+            MultivaluedHashMap<String, String> params =UriUtils.decodeQueryString(query);
+            for (String paramName : params.keySet()) {
+                if (FORBIDDEN_OIDC_PARAMS.contains(paramName.toLowerCase(Locale.ROOT))) {
+                    logger.warnf("Redirect URI rejected: contains forbidden OIDC parameter '%s' in query string: scheme=%s, host=%s, path=%s",
+                            paramName,
+                            originalRedirect.getScheme(),
+                            originalRedirect.getHost(),
+                            originalRedirect.getPath());
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static URI toUri(String redirectUri) {

--- a/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
+++ b/services/src/test/java/org/keycloak/protocol/oidc/utils/RedirectUtilsTest.java
@@ -318,4 +318,25 @@ public class RedirectUtilsTest {
         Assert.assertEquals("custom3://custom", RedirectUtils.verifyRedirectUri(session, null, "custom3://custom", set, false));
         Assert.assertEquals("https://test.com/lala", RedirectUtils.verifyRedirectUri(session, null, "https://test.com/lala", set, false));
     }
+
+    @Test
+    public void testVerifyRedirectUriWithPollutedParameters() {
+        Set<String> set = Stream.of(
+                "https://example.com/callback/*"
+        ).collect(Collectors.toSet());
+
+        Assert.assertNull("Should reject URL-encoded 'code' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?c%6Fde=attack", set, false));
+        Assert.assertNull("Should reject mixed-case forbidden parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?CODE=attack", set, false));
+        Assert.assertNull("Should reject redirect URI containing pre-loaded 'code' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?code=attacker_code", set, false));
+        Assert.assertNull("Should reject redirect URI containing pre-loaded 'state' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?state=attacker_state", set, false));
+        Assert.assertNull("Should reject redirect URI containing pre-loaded 'iss' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?iss=attacker_issuer", set, false));
+        Assert.assertNull("Should reject redirect URI if any forbidden OIDC parameter is mixed into the query string", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?legit_param=123&code=malicious", set, false));
+        Assert.assertNull("Should reject redirect URI containing 'session_state' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?session_state=attacker_session", set, false));
+        Assert.assertNull("Should reject redirect URI containing 'response' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?response=attacker_jwt", set, false));
+        Assert.assertNull("Should reject redirect URI containing 'kc_action' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?kc_action=evil_action", set, false));
+        Assert.assertNull("Should reject redirect URI containing 'kc_action_status' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?kc_action_status=evil_status", set, false));
+        Assert.assertNull("Should reject URL-encoded 'session_state' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?session%5Fstate=attack", set, false));
+        Assert.assertNull("Should reject mixed-case 'RESPONSE' parameter", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?RESPONSE=attack", set, false));
+        Assert.assertEquals("Should allow legitimate query parameters that do not conflict with OIDC protocol variables", "https://example.com/callback?legit_param=123", RedirectUtils.verifyRedirectUri(session, null, "https://example.com/callback?legit_param=123", set, false));
+    }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/OAuthRedirectUriTest.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URL;
 import java.util.List;
+import java.util.Objects;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.common.util.Encode;
@@ -476,6 +477,85 @@ public class OAuthRedirectUriTest extends AbstractKeycloakTest {
 
         Assert.assertEquals("Expected 400, but got something else", 400, tokenResponse.getStatusCode());
     }
+
+    @Test
+    public void testRedirectUriWithForbiddenCodeParameter() {
+        oauth.redirectUri(APP_ROOT + "/auth?code=attacker_injected");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithForbiddenStateParameter() {
+        oauth.redirectUri(APP_ROOT + "/auth?state=attacker_state");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithForbiddenSessionStateParameter() {
+        oauth.redirectUri(APP_ROOT + "/auth?session_state=attacker_state");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithForbiddenIssParameter() {
+        oauth.redirectUri(APP_ROOT + "/auth?iss=https://evil.com");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithMixedLegitimateAndForbiddenParameters() {
+        oauth.redirectUri(APP_ROOT + "/auth?custom=value&code=evil&other=data");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithUrlEncodedForbiddenParameter() {
+        // c%6Fde = "code" URL-encoded
+        oauth.redirectUri(APP_ROOT + "/auth?c%6Fde=evil");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithMixedCaseForbiddenParameter() {
+        oauth.redirectUri(APP_ROOT + "/auth?CODE=evil");
+        oauth.openLoginForm();
+
+        Assert.assertTrue(errorPage.isCurrent());
+        Assert.assertEquals("Invalid parameter: redirect_uri", errorPage.getError());
+    }
+
+    @Test
+    public void testRedirectUriWithLegitimateCustomParameters() throws IOException {
+        oauth.redirectUri(APP_ROOT + "/auth?custom_param=value&return_to=/home");
+        AuthorizationEndpointResponse response = oauth.doLogin("test-user@localhost", "password");
+
+        Assert.assertNotNull(response.getCode());
+        URL url = new URL(Objects.requireNonNull(driver.getCurrentUrl()));
+        Assert.assertTrue(url.toString().startsWith(APP_ROOT));
+        Assert.assertTrue(url.getQuery().contains("custom_param=value"));
+        Assert.assertTrue(url.getQuery().contains("return_to=/home"));
+        Assert.assertTrue(url.getQuery().contains("code="));
+        Assert.assertTrue(url.getQuery().contains("state="));
+    }
+
 
     private void checkRedirectUri(String redirectUri, boolean expectValid) throws IOException {
         checkRedirectUri(redirectUri, expectValid, false);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/AbstractOIDCResponseTypeTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oidc/flows/AbstractOIDCResponseTypeTest.java
@@ -40,7 +40,6 @@ import org.keycloak.testsuite.pages.LoginPage;
 import org.keycloak.testsuite.util.ClientManager;
 import org.keycloak.testsuite.util.TokenSignatureUtil;
 import org.keycloak.testsuite.util.oauth.AuthorizationEndpointResponse;
-import org.keycloak.testsuite.util.oauth.OAuthClient;
 
 import org.jboss.arquillian.graphene.page.Page;
 import org.junit.Rule;
@@ -90,21 +89,6 @@ public abstract class AbstractOIDCResponseTypeTest extends AbstractTestRealmKeyc
 
         for (IDToken idToken : idTokens) {
             Assert.assertEquals("abcdef123456", idToken.getNonce());
-            Assert.assertEquals(authzResponse.getSessionState(), idToken.getSessionState());
-        }
-    }
-
-
-    @Test
-    public void initialSessionStateUsedInRedirect() {
-        EventRepresentation loginEvent = loginUserWithRedirect("abcdef123456", OAuthClient.APP_ROOT + "/auth?session_state=foo");
-
-        AuthorizationEndpointResponse authzResponse = oauth.parseLoginResponse();
-        Assert.assertNotNull(authzResponse.getSessionState());
-
-        List<IDToken> idTokens = testAuthzResponseAndRetrieveIDTokens(authzResponse, loginEvent);
-
-        for (IDToken idToken : idTokens) {
             Assert.assertEquals(authzResponse.getSessionState(), idToken.getSessionState());
         }
     }


### PR DESCRIPTION
Closes #49430

Signed-off-by: Jimmy Chakkalakal <jimmy.chakkalakal@ibm.com>
(cherry picked from commit 18832bcae5bebd5a1d66c2ec5fcd640e576fa625)