### PR TITLE
[OID4VCI-HAIP] Pass oid4vci-1_0-issuer-batch-issuance

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/constants/OID4VCIConstants.java
+++ b/server-spi-private/src/main/java/org/keycloak/constants/OID4VCIConstants.java
@@ -28,6 +28,9 @@ import org.keycloak.representations.idm.RoleRepresentation;
  */
 public final class OID4VCIConstants {
 
+    // Hide ctor
+    private OID4VCIConstants() {}
+
     public static final String OID4VC_PROTOCOL = "oid4vc";
 
     public static final String C_NONCE_LIFETIME_IN_SECONDS = "vc.c-nonce-lifetime-seconds";
@@ -38,7 +41,7 @@ public final class OID4VCIConstants {
 
     // --- Keybinding/Credential Builder ---
     public static final String SOURCE_ENDPOINT = "source_endpoint";
-    public static final String BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE = "batch_credential_issuance.batch_size";
+
     // Comma-separated aliases of trust-material identity providers that expose trusted keys for key attestation proof validation
     public static final String OID4VCI_ATTESTER_TRUST_IDPS_ATTR = "oid4vci.attester_trust_idps";
 
@@ -57,6 +60,7 @@ public final class OID4VCIConstants {
     // Attribute used in the credential-offer email, which is sent by the admin to the user
     public static final String EMAIL_TEMPLATE_ATTR_CREDENTIAL_SCOPE_DISPLAY_NAME = "credentialScopeDisplayName";
 
-    private OID4VCIConstants() {
-    }
+    // Batch issuance
+    public static final String BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE = "oid4vci.batch_credential_issuance.batch_size";
+    public static final int BATCH_CREDENTIAL_ISSUANCE_DEFAULT_MAX_BATCH_SIZE = 2;
 }

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/issuance/OID4VCIssuerEndpoint.java
@@ -92,6 +92,7 @@ import org.keycloak.protocol.oid4vc.issuance.signing.CredentialSignerException;
 import org.keycloak.protocol.oid4vc.model.AttestationProof;
 import org.keycloak.protocol.oid4vc.model.ClaimsDescription;
 import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer.BatchCredentialIssuance;
 import org.keycloak.protocol.oid4vc.model.CredentialOfferURI;
 import org.keycloak.protocol.oid4vc.model.CredentialRequest;
 import org.keycloak.protocol.oid4vc.model.CredentialRequestEncryptionMetadata;
@@ -138,6 +139,7 @@ import org.jboss.logging.Logger;
 
 import static org.keycloak.OID4VCConstants.OID4VCI_ENABLED_ATTRIBUTE_KEY;
 import static org.keycloak.OID4VCConstants.OPENID_CREDENTIAL;
+import static org.keycloak.constants.OID4VCIConstants.BATCH_CREDENTIAL_ISSUANCE_DEFAULT_MAX_BATCH_SIZE;
 import static org.keycloak.constants.OID4VCIConstants.OID4VC_PROTOCOL;
 import static org.keycloak.protocol.oid4vc.issuance.OID4VCIssuerWellKnownProvider.getSupportedCredentials;
 import static org.keycloak.protocol.oid4vc.model.AuthorizationCodeGrant.AUTH_CODE_GRANT_TYPE;
@@ -999,6 +1001,8 @@ public class OID4VCIssuerEndpoint {
 
         // Get the list of all proofs (handles single proof, multiple proofs, or none)
         List<String> allProofs = getAllProofs(credentialRequest);
+        if (allProofs.stream().anyMatch(p -> p == null || p.isBlank()))
+            throw new BadRequestException(getErrorResponse(ErrorType.INVALID_PROOF, "Proof values must not be null or blank"));
 
         // Generate credential response
         CredentialResponse responseVO = new CredentialResponse();
@@ -1012,6 +1016,16 @@ public class OID4VCIssuerEndpoint {
             Proofs originalProofs = credentialRequest.getProofs();
             // Determine the proof type from the original proofs
             String proofType = originalProofs.getProofType();
+
+            if (allProofs.size() > 1) {
+                Integer maxBatchSize = Optional.ofNullable(issuerMetadata.getBatchCredentialIssuance())
+                        .map(BatchCredentialIssuance::getBatchSize)
+                        .orElse(BATCH_CREDENTIAL_ISSUANCE_DEFAULT_MAX_BATCH_SIZE);
+                if (allProofs.size() > maxBatchSize) {
+                    LOGGER.warnf("Reducing credential batch size to: %d", maxBatchSize);
+                    allProofs = allProofs.subList(0, maxBatchSize);
+                }
+            }
 
             for (String currentProof : allProofs) {
                 Proofs proofForIteration = Proofs.create(proofType, currentProof);

--- a/services/src/main/java/org/keycloak/protocol/oid4vc/model/Proofs.java
+++ b/services/src/main/java/org/keycloak/protocol/oid4vc/model/Proofs.java
@@ -73,15 +73,28 @@ public class Proofs {
      * Create proofs based on the proof type.
      * Sets the appropriate field (JWT or Attestation) depending on the proof type.
      *
-     * @param proofType the proof type (ProofType.JWT or ProofType.ATTESTATION)
-     * @param proof     the proof value to set
+     * @param proofType   the proof type (ProofType.JWT or ProofType.ATTESTATION)
+     * @param proofValues the proof values to set
      */
-    public static Proofs create(String proofType, String proof) {
+    public static Proofs create(String proofType, String... proofValues) {
+        if (proofType == null) {
+            throw new IllegalArgumentException("proofType cannot be null");
+        }
+        if (proofValues == null || proofValues.length == 0) {
+            throw new IllegalArgumentException("proofValues cannot be null or empty");
+        }
+        for (String proof : proofValues) {
+            if (proof == null || proof.isBlank()) {
+                throw new IllegalArgumentException("Null or blank proof value");
+            }
+        }
         Proofs proofs = new Proofs();
-        if (ProofType.JWT.equals(proofType)) {
-            proofs.setJwt(List.of(proof));
-        } else if (ProofType.ATTESTATION.equals(proofType)) {
-            proofs.setAttestation(List.of(proof));
+        switch (proofType) {
+            case ProofType.JWT ->
+                    proofs.setJwt(List.of(proofValues));
+            case ProofType.ATTESTATION ->
+                    proofs.setAttestation(List.of(proofValues));
+            default -> throw new IllegalArgumentException("Unknown proof type: " + proofType);
         }
         return proofs;
     }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCBasicWallet.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -243,13 +244,22 @@ public class OID4VCBasicWallet {
 
     public Proofs generateJwtProof(OID4VCTestContext ctx) {
         String nonce = nonceRequest().send().getNonce();
-        KeyWrapper ecKey = getECKeyPair(ctx, null);
-        return generateJwtProof(ctx, ecKey, nonce);
+        KeyWrapper vcKey = getECKeyPair(ctx, null);
+        return generateJwtProofs(ctx, nonce, vcKey);
     }
 
-    public Proofs generateJwtProof(OID4VCTestContext ctx, KeyWrapper ecKey, String nonce) {
+    public Proofs generateJwtProofs(OID4VCTestContext ctx, String nonce, KeyWrapper... keys) {
         String aud = getIssuerMetadata(ctx).getCredentialIssuer();
-        return Proofs.create(ProofType.JWT, OID4VCProofTestUtils.generateJwtProof(aud, ecKey, nonce));
+        if (keys == null || keys.length == 0) {
+            throw new IllegalArgumentException("keys cannot be null or empty");
+        }
+        if (Arrays.stream(keys).anyMatch(Objects::isNull)) {
+            throw new IllegalArgumentException("keys cannot contain null elements");
+        }
+        String[] proofValues = Arrays.stream(keys)
+                .map(k -> OID4VCProofTestUtils.generateJwtProof(aud, nonce, k))
+                .toArray(String[]::new);
+        return Proofs.create(ProofType.JWT, proofValues);
     }
 
     public KeyWrapper getECKeyPair(OID4VCTestContext ctx) {

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCProofTestUtils.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/OID4VCProofTestUtils.java
@@ -51,7 +51,7 @@ public final class OID4VCProofTestUtils {
         return generateJwtProofWithClaims(List.of(audience), nonce, null, null, null, null, createEcKeyPair("proof-key"));
     }
 
-    public static String generateJwtProof(String audience, KeyWrapper keyWrapper, String nonce) {
+    public static String generateJwtProof(String audience, String nonce, KeyWrapper keyWrapper) {
         return generateJwtProofWithClaims(List.of(audience), nonce, null, null, null, null, keyWrapper);
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/HAIPIssuerConformanceTest.java
@@ -1,19 +1,25 @@
 package org.keycloak.tests.oid4vc.abca;
 
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.keycloak.TokenVerifier;
 import org.keycloak.broker.trust.DefaultTrustIdentityProviderConfig;
 import org.keycloak.broker.trust.DefaultTrustIdentityProviderFactory;
-import org.keycloak.common.VerificationException;
 import org.keycloak.crypto.KeyWrapper;
 import org.keycloak.jose.jwk.JSONWebKeySet;
 import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
+import org.keycloak.jose.jws.JWSInput;
 import org.keycloak.models.RealmModel;
+import org.keycloak.protocol.oid4vc.issuance.TimeClaimNormalizer;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer;
+import org.keycloak.protocol.oid4vc.model.CredentialIssuer.BatchCredentialIssuance;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.CredentialResponse.Credential;
 import org.keycloak.protocol.oid4vc.model.CredentialScopeRepresentation;
 import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.representations.JsonWebToken;
@@ -28,6 +34,7 @@ import org.keycloak.tests.oid4vc.OID4VCTestContext;
 import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
 import org.keycloak.testsuite.util.oauth.ParResponse;
 import org.keycloak.testsuite.util.oauth.PkceGenerator;
+import org.keycloak.util.JWKSUtils;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.util.TokenUtil;
 
@@ -37,6 +44,9 @@ import org.junit.jupiter.api.Test;
 import static org.keycloak.OID4VCConstants.CLAIM_NAME_VCT;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_HEADER;
 import static org.keycloak.authentication.authenticators.client.AttestationBasedClientAuthenticator.OAUTH_CLIENT_ATTESTATION_POP_HEADER;
+import static org.keycloak.constants.OID4VCIConstants.BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE;
+import static org.keycloak.constants.OID4VCIConstants.TIME_CLAIMS_STRATEGY;
+import static org.keycloak.constants.OID4VCIConstants.TIME_RANDOMIZE_WINDOW_SECONDS;
 import static org.keycloak.tests.oid4vc.OID4VCProofTestUtils.createRsaKeyPair;
 import static org.keycloak.tests.oid4vc.OID4VCTestContext.CLIENT_ATTESTER_ATTACHMENT_KEY;
 
@@ -59,15 +69,22 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
 
     @TestSetup
     public void configure() throws Exception {
+
         var kw = createRsaKeyPair("openid-abca-attester-key");
         JWK jwk = JWKBuilder.create()
                 .kid(kw.getKid())
                 .algorithm(kw.getAlgorithm())
                 .rsa(kw.getPublicKey(), kw.getCertificate());
         JSONWebKeySet jwks = new JSONWebKeySet();
-        jwks.setKeys(new JWK[] { jwk });
+        jwks.setKeys(new JWK[]{jwk});
         attesterJwks = JsonSerialization.writeValueAsString(jwks);
         attester = new OIDCMockClientAttester(kw);
+
+        setRealmAttributes(Map.of(
+                BATCH_CREDENTIAL_ISSUANCE_BATCH_SIZE, "20",
+                TIME_CLAIMS_STRATEGY, TimeClaimNormalizer.Strategy.RANDOMIZE.name(),
+                TIME_RANDOMIZE_WINDOW_SECONDS, "300" // 5min
+        ));
     }
 
     @BeforeEach
@@ -144,7 +161,7 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         // Send Nonce Request
         //
         String nonce = wallet.nonceRequest().send().getNonce();
-        Proofs jwtProof = wallet.generateJwtProof(ctx, ecKey, nonce);
+        Proofs jwtProofs = wallet.generateJwtProofs(ctx, nonce, ecKey);
 
         // Send Credential Request
         // Note, we use the same EC key for DPoP and Holder identity
@@ -155,12 +172,110 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
         CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenType, accessToken)
                 .credentialIdentifier(credentialIdentifier)
                 .dpopProof(dpopProof)
-                .proofs(jwtProof)
+                .proofs(jwtProofs)
                 .send().getCredentialResponse();
 
         // Verify Credential Response
         //
-        verifyCredentialResponse(ctx, credResponse);
+        verifyCredentialResponse(ctx, jwtProofs, credResponse);
+    }
+
+    /**
+     * oid4vci-1_0-issuer-batch-issuance
+     * <p>
+     * Requests multiple credentials in a single credential request, as advertised by the 'batch_credential_issuance' credential issuer metadata.
+     * The wallet sends one key proof per requested credential and verifies that the issuer returns no more credentials than proofs sent,
+     * that all returned credentials contain the same Credential Dataset, and that each credential is bound to a distinct proof key.
+     */
+    @Test
+    public void testBatchIssuanceHappyFlow() throws Exception {
+
+        var ctx = new OID4VCTestContext(abcaClient, sdJwtTypeCredentialScope);
+        ctx.putAttachment(CLIENT_ATTESTER_ATTACHMENT_KEY, attester);
+
+        // Verify Issuer Metadata
+        //
+        CredentialIssuer issuerMetadata = wallet.getIssuerMetadata(ctx);
+        BatchCredentialIssuance bci = issuerMetadata.getBatchCredentialIssuance();
+        assertEquals(20, bci.getBatchSize());
+
+        // Generate ABCA Headers
+        //
+        KeyWrapper rsaKey = wallet.getRSAKeyPair(ctx);
+        String attestationJwt = wallet.buildClientAttestationJWT(ctx, rsaKey);
+        String attestationPoPJwt = wallet.buildClientAttestationPoPJWT(ctx, rsaKey);
+
+        // Send PAR Request
+        //
+        var pkce = PkceGenerator.s256();
+        String requestUri = oauth.pushedAuthorizationRequest()
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .scopeParam(ctx.getScope())
+                .codeChallenge(pkce)
+                .send().getRequestUri();
+        assertNotNull(requestUri, "No requestUri");
+
+        // Send Authorization Request
+        //
+        String authCode = wallet.authorizationRequest()
+                .requestUri(requestUri)
+                .codeChallenge(pkce)
+                .send(ctx.getHolder(), TEST_PASSWORD)
+                .getCode();
+        assertNotNull(authCode, "No auth code");
+
+        // Send Token Request
+        //
+
+        // Proves the wallet is the legitimate holder of the DPoP-bound access token.
+        // The access token is sender-constrained to the DPoP public key,
+        // so every protected request must be signed with the matching private key
+        KeyWrapper dpopKey = wallet.getECKeyPair(ctx, "dpopKey");
+
+        String tokenEndpoint = oauth.getEndpoints().getToken();
+        String dpopProof = wallet.generateSignedDPoPProof(tokenEndpoint, dpopKey, null);
+
+        AccessTokenResponse tokenResponse = wallet.accessTokenRequest(ctx, authCode)
+                .header(OAUTH_CLIENT_ATTESTATION_HEADER, attestationJwt)
+                .header(OAUTH_CLIENT_ATTESTATION_POP_HEADER, attestationPoPJwt)
+                .codeVerifier(pkce)
+                .dpopProof(dpopProof)
+                .send();
+        String tokenType = tokenResponse.getTokenType();
+        String accessToken = tokenResponse.getAccessToken();
+        assertEquals(TokenUtil.TOKEN_TYPE_DPOP, tokenType);
+        assertNotNull(accessToken, "No access token");
+
+        String credentialIdentifier = ctx.getAuthorizedCredentialIdentifier();
+        assertNotNull(credentialIdentifier, "No authorized credential identifier");
+
+        // Send Nonce Request
+        //
+        String nonce = wallet.nonceRequest().send().getNonce();
+
+        // Proves control of the key that the issued credential will be bound to.
+        // Proofs must include the issuer audience and, when available, the issuer c_nonce
+        KeyWrapper[] vcKeys = new KeyWrapper[bci.getBatchSize() + 2]; // two more keys than max batch-size
+        for (int i = 0; i < vcKeys.length; i++) {
+            vcKeys[i] = wallet.getECKeyPair(ctx, "vcKey" + (i + 1));
+        }
+        Proofs jwtProofs = wallet.generateJwtProofs(ctx, nonce, vcKeys);
+
+        // Send Credential Request (with multiple proofs)
+        //
+        String credentialEndpoint = oauth.getEndpoints().getOid4vcCredential();
+        dpopProof = wallet.generateSignedDPoPProof(credentialEndpoint, dpopKey, accessToken);
+
+        CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenType, accessToken)
+                .credentialIdentifier(credentialIdentifier)
+                .dpopProof(dpopProof)
+                .proofs(jwtProofs)
+                .send().getCredentialResponse();
+
+        // Verify Credential Response
+        //
+        verifyCredentialResponse(ctx, jwtProofs, credResponse);
     }
 
     /**
@@ -357,26 +472,52 @@ public class HAIPIssuerConformanceTest extends OID4VCIssuerTestBase {
 
     // Private ---------------------------------------------------------------------------------------------------------
 
-    private void verifyCredentialResponse(OID4VCTestContext ctx, CredentialResponse credResponse) throws VerificationException {
+    private void verifyCredentialResponse(OID4VCTestContext ctx, Proofs jwtProofs, CredentialResponse credResponse) throws Exception {
 
         CredentialScopeRepresentation credScope = ctx.getCredentialScope();
         String issuer = wallet.getIssuerMetadata(ctx).getCredentialIssuer();
-        CredentialResponse.Credential credObj = credResponse.getCredentials().get(0);
-        assertNotNull(credObj, "The first credential in the array should not be null");
+        List<Credential> credentials = credResponse.getCredentials();
+        assertNotNull(credentials, "No credentials");
 
-        SdJwtVP sdJwtVP = SdJwtVP.of(credObj.getCredential().toString());
-        IssuerSignedJWT issuerSignedJWT = sdJwtVP.getIssuerSignedJWT();
-        JsonWebToken vcSdJwt = TokenVerifier.create(issuerSignedJWT.getJws(), JsonWebToken.class).getToken();
-        Map<String, Object> otherClaims = vcSdJwt.getOtherClaims();
-        assertEquals(issuer, vcSdJwt.getIssuer());
-        assertEquals(credScope.getVct(), otherClaims.get(CLAIM_NAME_VCT));
+        CredentialIssuer issuerMetadata = wallet.getIssuerMetadata(ctx);
+        BatchCredentialIssuance bci = issuerMetadata.getBatchCredentialIssuance();
 
-        Map<String, String> claims = sdJwtVP.getClaims().values().stream().collect(Collectors.toMap(
-                arrayNode -> arrayNode.get(1).asText(),
-                arrayNode -> arrayNode.get(2).asText()
-        ));
-        assertEquals("Alice", claims.get("firstName"));
-        assertEquals("Wonderland", claims.get("lastName"));
-        assertEquals("alice@email.cz", claims.get("email"));
+        List<String> allProofs = jwtProofs.getAllProofs();
+        assertEquals(Math.min(allProofs.size(), bci.getBatchSize()), credentials.size(), "Number of proofs does not match number of credentials");
+
+        List<String> expThumbprints = new ArrayList<>();
+        for (String proof : allProofs) {
+            JWK proofJwk = new JWSInput(proof).getHeader().getKey();
+            expThumbprints.add(JWKSUtils.computeThumbprint(proofJwk));
+        }
+
+        for (int i = 0; i < credentials.size(); i++) {
+            Credential credObj = credentials.get(i);
+            assertNotNull(credObj, "No credential at index: " + i);
+
+            SdJwtVP sdJwtVP = SdJwtVP.of(credObj.getCredential().toString());
+            IssuerSignedJWT issuerSignedJWT = sdJwtVP.getIssuerSignedJWT();
+            var cnfJwkNode = issuerSignedJWT.getCnfClaim()
+                    .map(it -> it.get("jwk"))
+                    .orElse(null);
+            assertNotNull(cnfJwkNode, "Missing cnf.jwk claim at index: " + i);
+
+            JWK cnfJwk = JsonSerialization.mapper.convertValue(cnfJwkNode, JWK.class);
+            String wasThumbprint = JWKSUtils.computeThumbprint(cnfJwk);
+            assertEquals(expThumbprints.get(i), wasThumbprint);
+
+            JsonWebToken vcSdJwt = TokenVerifier.create(issuerSignedJWT.getJws(), JsonWebToken.class).getToken();
+            Map<String, Object> otherClaims = vcSdJwt.getOtherClaims();
+            assertEquals(issuer, vcSdJwt.getIssuer());
+            assertEquals(credScope.getVct(), otherClaims.get(CLAIM_NAME_VCT));
+
+            Map<String, String> claims = sdJwtVP.getClaims().values().stream().collect(Collectors.toMap(
+                    arrayNode -> arrayNode.get(1).asText(),
+                    arrayNode -> arrayNode.get(2).asText()
+            ));
+            assertEquals("Alice", claims.get("firstName"));
+            assertEquals("Wonderland", claims.get("lastName"));
+            assertEquals("alice@email.cz", claims.get("email"));
+        }
     }
 }

--- a/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oid4vc/abca/OIDCAttestationBasedClientAuthenticationTest.java
@@ -32,6 +32,7 @@ import org.keycloak.jose.jwk.JWK;
 import org.keycloak.jose.jwk.JWKBuilder;
 import org.keycloak.models.RealmModel;
 import org.keycloak.protocol.oid4vc.model.CredentialResponse;
+import org.keycloak.protocol.oid4vc.model.Proofs;
 import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.annotations.TestSetup;
@@ -180,6 +181,7 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         // Send Nonce Request
         //
         String nonce = wallet.nonceRequest().send().getNonce();
+        Proofs jwtProofs = wallet.generateJwtProofs(ctx, nonce, ecKey);
 
         // Send Credential Request
         //
@@ -187,7 +189,7 @@ public class OIDCAttestationBasedClientAuthenticationTest extends OID4VCIssuerTe
         CredentialResponse credResponse = wallet.credentialRequest(ctx, tokenType, accessToken)
                 .credentialIdentifier(credIdentifier)
                 .dpopProof(wallet.generateSignedDPoPProof(credentialEndpoint, ecKey, accessToken))
-                .proofs(wallet.generateJwtProof(ctx, ecKey, nonce))
+                .proofs(jwtProofs)
                 .send().getCredentialResponse();
 
         assertFalse(credResponse.getCredentials().isEmpty(), "No credential");


### PR DESCRIPTION
closes #50216

* Extend Proofs.create(...) to accept multiple proof values (varargs) and reject empty input.
* Update the basic wallet to generate multiple JWT proofs instead of a single proof
* Add/extend HAIP issuer conformance coverage for batch issuance 