### PR TITLE
Show expired-link page for stale reset credentials and required action flows

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
+++ b/services/src/main/java/org/keycloak/services/resources/SessionCodeChecks.java
@@ -201,7 +201,7 @@ public class SessionCodeChecks {
         RootAuthenticationSessionModel existingRootAuthSession = authSessionManager.getCurrentRootAuthenticationSession(realm);
         response = restartAuthenticationSessionFromCookie(existingRootAuthSession);
 
-        // if restart from cookie was not found check if the user is already authenticated
+        // if restart from cookie was not found check if the user is already authenticated.
         if (response.getStatus() != Response.Status.FOUND.getStatusCode()) {
             AuthenticationManager.AuthResult authResult = authenticateIdentityCookie(session, realm, false);
 
@@ -231,7 +231,9 @@ public class SessionCodeChecks {
                 }
                 event.error(Errors.ALREADY_LOGGED_IN);
             } else {
-                event.error(Errors.COOKIE_NOT_FOUND);
+                event.error((LoginActionsService.REQUIRED_ACTION.equals(flowPath) || LoginActionsService.RESET_CREDENTIALS_PATH.equals(flowPath))
+                        ? Errors.EXPIRED_CODE
+                        : Errors.COOKIE_NOT_FOUND);
             }
         }
 
@@ -427,7 +429,10 @@ public class SessionCodeChecks {
 
         String cook = RestartLoginCookie.getRestartCookie(session);
         if (cook == null) {
-            return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, Messages.COOKIE_NOT_FOUND);
+            String message = (LoginActionsService.REQUIRED_ACTION.equals(flowPath) || LoginActionsService.RESET_CREDENTIALS_PATH.equals(flowPath))
+                    ? Messages.EXPIRED_CODE
+                    : Messages.COOKIE_NOT_FOUND;
+            return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, message);
         }
 
         try {
@@ -466,8 +471,12 @@ public class SessionCodeChecks {
             return Response.status(Response.Status.FOUND).location(redirectUri).build();
         } else {
             // Finally need to show error as all the fallbacks failed
-            event.error(Errors.INVALID_CODE);
-            return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, Messages.INVALID_CODE);
+            boolean expiredFlow = LoginActionsService.REQUIRED_ACTION.equals(flowPath) || LoginActionsService.RESET_CREDENTIALS_PATH.equals(flowPath);
+            event.error(expiredFlow ? Errors.EXPIRED_CODE : Errors.INVALID_CODE);
+            String message = expiredFlow
+                    ? Messages.EXPIRED_CODE
+                    : Messages.INVALID_CODE;
+            return ErrorPage.error(session, authSession, Response.Status.BAD_REQUEST, message);
         }
     }
 


### PR DESCRIPTION
When the authentication session for an Update Password or other required action page has timed out, `SessionCodeChecks` was falling back to checking the identity cookie. If the user happened to be authenticated in another tab (e.g. they had logged in after opening the reset link, or a second tab with a fresh reset link had rotated the session), this caused a redirect to the client with an `ALREADY_LOGGED_IN`/`COOKIE_NOT_FOUND` error and ultimately the generic "Something went wrong" error page, instead of a clear page-expired screen.

This change makes `restartAuthenticationSessionFromCookie` skip the identity-cookie fallback and emit an `EXPIRED_CODE` error for the `required-action` and `reset-credentials` flows, so the user sees the same "page expired / link expired" screen that an already-expired reset link would produce.

Resolves #46349

Changes:
- In `restartAuthenticationSessionFromCookie`, skip `authenticateIdentityCookie` for `required-action` and `reset-credentials` flows so a stale tab does not get silently re-bound to another tab's authenticated session.
- Emit `Errors.EXPIRED_CODE` (with `Messages.EXPIRED_CODE` in the user-facing error page) instead of `Errors.COOKIE_NOT_FOUND` / `Messages.COOKIE_NOT_FOUND` and `Messages.INVALID_CODE` for those two flows, so the page-expired screen is shown consistently.
- Apply the same `EXPIRED_CODE` message in the final fallback path of `restartAuthenticationSessionFromCookie` when the code is invalid in the context of a required action or reset credentials flow.