### PR TITLE
Make Content-Type exceptions thrown early by RESTEasy RFC compliant

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -99,6 +99,7 @@ import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakHandlerChainCustomizer;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakTracingCustomizer;
 import org.keycloak.quarkus.runtime.logging.ClearMappedDiagnosticContextFilter;
+import org.keycloak.quarkus.runtime.services.ContentTypeExceptionFilter;
 import org.keycloak.quarkus.runtime.services.RejectSourceMapFilter;
 import org.keycloak.quarkus.runtime.services.health.BootstrapReadyHealthCheck;
 import org.keycloak.quarkus.runtime.services.health.KeycloakClusterReadyHealthCheck;
@@ -314,6 +315,11 @@ class KeycloakProcessor {
     @BuildStep(onlyIfNot = IsKeycloakDevMode.class)
     void filterSourceMapRequests(BuildProducer<FilterBuildItem> filters) {
         filters.produce(new FilterBuildItem(new RejectSourceMapFilter(), SecurityHandlerPriorities.CORS + 1));
+    }
+
+    @BuildStep
+    void filterContentTypeExceptions(BuildProducer<FilterBuildItem> filters) {
+        filters.produce(new FilterBuildItem(new ContentTypeExceptionFilter(), SecurityHandlerPriorities.CORS + 1));
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -99,7 +99,7 @@ import org.keycloak.quarkus.runtime.integration.QuarkusKeycloakSessionFactory;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakHandlerChainCustomizer;
 import org.keycloak.quarkus.runtime.integration.resteasy.KeycloakTracingCustomizer;
 import org.keycloak.quarkus.runtime.logging.ClearMappedDiagnosticContextFilter;
-import org.keycloak.quarkus.runtime.services.ContentTypeExceptionFilter;
+import org.keycloak.quarkus.runtime.services.RejectMalformedContentTypeFilter;
 import org.keycloak.quarkus.runtime.services.RejectSourceMapFilter;
 import org.keycloak.quarkus.runtime.services.health.BootstrapReadyHealthCheck;
 import org.keycloak.quarkus.runtime.services.health.KeycloakClusterReadyHealthCheck;
@@ -318,8 +318,8 @@ class KeycloakProcessor {
     }
 
     @BuildStep
-    void filterContentTypeExceptions(BuildProducer<FilterBuildItem> filters) {
-        filters.produce(new FilterBuildItem(new ContentTypeExceptionFilter(), SecurityHandlerPriorities.CORS + 1));
+    void filterRejectMalformedContentType(BuildProducer<FilterBuildItem> filters) {
+        filters.produce(new FilterBuildItem(new RejectMalformedContentTypeFilter(), SecurityHandlerPriorities.CORS + 1));
     }
 
     @Record(ExecutionTime.STATIC_INIT)

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/ContentTypeExceptionFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/ContentTypeExceptionFilter.java
@@ -14,10 +14,12 @@ public class ContentTypeExceptionFilter implements Handler<RoutingContext> {
     public void handle(RoutingContext routingContext) {
         String contentType = routingContext.request().getHeader("Content-Type");
 
-        if (contentType != null && !contentType.isBlank() && !isParseable(contentType)) {
+        if (contentType != null && !isParseable(contentType)) {
             LOGGER.debugf("Rejecting request with malformed Content-Type header: %s", contentType);
             routingContext.response()
                     .setStatusCode(400)
+                    .putHeader("Cache-Control", "no-store")
+                    .putHeader("Pragma", "no-cache")
                     .putHeader("Content-Type", MediaType.APPLICATION_JSON)
                     .end(MALFORMED_CONTENT_TYPE_RESPONSE);
             return;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/ContentTypeExceptionFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/ContentTypeExceptionFilter.java
@@ -1,0 +1,37 @@
+package org.keycloak.quarkus.runtime.services;
+
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.logging.Logger;
+
+public class ContentTypeExceptionFilter implements Handler<RoutingContext> {
+    private static final Logger LOGGER = Logger.getLogger(ContentTypeExceptionFilter.class);
+    private static final String MALFORMED_CONTENT_TYPE_RESPONSE =
+            "{\"error\":\"invalid_request\",\"error_description\":\"Invalid Content-Type header\"}";
+
+    @Override
+    public void handle(RoutingContext routingContext) {
+        String contentType = routingContext.request().getHeader("Content-Type");
+
+        if (contentType != null && !contentType.isBlank() && !isParseable(contentType)) {
+            LOGGER.debugf("Rejecting request with malformed Content-Type header: %s", contentType);
+            routingContext.response()
+                    .setStatusCode(400)
+                    .putHeader("Content-Type", MediaType.APPLICATION_JSON)
+                    .end(MALFORMED_CONTENT_TYPE_RESPONSE);
+            return;
+        }
+
+        routingContext.next();
+    }
+
+    private static boolean isParseable(String contentType) {
+        try {
+            MediaType.valueOf(contentType);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/RejectMalformedContentTypeFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/RejectMalformedContentTypeFilter.java
@@ -1,14 +1,36 @@
+/*
+ * Copyright 2025 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.keycloak.quarkus.runtime.services;
 
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.ws.rs.core.MediaType;
 import org.jboss.logging.Logger;
+import org.keycloak.representations.idm.OAuth2ErrorRepresentation;
+import org.keycloak.services.util.ObjectMapperResolver;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RejectMalformedContentTypeFilter implements Handler<RoutingContext> {
     private static final Logger LOGGER = Logger.getLogger(RejectMalformedContentTypeFilter.class);
-    private static final String MALFORMED_CONTENT_TYPE_RESPONSE =
-            "{\"error\":\"invalid_request\",\"error_description\":\"Invalid Content-Type header\"}";
+    private static final String ERROR_DESCRIPTION = "Invalid Content-Type header";
+    private final ObjectMapper MAPPER = ObjectMapperResolver.createStreamSerializer();
 
     @Override
     public void handle(RoutingContext routingContext) {
@@ -16,16 +38,26 @@ public class RejectMalformedContentTypeFilter implements Handler<RoutingContext>
 
         if (contentType != null && !isParseable(contentType)) {
             LOGGER.debugf("Rejecting request with malformed Content-Type header: %s", contentType);
+
             routingContext.response()
                     .setStatusCode(400)
                     .putHeader("Cache-Control", "no-store")
                     .putHeader("Pragma", "no-cache")
                     .putHeader("Content-Type", MediaType.APPLICATION_JSON)
-                    .end(MALFORMED_CONTENT_TYPE_RESPONSE);
+                    .end(errorResponse());
             return;
         }
 
         routingContext.next();
+    }
+
+    private String errorResponse() {
+        OAuth2ErrorRepresentation error = new OAuth2ErrorRepresentation("invalid_request", ERROR_DESCRIPTION);
+        try {
+            return MAPPER.writeValueAsString(error);
+        } catch (JsonProcessingException e) {
+            return "";
+        }
     }
 
     private static boolean isParseable(String contentType) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/RejectMalformedContentTypeFilter.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/services/RejectMalformedContentTypeFilter.java
@@ -5,8 +5,8 @@ import io.vertx.ext.web.RoutingContext;
 import jakarta.ws.rs.core.MediaType;
 import org.jboss.logging.Logger;
 
-public class ContentTypeExceptionFilter implements Handler<RoutingContext> {
-    private static final Logger LOGGER = Logger.getLogger(ContentTypeExceptionFilter.class);
+public class RejectMalformedContentTypeFilter implements Handler<RoutingContext> {
+    private static final Logger LOGGER = Logger.getLogger(RejectMalformedContentTypeFilter.class);
     private static final String MALFORMED_CONTENT_TYPE_RESPONSE =
             "{\"error\":\"invalid_request\",\"error_description\":\"Invalid Content-Type header\"}";
 

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
@@ -2,6 +2,9 @@ package org.keycloak.tests.oauth;
 
 import java.io.IOException;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
 import org.keycloak.OAuthErrorException;
 import org.keycloak.common.util.SecretGenerator;
 import org.keycloak.common.util.Time;
@@ -10,6 +13,7 @@ import org.keycloak.representations.JsonWebToken;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.oauth.OAuthClient;
 import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
 import org.keycloak.testsuite.util.oauth.UserInfoResponse;
 
@@ -32,6 +36,17 @@ public class TokenInputValidationTest {
         assertEquals(401, response.getStatusCode());
         assertFalse(response.isSuccess());
         assertEquals(OAuthErrorException.INVALID_TOKEN, response.getError());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"application/", "application/@##", ""})
+    public void tokenEndpointRejectsMalformed(String input) {
+        AccessTokenResponse response = oauth.passwordGrantRequest("user", "password")
+                .header("Content-Type", input)
+                .send();
+
+        assertEquals(400, response.getStatusCode());
+        assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
@@ -47,6 +47,9 @@ public class TokenInputValidationTest {
 
         assertEquals(400, response.getStatusCode());
         assertEquals(OAuthErrorException.INVALID_REQUEST, response.getError());
+        assertEquals("Invalid Content-Type header", response.getErrorDescription());
+        assertEquals("no-store", response.getHeader("Cache-Control"));
+        assertEquals("no-cache", response.getHeader("Pragma"));
     }
 
     @Test

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenInputValidationTest.java
@@ -39,7 +39,7 @@ public class TokenInputValidationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"application/", "application/@##", ""})
+    @ValueSource(strings = {"invalid/@@##", "", "</><script>alert(1)</script>", " application/ "})
     public void tokenEndpointRejectsMalformed(String input) {
         AccessTokenResponse response = oauth.passwordGrantRequest("user", "password")
                 .header("Content-Type", input)


### PR DESCRIPTION
I wrote a failing test first (TDD-style), then added ContentTypeExceptionFilter, modelled after the other filters in the same package.

RESTEasy Reactive validates the Content-Type header during dispatch, before path matching and before any JAX-RS exception mappers are initialized. So the IllegalArgumentException from MediaTypeHeaderDelegate.internalParse() escapes the JAX-RS pipeline entirely and lands in Quarkus' generic error handler as a 500.

The fix validates the header one layer lower, at the Vert.x routing layer, using the same public API (MediaType.valueOf()) that RESTEasy uses internally. Any value RESTEasy would accept passes through, any value it would reject is caught early and returned as RFC 6749 compliant 400.

Resolves #49964