### PR TITLE
Wait the switch to be disabled when loading the page

### DIFF
--- a/js/apps/admin-ui/test/realm-settings/general.spec.ts
+++ b/js/apps/admin-ui/test/realm-settings/general.spec.ts
@@ -63,11 +63,13 @@ test.describe.serial("Realm settings general tab tests", () => {
 
   test("realm enable/disable switch", async ({ page }) => {
     // Enable realm
-    await switchOn(page, `#${realmName}-switch`);
+    const realmSwitch = page.locator(`#${realmName}-switch`);
+    await expect(realmSwitch).not.toBeChecked();
+    await switchOn(page, realmSwitch);
     await assertNotificationMessage(page, "Realm successfully updated");
 
     // Disable realm
-    await switchOff(page, `#${realmName}-switch`);
+    await switchOff(page, realmSwitch);
     await confirmModal(page);
     await assertNotificationMessage(page, "Realm successfully updated");
   });


### PR DESCRIPTION
Closes #50195

The test just waits the loading of the page and set the switch to disabled before calling the enable. This test has been failing since https://github.com/keycloak/keycloak/commit/c0d40a05380109ddabefdd0a4827f6c1f8949a2b.
