### PR TITLE
[OID4VCI-FAPI2] Pass fapi2-security-profile-final-refresh-token

### DIFF
--- a/core/src/main/java/org/keycloak/representations/AccessToken.java
+++ b/core/src/main/java/org/keycloak/representations/AccessToken.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @version $Revision: 1 $
  */
 public class AccessToken extends IDToken {
+
     public static class Access implements Serializable {
         @JsonProperty("roles")
         protected Set<String> roles;
@@ -105,11 +106,15 @@ public class AccessToken extends IDToken {
     // KEYCLOAK-6771 Certificate Bound Token
     // https://tools.ietf.org/html/draft-ietf-oauth-mtls-08#section-3.1
     public static class Confirmation {
+
         @JsonProperty("x5t#S256")
         protected String certThumbprint;
 
         @JsonProperty("jkt")
         protected String keyThumbprint;
+
+        @JsonProperty("kc-jkt-type")
+        protected String jktType;
 
         public String getCertThumbprint() {
             return certThumbprint;
@@ -121,10 +126,18 @@ public class AccessToken extends IDToken {
 
         public String getKeyThumbprint() {
             return keyThumbprint;
-    }
+        }
 
-    public void setKeyThumbprint(String keyThumbprint) {
+        public void setKeyThumbprint(String keyThumbprint) {
             this.keyThumbprint = keyThumbprint;
+        }
+
+        public String getJktType() {
+            return jktType;
+        }
+
+        public void setJktType(String jktType) {
+            this.jktType = jktType;
         }
     }
 

--- a/server-spi-private/src/main/java/org/keycloak/models/Constants.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/Constants.java
@@ -254,7 +254,7 @@ public final class Constants {
     public static final String AUTHORIZATION_DETAILS_RESPONSE = "authorization_details_response";
 
     // Internal note for storing the authorization request uri
-    public static final String AUTHORIZATION_REQUEST_URI = "request_uri";
+    public static final String AUTHORIZATION_REQUEST_URI = "authorization_request_uri";
 
     // This attribute can be used in a realm import definition to signal that default client scopes should be created in addition to the client scopes defined by the realm import definition.
     // When this attribute is omitted or set to false, the default client scopes are not created if at least one other client scope is defined by the realm import definition.

--- a/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/client/AttestationBasedClientAuthenticator.java
@@ -96,6 +96,9 @@ public class AttestationBasedClientAuthenticator extends AbstractClientAuthentic
      */
     public static final String OAUTH_CLIENT_ATTESTATION_CONFIG_TRUST_IDPS = "attester_trust_idps";
 
+    /** The token confirmation type */
+    public static final String ABCA_JKT_TYPE = "Client-Attestation";
+
     @Override
     public String getId() {
         return PROVIDER_ID;

--- a/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesJwksEndpointLoader.java
+++ b/services/src/main/java/org/keycloak/broker/kubernetes/KubernetesJwksEndpointLoader.java
@@ -69,7 +69,7 @@ public class KubernetesJwksEndpointLoader implements PublicKeyLoader {
                 logger.trace("Including service account token in request");
                 return token;
             } else {
-                logger.debug("Not including service account token due to issuer missmatch");
+                logger.debug("Not including service account token due to issuer mismatch");
             }
         } catch (Exception e) {
             logger.warn("Failed to read service account token file", e);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/refresh/OID4VCIRefreshTokenProvider.java
@@ -87,6 +87,10 @@ public class OID4VCIRefreshTokenProvider extends AbstractRefreshTokenProvider im
 
         RefreshToken refreshToken = createRefreshToken(accessToken, initialRefreshTokenCtx.confirmation(), OID4VCIRefreshTokenProviderFactory.PROVIDER_ID);
 
+        if (refreshToken.getSubject() == null) {
+            refreshToken.subject(user.getId());
+        }
+
         if (initialRefreshTokenCtx.offlineTokenRequested()) {
             throw new RefreshTokenException(INVALID_REQUEST, "Unsupported to request offline access together with oid4vci credential");
         } else {
@@ -163,9 +167,10 @@ public class OID4VCIRefreshTokenProvider extends AbstractRefreshTokenProvider im
     }
 
 
-    // Might be eventually overriden for the scenarios where user not available in Keycloak DB
+    // Might eventually be overridden for scenarios where a user is not available in the Keycloak DB
     protected UserModel getUser(RealmModel realm, RefreshToken oldToken) {
-        return session.users().getUserById(realm, oldToken.getSubject());
+        String userId = oldToken.getSubject();
+        return session.users().getUserById(realm, userId);
     }
 
     protected IssuedVerifiableCredentialModel checkIssuedVerifiableCredential(KeycloakSession session, UserModel user, String issuedCredentialId, CredentialScopeModel expectedCredentialScope, ClientModel expectedClient) {

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -47,6 +47,7 @@ import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
 import org.keycloak.TokenCategory;
 import org.keycloak.TokenVerifier;
+import org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ABCAResult;
 import org.keycloak.authentication.authenticators.util.AcrStore;
 import org.keycloak.broker.oidc.OIDCIdentityProvider;
 import org.keycloak.broker.oidc.OIDCIdentityProviderConfig;
@@ -63,6 +64,7 @@ import org.keycloak.events.Details;
 import org.keycloak.events.Errors;
 import org.keycloak.events.EventBuilder;
 import org.keycloak.http.HttpRequest;
+import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.jose.jws.JWSInputException;
 import org.keycloak.jose.jws.crypto.HashUtils;
@@ -132,15 +134,18 @@ import org.keycloak.services.util.UserSessionUtil;
 import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.tracing.TracingAttributes;
 import org.keycloak.tracing.TracingProvider;
+import org.keycloak.util.JWKSUtils;
 import org.keycloak.util.TokenUtil;
 
 import org.jboss.logging.Logger;
 
 import static org.keycloak.OAuth2Constants.ORGANIZATION;
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ABCA_JKT_TYPE;
 import static org.keycloak.events.Details.REASON;
 import static org.keycloak.models.Constants.AUTHORIZATION_DETAILS_RESPONSE;
 import static org.keycloak.models.light.LightweightUserAdapter.isLightweightUser;
 import static org.keycloak.representations.IDToken.NONCE;
+import static org.keycloak.services.util.DPoPUtil.DPOP_JKT_TYPE;
 
 /**
  * Stateless object that creates tokens and manages oauth access codes
@@ -174,7 +179,7 @@ public class TokenManager {
             userSession = sessionManager.findOfflineUserSession(realm, oldToken.getSessionState());
             if (userSession != null) {
 
-                // Revoke timeouted offline userSession
+                // Revoke timed out offline userSession
                 if (!AuthenticationManager.isSessionValid(realm, userSession)) {
                     sessionManager.revokeOfflineUserSession(userSession);
                     throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Offline session not active", "Offline session not active");
@@ -347,16 +352,36 @@ public class TokenManager {
                 }
             }
 
-            if (Profile.isFeatureEnabled(Profile.Feature.DPOP)) {
-                if (DPoPUtil.isDPoPToken(refreshToken)) {
-                    DPoP dPoP = (DPoP) session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE);
-                    if (dPoP == null) {
-                        throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "DPoP proof is missing");
+            // Verify RefreshToken Confirmation
+            //
+            AccessToken.Confirmation cnf = refreshToken.getConfirmation();
+            if (cnf != null && cnf.getKeyThumbprint() != null) {
+                String jktType = Optional.ofNullable(cnf.getJktType()).orElse(DPOP_JKT_TYPE);
+                switch (jktType) {
+                    case ABCA_JKT_TYPE -> {
+                        ABCAResult abcaResult = session.getAttribute(ABCAResult.ABCA_RESULT, ABCAResult.class);
+                        if (abcaResult == null) {
+                            throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Invalid refresh token. Client attestation must be used with this refresh token");
+                        }
+                        JWK jwk = abcaResult.getAttestationJwt().getConfirmation().getJwk();
+                        String thumbprint = JWKSUtils.computeThumbprint(jwk);
+                        if (!Objects.equals(thumbprint, cnf.getKeyThumbprint())) {
+                            throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Attestation-Based Key mismatch");
+                        }
                     }
-                    try {
-                        DPoPUtil.validateBinding(refreshToken, dPoP);
-                    } catch (VerificationException ex) {
-                        throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, ex.getMessage());
+                    case DPOP_JKT_TYPE -> {
+                        DPoP dPoP = session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE, DPoP.class);
+                        if (dPoP == null) {
+                            throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "DPoP proof is missing");
+                        }
+                        try {
+                            DPoPUtil.validateBinding(refreshToken, dPoP);
+                        } catch (VerificationException ex) {
+                            throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, ex.getMessage());
+                        }
+                    }
+                    default -> {
+                        throw new OAuthErrorException(OAuthErrorException.INVALID_GRANT, "Unknown jkt type: " + jktType);
                     }
                 }
             }
@@ -462,7 +487,7 @@ public class TokenManager {
     }
 
 
-    public static void dettachClientSession(AuthenticatedClientSessionModel clientSession) {
+    public static void detachClientSession(AuthenticatedClientSessionModel clientSession) {
         UserSessionModel userSession = clientSession.getUserSession();
         if (userSession == null) {
             return;
@@ -1182,9 +1207,9 @@ public class TokenManager {
 
         private void generateRefreshToken(boolean offlineTokenRequested) {
             AuthenticatedClientSessionModel clientSession = clientSessionCtx.getClientSession();
-            AccessToken.Confirmation confirmation = getConfirmation(clientSession, accessToken);
+            AccessToken.Confirmation cnf = getRefreshTokenConfirmation(clientSession, accessToken);
 
-            InitialRefreshTokenContext initialRefreshTokenContext = new InitialRefreshTokenContext(clientSessionCtx, this, event, offlineTokenRequested, confirmation);
+            InitialRefreshTokenContext initialRefreshTokenContext = new InitialRefreshTokenContext(clientSessionCtx, this, event, offlineTokenRequested, cnf);
 
             RefreshTokenProvider refreshTokenProvider = session.getKeycloakSessionFactory()
                     .getProviderFactoriesStream(RefreshTokenProvider.class)
@@ -1203,9 +1228,10 @@ public class TokenManager {
             if (bindOnlyRefreshToken) {
                 DPoP dPoP = session.getAttribute(DPoPUtil.DPOP_SESSION_ATTRIBUTE, DPoP.class);
                 if (dPoP != null) {
-                    confirmation = new AccessToken.Confirmation();
-                    confirmation.setKeyThumbprint(dPoP.getThumbprint());
-                    refreshToken.setConfirmation(confirmation);
+                    cnf = new AccessToken.Confirmation();
+                    cnf.setKeyThumbprint(dPoP.getThumbprint());
+                    cnf.setJktType(DPOP_JKT_TYPE);
+                    refreshToken.setConfirmation(cnf);
                 }
             }
         }
@@ -1220,17 +1246,28 @@ public class TokenManager {
             sessionManager.createOrUpdateOfflineSession(clientSessionCtx.getClientSession(), userSession);
         }
 
-       /**
-        * RFC9449 chapter 5<br/>
-        * Refresh tokens issued to confidential clients are not bound to the DPoP proof public key because
-        * they are already sender-constrained with a different existing mechanism.<br/>
-        * <br/>
-        * Based on the definition above the confirmation is only returned for public-clients.
-        */
-        private AccessToken.Confirmation getConfirmation(AuthenticatedClientSessionModel clientSession,
-                                                         AccessToken accessToken) {
-            final boolean isPublicClient = clientSession.getClient().isPublicClient();
-            return isPublicClient ? accessToken.getConfirmation() : null;
+        private AccessToken.Confirmation getRefreshTokenConfirmation(AuthenticatedClientSessionModel clientSession, AccessToken accessToken) {
+
+            // RFC9449 chapter 5
+            // Refresh tokens issued to confidential clients are not bound to the DPoP proof public key because
+            // they are already sender-constrained with a different existing mechanism.
+            if (clientSession.getClient().isPublicClient()) {
+                AccessToken.Confirmation cnf = accessToken.getConfirmation();
+                return cnf;
+            }
+
+            // Authorization servers issuing a refresh token in response to a token request using the client attestation
+            // mechanism MUST bind the refresh token to the Client Instance and its associated public key
+            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-attestation-based-client-auth-07#section-10.3
+            ABCAResult abcaResult = session.getAttribute(ABCAResult.ABCA_RESULT, ABCAResult.class);
+            if (abcaResult != null) {
+                JWK jwk = abcaResult.getAttestationJwt().getConfirmation().getJwk();
+                AccessToken.Confirmation cnf = new AccessToken.Confirmation();
+                cnf.setKeyThumbprint(JWKSUtils.computeThumbprint(jwk));
+                cnf.setJktType(ABCA_JKT_TYPE);
+                return cnf;
+            }
+            return null;
         }
 
         public AccessTokenResponseBuilder generateIDToken() {

--- a/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/endpoints/TokenRevocationEndpoint.java
@@ -255,7 +255,7 @@ public class TokenRevocationEndpoint {
         if (userSession != null) {
             AuthenticatedClientSessionModel clientSession = userSession.getAuthenticatedClientSessionByClient(client.getId());
             if (clientSession != null) {
-                TokenManager.dettachClientSession(clientSession);
+                TokenManager.detachClientSession(clientSession);
 
                 revokeTokenExchangeSession(userSession);
 
@@ -289,7 +289,7 @@ public class TokenRevocationEndpoint {
         clientSessionModelMap.forEach((key, clientSessionModel) -> {
             if (clientSessionModel.getNote(Constants.TOKEN_EXCHANGE_SUBJECT_CLIENT + token.getIssuedFor()) != null) {
                 revokedClients.add(clientSessionModel.getClient().getClientId());
-                TokenManager.dettachClientSession(clientSessionModel);
+                TokenManager.detachClientSession(clientSessionModel);
             }
         });
         if (!revokedClients.isEmpty()) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -688,7 +688,7 @@ public class AuthenticationManager {
                     uriInfo,
                     headers);
             clientSession.setAction(AuthenticationSessionModel.Action.LOGGED_OUT.name());
-            TokenManager.dettachClientSession(clientSession);
+            TokenManager.detachClientSession(clientSession);
         }
     }
 

--- a/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
+++ b/services/src/main/java/org/keycloak/services/util/DPoPUtil.java
@@ -97,6 +97,7 @@ public class DPoPUtil {
 
     public static final int DEFAULT_PROOF_LIFETIME = 10;
     public static final int DEFAULT_ALLOWED_CLOCK_SKEW = 15; // sec;
+    public static final String DPOP_JKT_TYPE = "DPoP";
     public static final String DPOP_TOKEN_TYPE = "DPoP";
     public static final String DPOP_SCHEME = "DPoP";
     public final static String DPOP_SESSION_ATTRIBUTE = "dpop";
@@ -319,10 +320,6 @@ public class DPoPUtil {
             throw new CorsErrorResponseException(cors, OAuthErrorException.INVALID_REQUEST, errorMessage, Response.Status.BAD_REQUEST);
         }
 
-    }
-
-    public static boolean isDPoPToken(AccessToken refreshToken) {
-        return refreshToken.getConfirmation() != null && refreshToken.getConfirmation().getKeyThumbprint() != null;
     }
 
     private static class DPoPClaimsCheck implements TokenVerifier.Predicate<DPoP> {
@@ -625,13 +622,13 @@ public class DPoPUtil {
             if (bindOnlyRefreshToken) {
                 return super.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
             }
-            AccessToken.Confirmation confirmation = (AccessToken.Confirmation) token.getOtherClaims()
-                    .get(OAuth2Constants.CNF);
-            if (confirmation == null) {
-                confirmation = new AccessToken.Confirmation();
-                token.setConfirmation(confirmation);
+            AccessToken.Confirmation cnf = (AccessToken.Confirmation) token.getOtherClaims().get(OAuth2Constants.CNF);
+            if (cnf == null) {
+                cnf = new AccessToken.Confirmation();
+                token.setConfirmation(cnf);
             }
-            confirmation.setKeyThumbprint(dPoP.getThumbprint());
+            cnf.setKeyThumbprint(dPoP.getThumbprint());
+            cnf.setJktType(DPOP_JKT_TYPE);
             // make sure that the token-type is set to DPoP. This will be resolved if the AccessTokenResponse is built.
             token.type(DPOP_TOKEN_TYPE);
             return super.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
@@ -22,7 +22,9 @@ import org.keycloak.protocol.oid4vc.model.CredentialResponse;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse.Credential;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.Proofs;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.JsonWebToken;
+import org.keycloak.representations.RefreshToken;
 import org.keycloak.sdjwt.IssuerSignedJWT;
 import org.keycloak.sdjwt.vp.SdJwtVP;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
@@ -44,11 +46,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
+import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.ABCA_JKT_TYPE;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_HEADER;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_HEADER;
 import static org.keycloak.constants.OID4VCIConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE;
 import static org.keycloak.constants.OID4VCIConstants.TIME_CLAIMS_STRATEGY;
 import static org.keycloak.constants.OID4VCIConstants.TIME_RANDOMIZE_WINDOW_SECONDS;
+import static org.keycloak.services.util.DPoPUtil.DPOP_JKT_TYPE;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 
@@ -471,6 +475,153 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         } finally {
             oauth.config().client(clientId);
         }
+    }
+
+    /**
+     * fapi2-security-profile-final-refresh-token
+     *
+     * This test obtains refresh tokens and checks that the refresh token is correctly bound to the client.
+     */
+    @Test
+    public void testRefreshTokenHappyFlow() throws Exception {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        var pkce = PkceGenerator.s256();
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper abcaKey = wallet.getRSAKeyPair(ctx, "rsaABCA#1");
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, abcaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, abcaKey);
+
+        // Send PAR Request
+        //
+        String requestUri = oauth.pushedAuthorizationRequest()
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .scopeParam(ctx.getScope())
+                .codeChallenge(pkce)
+                .send().getRequestUri();
+        assertNotNull(requestUri, "No requestUri");
+
+        // Send Authorization Request
+        //
+        String authCode = wallet.authorizationRequest()
+                .requestUri(requestUri)
+                .codeChallenge(pkce)
+                .send(ctx.getHolder(), TEST_PASSWORD)
+                .getCode();
+        assertNotNull(authCode, "No auth code");
+
+        // Send AccessToken Request
+        //
+        KeyWrapper ecKey = wallet.getECKeyPair(ctx);
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+        String dpopProof = wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, null);
+
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .codeVerifier(pkce)
+                .dpopProof(dpopProof)
+                .send();
+
+        // Inspect AccessToken
+        //
+        assertTrue(tokenResponse.isSuccess());
+        String encodedAccessToken = tokenResponse.getAccessToken();
+        assertNotNull(encodedAccessToken, "No access token");
+        String tokenType = tokenResponse.getTokenType();
+        assertEquals(TokenUtil.TOKEN_TYPE_DPOP, tokenType);
+
+        AccessToken accessToken = new JWSInput(encodedAccessToken).readJsonContent(AccessToken.class);
+        AccessToken.Confirmation accessCnf = accessToken.getConfirmation();
+        assertNotNull(accessCnf, "No access confirmation");
+        assertEquals(DPOP_JKT_TYPE, accessCnf.getJktType());
+
+        // Inspect RefreshToken
+        //
+        String encodedRefreshToken = tokenResponse.getRefreshToken();
+        assertNotNull(encodedRefreshToken, "No refresh token");
+
+        RefreshToken refreshToken = new JWSInput(encodedRefreshToken).readJsonContent(RefreshToken.class);
+        AccessToken.Confirmation refreshCnf = refreshToken.getConfirmation();
+        assertNotNull(refreshCnf, "No refresh confirmation");
+        assertEquals(ABCA_JKT_TYPE, refreshCnf.getJktType());
+
+        JWK abcaJwk = JWKBuilder.create()
+                .kid(abcaKey.getKid())
+                .algorithm(abcaKey.getAlgorithm())
+                .rsa(abcaKey.getPublicKey(), abcaKey.getUse());
+        String abcaThumbprint = JWKSUtils.computeThumbprint(abcaJwk);
+        String cnfThumbprint = refreshCnf.getKeyThumbprint();
+        assertEquals(abcaThumbprint, cnfThumbprint, "Expected ABCA thumbprint in confirmation");
+
+        // Generate other ABCA Key/Headers (i.e. transferred refresh token)
+        //
+        KeyWrapper abcaKey2 = wallet.getRSAKeyPair(ctx, "rsaABCA#2");
+        String attestationJwt2 = wallet.buildClientAttestationJWT(ctx, abcaKey2);
+        String attestationPoPJwt2 = wallet.buildClientAttestationPoPJWT(ctx, abcaKey2);
+
+        // Exchange RefreshToken for new AccessToken (fails)
+        //
+        dpopProof = wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, encodedRefreshToken);
+        tokenResponse = oauth.refreshRequest(encodedRefreshToken)
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt2)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt2)
+                .dpopProof(dpopProof)
+                .send();
+        assertFalse(tokenResponse.isSuccess());
+        assertEquals("invalid_grant", tokenResponse.getError());
+        assertEquals("Attestation-Based Key mismatch", tokenResponse.getErrorDescription());
+
+        // Exchange RefreshToken for new AccessToken (success)
+        //
+        dpopProof = wallet.generateSignedDPoPProof(tokenEndpoint, ecKey, encodedRefreshToken);
+        tokenResponse = oauth.refreshRequest(encodedRefreshToken)
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .dpopProof(dpopProof)
+                .send();
+
+        // Inspect AccessToken
+        //
+        assertTrue(tokenResponse.isSuccess());
+        encodedAccessToken = tokenResponse.getAccessToken();
+        assertNotNull(encodedAccessToken, "No access token");
+        tokenType = tokenResponse.getTokenType();
+        assertEquals(TokenUtil.TOKEN_TYPE_DPOP, tokenType);
+
+        accessToken = new JWSInput(encodedAccessToken).readJsonContent(AccessToken.class);
+        accessCnf = accessToken.getConfirmation();
+        assertNotNull(accessCnf, "No access confirmation");
+        assertEquals(DPOP_JKT_TYPE, accessCnf.getJktType());
+
+        // Send Nonce Request
+        //
+        String nonce = wallet.nonceRequest().send().getNonce();
+        Proofs jwtProofs = wallet.generateJwtProofs(ctx, nonce, ecKey);
+
+        // Send Credential Request
+        // Note, we use the same EC key for DPoP and Holder identity
+        //
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(credentialIdentifier, "No authorized credential identifier");
+
+        String credentialEndpoint = oauth.getEndpoints().getOid4vcCredential();
+        dpopProof = wallet.generateSignedDPoPProof(credentialEndpoint, ecKey, encodedAccessToken);
+
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenType, encodedAccessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .dpopProof(dpopProof)
+                .proofs(jwtProofs)
+                .send().getCredentialResponse();
+
+        // Verify Credential Response
+        //
+        verifyCredentialResponse(ctx, jwtProofs, credResponse);
     }
 
     /**


### PR DESCRIPTION
closes #48071

* Add kc-jkt-type to the cnf (confirmation) structure in tokens and set it for DPoP / ABCA bindings.
* Bind refresh tokens to the ABCA client instance public key thumbprint when client attestation is used, and add server-side verification on refresh.
* Add an HAIP issuer conformance test that validates access token (DPoP) and refresh token (ABCA) binding behavior.
