### PR TITLE
Paginate UserSelect autocomplete and surface exact username match

### DIFF
--- a/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
+++ b/js/apps/admin-ui/maven-resources/theme/keycloak.v2/admin/messages/messages_en.properties
@@ -1681,6 +1681,7 @@ encryptionKeysConfigExplain=If you enable the "Encrypt assertions" below, the SA
 preserveGroupInheritanceHelp=Flag whether group inheritance from LDAP should be propagated to Keycloak. If false, then all LDAP groups will be mapped as flat top-level groups in Keycloak. Otherwise group inheritance is preserved into Keycloak, but the group sync might fail if LDAP structure contains recursions or multiple parent groups per child groups.
 createScopeBasedPermission=Create scope-based permission
 showMore=Show more
+showMoreUsers=Show more users
 operationType=Operation type
 userInitiatedActionLifespan=User-Initiated Action Lifespan
 decisionStrategy=Decision strategy

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -13,6 +13,7 @@ import {
   Select,
   SelectList,
   SelectOption,
+  Spinner,
   TextInputGroup,
   TextInputGroupMain,
   TextInputGroupUtilities,
@@ -32,6 +33,9 @@ type UserSelectProps = Omit<ComponentProps, "convertToName"> & {
   variant?: UserSelectVariant;
   isRequired?: boolean;
 };
+
+const USER_SEARCH_LIMIT = 20;
+const SHOW_MORE = "show-more";
 
 export const UserSelect = ({
   name,
@@ -54,11 +58,21 @@ export const UserSelect = ({
   const [open, toggleOpen, setOpen] = useToggle();
   const [selectedUsers, setSelectedUsers] = useState<UserRepresentation[]>([]);
   const [searchedUsers, setSearchedUsers] = useState<UserRepresentation[]>([]);
+  const [first, setFirst] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [search, setSearch] = useState("");
   const textInputRef = useRef<HTMLInputElement>();
+  const exactMatchId = useRef<string>();
 
-  const debounceFn = useCallback(debounce(setSearch, 500), []);
+  const debounceFn = useCallback(
+    debounce((value: string) => {
+      setFirst(0);
+      setSearch(value);
+    }, 500),
+    [],
+  );
 
   useFetch(
     async () => {
@@ -82,13 +96,43 @@ export const UserSelect = ({
   );
 
   useFetch(
-    async () =>
-      adminClient.users.find({
-        username: search,
-        max: 20,
-      }),
-    setSearchedUsers,
-    [search],
+    async () => {
+      const [page, exactMatches] = await Promise.all([
+        adminClient.users.find({
+          username: search,
+          first,
+          max: USER_SEARCH_LIMIT + 1,
+        }),
+        first === 0 && search
+          ? adminClient.users.find({ username: search, exact: true, max: 1 })
+          : Promise.resolve<UserRepresentation[]>([]),
+      ]);
+      return { page, exactMatch: exactMatches.at(0) };
+    },
+    ({ page, exactMatch }) => {
+      const more = page.length > USER_SEARCH_LIMIT;
+      const pageUsers = more ? page.slice(0, USER_SEARCH_LIMIT) : page;
+      if (first === 0) {
+        if (
+          exactMatch &&
+          !pageUsers.some((user) => user.id === exactMatch.id)
+        ) {
+          exactMatchId.current = exactMatch.id;
+          setSearchedUsers([exactMatch, ...pageUsers]);
+        } else {
+          exactMatchId.current = undefined;
+          setSearchedUsers(pageUsers);
+        }
+      } else {
+        setSearchedUsers((current) => [
+          ...current,
+          ...pageUsers.filter((user) => user.id !== exactMatchId.current),
+        ]);
+      }
+      setHasMore(more);
+      setLoadingMore(false);
+    },
+    [search, first],
   );
 
   useEffect(() => {
@@ -133,6 +177,8 @@ export const UserSelect = ({
         render={({ field }) => (
           <Select
             id={name!}
+            isScrollable
+            maxMenuHeight="300px"
             onOpenChange={toggleOpen}
             toggle={(ref) => (
               <MenuToggle
@@ -196,6 +242,7 @@ export const UserSelect = ({
                         onClick={() => {
                           setInputValue("");
                           setSearch("");
+                          setFirst(0);
                           field.onChange([]);
                           textInputRef.current?.focus();
                         }}
@@ -212,6 +259,11 @@ export const UserSelect = ({
             selected={field.value}
             onSelect={(_, v) => {
               const option = v?.toString();
+              if (option === SHOW_MORE) {
+                setLoadingMore(true);
+                setFirst((f) => f + USER_SEARCH_LIMIT);
+                return;
+              }
               if (variant !== "typeaheadMulti") {
                 const removed = field.value.includes(option);
 
@@ -238,7 +290,25 @@ export const UserSelect = ({
             }}
             aria-label={t(name!)}
           >
-            <SelectList>{convert(searchedUsers)}</SelectList>
+            <SelectList>
+              {convert(searchedUsers)}
+              {hasMore && (
+                <SelectOption
+                  key={SHOW_MORE}
+                  value={SHOW_MORE}
+                  isDisabled={loadingMore}
+                  aria-label={t("showMoreUsers")}
+                >
+                  {loadingMore ? (
+                    <>
+                      <Spinner size="sm" /> {t("spinnerLoading")}
+                    </>
+                  ) : (
+                    t("showMore")
+                  )}
+                </SelectOption>
+              )}
+            </SelectList>
           </Select>
         )}
       />

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -69,6 +69,10 @@ export const UserSelect = ({
   const debounceFn = useCallback(
     debounce((value: string) => {
       setFirst(0);
+      setHasMore(false);
+      setLoadingMore(false);
+      setPageUsers([]);
+      setExactMatch(undefined);
       setSearch(value);
     }, 500),
     [],

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -304,7 +304,9 @@ export const UserSelect = ({
                   key={SHOW_MORE}
                   value={SHOW_MORE}
                   isDisabled={loadingMore}
-                  aria-label={t("showMoreUsers")}
+                  aria-label={
+                    loadingMore ? t("spinnerLoading") : t("showMoreUsers")
+                  }
                 >
                   {loadingMore ? (
                     <>

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -242,9 +242,14 @@ export const UserSelect = ({
                       <Button
                         variant="plain"
                         onClick={() => {
+                          debounceFn.cancel();
                           setInputValue("");
-                          setSearch("");
                           setFirst(0);
+                          setHasMore(false);
+                          setLoadingMore(false);
+                          setPageUsers([]);
+                          setExactMatch(undefined);
+                          setSearch("");
                           field.onChange([]);
                           textInputRef.current?.focus();
                         }}

--- a/js/apps/admin-ui/src/components/users/UserSelect.tsx
+++ b/js/apps/admin-ui/src/components/users/UserSelect.tsx
@@ -57,14 +57,14 @@ export const UserSelect = ({
 
   const [open, toggleOpen, setOpen] = useToggle();
   const [selectedUsers, setSelectedUsers] = useState<UserRepresentation[]>([]);
-  const [searchedUsers, setSearchedUsers] = useState<UserRepresentation[]>([]);
+  const [pageUsers, setPageUsers] = useState<UserRepresentation[]>([]);
+  const [exactMatch, setExactMatch] = useState<UserRepresentation>();
   const [first, setFirst] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [search, setSearch] = useState("");
   const textInputRef = useRef<HTMLInputElement>();
-  const exactMatchId = useRef<string>();
 
   const debounceFn = useCallback(
     debounce((value: string) => {
@@ -96,43 +96,31 @@ export const UserSelect = ({
   );
 
   useFetch(
-    async () => {
-      const [page, exactMatches] = await Promise.all([
-        adminClient.users.find({
-          username: search,
-          first,
-          max: USER_SEARCH_LIMIT + 1,
-        }),
-        first === 0 && search
-          ? adminClient.users.find({ username: search, exact: true, max: 1 })
-          : Promise.resolve<UserRepresentation[]>([]),
-      ]);
-      return { page, exactMatch: exactMatches.at(0) };
-    },
-    ({ page, exactMatch }) => {
+    () =>
+      adminClient.users.find({
+        username: search,
+        first,
+        max: USER_SEARCH_LIMIT + 1,
+      }),
+    (page) => {
       const more = page.length > USER_SEARCH_LIMIT;
-      const pageUsers = more ? page.slice(0, USER_SEARCH_LIMIT) : page;
-      if (first === 0) {
-        if (
-          exactMatch &&
-          !pageUsers.some((user) => user.id === exactMatch.id)
-        ) {
-          exactMatchId.current = exactMatch.id;
-          setSearchedUsers([exactMatch, ...pageUsers]);
-        } else {
-          exactMatchId.current = undefined;
-          setSearchedUsers(pageUsers);
-        }
-      } else {
-        setSearchedUsers((current) => [
-          ...current,
-          ...pageUsers.filter((user) => user.id !== exactMatchId.current),
-        ]);
-      }
+      const nextUsers = more ? page.slice(0, USER_SEARCH_LIMIT) : page;
+      setPageUsers((current) =>
+        first === 0 ? nextUsers : [...current, ...nextUsers],
+      );
       setHasMore(more);
       setLoadingMore(false);
     },
     [search, first],
+  );
+
+  useFetch(
+    () =>
+      search
+        ? adminClient.users.find({ username: search, exact: true, max: 1 })
+        : Promise.resolve<UserRepresentation[]>([]),
+    (matches) => setExactMatch(matches.at(0)),
+    [search],
   );
 
   useEffect(() => {
@@ -141,6 +129,16 @@ export const UserSelect = ({
       setInputValue("");
     }
   }, [values]);
+
+  const searchedUsers = useMemo(() => {
+    if (!exactMatch) {
+      return pageUsers;
+    }
+    return [
+      exactMatch,
+      ...pageUsers.filter((user) => user.id !== exactMatch.id),
+    ];
+  }, [exactMatch, pageUsers]);
 
   const users = useMemo(
     () => [...selectedUsers, ...searchedUsers],


### PR DESCRIPTION
The shared UserSelect typeahead fetched at most 20 users with no pagination. When more than 20 users matched the typed term the target user could not be selected (e.g. typing the full username "jack" only listed 001jack..020jack, which sort first). This was a regression from the legacy Admin UI, which paginated.

Fetch max+1 to detect further results and render a "Show more" entry that loads the next page (reusing the existing showMore message), and run a parallel exact-username lookup so a fully typed username is shown at the top of the list. Pagination resets to the first page together with the debounced search term, and the menu is height-capped and scrollable so a long list does not stretch the page. The "Show more" entry shows a loading spinner while the next page is fetched.

Closes #49702


https://github.com/user-attachments/assets/dd9ed0c1-129f-4c3d-b6a1-18abf3af594f
