### PR TITLE
Use versioned FreeMarker Configuration defaults (26.6)

### DIFF
--- a/services/src/main/java/org/keycloak/theme/freemarker/DefaultFreeMarkerProvider.java
+++ b/services/src/main/java/org/keycloak/theme/freemarker/DefaultFreeMarkerProvider.java
@@ -56,7 +56,7 @@ public class DefaultFreeMarkerProvider implements FreeMarkerProvider {
     }
 
     private Template getTemplate(String templateName, Theme theme) throws IOException {
-        Configuration cfg = new Configuration();
+        Configuration cfg = new Configuration(Configuration.VERSION_2_3_32);
 
         // Assume *.ftl files are html.  This lets freemarker know how to
         // sanitize and prevent XSS attacks.


### PR DESCRIPTION
Initialize FreeMarker with the bundled VERSION_2_3_32 to avoid legacy 2.3.0 defaults and opt into current security and correctness improvements.

Closes #49922

PR:             https://github.com/keycloak/keycloak/pull/50099
Commit:         https://github.com/keycloak/keycloak/commit/468d5691c99f6dada6a64603d128b671a9888a27
PR branch:      backport-50099-26.6
Target branch:  https://github.com/keycloak/keycloak/tree/release/26.6
