### PR TITLE
identity chaining guide improvements

### DIFF
--- a/docs/guides/securing-apps/oauth-identity-authorization-chaining-across-domains.adoc
+++ b/docs/guides/securing-apps/oauth-identity-authorization-chaining-across-domains.adoc
@@ -7,7 +7,12 @@ title="OAuth Identity and Authorization Chaining Across Domains"
 priority=140
 summary="Guide for the draft about OAuth Identity and Authorization Chaining Across Domains.">
 
-Applications can require access to resources that are distributed across multiple trust domains where each trust domain has its own OAuth 2.0 authorization server. A request may transverse multiple resource servers in multiple trust domains before completing. The link:https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-chaining/[OAuth Identity and Authorization Chaining Across Domains] is a draft specification that refers to this scenario as **chaining**. It defines a common pattern for combining link:https://datatracker.ietf.org/doc/html/rfc8693[OAuth 2.0 Token Exchange (RFC8693)] and the link:https://datatracker.ietf.org/doc/html/rfc7523[JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants (RFC7523)] to access resources across multiple trust domains while preserving identity and authorization information.
+Applications can require access to resources that are distributed across multiple trust domains where each trust domain has its own OAuth 2.0 authorization server. A request may transverse multiple resource servers in multiple trust domains before completing.
+
+The link:https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-chaining/[OAuth Identity and Authorization Chaining Across Domains] is a draft specification that refers to this scenario as **chaining**. It defines a common pattern for combining two standards:
+
+* link:https://datatracker.ietf.org/doc/html/rfc8693[OAuth 2.0 Token Exchange (RFC8693)] to produce a JWT assertion targeted at the destination domain.
+* link:https://datatracker.ietf.org/doc/html/rfc7523[JWT Profile for OAuth 2.0 Client Authentication and Authorization Grants (RFC7523)] to convert the assertion into a valid access token in the destination domain.
 
 The following diagram illustrates the steps that the client in trust domain A needs to perform to access a protected resource in trust domain B.
 
@@ -21,17 +26,28 @@ image::identity-authorization-chaining.dio.svg[Identity and Authorization Chaini
 . Authorization server of trust domain B validates the JWT authorization grant and returns an access token.
 . The client in trust domain A uses the access token received from the authorization server in trust domain B to access the protected resource in trust domain B.
 
-{project_name} currently provides standard Token Exchange (see <@links.securingapps id="token-exchange" anchor="_standard-token-exchange" />) and JWT Authorization Grant (see <@links.securingapps id="jwt-authorization-grant" />) as supported features. This way, {project_name} can implement OAuth Identity and Authorization Chaining Across Domains between two different realms or servers. For domain A, domain B is an audience that can be restricted via token exchange. For domain B, domain A is an Identity Provider that is used to validate the assertion.
+{project_name} can implement OAuth Identity and Authorization Chaining Across Domains between two different realms or servers by combining the following supported features:
+
+* **Token Exchange**: Used in domain A to produce a JWT assertion for domain B. Domain B is configured as an audience that can be restricted via token exchange. See <@links.securingapps id="token-exchange" anchor="_standard-token-exchange" /> for more information.
+* **JWT Authorization Grant**: Used in domain B to validate the assertion and issue an access token. Domain A is configured as an Identity Provider that is used to validate the assertion. See <@links.securingapps id="jwt-authorization-grant" /> for more information.
 
 WARNING: OAuth Identity and Authorization Chaining Across Domains is still in draft, it is not yet a definitive standard.
 
-== Configuring Token Exchange in `domaina` for chaining
+== Overview of the complete flow
 
-In this sample configuration two realms, `domaina` and `domainb`, are used to represent the domains involved in the chaining diagram. This first chapter describes the steps done in `domaina`. With them, a client will be able to request a Token Exchange for `domainb`, and the resulting access token will be a valid assertion to be used for the JWT Authorization grant.
+To access resources in `domainb` from a client authenticated in `domaina`, you need to complete these three steps:
+
+* **Obtain token1**: Get an initial access token from `domaina` (via normal OAuth flow).
+* **Token Exchange**: Exchange token1 in `domaina` to get token2 (a JWT assertion for `domainb`).
+* **JWT Authorization Grant**: Present token2 to `domainb` to get token3 (the final access token for `domainb`).
+
+== Step 1: Configure Token Exchange in `domaina`
+
+In this sample configuration two realms, `domaina` and `domainb`, are used to represent the domains involved in the chaining diagram. This step configures `domaina` to enable a client to request a Token Exchange for `domainb`. The result will be a JWT assertion that can be used for JWT Authorization Grant in `domainb`.
 
 For more information about Standard Token Exchange, see <@links.securingapps id="token-exchange" anchor="_standard-token-exchange" />.
 
-=== Create a client that represents `domainb`
+=== 1.1 Create a client that represents `domainb`
 
 This client will also be the client configured in `domainb` for the identity provider access. Go to **Clients** and click **Create Client**.
 
@@ -44,7 +60,7 @@ This client will also be the client configured in `domainb` for the identity pro
 .Client that represents domainb in domaina
 image::jwt-authorization-grant-oidc-client-domaina.png[Client that represents domainb in domaina]
 
-=== Create a client scope to grant access to `domainb`
+=== 1.2 Create a client scope to grant access to `domainb`
 
 Create a client scope `access-domainb` to include the correct audience for the token when this scope is requested. An audience mapper for `domainb` will be added. In **Client scopes**, click **Create client scope**.
 
@@ -67,7 +83,7 @@ image::jwt-authorization-grant-oidc-client-scope-mapper.png[Client scope mapper 
 
 NOTE: This example allows any user to request that client scope. Roles can be used to restrict the scope of the client scope. This way only users with a specific role would be allowed to add the `domainb` audience.
 
-=== Create a client to perform the Token Exchange
+=== 1.3 Create a client to perform the Token Exchange
 
 Create a confidential OpenID Connect client `clienta` with **Standard flow**, **Direct access grants** and **Standard token exchange** capability enabled.
 
@@ -84,12 +100,12 @@ In the tab **Client scopes**, assign the previous `access-domainb` scope as opti
 .Add client scope as optional
 image::jwt-authorization-grant-oidc-add-scope.png[Add client scope as optional]
 
-=== Create a sample user
+=== 1.4 Create a sample user
 
 Finally create a sample user in `domaina` with username `testuser`. Set a password to the account.
 
 [[_example_token_exchange]]
-=== Example request for Token Exchange
+=== 1.5 Test Token Exchange
 
 Normally `clienta` will possess an initial token issued by `domaina`, obtained via normal authorization flow, or just because the client is a service endpoint that receives the token as a bearer. In this example, a direct access grant for `testuser` is requested to get `token1`.
 
@@ -121,15 +137,17 @@ curl -s -X POST \
   --data-urlencode "subject_token=$token1"
 ----
 
-The resulting access token `token2` will be a valid assertion for JWT Authorization Grant in `domainb`.
+The resulting token `token2` is a JWT assertion (not a bearer token) that must be presented to `domainb` via JWT Authorization Grant to obtain a valid access token.
 
-== Configuring JWT Authorization grant in `domainb` for chaining
+You have now completed the configuration in `domaina`. Next, you need to configure `domainb` to accept the JWT assertion and convert it into a valid access token.
 
-The next steps configure `domainb` to accept a JWT authorization grant using the assertion obtained via Token Exchange in `domaina` (see previous chapter). The resulting access token will be valid for `domainb`.
+== Step 2: Configure JWT Authorization Grant in `domainb`
+
+This step configures `domainb` to accept a JWT authorization grant using the assertion obtained via Token Exchange in `domaina`. This is required to convert the assertion into an access token that is valid for `domainb` and trusted by its resource servers.
 
 For more information about JWT Authorization Grant, see <@links.securingapps id="jwt-authorization-grant" />.
 
-=== Create an OpenID Connect Identity provider for `domaina`
+=== 2.1 Create an OpenID Connect Identity Provider for `domaina`
 
 Create a Identity Provider to establish the trust relationship with `domaina`. In **Identity providers**, click the **OpenID Connect v1.0** type.
 
@@ -143,7 +161,9 @@ image::jwt-authorization-grant-oidc-idp.png[Identity Provider for domaina]
 
 After creation, enable the **JWT Authorization Grant** option.
 
-=== Create a client to perform the JWT authorization grant
+IMPORTANT: This option must be enabled to allow the Identity Provider to accept JWT assertions from `domaina` and convert them into access tokens.
+
+=== 2.2 Create a client to perform the JWT Authorization Grant
 
 Create a confidential OpenID Connect client `clientb` with **JWT Authorization Grant** capability enabled. In the option **Allowed Identity Providers for JWT Authorization Grant** add the `domaina` Identity Provider.
 
@@ -156,7 +176,7 @@ Create a confidential OpenID Connect client `clientb` with **JWT Authorization G
 .Client for JWT authorization grant
 image::jwt-authorization-grant-oidc-clientb.png[Client for JWT authorization grant]
 
-=== Link the sample user in `domainb`
+=== 2.3 Link the sample user in `domainb`
 
 To test the JWT Authorization Grant, the sample user created in `domaina` should be linked in `domainb`. You can just access to the account page in `domainb`:
 
@@ -166,9 +186,9 @@ To test the JWT Authorization Grant, the sample user created in `domaina` should
 * Log in using the test user and the password assigned previously.
 * Check in **Account security** -> **Linked accounts** that the user is correctly linked to `domaina`.
 
-=== Example request for JWT authorization grant
+=== 2.4 Test JWT Authorization Grant
 
-The `token2` obtained in <<_example_token_exchange,Example request for Token Exchange>> will be a valid assertion for `domainb`. So, the `clientb` defined in `domainb` can send a JWT Authorization Grant with that token.
+The `token2` obtained in <<_example_token_exchange,Test Token Exchange>> is a valid assertion for `domainb`. The `clientb` defined in `domainb` can send a JWT Authorization Grant request with that token.
 
 [source,bash]
 ----
@@ -182,6 +202,6 @@ curl -s -X POST \
   --data-urlencode "assertion=$token2"
 ----
 
-The response will contain a new access token issued by `domainb`.
+The response will contain a new access token (`token3`) issued by `domainb`. This token3 is the final access token that can be used as a Bearer token to access protected resources in `domainb`.
 
 </@tmpl.guide>

--- a/docs/guides/securing-apps/specifications.adoc
+++ b/docs/guides/securing-apps/specifications.adoc
@@ -61,6 +61,7 @@ This {section} presents a list of specifications and standards that {project_nam
 |link:https://datatracker.ietf.org/doc/html/rfc9101[The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR) (RFC 9101)]|Supported||
 |link:https://datatracker.ietf.org/doc/html/rfc9207[OAuth 2.0 Authorization Server Issuer Identification (RFC 9207)]|Supported||
 |link:https://datatracker.ietf.org/doc/html/rfc9449[OAuth 2.0 Demonstrating Proof of Possession (DPoP) (RFC 9449)]|Supported||
+|link:https://datatracker.ietf.org/doc/html/draft-ietf-oauth-identity-chaining/[OAuth Identity and Authorization Chaining Across Domains] (Draft)|Supported||Combines Token Exchange (RFC 8693) and JWT Authorization Grant (RFC 7523) to enable cross-domain resource access while preserving user identity. See <@links.securingapps id="oauth-identity-authorization-chaining-across-domains" />.
 |===
 
 == Financial-grade API (FAPI)


### PR DESCRIPTION
Closes #50327

- Clarifies the use of Jwt Authorization Grant for identity chaining
- Adds the specification to the list of supported specifications

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
