### PR TITLE
[26.6] TimeSelector clears input and switches units when value is 0 in Admin Console

### DIFF
--- a/js/apps/admin-ui/src/components/time-selector/TimeSelector.tsx
+++ b/js/apps/admin-ui/src/components/time-selector/TimeSelector.tsx
@@ -90,14 +90,18 @@ export const TimeSelector = ({
   }, [units, multiplier]);
 
   useEffect(() => {
-    const multiplier = getTimeUnit(times, value).multiplier;
+    const calculatedMultiplier = getTimeUnit(times, value).multiplier;
 
-    if (value) {
-      setMultiplier(multiplier);
-      setTimeValue(value / multiplier);
-      setLastMultiplier(multiplier);
+    if (value != null && (value as string | number) !== "") {
+      const resolvedMultiplier =
+        String(value) === "0"
+          ? (multiplier ?? defaultMultiplier ?? 1)
+          : calculatedMultiplier;
+      setMultiplier(resolvedMultiplier);
+      setTimeValue(value / resolvedMultiplier);
+      setLastMultiplier(resolvedMultiplier);
     } else {
-      setTimeValue(value || "");
+      setTimeValue("");
       setMultiplier(lastMultiplier ?? defaultMultiplier);
       setLastMultiplier(lastMultiplier ?? defaultMultiplier);
     }


### PR DESCRIPTION
Closes #50300

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit fbf508167dab3ca97e65279db42b4cf16de21d93)
