### PR TITLE
fix(admin-ui): prevent attribute save crash when the key is an Object.prototype name

### DIFF
--- a/js/apps/admin-ui/src/components/key-value-form/key-value-convert.test.ts
+++ b/js/apps/admin-ui/src/components/key-value-form/key-value-convert.test.ts
@@ -66,4 +66,31 @@ describe("Tests the convert functions for attribute input", () => {
     //then
     expect(result).toEqual({ theKey: ["one", "two"] });
   });
+
+  it("converts prototype-name key safely", () => {
+    const result = keyValueToArray([{ key: "toString", value: "x" }]);
+
+    expect(Object.hasOwn(result, "toString")).toBe(true);
+    expect(result["toString"]).toEqual(["x"]);
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it("converts duplicate prototype-name keys safely", () => {
+    const result = keyValueToArray([
+      { key: "constructor", value: "a" },
+      { key: "constructor", value: "b" },
+    ]);
+
+    expect(Object.hasOwn(result, "constructor")).toBe(true);
+    expect(result["constructor"]).toEqual(["a", "b"]);
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
+
+  it("converts __proto__ key without mutating prototype", () => {
+    const result = keyValueToArray([{ key: "__proto__", value: "x" }]);
+
+    expect(Object.hasOwn(result, "__proto__")).toBe(true);
+    expect(result["__proto__"]).toEqual(["x"]);
+    expect(Object.getPrototypeOf(result)).toBeNull();
+  });
 });

--- a/js/apps/admin-ui/src/components/key-value-form/key-value-convert.ts
+++ b/js/apps/admin-ui/src/components/key-value-form/key-value-convert.ts
@@ -4,10 +4,10 @@ export type KeyValueType = { key: string; value: string };
 
 export function keyValueToArray(attributeArray: KeyValueType[] = []) {
   const validAttributes = attributeArray.filter(({ key }) => key !== "");
-  const result: Record<string, string[]> = {};
+  const result: Record<string, string[]> = Object.create(null);
 
   for (const { key, value } of validAttributes) {
-    if (key in result) {
+    if (Object.hasOwn(result, key)) {
       result[key].push(value);
     } else {
       result[key] = [value];


### PR DESCRIPTION
In the admin-ui key-value attribute editors (realm role attributes, user attributes, organization attributes, client authorization resources, etc.), `keyValueToArray` in `js/apps/admin-ui/src/components/key-value-form/key-value-convert.ts` built its accumulator as a plain `{}` and detected duplicate keys with `key in result`. For attribute keys that collide with inherited `Object.prototype` member names (`toString`, `valueOf`, `hasOwnProperty`, `constructor`, `__proto__`, and the rest), the `in` check incorrectly returned true even though the key was not an own property. The code then took the duplicate branch and called `.push` on the inherited function (or on `Object.prototype` for `__proto__`), throwing `TypeError: result[key].push is not a function` and preventing the form from saving. `__proto__` had the additional problem of silently reassigning the accumulator's prototype rather than storing a value.

The sibling conversions in the same area already use `Object.hasOwn` for this kind of own-key check (for example `user/form-state.ts` and `util.ts`), so the fix follows the same approach.

Resolves #50190

Changes:
- In `js/apps/admin-ui/src/components/key-value-form/key-value-convert.ts`, build the result with `Object.create(null)` so it has no prototype and keys named after `Object.prototype` members become ordinary own properties.
- Replace the duplicate-key check `key in result` with `Object.hasOwn(result, key)` so only true own-key collisions trigger the `.push` branch.
- Leave `arrayToKeyValue` and the `Record<string, string[]>` return type unchanged; consumers only use `Object.keys`/`Object.entries`/`JSON` on the result, which are unaffected.
- Add three regression tests in `js/apps/admin-ui/src/components/key-value-form/key-value-convert.test.ts` covering a single prototype-name key (`toString`), a duplicate prototype-name key (`constructor`), and `__proto__`, each asserted via `Object.hasOwn`, direct indexing, and `Object.getPrototypeOf(...) === null`.