### PR TITLE
Generate queryable fields documentation from code

### DIFF
--- a/docs/guides/admin-api/querying.adoc
+++ b/docs/guides/admin-api/querying.adoc
@@ -1,4 +1,5 @@
 <#import "/templates/guide.adoc" as tmpl>
+<#import "/templates/api.adoc" as api>
 
 <@tmpl.guide
 title="Admin API v2: Filtering and Projection"
@@ -71,46 +72,7 @@ Using an unknown field returns HTTP 400, unlike the SCIM API which silently igno
 
 ==== Common fields (all client types)
 
-[cols="1,1,3",options="header"]
-|===
-|Field |Type |Description
-
-|`uuid`
-|String
-|Internal unique identifier
-
-|`clientId`
-|String
-|Client identifier
-
-|`displayName`
-|String
-|Display name shown in the UI
-
-|`description`
-|String
-|Client description
-
-|`enabled`
-|Boolean
-|Whether the client is enabled
-
-|`protocol`
-|String
-|Protocol type (`openid-connect` or `saml`)
-
-|`appUrl`
-|String
-|Application base URL
-
-|`redirectUris`
-|Set<String>
-|Registered redirect URIs
-
-|`roles`
-|Set<String>
-|Client role names
-|===
+<@api.queryableFields group="common"/>
 
 ==== OIDC-specific fields
 
@@ -118,26 +80,7 @@ These fields are available only for `openid-connect` clients.
 They resolve to `null` for SAML clients, so value-based comparisons like `eq`, `co`, or `sw` will not match.
 However, `eq null` and `not ... pr` will match because the field is genuinely absent.
 
-[cols="1,1,3",options="header"]
-|===
-|Field |Type |Description
-
-|`loginFlows`
-|Set<String>
-|Enabled login flows (`STANDARD`, `IMPLICIT`, `DIRECT_GRANT`, `SERVICE_ACCOUNT`, `TOKEN_EXCHANGE`, `DEVICE`, `CIBA`)
-
-|`auth.method`
-|String
-|Client authentication method (e.g. `client-secret`, `client-secret-jwt`)
-
-|`webOrigins`
-|Set<String>
-|Allowed web origins
-
-|`serviceAccountRoles`
-|Set<String>
-|Roles assigned to the service account
-|===
+<@api.queryableFields group="openid-connect"/>
 
 ==== SAML-specific fields
 
@@ -145,58 +88,7 @@ These fields are available only for `saml` clients.
 They resolve to `null` for OIDC clients, so value-based comparisons like `eq`, `co`, or `sw` will not match.
 However, `eq null` and `not ... pr` will match because the field is genuinely absent.
 
-[cols="1,1,3",options="header"]
-|===
-|Field |Type |Description
-
-|`nameIdFormat`
-|String
-|Name ID format (`username`, `email`, `persistent`, `transient`)
-
-|`forceNameIdFormat`
-|Boolean
-|Force the specified Name ID format
-
-|`includeAuthnStatement`
-|Boolean
-|Include AuthnStatement in the response
-
-|`signDocuments`
-|Boolean
-|Sign SAML documents on the server side
-
-|`signAssertions`
-|Boolean
-|Sign SAML assertions
-
-|`clientSignatureRequired`
-|Boolean
-|Require the client to sign requests
-
-|`signatureAlgorithm`
-|String
-|Signature algorithm (e.g. `RSA_SHA256`)
-
-|`signatureCanonicalizationMethod`
-|String
-|Canonicalization method for XML signatures
-
-|`signingCertificate`
-|String
-|X.509 certificate for signing (PEM format, without headers)
-
-|`forcePostBinding`
-|Boolean
-|Force POST binding for responses
-
-|`frontChannelLogout`
-|Boolean
-|Use front-channel logout (browser redirect)
-
-|`allowEcpFlow`
-|Boolean
-|Allow Enhanced Client or Proxy flow
-|===
+<@api.queryableFields group="saml"/>
 
 === Collection field matching
 

--- a/docs/guides/templates/api.adoc
+++ b/docs/guides/templates/api.adoc
@@ -153,6 +153,22 @@ ${javaInterface?keep_after_last(".")} ${javaVar} = adminApi.${category}V2();
 </#list>
 </#macro>
 
+<#macro queryableFields group>
+<#assign fields = ctx.adminApiV2.getQueryableFields(group)>
+<#if fields?has_content>
+[cols="1,1,3",options="header"]
+|===
+|Field |Type |Description
+<#list fields as field>
+
+|`${field.name}`
+|${(field.type)!}
+|${(field.description)!}
+</#list>
+|===
+</#if>
+</#macro>
+
 <#macro schemas>
 <#assign schemaNames = ctx.adminApiV2.schemaNames>
 <#if schemaNames?has_content>

--- a/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/AdminApiV2.java
+++ b/docs/maven-plugin/src/main/java/org/keycloak/guides/maven/AdminApiV2.java
@@ -22,6 +22,7 @@ public class AdminApiV2 {
 
     private final Map<String, Object> categories;
     private final Map<String, Object> schemas;
+    private final Map<String, Object> queryableFields;
     private final Map<String, Object> cliExamples;
     private final Map<String, Object> jsExamples;
 
@@ -29,6 +30,7 @@ public class AdminApiV2 {
         Map<String, Object> doc = readFile(docFile);
         this.categories = optionalMap(doc, "categories");
         this.schemas = optionalMap(doc, "schemas");
+        this.queryableFields = optionalMap(doc, "queryableFields");
         this.cliExamples = readFile(cliExamplesFile);
         this.jsExamples = readFile(jsExamplesFile);
     }
@@ -70,6 +72,13 @@ public class AdminApiV2 {
         }
         String simpleName = iface.substring(iface.lastIndexOf('.') + 1);
         return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
+    }
+
+    public List<Map<String, Object>> getQueryableFields(String group) {
+        if (!queryableFields.containsKey(group)) {
+            return List.of();
+        }
+        return asList(queryableFields.get(group));
     }
 
     public String getCliExample(String operationId) {

--- a/js/libs/keycloak-admin-client/openapi.json
+++ b/js/libs/keycloak-admin-client/openapi.json
@@ -9,7 +9,7 @@
           "method" : {
             "type" : "string",
             "pattern" : "\\S",
-            "description" : "Which authentication method is used for this client. Validation: must not be blank; valid client authenticator type is required"
+            "description" : "Client authentication method (e.g. `client-secret`, `client-secret-jwt`). Validation: must not be blank; valid client authenticator type is required"
           },
           "secret" : {
             "type" : "string",

--- a/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/OIDCClientRepresentation.java
+++ b/rest/admin-v2/api/src/main/java/org/keycloak/representations/admin/v2/OIDCClientRepresentation.java
@@ -103,7 +103,7 @@ public class OIDCClientRepresentation extends BaseClientRepresentation {
 
         @NotBlank
         @ValidAuthMethod
-        @JsonPropertyDescription("Which authentication method is used for this client")
+        @JsonPropertyDescription("Client authentication method (e.g. `client-secret`, `client-secret-jwt`)")
         private String method;
 
         @Size(min = 6, max = 255)

--- a/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/JavaDocExampleGenerator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/JavaDocExampleGenerator.java
@@ -12,6 +12,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.keycloak.models.mapper.BaseClientModelMapper;
+import org.keycloak.models.mapper.OIDCClientModelMapper;
+import org.keycloak.models.mapper.SAMLClientModelMapper;
+import org.keycloak.representations.admin.v2.BaseClientRepresentation;
+import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
+import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -70,7 +77,9 @@ final class JavaDocExampleGenerator {
             Map<String, String> discriminatorMapping) {}
     record JavaExample(String interfaceName, String example) {}
 
-    record DocModel(Map<String, DocCategory> categories, Map<String, DocSchema> schemas) {}
+    record DocModel(Map<String, DocCategory> categories, Map<String, DocSchema> schemas,
+                    Map<String, List<QueryableField>> queryableFields) {}
+    record QueryableField(String name, String type, String description) {}
     record DocSchema(String parent, List<String> required, List<DocProperty> properties,
             List<String> enumValues) {}
     record DocProperty(String name, String type, String typeRef, String description, Boolean readOnly) {}
@@ -96,7 +105,8 @@ final class JavaDocExampleGenerator {
         Map<String, JavaExample> javaExamples = collectJavaExamples(checkBody);
         Map<String, DocCategory> categories = buildDocModel(openAPI, javaExamples);
         Map<String, DocSchema> schemas = collectSchemas(openAPI, categories);
-        DocModel doc = new DocModel(categories, schemas);
+        Map<String, List<QueryableField>> queryableFields = collectQueryableFields(schemas);
+        DocModel doc = new DocModel(categories, schemas, queryableFields);
         Path targetDir = Path.of(classesDir).getParent();
 
         try {
@@ -336,6 +346,140 @@ final class JavaDocExampleGenerator {
                 collectReferencedSchemas(allSchemas, refToSimpleName(prop.getItems().getRef()), referenced);
             }
         }
+    }
+
+    private static final List<ProtocolEntry> PROTOCOLS = List.of(
+            new ProtocolEntry("openid-connect",
+                    new OIDCClientModelMapper(), OIDCClientRepresentation.class),
+            new ProtocolEntry("saml",
+                    new SAMLClientModelMapper(), SAMLClientRepresentation.class)
+    );
+
+    record ProtocolEntry(String name, BaseClientModelMapper<?> mapper,
+                         Class<? extends BaseClientRepresentation> schemaClass) {}
+
+    private static Map<String, List<QueryableField>> collectQueryableFields(Map<String, DocSchema> schemas) {
+        Set<String> commonFieldNames = null;
+        Map<String, Set<String>> protocolFieldNames = new LinkedHashMap<>();
+
+        for (ProtocolEntry protocol : PROTOCOLS) {
+            Set<String> fieldNames = new LinkedHashSet<>(protocol.mapper().getFieldNames());
+            if (commonFieldNames == null) {
+                commonFieldNames = new LinkedHashSet<>(fieldNames);
+            } else {
+                commonFieldNames.retainAll(fieldNames);
+            }
+            protocolFieldNames.put(protocol.name(), fieldNames);
+        }
+
+        String baseSchemaName = BaseClientRepresentation.class.getSimpleName();
+        Map<String, List<QueryableField>> result = new LinkedHashMap<>();
+        result.put("common", resolveFields(commonFieldNames, schemas, baseSchemaName));
+
+        for (ProtocolEntry protocol : PROTOCOLS) {
+            Set<String> onlyFieldNames = protocolFieldNames.get(protocol.name());
+            onlyFieldNames.removeAll(commonFieldNames);
+            String schemaName = protocol.schemaClass().getSimpleName();
+            expandNestedFields(onlyFieldNames, schemas, schemaName);
+            result.put(protocol.name(), resolveFields(onlyFieldNames, schemas, schemaName));
+        }
+        return result;
+    }
+
+    private static void expandNestedFields(Set<String> fieldNames, Map<String, DocSchema> schemas, String schemaName) {
+        DocSchema schema = schemas.get(schemaName);
+        if (schema == null) {
+            return;
+        }
+        List<String> toRemove = new ArrayList<>();
+        List<String> toAdd = new ArrayList<>();
+        for (DocProperty prop : schema.properties()) {
+            if (fieldNames.contains(prop.name()) && prop.typeRef() != null && schemas.containsKey(prop.typeRef())) {
+                DocSchema nestedSchema = schemas.get(prop.typeRef());
+                if (!nestedSchema.properties().isEmpty()) {
+                    toRemove.add(prop.name());
+                    DocProperty first = nestedSchema.properties().get(0);
+                    toAdd.add(prop.name() + "." + first.name());
+                }
+            }
+        }
+        fieldNames.removeAll(toRemove);
+        fieldNames.addAll(toAdd);
+    }
+
+    private static List<QueryableField> resolveFields(Set<String> fieldNames, Map<String, DocSchema> schemas, String schemaName) {
+        List<QueryableField> fields = new ArrayList<>();
+        DocSchema schema = schemas.get(schemaName);
+        Map<String, DocProperty> propsByName = schemaPropertyMap(schema);
+
+        for (String name : fieldNames) {
+            int dot = name.indexOf('.');
+            if (dot > 0) {
+                String parentName = name.substring(0, dot);
+                String childName = name.substring(dot + 1);
+                DocProperty parentProp = propsByName.get(parentName);
+                if (parentProp != null && parentProp.typeRef() != null) {
+                    DocSchema nestedSchema = schemas.get(parentProp.typeRef());
+                    Map<String, DocProperty> nestedProps = schemaPropertyMap(nestedSchema);
+                    DocProperty childProp = nestedProps.get(childName);
+                    if (childProp != null) {
+                        fields.add(new QueryableField(name, toQueryableType(childProp.type()), stripValidationSuffix(childProp.description())));
+                        continue;
+                    }
+                }
+                fields.add(new QueryableField(name, null, null));
+            } else {
+                DocProperty prop = propsByName.get(name);
+                if (prop != null) {
+                    fields.add(new QueryableField(name, toQueryableType(prop.type()), stripValidationSuffix(prop.description())));
+                } else {
+                    fields.add(new QueryableField(name, null, null));
+                }
+            }
+        }
+        return fields;
+    }
+
+    private static Map<String, DocProperty> schemaPropertyMap(DocSchema schema) {
+        if (schema == null) {
+            return Map.of();
+        }
+        Map<String, DocProperty> propsByName = new LinkedHashMap<>();
+        for (DocProperty prop : schema.properties()) {
+            propsByName.put(prop.name(), prop);
+        }
+        return propsByName;
+    }
+
+    private static String toQueryableType(String schemaType) {
+        if (schemaType == null) {
+            return null;
+        }
+        return switch (schemaType) {
+            case "string" -> "String";
+            case "boolean" -> "Boolean";
+            case "integer" -> "Integer";
+            default -> {
+                if (schemaType.startsWith("array<")) {
+                    yield "Set<String>";
+                }
+                yield "String";
+            }
+        };
+    }
+
+    private static String stripValidationSuffix(String description) {
+        if (description == null) {
+            return null;
+        }
+        int idx = description.indexOf(". Validation:");
+        if (idx >= 0) {
+            return description.substring(0, idx);
+        }
+        if (description.startsWith("Validation:")) {
+            return null;
+        }
+        return description;
     }
 
     record PropertyType(String display, String ref) {}

--- a/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/JavaDocExampleGenerator.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/admin/internal/openapi/JavaDocExampleGenerator.java
@@ -18,6 +18,7 @@ import org.keycloak.models.mapper.SAMLClientModelMapper;
 import org.keycloak.representations.admin.v2.BaseClientRepresentation;
 import org.keycloak.representations.admin.v2.OIDCClientRepresentation;
 import org.keycloak.representations.admin.v2.SAMLClientRepresentation;
+import org.keycloak.services.client.query.FieldResolver;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -349,9 +350,9 @@ final class JavaDocExampleGenerator {
     }
 
     private static final List<ProtocolEntry> PROTOCOLS = List.of(
-            new ProtocolEntry("openid-connect",
+            new ProtocolEntry(OIDCClientRepresentation.PROTOCOL,
                     new OIDCClientModelMapper(), OIDCClientRepresentation.class),
-            new ProtocolEntry("saml",
+            new ProtocolEntry(SAMLClientRepresentation.PROTOCOL,
                     new SAMLClientModelMapper(), SAMLClientRepresentation.class)
     );
 
@@ -391,20 +392,37 @@ final class JavaDocExampleGenerator {
         if (schema == null) {
             return;
         }
-        List<String> toRemove = new ArrayList<>();
-        List<String> toAdd = new ArrayList<>();
+        Map<String, String> replacements = new LinkedHashMap<>();
         for (DocProperty prop : schema.properties()) {
-            if (fieldNames.contains(prop.name()) && prop.typeRef() != null && schemas.containsKey(prop.typeRef())) {
-                DocSchema nestedSchema = schemas.get(prop.typeRef());
-                if (!nestedSchema.properties().isEmpty()) {
-                    toRemove.add(prop.name());
-                    DocProperty first = nestedSchema.properties().get(0);
-                    toAdd.add(prop.name() + "." + first.name());
+            if (!fieldNames.contains(prop.name()) || prop.typeRef() == null || !schemas.containsKey(prop.typeRef())) {
+                continue;
+            }
+            DocSchema nestedSchema = schemas.get(prop.typeRef());
+            if (nestedSchema == null || nestedSchema.properties().isEmpty()) {
+                continue;
+            }
+            String match = null;
+            for (DocProperty nested : nestedSchema.properties()) {
+                String dotPath = prop.name() + "." + nested.name();
+                if (FieldResolver.isKnownField(dotPath)) {
+                    match = dotPath;
+                    break;
                 }
             }
+            if (match == null) {
+                throw new IllegalStateException("No nested property of '" + prop.name()
+                        + "' is recognized by FieldResolver — update FieldResolver or the schema");
+            }
+            replacements.put(prop.name(), match);
         }
-        fieldNames.removeAll(toRemove);
-        fieldNames.addAll(toAdd);
+        if (!replacements.isEmpty()) {
+            Set<String> reordered = new LinkedHashSet<>();
+            for (String name : fieldNames) {
+                reordered.add(replacements.getOrDefault(name, name));
+            }
+            fieldNames.clear();
+            fieldNames.addAll(reordered);
+        }
     }
 
     private static List<QueryableField> resolveFields(Set<String> fieldNames, Map<String, DocSchema> schemas, String schemaName) {

--- a/rest/admin-v2/services/src/main/java/org/keycloak/models/mapper/BaseClientModelMapper.java
+++ b/rest/admin-v2/services/src/main/java/org/keycloak/models/mapper/BaseClientModelMapper.java
@@ -1,5 +1,6 @@
 package org.keycloak.models.mapper;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -47,7 +48,11 @@ public abstract class BaseClientModelMapper<T extends BaseClientRepresentation> 
     }
  
     final Map<String, MappedField<BaseClientRepresentation>> fields = new LinkedHashMap<String, MappedField<BaseClientRepresentation>>();
-    
+
+    public Set<String> getFieldNames() {
+        return Collections.unmodifiableSet(fields.keySet());
+    }
+
     protected <F> void addMapping(String name, Function<T, F> repGetter, BiConsumer<T, F> repSetter, Function<ClientModel, F> modelGetter, BiConsumer<ClientModel, F> modelSetter) {
         MappedField prop = new MappedField<>();
         prop.repGetter = repGetter;


### PR DESCRIPTION
Closes #50087

The rendered output has minor cosmetic differences vs the old hand-written tables:
- field order - follows mapper registration order (e.g. `protocol` first in common fields),
- descriptions - come from `@JsonPropertyDescription` annotations, thus the slightly different wording,
- Enum values for `loginFlows` and `nameIdFormat` are no longer inlined (they're documented in the `Flow`/`NameIdFormat` enum schemas in the reference guide)

Also, I adjusted the `Auth.method` `@JsonPropertyDescription` from `"Which authentication method is used for this client"` to `"Client authentication method (e.g. client-secret, client-secret-jwt)"` to include example values, since this field has no enum schema to link to.
