### PR TITLE
contain classpath theme getTemplate path resolution

### DIFF
--- a/services/src/main/java/org/keycloak/theme/ClassLoaderTheme.java
+++ b/services/src/main/java/org/keycloak/theme/ClassLoaderTheme.java
@@ -102,7 +102,7 @@ public class ClassLoaderTheme extends FileBasedTheme {
 
     @Override
     public URL getTemplate(String name) {
-        return classLoader.getResource(templateRoot + name);
+        return ResourceLoader.getResource(classLoader, templateRoot, name);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/theme/ClasspathThemeResourceProviderFactory.java
+++ b/services/src/main/java/org/keycloak/theme/ClasspathThemeResourceProviderFactory.java
@@ -36,7 +36,7 @@ public class ClasspathThemeResourceProviderFactory implements ThemeResourceProvi
 
     @Override
     public URL getTemplate(String name) throws IOException {
-        return classLoader.getResource(THEME_RESOURCES_TEMPLATES + name);
+        return ResourceLoader.getResource(classLoader, THEME_RESOURCES_TEMPLATES, name);
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/theme/ResourceLoader.java
+++ b/services/src/main/java/org/keycloak/theme/ResourceLoader.java
@@ -9,19 +9,24 @@ import java.nio.file.Path;
 public class ResourceLoader {
 
     public static InputStream getResourceAsStream(String root, String resource) throws IOException {
-        if (root == null || resource == null) {
+        URL url = getResource(classLoader(), root, resource);
+        return url != null ? url.openStream() : null;
+    }
+
+    public static URL getResource(ClassLoader classLoader, String root, String resource) {
+        if (classLoader == null || root == null || resource == null) {
             return null;
         }
         Path rootPath = Path.of("/", root).normalize().toAbsolutePath();
         Path resourcePath = rootPath.resolve(resource).normalize().toAbsolutePath();
         if (resourcePath.startsWith(rootPath)) {
+            String contained;
             if (File.separatorChar == '/') {
-                resource = resourcePath.toString().substring(1);
+                contained = resourcePath.toString().substring(1);
             } else {
-                resource = resourcePath.toString().substring(2).replace('\\', '/');
+                contained = resourcePath.toString().substring(2).replace('\\', '/');
             }
-            URL url = classLoader().getResource(resource);
-            return url != null ? url.openStream() : null;
+            return classLoader.getResource(contained);
         } else {
             return null;
         }

--- a/services/src/test/java/org/keycloak/theme/ClasspathThemeTemplateTest.java
+++ b/services/src/test/java/org/keycloak/theme/ClasspathThemeTemplateTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.theme;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClasspathThemeTemplateTest {
+
+    @Test
+    public void classLoaderThemeContainsTemplatePath() throws Exception {
+        URL template = new URL("file:/template.ftl");
+        URL forbidden = new URL("file:/forbidden.ftl");
+        // The classloader resolves the traversal too, as a real classpath does (see ResourceLoaderTest).
+        ClassLoader classLoader = new StubClassLoader(Map.of(
+                "theme/test/login/login.ftl", template,
+                "theme/test/login/../../../forbidden.ftl", forbidden));
+
+        ClassLoaderTheme theme = new ClassLoaderTheme("test", Theme.Type.LOGIN, classLoader);
+
+        Assert.assertSame(template, theme.getTemplate("login.ftl"));
+        Assert.assertNull(theme.getTemplate("../../../forbidden.ftl"));
+    }
+
+    @Test
+    public void classpathResourceProviderContainsTemplatePath() throws Exception {
+        URL template = new URL("file:/template.ftl");
+        URL forbidden = new URL("file:/forbidden.ftl");
+        ClassLoader classLoader = new StubClassLoader(Map.of(
+                "theme-resources/templates/page.ftl", template,
+                "theme-resources/templates/../forbidden.ftl", forbidden));
+
+        ClasspathThemeResourceProviderFactory provider =
+                new ClasspathThemeResourceProviderFactory("classpath", classLoader);
+
+        Assert.assertSame(template, provider.getTemplate("page.ftl"));
+        Assert.assertNull(provider.getTemplate("../forbidden.ftl"));
+    }
+
+    private static class StubClassLoader extends ClassLoader {
+
+        private final Map<String, URL> resources;
+
+        StubClassLoader(Map<String, URL> resources) {
+            super(null);
+            this.resources = resources;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return resources.get(name);
+        }
+    }
+}

--- a/services/src/test/java/org/keycloak/theme/ResourceLoaderTest.java
+++ b/services/src/test/java/org/keycloak/theme/ResourceLoaderTest.java
@@ -34,6 +34,28 @@ public class ResourceLoaderTest {
     }
 
     @Test
+    public void testGetResource() {
+        String parent = "dummy-resources/parent";
+        ClassLoader classLoader = ResourceLoader.class.getClassLoader();
+
+        assertGetResource(classLoader, parent, "myresource.css", true, true);
+        assertGetResource(classLoader, parent, NONE + "forbidden.css", false, true);
+        assertGetResource(classLoader, parent, "one/" + NONE + NONE + "forbidden.css", false, true);
+    }
+
+    private void assertGetResource(ClassLoader classLoader, String parent, String resource, boolean expectValid, boolean expectResourceToExist) {
+        if (expectValid) {
+            Assert.assertNotNull(ResourceLoader.getResource(classLoader, parent, resource));
+        } else {
+            Assert.assertNull(ResourceLoader.getResource(classLoader, parent, resource));
+        }
+
+        if (expectResourceToExist) {
+            Assert.assertNotNull(classLoader.getResource(parent + "/" + resource));
+        }
+    }
+
+    @Test
     public void testFiles() throws IOException {
         Path tempDirectory = Files.createTempDirectory("safepath-test");
 


### PR DESCRIPTION
Repro: resolve a template through `ClassLoaderTheme` or `ClasspathThemeResourceProviderFactory` with a name containing `../` (e.g. `../../../forbidden.ftl`); it resolves to a classpath resource outside the theme template root.

Cause: both `getTemplate()` methods concatenate `root + name` straight into `classLoader.getResource(...)`, while their sibling `getResourceAsStream()` routes through `ResourceLoader`, which normalizes the resolved path and enforces a `startsWith(root)` guard. #49961 / da3cc05d closed this gap for `FolderTheme.getTemplate()` but the two classpath-based providers kept the raw concatenation. That the classloader resolves the traversal is already shown by `ResourceLoaderTest.testResource()`.

Fix: route both `getTemplate()` methods through a shared `ResourceLoader.getResource(classLoader, root, name)` so they apply the same containment check, preserving each provider's own classloader.

Closes #50265