### PR TITLE
TimeSelector clears input and switches units when value is 0 in Admin Console

### DIFF
--- a/js/apps/admin-ui/src/components/time-selector/TimeSelector.tsx
+++ b/js/apps/admin-ui/src/components/time-selector/TimeSelector.tsx
@@ -90,14 +90,18 @@ export const TimeSelector = ({
   }, [units, multiplier]);
 
   useEffect(() => {
-    const multiplier = getTimeUnit(times, value).multiplier;
+    const calculatedMultiplier = getTimeUnit(times, value).multiplier;
 
-    if (value) {
-      setMultiplier(multiplier);
-      setTimeValue(value / multiplier);
-      setLastMultiplier(multiplier);
+    if (value != null && (value as string | number) !== "") {
+      const resolvedMultiplier =
+        String(value) === "0"
+          ? (multiplier ?? defaultMultiplier ?? 1)
+          : calculatedMultiplier;
+      setMultiplier(resolvedMultiplier);
+      setTimeValue(value / resolvedMultiplier);
+      setLastMultiplier(resolvedMultiplier);
     } else {
-      setTimeValue(value || "");
+      setTimeValue("");
       setMultiplier(lastMultiplier ?? defaultMultiplier);
       setLastMultiplier(lastMultiplier ?? defaultMultiplier);
     }


### PR DESCRIPTION
- Closes #50300
----------------- 
### Solves
- When a field is set to 0 (e.g., "Minimum Quick Login Wait" in Brute Force Detection), the input appears blank instead of showing 0
- The time unit selector jumps to "Days" when the value is 0, because 0 % multiplier === 0 matches every unit and the largest one wins
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
