### PR TITLE
Review of ClientTest

### DIFF
--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -123,6 +123,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 @KeycloakIntegrationTest
 public class ClientTest {
 
+    private static final String TEST_CLIENT_ID = "my-app";
+    private static final String TEST_CLIENT_DESCRIPTION = "my-app description";
+    private static final String TEST_USER_USERNAME = "test-user@localhost";
+    private static final String TEST_USER_PASSWORD = "password";
+
     @InjectRealm(ref = "default", config = ClientTestRealmConfig.class)
     ManagedRealm managedRealm;
 
@@ -156,8 +161,8 @@ public class ClientTest {
 
     private ClientRepresentation createClient(String protocol) {
         ClientRepresentation rep = new ClientRepresentation();
-        rep.setClientId("my-app");
-        rep.setDescription("my-app description");
+        rep.setClientId(TEST_CLIENT_ID);
+        rep.setDescription(TEST_CLIENT_DESCRIPTION);
         rep.setEnabled(true);
         rep.setPublicClient(true);
         if (protocol != null) {
@@ -166,9 +171,9 @@ public class ClientTest {
         Response response = managedRealm.admin().clients().create(rep);
         String id = ApiUtil.getCreatedId(response);
         managedRealm.cleanup().add(r -> r.clients().get(id).remove());
-        ClientRepresentation found = AdminApiUtil.findClientByClientId(managedRealm.admin(), "my-app").toRepresentation();
+        ClientRepresentation found = AdminApiUtil.findClientByClientId(managedRealm.admin(), TEST_CLIENT_ID).toRepresentation();
 
-        assertEquals("my-app", found.getClientId());
+        assertEquals(TEST_CLIENT_ID, found.getClientId());
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.clientResourcePath(id), rep, ResourceType.CLIENT);
 
         rep.setId(id);
@@ -178,8 +183,8 @@ public class ClientTest {
 
     private ClientRepresentation createClientNonPublic(Consumer<ClientRepresentation> additionalStep) {
         ClientRepresentation rep = new ClientRepresentation();
-        rep.setClientId("my-app");
-        rep.setDescription("my-app description");
+        rep.setClientId(TEST_CLIENT_ID);
+        rep.setDescription(TEST_CLIENT_DESCRIPTION);
         rep.setEnabled(true);
         rep.setPublicClient(false);
 
@@ -188,9 +193,9 @@ public class ClientTest {
         Response response = managedRealm.admin().clients().create(rep);
         String id = ApiUtil.getCreatedId(response);
         managedRealm.cleanup().add(r -> r.clients().get(id).remove());
-        ClientRepresentation found = AdminApiUtil.findClientByClientId(managedRealm.admin(), "my-app").toRepresentation();
+        ClientRepresentation found = AdminApiUtil.findClientByClientId(managedRealm.admin(), TEST_CLIENT_ID).toRepresentation();
 
-        assertEquals("my-app", found.getClientId());
+        assertEquals(TEST_CLIENT_ID, found.getClientId());
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.CREATE, AdminEventPaths.clientResourcePath(id), rep, ResourceType.CLIENT);
 
         rep.setId(id);
@@ -211,7 +216,7 @@ public class ClientTest {
     // Issue 48868
     @Test
     public void createBearerOnlyClientVerifyWithSecret() {
-        String id = createClientNonPublic((rep) -> { rep.setBearerOnly(true); })
+        String id = createClientNonPublic((rep) -> rep.setBearerOnly(true))
                 .getId();
 
         ClientResource client = managedRealm.admin().clients().get(id);
@@ -504,10 +509,10 @@ public class ClientTest {
 
     @Test
     public void getClientSessions() {
-        AccessTokenResponse response = oauth.doPasswordGrantRequest("test-user@localhost", "password");
+        AccessTokenResponse response = oauth.doPasswordGrantRequest(TEST_USER_USERNAME, TEST_USER_PASSWORD);
         assertEquals(200, response.getStatusCode());
 
-        AuthorizationEndpointResponse codeResponse = oauth.doLogin("test-user@localhost", "password");
+        AuthorizationEndpointResponse codeResponse = oauth.doLogin(TEST_USER_USERNAME, TEST_USER_PASSWORD);
 
         AccessTokenResponse response2 = oauth.doAccessTokenRequest(codeResponse.getCode());
         assertEquals(200, response2.getStatusCode());
@@ -710,7 +715,7 @@ public class ClientTest {
     }
 
     @Test
-    public void nodesUsingClientEndpointAndJwt() throws MalformedURLException, InterruptedException {
+    public void nodesUsingClientEndpointAndJwt() throws InterruptedException {
         testApp.kcAdmin().clear();
 
         ClientResource clientResource = AdminApiUtil.findClientByClientId(managedRealm.admin(), "test-app");
@@ -977,12 +982,10 @@ public class ClientTest {
         String usernameMapperId = null;
         String fooMapperId = null;
         for (ProtocolMapperRepresentation mapper : protocolMappers) {
-            if (mapper.getName().equals(OIDCLoginProtocolFactory.EMAIL)) {
-                emailMapperId = mapper.getId();
-            } else if (mapper.getName().equals(OIDCLoginProtocolFactory.USERNAME)) {
-                usernameMapperId = mapper.getId();
-            } else if (mapper.getName().equals("foo")) {
-                fooMapperId = mapper.getId();
+            switch (mapper.getName()) {
+                case OIDCLoginProtocolFactory.EMAIL -> emailMapperId = mapper.getId();
+                case OIDCLoginProtocolFactory.USERNAME -> usernameMapperId = mapper.getId();
+                case "foo" -> fooMapperId = mapper.getId();
             }
         }
 
@@ -1012,7 +1015,7 @@ public class ClientTest {
 
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientProtocolMapperPath(clientDbId, fooMapperId), fooMapper, ResourceType.PROTOCOL_MAPPER);
 
-        fooMapper = mappersResource.getMapperById(fooMapperId);
+        mappersResource.getMapperById(fooMapperId);
 
         // Remove foo mapper
         mappersResource.delete(fooMapperId);
@@ -1160,12 +1163,11 @@ public class ClientTest {
     private static class ClientTestRealmConfig implements RealmConfig {
         @Override
         public RealmBuilder configure(RealmBuilder realm) {
-
-            realm.users(UserBuilder.create("test-user@localhost")
+            realm.users(UserBuilder.create(TEST_USER_USERNAME)
                     .enabled(true)
-                    .email("test-user@localhost")
+                    .email(TEST_USER_USERNAME)
                     .name("Tom", "Brady")
-                    .password("password"));
+                    .password(TEST_USER_PASSWORD));
             return realm;
         }
     }
@@ -1181,9 +1183,7 @@ public class ClientTest {
         }
 
         RealmRepresentation oldRepresentation = managedRealm.admin().toRepresentation();
-        managedRealm.cleanup().add(rr -> {
-            rr.update(oldRepresentation);
-        });
+        managedRealm.cleanup().add(rr -> rr.update(oldRepresentation));
 
         // Remember-Me Disabled
         RealmRepresentation realm = managedRealm.admin().toRepresentation();
@@ -1263,8 +1263,8 @@ public class ClientTest {
         ClientRepresentation rep = new ClientRepresentation();
         rep.setClientId("update-empty-uris-client");
         rep.setEnabled(true);
-        rep.setRedirectUris(Arrays.asList("https://example.com"));
-        rep.setWebOrigins(Arrays.asList("https://example.com"));
+        rep.setRedirectUris(List.of("https://example.com"));
+        rep.setWebOrigins(List.of("https://example.com"));
 
         Response response = managedRealm.admin().clients().create(rep);
         assertEquals(201, response.getStatus());

--- a/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/admin/ClientTest.java
@@ -1015,7 +1015,7 @@ public class ClientTest {
 
         AdminEventAssertion.assertEvent(adminEvents.poll(), OperationType.UPDATE, AdminEventPaths.clientProtocolMapperPath(clientDbId, fooMapperId), fooMapper, ResourceType.PROTOCOL_MAPPER);
 
-        mappersResource.getMapperById(fooMapperId);
+        assertNotNull(mappersResource.getMapperById(fooMapperId));
 
         // Remove foo mapper
         mappersResource.delete(fooMapperId);


### PR DESCRIPTION
- Add constants for magic strings (TEST_CLIENT_ID, TEST_CLIENT_DESCRIPTION, TEST_USER_USERNAME, TEST_USER_PASSWORD)
- Replace hardcoded strings with constants throughout the test
- Simplify lambda expression in createBearerOnlyClientVerifyWithSecret
- Remove unused MalformedURLException from nodesUsingClientEndpointAndJwt signature
- Improve code readability and maintainability

Closes #48191

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
