### PR TITLE
Configuration and defaults should honor long values

### DIFF
--- a/core/src/main/java/org/keycloak/representations/oidc/OIDCClientRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/oidc/OIDCClientRepresentation.java
@@ -446,10 +446,16 @@ public class OIDCClientRepresentation {
         this.client_id_issued_at = clientIdIssuedAt;
     }
 
-    public Long getClientSecretExpiresAt() {
-        return client_secret_expires_at;
+    public Integer getClientSecretExpiresAt() {
+        return client_secret_expires_at == null ? null : client_secret_expires_at.intValue();
     }
 
+    public void setClientSecretExpiresAt(Integer client_secret_expires_at) {
+        this.client_secret_expires_at = client_secret_expires_at == null ? null : client_secret_expires_at.longValue();
+    }
+
+    // Long overload to avoid integer overflow for timestamps beyond January 2038 (Y2K38)
+    // Jackson uses the Long field directly for serialization
     public void setClientSecretExpiresAt(Long client_secret_expires_at) {
         this.client_secret_expires_at = client_secret_expires_at;
     }

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutor.java
@@ -112,7 +112,7 @@ public class ClientSecretRotationExecutor implements
 
             if (adminContext instanceof DynamicClientUpdatedContext) {
                 long startRemainingWindow = clientConfigWrapper.getClientSecretExpirationTime()
-                        - (long) configuration.remainExpirationPeriod;
+                        - configuration.remainExpirationPeriod;
 
                 debugDynamicInfo(clientConfigWrapper, startRemainingWindow);
 
@@ -135,8 +135,7 @@ public class ClientSecretRotationExecutor implements
     private void rotateSecret(ClientCRUDContext crudContext,
                               OIDCClientSecretConfigWrapper clientConfigWrapper) {
 
-        if (crudContext instanceof ClientSecretRotationContext) {
-            ClientSecretRotationContext secretRotationContext = ((ClientSecretRotationContext) crudContext);
+        if (crudContext instanceof ClientSecretRotationContext secretRotationContext) {
             if (secretRotationContext.isForceRotation()) {
                 logger.debugv("Force rotation for client {0}", clientConfigWrapper.getId());
                 updateRotateSecret(clientConfigWrapper, secretRotationContext.getCurrentSecret());
@@ -191,11 +190,11 @@ public class ClientSecretRotationExecutor implements
     public static class Configuration extends ClientPolicyExecutorConfigurationRepresentation {
 
         @JsonProperty(ClientSecretRotationExecutorFactory.SECRET_EXPIRATION_PERIOD)
-        protected Integer expirationPeriod;
+        protected Long expirationPeriod;
         @JsonProperty(ClientSecretRotationExecutorFactory.SECRET_REMAINING_ROTATION_PERIOD)
-        protected Integer remainExpirationPeriod;
+        protected Long remainExpirationPeriod;
         @JsonProperty(ClientSecretRotationExecutorFactory.SECRET_ROTATED_EXPIRATION_PERIOD)
-        private Integer rotatedExpirationPeriod;
+        private Long rotatedExpirationPeriod;
 
         @Override
         public boolean validateConfig() {
@@ -218,27 +217,27 @@ public class ClientSecretRotationExecutor implements
             return true;
         }
 
-        public Integer getExpirationPeriod() {
+        public Long getExpirationPeriod() {
             return expirationPeriod;
         }
 
-        public void setExpirationPeriod(Integer expirationPeriod) {
+        public void setExpirationPeriod(Long expirationPeriod) {
             this.expirationPeriod = expirationPeriod;
         }
 
-        public Integer getRemainExpirationPeriod() {
+        public Long getRemainExpirationPeriod() {
             return remainExpirationPeriod;
         }
 
-        public void setRemainExpirationPeriod(Integer remainExpirationPeriod) {
+        public void setRemainExpirationPeriod(Long remainExpirationPeriod) {
             this.remainExpirationPeriod = remainExpirationPeriod;
         }
 
-        public Integer getRotatedExpirationPeriod() {
+        public Long getRotatedExpirationPeriod() {
             return rotatedExpirationPeriod;
         }
 
-        public void setRotatedExpirationPeriod(Integer rotatedExpirationPeriod) {
+        public void setRotatedExpirationPeriod(Long rotatedExpirationPeriod) {
             this.rotatedExpirationPeriod = rotatedExpirationPeriod;
         }
 

--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutorFactory.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/ClientSecretRotationExecutorFactory.java
@@ -22,16 +22,13 @@ public class ClientSecretRotationExecutorFactory implements ClientPolicyExecutor
     public static final String PROVIDER_ID = "secret-rotation";
 
     public static final String SECRET_EXPIRATION_PERIOD = "expiration-period";
-    public static final Integer DEFAULT_SECRET_EXPIRATION_PERIOD = Long.valueOf(
-        TimeUnit.DAYS.toSeconds(29)).intValue();
+    public static final Long DEFAULT_SECRET_EXPIRATION_PERIOD = TimeUnit.DAYS.toSeconds(29);
 
     public static final String SECRET_REMAINING_ROTATION_PERIOD = "remaining-rotation-period";
-    public static final Integer DEFAULT_SECRET_REMAINING_ROTATION_PERIOD = Long.valueOf(
-        TimeUnit.DAYS.toSeconds(10)).intValue();
+    public static final Long DEFAULT_SECRET_REMAINING_ROTATION_PERIOD = TimeUnit.DAYS.toSeconds(10);
 
     public static final String SECRET_ROTATED_EXPIRATION_PERIOD = "rotated-expiration-period";
-    public static final Integer DEFAULT_SECRET_ROTATED_EXPIRATION_PERIOD = Long.valueOf(
-        TimeUnit.DAYS.toSeconds(2)).intValue();
+    public static final Long DEFAULT_SECRET_ROTATED_EXPIRATION_PERIOD = TimeUnit.DAYS.toSeconds(2);
     private static final List<ProviderConfigProperty> configProperties = new ArrayList<ProviderConfigProperty>();
 
     static {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/ClientSecretRotationTest.java
@@ -564,6 +564,22 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
 
     }
 
+    @Test
+    public void secretExpirationWithLargeOffsetDoesNotOverflow() throws Exception {
+        long fiftyYearsInSeconds = TimeUnit.DAYS.toSeconds(365 * 50);
+        doConfigProfileAndPolicy(new ClientProfileBuilder(),
+                getClientProfileConfiguration(fiftyYearsInSeconds, TimeUnit.DAYS.toSeconds(2), TimeUnit.DAYS.toSeconds(10)));
+
+        String cidConfidential = createClientByAdmin(DEFAULT_CLIENT_ID);
+        ClientResource clientResource = adminClient.realm(REALM_NAME).clients().get(cidConfidential);
+
+        OIDCClientSecretConfigWrapper wrapper = OIDCClientSecretConfigWrapper.fromClientRepresentation(
+                clientResource.toRepresentation());
+        long expirationTime = wrapper.getClientSecretExpirationTime();
+
+        assertThat(expirationTime, is(greaterThan((long) Integer.MAX_VALUE)));
+    }
+
     /**
      * After rotate the secret the endpoint must return the rotated secret
      *
@@ -754,7 +770,7 @@ public class ClientSecretRotationTest extends AbstractRestServiceTest {
 
     @NotNull
     private ClientSecretRotationExecutor.Configuration getClientProfileConfiguration(
-            int expirationPeriod, int rotatedExpirationPeriod, int remainExpirationPeriod) {
+            long expirationPeriod, long rotatedExpirationPeriod, long remainExpirationPeriod) {
         ClientSecretRotationExecutor.Configuration profileConfig = new ClientSecretRotationExecutor.Configuration();
         profileConfig.setExpirationPeriod(expirationPeriod);
         profileConfig.setRotatedExpirationPeriod(rotatedExpirationPeriod);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/OIDCClientRegistrationTest.java
@@ -160,7 +160,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         assertNotNull(response.getClientIdIssuedAt());
         assertNotNull(response.getClientId());
         assertNotNull(response.getClientSecret());
-        assertEquals(0, response.getClientSecretExpiresAt().longValue());
+        assertEquals(0, response.getClientSecretExpiresAt().intValue());
         assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
         assertEquals("RegistrationAccessTokenTest", response.getClientName());
         assertEquals("http://root", response.getClientUri());
@@ -185,7 +185,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         assertTrue(CollectionUtil.collectionEquals(Arrays.asList("code", "none"), response.getResponseTypes()));
         assertTrue(CollectionUtil.collectionEquals(Arrays.asList(OAuth2Constants.AUTHORIZATION_CODE, OAuth2Constants.REFRESH_TOKEN), response.getGrantTypes()));
         assertNotNull(response.getClientSecret());
-        assertEquals(0, response.getClientSecretExpiresAt().longValue());
+        assertEquals(0, response.getClientSecretExpiresAt().intValue());
         assertEquals(OIDCLoginProtocol.CLIENT_SECRET_BASIC, response.getTokenEndpointAuthMethod());
         assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
     }
@@ -225,7 +225,7 @@ public class OIDCClientRegistrationTest extends AbstractClientRegistrationTest {
         assertNotNull(response.getClientIdIssuedAt());
         assertNotNull(response.getClientId());
         assertNotNull(response.getClientSecret());
-        assertEquals(0, response.getClientSecretExpiresAt().longValue());
+        assertEquals(0, response.getClientSecretExpiresAt().intValue());
         assertEquals(AUTH_SERVER_ROOT + "/realms/" + REALM_NAME + "/clients-registrations/openid-connect/" + response.getClientId(), response.getRegistrationClientUri());
         assertEquals("RegistrationAccessTokenTest", response.getClientName());
         assertEquals("http://root", response.getClientUri());

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/AbstractClientPoliciesTest.java
@@ -1580,7 +1580,7 @@ public abstract class AbstractClientPoliciesTest extends AbstractKeycloakTest {
 
     @NotNull
     protected ClientSecretRotationExecutor.Configuration getClientProfileConfiguration(
-            int expirationPeriod, int rotatedExpirationPeriod, int remainExpirationPeriod) {
+            long expirationPeriod, long rotatedExpirationPeriod, long remainExpirationPeriod) {
         ClientSecretRotationExecutor.Configuration profileConfig = new ClientSecretRotationExecutor.Configuration();
         profileConfig.setExpirationPeriod(expirationPeriod);
         profileConfig.setRotatedExpirationPeriod(rotatedExpirationPeriod);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/ClientPoliciesTest.java
@@ -1188,7 +1188,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         });
         OIDCClientRepresentation response = getClientDynamically(clientId);
         assertThat(response.getClientSecret(), notNullValue());
-        assertThat(response.getClientSecretExpiresAt(), greaterThan(0L));
+        assertThat(response.getClientSecretExpiresAt(), greaterThan(0));
 
     }
 
@@ -1208,7 +1208,7 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         OIDCClientRepresentation response = getClientDynamically(clientId);
 
         String firstSecret = response.getClientSecret();
-        Long firstSecretExpiration = response.getClientSecretExpiresAt();
+        Integer firstSecretExpiration = response.getClientSecretExpiresAt();
 
         updateClientDynamically(clientId, (OIDCClientRepresentation clientRep) -> clientRep.setContacts(Collections.singletonList("keycloak@keycloak.org")));
 
@@ -1265,9 +1265,9 @@ public class ClientPoliciesTest extends AbstractClientPoliciesTest {
         OIDCClientRepresentation response = getClientDynamically(clientId);
 
         String firstSecret = response.getClientSecret();
-        Long firstSecretExpiration = response.getClientSecretExpiresAt();
+        Integer firstSecretExpiration = response.getClientSecretExpiresAt();
 
-        assertThat(firstSecretExpiration, is(greaterThan(Time.currentTimeSeconds())));
+        assertThat(firstSecretExpiration, is(greaterThan(Time.currentTime())));
 
         //Enter in Remaining expiration window
         timeOffSet.set(41);

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/oauth/ClientAuthSecretSignedJWTTest.java
@@ -560,7 +560,7 @@ public class ClientAuthSecretSignedJWTTest extends AbstractKeycloakTest {
 
     @NotNull
     private ClientSecretRotationExecutor.Configuration getClientProfileConfiguration(
-            int expirationPeriod, int rotatedExpirationPeriod, int remainExpirationPeriod) {
+            long expirationPeriod, long rotatedExpirationPeriod, long remainExpirationPeriod) {
         ClientSecretRotationExecutor.Configuration profileConfig = new ClientSecretRotationExecutor.Configuration();
         profileConfig.setExpirationPeriod(expirationPeriod);
         profileConfig.setRotatedExpirationPeriod(rotatedExpirationPeriod);


### PR DESCRIPTION
- Closes #50414
- Removes code-breaking changes introduced in the https://github.com/keycloak/keycloak/pull/50315
- For Keycloak 27, we can provide the breaking changes on the core level for the OIDC client representation - right now, we don't need to have it for the client secret rotation feature capabilities - see https://github.com/keycloak/keycloak/issues/50416

@keycloak/core-authn Could you please check it? Thanks!

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
