### PR TITLE
Fix ConcurrentModificationException in client-registration policy reads

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicy.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ClientModel;
@@ -122,18 +121,14 @@ public class ClientScopesClientRegistrationPolicy implements ClientRegistrationP
     }
 
     private List<String> getAllowedScopeNames(RealmModel realm, boolean defaultScopes) {
-        List<String> allAllowed = new LinkedList<>();
-
         // Add client scopes allowed by config
         List<String> allowedScopesConfig = componentModel.getConfig().getOrDefault(ClientScopesClientRegistrationPolicyFactory.ALLOWED_CLIENT_SCOPES, Collections.emptyList());
-        if (allowedScopesConfig != null) {
-            allAllowed.addAll(allowedScopesConfig);
-        }
+        List<String> allAllowed = new LinkedList<>(allowedScopesConfig);
 
         // If allowDefaultScopes, then realm default scopes are allowed as default scopes (+ optional scopes are allowed as optional scopes)
         boolean allowDefaultScopes = componentModel.get(ClientScopesClientRegistrationPolicyFactory.ALLOW_DEFAULT_SCOPES, true);
         if (allowDefaultScopes) {
-            allAllowed.addAll(realm.getDefaultClientScopesStream(defaultScopes).map(ClientScopeModel::getName).collect(Collectors.toList()));
+            allAllowed.addAll(realm.getDefaultClientScopesStream(defaultScopes).map(ClientScopeModel::getName).toList());
         }
 
         return allAllowed;

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicy.java
@@ -18,6 +18,7 @@
 package org.keycloak.services.clientregistration.policy.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -124,7 +125,7 @@ public class ClientScopesClientRegistrationPolicy implements ClientRegistrationP
         List<String> allAllowed = new LinkedList<>();
 
         // Add client scopes allowed by config
-        List<String> allowedScopesConfig = componentModel.getConfig().getList(ClientScopesClientRegistrationPolicyFactory.ALLOWED_CLIENT_SCOPES);
+        List<String> allowedScopesConfig = componentModel.getConfig().getOrDefault(ClientScopesClientRegistrationPolicyFactory.ALLOWED_CLIENT_SCOPES, Collections.emptyList());
         if (allowedScopesConfig != null) {
             allAllowed.addAll(allowedScopesConfig);
         }

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicyFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ClientScopesClientRegistrationPolicyFactory.java
@@ -105,7 +105,7 @@ public class ClientScopesClientRegistrationPolicyFactory extends AbstractClientR
 
     @Override
     public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel config) throws ComponentValidationException {
-        List<String> allowedScopesConfig = config.getConfig().getList(ClientScopesClientRegistrationPolicyFactory.ALLOWED_CLIENT_SCOPES);
+        List<String> allowedScopesConfig = config.getConfig().getOrDefault(ClientScopesClientRegistrationPolicyFactory.ALLOWED_CLIENT_SCOPES, Collections.emptyList());
         if (!getClientScopes(session).containsAll(allowedScopesConfig)) {
             throw new ComponentValidationException("Client scopes not allowed: " + allowedScopesConfig);
         }

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/ProtocolMappersClientRegistrationPolicy.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.clientregistration.policy.impl;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -132,7 +133,7 @@ public class ProtocolMappersClientRegistrationPolicy implements ClientRegistrati
     }
 
     private List<String> getAllowedMapperProviders() {
-        return componentModel.getConfig().getList(ProtocolMappersClientRegistrationPolicyFactory.ALLOWED_PROTOCOL_MAPPER_TYPES);
+        return componentModel.getConfig().getOrDefault(ProtocolMappersClientRegistrationPolicyFactory.ALLOWED_PROTOCOL_MAPPER_TYPES, Collections.emptyList());
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicy.java
@@ -46,7 +46,7 @@ public class RegistrationWebOriginsPolicy implements ClientRegistrationPolicy {
 
     @Override
     public Collection<String> getAllowedOrigins() {
-        return allowedWebOrigins != null ? allowedWebOrigins : Collections.emptyList();
+        return allowedWebOrigins;
     }
 
 }

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicy.java
@@ -17,7 +17,7 @@ public class RegistrationWebOriginsPolicy implements ClientRegistrationPolicy {
     private final List<String> allowedWebOrigins;
 
     public RegistrationWebOriginsPolicy(KeycloakSession session, ComponentModel model) {
-        allowedWebOrigins = model.getConfig().getList(RegistrationWebOriginsPolicyFactory.WEB_ORIGINS);
+        allowedWebOrigins = model.getConfig().getOrDefault(RegistrationWebOriginsPolicyFactory.WEB_ORIGINS, Collections.emptyList());
     }
 
     @Override

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicy.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -130,7 +131,7 @@ public class TrustedHostClientRegistrationPolicy implements ClientRegistrationPo
 
 
     protected List<String> getTrustedHosts() {
-        List<String> trustedHostsConfig = componentModel.getConfig().getList(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS);
+        List<String> trustedHostsConfig = componentModel.getConfig().getOrDefault(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS, Collections.emptyList());
         return trustedHostsConfig.stream().filter((String hostname) -> {
 
             return !hostname.startsWith("*.");
@@ -140,7 +141,7 @@ public class TrustedHostClientRegistrationPolicy implements ClientRegistrationPo
 
 
     protected List<String> getTrustedDomains() {
-        return componentModel.getConfig().getList(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS);
+        return componentModel.getConfig().getOrDefault(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS, Collections.emptyList());
     }
 
     protected String verifyHostInTrustedHosts(String hostAddress, List<String> trustedHosts) {

--- a/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicy.java
+++ b/services/src/main/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicy.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.keycloak.component.ComponentModel;
 import org.keycloak.models.ClientModel;
@@ -132,11 +131,7 @@ public class TrustedHostClientRegistrationPolicy implements ClientRegistrationPo
 
     protected List<String> getTrustedHosts() {
         List<String> trustedHostsConfig = componentModel.getConfig().getOrDefault(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS, Collections.emptyList());
-        return trustedHostsConfig.stream().filter((String hostname) -> {
-
-            return !hostname.startsWith("*.");
-
-        }).collect(Collectors.toList());
+        return trustedHostsConfig.stream().filter((String hostname) -> !hostname.startsWith("*.")).toList();
     }
 
 

--- a/services/src/test/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicyTest.java
+++ b/services/src/test/java/org/keycloak/services/clientregistration/policy/impl/RegistrationWebOriginsPolicyTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.keycloak.services.clientregistration.policy.impl;
+
+import org.keycloak.common.Profile;
+import org.keycloak.common.crypto.CryptoIntegration;
+import org.keycloak.common.crypto.CryptoProvider;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSession;
+import org.keycloak.services.resteasy.ResteasyKeycloakSessionFactory;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RegistrationWebOriginsPolicyTest {
+
+    private static KeycloakSession session;
+
+    @BeforeClass
+    public static void beforeClass() {
+        Profile.defaults();
+        CryptoIntegration.init(CryptoProvider.class.getClassLoader());
+        ResteasyKeycloakSessionFactory sessionFactory = new ResteasyKeycloakSessionFactory();
+        sessionFactory.init();
+        session = new ResteasyKeycloakSession(sessionFactory);
+    }
+
+    @Test
+    public void testConstructionDoesNotMutateConfig() {
+        // Issue #50286: the web-origins policy reads its config in the constructor;
+        // that read must not mutate the shared cached ComponentModel.
+        RegistrationWebOriginsPolicyFactory factory = new RegistrationWebOriginsPolicyFactory();
+        ComponentModel model = new ComponentModel();
+
+        assertFalse(model.getConfig().containsKey(RegistrationWebOriginsPolicyFactory.WEB_ORIGINS));
+        RegistrationWebOriginsPolicy policy = (RegistrationWebOriginsPolicy) factory.create(session, model);
+        assertFalse("constructing the policy must not mutate the shared component config",
+                model.getConfig().containsKey(RegistrationWebOriginsPolicyFactory.WEB_ORIGINS));
+        assertTrue("allowed origins must be empty when none are configured",
+                policy.getAllowedOrigins().isEmpty());
+    }
+}

--- a/services/src/test/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicyTest.java
+++ b/services/src/test/java/org/keycloak/services/clientregistration/policy/impl/TrustedHostClientRegistrationPolicyTest.java
@@ -116,6 +116,25 @@ public class TrustedHostClientRegistrationPolicyTest {
         assertFalse(policy.verifyHost("otherlocalhost"));
     }
 
+    @Test
+    public void testReadingTrustedHostsDoesNotMutateConfig() {
+        // Issue #50286: reading the policy config must not mutate the shared cached
+        // ComponentModel (getList would insert the absent trusted-hosts key).
+        TrustedHostClientRegistrationPolicyFactory factory = new TrustedHostClientRegistrationPolicyFactory();
+        ComponentModel model = new ComponentModel();
+        model.put(TrustedHostClientRegistrationPolicyFactory.HOST_SENDING_REGISTRATION_REQUEST_MUST_MATCH, "true");
+        model.put(TrustedHostClientRegistrationPolicyFactory.CLIENT_URIS_MUST_MATCH, "true");
+        TrustedHostClientRegistrationPolicy policy = (TrustedHostClientRegistrationPolicy) factory.create(session, model);
+
+        assertFalse(model.getConfig().containsKey(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS));
+        policy.getTrustedHosts();
+        policy.getTrustedDomains();
+        assertFalse("reading trusted hosts must not mutate the shared component config",
+                model.getConfig().containsKey(TrustedHostClientRegistrationPolicyFactory.TRUSTED_HOSTS));
+        assertTrue("trusted hosts and domains must be empty when none are configured",
+                policy.getTrustedHosts().isEmpty() && policy.getTrustedDomains().isEmpty());
+    }
+
     private ComponentModel createComponentModel(String... hosts) {
         ComponentModel model = new ComponentModel();
         model.put(TrustedHostClientRegistrationPolicyFactory.HOST_SENDING_REGISTRATION_REQUEST_MUST_MATCH, "true");


### PR DESCRIPTION
Closes #50286

The client-registration policies read their config with the mutating `getConfig().getList(key)`, which inserts the absent key into the cached, shared `ComponentModel` and lets concurrent registrations race on `HashMap.compute`. Switched the six reads to the non-mutating `getConfig().getOrDefault(key, Collections.emptyList())` (the idiom used elsewhere for config), preserving the empty-on-absent contract.

Deterministic tests (TrustedHost and WebOrigins) assert a read does not mutate the shared config: red without the fix, green with it.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
