### PR TITLE
use SHA384 for hashing for session cookies

### DIFF
--- a/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
+++ b/core/src/main/java/org/keycloak/jose/jws/crypto/HashUtils.java
@@ -81,4 +81,10 @@ public class HashUtils {
         return Base64Url.encode(hashedOutput);
     }
 
+    public static String sha384UrlEncodedHash(String input, Charset charset) {
+        byte[] inputBytes = input.getBytes(charset);
+        byte[] hashedOutput = hash(JavaAlgorithm.SHA384, inputBytes);
+        return Base64Url.encode(hashedOutput);
+    }
+
 }

--- a/core/src/test/java/org/keycloak/HashTest.java
+++ b/core/src/test/java/org/keycloak/HashTest.java
@@ -49,4 +49,22 @@ public class HashTest {
         String hash1 = HashUtils.sha256UrlEncodedHash(codeVerifier, charset);
         Assert.assertEquals(hash1, expectedHash);
     }
+
+    @Test
+    public void testSha384Hash() throws Exception {
+        testSha384Hash("myCodeVerifier", StandardCharsets.ISO_8859_1, "FR9XKX1Hj0Ch30EY5yjwuk6k6XYF0r222aJT252YCwgVyjs-OzRZfzfRTtkccnRf");
+        testSha384Hash("myCodeVerifier", StandardCharsets.UTF_8, "FR9XKX1Hj0Ch30EY5yjwuk6k6XYF0r222aJT252YCwgVyjs-OzRZfzfRTtkccnRf");
+
+        testSha384Hash("Some1[^&*$#", StandardCharsets.ISO_8859_1, "ecnvzy92VQYCMWkJfmCjaV9IJEH8dOKvMWQXUcbd1nShOKLoTaX7P63-y3sdNKeu");
+        testSha384Hash("Some1[^&*$#", StandardCharsets.UTF_8, "ecnvzy92VQYCMWkJfmCjaV9IJEH8dOKvMWQXUcbd1nShOKLoTaX7P63-y3sdNKeu");
+
+        // This will differ between ISO-8859-1 and UTF8 due the special character
+        testSha384Hash("krák", StandardCharsets.ISO_8859_1, "UPCWowTLOiw_D6TAzfg8zWF0TJMFa_8WTdHplEHVwe97H8uAR83jEUFNxmDYvlIr");
+        testSha384Hash("krák", StandardCharsets.UTF_8, "m4rJEhnndCOd2i98y6ii6ETK8Qek-h4hKXixEzHGrlZiohINl6ev3QLRf3TvToOP");
+    }
+
+    private void testSha384Hash(String codeVerifier, Charset charset, String expectedHash) {
+        String hash1 = HashUtils.sha384UrlEncodedHash(codeVerifier, charset);
+        Assert.assertEquals(hash1, expectedHash);
+    }
 }

--- a/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_7_0.adoc
@@ -209,6 +209,12 @@ Existing realms are not affected - only newly created key providers use the new 
 To migrate an existing realm, add a new aes-generated key provider with key size 32 and a higher priority.
 The old provider can be removed once all sessions using the old key have expired.
 
+=== Session cookies now use SHA-384
+
+The `KC_AUTH_SESSION_HASH` and `KEYCLOAK_SESSION` cookies are now hashed with SHA-384 instead of SHA-256. Although SHA-256 is still safe, CNSA 2.0 specifies SHA-384 as the minimum required hashing algorithm for national security systems.
+
+No configuration change is required, and active sessions are not affected. After upgrading, an old `KEYCLOAK_SESSION` cookie no longer matches the new format and is silently replaced on the user's next request. Users with a valid session stay logged in; only users whose session has already expired have to log in again, as they normally would.
+
 // ------------------------ Deprecated features ------------------------ //
 == Deprecated features
 

--- a/js/themes-vendor/src/main/js/web-crypto-shim.js
+++ b/js/themes-vendor/src/main/js/web-crypto-shim.js
@@ -1,4 +1,4 @@
-import { sha256 } from "@noble/hashes/sha2.js";
+import { sha256, sha384 } from "@noble/hashes/sha2.js";
 import { v4 as uuidv4 } from "uuid";
 
 // Shim for Web Crypto API specifically for Keycloak JS, as this API can sometimes be missing, for example in an insecure context:
@@ -14,6 +14,10 @@ if (typeof crypto.subtle === "undefined") {
       digest: async (algorithm, data) => {
         if (algorithm === "SHA-256") {
           return sha256(data);
+        }
+
+        if (algorithm === "SHA-384") {
+          return sha384(data);
         }
 
         throw new Error("Unsupported algorithm");

--- a/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationSessionBean.java
+++ b/services/src/main/java/org/keycloak/forms/login/freemarker/model/AuthenticationSessionBean.java
@@ -36,7 +36,7 @@ public class AuthenticationSessionBean {
 
     public AuthenticationSessionBean(String authSessionId, String tabId) {
         this.authSessionId = authSessionId;
-        this.authSessionIdHash = Base64.getEncoder().withoutPadding().encodeToString(HashUtils.hash(JavaAlgorithm.SHA256, authSessionId.getBytes(StandardCharsets.UTF_8)));
+        this.authSessionIdHash = Base64.getEncoder().withoutPadding().encodeToString(HashUtils.hash(JavaAlgorithm.SHA384, authSessionId.getBytes(StandardCharsets.UTF_8)));
         this.tabId = tabId;
     }
 

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationManager.java
@@ -869,7 +869,7 @@ public class AuthenticationManager {
         }
         keycloakSession.getProvider(CookieProvider.class).set(CookieType.IDENTITY, encoded, maxAge);
 
-        String sessionCookieValue = sha256UrlEncodedHash(session.getId());
+        String sessionCookieValue = sha384UrlEncodedHash(session.getId());
 
         // THIS SHOULD NOT BE A HTTPONLY COOKIE!  It is used for OpenID Connect Iframe Session support!
         // Max age should be set to the max lifespan of the session as it's used to invalidate old-sessions on re-login
@@ -1008,7 +1008,7 @@ public class AuthenticationManager {
             return false;
         }
 
-        if (cookie.equals(sha256UrlEncodedHash(sessionId))) return true;
+        if (cookie.equals(sha384UrlEncodedHash(sessionId))) return true;
 
         // Backwards compatibility
         String[] split = cookie.split("/");
@@ -1776,8 +1776,8 @@ public class AuthenticationManager {
         return null;
     }
 
-    public static String sha256UrlEncodedHash(String input) {
-        return HashUtils.sha256UrlEncodedHash(input, StandardCharsets.ISO_8859_1);
+    public static String sha384UrlEncodedHash(String input) {
+        return HashUtils.sha384UrlEncodedHash(input, StandardCharsets.ISO_8859_1);
     }
 
     public static String getRequestedScopes(KeycloakSession session) {

--- a/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
+++ b/services/src/main/java/org/keycloak/services/managers/AuthenticationSessionManager.java
@@ -119,7 +119,7 @@ public class AuthenticationSessionManager {
      * @param authSessionId decoded authSessionId (without route info attached)
      */
     public void setAuthSessionIdHashCookie(String authSessionId) {
-        String authSessionIdHash = BASE_64_ENCODER_NO_PADDING.encodeToString(HashUtils.hash(JavaAlgorithm.SHA256, authSessionId.getBytes(StandardCharsets.UTF_8)));
+        String authSessionIdHash = BASE_64_ENCODER_NO_PADDING.encodeToString(HashUtils.hash(JavaAlgorithm.SHA384, authSessionId.getBytes(StandardCharsets.UTF_8)));
 
         session.getProvider(CookieProvider.class).set(CookieType.AUTH_SESSION_ID_HASH, authSessionIdHash);
 

--- a/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.ftl
+++ b/services/src/main/resources/org/keycloak/protocol/oidc/endpoints/login-status-iframe.ftl
@@ -141,7 +141,7 @@
         * @param {string} message
         * @see https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#basic_example
         */
-      async function sha256Digest(message) {
+      async function sha384Digest(message) {
         const encoder = new TextEncoder();
         const data = encoder.encode(message);
 
@@ -149,12 +149,12 @@
           throw new Error("Web Crypto API is not available.");
         }
 
-        return await crypto.subtle.digest("SHA-256", data);
+        return await crypto.subtle.digest("SHA-384", data);
       }
 
       async function hashString(str) {
         // hash codeVerifier, then encode as url-safe base64 without padding
-        const hashBytes = new Uint8Array(await sha256Digest(str));
+        const hashBytes = new Uint8Array(await sha384Digest(str));
         const encodedHash = bytesToBase64(hashBytes)
             .replace(/\+/g, '-')
             .replace(/\//g, '_')


### PR DESCRIPTION
Switches the hashing of the session-related cookies KEYCLOAK_SESSION and KC_AUTH_SESSION_HASH from SHA-256 to SHA-384, in both the server-side code and the login-status iframe so the server and the browser stay consistent. Also adds the matching SHA-384 support to the Web Crypto shim (used in insecure contexts) and a unit test for the new hash.

To be clear about the motivation after the review discussion: SHA-256 is not broken and is not quantum-vulnerable. Current NIST guidance ([NIST IR 8547](https://csrc.nist.gov/pubs/ir/8547/ipd)) states that symmetric primitives — including hash functions — do not need to be replaced for the post-quantum transition. So this is not a post-quantum fix, and I've removed the earlier source document (2012) NSA Suite B reference and the PQC wording.

The change simply moves to a wider hash for extra security margin, as discussed and decided in #48827.





<img width="873" height="227" alt="Screenshot 2026-06-24 at 10 25 00" src="https://github.com/user-attachments/assets/f7a7a4c9-e8c0-440d-a66e-249116e8a1a4" />





Closes #49860

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
