### PR TITLE
Increase AUTHENTICATOR column length to support longer authenticator names

### DIFF
--- a/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
+++ b/model/jpa/src/main/resources/META-INF/jpa-changelog-26.7.0.xml
@@ -399,4 +399,8 @@
         </createIndex>
     </changeSet>
 
+    <changeSet author="keycloak" id="26.7.0-authenticator-character-limit">
+        <modifyDataType tableName="AUTHENTICATION_EXECUTION" columnName="AUTHENTICATOR" newDataType="VARCHAR(255)"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Resolves #46094.

The `AUTHENTICATOR` column on the `AUTHENTICATION_EXECUTION` table is `VARCHAR(36)`, which is too short for longer authenticator references such as script execution paths (for example `script-executions/provision-workspace-user.js`). Adding an execution with a longer name fails at insert time with `value too long for type character varying(36)`, as reported in the issue.

This widens the column to `VARCHAR(255)` with a Liquibase changeset in the 26.7.0 changelog.
