### PR TITLE
Fix SAML client creation failing for client IDs containing special characters

### DIFF
--- a/crypto/default/src/main/java/org/keycloak/crypto/def/BCCertificateUtilsProvider.java
+++ b/crypto/default/src/main/java/org/keycloak/crypto/def/BCCertificateUtilsProvider.java
@@ -43,6 +43,8 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.CertificatePolicies;
@@ -89,7 +91,7 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
                                                  String subject) {
         try {
-            X500Name subjectDN = new X500Name("CN=" + subject);
+            X500Name subjectDN = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, subject).build();
 
             // Serial Number
             SecureRandom random = new SecureRandom();
@@ -170,7 +172,7 @@ public class BCCertificateUtilsProvider implements CertificateUtilsProvider {
     @Override
     public X509Certificate generateV1SelfSignedCertificate(KeyPair caKeyPair, String subject, BigInteger serialNumber, Date validityEndDate) {
         try {
-            X500Name subjectDN = new X500Name("CN=" + subject);
+            X500Name subjectDN = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, subject).build();
             Date validityStartDate = new Date(System.currentTimeMillis() - 100000);
             SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo.getInstance(caKeyPair.getPublic().getEncoded());
 

--- a/crypto/default/src/test/java/org/keycloak/crypto/def/test/BCCertificateUtilsProviderTest.java
+++ b/crypto/default/src/test/java/org/keycloak/crypto/def/test/BCCertificateUtilsProviderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.crypto.def.test;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+
+import org.keycloak.common.util.CertificateUtils;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.rule.CryptoInitRule;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Regression test for https://github.com/keycloak/keycloak/issues/50177 - the subject used to build the
+ * certificate must not be parsed as an RFC2253 DN string, since values such as client IDs may contain
+ * characters (e.g. '=', ',') that are not valid there.
+ */
+public class BCCertificateUtilsProviderTest {
+
+    @ClassRule
+    public static CryptoInitRule cryptoInitRule = new CryptoInitRule();
+
+    @Test
+    public void testV1SelfSignedCertificateWithSpecialCharactersInSubject() {
+        String subject = "https://example.com/?action=sso_id";
+        KeyPair keyPair = KeyUtils.generateRsaKeyPair(2048);
+
+        X509Certificate certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, subject);
+
+        Assert.assertEquals(subject, extractCN(certificate));
+    }
+
+    @Test
+    public void testV3CertificateWithSpecialCharactersInSubject() throws Exception {
+        String subject = "https://example.com/?action=sso_id";
+        KeyPair caKeyPair = KeyUtils.generateRsaKeyPair(2048);
+        X509Certificate caCert = CertificateUtils.generateV1SelfSignedCertificate(caKeyPair, "ca");
+
+        KeyPair keyPair = KeyUtils.generateRsaKeyPair(2048);
+        X509Certificate certificate = CertificateUtils.generateV3Certificate(keyPair, caKeyPair.getPrivate(), caCert, subject);
+
+        Assert.assertEquals(subject, extractCN(certificate));
+    }
+
+    private static String extractCN(X509Certificate certificate) {
+        try {
+            ASN1Encodable value = new JcaX509CertificateHolder(certificate).getSubject().getRDNs(BCStyle.CN)[0].getFirst().getValue();
+            return ((ASN1String) value).getString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronCertificateUtilsProvider.java
+++ b/crypto/elytron/src/main/java/org/keycloak/crypto/elytron/ElytronCertificateUtilsProvider.java
@@ -42,6 +42,8 @@ import org.wildfly.security.asn1.ASN1;
 import org.wildfly.security.asn1.DERDecoder;
 import org.wildfly.security.x500.GeneralName;
 import org.wildfly.security.x500.X500;
+import org.wildfly.security.x500.X500AttributeTypeAndValue;
+import org.wildfly.security.x500.X500PrincipalBuilder;
 import org.wildfly.security.x500.cert.AuthorityKeyIdentifierExtension;
 import org.wildfly.security.x500.cert.BasicConstraintsExtension;
 import org.wildfly.security.x500.cert.CertificatePoliciesExtension;
@@ -82,7 +84,7 @@ public class ElytronCertificateUtilsProvider implements CertificateUtilsProvider
             String subject) throws Exception {
         try {
 
-            X500Principal subjectdn = subjectToX500Principle(subject);
+            X500Principal subjectdn = cnToX500Principal(subject);
             X500Principal issuerdn = caCert.getSubjectX500Principal();
 
             // Validity
@@ -175,7 +177,7 @@ public class ElytronCertificateUtilsProvider implements CertificateUtilsProvider
     public X509Certificate generateV1SelfSignedCertificate(KeyPair caKeyPair, String subject, BigInteger serialNumber, Date validityEndDate) {
         try {
 
-            X500Principal subjectdn = subjectToX500Principle(subject);
+            X500Principal subjectdn = cnToX500Principal(subject);
 
             ZonedDateTime notBefore = ZonedDateTime.ofInstant(
                     (new Date(System.currentTimeMillis() - 100000)).toInstant(),
@@ -217,6 +219,21 @@ public class ElytronCertificateUtilsProvider implements CertificateUtilsProvider
             subject = "CN="+subject;
         }
         return new X500Principal(subject);
+    }
+
+    /**
+     * Builds an {@link X500Principal} with a single CN RDN, encoding the given value directly as the
+     * RDN's attribute value rather than parsing it as part of an RFC 2253 DN string. This allows the
+     * value (e.g. a client ID) to contain characters that would otherwise need escaping, such as '=' or ','.
+     *
+     * @param commonName the raw CN value
+     *
+     * @return the X500Principal with a single CN RDN set to the given value
+     */
+    private static X500Principal cnToX500Principal(String commonName) {
+        return new X500PrincipalBuilder()
+                .addItem(X500AttributeTypeAndValue.createUtf8(X500.OID_AT_COMMON_NAME, commonName))
+                .build();
     }
 
     @Override

--- a/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronCertificateUtilsProviderTest.java
+++ b/crypto/elytron/src/test/java/org/keycloak/crypto/elytron/test/ElytronCertificateUtilsProviderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.crypto.elytron.test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
+import javax.naming.ldap.LdapName;
+import javax.security.auth.x500.X500Principal;
+
+import org.keycloak.crypto.elytron.ElytronCertificateUtilsProvider;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Regression test for https://github.com/keycloak/keycloak/issues/50177 - the subject used to build a
+ * certificate (e.g. a client ID) must not be parsed as an RFC 2253 DN string, since it may contain
+ * reserved characters (e.g. '=', ',', '+', '"').
+ */
+public class ElytronCertificateUtilsProviderTest {
+
+    private final ElytronCertificateUtilsProvider provider = new ElytronCertificateUtilsProvider();
+
+    @Test
+    public void testV1SelfSignedCertificateWithQueryStringSubject() throws Exception {
+        assertSubjectRoundTrips("https://example.com/?action=sso_id");
+    }
+
+    @Test
+    public void testV1SelfSignedCertificateWithCommaInSubject() throws Exception {
+        assertSubjectRoundTrips("client,id");
+    }
+
+    @Test
+    public void testV1SelfSignedCertificateWithPlusAndQuoteInSubject() throws Exception {
+        assertSubjectRoundTrips("client+id\"with\"quotes");
+    }
+
+    @Test
+    public void testV3CertificateWithQueryStringSubject() throws Exception {
+        String subject = "https://example.com/?action=sso_id";
+        KeyPair caKeyPair = generateRsaKeyPair();
+        X509Certificate caCert = provider.generateV1SelfSignedCertificate(caKeyPair, "ca");
+
+        X509Certificate certificate = provider.generateV3Certificate(generateRsaKeyPair(), caKeyPair.getPrivate(), caCert, subject);
+
+        Assert.assertEquals(subject, extractCN(certificate));
+    }
+
+    private void assertSubjectRoundTrips(String subject) throws Exception {
+        X509Certificate certificate = provider.generateV1SelfSignedCertificate(generateRsaKeyPair(), subject);
+
+        Assert.assertEquals(subject, extractCN(certificate));
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private static String extractCN(X509Certificate certificate) throws Exception {
+        X500Principal principal = certificate.getSubjectX500Principal();
+        LdapName ldapName = new LdapName(principal.getName());
+        return (String) ldapName.getRdn(0).toAttributes().get("CN").get();
+    }
+}

--- a/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSCertificateUtilsProvider.java
+++ b/crypto/fips1402/src/main/java/org/keycloak/crypto/fips/BCFIPSCertificateUtilsProvider.java
@@ -43,6 +43,8 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
 import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.CertificatePolicies;
@@ -90,7 +92,7 @@ public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
     public X509Certificate generateV3Certificate(KeyPair keyPair, PrivateKey caPrivateKey, X509Certificate caCert,
             String subject) {
         try {
-            X500Name subjectDN = new X500Name("CN=" + subject);
+            X500Name subjectDN = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, subject).build();
 
             // Serial Number
             SecureRandom random = new SecureRandom();
@@ -172,7 +174,7 @@ public class BCFIPSCertificateUtilsProvider implements CertificateUtilsProvider{
     @Override
     public X509Certificate generateV1SelfSignedCertificate(KeyPair caKeyPair, String subject, BigInteger serialNumber, Date validityEndDate) {
         try {
-            X500Name subjectDN = new X500Name("CN=" + subject);
+            X500Name subjectDN = new X500NameBuilder(BCStyle.INSTANCE).addRDN(BCStyle.CN, subject).build();
             Date validityStartDate = new Date(System.currentTimeMillis() - 100000);
             SubjectPublicKeyInfo subPubKeyInfo = SubjectPublicKeyInfo.getInstance(caKeyPair.getPublic().getEncoded());
 

--- a/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/BCFIPSCertificateUtilsProviderTest.java
+++ b/crypto/fips1402/src/test/java/org/keycloak/crypto/fips/test/BCFIPSCertificateUtilsProviderTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ *  and other contributors as indicated by the @author tags.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.keycloak.crypto.fips.test;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+
+import org.keycloak.common.util.CertificateUtils;
+import org.keycloak.common.util.KeyUtils;
+import org.keycloak.rule.CryptoInitRule;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Regression test for https://github.com/keycloak/keycloak/issues/50177 - the subject used to build the
+ * certificate must not be parsed as an RFC2253 DN string, since values such as client IDs may contain
+ * characters (e.g. '=', ',') that are not valid there.
+ */
+public class BCFIPSCertificateUtilsProviderTest {
+
+    @ClassRule
+    public static CryptoInitRule cryptoInitRule = new CryptoInitRule();
+
+    @Test
+    public void testV1SelfSignedCertificateWithSpecialCharactersInSubject() {
+        String subject = "https://example.com/?action=sso_id";
+        KeyPair keyPair = KeyUtils.generateRsaKeyPair(2048);
+
+        X509Certificate certificate = CertificateUtils.generateV1SelfSignedCertificate(keyPair, subject);
+
+        Assert.assertEquals(subject, extractCN(certificate));
+    }
+
+    @Test
+    public void testV3CertificateWithSpecialCharactersInSubject() throws Exception {
+        String subject = "https://example.com/?action=sso_id";
+        KeyPair caKeyPair = KeyUtils.generateRsaKeyPair(2048);
+        X509Certificate caCert = CertificateUtils.generateV1SelfSignedCertificate(caKeyPair, "ca");
+
+        KeyPair keyPair = KeyUtils.generateRsaKeyPair(2048);
+        X509Certificate certificate = CertificateUtils.generateV3Certificate(keyPair, caKeyPair.getPrivate(), caCert, subject);
+
+        Assert.assertEquals(subject, extractCN(certificate));
+    }
+
+    private static String extractCN(X509Certificate certificate) {
+        try {
+            ASN1Encodable value = new JcaX509CertificateHolder(certificate).getSubject().getRDNs(BCStyle.CN)[0].getFirst().getValue();
+            return ((ASN1String) value).getString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Closes #50177

SAML client creation could fail when the Client ID contained characters such as `=` that are reserved in RFC 2253 DN strings. During certificate generation, the Client ID was used to construct the certificate subject, causing certificate creation to fail for certain valid Client IDs.

Implementations now construct the Subject DN using `X500NameBuilder` instead of parsing a DN string.
