### PR TITLE
Document changes for Should have the admin UI and admin API on a separate hostname traefik & HA Proxy reencrypt

### DIFF
--- a/docs/guides/server/haproxy-passthrough.adoc
+++ b/docs/guides/server/haproxy-passthrough.adoc
@@ -16,7 +16,7 @@ The TLS handshake occurs between the client and {project_name}, preserving end-t
 
 For a general overview of TLS passthrough and how it compares to re-encrypt, see the <@links.server id="reverseproxy"/> {section}.
 
-A ready-to-run example with Docker Compose is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/haproxy/passthrough[quickstart repository].
+A ready-to-run example with a Compose file is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/haproxy/passthrough[quickstart repository].
 
 [[haproxy-configuration-passthrough]]
 == HAProxy configuration

--- a/docs/guides/server/haproxy-reencrypt.adoc
+++ b/docs/guides/server/haproxy-reencrypt.adoc
@@ -175,6 +175,51 @@ If the number of intermediate certificates in your certificate chain is longer t
 
 See <@links.server id="reverseproxy" /> for more details.
 
+[[admin-dedicated-port-haproxy-reencrypt]]
+== Optional: Admin UI and Admin API on a dedicated port
+
+By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints, protected only by the source IP filtering (`is_allowed_src`).
+For stricter network-level isolation, you can move them to a dedicated port (8444) so they can be independently firewalled.
+
+The dedicated admin port uses the *same hostname* as the public port, so the existing external certificate already covers it and no additional Subject Alternative Name is required.
+Because the admin port and the public port share the same HAProxy frontend, the header filtering and client certificate forwarding described above apply to both automatically.
+
+[NOTE]
+====
+Setting `hostname-admin` only changes the URLs {project_name} generates for the Admin Console and Admin API.
+It does not stop the Admin API from also answering on the public frontend URL — restricting administration access to the dedicated port must be enforced at the reverse proxy, which is what the rules below do.
+See the <@links.server id="hostname"/> {section}.
+====
+
+To enable this, add the following configuration:
+
+*`docker-compose.yaml`*::
+* Add `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` which tells each {project_name} node to serve the Admin UI and Admin API on the admin port.
+(`KC_HOSTNAME` is already set to the required `https://${KC_HOST}:8443` URL form.)
+* Add port `8444:8444` under the `haproxy` service — exposes the admin port on the host.
+
+*`haproxy.cfg`*::
+* Add the second `bind *:8444 ...`  which makes the frontend also listen on the admin port.
+* Replace the default `http-request deny unless is_public_path or is_allowed_src` rule with the three isolation rules:
++
+[source,haproxy]
+----
+acl is_admin_port dst_port 8444
+http-request deny if !is_admin_port !is_public_path
+http-request deny if is_admin_port !is_allowed_src
+----
+
+These rules route by destination port:
+
+* *Public port (8443):* only the public paths (`/realms/`, `/resources/`, `/.well-known/`) are served; any other path, including the Admin Console and Admin API, is denied.
+* *Admin port (8444):* all paths are served, but only to the allowed source IP ranges.
+
+[NOTE]
+====
+With this setup, any request to an admin path on port 8443 is denied with an HTTP 403 response.
+Because the admin port shares the hostname with the public port, in production, restrict the admin port (8444) to an internal/management network at the firewall.
+====
+
 [[graceful-shutdown-considerations-haproxy-reencrypt]]
 == Graceful shutdown considerations
 

--- a/docs/guides/server/haproxy-reencrypt.adoc
+++ b/docs/guides/server/haproxy-reencrypt.adoc
@@ -195,7 +195,7 @@ To enable this, add the following configuration:
 
 *`docker-compose.yaml`*::
 * Add `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` which tells each {project_name} node to serve the Admin UI and Admin API on the admin port.
-(`KC_HOSTNAME` is already set to the required `https://${KC_HOST}:8443` URL form.)
+(`KC_HOSTNAME` is already set to the required `https://${r"${KC_HOST}"}:8443` URL form.)
 * Add port `8444:8444` under the `haproxy` service — exposes the admin port on the host.
 
 *`haproxy.cfg`*::

--- a/docs/guides/server/haproxy-reencrypt.adoc
+++ b/docs/guides/server/haproxy-reencrypt.adoc
@@ -15,7 +15,7 @@ HAProxy operates at Layer 7 (HTTP). Unlike passthrough, end-to-end TLS encryptio
 
 For a general overview of TLS re-encrypt and how it compares to passthrough, see the <@links.server id="reverseproxy"/> {section}.
 
-A ready-to-run example with Docker Compose is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/haproxy/reencrypt[quickstart repository].
+A ready-to-run example with a Compose file is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/haproxy/reencrypt[quickstart repository].
 
 [[haproxy-configuration-reencrypt]]
 == HAProxy configuration
@@ -176,13 +176,19 @@ If the number of intermediate certificates in your certificate chain is longer t
 See <@links.server id="reverseproxy" /> for more details.
 
 [[admin-dedicated-port-haproxy-reencrypt]]
-== Optional: Admin UI and Admin API on a dedicated port
+== Optional: Admin UI and Admin API on a dedicated hostname and port
 
-By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints, protected only by the source IP filtering (`is_allowed_src`).
-For stricter network-level isolation, you can move them to a dedicated port (8444) so they can be independently firewalled.
+By default, the Admin UI and Admin API are served on the same port as the public endpoints, protected only by the source IP filtering (`is_allowed_src`).
+For stricter network-level isolation, you can move them to a dedicated hostname and port so they can be independently firewalled.
 
-The dedicated admin port uses the *same hostname* as the public port, so the existing external certificate already covers it and no additional Subject Alternative Name is required.
 Because the admin port and the public port share the same HAProxy frontend, the header filtering and client certificate forwarding described above apply to both automatically.
+
+To enable this, add the configurations outlined in the following subsections.
+
+=== {project_name} configuration
+
+`+--hostname-admin=https://...+`::
+Add the full admin URL with its hostname and the port (if it is a non-standard port) to the {project_name} configuration.
 
 [NOTE]
 ====
@@ -191,15 +197,14 @@ It does not stop the Admin API from also answering on the public frontend URL â€
 See the <@links.server id="hostname"/> {section}.
 ====
 
-To enable this, add the following configuration:
+=== HAProxy configuration
 
-*`docker-compose.yaml`*::
-* Add `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` which tells each {project_name} node to serve the Admin UI and Admin API on the admin port.
-(`KC_HOSTNAME` is already set to the required `https://${r"${KC_HOST}"}:8443` URL form.)
-* Add port `8444:8444` under the `haproxy` service â€” exposes the admin port on the host.
+TLS certificate::
+If you choose to have a different hostname for the admin API, update your certificate to include the admin hostname as an additional Subject Alternative Name in the certificate, or issue a separate certificate.
 
-*`haproxy.cfg`*::
-* Add the second `bind *:8444 ...`  which makes the frontend also listen on the admin port.
+`haproxy.cfg`::
+* Add the second `bind *:8444 ...`, which makes the frontend also listen on the admin port.
+If you choose a different port, replace `8444` in the examples below with your chosen port.
 * Replace the default `http-request deny unless is_public_path or is_allowed_src` rule with the three isolation rules:
 +
 [source,haproxy]
@@ -211,13 +216,12 @@ http-request deny if is_admin_port !is_allowed_src
 
 These rules route by destination port:
 
-* *Public port (8443):* only the public paths (`/realms/`, `/resources/`, `/.well-known/`) are served; any other path, including the Admin Console and Admin API, is denied.
-* *Admin port (8444):* all paths are served, but only to the allowed source IP ranges.
+* *Public port:* only the public paths (`/realms/`, `/resources/`, `/.well-known/`) are served; any other path, including the Admin Console and Admin API, is denied.
+* *Admin port:* all paths are served, but only to the allowed source IP ranges.
 
 [NOTE]
 ====
-With this setup, any request to an admin path on port 8443 is denied with an HTTP 403 response.
-Because the admin port shares the hostname with the public port, in production, restrict the admin port (8444) to an internal/management network at the firewall.
+With this setup, any request to an admin path on the public port is denied with an HTTP 403 response.
 ====
 
 [[graceful-shutdown-considerations-haproxy-reencrypt]]

--- a/docs/guides/server/traefik-passthrough.adoc
+++ b/docs/guides/server/traefik-passthrough.adoc
@@ -13,7 +13,7 @@ The TLS handshake occurs between the client and {project_name}, preserving end-t
 
 For a general overview of TLS passthrough and how it compares to re-encrypt, see the <@links.server id="reverseproxy"/> {section}.
 
-A ready-to-run example with Docker Compose is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/traefik/passthrough[quickstart repository].
+A ready-to-run example with a Compose file is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/traefik/passthrough[quickstart repository].
 
 [[traefik-configuration-passthrough]]
 == Traefik configuration

--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -16,7 +16,7 @@ Unlike passthrough, end-to-end TLS encryption between client and {project_name} 
 
 For a general overview of TLS re-encrypt and how it compares to passthrough, see the <@links.server id="reverseproxy"/> {section}.
 
-A ready-to-run example with Docker Compose is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/traefik/reencrypt[quickstart repository].
+A ready-to-run example with a Compose file is available in the link:https://github.com/keycloak/keycloak-quickstarts/tree/main/proxy/traefik/reencrypt[quickstart repository].
 
 [[traefik-configuration-reencrypt]]
 == Traefik configuration
@@ -214,27 +214,65 @@ This allows Traefik to perform HTTPS health checks against the management port (
 [[admin-dedicated-port-traefik-reencrypt]]
 == Optional: Admin UI and Admin API on a dedicated hostname and port
 
-By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints, protected only by the `ip-allowlist` middleware.
-For stricter network-level isolation, you can move them to a dedicated hostname and port (8444) so they can be independently firewalled.
+By default, the Admin UI and Admin API are served on the same port as the public endpoints, protected only by the `ip-allowlist` middleware.
+For stricter network-level isolation, you can move them to a dedicated hostname and port so they can be independently firewalled.
 
-To enable this, add the following configuration:
+To enable this, add the configurations outlined in the following subsections.
 
-*`docker-compose.yaml`*::
-* Add `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` which tells each {project_name} node to serve the Admin UI and Admin API on the admin hostname.
-* Add port `8444:8444` under the `traefik` service — exposes the admin port on the host.
+=== {project_name} configuration
 
-*`traefik.yaml`*::
-* Add the `keycloak-admin` entrypoint which adds a second Traefik entrypoint listening on port 8444.
-
-*`keycloak.yaml`*::
-* Add the `keycloak-admin` router — routes all traffic coming on the `keycloak-admin` entrypoint to the {project_name} service, restricted to the `ip-allowlist`.
-* Remove the `keycloak-internal` router as it is no longer needed, as the admin paths are now handled exclusively by the dedicated `keycloak-admin` router on port 8444.
-Leaving both enabled would cause the `keycloak-internal` router to match admin paths on port 8443 as well.
+`+--hostname-admin=https://...+`::
+Add the full admin URL with its hostname and the port (if it is a non-standard port) to the {project_name} configuration.
 
 [NOTE]
 ====
-With this setup, any request to an admin path on port 8443 will fall through to the `keycloak-public` router, which only matches `/realms/`, `/resources/`, and `/.well-known/`.
-Admin paths on port 8443 will return a 404.
+Setting `hostname-admin` only changes the URLs {project_name} generates for the Admin Console and Admin API.
+It does not stop the Admin API from also answering on the public frontend URL — restricting administration access to the dedicated port must be enforced at the reverse proxy, which is what the rules below do.
+See the <@links.server id="hostname"/> {section}.
+====
+
+=== Traefik configuration
+
+TLS certificate::
+If you choose to have a different hostname for the admin API, update your certificate to include the admin hostname as an additional Subject Alternative Name in the certificate, or issue a separate certificate.
+
+`traefik.yaml`::
+Add the `keycloak-admin` entrypoint to create a second Traefik listener on port 8444:
++
+[source,yaml]
+----
+entryPoints:
+  keycloak-admin:
+    ...
+    address: ":8444" # <1>
+----
+<1> Replace with a port of your choice, matching the port configured as admin URL in {project_name}.
+
+`keycloak.yaml`::
+. Remove the `keycloak-internal` router as it is no longer needed. The admin paths are now handled exclusively by the dedicated `keycloak-admin` router.
+Leaving both enabled would cause the `keycloak-internal` router to match admin paths on the original endpoint as well.
+. Add the `keycloak-admin` router, which routes all traffic on the `keycloak-admin` entrypoint to the `keycloak` service, restricted to the `ip-allowlist`.
++
+[source,yaml]
+----
+  routers:
+    ...
+    keycloak-admin:
+      entryPoints:
+        - keycloak-admin
+      rule: "PathPrefix(`/`)"
+      middlewares:
+        - filter-headers
+        - pass-client-cert
+        - ip-allowlist
+      tls: { }
+      service: keycloak
+----
+
+[NOTE]
+====
+With this setup, any request to an admin path on the public port (8443 in our example) will fall through to the `keycloak-public` router, which only matches `/realms/`, `/resources/`, and `/.well-known/`.
+Admin paths on this port will return a 404.
 ====
 
 [[graceful-shutdown-considerations-traefik-reencrypt]]

--- a/docs/guides/server/traefik-reencrypt.adoc
+++ b/docs/guides/server/traefik-reencrypt.adoc
@@ -211,6 +211,32 @@ See the <@links.server id="mutual-tls"/> guide for additional details.
 Disables the client authentication requirement for the management endpoint.
 This allows Traefik to perform HTTPS health checks against the management port (`9000`) without needing to present the mTLS client certificate.
 
+[[admin-dedicated-port-traefik-reencrypt]]
+== Optional: Admin UI and Admin API on a dedicated hostname and port
+
+By default, the Admin UI and Admin API are served on the same port (8443) as the public endpoints, protected only by the `ip-allowlist` middleware.
+For stricter network-level isolation, you can move them to a dedicated hostname and port (8444) so they can be independently firewalled.
+
+To enable this, add the following configuration:
+
+*`docker-compose.yaml`*::
+* Add `KC_HOSTNAME_ADMIN` on both `keycloak1` and `keycloak2` which tells each {project_name} node to serve the Admin UI and Admin API on the admin hostname.
+* Add port `8444:8444` under the `traefik` service — exposes the admin port on the host.
+
+*`traefik.yaml`*::
+* Add the `keycloak-admin` entrypoint which adds a second Traefik entrypoint listening on port 8444.
+
+*`keycloak.yaml`*::
+* Add the `keycloak-admin` router — routes all traffic coming on the `keycloak-admin` entrypoint to the {project_name} service, restricted to the `ip-allowlist`.
+* Remove the `keycloak-internal` router as it is no longer needed, as the admin paths are now handled exclusively by the dedicated `keycloak-admin` router on port 8444.
+Leaving both enabled would cause the `keycloak-internal` router to match admin paths on port 8443 as well.
+
+[NOTE]
+====
+With this setup, any request to an admin path on port 8443 will fall through to the `keycloak-public` router, which only matches `/realms/`, `/resources/`, and `/.well-known/`.
+Admin paths on port 8443 will return a 404.
+====
+
 [[graceful-shutdown-considerations-traefik-reencrypt]]
 == Graceful shutdown considerations
 


### PR DESCRIPTION
This PR shows the document changes for the blueprint changes for Should have the admin UI and admin API on a separate hostname traefik & HA Proxy reencrypt for the below:

https://github.com/keycloak/keycloak/issues/49683
https://github.com/keycloak/keycloak/issues/49871

**PS: We have added comments in the quickstart repo but have asked the users to directly add the config here in keycloak.**

Closes #48739
Signed-off-by: Ruchika <ruchika.jha1@ibm.com>

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
