### PR TITLE
Validate scopes are associated with resources in scope permissions

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/RepresentationToModel.java
@@ -134,6 +134,7 @@ import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceOwnerRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
+import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import org.keycloak.representations.idm.oid4vc.IssuedVerifiableCredentialRepresentation;
 import org.keycloak.representations.idm.oid4vc.UserVerifiableCredentialRepresentation;
@@ -1421,6 +1422,7 @@ public class RepresentationToModel {
 
         updateResources(representation, model, authorization);
         updateScopes(representation, model, storeFactory);
+        validateScopesAssociatedWithResources(representation, model, authorization);
         updateAssociatedPolicies(representation, model, storeFactory);
 
         PolicyProviderFactory provider = authorization.getProviderFactory(model.getType());
@@ -1493,6 +1495,48 @@ public class RepresentationToModel {
         }
 
         policy.removeConfig("scopes");
+    }
+
+    private static void validateScopesAssociatedWithResources(AbstractPolicyRepresentation representation, Policy policy, AuthorizationProvider authorization) {
+        if (!(representation instanceof ScopePermissionRepresentation)) {
+            // only scope-based permissions bind scopes to specific resources
+            return;
+        }
+
+        String resourceType = representation.getResourceType();
+
+        if (StringUtil.isNotBlank(resourceType)) {
+            // permissions applied to a resource type manage their scopes through the type
+            return;
+        }
+
+        if (policy.getResources().isEmpty() || policy.getScopes().isEmpty()) {
+            // resource-less scope permissions are not bound to any resource
+            return;
+        }
+
+        ResourceServer resourceServer = policy.getResourceServer();
+        ResourceStore resourceStore = authorization.getStoreFactory().getResourceStore();
+        Set<String> resourceScopeIds = new HashSet<>();
+
+        for (Resource resource : policy.getResources()) {
+            resource.getScopes().forEach(scope -> resourceScopeIds.add(scope.getId()));
+
+            // a typed resource not owned by the resource server inherits the scopes defined by its resource type
+            if (resource.getType() != null && !resourceServer.getClientId().equals(resource.getOwner())) {
+                resourceStore.findByType(resourceServer, resource.getType(), resourceServer.getClientId(), typed -> {
+                    if (!typed.getId().equals(resource.getId())) {
+                        typed.getScopes().forEach(scope -> resourceScopeIds.add(scope.getId()));
+                    }
+                });
+            }
+        }
+
+        for (Scope scope : policy.getScopes()) {
+            if (!resourceScopeIds.contains(scope.getId())) {
+                throw new ModelValidationException("Scope [" + scope.getName() + "] is not associated with any of the resources set to the permission");
+            }
+        }
     }
 
     private static void updateAssociatedPolicies(AbstractPolicyRepresentation representation, Policy policy, StoreFactory storeFactory) {

--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -81,7 +81,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             OAuth2ErrorRepresentation error = new OAuth2ErrorRepresentation();
 
             error.setError(getErrorCode(throwable));
-            if (throwable.getCause() instanceof ModelException) {
+            if (throwable instanceof ModelValidationException || throwable.getCause() instanceof ModelException) {
                 error.setErrorDescription(throwable.getMessage());
             } if (throwable instanceof ModelDuplicateException) {
                 error.setErrorDescription(throwable.getMessage());
@@ -146,6 +146,10 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
 
         if (cause instanceof ModelDuplicateException || throwable instanceof ModelDuplicateException) {
             return "conflict";
+        }
+
+        if (throwable instanceof ModelValidationException) {
+            return OAuthErrorException.INVALID_REQUEST;
         }
 
         if (throwable instanceof WebApplicationException && throwable.getMessage() != null) {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/PolicyEvaluationCompositeRoleTest.java
@@ -19,6 +19,7 @@ package org.keycloak.testsuite.authz;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.authorization.AuthorizationProvider;
@@ -78,6 +79,7 @@ public class PolicyEvaluationCompositeRoleTest extends AbstractAuthzTest {
 
         Scope scope = authz.getStoreFactory().getScopeStore().create(resourceServer, "myscope");
         Resource resource = authz.getStoreFactory().getResourceStore().create(resourceServer, "myresource", resourceServer.getClientId());
+        resource.updateScopes(Set.of(scope));
         addScopePermission(authz, resourceServer, "mypermission", resource, scope, policy);
 
         RoleModel composite = realm.addRole("composite");

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/AbstractPolicyManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/AbstractPolicyManagementTest.java
@@ -103,7 +103,7 @@ public abstract class AbstractPolicyManagementTest extends AbstractKeycloakTest 
 
         if (expected.getPolicies() != null) {
             assertEquals(expected.getPolicies().size(), associatedPolicies.size());
-            assertEquals(0, associatedPolicies.stream().map(representation1 -> representation1.getName()).filter(policyName -> !expected.getPolicies().contains(policyName)).count());
+            assertEquals(0, associatedPolicies.stream().map(AbstractPolicyRepresentation::getName).filter(policyName -> !expected.getPolicies().contains(policyName)).count());
         } else {
             assertTrue(associatedPolicies.isEmpty());
         }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ScopePermissionManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ScopePermissionManagementTest.java
@@ -16,19 +16,24 @@
  */
 package org.keycloak.testsuite.authz.admin;
 
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 
 import org.keycloak.admin.client.resource.AuthorizationResource;
 import org.keycloak.admin.client.resource.ScopePermissionResource;
 import org.keycloak.admin.client.resource.ScopePermissionsResource;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
 import org.keycloak.representations.idm.authorization.DecisionStrategy;
 import org.keycloak.representations.idm.authorization.Logic;
+import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ScopePermissionRepresentation;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 
 import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -143,6 +148,168 @@ public class ScopePermissionManagementTest extends AbstractPolicyManagementTest 
 
         try (Response response = permissions.create(permission2)) {
             assertEquals(Response.Status.CONFLICT.getStatusCode(), response.getStatus());
+        }
+    }
+
+    @Test
+    public void failCreateWithScopeNotAssociatedWithResource() {
+        AuthorizationResource authorization = getClient().authorization();
+
+        // a scope that exists in the resource server but is not associated with "Resource A"
+        authorization.scopes().create(new ScopeRepresentation("delete")).close();
+
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+
+        representation.setName("Invalid Scope Permission");
+        representation.addResource("Resource A");
+        representation.addScope("delete");
+        representation.addPolicy("Only Marta Policy");
+
+        ScopePermissionsResource permissions = authorization.permissions().scope();
+
+        try (Response response = permissions.create(representation)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+
+            // the validation error must be surfaced to the client instead of an opaque unknown_error
+            OAuth2ErrorRepresentation error = response.readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("invalid_request", error.getError());
+            assertTrue(error.getErrorDescription() != null && error.getErrorDescription().contains("delete"),
+                    "Expected the offending scope name in the error description");
+        }
+    }
+
+    @Test
+    public void failCreateWithScopeNotAssociatedWithResourceWhenResourceTypeIsBlank() {
+        AuthorizationResource authorization = getClient().authorization();
+
+        authorization.scopes().create(new ScopeRepresentation("delete")).close();
+
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+
+        representation.setName("Blank ResourceType Scope Permission");
+        representation.setResourceType("   ");
+        representation.addResource("Resource A");
+        representation.addScope("delete");
+        representation.addPolicy("Only Marta Policy");
+
+        ScopePermissionsResource permissions = authorization.permissions().scope();
+
+        try (Response response = permissions.create(representation)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+
+            OAuth2ErrorRepresentation error = response.readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("invalid_request", error.getError());
+            assertTrue(error.getErrorDescription() != null && error.getErrorDescription().contains("delete"),
+                    "Expected the offending scope name in the error description");
+        }
+    }
+
+    @Test
+    public void failUpdateWithScopeNotAssociatedWithResource() {
+        AuthorizationResource authorization = getClient().authorization();
+
+        // a scope that exists in the resource server but is not associated with "Resource A"
+        authorization.scopes().create(new ScopeRepresentation("delete")).close();
+
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+
+        representation.setName("Update To Invalid Scope Permission");
+        representation.addResource("Resource A");
+        representation.addScope("read");
+        representation.addPolicy("Only Marta Policy");
+
+        assertCreated(authorization, representation);
+
+        representation.getScopes().clear();
+        representation.addScope("delete");
+
+        ScopePermissionsResource permissions = authorization.permissions().scope();
+        ScopePermissionResource permission = permissions.findById(representation.getId());
+
+        try {
+            permission.update(representation);
+            fail("Expected a Bad Request for a scope not associated with the resource");
+        } catch (BadRequestException expected) {
+            OAuth2ErrorRepresentation error = expected.getResponse().readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("invalid_request", error.getError());
+            assertTrue(error.getErrorDescription() != null && error.getErrorDescription().contains("delete"),
+                    "Expected the offending scope name in the error description");
+        }
+    }
+
+    @Test
+    public void testAllowScopeInheritedFromTypedResource() {
+        AuthorizationResource authorization = getClient().authorization();
+
+        authorization.scopes().create(new ScopeRepresentation("manage")).close();
+
+        ResourceRepresentation typeResource = new ResourceRepresentation();
+        typeResource.setName("Type Resource");
+        typeResource.setType("test-type");
+        typeResource.addScope("manage");
+        authorization.resources().create(typeResource).close();
+
+        ResourceRepresentation userResource = new ResourceRepresentation();
+        userResource.setName("User Typed Resource");
+        userResource.setType("test-type");
+        userResource.setOwner("marta");
+
+        String userResourceId;
+        try (Response response = authorization.resources().create(userResource)) {
+            userResourceId = response.readEntity(ResourceRepresentation.class).getId();
+        }
+
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+        representation.setName("Typed Resource Inherited Scope Permission");
+        representation.addResource(userResourceId);
+        representation.addScope("manage");
+        representation.addPolicy("Only Marta Policy");
+
+        ScopePermissionsResource permissions = authorization.permissions().scope();
+
+        try (Response response = permissions.create(representation)) {
+            assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
+        }
+    }
+
+    @Test
+    public void failCreateWithScopeNotInheritedByTypedResource() {
+        AuthorizationResource authorization = getClient().authorization();
+
+        authorization.scopes().create(new ScopeRepresentation("manage")).close();
+        authorization.scopes().create(new ScopeRepresentation("archive")).close();
+
+        ResourceRepresentation typeResource = new ResourceRepresentation();
+        typeResource.setName("Typed Resource For Reject");
+        typeResource.setType("reject-type");
+        typeResource.addScope("manage");
+        authorization.resources().create(typeResource).close();
+
+        ResourceRepresentation userResource = new ResourceRepresentation();
+        userResource.setName("User Typed Resource For Reject");
+        userResource.setType("reject-type");
+        userResource.setOwner("marta");
+
+        String userResourceId;
+        try (Response response = authorization.resources().create(userResource)) {
+            userResourceId = response.readEntity(ResourceRepresentation.class).getId();
+        }
+
+        ScopePermissionRepresentation representation = new ScopePermissionRepresentation();
+        representation.setName("Reject Non-Inherited Scope Permission");
+        representation.addResource(userResourceId);
+        representation.addScope("archive");
+        representation.addPolicy("Only Marta Policy");
+
+        ScopePermissionsResource permissions = authorization.permissions().scope();
+
+        try (Response response = permissions.create(representation)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+
+            OAuth2ErrorRepresentation error = response.readEntity(OAuth2ErrorRepresentation.class);
+            assertEquals("invalid_request", error.getError());
+            assertTrue(error.getErrorDescription() != null && error.getErrorDescription().contains("archive"),
+                    "Expected the offending scope name in the error description");
         }
     }
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/federation/ldap/LDAPProvidersIntegrationTest.java
@@ -271,7 +271,7 @@ public class LDAPProvidersIntegrationTest extends AbstractLDAPTest {
             try (Response resp = managedRealm.admin().users().create(newUser1)) {
                 Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), resp.getStatus());
                 OAuth2ErrorRepresentation error = resp.readEntity(OAuth2ErrorRepresentation.class);
-                Assertions.assertEquals("unknown_error", error.getError());
+                Assertions.assertEquals("invalid_request", error.getError());
             }
             Assertions.assertTrue(managedRealm.admin().users().search("newuser1").isEmpty());
 


### PR DESCRIPTION
Closes #50178

## Problem

When creating or updating a **scope-based permission** via the Admin REST API (`POST/PUT .../authz/resource-server/permission/scope`) with both `resources` and `scopes` set, the server accepted a scope that is **not associated** with the given resource(s) and returned `201`/`204`.

The admin console already prevents this — `ScopeSelect` only offers scopes returned by `listScopesByResource()` for the selected resource — but the backend performed no equivalent check. The result is a "dead" permission that can never match at evaluation time, and whose mandatory *Authorization scopes* field shows up empty when reopened in the console.

This is the same class of validation gap that was fixed for resource **type** consistency in #48434.

## Cause

`RepresentationToModel#updateScopes` and `updateResources` only validate that each scope/resource **exists** in the resource server; neither checks that the scopes are associated with the resources set on the permission.

## Fix

`RepresentationToModel#toModel` now validates, after resources and scopes are applied, that every scope of a `ScopePermissionRepresentation` is associated with at least one of the permission's resources (`Resource#getScopes()` — the same association the console relies on). If not, a `ModelValidationException` is thrown and mapped to `400 Bad Request`.

The check is intentionally narrow:
- only `ScopePermissionRepresentation` (the typed `permission/scope` endpoint) —  realm import uses `PolicyRepresentation` and is left unaffected;
- skipped when a `resourceType` is set (resource-type / FGAP permissions manage  their scopes through the type);
- skipped for resource-less scope permissions (scopes only).

## Testing

Added to `ScopePermissionManagementTest`:
- `failCreateWithScopeNotAssociatedWithResource` — create is rejected with `400`;
- `failUpdateWithScopeNotAssociatedWithResource` — update is rejected as well.

Existing positive cases (scopes associated with the resource, and resource-less scope permissions) remain green.
