### PR TITLE
[26.6] Client Secret Rotation docs incorrectly mark feature as experimental instead of preview

### DIFF
--- a/docs/documentation/server_admin/topics/clients/oidc/con-secret-rotation.adoc
+++ b/docs/documentation/server_admin/topics/clients/oidc/con-secret-rotation.adoc
@@ -3,10 +3,9 @@
 = Client Secret Rotation
 [role="_abstract"]
 
-[IMPORTANT]
-====
-Please note that Client Secret Rotation support is in development. Use this feature experimentally.
-====
+:tech_feature_name: Client Secret Rotation
+:tech_feature_id: client-secret-rotation
+include::../../../topics/templates/techpreview.adoc[]
 
 For a client with <<_client-credentials, Confidential>> <<_access-type, Client authentication>> {project_name} supports the functionality of rotating client secrets through <<_client_policies, Client Policies>>.
 


### PR DESCRIPTION
Closes #50139

Signed-off-by: Martin Bartoš <mabartos@redhat.com>
(cherry picked from commit e878757adc1e269e212358d2cbd4d7730da12df6)

@rmartinc @keycloak/core-authn  Could you please check it? Thanks!
