### PR TITLE
fix for CORS headers missing on /account 401 response when session expired

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -116,10 +116,12 @@ public class AccountLoader {
 
     private AccountRestService getAccountRestService(ClientModel client, String versionStr) {
         AccountRestService.checkAccountApiEnabled();
+        final var errorCors = Cors.builder().auth().allowAllOrigins().allowedMethods(request.getHttpMethod()).auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS);
 
         AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
                 .authenticate();
         if (authResult == null) {
+            errorCors.add();
             throw new NotAuthorizedException("Bearer token required");
         }
 
@@ -133,6 +135,7 @@ public class AccountLoader {
         }
 
         if (!accessToken.hasAudience(client.getClientId())) {
+            errorCors.add();
             throw new NotAuthorizedException("Invalid audience for client " + client.getClientId());
         }
 

--- a/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
+++ b/services/src/main/java/org/keycloak/services/resources/account/AccountLoader.java
@@ -116,12 +116,11 @@ public class AccountLoader {
 
     private AccountRestService getAccountRestService(ClientModel client, String versionStr) {
         AccountRestService.checkAccountApiEnabled();
-        final var errorCors = Cors.builder().auth().allowAllOrigins().allowedMethods(request.getHttpMethod()).auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS);
 
         AuthenticationManager.AuthResult authResult = new AppAuthManager.BearerTokenAuthenticator(session)
                 .authenticate();
         if (authResult == null) {
-            errorCors.add();
+            Cors.builder().auth().allowAllOrigins().allowedMethods(request.getHttpMethod()).auth().exposedHeaders(Cors.ACCESS_CONTROL_ALLOW_METHODS).add();
             throw new NotAuthorizedException("Bearer token required");
         }
 
@@ -134,15 +133,12 @@ public class AccountLoader {
             accessToken = provider.transformAccessToken(accessToken, authResult.session());
         }
 
+        Cors.builder().checkAllowedOrigins(accessToken).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
         if (!accessToken.hasAudience(client.getClientId())) {
-            errorCors.add();
             throw new NotAuthorizedException("Invalid audience for client " + client.getClientId());
         }
 
         Auth auth = new Auth(session.getContext().getRealm(), accessToken, authResult.user(), client, authResult.session(), false);
-
-        Cors.builder().checkAllowedOrigins(auth.getToken()).allowedMethods("GET", "PUT", "POST", "DELETE").auth().add();
-
         if (authResult.user().getServiceAccountClientLink() != null) {
             throw new NotAuthorizedException("Service accounts are not allowed to access this service");
         }

--- a/tests/base/src/test/java/org/keycloak/tests/account/AccountEndpointCorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/account/AccountEndpointCorsTest.java
@@ -44,9 +44,9 @@ public class AccountEndpointCorsTest {
 
         String accountUrl = realm.getBaseUrl() + "/account";
         final var accountResponse = oauth
-                .origin(VALID_CORS_URL)
                 .accountRequest(response.getAccessToken())
                 .endpoint(accountUrl)
+                .header("Origin", VALID_CORS_URL)
                 .send();
         assertEquals(200, accountResponse.getStatusCode());
         assertCors(accountResponse);
@@ -55,9 +55,9 @@ public class AccountEndpointCorsTest {
         realm.admin().users().get(userRep.getId()).logout();
 
         final var accountResponseAfterLogout = oauth
-                .origin(VALID_CORS_URL)
                 .accountRequest(response.getAccessToken())
                 .endpoint(accountUrl)
+                .header("Origin", VALID_CORS_URL)
                 .send();
         assertEquals(401, accountResponseAfterLogout.getStatusCode());
         assertCors(accountResponseAfterLogout);
@@ -70,9 +70,9 @@ public class AccountEndpointCorsTest {
 
         String accountUrl = realm.getBaseUrl() + "/account";
         final var accountResponse = oauth
-                .origin(INVALID_CORS_URL)
                 .accountRequest(response.getAccessToken())
                 .endpoint(accountUrl)
+                .header("Origin", INVALID_CORS_URL)
                 .send();
         assertEquals(403, accountResponse.getStatusCode());
         assertNotCors(accountResponse);
@@ -85,9 +85,9 @@ public class AccountEndpointCorsTest {
 
         String accountUrl = realm.getBaseUrl() + "/account";
         final var accountResponse = oauthNoAudience
-                .origin(VALID_CORS_URL)
                 .accountRequest(response.getAccessToken())
                 .endpoint(accountUrl)
+                .header("Origin", VALID_CORS_URL)
                 .send();
         assertEquals(401, accountResponse.getStatusCode());
         assertCors(accountResponse);

--- a/tests/base/src/test/java/org/keycloak/tests/account/AccountEndpointCorsTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/account/AccountEndpointCorsTest.java
@@ -1,0 +1,162 @@
+package org.keycloak.tests.account;
+
+import java.util.Map;
+
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.AccountResponse;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@KeycloakIntegrationTest
+public class AccountEndpointCorsTest {
+
+    private static final String VALID_CORS_URL = "http://localtest.me:8180";
+    private static final String INVALID_CORS_URL = "http://invalid.localtest.me:8180";
+    private static final String REALM_NAME = "test";
+
+    @InjectRealm(ref = REALM_NAME, config = TestRealmConfig.class)
+    protected ManagedRealm realm;
+
+    @InjectOAuthClient(realmRef = REALM_NAME, config = TestOAuthClientConfig.class)
+    protected OAuthClient oauth;
+
+    @InjectOAuthClient(ref = "no-audience-client", realmRef = REALM_NAME, config = TestOAuthClientNoAudienceConfig.class)
+    protected OAuthClient oauthNoAudience;
+
+    @Test
+    public void accountEndpointCorsResponseWhenSessionEnded() throws Exception {
+        AccessTokenResponse response = oauth.doPasswordGrantRequest("test-user", "password");
+        assertEquals(200, response.getStatusCode());
+
+        String accountUrl = realm.getBaseUrl() + "/account";
+        final var accountResponse = oauth
+                .origin(VALID_CORS_URL)
+                .accountRequest(response.getAccessToken())
+                .endpoint(accountUrl)
+                .send();
+        assertEquals(200, accountResponse.getStatusCode());
+        assertCors(accountResponse);
+
+        final var userRep = realm.admin().users().searchByUsername("test-user", true).get(0);
+        realm.admin().users().get(userRep.getId()).logout();
+
+        final var accountResponseAfterLogout = oauth
+                .origin(VALID_CORS_URL)
+                .accountRequest(response.getAccessToken())
+                .endpoint(accountUrl)
+                .send();
+        assertEquals(401, accountResponseAfterLogout.getStatusCode());
+        assertCors(accountResponseAfterLogout);
+    }
+
+    @Test
+    public void accountEndpointCorsResponseWhenInvalidUrl() throws Exception {
+        AccessTokenResponse response = oauth.doPasswordGrantRequest("test-user", "password");
+        assertEquals(200, response.getStatusCode());
+
+        String accountUrl = realm.getBaseUrl() + "/account";
+        final var accountResponse = oauth
+                .origin(INVALID_CORS_URL)
+                .accountRequest(response.getAccessToken())
+                .endpoint(accountUrl)
+                .send();
+        assertEquals(403, accountResponse.getStatusCode());
+        assertNotCors(accountResponse);
+    }
+
+    @Test
+    public void accountEndpointCorsResponseWhenInvalidAudience() throws Exception {
+        AccessTokenResponse response = oauthNoAudience.doPasswordGrantRequest("test-user-no-account-roles", "password");
+        assertEquals(200, response.getStatusCode());
+
+        String accountUrl = realm.getBaseUrl() + "/account";
+        final var accountResponse = oauthNoAudience
+                .origin(VALID_CORS_URL)
+                .accountRequest(response.getAccessToken())
+                .endpoint(accountUrl)
+                .send();
+        assertEquals(401, accountResponse.getStatusCode());
+        assertCors(accountResponse);
+    }
+
+    private static void assertCors(AccountResponse response) {
+        assertEquals("true", response.getHeaders().get("Access-Control-Allow-Credentials"));
+        assertEquals(VALID_CORS_URL, response.getHeaders().get("Access-Control-Allow-Origin"));
+    }
+
+    private static void assertNotCors(AccountResponse response) {
+        assertNull(response.getHeaders().get("Access-Control-Allow-Credentials"));
+        assertNull(response.getHeaders().get("Access-Control-Allow-Origin"));
+        assertNull(response.getHeaders().get("Access-Control-Expose-Headers"));
+    }
+
+    static class TestRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm
+                    .enabled(true)
+                    .users(
+                            UserBuilder.create("test-user")
+                                    .name("Test", "User")
+                                    .email("test-user@localhost")
+                                    .emailVerified(true)
+                                    .clientRoles("account", "view-profile", "manage-account")
+                                    .password("password"),
+                            UserBuilder.create("test-user-no-account-roles")
+                                    .name("Test", "UserNoRoles")
+                                    .email("test-user-no-account-roles@localhost")
+                                    .emailVerified(true)
+                                    .password("password"));
+        }
+    }
+
+    static class TestOAuthClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                    .clientId("test-app")
+                    .publicClient()
+                    .directAccessGrantsEnabled()
+                    .webOrigins(VALID_CORS_URL)
+                    .protocolMappers(audienceMapper("aud-account", "account"));
+        }
+    }
+
+    static class TestOAuthClientNoAudienceConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client
+                    .clientId("test-app-no-audience")
+                    .publicClient()
+                    .directAccessGrantsEnabled()
+                    .webOrigins(VALID_CORS_URL);
+        }
+    }
+
+    private static ProtocolMapperRepresentation audienceMapper(String name, String includedClientAudience) {
+        ProtocolMapperRepresentation mapper = new ProtocolMapperRepresentation();
+        mapper.setName(name);
+        mapper.setProtocol("openid-connect");
+        mapper.setProtocolMapper("oidc-audience-mapper");
+        mapper.setConfig(Map.of(
+                "included.client.audience", includedClientAudience,
+                "id.token.claim", "true",
+                "access.token.claim", "true"
+        ));
+        return mapper;
+    }
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AbstractOAuthClient.java
@@ -190,6 +190,14 @@ public abstract class AbstractOAuthClient<T> {
         return userInfoRequest(accessToken).send();
     }
 
+    public AccountRequest accountRequest(String accessToken) {
+        return new AccountRequest(accessToken, this);
+    }
+
+    public AccountResponse doAccountRequest(String accessToken) {
+        return accountRequest(accessToken).send();
+    }
+
     public IntrospectionRequest introspectionRequest(String tokenToIntrospect) {
         return new IntrospectionRequest(tokenToIntrospect, this);
     }

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccountRequest.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccountRequest.java
@@ -1,0 +1,46 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.keycloak.util.TokenUtil;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class AccountRequest extends AbstractHttpGetRequest<AccountRequest, AccountResponse> {
+
+    private final String token;
+
+    private boolean dpop = false;
+    private String dpopProof;
+
+    public AccountRequest(String token, AbstractOAuthClient<?> client) {
+        super(client);
+        this.token = token;
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return UriBuilder.fromUri(client.getBaseUrl()).path("realms/{realm}/account").build(client.getRealm()).toString();
+    }
+
+    public AccountRequest dpop(String dpopProof) {
+        this.dpop = true;
+        this.dpopProof = dpopProof;
+        return this;
+    }
+
+    @Override
+    protected void initRequest() {
+        String authorization = (dpop ? "DPoP" : "Bearer") + " " + token;
+        header("Authorization", authorization);
+        header(TokenUtil.TOKEN_TYPE_DPOP, dpopProof);
+    }
+
+    @Override
+    protected AccountResponse toResponse(CloseableHttpResponse response) throws IOException {
+        return new AccountResponse(response);
+    }
+
+}

--- a/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccountResponse.java
+++ b/tests/utils-shared/src/main/java/org/keycloak/testsuite/util/oauth/AccountResponse.java
@@ -1,0 +1,26 @@
+package org.keycloak.testsuite.util.oauth;
+
+import java.io.IOException;
+
+import org.keycloak.representations.account.UserRepresentation;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+
+public class AccountResponse extends AbstractHttpResponse {
+
+    private UserRepresentation userRepresentation;
+
+    public AccountResponse(CloseableHttpResponse response) throws IOException {
+        super(response);
+    }
+
+    @Override
+    protected void parseContent() throws IOException {
+        userRepresentation = asJson(UserRepresentation.class);
+    }
+
+    public UserRepresentation getUserRepresentation() {
+        return userRepresentation;
+    }
+}


### PR DESCRIPTION
fix for #47934: when a user session ends and the JS adapter calls /account, the 401 response was missing CORS headers, causing the browser to throw a TypeError instead of handling the 401 and redirecting to login.

Also adds AccountRequest/AccountResponse test utilities and an integration test covering this scenario.

Resolves #47934

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
