### PR TITLE
Enforce allowed-protocol-mappers on Admin REST API protocol mapper operations

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/ProtocolMapperPolicyValidator.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/ProtocolMapperPolicyValidator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.keycloak.events.Errors;
+import org.keycloak.models.ProtocolMapperContainerModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.services.ServicesLogger;
+
+/**
+ * Validates protocol mapper types against an allowed whitelist.
+ */
+public final class ProtocolMapperPolicyValidator {
+
+    public static final String PROTOCOL_MAPPER_TYPE_NOT_ALLOWED = "ProtocolMapper type not allowed";
+
+    private ProtocolMapperPolicyValidator() {
+    }
+
+    public static void validateProtocolMappers(List<ProtocolMapperRepresentation> protocolMappers,
+            List<String> allowedMapperProviders, ProtocolMapperContainerModel container) throws ClientPolicyException {
+        if (protocolMappers == null || protocolMappers.isEmpty()) {
+            return;
+        }
+        for (ProtocolMapperRepresentation mapperRepresentation : protocolMappers) {
+            validateProtocolMapper(mapperRepresentation, allowedMapperProviders, container);
+        }
+    }
+
+    public static void validateProtocolMapper(ProtocolMapperRepresentation mapperRepresentation,
+            List<String> allowedMapperProviders, ProtocolMapperContainerModel container) throws ClientPolicyException {
+        if (mapperRepresentation == null) {
+            return;
+        }
+
+        String mapperType = mapperRepresentation.getProtocolMapper();
+        if (allowedMapperProviders.contains(mapperType)) {
+            return;
+        }
+
+        if (container == null) {
+            failWithProtocolMapperTypeNotAllowed(mapperRepresentation);
+        }
+
+        String mapperRepresentationId = mapperRepresentation.getId();
+        if (mapperRepresentationId == null) {
+            failWithProtocolMapperTypeNotAllowed(mapperRepresentation);
+        }
+
+        ProtocolMapperModel mapperModel = container.getProtocolMapperById(mapperRepresentationId);
+        if (mapperModel == null) {
+            String message = "No existing mapper model found for id '%s'".formatted(mapperRepresentationId);
+            ServicesLogger.LOGGER.warn(message);
+            throw new ClientPolicyException(Errors.INVALID_REGISTRATION, message);
+        }
+
+        Map<String, String> modelConfig = mapperModel.getConfig();
+        Map<String, String> representationConfig = mapperRepresentation.getConfig();
+        if (!Objects.equals(representationConfig, modelConfig)) {
+            failWithProtocolMapperTypeNotAllowed(mapperRepresentation);
+        }
+    }
+
+    private static void failWithProtocolMapperTypeNotAllowed(ProtocolMapperRepresentation mapper) throws ClientPolicyException {
+        ServicesLogger.LOGGER.clientRegistrationMapperNotAllowed(mapper.getName(), mapper.getProtocolMapper());
+        throw new ClientPolicyException(Errors.INVALID_REGISTRATION, PROTOCOL_MAPPER_TYPE_NOT_ALLOWED);
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/AllowedProtocolMappersExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/AllowedProtocolMappersExecutor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.List;
+
+import org.keycloak.models.ClientModel;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.services.clientpolicy.ClientPolicyContext;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ProtocolMapperPolicyValidator;
+import org.keycloak.services.clientpolicy.context.ClientCRUDContext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Enforces a whitelist of allowed protocol mapper types during client create/update
+ * and Admin REST API protocol mapper operations.
+ */
+public class AllowedProtocolMappersExecutor implements ClientPolicyExecutorProvider<AllowedProtocolMappersExecutor.Configuration> {
+
+    private AllowedProtocolMappersExecutor.Configuration configuration;
+
+    @Override
+    public void executeOnEvent(ClientPolicyContext context) throws ClientPolicyException {
+        List<String> allowedMapperProviders = getAllowedMapperProviders();
+        if (allowedMapperProviders == null || allowedMapperProviders.isEmpty()) {
+            return;
+        }
+
+        switch (context.getEvent()) {
+            case REGISTER:
+            case UPDATE:
+                ClientCRUDContext clientCrudContext = (ClientCRUDContext) context;
+                ClientRepresentation proposedClient = clientCrudContext.getProposedClientRepresentation();
+                ProtocolMapperPolicyValidator.validateProtocolMappers(
+                        proposedClient.getProtocolMappers(),
+                        allowedMapperProviders,
+                        clientCrudContext.getTargetClient());
+                break;
+            default:
+                return;
+        }
+    }
+
+    @Override
+    public void setupConfiguration(AllowedProtocolMappersExecutor.Configuration config) {
+        this.configuration = config;
+    }
+
+    @Override
+    public Class<AllowedProtocolMappersExecutor.Configuration> getExecutorConfigurationClass() {
+        return AllowedProtocolMappersExecutor.Configuration.class;
+    }
+
+    @Override
+    public String getProviderId() {
+        return AllowedProtocolMappersExecutorFactory.PROVIDER_ID;
+    }
+
+    private List<String> getAllowedMapperProviders() {
+        if (configuration.getAllowedProtocolMapperTypes() != null) {
+            return configuration.getAllowedProtocolMapperTypes();
+        }
+        Object value = configuration.getConfigAsMap().get(AllowedProtocolMappersExecutorFactory.ALLOWED_PROTOCOL_MAPPER_TYPES);
+        if (value instanceof List<?> list) {
+            return list.stream().map(String::valueOf).toList();
+        }
+        return null;
+    }
+
+    public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
+
+        @JsonProperty(AllowedProtocolMappersExecutorFactory.ALLOWED_PROTOCOL_MAPPER_TYPES)
+        protected List<String> allowedProtocolMapperTypes;
+
+        public List<String> getAllowedProtocolMapperTypes() {
+            return allowedProtocolMapperTypes;
+        }
+
+        public void setAllowedProtocolMapperTypes(List<String> allowedProtocolMapperTypes) {
+            this.allowedProtocolMapperTypes = allowedProtocolMapperTypes;
+        }
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/AllowedProtocolMappersExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/AllowedProtocolMappersExecutorFactory.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.services.clientpolicy.executor;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.keycloak.Config.Scope;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderFactory;
+
+/**
+ * Factory for the allowed-protocol-mappers client policy executor.
+ */
+public class AllowedProtocolMappersExecutorFactory implements ClientPolicyExecutorProviderFactory {
+
+    public static final String PROVIDER_ID = "allowed-protocol-mappers";
+
+    public static final String ALLOWED_PROTOCOL_MAPPER_TYPES = "allowed-protocol-mapper-types";
+
+    private final List<ProviderConfigProperty> configProperties = new LinkedList<>();
+    private KeycloakSessionFactory sessionFactory;
+
+    @Override
+    public ClientPolicyExecutorProvider create(KeycloakSession session) {
+        return new AllowedProtocolMappersExecutor();
+    }
+
+    @Override
+    public void init(Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        this.sessionFactory = factory;
+
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setName(ALLOWED_PROTOCOL_MAPPER_TYPES);
+        property.setLabel("allowed-protocol-mappers.label");
+        property.setHelpText("allowed-protocol-mappers.tooltip");
+        property.setType(ProviderConfigProperty.MULTIVALUED_LIST_TYPE);
+        property.setOptions(getProtocolMapperFactoryIds());
+        configProperties.add(property);
+    }
+
+    private List<String> getProtocolMapperFactoryIds() {
+        return sessionFactory.getProviderFactoriesStream(ProtocolMapper.class)
+                .map(ProviderFactory::getId)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "When present, it allows to specify whitelist of protocol mapper types, which will be allowed when creating or updating clients and protocol mappers";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+}

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
@@ -18,16 +18,14 @@
 package org.keycloak.services.clientregistration.policy.impl;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.ProtocolMapperModel;
-import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.services.ServicesLogger;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.ProtocolMapperPolicyValidator;
 import org.keycloak.services.clientregistration.ClientRegistrationContext;
 import org.keycloak.services.clientregistration.ClientRegistrationProvider;
 import org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy;
@@ -56,48 +54,15 @@ public class ProtocolMappersClientRegistrationPolicy implements ClientRegistrati
     }
 
     protected void testMappers(ClientRegistrationContext context, ClientModel clientModel) throws ClientRegistrationPolicyException {
-        List<ProtocolMapperRepresentation> protocolMappers = context.getClient().getProtocolMappers();
-        if (protocolMappers == null) {
-            return;
+        try {
+            ProtocolMapperPolicyValidator.validateProtocolMappers(
+                    context.getClient().getProtocolMappers(),
+                    getAllowedMapperProviders(),
+                    clientModel);
+        } catch (ClientPolicyException e) {
+            throw new ClientRegistrationPolicyException(e.getErrorDetail());
         }
-
-        List<String> allowedMapperProviders = getAllowedMapperProviders();
-
-        for (ProtocolMapperRepresentation mapperRepresentation : protocolMappers) {
-            String mapperType = mapperRepresentation.getProtocolMapper();
-
-			if (allowedMapperProviders.contains(mapperType)) {
-				continue;
-			}
-			if (clientModel == null) {
-				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
-				return;
-			}
-			String mapperRepresentationId = mapperRepresentation.getId();
-			if (mapperRepresentationId == null) {
-				String message = "Missing id for mapper named '%s'".formatted(mapperRepresentation.getName());
-				ServicesLogger.LOGGER.warn(message);
-				throw new ClientRegistrationPolicyException(message);
-			}
-			ProtocolMapperModel mapperModel = clientModel.getProtocolMapperById(mapperRepresentationId);
-			if (mapperModel == null) {
-				String message = "No existing mapper model found for id '%s'".formatted(mapperRepresentationId);
-				ServicesLogger.LOGGER.warn(message);
-				throw new ClientRegistrationPolicyException(message);
-			}
-			Map<String, String> modelConfig = mapperModel.getConfig();
-			Map<String, String> representationConfig = mapperRepresentation.getConfig();
-			if (!Objects.equals(representationConfig, modelConfig)) {
-				failWithProtocolMapperTypeNotAllowedError(mapperRepresentation);
-				return;
-			}
-		}
     }
-
-	protected void failWithProtocolMapperTypeNotAllowedError(ProtocolMapperRepresentation mapper) {
-		ServicesLogger.LOGGER.clientRegistrationMapperNotAllowed(mapper.getName(), mapper.getProtocolMapper());
-		throw new ClientRegistrationPolicyException("ProtocolMapper type not allowed");
-	}
 
     // Remove builtin mappers of unsupported types too
     @Override

--- a/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/admin/ProtocolMappersResource.java
@@ -36,6 +36,7 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.events.admin.OperationType;
 import org.keycloak.events.admin.ResourceType;
+import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ModelDuplicateException;
 import org.keycloak.models.ProtocolMapperContainerModel;
@@ -45,9 +46,12 @@ import org.keycloak.models.utils.ModelToRepresentation;
 import org.keycloak.models.utils.RepresentationToModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.ProtocolMapperRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.ErrorResponseException;
+import org.keycloak.services.clientpolicy.ClientPolicyException;
+import org.keycloak.services.clientpolicy.context.AdminClientUpdateContext;
 import org.keycloak.services.resources.KeycloakOpenAPI;
 import org.keycloak.services.resources.admin.fgap.AdminPermissionEvaluator;
 
@@ -139,6 +143,7 @@ public class ProtocolMappersResource {
 
         ProtocolMapperModel model = null;
         try {
+            triggerProtocolMapperCreatePolicy(rep);
             model = RepresentationToModel.toModel(rep);
             validateModel(model);
             model = client.addProtocolMapper(model);
@@ -146,6 +151,8 @@ public class ProtocolMappersResource {
 
         } catch (ModelDuplicateException e) {
             throw ErrorResponse.exists("Protocol mapper exists with same name");
+        } catch (ClientPolicyException e) {
+            throw new ErrorResponseException(e.getError(), e.getErrorDetail(), Response.Status.BAD_REQUEST);
         }
 
         return Response.created(session.getContext().getUri().getAbsolutePathBuilder().path(model.getId()).build()).build();
@@ -165,12 +172,17 @@ public class ProtocolMappersResource {
         managePermission.require();
 
         ProtocolMapperModel model = null;
-        for (ProtocolMapperRepresentation rep : reps) {
-            model = RepresentationToModel.toModel(rep);
-            validateModel(model);
-            model = client.addProtocolMapper(model);
+        try {
+            for (ProtocolMapperRepresentation rep : reps) {
+                triggerProtocolMapperCreatePolicy(rep);
+                model = RepresentationToModel.toModel(rep);
+                validateModel(model);
+                model = client.addProtocolMapper(model);
+            }
+            adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri()).representation(reps).success();
+        } catch (ClientPolicyException e) {
+            throw new ErrorResponseException(e.getError(), e.getErrorDetail(), Response.Status.BAD_REQUEST);
         }
-        adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri()).representation(reps).success();
     }
 
     /**
@@ -240,12 +252,18 @@ public class ProtocolMappersResource {
 
         ProtocolMapperModel model = client.getProtocolMapperById(id);
         if (model == null) throw new NotFoundException("Model not found");
-        model = RepresentationToModel.toModel(rep);
+        try {
+            rep.setId(id);
+            triggerProtocolMapperUpdatePolicy(rep);
+            model = RepresentationToModel.toModel(rep);
 
-        validateModel(model);
+            validateModel(model);
 
-        client.updateProtocolMapper(model);
-        adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
+            client.updateProtocolMapper(model);
+            adminEvent.operation(OperationType.UPDATE).resourcePath(session.getContext().getUri()).representation(rep).success();
+        } catch (ClientPolicyException e) {
+            throw new ErrorResponseException(e.getError(), e.getErrorDetail(), Response.Status.BAD_REQUEST);
+        }
     }
 
     /**
@@ -266,6 +284,23 @@ public class ProtocolMappersResource {
         client.removeProtocolMapper(model);
         adminEvent.operation(OperationType.DELETE).resourcePath(session.getContext().getUri()).success();
 
+    }
+
+    private void triggerProtocolMapperCreatePolicy(ProtocolMapperRepresentation rep) throws ClientPolicyException {
+        triggerProtocolMapperPolicy(rep);
+    }
+
+    private void triggerProtocolMapperUpdatePolicy(ProtocolMapperRepresentation rep) throws ClientPolicyException {
+        triggerProtocolMapperPolicy(rep);
+    }
+
+    private void triggerProtocolMapperPolicy(ProtocolMapperRepresentation rep) throws ClientPolicyException {
+        if (!(client instanceof ClientModel clientModel)) {
+            return;
+        }
+        ClientRepresentation clientRep = new ClientRepresentation();
+        clientRep.setProtocolMappers(List.of(rep));
+        session.clientPolicy().triggerOnEvent(new AdminClientUpdateContext(clientRep, clientModel, auth.adminAuth()));
     }
 
     private void validateModel(ProtocolMapperModel model) {

--- a/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
+++ b/services/src/main/resources/META-INF/services/org.keycloak.services.clientpolicy.executor.ClientPolicyExecutorProviderFactory
@@ -9,6 +9,7 @@ org.keycloak.services.clientpolicy.executor.SecureSigningAlgorithmForSignedJwtEx
 org.keycloak.services.clientpolicy.executor.HolderOfKeyEnforcerExecutorFactory
 org.keycloak.services.clientpolicy.executor.ConfidentialClientAcceptExecutorFactory
 org.keycloak.services.clientpolicy.executor.ConsentRequiredExecutorFactory
+org.keycloak.services.clientpolicy.executor.AllowedProtocolMappersExecutorFactory
 org.keycloak.services.clientpolicy.executor.FullScopeDisabledExecutorFactory
 org.keycloak.services.clientpolicy.executor.SecureClientUrisPatternExecutorFactory
 org.keycloak.protocol.oidc.grants.ciba.clientpolicy.executor.SecureCibaSessionEnforceExecutorFactory

--- a/tests/base/src/test/java/org/keycloak/tests/client/policies/AllowedProtocolMappersClientPolicyTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/client/policies/AllowedProtocolMappersClientPolicyTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.tests.client.policies;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.FullNameMapper;
+import org.keycloak.protocol.oidc.mappers.HardcodedRole;
+import org.keycloak.representations.idm.ClientPolicyConditionConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientPolicyExecutorConfigurationRepresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.services.clientpolicy.condition.AnyClientConditionFactory;
+import org.keycloak.services.clientpolicy.executor.AllowedProtocolMappersExecutorFactory;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies allowed-protocol-mappers client policy enforcement on Admin REST API operations.
+ */
+@KeycloakIntegrationTest
+public class AllowedProtocolMappersClientPolicyTest extends AbstractClientPoliciesTest {
+
+    @InjectRealm(lifecycle = LifeCycle.METHOD)
+    ManagedRealm realm;
+
+    @InjectClient(config = TestClient.class)
+    ManagedClient client;
+
+    @BeforeEach
+    public void setupPolicy() throws Exception {
+        ClientPolicyExecutorConfigurationRepresentation executorConfig = new ClientPolicyExecutorConfigurationRepresentation();
+        executorConfig.setConfigAsMap(AllowedProtocolMappersExecutorFactory.ALLOWED_PROTOCOL_MAPPER_TYPES,
+                List.of(FullNameMapper.PROVIDER_ID));
+
+        setupPolicy(realm,
+                AllowedProtocolMappersExecutorFactory.PROVIDER_ID,
+                executorConfig,
+                AnyClientConditionFactory.PROVIDER_ID,
+                new ClientPolicyConditionConfigurationRepresentation());
+    }
+
+    @Test
+    public void testAdminProtocolMapperCreateRejected() {
+        ProtocolMapperRepresentation mapper = createHardcodedMapperRep();
+
+        try (Response response = client.admin().getProtocolMappers().createMapper(mapper)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        }
+    }
+
+    @Test
+    public void testAdminProtocolMapperCreateAllowed() {
+        ProtocolMapperRepresentation mapper = createFullNameMapperRep();
+
+        try (Response response = client.admin().getProtocolMappers().createMapper(mapper)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    @Test
+    public void testAdminClientUpdateWithDisallowedMapperRejected() {
+        ClientRepresentation clientRep = client.admin().toRepresentation();
+        clientRep.setProtocolMappers(Collections.singletonList(createHardcodedMapperRep()));
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> client.admin().update(clientRep));
+        try (Response response = ex.getResponse()) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        }
+    }
+
+    private ProtocolMapperRepresentation createHardcodedMapperRep() {
+        ProtocolMapperRepresentation protocolMapper = new ProtocolMapperRepresentation();
+        protocolMapper.setName("Hardcoded foo role");
+        protocolMapper.setProtocolMapper(HardcodedRole.PROVIDER_ID);
+        protocolMapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        protocolMapper.getConfig().put(HardcodedRole.ROLE_CONFIG, "foo-role");
+        return protocolMapper;
+    }
+
+    private ProtocolMapperRepresentation createFullNameMapperRep() {
+        ProtocolMapperRepresentation protocolMapper = new ProtocolMapperRepresentation();
+        protocolMapper.setName("Full name");
+        protocolMapper.setProtocolMapper(FullNameMapper.PROVIDER_ID);
+        protocolMapper.setProtocol(OIDCLoginProtocol.LOGIN_PROTOCOL);
+        return protocolMapper;
+    }
+
+    public static class TestClient implements ClientConfig {
+
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client.clientId("allowed-protocol-mappers-test-client")
+                    .name("allowed-protocol-mappers-test-client")
+                    .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                    .publicClient(true)
+                    .redirectUris("http://localhost:8080/*");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add an `allowed-protocol-mappers` **Client Policy executor** so protocol mapper whitelist rules apply to Admin REST API mapper CRUD and client create/update, not only dynamic client registration.
- Extract shared validation into `ProtocolMapperPolicyValidator`, reused by both the new executor and the existing Client Registration Policy.
- Hook `ProtocolMappersResource` to trigger client policies before create/update mapper operations.

Fixes #50131

