### PR TITLE
fix: return 400 instead of 500 for malformed Content-Type headers on token endpoint

### DIFF
--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -132,7 +132,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             return Response.Status.CONFLICT;
         }
 
-        if (throwable instanceof IllegalArgumentException) {
+        if (throwable instanceof IllegalArgumentException && isMediaTypeParsingError(throwable)) {
             return Response.Status.BAD_REQUEST;
         }
 
@@ -150,7 +150,7 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             return "conflict";
         }
 
-        if (throwable instanceof IllegalArgumentException) {
+        if (throwable instanceof IllegalArgumentException && isMediaTypeParsingError(throwable)) {
             return OAuthErrorException.INVALID_REQUEST;
         }
 
@@ -159,6 +159,26 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
         }
 
         return "unknown_error";
+    }
+
+    private static boolean isMediaTypeParsingError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String msg = current.getMessage();
+            if (msg != null) {
+                String lower = msg.toLowerCase(Locale.ROOT);
+                if (lower.contains("media type") || lower.contains("content-type") ||
+                    lower.contains("could not find") || lower.contains("invalid")) {
+                    return true;
+                }
+            }
+            Class<?> cls = current.getClass();
+            if (cls.getName().contains("MediaType") || cls.getName().contains("BadRequest")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     private static RealmModel resolveRealm(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
+++ b/services/src/main/java/org/keycloak/services/error/KeycloakErrorHandler.java
@@ -132,6 +132,10 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
             return Response.Status.CONFLICT;
         }
 
+        if (throwable instanceof IllegalArgumentException) {
+            return Response.Status.BAD_REQUEST;
+        }
+
         return Response.Status.INTERNAL_SERVER_ERROR;
     }
 
@@ -144,6 +148,10 @@ public class KeycloakErrorHandler implements ExceptionMapper<Throwable> {
 
         if (cause instanceof ModelDuplicateException || throwable instanceof ModelDuplicateException) {
             return "conflict";
+        }
+
+        if (throwable instanceof IllegalArgumentException) {
+            return OAuthErrorException.INVALID_REQUEST;
         }
 
         if (throwable instanceof WebApplicationException && throwable.getMessage() != null) {

--- a/tests/base/src/test/java/org/keycloak/tests/error/MalformedContentTypeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/error/MalformedContentTypeTest.java
@@ -1,0 +1,85 @@
+package org.keycloak.tests.error;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.keycloak.OAuthErrorException;
+import org.keycloak.common.util.KeycloakUriBuilder;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.testframework.annotations.InjectHttpClient;
+import org.keycloak.testframework.annotations.InjectKeycloakUrls;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.server.KeycloakUrls;
+import org.keycloak.util.JsonSerialization;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@KeycloakIntegrationTest
+class MalformedContentTypeTest {
+
+    @InjectKeycloakUrls
+    KeycloakUrls keycloakUrls;
+
+    @InjectHttpClient
+    HttpClient httpClient;
+
+    @InjectRealm(attachTo = "master")
+    ManagedRealm masterRealm;
+
+    @Test
+    void malformedContentTypeOnTokenEndpoint() throws IOException {
+        HttpPost post = new HttpPost(tokenUri());
+        post.setHeader("Content-Type", "invalid/@@##");
+        post.setEntity(new StringEntity("grant_type=password&client_id=admin-cli&username=admin&password=admin"));
+
+        HttpResponse response = httpClient.execute(post);
+        assertThat("status code should be 400", response.getStatusLine().getStatusCode(), is(400));
+
+        OAuth2ErrorRepresentation error = JsonSerialization.readValue(
+                response.getEntity().getContent(), OAuth2ErrorRepresentation.class);
+        assertThat("error code", error.getError(), is(OAuthErrorException.INVALID_REQUEST));
+    }
+
+    @Test
+    void emptyContentTypeOnTokenEndpoint() throws IOException {
+        HttpPost post = new HttpPost(tokenUri());
+        post.setHeader("Content-Type", "");
+        post.setEntity(new StringEntity("grant_type=password&client_id=admin-cli&username=admin&password=admin"));
+
+        HttpResponse response = httpClient.execute(post);
+        assertThat("status code should be 400", response.getStatusLine().getStatusCode(), is(400));
+
+        OAuth2ErrorRepresentation error = JsonSerialization.readValue(
+                response.getEntity().getContent(), OAuth2ErrorRepresentation.class);
+        assertThat("error code", error.getError(), is(OAuthErrorException.INVALID_REQUEST));
+    }
+
+    @Test
+    void xssPayloadContentTypeOnTokenEndpoint() throws IOException {
+        HttpPost post = new HttpPost(tokenUri());
+        post.setHeader("Content-Type", "</>\"alert(1)");
+        post.setEntity(new StringEntity("grant_type=password&client_id=admin-cli&username=admin&password=admin"));
+
+        HttpResponse response = httpClient.execute(post);
+        assertThat("status code should be 400", response.getStatusLine().getStatusCode(), is(400));
+
+        OAuth2ErrorRepresentation error = JsonSerialization.readValue(
+                response.getEntity().getContent(), OAuth2ErrorRepresentation.class);
+        assertThat("error code", error.getError(), is(OAuthErrorException.INVALID_REQUEST));
+    }
+
+    private URI tokenUri() {
+        return KeycloakUriBuilder.fromUri(keycloakUrls.getMasterRealm())
+                .path("protocol/openid-connect/token")
+                .build();
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/error/MalformedContentTypeTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/error/MalformedContentTypeTest.java
@@ -77,6 +77,20 @@ class MalformedContentTypeTest {
         assertThat("error code", error.getError(), is(OAuthErrorException.INVALID_REQUEST));
     }
 
+    @Test
+    void xssScriptPayloadContentTypeOnTokenEndpoint() throws IOException {
+        HttpPost post = new HttpPost(tokenUri());
+        post.setHeader("Content-Type", "</><script>alert(1)</script>");
+        post.setEntity(new StringEntity("grant_type=password&client_id=admin-cli&username=admin&password=admin"));
+
+        HttpResponse response = httpClient.execute(post);
+        assertThat("status code should be 400", response.getStatusLine().getStatusCode(), is(400));
+
+        OAuth2ErrorRepresentation error = JsonSerialization.readValue(
+                response.getEntity().getContent(), OAuth2ErrorRepresentation.class);
+        assertThat("error code", error.getError(), is(OAuthErrorException.INVALID_REQUEST));
+    }
+
     private URI tokenUri() {
         return KeycloakUriBuilder.fromUri(keycloakUrls.getMasterRealm())
                 .path("protocol/openid-connect/token")


### PR DESCRIPTION
## Problem

Malformed  headers (e.g. , empty strings, XSS payloads) sent to the OAuth 2.0 token endpoint cause RESTEasy's  to throw an . The  catches this but maps it to HTTP 500 with an  response body.

Per [RFC 6749 section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2), the token endpoint **MUST** return HTTP 400 with an  parameter (e.g. ) for malformed requests.

## Fix

Added  handling in  to return HTTP 400 Bad Request with  error code instead of HTTP 500 Internal Server Error with .

### Changes:
- ****: Added  checks in both  and  methods
- ****: Added integration tests covering malformed, empty, and XSS payload Content-Type headers

## How to Reproduce



**Before**: HTTP 500 with 
**After**: HTTP 400 with 

Closes #49964