### PR TITLE
Validate client URLs during partial import

### DIFF
--- a/services/src/main/java/org/keycloak/partialimport/ClientsPartialImport.java
+++ b/services/src/main/java/org/keycloak/partialimport/ClientsPartialImport.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
@@ -34,6 +36,8 @@ import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.PartialImportRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.services.ErrorResponse;
+import org.keycloak.validation.ValidationUtil;
 
 import org.jboss.logging.Logger;
 
@@ -124,6 +128,10 @@ public class ClientsPartialImport extends AbstractPartialImport<ClientRepresenta
             OIDCAdvancedConfigWrapper.fromClientModel(client).setPostLogoutRedirectUris(Collections.singletonList("+"));
         }
         RepresentationToModel.importAuthorizationSettings(clientRep, client, session);
+
+        ValidationUtil.validateClient(session, client, true, r -> {
+            throw ErrorResponse.error(r.getAllErrorsAsString(), Response.Status.BAD_REQUEST);
+        });
     }
 
     public static boolean isInternalClient(String clientId) {

--- a/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/partialimport/PartialImportClientTest.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.ws.rs.core.Response;
+
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ClientResource;
 import org.keycloak.admin.client.resource.UserResource;
@@ -31,6 +33,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @KeycloakIntegrationTest(config = AbstractPartialImportTest.PartialImportServerConfig.class)
 public class PartialImportClientTest extends AbstractPartialImportTest {
+
+    @Test
+    public void testIllegalSchemeBaseUrlPartialImport() {
+        setFail();
+        ClientRepresentation client = new ClientRepresentation();
+        client.setClientId("evil-partial-import-test");
+        client.setEnabled(true);
+        client.setPublicClient(true);
+        client.setRedirectUris(List.of("http://localhost/*"));
+        client.setBaseUrl("javascript:confirm(document.domain)/*");
+        piRep.setClients(List.of(client));
+
+        try (Response response = managedRealm.admin().partialImport(piRep)) {
+            response.bufferEntity();
+            String body = response.readEntity(String.class);
+            assertEquals(400, response.getStatus(), body);
+            assertTrue(body.contains("Base URL uses an illegal scheme"), body);
+        }
+
+        assertTrue(managedRealm.admin().clients().findByClientId("evil-partial-import-test").isEmpty());
+    }
 
     @Test
     @DatabaseTest


### PR DESCRIPTION
Partial import created clients without running ValidationUtil.validateClient, so baseUrl values with disallowed schemes (e.g. javascript:) could bypass checks enforced on Admin API create/update. Run the same validation after client creation in ClientsPartialImport and add a regression test.

Closes #50123

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
