### PR TITLE
Fix empty post-logout redirect URIs handling in SecureRedirectUrisEnforcerExecutor

### DIFF
--- a/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
+++ b/services/src/main/java/org/keycloak/services/clientpolicy/executor/SecureRedirectUrisEnforcerExecutor.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.keycloak.OAuth2Constants;
 import org.keycloak.OAuthErrorException;
@@ -239,8 +240,14 @@ public class SecureRedirectUrisEnforcerExecutor implements ClientPolicyExecutorP
         if (postLogoutRedirectUris == null || postLogoutRedirectUris.isEmpty()) {
             return;
         }
+        List<String> filtered = postLogoutRedirectUris.stream()
+                .filter(uri -> uri != null && !uri.isEmpty())
+                .collect(Collectors.toList());
+        if (filtered.isEmpty()) {
+            return;
+        }
         logger.tracef("Verifying post-logout redirect uris. Target client: %s, Effective post-logout uris: %s", client.getClientId(), postLogoutRedirectUris);
-        verifyRedirectUris(client.getRootUrl(), postLogoutRedirectUris);
+        verifyRedirectUris(client.getRootUrl(), filtered);
     }
 
     void verifyRedirectUris(String rootUri, List<String> redirectUris) throws ClientPolicyException {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SecureRedirectUrisEnforcerExecutorTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/client/policies/SecureRedirectUrisEnforcerExecutorTest.java
@@ -668,6 +668,14 @@ public class SecureRedirectUrisEnforcerExecutorTest extends AbstractClientPolici
         clientRepp = reg.oidc().get(clientId);
         Assertions.assertEquals(List.of("https://oauth.redirect/some"), clientRepp.getRedirectUris());
         Assertions.assertEquals(List.of("https://oauth.redirect/some-post-logout"), clientRepp.getPostLogoutRedirectUris());
+
+        // Success - update with empty post-logout redirect uris (should be treated like "+")
+        updateClientDynamically(clientId, (OIDCClientRepresentation clientRep) -> {
+            clientRep.setRedirectUris(List.of("https://oauth.redirect/some"));
+            clientRep.setPostLogoutRedirectUris(List.of(""));
+        });
+        clientRepp = reg.oidc().get(clientId);
+        Assertions.assertEquals(List.of("https://oauth.redirect/some"), clientRepp.getRedirectUris());
     }
 
     @Test


### PR DESCRIPTION
Closes #49911

The `verifyPostLogoutRedirectUriUpdate` method fails when the admin UI sends `[""]` (a list containing one empty string) for the "Valid post logout redirect URIs" field instead of `[]` (an empty list). The existing null/empty check only catches `null` or `[]`, so the empty string passes through to URI validation and fails.

Fixed by filtering out null and empty strings from the list before validation. If the filtered list is empty, the check is skipped entirely — same behavior as if the field was null or empty.

Has tests.
AI disclosure: This contribution was developed with assistance from AI agents.