### PR TITLE
confine ssf push url wildcard match to the allow-listed host

### DIFF
--- a/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidator.java
+++ b/ssf/transmitter/src/main/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidator.java
@@ -158,6 +158,19 @@ public final class SsfPushUrlValidator {
                 String r = idx == -1 ? pushUrl : pushUrl.substring(0, idx);
                 int length = validUrl.length() - 1;
                 String trimmed = validUrl.substring(0, length);
+                // When the '*' is attached directly to the authority (no path
+                // separator after scheme://), a bare prefix match would also
+                // accept hosts that merely start with the allow-listed host,
+                // e.g. "https://host*" matching "https://host.evil.example/".
+                // RedirectUtils.checkValidRedirectWildcard guards this by
+                // treating "scheme://host*" as "scheme://host/*"; require the
+                // host boundary here too so a wildcard stays confined to the
+                // host the operator reviewed.
+                int schemeIdx = trimmed.indexOf("://");
+                if (schemeIdx >= 0 && trimmed.indexOf('/', schemeIdx + 3) == -1
+                        && !trimmed.equals(r) && !r.startsWith(trimmed + "/")) {
+                    continue;
+                }
                 if (r.startsWith(trimmed)) {
                     return trimmed;
                 }

--- a/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidatorTest.java
+++ b/ssf/transmitter/src/test/java/org/keycloak/ssf/transmitter/support/SsfPushUrlValidatorTest.java
@@ -187,6 +187,37 @@ class SsfPushUrlValidatorTest {
                 SsfPushUrlValidator.matchesAllowList(allow, "https://backup.example.com/feeds/x"));
     }
 
+    @Test
+    void match_authorityWildcardStaysConfinedToHost() {
+        // "https://example.com*" — the '*' sits on the authority with no path
+        // separator. It must behave like "https://example.com/*": match the
+        // host and anything under it, but never a different host that merely
+        // begins with the same characters. Mirrors RedirectUtils.
+        Set<String> allow = set("https://example.com*");
+
+        assertEquals("https://example.com",
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com"));
+        assertEquals("https://example.com",
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com/feeds/x"));
+
+        assertEquals(null,
+                SsfPushUrlValidator.matchesAllowList(allow, "https://example.com.attacker.example/feeds/x"),
+                "an authority-attached wildcard must not match an extended host");
+    }
+
+    @Test
+    void validate_rejectsAuthorityWildcardHostExtension() {
+        // End-to-end: a wildcard that sits on the authority must not let the
+        // push target slip onto a different, attacker-controlled host outside
+        // the host the operator reviewed.
+        SsfPushUrlValidationException ex = assertThrows(SsfPushUrlValidationException.class,
+                () -> strict.validate(
+                        "https://example.com.attacker.example/feeds/x",
+                        set("https://example.com*")));
+
+        assertEquals(Reason.NOT_IN_ALLOWLIST, ex.getReason());
+    }
+
     // -- validate(): rejection codes ----------------------------------------
 
     @Test


### PR DESCRIPTION
Repro: set a receiver's `ssf.validPushUrls` to an authority-attached wildcard such as `https://receiver.example*`, then register a stream whose `delivery.endpoint_url` is `https://receiver.example.attacker.example/sink`. The allow-list check passes.
Cause: `SsfPushUrlValidator.matchesAllowList` strips the trailing `*` and prefix-matches, so `https://receiver.example` also matches `https://receiver.example.attacker.example`. `RedirectUtils.checkValidRedirectWildcard`, which this matcher is documented to mirror, instead rewrites `scheme://host*` as `scheme://host/*` and keeps the host boundary, so the same input is rejected there.
Fix: when the `*` sits on the authority (no path after `scheme://`), require the URL to equal the host or start with host + `/`. Path-attached wildcards and exact entries are unaffected.
