### PR TITLE
Use constant-time comparison when validating OTP codes

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
+++ b/server-spi-private/src/main/java/org/keycloak/models/utils/TimeBasedOTP.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.models.utils;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -94,7 +96,7 @@ public class TimeBasedOTP extends HmacOTP {
 
             String candidate = generateOTP(secret, steps, this.numberDigits, this.algorithm);
 
-            if (candidate.equals(token)) {
+            if (token != null && MessageDigest.isEqual(candidate.getBytes(StandardCharsets.UTF_8), token.getBytes(StandardCharsets.UTF_8))) {
                 return true;
             }
         }

--- a/server-spi/src/main/java/org/keycloak/models/utils/HmacOTP.java
+++ b/server-spi/src/main/java/org/keycloak/models/utils/HmacOTP.java
@@ -18,6 +18,8 @@
 package org.keycloak.models.utils;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -82,7 +84,7 @@ public class HmacOTP {
         int newCounter = counter;
         for (newCounter = counter; newCounter <= counter + lookAroundWindow; newCounter++) {
             String candidate = generateHOTP(key, newCounter);
-            if (candidate.equals(token)) {
+            if (token != null && MessageDigest.isEqual(candidate.getBytes(StandardCharsets.UTF_8), token.getBytes(StandardCharsets.UTF_8))) {
                 return newCounter + 1;
             }
 


### PR DESCRIPTION
HmacOTP.validateHOTP and TimeBasedOTP.validateTOTP compare the generated code against the submitted token with String.equals, which bails out at the first differing character. The token is attacker-controlled input from the authentication form and the candidate is derived from the user's OTP secret, so this comparison should be constant-time like the other secret checks here (client secret, recovery codes, the pre-authorized tx_code). Switched both to MessageDigest.isEqual, keeping the existing null handling.

Closes #50316