### PR TITLE
Add missing import for ClientBuilder in UserTest

### DIFF
--- a/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
+++ b/scim/tests/base/src/test/java/org/keycloak/tests/scim/tck/UserTest.java
@@ -38,6 +38,7 @@ import org.keycloak.scim.resource.user.Name;
 import org.keycloak.scim.resource.user.User;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
 import org.keycloak.testframework.events.AdminEventAssertion;
+import org.keycloak.testframework.realm.ClientBuilder;
 import org.keycloak.testframework.realm.GroupBuilder;
 import org.keycloak.testframework.realm.UserBuilder;
 import org.keycloak.testframework.scim.client.annotations.InjectScimClient;


### PR DESCRIPTION
possible follow up from https://github.com/keycloak/keycloak/pull/50284

Closes #50283

@ahus1 @pedroigor I think the PR above broke the build, see my pipeline here: https://github.com/keycloak/keycloak/actions/runs/28106737083/job/83222955724?pr=50285

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
