### PR TITLE
Return null from PathMatcher.buildUriFromTemplate on a template missing its closing brace

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/PathMatcher.java
+++ b/common/src/main/java/org/keycloak/common/util/PathMatcher.java
@@ -36,7 +36,7 @@ public abstract class PathMatcher<P> {
         for (P entry : getPaths()) {
             String expectedUri = getPath(entry);
 
-            if (expectedUri == null) {
+            if (expectedUri == null || expectedUri.isEmpty()) {
                 continue;
             }
 
@@ -221,9 +221,6 @@ public abstract class PathMatcher<P> {
                             if (openBraceIndex == -1 || closingBraceIndex == -1 || closingBraceIndex < openBraceIndex) {
                                 return null;
                             }
-                            if (closingBraceIndex == openBraceIndex + 1) {
-                                return null;
-                            }
                             String paramName = uri.substring(openBraceIndex + 1, closingBraceIndex);
                             if (paramName.indexOf('/') != -1) {
                                 return null;
@@ -231,7 +228,7 @@ public abstract class PathMatcher<P> {
                             uri.replace(openBraceIndex, closingBraceIndex + 1, value.toString());
                         }
 
-                        if (value.charAt(value.length() - 1) == '}') {
+                        if (value.length() > 0 && value.charAt(value.length() - 1) == '}') {
                             lastPattern = uri.indexOf(value.toString()) + value.length();
                         }
 
@@ -309,7 +306,7 @@ public abstract class PathMatcher<P> {
         if (asteriskIndex != -1) {
             boolean validTrailing = uri.endsWith("/*") && asteriskIndex == uri.length() - 1;
             boolean validSuffix = asteriskIndex > 0 && uri.charAt(asteriskIndex - 1) == '/'
-                    && asteriskIndex + 1 < uri.length() && uri.charAt(asteriskIndex + 1) == '.'
+                    && asteriskIndex + 2 < uri.length() && uri.charAt(asteriskIndex + 1) == '.'
                     && uri.indexOf('*', asteriskIndex + 1) == -1
                     && uri.indexOf('/', asteriskIndex + 1) == -1;
             if (!validTrailing && !validSuffix) {

--- a/common/src/main/java/org/keycloak/common/util/PathMatcher.java
+++ b/common/src/main/java/org/keycloak/common/util/PathMatcher.java
@@ -216,7 +216,11 @@ public abstract class PathMatcher<P> {
                         }
 
                         if (c == '{') {
-                            uri.replace(uri.indexOf("{", lastPattern), uri.indexOf("}", lastPattern) + 1, value.toString());
+                            int closingBraceIndex = uri.indexOf("}", lastPattern);
+                            if (closingBraceIndex == -1) {
+                                return null;
+                            }
+                            uri.replace(uri.indexOf("{", lastPattern), closingBraceIndex + 1, value.toString());
                         }
 
                         if (value.charAt(value.length() - 1) == '}') {

--- a/common/src/main/java/org/keycloak/common/util/PathMatcher.java
+++ b/common/src/main/java/org/keycloak/common/util/PathMatcher.java
@@ -216,11 +216,16 @@ public abstract class PathMatcher<P> {
                         }
 
                         if (c == '{') {
+                            int openBraceIndex = uri.indexOf("{", lastPattern);
                             int closingBraceIndex = uri.indexOf("}", lastPattern);
-                            if (closingBraceIndex == -1) {
+                            if (openBraceIndex == -1 || closingBraceIndex == -1 || closingBraceIndex < openBraceIndex) {
                                 return null;
                             }
-                            uri.replace(uri.indexOf("{", lastPattern), closingBraceIndex + 1, value.toString());
+                            String paramName = uri.substring(openBraceIndex + 1, closingBraceIndex);
+                            if (paramName.indexOf('/') != -1) {
+                                return null;
+                            }
+                            uri.replace(openBraceIndex, closingBraceIndex + 1, value.toString());
                         }
 
                         if (value.charAt(value.length() - 1) == '}') {

--- a/common/src/main/java/org/keycloak/common/util/PathMatcher.java
+++ b/common/src/main/java/org/keycloak/common/util/PathMatcher.java
@@ -221,6 +221,9 @@ public abstract class PathMatcher<P> {
                             if (openBraceIndex == -1 || closingBraceIndex == -1 || closingBraceIndex < openBraceIndex) {
                                 return null;
                             }
+                            if (closingBraceIndex == openBraceIndex + 1) {
+                                return null;
+                            }
                             String paramName = uri.substring(openBraceIndex + 1, closingBraceIndex);
                             if (paramName.indexOf('/') != -1) {
                                 return null;
@@ -265,6 +268,56 @@ public abstract class PathMatcher<P> {
 
     private boolean isTemplate(String uri) {
         return uri.indexOf("{") != -1;
+    }
+
+    /**
+     * Validates that the given URI is a well-formed path template.
+     *
+     * @return an error message if the URI is invalid, or {@code null} if it is valid
+     */
+    public static String validateTemplate(String uri) {
+        boolean inBrace = false;
+        boolean empty = true;
+
+        for (int i = 0; i < uri.length(); i++) {
+            char c = uri.charAt(i);
+
+            if (c == '{') {
+                if (inBrace) {
+                    return "nested '{'";
+                }
+                inBrace = true;
+                empty = true;
+            } else if (c == '}') {
+                if (!inBrace || empty) {
+                    return "unexpected '}' or empty parameter name";
+                }
+                inBrace = false;
+            } else if (inBrace) {
+                if (c == '/') {
+                    return "parameter name contains '/'";
+                }
+                empty = false;
+            }
+        }
+
+        if (inBrace) {
+            return "missing closing '}'";
+        }
+
+        int asteriskIndex = uri.indexOf('*');
+        if (asteriskIndex != -1) {
+            boolean validTrailing = uri.endsWith("/*") && asteriskIndex == uri.length() - 1;
+            boolean validSuffix = asteriskIndex > 0 && uri.charAt(asteriskIndex - 1) == '/'
+                    && asteriskIndex + 1 < uri.length() && uri.charAt(asteriskIndex + 1) == '.'
+                    && uri.indexOf('*', asteriskIndex + 1) == -1
+                    && uri.indexOf('/', asteriskIndex + 1) == -1;
+            if (!validTrailing && !validSuffix) {
+                return "wildcard '*' is only supported as trailing '/*' or as a suffix pattern '/*.ext'";
+            }
+        }
+
+        return null;
     }
 
     protected P resolvePathConfig(P entry, String path) {

--- a/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
+++ b/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
@@ -104,7 +104,7 @@ public class PathMatcherTest {
     }
 
     @Test
-    public void validateUriAcceptsValidPatterns() {
+    public void validateTemplateAcceptsValidPatterns() {
         Assertions.assertNull(PathMatcher.validateTemplate("/api/foo"));
         Assertions.assertNull(PathMatcher.validateTemplate("/api/{id}/info"));
         Assertions.assertNull(PathMatcher.validateTemplate("/api/{id}/*"));
@@ -114,7 +114,7 @@ public class PathMatcherTest {
     }
 
     @Test
-    public void validateUriRejectsMalformedBraces() {
+    public void validateTemplateRejectsMalformedBraces() {
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/{id"));
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/id}"));
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/{}"));
@@ -123,7 +123,7 @@ public class PathMatcherTest {
     }
 
     @Test
-    public void validateUriRejectsMalformedWildcards() {
+    public void validateTemplateRejectsMalformedWildcards() {
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/*/info"));
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/*/info/*"));
         Assertions.assertNotNull(PathMatcher.validateTemplate("/a/b/c/*.html/c/d"));

--- a/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
+++ b/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 public class PathMatcherTest {
 
     @Test
-    public void keycloak15833Test() {
+    public void templateWithWildcardMatchesCorrectPathOnly() {
         TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
                 "/api/v1/{clientId}/campaigns/*"
         ));
@@ -74,12 +74,22 @@ public class PathMatcherTest {
     }
 
     @Test
-    public void emptyPlaceholderShouldNotMatch() {
-        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
-                "/api/{}/foo"
-        ));
+    public void emptyPlaceholderMatchesForLegacyCompatibility() {
+        String template = "/api/{}/foo";
+        Assertions.assertNotNull(PathMatcher.validateTemplate(template));
 
-        Assertions.assertNull(matcher.matches("/api/1/foo"));
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(template));
+        Assertions.assertNotNull(matcher.matches("/api/1/foo"));
+    }
+
+    @Test
+    public void emptyExtensionSuffixMatchesForLegacyCompatibility() {
+        String template = "/*.";
+        Assertions.assertNotNull(PathMatcher.validateTemplate(template));
+
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(template));
+        Assertions.assertNotNull(matcher.matches("/file."));
+        Assertions.assertNull(matcher.matches("/file.txt"));
     }
 
     @Test
@@ -127,6 +137,26 @@ public class PathMatcherTest {
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/*/info"));
         Assertions.assertNotNull(PathMatcher.validateTemplate("/api/*/info/*"));
         Assertions.assertNotNull(PathMatcher.validateTemplate("/a/b/c/*.html/c/d"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/*."));
+    }
+
+    @Test
+    public void emptyTemplateShouldNotMatch() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                ""
+        ));
+
+        Assertions.assertNull(matcher.matches("/foo"));
+        Assertions.assertNull(matcher.matches(""));
+    }
+
+    @Test
+    public void templateStartingWithPlaceholderShouldNotMatch() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "{id}/foo"
+        ));
+
+        Assertions.assertNull(matcher.matches("/1/foo"));
     }
 
     private static final class TestingPathMatcher extends PathMatcher<String> {

--- a/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
+++ b/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
@@ -74,6 +74,15 @@ public class PathMatcherTest {
     }
 
     @Test
+    public void emptyPlaceholderShouldNotMatch() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{}/foo"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/1/foo"));
+    }
+
+    @Test
     public void slashInsidePlaceholderWithTrailingWildcard() {
         TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
                 "/api/{a/b}/*"
@@ -92,6 +101,32 @@ public class PathMatcherTest {
         // inflated segment count makes this unmatchable
         Assertions.assertNull(matcher.matches("/api/1/foo"));
         Assertions.assertNull(matcher.matches("/api/1/b/foo"));
+    }
+
+    @Test
+    public void validateUriAcceptsValidPatterns() {
+        Assertions.assertNull(PathMatcher.validateTemplate("/api/foo"));
+        Assertions.assertNull(PathMatcher.validateTemplate("/api/{id}/info"));
+        Assertions.assertNull(PathMatcher.validateTemplate("/api/{id}/*"));
+        Assertions.assertNull(PathMatcher.validateTemplate("/*"));
+        Assertions.assertNull(PathMatcher.validateTemplate("/*.html"));
+        Assertions.assertNull(PathMatcher.validateTemplate("/api/{id}/*.json"));
+    }
+
+    @Test
+    public void validateUriRejectsMalformedBraces() {
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/{id"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/id}"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/{}"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/{{id}}"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/{a/b}"));
+    }
+
+    @Test
+    public void validateUriRejectsMalformedWildcards() {
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/*/info"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/api/*/info/*"));
+        Assertions.assertNotNull(PathMatcher.validateTemplate("/a/b/c/*.html/c/d"));
     }
 
     private static final class TestingPathMatcher extends PathMatcher<String> {

--- a/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
+++ b/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
@@ -1,6 +1,7 @@
 package org.keycloak.common.util;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -9,35 +10,105 @@ public class PathMatcherTest {
 
     @Test
     public void keycloak15833Test() {
-        TestingPathMatcher matcher = new TestingPathMatcher();
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/v1/{clientId}/campaigns/*"
+        ));
 
-        Assertions.assertEquals("/api/v1/1/campaigns/*/excelFiles", matcher.customBuildUriFromTemplate("/api/v1/{clientId}/campaigns/*/excelFiles", "/api/v1/1/contentConnectorConfigs/29/contentConnectorContents", false));
+        Assertions.assertNotNull(matcher.matches("/api/v1/1/campaigns/summer"));
+        Assertions.assertNull(matcher.matches("/api/v1/1/contentConnectorConfigs/29/contentConnectorContents"));
     }
 
     @Test
     public void missingClosingBraceShouldReturnNull() {
-        TestingPathMatcher matcher = new TestingPathMatcher();
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{clientId"
+        ));
 
-        // A template with no closing '}' must not throw; buildUriFromTemplate
-        // should return null (treated as non-matching).
-        Assertions.assertNull(matcher.customBuildUriFromTemplate("/api/{clientId", "/api/123", false));
+        Assertions.assertNull(matcher.matches("/api/123"));
     }
-    
-    private static final class TestingPathMatcher extends PathMatcher<Object> {
 
-        @Override
-        protected String getPath(Object entry) {
-            return null;
+    @Test
+    public void strayClosingBraceBetweenTwoParamsShouldNotThrow() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{p1}/}/c/{p2}"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/1/2/c/3"));
+    }
+
+    @Test
+    public void strayClosingBraceEmbeddedBetweenTwoParamsShouldNotThrow() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{p1}/x}y/{p2}"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/1/x}y/2"));
+    }
+
+    @Test
+    public void doubleClosingBraceBetweenTwoParamsShouldNotThrow() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{p1}}/{p2}"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/1/2"));
+    }
+
+    @Test
+    public void strayClosingBraceAfterAllParamsIsLiteral() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{p1}/foo}/*"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/1/foo/anything"));
+        Assertions.assertNotNull(matcher.matches("/api/1/foo}/anything"));
+    }
+
+    @Test
+    public void strayClosingBraceBeforeFirstParamShouldNotMatch() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/}/{p1}/*"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/}/1/anything"));
+    }
+
+    @Test
+    public void slashInsidePlaceholderWithTrailingWildcard() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{a/b}/*"
+        ));
+
+        Assertions.assertNull(matcher.matches("/api/1/anything"));
+        Assertions.assertNull(matcher.matches("/api/1/x/y/z"));
+    }
+
+    @Test
+    public void slashInsidePlaceholderWithoutWildcard() {
+        TestingPathMatcher matcher = new TestingPathMatcher(Collections.singletonList(
+                "/api/{a/b}/foo"
+        ));
+
+        // inflated segment count makes this unmatchable
+        Assertions.assertNull(matcher.matches("/api/1/foo"));
+        Assertions.assertNull(matcher.matches("/api/1/b/foo"));
+    }
+
+    private static final class TestingPathMatcher extends PathMatcher<String> {
+        private final Collection<String> paths;
+
+        TestingPathMatcher(Collection<String> paths) {
+            this.paths = paths;
         }
 
         @Override
-        protected Collection<Object> getPaths() {
-            return null;
+        protected String getPath(String entry) {
+            return entry;
         }
 
-        // Make buildUriFromTemplate accessible from test
-        public String customBuildUriFromTemplate(String template, String targetUri, boolean onlyFirstParam) {
-            return buildUriFromTemplate(template, targetUri, onlyFirstParam);
+        @Override
+        protected Collection<String> getPaths() {
+            return paths;
         }
     }
 }

--- a/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
+++ b/common/src/test/java/org/keycloak/common/util/PathMatcherTest.java
@@ -13,6 +13,15 @@ public class PathMatcherTest {
 
         Assertions.assertEquals("/api/v1/1/campaigns/*/excelFiles", matcher.customBuildUriFromTemplate("/api/v1/{clientId}/campaigns/*/excelFiles", "/api/v1/1/contentConnectorConfigs/29/contentConnectorContents", false));
     }
+
+    @Test
+    public void missingClosingBraceShouldReturnNull() {
+        TestingPathMatcher matcher = new TestingPathMatcher();
+
+        // A template with no closing '}' must not throw; buildUriFromTemplate
+        // should return null (treated as non-matching).
+        Assertions.assertNull(matcher.customBuildUriFromTemplate("/api/{clientId", "/api/123", false));
+    }
     
     private static final class TestingPathMatcher extends PathMatcher<Object> {
 

--- a/docs/documentation/authorization_services/topics/resource-create.adoc
+++ b/docs/documentation/authorization_services/topics/resource-create.adoc
@@ -26,6 +26,15 @@ A string uniquely identifying the type of a set of one or more resources. The ty
 URIS that provides the locations/addresses for the resource. For HTTP resources, the URIS
 are usually the relative paths used to serve these resources.
 +
+URIs can use the following pattern syntax for path matching:
++
+** `+{param}+` -- A named path parameter that matches a single path segment. For example, `+/api/{id}/info+` matches `+/api/123/info+`. Parameter names must not contain `+/+`.
+** `+/*+` -- A trailing wildcard that matches any path starting with the prefix. For example, `+/api/*+` matches `+/api/foo+` and `+/api/foo/bar/baz+`.
+** `+/*.ext+` -- A suffix wildcard that matches any URI ending with the given file extension. For example, `+/*.html+` matches `+/page.html+` and `+/some/path/report.html+`.
++
+These patterns can be combined, for example `+/api/{id}/files/*+`.
+Wildcards (`+*+`) are only supported as a trailing `+/*+` or as a suffix `+/*.ext+`. A wildcard in the middle of a path, such as `+/api/*/info+`, is not supported and will not match any URI.
++
 * *Scopes*
 +
 One or more scopes to associate with the resource.

--- a/docs/documentation/authorization_services/topics/resource-create.adoc
+++ b/docs/documentation/authorization_services/topics/resource-create.adoc
@@ -28,12 +28,12 @@ are usually the relative paths used to serve these resources.
 +
 URIs can use the following pattern syntax for path matching:
 +
-** `+{param}+` -- A named path parameter that matches a single path segment. For example, `+/api/{id}/info+` matches `+/api/123/info+`. Parameter names must not contain `+/+`.
+** `+{param}+` -- A named path parameter that matches a single path segment. For example, `+/api/{id}/info+` matches `+/api/123/info+`. Parameter names must not be empty and must not contain `+/+`.
 ** `+/*+` -- A trailing wildcard that matches any path starting with the prefix. For example, `+/api/*+` matches `+/api/foo+` and `+/api/foo/bar/baz+`.
 ** `+/*.ext+` -- A suffix wildcard that matches any URI ending with the given file extension. For example, `+/*.html+` matches `+/page.html+` and `+/some/path/report.html+`.
 +
 These patterns can be combined, for example `+/api/{id}/files/*+`.
-Wildcards (`+*+`) are only supported as a trailing `+/*+` or as a suffix `+/*.ext+`. A wildcard in the middle of a path, such as `+/api/*/info+`, is not supported and will not match any URI.
+Wildcards (`+*+`) are only supported as a trailing `+/*+` or as a suffix `+/*.ext+`. A wildcard in the middle of a path, such as `+/api/*/info+`, never matches and will be rejected when creating or updating resources.
 +
 * *Scopes*
 +

--- a/docs/documentation/authorization_services/topics/resource-create.adoc
+++ b/docs/documentation/authorization_services/topics/resource-create.adoc
@@ -30,7 +30,7 @@ URIs can use the following pattern syntax for path matching:
 +
 ** `+{param}+` -- A named path parameter that matches a single path segment. For example, `+/api/{id}/info+` matches `+/api/123/info+`. Parameter names must not be empty and must not contain `+/+`.
 ** `+/*+` -- A trailing wildcard that matches any path starting with the prefix. For example, `+/api/*+` matches `+/api/foo+` and `+/api/foo/bar/baz+`.
-** `+/*.ext+` -- A suffix wildcard that matches any URI ending with the given file extension. For example, `+/*.html+` matches `+/page.html+` and `+/some/path/report.html+`.
+** `+/*.ext+` -- A suffix wildcard that matches any URI ending with the given file extension. The extension must not be empty (`+/*.+` is not valid). For example, `+/*.html+` matches `+/page.html+` and `+/some/path/report.html+`.
 +
 These patterns can be combined, for example `+/api/{id}/files/*+`.
 Wildcards (`+*+`) are only supported as a trailing `+/*+` or as a suffix `+/*.ext+`. A wildcard in the middle of a path, such as `+/api/*/info+`, never matches and will be rejected when creating or updating resources.

--- a/docs/documentation/tests/src/test/resources/ignored-variables
+++ b/docs/documentation/tests/src/test/resources/ignored-variables
@@ -44,6 +44,7 @@ groupIdB
 userId
 userId1
 userId2
+param
 11
 1
 2

--- a/docs/documentation/tests/src/test/resources/ignored-variables
+++ b/docs/documentation/tests/src/test/resources/ignored-variables
@@ -45,6 +45,7 @@ userId
 userId1
 userId2
 param
+...
 11
 1
 2

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -64,6 +64,36 @@ Before upgrading, you should check if any of your users, service accounts, or gr
 information after the upgrade. The `manage-realm` admin role is a high-privileged role and should only be granted to
 highly-trusted accounts.
 
+=== Stricter validation of resource URI templates in Authorization Services
+
+Resource URI templates used in Authorization Services are now validated more strictly when creating or updating resources via the Admin REST API.
+The following URI patterns are now rejected:
+
+* Placeholder names containing a slash, for example `+/api/{client/id}/foo+`
+* Wildcards in the middle of a path, for example `+/api/*/info+`
+* Stray closing braces outside a placeholder, for example `+/api/{id}/foo}/bar+`
+
+Wildcards are only supported as a trailing `+/*+` (path prefix match) or as a suffix pattern `+/*.ext+` (file extension match).
+
+Previously, these malformed templates were silently accepted but either never matched any URI or could cause runtime errors during authorization evaluation.
+
+Before upgrading, review any existing authorization resources that use URI templates.
+You can check for affected resources by querying the Admin REST API for each client that uses Authorization Services:
+
+[source]
+----
+GET /admin/realms/{realm}/clients/{client-id}/authz/resource-server/resource
+----
+
+Inspect the `+uris+` field of each resource and verify that:
+
+* All `+{...}+` placeholders have matching braces and do not contain `+/+` in the parameter name.
+* Wildcards (`+*+`) appear only at the end of the URI as `+/*+` or as a suffix pattern like `+/*.html+`.
+
+Resources with malformed URI templates should be corrected before upgrading.
+After the upgrade, existing resources with malformed templates will continue to be stored but will not match any request URI during authorization evaluation.
+Any update to such a resource will require fixing the URI template at the same time, as the stricter validation applies to all create and update operations.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -69,6 +69,7 @@ highly-trusted accounts.
 Resource URI templates used in Authorization Services are now validated more strictly when creating or updating resources via the Admin REST API.
 The following URI patterns are now rejected:
 
+* Empty placeholders, for example `+/api/{}/foo+`
 * Placeholder names containing a slash, for example `+/api/{client/id}/foo+`
 * Wildcards in the middle of a path, for example `+/api/*/info+`
 * Stray closing braces outside a placeholder, for example `+/api/{id}/foo}/bar+`
@@ -87,7 +88,7 @@ GET /admin/realms/{realm}/clients/{client-id}/authz/resource-server/resource
 
 Inspect the `+uris+` field of each resource and verify that:
 
-* All `+{...}+` placeholders have matching braces and do not contain `+/+` in the parameter name.
+* All `+{...}+` placeholders have matching braces, are not empty, and do not contain `+/+` in the parameter name.
 * Wildcards (`+*+`) appear only at the end of the URI as `+/*+` or as a suffix pattern like `+/*.html+`.
 
 Resources with malformed URI templates should be corrected before upgrading.

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -64,22 +64,26 @@ Before upgrading, you should check if any of your users, service accounts, or gr
 information after the upgrade. The `manage-realm` admin role is a high-privileged role and should only be granted to
 highly-trusted accounts.
 
+// ------------------------ Notable changes ------------------------ //
+== Notable changes
+
+Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
+It also lists significant changes to internal APIs.
+
 === Stricter validation of resource URI templates in Authorization Services
 
 Resource URI templates used in Authorization Services are now validated more strictly when creating or updating resources via the Admin REST API.
-The following URI patterns are now rejected:
+The documented patterns — named placeholders like `+/api/{id}/info+`, trailing wildcards like `+/api/*+`, suffix patterns like `+/*.html+`, and combinations like `+/api/{id}/files/*+` — continue to work unchanged.
+
+The following malformed URI patterns, which previously were silently accepted but either never matched any URI or could cause runtime errors during authorization evaluation:
 
 * Empty placeholders, for example `+/api/{}/foo+`
 * Placeholder names containing a slash, for example `+/api/{client/id}/foo+`
 * Wildcards in the middle of a path, for example `+/api/*/info+`
+* Suffix patterns with an empty file extension, for example `+/*.+`
 * Stray closing braces outside a placeholder, for example `+/api/{id}/foo}/bar+`
 
-Wildcards are only supported as a trailing `+/*+` (path prefix match) or as a suffix pattern `+/*.ext+` (file extension match).
-
-Previously, these malformed templates were silently accepted but either never matched any URI or could cause runtime errors during authorization evaluation.
-
-Before upgrading, review any existing authorization resources that use URI templates.
-You can check for affected resources by querying the Admin REST API for each client that uses Authorization Services:
+Before upgrading, you can check for affected resources by querying the Admin REST API for each client that uses Authorization Services:
 
 [source]
 ----
@@ -89,17 +93,11 @@ GET /admin/realms/{realm}/clients/{client-id}/authz/resource-server/resource
 Inspect the `+uris+` field of each resource and verify that:
 
 * All `+{...}+` placeholders have matching braces, are not empty, and do not contain `+/+` in the parameter name.
-* Wildcards (`+*+`) appear only at the end of the URI as `+/*+` or as a suffix pattern like `+/*.html+`.
+* Wildcards (`+*+`) appear only at the end of the URI as `+/*+` or as a suffix pattern like `+/*.html+` with a non-empty extension.
 
 Resources with malformed URI templates should be corrected before upgrading.
 After the upgrade, existing resources with malformed templates will continue to be stored, but they may not match request URIs as intended.
 Any update to such a resource will require fixing the URI template at the same time, as the stricter validation applies to all create and update operations.
-
-// ------------------------ Notable changes ------------------------ //
-== Notable changes
-
-Notable changes may include internal behavior changes that prevent common misconfigurations, bugs that are fixed, or changes to simplify running {project_name}.
-It also lists significant changes to internal APIs.
 
 === Organization invitation filters use exact matching
 

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -92,7 +92,7 @@ Inspect the `+uris+` field of each resource and verify that:
 * Wildcards (`+*+`) appear only at the end of the URI as `+/*+` or as a suffix pattern like `+/*.html+`.
 
 Resources with malformed URI templates should be corrected before upgrading.
-After the upgrade, existing resources with malformed templates will continue to be stored but will not match any request URI during authorization evaluation.
+After the upgrade, existing resources with malformed templates will continue to be stored, but they may not match request URIs as intended.
 Any update to such a resource will require fixing the URI template at the same time, as the stricter validation applies to all create and update operations.
 
 // ------------------------ Notable changes ------------------------ //

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -553,53 +553,12 @@ public class ResourceSetService {
         }
 
         for (String uri : uris) {
-            boolean inBrace = false;
-            boolean empty = true;
-
-            for (int i = 0; i < uri.length(); i++) {
-                char c = uri.charAt(i);
-
-                if (c == '{') {
-                    if (inBrace) {
-                        throw malformedUri(uri);
-                    }
-                    inBrace = true;
-                    empty = true;
-                } else if (c == '}') {
-                    if (!inBrace || empty) {
-                        throw malformedUri(uri);
-                    }
-                    inBrace = false;
-                } else if (inBrace) {
-                    if (c == '/') {
-                        throw malformedUri(uri);
-                    }
-                    empty = false;
-                }
-            }
-
-            if (inBrace) {
-                throw malformedUri(uri);
-            }
-
-            int asteriskIndex = uri.indexOf('*');
-            if (asteriskIndex != -1) {
-                boolean validTrailing = uri.endsWith("/*");
-                boolean validSuffix = asteriskIndex > 0 && uri.charAt(asteriskIndex - 1) == '/'
-                        && asteriskIndex + 1 < uri.length() && uri.charAt(asteriskIndex + 1) == '.'
-                        && uri.indexOf('*', asteriskIndex + 1) == -1
-                        && uri.indexOf('/', asteriskIndex + 1) == -1;
-                if (!validTrailing && !validSuffix) {
-                    throw malformedUri(uri);
-                }
+            String error = PathMatcher.validateTemplate(uri);
+            if (error != null) {
+                throw new ErrorResponseException(OAuthErrorException.INVALID_REQUEST,
+                        "URI [" + uri + "] is not a valid template: " + error,
+                        Status.BAD_REQUEST);
             }
         }
-    }
-
-    private static ErrorResponseException malformedUri(String uri) {
-        return new ErrorResponseException(OAuthErrorException.INVALID_REQUEST,
-                "URI [" + uri + "] is not a valid template; '{' and '}' must be matched and enclose a parameter name that does not contain '/'."
-                        + " Wildcards are only supported as trailing '/*' or as a suffix pattern '/*.ext'.",
-                Status.BAD_REQUEST);
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -130,6 +130,7 @@ public class ResourceSetService {
         AdminPermissionsSchema.SCHEMA.throwExceptionIfAdminPermissionClient(session, resourceServer.getId());
 
         requireManage();
+        validateUris(resource);
         StoreFactory storeFactory = this.authorization.getStoreFactory();
         ResourceOwnerRepresentation owner = resource.getOwner();
 
@@ -165,6 +166,7 @@ public class ResourceSetService {
     public Response update(@PathParam("resource-id") String id, ResourceRepresentation resource) {
         AdminPermissionsSchema.SCHEMA.throwExceptionIfAdminPermissionClient(session, resourceServer.getId());
         requireManage();
+        validateUris(resource);
         resource.setId(id);
         getResource(id);
         toModel(resource, resourceServer, authorization);
@@ -541,5 +543,47 @@ public class ResourceSetService {
         } else {
             adminEvent.operation(operation).resourcePath(session.getContext().getUri()).representation(resource).success();
         }
+    }
+
+    private static void validateUris(ResourceRepresentation resource) {
+        Set<String> uris = resource.getUris();
+
+        if (uris == null) {
+            return;
+        }
+
+        for (String uri : uris) {
+            boolean inBrace = false;
+            boolean empty = true;
+
+            for (int i = 0; i < uri.length(); i++) {
+                char c = uri.charAt(i);
+
+                if (c == '{') {
+                    if (inBrace) {
+                        throw malformedUri(uri);
+                    }
+                    inBrace = true;
+                    empty = true;
+                } else if (c == '}') {
+                    if (!inBrace || empty) {
+                        throw malformedUri(uri);
+                    }
+                    inBrace = false;
+                } else if (inBrace) {
+                    empty = false;
+                }
+            }
+
+            if (inBrace) {
+                throw malformedUri(uri);
+            }
+        }
+    }
+
+    private static ErrorResponseException malformedUri(String uri) {
+        return new ErrorResponseException(OAuthErrorException.INVALID_REQUEST,
+                "URI [" + uri + "] is not a valid template; '{' and '}' must be matched and enclose a parameter name.",
+                Status.BAD_REQUEST);
     }
 }

--- a/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
+++ b/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java
@@ -571,6 +571,9 @@ public class ResourceSetService {
                     }
                     inBrace = false;
                 } else if (inBrace) {
+                    if (c == '/') {
+                        throw malformedUri(uri);
+                    }
                     empty = false;
                 }
             }
@@ -578,12 +581,25 @@ public class ResourceSetService {
             if (inBrace) {
                 throw malformedUri(uri);
             }
+
+            int asteriskIndex = uri.indexOf('*');
+            if (asteriskIndex != -1) {
+                boolean validTrailing = uri.endsWith("/*");
+                boolean validSuffix = asteriskIndex > 0 && uri.charAt(asteriskIndex - 1) == '/'
+                        && asteriskIndex + 1 < uri.length() && uri.charAt(asteriskIndex + 1) == '.'
+                        && uri.indexOf('*', asteriskIndex + 1) == -1
+                        && uri.indexOf('/', asteriskIndex + 1) == -1;
+                if (!validTrailing && !validSuffix) {
+                    throw malformedUri(uri);
+                }
+            }
         }
     }
 
     private static ErrorResponseException malformedUri(String uri) {
         return new ErrorResponseException(OAuthErrorException.INVALID_REQUEST,
-                "URI [" + uri + "] is not a valid template; '{' and '}' must be matched and enclose a parameter name.",
+                "URI [" + uri + "] is not a valid template; '{' and '}' must be matched and enclose a parameter name that does not contain '/'."
+                        + " Wildcards are only supported as trailing '/*' or as a suffix pattern '/*.ext'.",
                 Status.BAD_REQUEST);
     }
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementTest.java
@@ -510,4 +510,20 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
         }
     }
 
+    @Test
+    public void failCreateWithMultipleWildcards() {
+        ResourceRepresentation newResource = new ResourceRepresentation();
+
+        newResource.setName("Multiple Wildcards Resource");
+        newResource.setUris(new HashSet<>(Arrays.asList("/api/*/info/*")));
+
+        try {
+            doCreateResource(newResource);
+            fail("Cannot create a resource with multiple wildcards");
+        } catch (Exception e) {
+            assertEquals(HttpResponseException.class, e.getCause().getClass());
+            assertEquals(400, HttpResponseException.class.cast(e.getCause()).getStatusCode());
+        }
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementTest.java
@@ -445,4 +445,21 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
         ResourcesResource resources = getClientResource().authorization().resources();
         resources.resource(resource.getId()).remove();
     }
+
+    @Test
+    public void failCreateWithMalformedUriTemplate() {
+        ResourceRepresentation newResource = new ResourceRepresentation();
+
+        newResource.setName("Malformed URI Template Resource");
+        newResource.setUris(new HashSet<>(Arrays.asList("/api/{clientId")));
+
+        try {
+            doCreateResource(newResource);
+            fail("Can not create a resource with a malformed URI template");
+        } catch (Exception e) {
+            assertEquals(HttpResponseException.class, e.getCause().getClass());
+            assertEquals(400, HttpResponseException.class.cast(e.getCause()).getStatusCode());
+        }
+    }
+
 }

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/authz/admin/ResourceManagementTest.java
@@ -226,7 +226,7 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
             newResource.setId(null);
             newResource.setOwner((ResourceOwnerRepresentation) null);
             doCreateResource(newResource);
-            fail("Can not create resources with the same name and owner");
+            fail("Cannot create resources with the same name and owner");
         } catch (Exception e) {
             assertEquals(HttpResponseException.class, e.getCause().getClass());
             assertEquals(409, HttpResponseException.class.cast(e.getCause()).getStatusCode());
@@ -455,7 +455,55 @@ public class ResourceManagementTest extends AbstractAuthorizationTest {
 
         try {
             doCreateResource(newResource);
-            fail("Can not create a resource with a malformed URI template");
+            fail("Cannot create a resource with a malformed URI template");
+        } catch (Exception e) {
+            assertEquals(HttpResponseException.class, e.getCause().getClass());
+            assertEquals(400, HttpResponseException.class.cast(e.getCause()).getStatusCode());
+        }
+    }
+
+    @Test
+    public void failCreateWithSlashInPlaceholderName() {
+        ResourceRepresentation newResource = new ResourceRepresentation();
+
+        newResource.setName("Slash In Placeholder Resource");
+        newResource.setUris(new HashSet<>(Arrays.asList("/api/{client/id}/foo")));
+
+        try {
+            doCreateResource(newResource);
+            fail("Cannot create a resource with a slash inside a placeholder name");
+        } catch (Exception e) {
+            assertEquals(HttpResponseException.class, e.getCause().getClass());
+            assertEquals(400, HttpResponseException.class.cast(e.getCause()).getStatusCode());
+        }
+    }
+
+    @Test
+    public void failCreateWithWildcardInMiddleOfPath() {
+        ResourceRepresentation newResource = new ResourceRepresentation();
+
+        newResource.setName("Wildcard In Middle Resource");
+        newResource.setUris(new HashSet<>(Arrays.asList("/api/*/info")));
+
+        try {
+            doCreateResource(newResource);
+            fail("Cannot create a resource with a wildcard in the middle of a path");
+        } catch (Exception e) {
+            assertEquals(HttpResponseException.class, e.getCause().getClass());
+            assertEquals(400, HttpResponseException.class.cast(e.getCause()).getStatusCode());
+        }
+    }
+
+    @Test
+    public void failCreateWithSuffixPatternInMiddleOfPath() {
+        ResourceRepresentation newResource = new ResourceRepresentation();
+
+        newResource.setName("Suffix Pattern In Middle Resource");
+        newResource.setUris(new HashSet<>(Arrays.asList("/a/b/c/*.html/c/d")));
+
+        try {
+            doCreateResource(newResource);
+            fail("Cannot create a resource with a suffix pattern in the middle of a path");
         } catch (Exception e) {
             assertEquals(HttpResponseException.class, e.getCause().getClass());
             assertEquals(400, HttpResponseException.class.cast(e.getCause()).getStatusCode());


### PR DESCRIPTION
Closes #50291

## Problem

`PathMatcher.buildUriFromTemplate` replaces a `{placeholder}` using `uri.indexOf("}", lastPattern)` as the end index:

```java
if (c == '{') {
    uri.replace(uri.indexOf("{", lastPattern), uri.indexOf("}", lastPattern) + 1, value.toString());
}
```

When the template contains an opening `{` with no matching `}`, `indexOf("}", ...)` returns `-1`, so the call becomes `uri.replace(start, 0, value)` with `start > end`. That throws `StringIndexOutOfBoundsException` (e.g. `start 5, end 0`) instead of treating the input as non-matching.

## Fix

Guard the missing-closing-brace case and return `null`, consistent with the method's other no-match results.

## Test

Adds `missingClosingBraceShouldReturnNull` to `PathMatcherTest`. It fails on `main` (`StringIndexOutOfBoundsException`) and passes with this change.

Resolves #50359

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
