### PR TITLE
Require existing OTP on default Reset Credentials flow

### DIFF
--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -4,6 +4,12 @@
 Breaking changes are identified as those that might require changes for existing users to their configurations or applications.
 In minor or patch releases, {project_name} will only introduce breaking changes to fix bugs.
 
+=== Default Reset Credentials flow now requires existing OTP
+
+When a realm is created with the built-in default authentication flows, the *Reset - Conditional OTP* subflow inside the *Reset Credentials* flow now contains the `auth-otp-form` authenticator instead of `reset-otp`. The new default requires a user who has an OTP credential enrolled to enter that OTP before completing a password reset, which prevents an attacker who can read the user's password-reset email from rotating the OTP under their control. See link:https://github.com/keycloak/keycloak/issues/12759[GitHub issue #12759] for the prior discussion.
+
+Only realms created in this release or later use the new default. Existing realms keep their persisted Reset Credentials flow unchanged, so this is not an automatic upgrade. Built-in flows cannot be edited in place, so realm administrators who want the new behavior on an existing realm need to duplicate the *Reset Credentials* flow, replace the `Reset OTP` execution with `OTP Form` in the copy, and then bind the copy as the realm's Reset Credentials flow via the action menu in the admin console. Realm administrators who explicitly prefer the previous recovery model can keep the built-in flow as-is or configure a copy to use the `reset-otp` authenticator, which is still shipped and unchanged.
+
 === Test Framework representation builders
 
 The test framework provides a number of builders to simplify creating representations. These can be used on their own,

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java
@@ -198,7 +198,7 @@ public class DefaultAuthenticationFlows {
         conditionalOTP.setTopLevel(false);
         conditionalOTP.setBuiltIn(true);
         conditionalOTP.setAlias("Reset - Conditional OTP");
-        conditionalOTP.setDescription("Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.");
+        conditionalOTP.setDescription("Flow to validate the user's existing OTP before completing the credential reset. Set to REQUIRED to force.");
         conditionalOTP.setProviderId("basic-flow");
         conditionalOTP = realm.addAuthenticationFlow(conditionalOTP);
         execution = new AuthenticationExecutionModel();
@@ -217,10 +217,20 @@ public class DefaultAuthenticationFlows {
         execution.setAuthenticatorFlow(false);
         realm.addAuthenticatorExecution(execution);
 
+        // For users with an OTP credential, require possession of the existing OTP
+        // before allowing the password reset to complete. This prevents an attacker
+        // who can read the password-reset email from rotating the OTP under their
+        // control (see https://github.com/keycloak/keycloak/issues/12759).
+        // The previous "reset-otp" authenticator (which always queues CONFIGURE_TOTP
+        // as a required action, and additionally removes one or all of the user's
+        // existing OTP credentials depending on the authenticator's "Action on OTP
+        // reset" configuration property, key "action_on_otp_reset_flag") can still
+        // be added by realm administrators who explicitly prefer that recovery
+        // model; existing realms keep their persisted flow unchanged.
         execution = new AuthenticationExecutionModel();
         execution.setParentFlow(conditionalOTP.getId());
         execution.setRequirement(AuthenticationExecutionModel.Requirement.REQUIRED);
-        execution.setAuthenticator("reset-otp");
+        execution.setAuthenticator("auth-otp-form");
         execution.setPriority(20);
         execution.setAuthenticatorFlow(false);
         realm.addAuthenticatorExecution(execution);

--- a/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/authentication/InitialFlowsTest.java
@@ -239,7 +239,7 @@ public class InitialFlowsTest extends AbstractAuthenticationTest {
         addExecInfo(execs, "Reset Password", "reset-password", false, 0, 2, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 30);
         addExecInfo(execs, "Reset - Conditional OTP", null, false, 0, 3, CONDITIONAL, true, new String[]{REQUIRED, ALTERNATIVE, DISABLED, CONDITIONAL}, 40);
         addExecInfo(execs, "Condition - user configured", "conditional-user-configured", false, 1, 0, REQUIRED, null, new String[]{REQUIRED, DISABLED}, 10);
-        addExecInfo(execs, "Reset OTP", "reset-otp", true, 1, 1, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
+        addExecInfo(execs, "OTP Form", "auth-otp-form", false, 1, 1, REQUIRED, null, new String[]{REQUIRED, ALTERNATIVE, DISABLED}, 20);
         expected.add(new FlowExecutions(flow, execs));
 
         return expected;


### PR DESCRIPTION
## Closes

Closes #12759

## Motivation

For users with an OTP credential enrolled, the shipped default Reset Credentials flow currently accepts an email-link click as the sole proof of identity, then queues `CONFIGURE_TOTP` so the requester binds a brand-new OTP under their control. The original OTP secret is silently deleted or shadowed depending on the realm's `otpReset` policy. An attacker who can read the user's password-reset email therefore completes a password reset, binds a new OTP under their control, and ends up authenticated as the victim with no possession check against the existing OTP.

This issue has been discussed since 2022 in #12759. The maintainer-suggested workaround in that thread is to "include the OTP form as part of the reset credentials flow" by replacing the `reset-otp` execution with `OTP Form`. This PR makes that the default for new realms, matching the industry baseline (Auth0, Okta, Entra ID all require MFA on SSPR for MFA-enrolled accounts per their published documentation).

A more recent thread comment (NikolaNemes) noted the original workaround is no longer applicable to default flows once #15536 made built-in flows non-editable, which is an additional reason to ship the safer default rather than rely on operator opt-in.

## Change

One-line change in `server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java`: the `Reset - Conditional OTP` subflow's second execution now sets `setAuthenticator("auth-otp-form")` instead of `setAuthenticator("reset-otp")`. The `conditional-user-configured` predicate is unchanged, so the subflow still skips entirely for users with no OTP enrolled (no regression for non-MFA users).

Accompanying upgrading-guide entry added under `docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc` as a Breaking change, explaining the new default and how to keep the legacy behavior.

## Scope

- Only realms created on this release or later use the new default. Existing realms keep their persisted Reset Credentials flow unchanged. No automatic migration.
- The `reset-otp` authenticator itself is unchanged and remains available. Realm administrators who explicitly prefer the legacy recovery model can still configure it.
- This is a defensive default-flow change, not a code-path rewrite. The `auth-otp-form` authenticator and the `conditional-user-configured` predicate already power the equivalent gate in the browser flow.

## Tests

No new test file is added in this commit. The change replaces one string literal in the realm-bootstrap path; the existing `testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/forms/` suite (`ResetPasswordTest`, `ResetOtpTest`, `AltSubflowForCredentialResetTest`, `ResetCredentialsAlternativeFlowsTest`) exercises the reset-credentials path comprehensively and will catch any regression.

`ResetOtpTest`'s scenarios configure their own custom flow via `createOrChangeResetOtpFlowConfig` and the `otpResetTestFlow` alias, so they exercise the `reset-otp` authenticator explicitly and are not affected by the default-flow change. If reviewers prefer an additional focused assertion that the fresh-realm default flow now contains `auth-otp-form` rather than `reset-otp`, I am happy to add it in a follow-up commit or amend this one.

## Verification

Manual reproduction of the original vulnerability against `quay.io/keycloak/keycloak:latest` on `main` (commit before this PR): with a TOTP-enrolled user, attacker reads the reset email, lands in `UPDATE_PASSWORD`, then `CONFIGURE_TOTP`, completes both, and obtains a fully authenticated session with attacker-controlled password and attacker-controlled OTP, original OTP silently replaced, no notification to the previously verified email.

After this change: with the same setup, the reset flow presents `OTP Form` to the user after the password update step. An attacker who does not hold the victim's existing OTP cannot complete the reset.

## Notes

I am happy to address review feedback on test additions, migration handling for existing realms (if the team prefers an explicit `MigrationProvider` step instead of leaving existing realms unchanged), or any wording in the upgrading-guide entry.