### PR TITLE
Pin UBI base images by digest in container Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,3 +54,23 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: docker
+    directories:
+      - "/quarkus/container"
+      - "/operator"
+      - "/test-framework/db-edb/container"
+    schedule:
+      interval: weekly
+      day: "sunday"
+      time: "03:00"
+      timezone: Etc/GMT
+    open-pull-requests-limit: 5
+    rebase-strategy: disabled
+    labels:
+      - area/dependencies
+      - team/cloud-native
+    groups:
+      ubi-base-images:
+        patterns:
+          - "registry.access.redhat.com/ubi9*"

--- a/.github/scripts/fips-ubi-image.sh
+++ b/.github/scripts/fips-ubi-image.sh
@@ -11,7 +11,12 @@ if [[ ! -f "${DOCKERFILE}" ]]; then
 fi
 
 UBI9_IMAGE=$(awk '$1 == "FROM" && $2 ~ /^registry\.access\.redhat\.com\/ubi9@/ { print $2; exit }' "${DOCKERFILE}")
+
+if [[ -z "${UBI9_IMAGE}" ]]; then
+  echo "Failed to extract registry.access.redhat.com/ubi9@sha256:... digest from ${DOCKERFILE}" >&2
+  exit 1
 fi
+
 if [[ "${UBI9_IMAGE}" != registry.access.redhat.com/ubi9@sha256:* ]]; then
   echo "Expected registry.access.redhat.com/ubi9@sha256:... from ${DOCKERFILE}, got: ${UBI9_IMAGE}" >&2
   exit 1

--- a/.github/scripts/fips-ubi-image.sh
+++ b/.github/scripts/fips-ubi-image.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# UBI digest is pinned in quarkus/container/Dockerfile; FIPS CI reuses it so Dependabot
+# updates do not require a separate digest in .github/workflows/ci.yml.
+# Use ubi9@sha256: (not ubi9/ubi) so the repository path matches the digest source.
+DOCKERFILE="quarkus/container/Dockerfile"
+if [[ ! -f "${DOCKERFILE}" ]]; then
+  echo "Dockerfile not found: ${DOCKERFILE}" >&2
+  exit 1
+fi
+
+UBI9_IMAGE=$(grep -m1 '^FROM registry.access.redhat.com/ubi9@' "${DOCKERFILE}" | awk '{print $2}')
+if [[ -z "${UBI9_IMAGE}" ]]; then
+  echo "No pinned ubi9 base image found in ${DOCKERFILE}" >&2
+  exit 1
+fi
+if [[ "${UBI9_IMAGE}" != registry.access.redhat.com/ubi9@sha256:* ]]; then
+  echo "Expected registry.access.redhat.com/ubi9@sha256:... from ${DOCKERFILE}, got: ${UBI9_IMAGE}" >&2
+  exit 1
+fi
+echo "${UBI9_IMAGE}"

--- a/.github/scripts/fips-ubi-image.sh
+++ b/.github/scripts/fips-ubi-image.sh
@@ -10,10 +10,7 @@ if [[ ! -f "${DOCKERFILE}" ]]; then
   exit 1
 fi
 
-UBI9_IMAGE=$(grep -m1 '^FROM registry.access.redhat.com/ubi9@' "${DOCKERFILE}" | awk '{print $2}')
-if [[ -z "${UBI9_IMAGE}" ]]; then
-  echo "No pinned ubi9 base image found in ${DOCKERFILE}" >&2
-  exit 1
+UBI9_IMAGE=$(awk '$1 == "FROM" && $2 ~ /^registry\.access\.redhat\.com\/ubi9@/ { print $2; exit }' "${DOCKERFILE}")
 fi
 if [[ "${UBI9_IMAGE}" != registry.access.redhat.com/ubi9@sha256:* ]]; then
   echo "Expected registry.access.redhat.com/ubi9@sha256:... from ${DOCKERFILE}, got: ${UBI9_IMAGE}" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1022,7 +1022,13 @@ jobs:
           sudo insmod fake_fips.ko
 
       - name: Run crypto tests
-        run: docker run --rm --workdir /github/workspace -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi9/ubi:latest .github/scripts/run-fips-ut.sh
+        run: |
+          UBI9_IMAGE=$(.github/scripts/fips-ubi-image.sh)
+          docker run --rm --workdir /github/workspace \
+            -v "${{ github.workspace }}:/github/workspace" \
+            -v "$HOME/.m2:/root/.m2" \
+            "${UBI9_IMAGE}" \
+            .github/scripts/run-fips-ut.sh
 
   fips-integration-tests:
     name: FIPS IT
@@ -1049,7 +1055,14 @@ jobs:
           sudo insmod fake_fips.ko
 
       - name: Run base tests
-        run: docker run --rm --workdir /github/workspace -e "SUREFIRE_RERUN_FAILING_COUNT" -v "${{ github.workspace }}":"/github/workspace" -v "$HOME/.m2":"/root/.m2" registry.access.redhat.com/ubi9/ubi:latest .github/scripts/run-fips-it.sh ${{ matrix.mode }}
+        run: |
+          UBI9_IMAGE=$(.github/scripts/fips-ubi-image.sh)
+          docker run --rm --workdir /github/workspace \
+            -e "SUREFIRE_RERUN_FAILING_COUNT" \
+            -v "${{ github.workspace }}:/github/workspace" \
+            -v "$HOME/.m2:/root/.m2" \
+            "${UBI9_IMAGE}" \
+            .github/scripts/run-fips-it.sh ${{ matrix.mode }}
 
       - uses: ./.github/actions/upload-flaky-tests
         name: Upload flaky tests

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
+FROM registry.access.redhat.com/ubi9@sha256:1b99266db480e8aa6dfda6900697a07ec99334095b4f87d1687edfc06c965132 AS ubi-micro-build
 
 ADD target/ubi-null.sh /tmp/
 RUN bash /tmp/ubi-null.sh java-25-openjdk-headless glibc-langpack-en
 
-FROM registry.access.redhat.com/ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 ENV LANG=en_US.UTF-8
 
 COPY --from=ubi-micro-build /tmp/null/rootfs/ /

--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
+FROM registry.access.redhat.com/ubi9@sha256:1b99266db480e8aa6dfda6900697a07ec99334095b4f87d1687edfc06c965132 AS ubi-micro-build
 
 ARG KEYCLOAK_VERSION=999.0.0-SNAPSHOT
 ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
@@ -19,7 +19,7 @@ RUN chmod -R g+rwX /opt/keycloak
 ADD ubi-null.sh /tmp/
 RUN bash /tmp/ubi-null.sh java-21-openjdk-headless glibc-langpack-en findutils
 
-FROM registry.access.redhat.com/ubi9-micro
+FROM registry.access.redhat.com/ubi9-micro@sha256:b498b3ea26111ab4b81d65139f2ebd2ef9a2abb7a4588b7fdcc54889f95e9caa
 ENV LANG=en_US.UTF-8
 
 # Flag for determining app is running in container

--- a/test-framework/db-edb/container/Dockerfile
+++ b/test-framework/db-edb/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9
+FROM registry.access.redhat.com/ubi9@sha256:1b99266db480e8aa6dfda6900697a07ec99334095b4f87d1687edfc06c965132
 
 ENV VERSION=18
 ENV PGUSER=enterprisedb


### PR DESCRIPTION
Pin ubi9 and ubi9-micro in server and operator Dockerfiles, FIPS CI workflow, and db-edb test container for build reproducibility and supply-chain integrity. Add Dependabot docker updates for ongoing digest bumps.

Closes #50089

