### PR TITLE
Update vc and vci to reference credential scopes by ID

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/oid4vc/UserVerifiableCredentialRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/oid4vc/UserVerifiableCredentialRepresentation.java
@@ -67,6 +67,6 @@ public class UserVerifiableCredentialRepresentation {
 
     @Override
     public int hashCode() {
-        return Objects.hash(credentialScopeName, credentialConfigurationId ,revision, createdDate, userAttributes);
+        return Objects.hash(credentialScopeName, credentialConfigurationId, revision, createdDate, userAttributes);
     }
 }

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/UserCacheSession.java
@@ -874,9 +874,9 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     @Override
-    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+    public boolean removeVerifiableCredential(String userId, String clientScopeId) {
         invalidateVerifiableCredentials(userId);
-        return getDelegate().removeVerifiableCredential(userId, credentialScopeName);
+        return getDelegate().removeVerifiableCredential(userId, clientScopeId);
     }
 
     private void invalidateVerifiableCredentials(String userId) {
@@ -913,17 +913,31 @@ public class UserCacheSession implements UserCache, OnCreateComponent, OnUpdateC
     }
 
     private UserVerifiableCredentialModel toCredentialModel(CachedUserVerifiableCredential cachedCredential) {
-        UserVerifiableCredentialModel credentialModel = new UserVerifiableCredentialModel(cachedCredential.getCredentialScopeName());
+        UserVerifiableCredentialModel credentialModel = new UserVerifiableCredentialModel(cachedCredential.getId(), cachedCredential.getClientScopeId());
         credentialModel.setRevision(cachedCredential.getRevision());
         credentialModel.setCreatedDate(cachedCredential.getCreatedDate());
+        credentialModel.setUpdatedDate(cachedCredential.getUpdatedDate());
         credentialModel.setUserAttributes(cachedCredential.getUserAttributes());
         return credentialModel;
     }
 
     @Override
-    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName) {
+    public UserVerifiableCredentialModel getVerifiableCredentialById(String id) {
+        return getDelegate().getVerifiableCredentialById(id);
+    }
+
+    @Override
+    public UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId) {
+        return getVerifiableCredentialsByUser(userId)
+                .filter(vc -> clientScopeId.equals(vc.getClientScopeId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String clientScopeId) {
         invalidateVerifiableCredentials(userId);
-        return getDelegate().updateVerifiableCredential(userId, credentialScopeName);
+        return getDelegate().updateVerifiableCredential(userId, clientScopeId);
     }
 
     @Override

--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserVerifiableCredential.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/entities/CachedUserVerifiableCredential.java
@@ -9,15 +9,19 @@ import org.keycloak.models.UserVerifiableCredentialModel;
 
 public class CachedUserVerifiableCredential {
 
-    private final String credentialScopeName;
+    private final String id;
+    private final String clientScopeId;
     private final String revision;
     private final Long createdDate;
+    private final Long updatedDate;
     private final MultivaluedHashMap<String, String> userAttributes;
 
     public CachedUserVerifiableCredential(UserVerifiableCredentialModel credentialModel) {
-        this.credentialScopeName = credentialModel.getCredentialScopeName();
+        this.id = credentialModel.getId();
+        this.clientScopeId = credentialModel.getClientScopeId();
         this.revision = credentialModel.getRevision();
         this.createdDate = credentialModel.getCreatedDate();
+        this.updatedDate = credentialModel.getUpdatedDate();
 
         this.userAttributes = new MultivaluedHashMap<>();
         if (credentialModel.getUserAttributes() != null) {
@@ -27,8 +31,12 @@ public class CachedUserVerifiableCredential {
         }
     }
 
-    public String getCredentialScopeName() {
-        return credentialScopeName;
+    public String getId() {
+        return id;
+    }
+
+    public String getClientScopeId() {
+        return clientScopeId;
     }
 
     public String getRevision() {
@@ -37,6 +45,10 @@ public class CachedUserVerifiableCredential {
 
     public Long getCreatedDate() {
         return createdDate;
+    }
+
+    public Long getUpdatedDate() {
+        return updatedDate;
     }
 
     public Map<String, List<String>> getUserAttributes() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/JpaUserProvider.java
@@ -175,8 +175,8 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         em.createNamedQuery("deleteUserGroupMembershipsByUser").setParameter("user", user).executeUpdate();
         em.createNamedQuery("deleteUserConsentClientScopesByUser").setParameter("user", user).executeUpdate();
         em.createNamedQuery("deleteUserConsentsByUser").setParameter("user", user).executeUpdate();
-        em.createNamedQuery("deleteVerifiableCredentialsByUser").setParameter("user", user).executeUpdate();
         em.createNamedQuery("deleteIssuedVcsByUser").setParameter("userId", user.getId()).executeUpdate();
+        em.createNamedQuery("deleteVerifiableCredentialsByUser").setParameter("user", user).executeUpdate();
 
         em.remove(user);
         em.flush();
@@ -394,12 +394,13 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
 
     @Override
     public UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel verifCredentialModel) {
-        if (verifCredentialModel.getCredentialScopeName() == null) {
+        if (verifCredentialModel.getClientScopeId() == null) {
             throw new BadRequestException("Credential scope not specified");
         }
 
         UserVerifiableCredentialEntity vcEntity = new UserVerifiableCredentialEntity();
-        vcEntity.setId(KeycloakModelUtils.generateId());
+        String id = KeycloakModelUtils.generateId();
+        vcEntity.setId(id);
         vcEntity.setUser(em.getReference(UserEntity.class, userId));
 
         String revision = verifCredentialModel.getRevision() == null ? SecretGenerator.getInstance().generateSecureID() : verifCredentialModel.getRevision();
@@ -411,7 +412,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         long updatedDate = verifCredentialModel.getUpdatedDate() == null ? createdDate : verifCredentialModel.getUpdatedDate();
         vcEntity.setUpdatedDate(updatedDate);
 
-        vcEntity.setCredentialScopeName(verifCredentialModel.getCredentialScopeName());
+        vcEntity.setClientScopeId(verifCredentialModel.getClientScopeId());
 
         Map<String, List<String>> userAttributes;
         if (verifCredentialModel.getUserAttributes() != null) {
@@ -437,21 +438,21 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     }
 
     @Override
-    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+    public boolean removeVerifiableCredential(String userId, String clientScopeId) {
         UserVerifiableCredentialEntity found = getVerifiableCredentialsEntitiesByUser(userId)
-                .filter(vcEnt -> vcEnt.getCredentialScopeName().equals(credentialScopeName))
+                .filter(vcEnt -> vcEnt.getClientScopeId().equals(clientScopeId))
                 .findFirst()
                 .orElse(null);
 
         if (found == null) return false;
 
-        em.remove(found);
-
+        // Delete issued VCs first, then the VC itself (FK constraint)
         em.createNamedQuery("deleteIssuedVcsByUserAndType")
                 .setParameter("userId", userId)
-                .setParameter("credentialType", credentialScopeName)
+                .setParameter("verifiableCredentialId", found.getId())
                 .executeUpdate();
 
+        em.remove(found);
         em.flush();
         return true;
     }
@@ -460,11 +461,26 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
         return getVerifiableCredentialsEntitiesByUser(userId)
                 .map(this::toVerifiableCredentialModel)
-                .sorted(Comparator.comparing(UserVerifiableCredentialModel::getCredentialScopeName));
+                .sorted(Comparator.comparing(UserVerifiableCredentialModel::getClientScopeId));
     }
 
     @Override
-    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName) {
+    public UserVerifiableCredentialModel getVerifiableCredentialById(String id) {
+        UserVerifiableCredentialEntity entity = em.find(UserVerifiableCredentialEntity.class, id);
+        return entity != null ? toVerifiableCredentialModel(entity) : null;
+    }
+
+    @Override
+    public UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId) {
+        return getVerifiableCredentialsEntitiesByUser(userId)
+                .filter(vc -> clientScopeId.equals(vc.getClientScopeId()))
+                .findFirst()
+                .map(this::toVerifiableCredentialModel)
+                .orElse(null);
+    }
+
+    @Override
+    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String clientScopeId) {
         UserEntity userEntity = em.find(UserEntity.class, userId);
         if (userEntity == null || !session.getContext().getRealm().getId().equals(userEntity.getRealmId())) {
             throw new ModelException("User not found: " + userId);
@@ -472,10 +488,10 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         UserModel user = new UserAdapter(session, session.getContext().getRealm(), em, userEntity);
 
         UserVerifiableCredentialEntity entity = getVerifiableCredentialsEntitiesByUser(userId)
-                .filter(vc -> credentialScopeName.equals(vc.getCredentialScopeName()))
+                .filter(vc -> clientScopeId.equals(vc.getClientScopeId()))
                 .findFirst()
                 .orElseThrow(() -> new ModelException(
-                        "Verifiable credential not found: " + credentialScopeName));
+                        "Verifiable credential not found: " + clientScopeId));
 
 
         // Filter attributes using UserProfile with admin context to include only admin-visible attributes
@@ -509,7 +525,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
     }
 
     private UserVerifiableCredentialModel toVerifiableCredentialModel(UserVerifiableCredentialEntity entity) {
-        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(entity.getCredentialScopeName());
+        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(entity.getId(), entity.getClientScopeId());
         model.setRevision(entity.getRevision());
         model.setCreatedDate(entity.getCreatedDate());
         model.setUpdatedDate(entity.getUpdatedDate());
@@ -560,9 +576,9 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
                 .setParameter("realmId", realm.getId()).executeUpdate();
         em.createNamedQuery("deleteUserConsentsByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
-        em.createNamedQuery("deleteVerifiableCredentialsByRealm")
-                .setParameter("realmId", realm.getId()).executeUpdate();
         em.createNamedQuery("deleteIssuedVcsByRealm")
+                .setParameter("realmId", realm.getId()).executeUpdate();
+        em.createNamedQuery("deleteVerifiableCredentialsByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
         em.createNamedQuery("deleteUserRoleMappingsByRealm")
                 .setParameter("realmId", realm.getId()).executeUpdate();
@@ -669,11 +685,11 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         em.createNamedQuery("deleteUserConsentClientScopesByClientScope")
                 .setParameter("scopeId", clientScope.getId())
                 .executeUpdate();
-        em.createNamedQuery("deleteVerifiableCredentialsByClientScope")
-                .setParameter("scopeName", clientScope.getName())
-                .executeUpdate();
         em.createNamedQuery("deleteIssuedVcsByClientScope")
-                .setParameter("scopeName", clientScope.getName())
+                .setParameter("scopeId", clientScope.getId())
+                .executeUpdate();
+        em.createNamedQuery("deleteVerifiableCredentialsByClientScope")
+                .setParameter("scopeId", clientScope.getId())
                 .executeUpdate();
     }
 
@@ -1139,11 +1155,10 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         if (model.getRevision() != null) {
             revision = model.getRevision();
         } else {
-            UserVerifiableCredentialEntity userVerifiableCredentialEntity = getVerifiableCredentialsEntitiesByUser(model.getUserId())
-                    .filter(vc -> model.getCredentialType().equals(vc.getCredentialScopeName()))
-                    .findFirst()
-                    .orElseThrow(() -> new ModelException(
-                            "Verifiable credential not found: " + model.getCredentialType()));
+            UserVerifiableCredentialEntity userVerifiableCredentialEntity = em.find(UserVerifiableCredentialEntity.class, model.getVerifiableCredentialId());
+            if (userVerifiableCredentialEntity == null) {
+                throw new ModelException("Verifiable credential not found: " + model.getVerifiableCredentialId());
+            }
             revision = userVerifiableCredentialEntity.getRevision();
         }
 
@@ -1151,7 +1166,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
 
         issuedVerifiableCredentialEntity.setId(SecretGenerator.getInstance().generateSecureID());
         issuedVerifiableCredentialEntity.setUser(em.getReference(UserEntity.class, model.getUserId()));
-        issuedVerifiableCredentialEntity.setCredentialType(model.getCredentialType());
+        issuedVerifiableCredentialEntity.setVerifiableCredentialId(model.getVerifiableCredentialId());
         issuedVerifiableCredentialEntity.setClientId(model.getClientId());
         issuedVerifiableCredentialEntity.setRevision(revision);
 
@@ -1377,7 +1392,7 @@ public class JpaUserProvider implements UserProvider, UserCredentialStore, JpaUs
         IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel();
         model.setId(entity.getId());
         model.setUserId(entity.getUser().getId());
-        model.setCredentialType(entity.getCredentialType());
+        model.setVerifiableCredentialId(entity.getVerifiableCredentialId());
         model.setRevision(entity.getRevision());
         model.setIssuedAt(entity.getIssuedAt());
         model.setExpiresAt(entity.getExpiresAt());

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IssuedVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/IssuedVerifiableCredentialEntity.java
@@ -18,10 +18,10 @@ import jakarta.persistence.Table;
         @NamedQuery(name="issuedVcsByUser", query="select vc from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId order by vc.issuedAt desc"),
         @NamedQuery(name="deleteIssuedVcsByRealm", query="delete from IssuedVerifiableCredentialEntity vc where vc.user IN (select u from UserEntity u where u.realmId = :realmId)"),
         @NamedQuery(name="deleteIssuedVcsByUser",  query="delete from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId"),
-        @NamedQuery(name="deleteIssuedVcsByClientScope", query="delete from IssuedVerifiableCredentialEntity vc where vc.credentialType = :scopeName"),
+        @NamedQuery(name="deleteIssuedVcsByClientScope", query="delete from IssuedVerifiableCredentialEntity vc where vc.verifiableCredentialId in (select uvc.id from UserVerifiableCredentialEntity uvc where uvc.clientScopeId = :scopeId)"),
         @NamedQuery(name="deleteIssuedVcsByClient", query="delete from IssuedVerifiableCredentialEntity vc where vc.clientId = :clientId"),
-        @NamedQuery(name="deleteIssuedVcsByUserAndType", query="delete from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId and vc.credentialType = :credentialType"),
         @NamedQuery(name="deleteExpiredIssuedVcs", query="delete from IssuedVerifiableCredentialEntity vc where vc.expiresAt IS NOT NULL and vc.expiresAt < :currentTime"),
+        @NamedQuery(name="deleteIssuedVcsByUserAndType", query="delete from IssuedVerifiableCredentialEntity vc where vc.user.id = :userId and vc.verifiableCredentialId = :verifiableCredentialId"),
 })
 public class IssuedVerifiableCredentialEntity {
 
@@ -34,8 +34,8 @@ public class IssuedVerifiableCredentialEntity {
     @JoinColumn(name="USER_ID")
     protected UserEntity user;
 
-    @Column(name="CREDENTIAL_TYPE")
-    protected String credentialType;
+    @Column(name="VER_CREDENTIAL_ID")
+    protected String verifiableCredentialId;
 
     @Column(name="ISSUED_AT")
     protected Long issuedAt;
@@ -66,12 +66,12 @@ public class IssuedVerifiableCredentialEntity {
         this.user = user;
     }
 
-    public String getCredentialType() {
-        return credentialType;
+    public String getVerifiableCredentialId() {
+        return verifiableCredentialId;
     }
 
-    public void setCredentialType(String credentialType) {
-        this.credentialType = credentialType;
+    public void setVerifiableCredentialId(String verifiableCredentialId) {
+        this.verifiableCredentialId = verifiableCredentialId;
     }
 
     public Long getIssuedAt() {

--- a/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserVerifiableCredentialEntity.java
+++ b/model/jpa/src/main/java/org/keycloak/models/jpa/entities/UserVerifiableCredentialEntity.java
@@ -16,12 +16,12 @@ import jakarta.persistence.Version;
 
 @Entity
 @Table(name="USER_VER_CREDENTIAL", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"USER_ID", "CREDENTIAL_SCOPE_ID"})
+        @UniqueConstraint(columnNames = {"USER_ID", "CLIENT_SCOPE_ID"})
 })
 @NamedQueries({
         @NamedQuery(name="verifiableCredentialsByUser", query="select vc from UserVerifiableCredentialEntity vc where vc.user.id = :userId"),
         @NamedQuery(name="deleteVerifiableCredentialsByRealm", query="delete from UserVerifiableCredentialEntity vc where vc.user IN (select user from UserEntity user where user.realmId = :realmId)"),
-        @NamedQuery(name="deleteVerifiableCredentialsByClientScope", query="delete from UserVerifiableCredentialEntity vc where vc.credentialScopeName = :scopeName"),
+        @NamedQuery(name="deleteVerifiableCredentialsByClientScope", query="delete from UserVerifiableCredentialEntity vc where vc.clientScopeId = :scopeId"),
         @NamedQuery(name="deleteVerifiableCredentialsByUser", query="delete from UserVerifiableCredentialEntity vc where vc.user = :user"),
 })
 public class UserVerifiableCredentialEntity {
@@ -35,8 +35,8 @@ public class UserVerifiableCredentialEntity {
     @JoinColumn(name="USER_ID")
     protected UserEntity user;
 
-    @Column(name="CREDENTIAL_SCOPE_NAME")
-    protected String credentialScopeName;
+    @Column(name="CLIENT_SCOPE_ID")
+    protected String clientScopeId;
 
     @Column(name="REVISION")
     protected String revision;
@@ -70,12 +70,12 @@ public class UserVerifiableCredentialEntity {
         this.user = user;
     }
 
-    public String getCredentialScopeName() {
-        return credentialScopeName;
+    public String getClientScopeId() {
+        return clientScopeId;
     }
 
-    public void setCredentialScopeName(String credentialScopeName) {
-        this.credentialScopeName = credentialScopeName;
+    public void setClientScopeId(String clientScopeId) {
+        this.clientScopeId = clientScopeId;
     }
 
     public String getRevision() {

--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -50,7 +50,7 @@
             <column name="ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="CREDENTIAL_SCOPE_NAME" type="VARCHAR(255)">
+            <column name="CLIENT_SCOPE_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="USER_ID" type="VARCHAR(36)">
@@ -68,7 +68,7 @@
         </createTable>
         <addPrimaryKey columnNames="ID" constraintName="CONSTRAINT_VCRED_PM" tableName="USER_VER_CREDENTIAL"/>
         <addForeignKeyConstraint baseColumnNames="USER_ID" baseTableName="USER_VER_CREDENTIAL" constraintName="FK_VCRED_USER" referencedColumnNames="ID" referencedTableName="USER_ENTITY"/>
-        <addUniqueConstraint columnNames="CREDENTIAL_SCOPE_NAME, USER_ID" constraintName="UK_KKUWUVD67ONTGSUGOGM8UEWRE" tableName="USER_VER_CREDENTIAL"/>
+        <addUniqueConstraint columnNames="USER_ID, CLIENT_SCOPE_ID" constraintName="UK_KKUWUVD67ONTGSUGOGM8UEWRE" tableName="USER_VER_CREDENTIAL"/>
     </changeSet>
 
     <changeSet author="keycloak" id="26.7.0-outbox">
@@ -230,7 +230,7 @@
             <column name="USER_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="CREDENTIAL_TYPE" type="VARCHAR(255)">
+            <column name="VER_CREDENTIAL_ID" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="ISSUED_AT" type="BIGINT">
@@ -250,6 +250,12 @@
                                  referencedColumnNames="ID"
                                  referencedTableName="USER_ENTITY"/>
 
+        <addForeignKeyConstraint baseColumnNames="VER_CREDENTIAL_ID"
+                                 baseTableName="ISSUED_VER_CREDENTIAL"
+                                 constraintName="FK_ISSUED_VER_CREDENTIAL_VC"
+                                 referencedColumnNames="ID"
+                                 referencedTableName="USER_VER_CREDENTIAL"/>
+
         <!-- Index for listing user's credentials -->
         <createIndex tableName="ISSUED_VER_CREDENTIAL" indexName="IDX_ISSUED_VER_CREDENTIAL_USER">
             <column name="USER_ID"/>
@@ -260,6 +266,12 @@
     <changeSet author="keycloak" id="26.7.0-issued-ver-credential-expires-at-index">
         <createIndex tableName="ISSUED_VER_CREDENTIAL" indexName="IDX_ISSUED_VER_CREDENTIAL_EXPIRES_AT">
             <column name="EXPIRES_AT"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet author="keycloak" id="26.7.0-issued-ver-credential-vc-id-index">
+        <createIndex tableName="ISSUED_VER_CREDENTIAL" indexName="IDX_ISSUED_VER_CREDENTIAL_VC">
+            <column name="VER_CREDENTIAL_ID"/>
         </createIndex>
     </changeSet>
 

--- a/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
+++ b/model/storage-private/src/main/java/org/keycloak/exportimport/util/ExportUtils.java
@@ -446,7 +446,7 @@ public class ExportUtils {
 
         // Verifiable credentials
         List<UserVerifiableCredentialRepresentation> verifiableCredentialReps = session.users().getVerifiableCredentialsByUser(user.getId())
-                .map(ModelToRepresentation::toRepresentation)
+                .map(model -> ModelToRepresentation.toRepresentation(model, realm))
                 .toList();
         if (!verifiableCredentialReps.isEmpty()) {
             userRep.setVerifiableCredentials(verifiableCredentialReps);
@@ -454,7 +454,7 @@ public class ExportUtils {
 
         // Issued verifiable credentials
         List<IssuedVerifiableCredentialRepresentation> issuedCredentialReps = session.users().getIssuedVerifiableCredentialsStreamByUser(user.getId())
-                .map(ModelToRepresentation::toRepresentation)
+                .map(model -> ModelToRepresentation.toRepresentation(model, session, realm))
                 .toList();
         if (!issuedCredentialReps.isEmpty()) {
             userRep.setIssuedVerifiableCredentials(issuedCredentialReps);

--- a/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
+++ b/model/storage-private/src/main/java/org/keycloak/storage/UserStorageManager.java
@@ -942,18 +942,18 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     }
 
     @Override
-    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName) {
+    public UserVerifiableCredentialModel updateVerifiableCredential(String userId, String clientScopeId) {
         if (StorageId.isLocalStorage(userId)) {
-            return localStorage().updateVerifiableCredential(userId, credentialScopeName);
+            return localStorage().updateVerifiableCredential(userId, clientScopeId);
         } else {
             throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
         }
     }
 
     @Override
-    public boolean removeVerifiableCredential(String userId, String credentialScopeName) {
+    public boolean removeVerifiableCredential(String userId, String clientScopeId) {
         if (StorageId.isLocalStorage(userId)) {
-            return localStorage().removeVerifiableCredential(userId, credentialScopeName);
+            return localStorage().removeVerifiableCredential(userId, clientScopeId);
         } else {
             throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
         }
@@ -963,6 +963,20 @@ public class UserStorageManager extends AbstractStorageManager<UserStorageProvid
     public Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId) {
         if (StorageId.isLocalStorage(userId)) {
             return localStorage().getVerifiableCredentialsByUser(userId);
+        } else {
+            throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
+        }
+    }
+
+    @Override
+    public UserVerifiableCredentialModel getVerifiableCredentialById(String id) {
+        return localStorage().getVerifiableCredentialById(id);
+    }
+
+    @Override
+    public UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId) {
+        if (StorageId.isLocalStorage(userId)) {
+            return localStorage().getVerifiableCredentialByClientScope(userId, clientScopeId);
         } else {
             throw new UnsupportedOperationException("Verifiable credential operations not yet supported on federated users");
         }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/ModelToRepresentation.java
@@ -49,6 +49,7 @@ import org.keycloak.common.Profile;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.common.util.Time;
 import org.keycloak.component.ComponentModel;
+import org.keycloak.constants.OID4VCIConstants;
 import org.keycloak.credential.CredentialMetadata;
 import org.keycloak.credential.CredentialModel;
 import org.keycloak.deployment.DeployedConfigurationsManager;
@@ -91,6 +92,7 @@ import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.WebAuthnPolicy;
 import org.keycloak.models.credential.OTPCredentialModel;
 import org.keycloak.models.light.LightweightUserAdapter;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.account.CredentialMetadataRepresentation;
 import org.keycloak.representations.account.LocalizedMessage;
@@ -1061,13 +1063,32 @@ public class ModelToRepresentation {
         return consentRep;
     }
 
-    public static UserVerifiableCredentialRepresentation toRepresentation(UserVerifiableCredentialModel model) {
+    public static UserVerifiableCredentialRepresentation toRepresentation(UserVerifiableCredentialModel model, String credentialScopeName) {
         UserVerifiableCredentialRepresentation rep = new UserVerifiableCredentialRepresentation();
-        rep.setCredentialScopeName(model.getCredentialScopeName());
+        rep.setCredentialScopeName(credentialScopeName);
         rep.setRevision(model.getRevision());
         rep.setCreatedDate(model.getCreatedDate());
         rep.setUpdatedDate(model.getUpdatedDate());
         rep.setUserAttributes(model.getUserAttributes());
+        return rep;
+    }
+
+    public static UserVerifiableCredentialRepresentation toRepresentation(UserVerifiableCredentialModel model, RealmModel realm) {
+        ClientScopeModel clientScope = realm.getClientScopeById(model.getClientScopeId());
+        String scopeName = null;
+
+        if (clientScope != null) {
+            scopeName = clientScope.getName();
+        }
+
+        UserVerifiableCredentialRepresentation rep = toRepresentation(model, scopeName);
+
+        // Enrich with credentialConfigurationId if it's an OID4VCI scope
+        if (clientScope != null && OID4VCIConstants.OID4VC_PROTOCOL.equals(clientScope.getProtocol())) {
+            CredentialScopeModel credentialScope = new CredentialScopeModel(clientScope);
+            rep.setCredentialConfigurationId(credentialScope.getCredentialConfigurationId());
+        }
+
         return rep;
     }
 
@@ -1507,16 +1528,28 @@ public class ModelToRepresentation {
         return representation;
     }
 
-    public static IssuedVerifiableCredentialRepresentation toRepresentation(IssuedVerifiableCredentialModel model) {
+    public static IssuedVerifiableCredentialRepresentation toRepresentation(IssuedVerifiableCredentialModel model, String credentialType) {
         IssuedVerifiableCredentialRepresentation rep = new IssuedVerifiableCredentialRepresentation();
         rep.setId(model.getId());
         rep.setUserId(model.getUserId());
-        rep.setCredentialType(model.getCredentialType());
+        rep.setCredentialType(credentialType);
         rep.setRevision(model.getRevision());
         rep.setIssuedAt(model.getIssuedAt());
         rep.setExpiresAt(model.getExpiresAt());
         rep.setClientId(model.getClientId());
         return rep;
+    }
+
+    public static IssuedVerifiableCredentialRepresentation toRepresentation(IssuedVerifiableCredentialModel model, KeycloakSession session, RealmModel realm) {
+        String credentialType = null;
+        UserVerifiableCredentialModel vcModel = session.users().getVerifiableCredentialById(model.getVerifiableCredentialId());
+        if (vcModel != null) {
+            ClientScopeModel clientScope = realm.getClientScopeById(vcModel.getClientScopeId());
+            if (clientScope != null) {
+                credentialType = clientScope.getName();
+            }
+        }
+        return toRepresentation(model, credentialType);
     }
 
 }

--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -822,16 +822,29 @@ public class RepresentationToModel {
 
     public static void createVerifiableCredentials(UserRepresentation userRep, KeycloakSession session, UserModel user) {
         if (userRep.getVerifiableCredentials() != null) {
+            RealmModel realm = session.getContext().getRealm();
             for (UserVerifiableCredentialRepresentation verifiableCred : userRep.getVerifiableCredentials()) {
-                session.users().addVerifiableCredential(user.getId(), toModel(verifiableCred));
+                session.users().addVerifiableCredential(user.getId(), toModel(verifiableCred, realm));
             }
         }
     }
 
     public static void createIssuedVerifiableCredentials(UserRepresentation userRep, KeycloakSession session, UserModel user) {
         if (userRep.getIssuedVerifiableCredentials() != null) {
+            RealmModel realm = session.getContext().getRealm();
             for (IssuedVerifiableCredentialRepresentation issuedCred : userRep.getIssuedVerifiableCredentials()) {
-                session.users().addIssuedVerifiableCredential(toModel(issuedCred));
+                ClientScopeModel clientScope = KeycloakModelUtils.getClientScopeByName(realm, issuedCred.getCredentialType());
+                if (clientScope == null) {
+                    throw new ModelException("Client scope not found: " + issuedCred.getCredentialType());
+                }
+
+                UserVerifiableCredentialModel verifiableCredential = session.users()
+                        .getVerifiableCredentialByClientScope(user.getId(), clientScope.getId());
+                if (verifiableCredential == null) {
+                    throw new ModelException("User verifiable credential not found for scope: " + issuedCred.getCredentialType());
+                }
+
+                session.users().addIssuedVerifiableCredential(toModel(issuedCred, verifiableCredential.getId()));
             }
         }
     }
@@ -1025,13 +1038,22 @@ public class RepresentationToModel {
         return consentModel;
     }
 
-    public static UserVerifiableCredentialModel toModel(UserVerifiableCredentialRepresentation rep) {
-        UserVerifiableCredentialModel verifCredentialModel = new UserVerifiableCredentialModel(rep.getCredentialScopeName());
-        verifCredentialModel.setRevision(rep.getRevision());
-        verifCredentialModel.setCreatedDate(rep.getCreatedDate());
-        verifCredentialModel.setUpdatedDate(rep.getUpdatedDate());
-        verifCredentialModel.setUserAttributes(rep.getUserAttributes());
-        return verifCredentialModel;
+    public static UserVerifiableCredentialModel toModel(UserVerifiableCredentialRepresentation rep, RealmModel realm) {
+        if (rep.getCredentialScopeName() == null) {
+            throw new ModelException("credentialScopeName is required");
+        }
+
+        ClientScopeModel clientScope = KeycloakModelUtils.getClientScopeByName(realm, rep.getCredentialScopeName());
+        if (clientScope == null) {
+            throw new ModelException("Client scope not found: " + rep.getCredentialScopeName());
+        }
+
+        UserVerifiableCredentialModel model = new UserVerifiableCredentialModel(null, clientScope.getId());
+        model.setRevision(rep.getRevision());
+        model.setCreatedDate(rep.getCreatedDate());
+        model.setUpdatedDate(rep.getUpdatedDate());
+        model.setUserAttributes(rep.getUserAttributes());
+        return model;
     }
 
     public static AuthenticationFlowModel toModel(AuthenticationFlowRepresentation rep) {
@@ -1805,11 +1827,11 @@ public class RepresentationToModel {
         return new OrganizationDomainModel(domainRepresentation.getName(), domainRepresentation.isVerified());
     }
 
-    public static IssuedVerifiableCredentialModel toModel(IssuedVerifiableCredentialRepresentation representation) {
+    public static IssuedVerifiableCredentialModel toModel(IssuedVerifiableCredentialRepresentation representation, String verifiableCredentialId) {
         IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel();
         model.setId(representation.getId());
         model.setUserId(representation.getUserId());
-        model.setCredentialType(representation.getCredentialType());
+        model.setVerifiableCredentialId(verifiableCredentialId);
         model.setIssuedAt(representation.getIssuedAt());
         model.setExpiresAt(representation.getExpiresAt());
         model.setClientId(representation.getClientId());

--- a/server-spi/src/main/java/org/keycloak/models/IssuedVerifiableCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/IssuedVerifiableCredentialModel.java
@@ -4,7 +4,7 @@ public class IssuedVerifiableCredentialModel {
 
     private String id;
     private String userId;
-    private String credentialType;
+    private String verifiableCredentialId;
     private Long issuedAt;
     private Long expiresAt;
     // This represents UUID of the client, which acts as OID4VCI wallet
@@ -14,9 +14,9 @@ public class IssuedVerifiableCredentialModel {
     public IssuedVerifiableCredentialModel() {
     }
 
-    public IssuedVerifiableCredentialModel(String userId, String credentialType, String clientId) {
+    public IssuedVerifiableCredentialModel(String userId, String verifiableCredentialId, String clientId) {
         this.userId = userId;
-        this.credentialType = credentialType;
+        this.verifiableCredentialId = verifiableCredentialId;
         this.clientId = clientId;
     }
 
@@ -36,12 +36,12 @@ public class IssuedVerifiableCredentialModel {
         this.userId = userId;
     }
 
-    public String getCredentialType() {
-        return credentialType;
+    public String getVerifiableCredentialId() {
+        return verifiableCredentialId;
     }
 
-    public void setCredentialType(String credentialType) {
-        this.credentialType = credentialType;
+    public void setVerifiableCredentialId(String verifiableCredentialId) {
+        this.verifiableCredentialId = verifiableCredentialId;
     }
 
     public Long getIssuedAt() {

--- a/server-spi/src/main/java/org/keycloak/models/UserProvider.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserProvider.java
@@ -161,7 +161,7 @@ public interface UserProvider extends Provider,
      * Create verifiable credential of specified credential scope for this user
      *
      * @param userId id of the user
-     * @param credentialModel credential model with "credentialScopeName" set. The other fields will be generated if not set
+     * @param credentialModel credential model with "clientScopeId" set. The other fields will be generated if not set
      * @return credentialModel with all the fields set
      */
     UserVerifiableCredentialModel addVerifiableCredential(String userId, UserVerifiableCredentialModel credentialModel);
@@ -170,10 +170,10 @@ public interface UserProvider extends Provider,
      * Remove verifiable credential of specified client scope from this user
      *
      * @param userId id if the user
-     * @param credentialScopeName credential scope name to delete
+     * @param clientScopeId client scope ID to delete
      * @return true if credential was successfully removed. False otherwise
      */
-    boolean removeVerifiableCredential(String userId, String credentialScopeName);
+    boolean removeVerifiableCredential(String userId, String clientScopeId);
 
     /**
      * Return all verifiable credentials of specified user
@@ -184,14 +184,31 @@ public interface UserProvider extends Provider,
     Stream<UserVerifiableCredentialModel> getVerifiableCredentialsByUser(String userId);
 
     /**
+     * Get a verifiable credential by its ID
+     *
+     * @param id the verifiable credential ID
+     * @return the credential model, or null if not found
+     */
+    UserVerifiableCredentialModel getVerifiableCredentialById(String id);
+
+    /**
+     * Get a verifiable credential for a user by client scope ID
+     *
+     * @param userId id of the user
+     * @param clientScopeId client scope ID
+     * @return the credential model, or null if not found
+     */
+    UserVerifiableCredentialModel getVerifiableCredentialByClientScope(String userId, String clientScopeId);
+
+    /**
      * Update verifiable credential by refreshing user attributes snapshot and incrementing revision
      *
      * @param userId id of the user
-     * @param credentialScopeName credential scope name to update
+     * @param clientScopeId client scope ID to update
      * @return updated credential model
      * @throws ModelException if credential doesn't exist
      */
-    UserVerifiableCredentialModel updateVerifiableCredential(String userId, String credentialScopeName);
+    UserVerifiableCredentialModel updateVerifiableCredential(String userId, String clientScopeId);
 
     /* FEDERATED IDENTITIES methods */
 
@@ -343,7 +360,7 @@ public interface UserProvider extends Provider,
     /**
      * Record that a verifiable credential was issued to a user.
      *
-     * @param issuedVc model with userId, clientId, credentialType set
+     * @param issuedVc model with userId, clientId, verifiableCredentialId set
      * @return issuedVerifiableCredentialModel with all the fields set (including ID)
      */
     IssuedVerifiableCredentialModel addIssuedVerifiableCredential(IssuedVerifiableCredentialModel issuedVc);

--- a/server-spi/src/main/java/org/keycloak/models/UserVerifiableCredentialModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserVerifiableCredentialModel.java
@@ -5,18 +5,32 @@ import java.util.Map;
 
 public class UserVerifiableCredentialModel {
 
-    private final String credentialScopeName;
+    private String id;
+    private String clientScopeId;
     private String revision;
     private Long createdDate;
     private Long updatedDate;
     private Map<String, List<String>> userAttributes;
 
-    public UserVerifiableCredentialModel(String credentialScopeName) {
-        this.credentialScopeName = credentialScopeName;
+    public UserVerifiableCredentialModel(String id, String clientScopeId) {
+        this.id = id;
+        this.clientScopeId = clientScopeId;
     }
 
-    public String getCredentialScopeName() {
-        return credentialScopeName;
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getClientScopeId() {
+        return clientScopeId;
+    }
+
+    public void setClientScopeId(String clientScopeId) {
+        this.clientScopeId = clientScopeId;
     }
 
     public String getRevision() {

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCAuthorizationDetailsProcessor.java
@@ -35,6 +35,7 @@ import org.keycloak.models.ModelException;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
 import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
@@ -382,7 +383,14 @@ public class OID4VCAuthorizationDetailsProcessor implements AuthorizationDetails
     protected IssuedVerifiableCredentialModel createIssuedVerifiableCredential(UserModel userModel, ClientModel clientModel, CredentialScopeModel credentialScope) {
         String credentialScopeName = credentialScope.getName();
         try {
-            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userModel.getId(), credentialScopeName, clientModel.getId());
+            // Lookup the UserVerifiableCredential by client scope ID to get its ID
+            UserVerifiableCredentialModel verifiableCredential = session.users()
+                    .getVerifiableCredentialByClientScope(userModel.getId(), credentialScope.getId());
+            if (verifiableCredential == null) {
+                throw new ModelException("User verifiable credential not found for scope: " + credentialScopeName);
+            }
+
+            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userModel.getId(), verifiableCredential.getId(), clientModel.getId());
 
             long issuedAt = Time.currentTimeMillis();
             model.setIssuedAt(issuedAt);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/resources/admin/UserVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/resources/admin/UserVerifiableCredentialResource.java
@@ -106,10 +106,10 @@ public class UserVerifiableCredentialResource {
         CredentialScopeModel credentialScope = checkCredentialScope(representation.getCredentialScopeName());
 
         try {
-            UserVerifiableCredentialModel modelToCreate = RepresentationToModel.toModel(representation);
+            UserVerifiableCredentialModel modelToCreate = RepresentationToModel.toModel(representation, realm);
             UserVerifiableCredentialModel createdModel = session.users().addVerifiableCredential(user.getId(), modelToCreate);
 
-            UserVerifiableCredentialRepresentation createdRep = ModelToRepresentation.toRepresentation(createdModel);
+            UserVerifiableCredentialRepresentation createdRep = ModelToRepresentation.toRepresentation(createdModel, credentialScope.getName());
             createdRep.setCredentialConfigurationId(credentialScope.getCredentialConfigurationId());
             adminEvent.operation(OperationType.CREATE).resourcePath(session.getContext().getUri()).representation(createdRep).success();
             return createdRep;
@@ -139,11 +139,7 @@ public class UserVerifiableCredentialResource {
         checkOid4VCIEnabled();
 
         return session.users().getVerifiableCredentialsByUser(user.getId())
-                .map(ModelToRepresentation::toRepresentation)
-                .peek(userVerifiableCredential -> {
-                    CredentialScopeModel credentialScope = checkCredentialScope(userVerifiableCredential.getCredentialScopeName());
-                    userVerifiableCredential.setCredentialConfigurationId(credentialScope.getCredentialConfigurationId());
-                })
+                .map(model -> ModelToRepresentation.toRepresentation(model, realm))
                 .toList();
     }
 
@@ -163,12 +159,18 @@ public class UserVerifiableCredentialResource {
         auth.users().requireManage(user);
         checkOid4VCIEnabled();
 
+        // Resolve name to ID
+        ClientScopeModel clientScope = realm.getClientScopesStream()
+                .filter(s -> s.getName().equals(credentialScopeName))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Client scope not found: " + credentialScopeName));
+
         try {
-            UserVerifiableCredentialModel updatedModel = session.users().updateVerifiableCredential(user.getId(), credentialScopeName);
+            UserVerifiableCredentialModel updatedModel = session.users().updateVerifiableCredential(user.getId(), clientScope.getId());
 
-            UserVerifiableCredentialRepresentation updatedRep = ModelToRepresentation.toRepresentation(updatedModel);
+            UserVerifiableCredentialRepresentation updatedRep = ModelToRepresentation.toRepresentation(updatedModel, realm);
 
-            CredentialScopeModel credentialScope = checkCredentialScope(updatedRep.getCredentialScopeName());
+            CredentialScopeModel credentialScope = new CredentialScopeModel(clientScope);
             updatedRep.setCredentialConfigurationId(credentialScope.getCredentialConfigurationId());
 
             adminEvent.operation(OperationType.UPDATE)
@@ -204,7 +206,13 @@ public class UserVerifiableCredentialResource {
         auth.users().requireManage(user);
         checkOid4VCIEnabled();
 
-        boolean removed = session.users().removeVerifiableCredential(user.getId(), credentialScopeName);
+        // Resolve name to ID
+        ClientScopeModel clientScope = realm.getClientScopesStream()
+                .filter(s -> s.getName().equals(credentialScopeName))
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException("Client scope not found: " + credentialScopeName));
+
+        boolean removed = session.users().removeVerifiableCredential(user.getId(), clientScope.getId());
         if (!removed) {
             logger.warn(String.format("Verifiable credential '%s' not found for user '%s' in the realm '%s'.",
                     credentialScopeName, user.getUsername(), realm.getName()));
@@ -228,7 +236,7 @@ public class UserVerifiableCredentialResource {
         checkOid4VCIEnabled();
 
         return session.users().getIssuedVerifiableCredentialsStreamByUser(user.getId())
-                .map(ModelToRepresentation::toRepresentation)
+                .map(model -> ModelToRepresentation.toRepresentation(model, session, realm))
                 .toList();
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/utils/OID4VCUtil.java
@@ -10,6 +10,7 @@ import org.keycloak.models.ClientModel;
 import org.keycloak.models.IssuedVerifiableCredentialModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserVerifiableCredentialModel;
 import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.oid4vc.OID4VCLoginProtocolFactory;
 import org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider;
@@ -41,7 +42,7 @@ public class OID4VCUtil {
      */
     public static boolean hasVerifiableCredential(KeycloakSession session, UserModel user, CredentialScopeModel credentialScope) {
         return session.users().getVerifiableCredentialsByUser(user.getId())
-                .anyMatch(credential -> credential.getCredentialScopeName().equals(credentialScope.getName()));
+                .anyMatch(credential -> credential.getClientScopeId().equals(credentialScope.getId()));
     }
 
     /**
@@ -69,7 +70,14 @@ public class OID4VCUtil {
         if (!expectedClient.getId().equals(issuedCred.get().getClientId())) {
             throw new IllegalStateException("Different client sent credential request than client from issued-credential");
         }
-        if (!expectedCredentialScope.getName().equals(issuedCred.get().getCredentialType())) {
+
+        // Resolve verifiableCredentialId to check against expected scope
+        UserVerifiableCredentialModel verifiableCredential = session.users()
+                .getVerifiableCredentialById(issuedCred.get().getVerifiableCredentialId());
+        if (verifiableCredential == null) {
+            throw new IllegalStateException("User verifiable credential not found for issued credential");
+        }
+        if (!expectedCredentialScope.getId().equals(verifiableCredential.getClientScopeId())) {
             throw new IllegalStateException("Different client scope than client scope from issued-credential");
         }
     }

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/AuthorizationEndpointChecker.java
@@ -18,8 +18,6 @@
 
 package org.keycloak.protocol.oidc.endpoints;
 
-import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,14 +33,6 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
-import org.keycloak.protocol.oid4vc.clientpolicy.PredicateCredentialClientPolicy;
-import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferState;
-import org.keycloak.protocol.oid4vc.issuance.credentialoffer.CredentialOfferStorage;
-import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
-import org.keycloak.protocol.oid4vc.model.CredentialsOffer;
-import org.keycloak.protocol.oid4vc.model.IssuerState;
-import org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils;
 import org.keycloak.protocol.oidc.OIDCAdvancedConfigWrapper;
 import org.keycloak.protocol.oidc.OIDCConfigAttributes;
 import org.keycloak.protocol.oidc.OIDCLoginProtocol;
@@ -69,8 +59,6 @@ import org.keycloak.utils.StringUtil;
 import org.jboss.logging.Logger;
 
 import static org.keycloak.OAuth2Constants.AUTHORIZATION_DETAILS;
-import static org.keycloak.OAuth2Constants.ISSUER_STATE;
-import static org.keycloak.protocol.oid4vc.clientpolicy.CredentialClientPolicies.VC_POLICY_CREDENTIAL_OFFER_REQUIRED;
 import static org.keycloak.protocol.oidc.endpoints.request.AuthorizationEndpointRequestParserProcessor.getRequestUriType;
 
 /**
@@ -380,47 +368,6 @@ public class AuthorizationEndpointChecker {
         Set<AuthorizationEndpointCheckProvider> additionalChecks = session.getAllProviders(AuthorizationEndpointCheckProvider.class);
         for (AuthorizationEndpointCheckProvider check : additionalChecks) {
             check.check(this);
-        }
-    }
-
-    public void checkCredentialScope() throws AuthorizationCheckException {
-
-        // Get the list of requested credential scopes that are associated with this client
-        //
-        List<CredentialScopeModel> credScopes = CredentialScopeUtils.getCredentialScopesForAuthorization(client, request);
-
-        // Proceed when there are requested credential scopes
-        //
-        if (!credScopes.isEmpty()) {
-
-            PredicateCredentialClientPolicy offerRequiredPolicy = VC_POLICY_CREDENTIAL_OFFER_REQUIRED;
-
-            // Get the potential offer state derived from issuer_state
-            //
-            String issuerStateParam = request.getAdditionalReqParams().get(ISSUER_STATE);
-            CredentialOfferStorage offerStorage = session.getProvider(CredentialOfferStorage.class);
-            CredentialOfferState offerState = Optional.ofNullable(issuerStateParam)
-                    .map(IssuerState::fromEncodedString)
-                    .map(IssuerState::getCredentialsOfferId)
-                    .map(offerStorage::getOfferStateById)
-                    .orElse(null);
-
-            List<String> offeredConfigurationIds = Optional.ofNullable(offerState)
-                    .map(CredentialOfferState::getCredentialsOffer)
-                    .map(CredentialsOffer::getCredentialConfigurationIds)
-                    .orElse(List.of());
-
-            // Check whether each requested credential_configuration_id has actually been offered
-            //
-            for (CredentialScopeModel credScope : credScopes) {
-                String credConfigId = credScope.getCredentialConfigurationId();
-
-                boolean requiredByScope = offerRequiredPolicy.validate(new CredentialScopeRepresentation(credScope));
-                if (requiredByScope && !offeredConfigurationIds.contains(credConfigId)) {
-                    String errorDetail = "Authorization request rejected by policy " + offerRequiredPolicy.getName() + " for scope: " + credScope.getName();
-                    throw new AuthorizationCheckException(Response.Status.BAD_REQUEST, OAuthErrorException.INVALID_REQUEST, errorDetail);
-                }
-            }
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountIssuedVerifiableCredentialResource.java
@@ -74,7 +74,7 @@ public class AccountIssuedVerifiableCredentialResource {
 
         List<IssuedVerifiableCredentialRepresentation> credentials = session.users()
                 .getIssuedVerifiableCredentialsStreamByUser(user.getId())
-                .map(ModelToRepresentation::toRepresentation)
+                .map(model -> ModelToRepresentation.toRepresentation(model, session, realm))
                 .map(rep -> enrichWithClientInfo(rep, session, realm))
                 .toList();
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountVerifiableCredentialResource.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountVerifiableCredentialResource.java
@@ -29,12 +29,12 @@ import jakarta.ws.rs.core.Response;
 
 import org.keycloak.common.Profile;
 import org.keycloak.models.AccountRoles;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.models.oid4vci.CredentialScopeModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
 import org.keycloak.models.utils.ModelToRepresentation;
-import org.keycloak.protocol.oid4vc.utils.CredentialScopeUtils;
 import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
 import org.keycloak.services.ErrorResponse;
 import org.keycloak.services.cors.Cors;
@@ -74,14 +74,7 @@ public class AccountVerifiableCredentialResource {
 
         List<UserVerifiableCredentialRepresentation> credentials = session.users()
                 .getVerifiableCredentialsByUser(user.getId())
-                .map(model -> {
-                    UserVerifiableCredentialRepresentation userVerifiableCredentialRepresentation = ModelToRepresentation.toRepresentation(model);
-                    CredentialScopeModel credScope = CredentialScopeUtils.findCredentialScopeModelByName(realm, realm::getClientScopesStream, model.getCredentialScopeName());
-                    if(credScope != null){
-                         userVerifiableCredentialRepresentation.setCredentialConfigurationId(credScope.getCredentialConfigurationId());
-                    }
-                    return userVerifiableCredentialRepresentation;
-                })
+                .map(model -> ModelToRepresentation.toRepresentation(model, realm))
                 .peek(rep -> rep.setUserAttributes(null))  // Do not expose attributes snapshot to users
                 .toList();
 
@@ -103,7 +96,13 @@ public class AccountVerifiableCredentialResource {
         auth.requireOneOf(AccountRoles.MANAGE_ACCOUNT, AccountRoles.MANAGE_VERIFIABLE_CREDENTIALS);
         checkOid4VCIEnabled();
 
-        boolean removed = session.users().removeVerifiableCredential(user.getId(), credentialScopeName);
+        // Resolve name to ID
+        ClientScopeModel clientScope = KeycloakModelUtils.getClientScopeByName(realm, credentialScopeName);
+        if (clientScope == null) {
+            throw new NotFoundException("Client scope not found: " + credentialScopeName);
+        }
+
+        boolean removed = session.users().removeVerifiableCredential(user.getId(), clientScope.getId());
         if (!removed) {
             logger.warn(String.format("Verifiable credential '%s' not found for user '%s' in the realm '%s'.",
                     credentialScopeName, user.getUsername(), realm.getName()));

--- a/tests/base/src/test/java/org/keycloak/tests/admin/user/IssuedVerifiableCredentialTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/user/IssuedVerifiableCredentialTest.java
@@ -46,6 +46,9 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
 
     private static final String CREDENTIAL_TYPE_1 = jwtTypeNaturalPersonScopeName;
     private static final String CREDENTIAL_TYPE_2 = "education-cert";
+    private static final String CERT_1 = "cert-1";
+    private static final String CERT_2 = "cert-2";
+    private static final String CERT_3 = "cert-3";
 
     @InjectRealm(config = IssuedVcTestRealmConfig.class)
     protected ManagedRealm testRealm;
@@ -96,18 +99,18 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
         String userId = createUser();
         long baseTime = Time.currentTimeMillis();
 
-        createIssuedVcViaModelLayer(userId, "cert-1", "wallet-1", "rev-1", baseTime);
-        createIssuedVcViaModelLayer(userId, "cert-2", "wallet-2", "rev-2", baseTime + 1000);
-        createIssuedVcViaModelLayer(userId, "cert-3", "wallet-3", "rev-3", baseTime + 2000);
+        createIssuedVcViaModelLayer(userId, CERT_1, "wallet-1", "rev-1", baseTime);
+        createIssuedVcViaModelLayer(userId, CERT_2, "wallet-2", "rev-2", baseTime + 1000);
+        createIssuedVcViaModelLayer(userId, CERT_3, "wallet-3", "rev-3", baseTime + 2000);
 
         UserResource userResource = managedRealm.admin().users().get(userId);
         List<IssuedVerifiableCredentialRepresentation> issuedCreds = userResource.verifiableCredentials().getIssuedCredentials();
 
         assertThat(issuedCreds, hasSize(3));
 
-        assertEquals("cert-3", issuedCreds.get(0).getCredentialType());
-        assertEquals("cert-2", issuedCreds.get(1).getCredentialType());
-        assertEquals("cert-1", issuedCreds.get(2).getCredentialType());
+        assertEquals(CERT_3, issuedCreds.get(0).getCredentialType());
+        assertEquals(CERT_2, issuedCreds.get(1).getCredentialType());
+        assertEquals(CERT_1, issuedCreds.get(2).getCredentialType());
     }
 
     @Test
@@ -116,22 +119,22 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
         String user1Id = createUser("user1", "user1@test.com");
         String user2Id = createUser("user2", "user2@test.com");
 
-        createIssuedVcViaModelLayer(user1Id, "user1-cert", "wallet1", "rev1");
-        createIssuedVcViaModelLayer(user2Id, "user2-cert", "wallet2", "rev2");
+        createIssuedVcViaModelLayer(user1Id, CREDENTIAL_TYPE_1, "wallet1", "rev1");
+        createIssuedVcViaModelLayer(user2Id, CREDENTIAL_TYPE_2, "wallet2", "rev2");
 
         // User 1 should only see their VC
         List<IssuedVerifiableCredentialRepresentation> user1Creds =
                 managedRealm.admin().users().get(user1Id).verifiableCredentials().getIssuedCredentials();
 
         assertThat(user1Creds, hasSize(1));
-        assertEquals("user1-cert", user1Creds.get(0).getCredentialType());
+        assertEquals(CREDENTIAL_TYPE_1, user1Creds.get(0).getCredentialType());
 
         // User 2 should only see their VC
         List<IssuedVerifiableCredentialRepresentation> user2Creds =
                 managedRealm.admin().users().get(user2Id).verifiableCredentials().getIssuedCredentials();
 
         assertThat(user2Creds, hasSize(1));
-        assertEquals("user2-cert", user2Creds.get(0).getCredentialType());
+        assertEquals(CREDENTIAL_TYPE_2, user2Creds.get(0).getCredentialType());
     }
 
     @Test
@@ -141,14 +144,19 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
         long issuedAt = Time.currentTimeMillis();
         long expiresAt = issuedAt + 86400000L; // 24 hours later
 
-        runOnServer.run(session -> {
-            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
-            vcModel.setRevision("rev-001");
-            session.users().addVerifiableCredential(userId, vcModel);
-        });
+        // Resolve scope ID
+        String clientScopeId = managedRealm.admin().clientScopes().findAll().stream()
+                .filter(s -> CREDENTIAL_TYPE_1.equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Client scope not found: " + CREDENTIAL_TYPE_1))
+                .getId();
 
         runOnServer.run(session -> {
-            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userId, CREDENTIAL_TYPE_1, "wallet-123");
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(null, clientScopeId);
+            vcModel.setRevision("rev-001");
+            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(userId, vcModel);
+
+            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userId, added.getId(), "wallet-123");
             model.setRevision("rev-001");
             model.setIssuedAt(issuedAt);
             model.setExpiresAt(expiresAt);
@@ -316,21 +324,27 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
 
         long now = Time.currentTimeMillis();
         long oneHourInMs = 3600000L;
-        // Create two credentials, both expiring in 1 hour
-        runOnServer.run(session -> {
-            UserVerifiableCredentialModel vcModel1 = new UserVerifiableCredentialModel(CREDENTIAL_TYPE_1);
-            vcModel1.setRevision("rev-001");
-            session.users().addVerifiableCredential(userId, vcModel1);
 
-        });
+        // Resolve scope ID
+        String clientScopeId = managedRealm.admin().clientScopes().findAll().stream()
+                .filter(s -> CREDENTIAL_TYPE_1.equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Client scope not found: " + CREDENTIAL_TYPE_1))
+                .getId();
+
+        // Create one verifiable credential and two issued credentials with different expiration times
         runOnServer.run(session -> {
-            IssuedVerifiableCredentialModel model1 = new IssuedVerifiableCredentialModel(userId, CREDENTIAL_TYPE_1, clientId);
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(null, clientScopeId);
+            vcModel.setRevision("rev-001");
+            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(userId, vcModel);
+
+            IssuedVerifiableCredentialModel model1 = new IssuedVerifiableCredentialModel(userId, added.getId(), clientId);
             model1.setRevision("rev-001");
             model1.setIssuedAt(now);
             model1.setExpiresAt(now + oneHourInMs); // Expires in 1 hour
             session.users().addIssuedVerifiableCredential(model1);
 
-            IssuedVerifiableCredentialModel model2 = new IssuedVerifiableCredentialModel(userId, CREDENTIAL_TYPE_1, clientId);
+            IssuedVerifiableCredentialModel model2 = new IssuedVerifiableCredentialModel(userId, added.getId(), clientId);
             model2.setRevision("rev-002");
             model2.setIssuedAt(now);
             model2.setExpiresAt(now + oneHourInMs * 2); // Expires in 2 hour
@@ -367,14 +381,19 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
 
     protected void createIssuedVcViaModelLayer(String userId, String credentialType,
                                                String clientId, String revision, Long issuedAt) {
-        runOnServer.run(session -> {
-            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(credentialType);
-            vcModel.setRevision(revision);
-            session.users().addVerifiableCredential(userId, vcModel);
-        });
+        // Resolve scope ID
+        String clientScopeId = testRealm.admin().clientScopes().findAll().stream()
+                .filter(s -> credentialType.equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Client scope not found: " + credentialType))
+                .getId();
 
         runOnServer.run(session -> {
-            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userId, credentialType, clientId);
+            UserVerifiableCredentialModel vcModel = new UserVerifiableCredentialModel(null, clientScopeId);
+            vcModel.setRevision(revision);
+            UserVerifiableCredentialModel added = session.users().addVerifiableCredential(userId, vcModel);
+
+            IssuedVerifiableCredentialModel model = new IssuedVerifiableCredentialModel(userId, added.getId(), clientId);
             model.setRevision(revision);
             if (issuedAt != null) {
                 model.setIssuedAt(issuedAt);
@@ -405,7 +424,13 @@ public class IssuedVerifiableCredentialTest extends AbstractUserTest {
                     .eventsEnabled(true)
                     .eventsListeners("jboss-logging")
                     .verifiableCredentialsEnabled(true)
-                    .clientScopes(createCredentialScope(CREDENTIAL_TYPE_1), createCredentialScope(CREDENTIAL_TYPE_2));
+                    .clientScopes(
+                            createCredentialScope(CREDENTIAL_TYPE_1),
+                            createCredentialScope(CREDENTIAL_TYPE_2),
+                            createCredentialScope(CERT_1),
+                            createCredentialScope(CERT_2),
+                            createCredentialScope(CERT_3)
+                    );
         }
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCExportImportTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCExportImportTest.java
@@ -12,6 +12,7 @@ import org.keycloak.exportimport.ExportImportManager;
 import org.keycloak.exportimport.dir.DirExportProvider;
 import org.keycloak.exportimport.singlefile.SingleFileExportProviderFactory;
 import org.keycloak.models.IssuedVerifiableCredentialModel;
+import org.keycloak.models.RealmModel;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
 import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
@@ -158,14 +159,32 @@ public class OID4VCExportImportTest extends OID4VCIssuerTestBase {
                 .orElseThrow()
                 .getId();
 
+        String scope1Id = testRealm.admin().clientScopes().findAll().stream()
+                .filter(s -> jwtTypeCredentialScopeName.equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Client scope not found: " + jwtTypeCredentialScopeName))
+                .getId();
+
+        String scope2Id = testRealm.admin().clientScopes().findAll().stream()
+                .filter(s -> sdJwtTypeCredentialScopeName.equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Client scope not found: " + sdJwtTypeCredentialScopeName))
+                .getId();
+
         // Create issued credentials based on existing verifiable credentials
         runOnServer.run(session -> {
-            IssuedVerifiableCredentialModel issuedCred1 = new IssuedVerifiableCredentialModel(userId, jwtTypeCredentialScopeName, walletClientId);
+            RealmModel realm = session.realms().getRealmByName(VCTestRealmConfig.TEST_REALM_NAME);
+            session.getContext().setRealm(realm);
+
+            String vc1Id = session.users().getVerifiableCredentialByClientScope(userId, scope1Id).getId();
+            String vc2Id = session.users().getVerifiableCredentialByClientScope(userId, scope2Id).getId();
+
+            IssuedVerifiableCredentialModel issuedCred1 = new IssuedVerifiableCredentialModel(userId, vc1Id, walletClientId);
             issuedCred1.setRevision("rev-001");
             issuedCred1.setIssuedAt(System.currentTimeMillis());
             session.users().addIssuedVerifiableCredential(issuedCred1);
 
-            IssuedVerifiableCredentialModel issuedCred2 = new IssuedVerifiableCredentialModel(userId, sdJwtTypeCredentialScopeName, walletClientId);
+            IssuedVerifiableCredentialModel issuedCred2 = new IssuedVerifiableCredentialModel(userId, vc2Id, walletClientId);
             issuedCred2.setRevision("rev-002");
             issuedCred2.setIssuedAt(System.currentTimeMillis());
             session.users().addIssuedVerifiableCredential(issuedCred2);


### PR DESCRIPTION
Closes #50065

  - Replaced `credentialScopeName` with `clientScopeId` in `UserVerifiableCredential`
  - Add FK constraint from `IssuedVerifiableCredential` to `UserVerifiableCredential`
  - No REST API changes (representations still use scope names)
  - No UI changes

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
