### PR TITLE
reject sd-jwt disclosure whose claim name already exists

### DIFF
--- a/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
+++ b/core/src/main/java/org/keycloak/sdjwt/SdJwtVerificationContext.java
@@ -365,12 +365,19 @@ public class SdJwtVerificationContext {
                         // Mark salt as visited
                         markSaltAsVisited(decodedDisclosure.getSaltValue(), visitedSalts);
 
+                        // If the claim name already exists at the level of the _sd key,
+                        // the SD-JWT MUST be rejected (selective-disclosure-jwt, verification
+                        // of the Issuer-signed JWT). Otherwise a Disclosure could silently
+                        // shadow a claim that is present in plaintext or added by another Disclosure.
+                        String claimName = decodedDisclosure.getClaimName();
+                        if (currentObjectNode.has(claimName)) {
+                            throw new VerificationException(
+                                    "Disclosure claim name already present in the payload: " + claimName);
+                        }
+
                         // Insert, at the level of the _sd key, a new claim using the claim name
                         // and claim value from the Disclosure
-                        currentObjectNode.set(
-                                decodedDisclosure.getClaimName(),
-                                decodedDisclosure.getClaimValue()
-                        );
+                        currentObjectNode.set(claimName, decodedDisclosure.getClaimValue());
                     }
                 }
             }

--- a/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
@@ -26,6 +26,7 @@ import org.keycloak.OID4VCConstants;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.crypto.SignatureVerifierContext;
 import org.keycloak.rule.CryptoInitRule;
 
@@ -493,6 +494,43 @@ public abstract class SdJwtVerificationTest {
         );
 
         assertTrue(exception.getMessage().startsWith("A digest was encountered more than once:"));
+    }
+
+    @Test
+    public void sdJwtVerificationShouldFail_IfDisclosureClaimNameAlreadyPresent() throws Exception {
+        // Build a real Disclosure for "given_name" along with its digest in the _sd array.
+        ObjectNode disclosedClaims = mapper.createObjectNode();
+        disclosedClaims.put("given_name", "Jane");
+
+        IssuerSignedJWT helper = exampleFlatSdJwtV2(disclosedClaims,
+                DisclosureSpec.builder()
+                              .withUndisclosedClaim("given_name", "eluV5Og3gSNII8EYnsxA_A")
+                              .build()).build();
+
+        String disclosure = helper.getDisclosureClaims().get(0).getDisclosureStrings().get(0);
+
+        // Keep the _sd digest but also surface "given_name" in plaintext, so the Disclosure
+        // collides with a claim already present at the same level.
+        ObjectNode tamperedPayload = helper.getPayload().deepCopy();
+        tamperedPayload.put("given_name", "John");
+
+        IssuerSignedJWT tampered = new IssuerSignedJWT(new JWSHeader(), tamperedPayload);
+        tampered.sign(testSettings.issuerSigContext);
+
+        SdJwtVerificationContext ctx =
+                new SdJwtVerificationContext(tampered, Collections.singletonList(disclosure));
+
+        VerificationException exception = assertThrows(
+                VerificationException.class,
+                () -> ctx.verifyIssuance(
+                    defaultIssuerVerifyingKeys(),
+                    optionalTimeClaimVerificationOpts().build(),
+                    null
+                )
+        );
+
+        assertEquals("Disclosure claim name already present in the payload: given_name",
+                     exception.getMessage());
     }
 
     @Test

--- a/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
+++ b/core/src/test/java/org/keycloak/sdjwt/SdJwtVerificationTest.java
@@ -26,8 +26,8 @@ import org.keycloak.OID4VCConstants;
 import org.keycloak.common.VerificationException;
 import org.keycloak.common.util.Time;
 import org.keycloak.crypto.SignatureSignerContext;
-import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.crypto.SignatureVerifierContext;
+import org.keycloak.jose.jws.JWSHeader;
 import org.keycloak.rule.CryptoInitRule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
Repro: verify an SD-JWT whose Issuer-signed payload holds a claim in plaintext (e.g. `given_name`) and also carries an `_sd` digest whose Disclosure resolves to that same name.
Cause: `validateViaRecursiveDisclosing` inserts each resolved Disclosure with `currentObjectNode.set(...)` without checking the name is free, so the Disclosure silently overwrites the plaintext claim (the disclosed value wins). The same gap lets two Disclosures collide on one name.
Fix: reject when the disclosed claim name already exists at the level of the `_sd` key, next to the existing `_sd`/`...` name rejection. This is the MUST from the SD-JWT verification algorithm (draft-ietf-oauth-selective-disclosure-jwt, verification of the Issuer-signed JWT, step 3.ii.2.3), the sibling of which step 3.ii.2.2 is already enforced here.

Added a regression test that fails before the change (no exception, value shadowed) and passes after.

closes #50240