### PR TITLE
Timestamp overflow in client secret rotation feature leads to next refresh time being set to the past

### DIFF
--- a/common/src/main/java/org/keycloak/common/util/Time.java
+++ b/common/src/main/java/org/keycloak/common/util/Time.java
@@ -27,15 +27,26 @@ public class Time {
     private static volatile int offset;
 
     /**
-     * Returns current time in seconds adjusted by adding {@link #offset) seconds.
+     * Returns current time in seconds adjusted by adding {@link #offset} seconds.
      * @return see description
+     * @deprecated Use {@link #currentTimeSeconds()} to avoid integer overflow beyond year 2038.
      */
+    @Deprecated
     public static int currentTime() {
         return ((int) (System.currentTimeMillis() / 1000)) + offset;
     }
 
     /**
-     * Returns current time in milliseconds adjusted by adding {@link #offset) seconds.
+     * Returns current time in seconds adjusted by adding {@link #offset} seconds.
+     * Unlike {@link #currentTime()}, this method returns a {@code long} to avoid integer overflow beyond year 2038.
+     * @return see description
+     */
+    public static long currentTimeSeconds() {
+        return (System.currentTimeMillis() / 1000) + offset;
+    }
+
+    /**
+     * Returns current time in milliseconds adjusted by adding {@link #offset} seconds.
      * @return see description
      */
     public static long currentTimeMillis() {

--- a/common/src/test/java/org/keycloak/common/util/TimeTest.java
+++ b/common/src/test/java/org/keycloak/common/util/TimeTest.java
@@ -1,0 +1,28 @@
+package org.keycloak.common.util;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TimeTest {
+
+    private static final long TWENTY_YEARS_IN_SECONDS = TimeUnit.DAYS.toSeconds(365 * 20);
+
+    @Test
+    void currentTimeSecondsDoesNotOverflowWithLargeOffset() {
+        long now = Time.currentTimeSeconds();
+        long future = now + TWENTY_YEARS_IN_SECONDS;
+
+        assertTrue(future > now, "Adding a 20-year offset must not overflow to a value less than now");
+    }
+
+    @Test
+    void currentTimeOverflowsWithLargeOffset() {
+        int now = Time.currentTime();
+        int future = now + (int) TWENTY_YEARS_IN_SECONDS;
+
+        assertTrue(future < 0, "int-based currentTime overflows with a 20-year addition, demonstrating the Y2038 bug");
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/oidc/OIDCClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/oidc/OIDCClientRepresentation.java
@@ -117,7 +117,7 @@ public class OIDCClientRepresentation {
     // OIDC Dynamic Client Registration Response
     private Integer client_id_issued_at;
 
-    private Integer client_secret_expires_at;
+    private Long client_secret_expires_at;
 
     private String registration_client_uri;
 
@@ -446,11 +446,11 @@ public class OIDCClientRepresentation {
         this.client_id_issued_at = clientIdIssuedAt;
     }
 
-    public Integer getClientSecretExpiresAt() {
+    public Long getClientSecretExpiresAt() {
         return client_secret_expires_at;
     }
 
-    public void setClientSecretExpiresAt(Integer client_secret_expires_at) {
+    public void setClientSecretExpiresAt(Long client_secret_expires_at) {
         this.client_secret_expires_at = client_secret_expires_at;
     }
 

--- a/integration/client-registration/src/main/java/org/keycloak/client/registration/OIDCClientRepresentationMixIn.java
+++ b/integration/client-registration/src/main/java/org/keycloak/client/registration/OIDCClientRepresentationMixIn.java
@@ -28,7 +28,7 @@ abstract class OIDCClientRepresentationMixIn {
     private Integer client_id_issued_at;
 
     @JsonIgnore
-    private Integer client_secret_expires_at;
+    private Long client_secret_expires_at;
 
     @JsonIgnore
     private String registration_client_uri;

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCClientSecretConfigWrapper.java
@@ -3,9 +3,11 @@ package org.keycloak.protocol.oidc;
 import java.io.InvalidObjectException;
 import java.security.MessageDigest;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
@@ -89,12 +91,12 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
         }
     }
 
-    public int getClientSecretCreationTime() {
+    public long getClientSecretCreationTime() {
         String creationTime = getAttribute(CLIENT_SECRET_CREATION_TIME);
-        return StringUtil.isBlank(creationTime) ? 0 : Integer.parseInt(creationTime);
+        return StringUtil.isBlank(creationTime) ? 0 : Long.parseLong(creationTime);
     }
 
-    public void setClientSecretCreationTime(int creationTime) {
+    public void setClientSecretCreationTime(long creationTime) {
         setAttribute(CLIENT_SECRET_CREATION_TIME, String.valueOf(creationTime));
     }
 
@@ -111,13 +113,13 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
         setAttribute(CLIENT_ROTATED_SECRET, secret);
     }
 
-    public int getClientRotatedSecretCreationTime() {
+    public long getClientRotatedSecretCreationTime() {
         String rotatedCreationTime = getAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME);
-        if (StringUtil.isNotBlank(rotatedCreationTime)) return Integer.parseInt(rotatedCreationTime);
+        if (StringUtil.isNotBlank(rotatedCreationTime)) return Long.parseLong(rotatedCreationTime);
         return 0;
     }
 
-    public void setClientRotatedSecretCreationTime(Integer rotatedTime) {
+    public void setClientRotatedSecretCreationTime(Long rotatedTime) {
         setAttribute(CLIENT_ROTATED_SECRET_CREATION_TIME, rotatedTime != null ? String.valueOf(rotatedTime) : null);
     }
 
@@ -125,11 +127,11 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
     Update the creation time of a secret with current date time value
      */
     public void setClientSecretCreationTime() {
-        setClientSecretCreationTime(Time.currentTime());
+        setClientSecretCreationTime(Time.currentTimeSeconds());
     }
 
     public void setClientRotatedSecretCreationTime() {
-        setClientRotatedSecretCreationTime(Time.currentTime());
+        setClientRotatedSecretCreationTime(Time.currentTimeSeconds());
     }
 
     public void updateClientRepresentationAttributes(ClientRepresentation rep) {
@@ -144,30 +146,30 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
         return getClientSecretExpirationTime() > 0;
     }
 
-    public int getClientSecretExpirationTime() {
+    public long getClientSecretExpirationTime() {
         String expiration = getAttribute(CLIENT_SECRET_EXPIRATION);
-        return expiration == null ? 0 : Integer.parseInt(expiration);
+        return expiration == null ? 0 : Long.parseLong(expiration);
     }
 
-    public void setClientSecretExpirationTime(Integer expiration) {
+    public void setClientSecretExpirationTime(Long expiration) {
         setAttribute(ClientSecretConstants.CLIENT_SECRET_EXPIRATION, expiration != null ? String.valueOf(expiration) : null);
     }
 
     public boolean isClientSecretExpired() {
         if (hasClientSecretExpirationTime()) {
-            return getClientSecretExpirationTime() < Time.currentTime();
+            return getClientSecretExpirationTime() < Time.currentTimeSeconds();
         }
         return false;
     }
 
-    public int getClientRotatedSecretExpirationTime() {
+    public long getClientRotatedSecretExpirationTime() {
         if (hasClientRotatedSecretExpirationTime()) {
-            return Integer.valueOf(getAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_EXPIRATION_TIME));
+            return Long.parseLong(getAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_EXPIRATION_TIME));
         }
         return 0;
     }
 
-    public void setClientRotatedSecretExpirationTime(Integer expiration) {
+    public void setClientRotatedSecretExpirationTime(Long expiration) {
         setAttribute(ClientSecretConstants.CLIENT_ROTATED_SECRET_EXPIRATION_TIME, expiration != null ? String.valueOf(expiration) : null);
     }
 
@@ -177,7 +179,7 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
 
     public boolean isClientRotatedSecretExpired() {
         if (hasClientRotatedSecretExpirationTime()) {
-            return getClientRotatedSecretExpirationTime() < Time.currentTime();
+            return getClientRotatedSecretExpirationTime() < Time.currentTimeSeconds();
         }
         return true;
     }
@@ -229,13 +231,13 @@ public class OIDCClientSecretConfigWrapper extends AbstractClientConfigWrapper {
             map.put("clientId", getId());
             map.put("clientName", getName());
             map.put("secretCreationTimeSeconds", getClientSecretCreationTime());
-            map.put("secretCreationTime", sdf.format(Time.toDate(getClientSecretCreationTime())));
+            map.put("secretCreationTime", sdf.format(new Date(TimeUnit.SECONDS.toMillis(getClientSecretCreationTime()))));
             map.put("secretExpirationTimeSeconds", getClientSecretExpirationTime());
-            map.put("secretExpirationTime", sdf.format(Time.toDate(getClientSecretExpirationTime())));
+            map.put("secretExpirationTime", sdf.format(new Date(TimeUnit.SECONDS.toMillis(getClientSecretExpirationTime()))));
             map.put("rotatedSecretCreationTimeSeconds", getClientRotatedSecretCreationTime());
-            map.put("rotatedSecretCreationTime", sdf.format(Time.toDate(getClientRotatedSecretCreationTime())));
+            map.put("rotatedSecretCreationTime", sdf.format(new Date(TimeUnit.SECONDS.toMillis(getClientRotatedSecretCreationTime()))));
             map.put("rotatedSecretExpirationTimeSeconds", getClientRotatedSecretExpirationTime());
-            map.put("rotatedSecretExpirationTime", sdf.format(Time.toDate(getClientRotatedSecretExpirationTime())));
+            map.put("rotatedSecretExpirationTime", sdf.format(new Date(TimeUnit.SECONDS.toMillis(getClientRotatedSecretExpirationTime()))));
             return mapper.writeValueAsString(map);
         } catch (JsonProcessingException e) {
             return "";

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutor.java
@@ -1,7 +1,9 @@
 package org.keycloak.services.clientpolicy.executor;
 
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.keycloak.common.util.Time;
 import org.keycloak.models.ClientModel;
@@ -109,24 +111,24 @@ public class ClientSecretRotationExecutor implements
         } else {
 
             if (adminContext instanceof DynamicClientUpdatedContext) {
-                int startRemainingWindow = clientConfigWrapper.getClientSecretExpirationTime()
-                        - configuration.remainExpirationPeriod;
+                long startRemainingWindow = clientConfigWrapper.getClientSecretExpirationTime()
+                        - (long) configuration.remainExpirationPeriod;
 
                 debugDynamicInfo(clientConfigWrapper, startRemainingWindow);
 
-                if (Time.currentTime() >= startRemainingWindow) {
-                    logger.debugv("Executing rotation for the dynamic client {0} due to remaining expiration time that starts at {1}", adminContext.getTargetClient().getClientId(), Time.toDate(startRemainingWindow));
+                if (Time.currentTimeSeconds() >= startRemainingWindow) {
+                    logger.debugv("Executing rotation for the dynamic client {0} due to remaining expiration time that starts at {1}", adminContext.getTargetClient().getClientId(), new Date(TimeUnit.SECONDS.toMillis(startRemainingWindow)));
                     rotateSecret(adminContext, clientConfigWrapper);
                 }
             }
         }
     }
 
-    private void debugDynamicInfo(OIDCClientSecretConfigWrapper clientConfigWrapper, int startRemainingWindow) {
+    private void debugDynamicInfo(OIDCClientSecretConfigWrapper clientConfigWrapper, long startRemainingWindow) {
         if (logger.isDebugEnabled()) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-            logger.debugv("client expiration time: {0}, remaining time: {1}, current time: {2}, Time offset: {3}", clientConfigWrapper.getClientSecretExpirationTime(), startRemainingWindow, Time.currentTime(), Time.getOffset());
-            logger.debugv("client expiration date: {0}, window remaining date: {1}, current date: {2}", sdf.format(Time.toDate(clientConfigWrapper.getClientSecretExpirationTime())), sdf.format(Time.toDate(startRemainingWindow)), sdf.format(Time.toDate(Time.currentTime())));
+            logger.debugv("client expiration time: {0}, remaining time: {1}, current time: {2}, Time offset: {3}", clientConfigWrapper.getClientSecretExpirationTime(), startRemainingWindow, Time.currentTimeSeconds(), Time.getOffset());
+            logger.debugv("client expiration date: {0}, window remaining date: {1}, current date: {2}", sdf.format(new Date(TimeUnit.SECONDS.toMillis(clientConfigWrapper.getClientSecretExpirationTime()))), sdf.format(new Date(TimeUnit.SECONDS.toMillis(startRemainingWindow))), sdf.format(new Date(Time.currentTimeMillis())));
         }
     }
 
@@ -161,12 +163,12 @@ public class ClientSecretRotationExecutor implements
 
     private void updatedSecretExpiration(OIDCClientSecretConfigWrapper clientConfigWrapper) {
         clientConfigWrapper.setClientSecretExpirationTime(
-                Time.currentTime() + configuration.getExpirationPeriod());
-        logger.debugv("A new secret expiration is configured for client {0}. Expires at {1}", clientConfigWrapper.getId(), Time.toDate(clientConfigWrapper.getClientSecretExpirationTime()));
+                Time.currentTimeSeconds() + configuration.getExpirationPeriod());
+        logger.debugv("A new secret expiration is configured for client {0}. Expires at {1}", clientConfigWrapper.getId(), new Date(TimeUnit.SECONDS.toMillis(clientConfigWrapper.getClientSecretExpirationTime())));
     }
 
     private void updateClientConfigProperties(OIDCClientSecretConfigWrapper clientConfigWrapper) {
-        clientConfigWrapper.setClientSecretCreationTime(Time.currentTime());
+        clientConfigWrapper.setClientSecretCreationTime(Time.currentTimeSeconds());
         updatedSecretExpiration(clientConfigWrapper);
     }
 
@@ -176,8 +178,8 @@ public class ClientSecretRotationExecutor implements
             clientConfigWrapper.setClientRotatedSecret(secret);
             clientConfigWrapper.setClientRotatedSecretCreationTime();
             clientConfigWrapper.setClientRotatedSecretExpirationTime(
-                    Time.currentTime() + configuration.getRotatedExpirationPeriod());
-            logger.debugv("Rotating the secret for client {0}. Secret creation at {1}. Secret expiration at {2}", clientConfigWrapper.getId(), Time.toDate(clientConfigWrapper.getClientRotatedSecretCreationTime()), Time.toDate(clientConfigWrapper.getClientRotatedSecretExpirationTime()));
+                    Time.currentTimeSeconds() + configuration.getRotatedExpirationPeriod());
+            logger.debugv("Rotating the secret for client {0}. Secret creation at {1}. Secret expiration at {2}", clientConfigWrapper.getId(), new Date(TimeUnit.SECONDS.toMillis(clientConfigWrapper.getClientRotatedSecretCreationTime())), new Date(TimeUnit.SECONDS.toMillis(clientConfigWrapper.getClientRotatedSecretExpirationTime())));
         } else {
             logger.debugv("Removing rotation for client {0}", clientConfigWrapper.getId());
             clientConfigWrapper.setClientRotatedSecret(null);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
@@ -3,6 +3,7 @@ package org.keycloak.testsuite.client;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -177,12 +178,12 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
         ClientResource clientResource = adminClient.realm(REALM_NAME).clients()
                 .get(cidConfidential);
         String secret = clientResource.getSecret().getValue();
-        int secretCreationTime = OIDCClientSecretConfigWrapper.fromClientRepresentation(
+        long secretCreationTime = OIDCClientSecretConfigWrapper.fromClientRepresentation(
                 clientResource.toRepresentation()).getClientSecretCreationTime();
         assertThat(secret, equalTo(DEFAULT_SECRET));
         String newSecret = clientResource.generateNewSecret().getValue();
         assertThat(newSecret, not(equalTo(secret)));
-        int updatedSecretCreationTime = OIDCClientSecretConfigWrapper.fromClientRepresentation(
+        long updatedSecretCreationTime = OIDCClientSecretConfigWrapper.fromClientRepresentation(
                 clientResource.toRepresentation()).getClientSecretCreationTime();
         assertThat(updatedSecretCreationTime, greaterThanOrEqualTo(secretCreationTime));
     }
@@ -203,7 +204,7 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
                 .get(cidConfidential);
         String secret = clientResource.getSecret().getValue();
         ClientRepresentation clientRepresentation = clientResource.toRepresentation();
-        int secretCreationTime = OIDCClientSecretConfigWrapper.fromClientRepresentation(
+        long secretCreationTime = OIDCClientSecretConfigWrapper.fromClientRepresentation(
                         clientRepresentation)
                 .getClientSecretCreationTime();
         clientRepresentation.setDescription("New Description Updated");
@@ -269,9 +270,9 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
                 clientResource.toRepresentation());
         assertThat(wrapper.hasRotatedSecret(), is(Boolean.TRUE));
         assertThat(wrapper.getClientRotatedSecret(null), equalTo(secondSecret));
-        int rotatedCreationTime = wrapper.getClientSecretCreationTime();
+        long rotatedCreationTime = wrapper.getClientSecretCreationTime();
         assertThat(rotatedCreationTime, is(notNullValue()));
-        assertThat(rotatedCreationTime, greaterThan(0));
+        assertThat(rotatedCreationTime, greaterThan(0L));
 
     }
 
@@ -296,7 +297,7 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
 
         OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientRepresentation(
                 clientResource.toRepresentation());
-        int secretCreationTime = wrapper.getClientSecretCreationTime();
+        long secretCreationTime = wrapper.getClientSecretCreationTime();
 
         logger.debug("Current time " + Time.toDate(Time.currentTime()));
         //advance 1 hour
@@ -457,10 +458,10 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
         timeOffSet.set(3601);
         clientResource.update(clientResource.toRepresentation());
 
-        logger.debug(">>> secret expiration time after first update " + Time.toDate(
+        logger.debug(">>> secret expiration time after first update " + new Date(TimeUnit.SECONDS.toMillis(
                 OIDCClientSecretConfigWrapper.fromClientRepresentation(
                                 clientResource.toRepresentation())
-                        .getClientSecretExpirationTime()) + " | Time: " + Time.toDate(Time.currentTime()));
+                        .getClientSecretExpirationTime())) + " | Time: " + Time.toDate(Time.currentTime()));
 
         // force rotation
         String updatedSecret = clientResource.getSecret().getValue();
@@ -470,18 +471,18 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
                 clientRepresentation);
 
         logger.debug(
-                ">>> secret expiration configured " + Time.toDate(
-                        wrapper.getClientSecretExpirationTime())
+                ">>> secret expiration configured " + new Date(TimeUnit.SECONDS.toMillis(
+                        wrapper.getClientSecretExpirationTime()))
                         + " | Time: " + Time.toDate(Time.currentTime()));
 
         oauth.client(clientId);
 
         timeOffSet.set(7201);
 
-        logger.debug("client secret:" + updatedSecret + "\nsecret expiration: " + Time.toDate(
-                wrapper.getClientSecretExpirationTime()) + "\nrotated secret: "
-                + wrapper.getClientRotatedSecret(null) + "\nrotated expiration: " + Time.toDate(
-                wrapper.getClientRotatedSecretExpirationTime()) + " | Time: " + Time.toDate(
+        logger.debug("client secret:" + updatedSecret + "\nsecret expiration: " + new Date(TimeUnit.SECONDS.toMillis(
+                wrapper.getClientSecretExpirationTime())) + "\nrotated secret: "
+                + wrapper.getClientRotatedSecret(null) + "\nrotated expiration: " + new Date(TimeUnit.SECONDS.toMillis(
+                wrapper.getClientRotatedSecretExpirationTime())) + " | Time: " + Time.toDate(
                 Time.currentTime()));
         logger.debug(">>> trying login at time " + Time.toDate(Time.currentTime()));
 
@@ -558,8 +559,8 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
 
         OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientRepresentation(
                 clientResource.toRepresentation());
-        int clientSecretExpirationTime = wrapper.getClientSecretExpirationTime();
-        assertThat(clientSecretExpirationTime, is(not(0)));
+        long clientSecretExpirationTime = wrapper.getClientSecretExpirationTime();
+        assertThat(clientSecretExpirationTime, is(not(0L)));
 
     }
 
@@ -663,7 +664,7 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
         OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientRepresentation(clientRepresentation);
 
         assertThat(wrapper.hasRotatedSecret(), is(false));
-        assertThat(wrapper.getClientSecretExpirationTime(),is(0));
+        assertThat(wrapper.getClientSecretExpirationTime(),is(0L));
     }
 
     /**
@@ -695,7 +696,7 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
         OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientRepresentation(clientRepresentation);
         assertThat(clientResource.getSecret().getValue(),equalTo(newSecret));
         assertThat(wrapper.hasRotatedSecret(), is(false));
-        assertThat(wrapper.getClientSecretExpirationTime(),is(0));
+        assertThat(wrapper.getClientSecretExpirationTime(),is(0L));
     }
 
     /**

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -160,7 +160,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         assertNotNull(response.getClientIdIssuedAt());
         assertNotNull(response.getClientId());
         assertNotNull(response.getClientSecret());
-        assertEquals(0, response.getClientSecretExpiresAt().intValue());
+        assertEquals(0, response.getClientSecretExpiresAt().longValue());
         assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
         assertEquals("RegistrationAccessTokenTest", response.getClientName());
         assertEquals("http://root", response.getClientUri());
@@ -185,7 +185,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         assertTrue(CollectionUtil.collectionEquals(Arrays.asList("code", "none"), response.getResponseTypes()));
         assertTrue(CollectionUtil.collectionEquals(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN), response.getGrantTypes()));
         assertNotNull(response.getClientSecret());
-        assertEquals(0, response.getClientSecretExpiresAt().intValue());
+        assertEquals(0, response.getClientSecretExpiresAt().longValue());
         assertEquals(OIDCLoginProtocol.CLIENT_SECRET_BASIC, response.getTokenEndpointAuthMethod());
         assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
     }
@@ -225,7 +225,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         assertNotNull(response.getClientIdIssuedAt());
         assertNotNull(response.getClientId());
         assertNotNull(response.getClientSecret());
-        assertEquals(0, response.getClientSecretExpiresAt().intValue());
+        assertEquals(0, response.getClientSecretExpiresAt().longValue());
         assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
         assertEquals("RegistrationAccessTokenTest", response.getClientName());
         assertEquals("http://root", response.getClientUri());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -1188,7 +1188,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         });
         OIDCClientRepresentation response = getClientDynamically(clientId);
         assertThat(response.getClientSecret(), notNullValue());
-        assertThat(response.getClientSecretExpiresAt(), greaterThan(0));
+        assertThat(response.getClientSecretExpiresAt(), greaterThan(0L));
 
     }
 
@@ -1208,7 +1208,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         OIDCClientRepresentation response = getClientDynamically(clientId);
 
         String firstSecret = response.getClientSecret();
-        Integer firstSecretExpiration = response.getClientSecretExpiresAt();
+        Long firstSecretExpiration = response.getClientSecretExpiresAt();
 
         updateClientDynamically(clientId, (OIDCClientRepresentation clientRep) -> clientRep.setContacts(Collections.singletonList("keycloak@keycloak.org")));
 
@@ -1265,9 +1265,9 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         OIDCClientRepresentation response = getClientDynamically(clientId);
 
         String firstSecret = response.getClientSecret();
-        Integer firstSecretExpiration = response.getClientSecretExpiresAt();
+        Long firstSecretExpiration = response.getClientSecretExpiresAt();
 
-        assertThat(firstSecretExpiration, is(greaterThan(Time.currentTime())));
+        assertThat(firstSecretExpiration, is(greaterThan(Time.currentTimeSeconds())));
 
         //Enter in Remaining expiration window
         timeOffSet.set(41);


### PR DESCRIPTION
  - Closes #35104
  - Fixes integer overflow (Y2K38 problem) in the client secret rotation feature where adding a large expiration period (e.g. 20 years) to the current Unix timestamp exceeded `Integer.MAX_VALUE`, resulting in the expiration being set to the past
  - Changes all timestamp-related fields from `int/Integer` to `long/Long`
  - Deprecates the `int Time.currentTime()` and provides the `long Time.currentTimeSeconds()` that is prone to Y2K38
  - Follow-up issue might be to have a switch for disabling the secret expiration

### Breaking changes
Possible breaking changes are only in the `core` module for the `OIDCClientRepresentation.getClientSecretExpiresAt()`, but as the method is exclusively used by the client secret rotation feature, which is still in preview/experimental, we should be fine. 
