### PR TITLE
Document Hardcoded LDAP Attribute Mapper in Server Administration Guide

### DIFF
--- a/docs/documentation/server_admin/topics/user-federation/ldap.adoc
+++ b/docs/documentation/server_admin/topics/user-federation/ldap.adoc
@@ -178,6 +178,9 @@ When you register new users in {project_name} and `Sync Registrations` is ON for
 Hardcoded Attribute Mapper::
 This mapper adds a hardcoded attribute value to each {project_name} user linked with LDAP. This mapper can also force values for the `enabled` or `emailVerified` user properties.
 
+Hardcoded LDAP Attribute Mapper::
+This mapper writes a hardcoded value to a specified attribute on the user's LDAP entry. It only fires when a new user is created in {project_name} and the LDAP provider has `Edit Mode = WRITABLE` and `Sync Registrations = ON`; it does not write values when users are imported from LDAP. The target attribute must be defined in the LDAP schema and permitted by at least one `objectClass` on the user entry, otherwise the LDAP write fails with an `undefined attribute type` or `objectClassViolation` error. The value supports the `+${RANDOM}+` token, which is replaced with a 30-character random string. The mapper marks the attribute as read-only for subsequent updates so that changes in {project_name} are not propagated back to LDAP.
+
 Role Mapper::
 This mapper configures role mappings from LDAP into {project_name} role mappings. A single role mapper can map LDAP roles (usually groups from a particular branch of the LDAP tree) into roles corresponding to a specified client's realm roles or client roles. You can configure more Role mappers for the same LDAP provider. For example, you can specify that role mappings from groups under `ou=main,dc=example,dc=org` map to realm role mappings, and role mappings from groups under `ou=finance,dc=example,dc=org` map to client role mappings of client `finance`.
 


### PR DESCRIPTION
Closes #50154

Summary
Adds a missing entry for the hardcoded-ldap-attribute-mapper provider under LDAP Mappers in the Server Administration Guide. The Keycloak codebase ships this mapper (HardcodedLDAPAttributeMapperFactory, HardcodedLDAPAttributeMapper in federation/ldap), but it was never documented; only the related hardcoded-attribute-mapper is documented today.

Documentation
Adds a new Hardcoded LDAP Attribute Mapper entry in docs/documentation/server_admin/topics/user-federation/ldap.adoc describing direction (Keycloak → LDAP), prerequisites (Edit Mode = WRITABLE, Sync Registrations = ON, schema/objectClass requirement on the target attribute), the ${RANDOM} token, and the read-only-after-create behaviour.
AI assistance disclosure
AI tooling was used to help draft the wording; all content was reviewed and validated against the source code in federation/ldap/src/main/java/org/keycloak/storage/ldap/mappers/.
