### PR TITLE
Tolerate a null username and stop broker mappers from blanking it

### DIFF
--- a/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserUpdatedEvent.java
+++ b/model/infinispan/src/main/java/org/keycloak/models/cache/infinispan/events/UserUpdatedEvent.java
@@ -42,7 +42,7 @@ public class UserUpdatedEvent extends InvalidationEvent implements UserCacheInva
 
     private UserUpdatedEvent(String id, String username, String email, String realmId) {
         super(id);
-        this.username = Objects.requireNonNull(username);
+        this.username = username;
         this.email = email;
         this.realmId = Objects.requireNonNull(realmId);
     }

--- a/services/src/main/java/org/keycloak/broker/oidc/mappers/UserAttributeMapper.java
+++ b/services/src/main/java/org/keycloak/broker/oidc/mappers/UserAttributeMapper.java
@@ -51,6 +51,7 @@ public class UserAttributeMapper extends AbstractClaimMapper {
 
     public static final String USER_ATTRIBUTE = "user.attribute";
     public static final String ALLOW_NULLABLE = "allow.nullable.property";
+    public static final String USERNAME = "username";
     public static final String EMAIL = "email";
     public static final String FIRST_NAME = "firstName";
     public static final String LAST_NAME = "lastName";
@@ -69,7 +70,7 @@ public class UserAttributeMapper extends AbstractClaimMapper {
         property = new ProviderConfigProperty();
         property.setName(USER_ATTRIBUTE);
         property.setLabel("User Attribute Name");
-        property.setHelpText("User attribute name to store claim.  Use email, lastName, and firstName to map to those predefined user properties.");
+        property.setHelpText("User attribute name to store claim.  Use username, email, lastName, and firstName to map to those predefined user properties.");
         property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
         configProperties.add(property);
         allowNullableProperty = new ProviderConfigProperty();
@@ -122,7 +123,9 @@ public class UserAttributeMapper extends AbstractClaimMapper {
         Object value = getClaimValue(mapperModel, context);
         List<String> values = toList(value);
 
-        if (EMAIL.equalsIgnoreCase(attribute)) {
+        if (USERNAME.equalsIgnoreCase(attribute)) {
+            setIfNotBlank(context::setModelUsername, values);
+        } else if (EMAIL.equalsIgnoreCase(attribute)) {
             setIfNotEmpty(context::setEmail, values);
         } else if (FIRST_NAME.equalsIgnoreCase(attribute)) {
             setIfNotEmpty(context::setFirstName, values);
@@ -140,6 +143,12 @@ public class UserAttributeMapper extends AbstractClaimMapper {
 
     private void setIfNotEmpty(Consumer<String> consumer, List<String> values) {
         if (values != null && !values.isEmpty()) {
+            consumer.accept(values.get(0));
+        }
+    }
+
+    private void setIfNotBlank(Consumer<String> consumer, List<String> values) {
+        if (values != null && !values.isEmpty() && !values.get(0).isBlank()) {
             consumer.accept(values.get(0));
         }
     }
@@ -168,7 +177,9 @@ public class UserAttributeMapper extends AbstractClaimMapper {
         List<String> values = toList(value);
         boolean isNullableProperty = Boolean.parseBoolean(mapperModel.getConfig().getOrDefault(ALLOW_NULLABLE, Boolean.FALSE.toString()));
 
-        if (EMAIL.equalsIgnoreCase(attribute)) {
+        if (USERNAME.equalsIgnoreCase(attribute)) {
+            setIfNotBlank(user::setUsername, values);
+        } else if (EMAIL.equalsIgnoreCase(attribute)) {
             if (isNullableProperty) {
                 setNullable(user::setEmail, values);
             } else {

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcUserAttributeMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/OidcUserAttributeMapperTest.java
@@ -54,7 +54,16 @@ public class OidcUserAttributeMapperTest extends AbstractUserAttributeMapperTest
           .put(UserAttributeMapper.USER_ATTRIBUTE, "dotted.email")
           .build());
 
-        return Lists.newArrayList(attrMapper1, emailAttrMapper, nestedEmailAttrMapper, dottedEmailAttrMapper);
+        IdentityProviderMapperRepresentation usernameAttrMapper = new IdentityProviderMapperRepresentation();
+        usernameAttrMapper.setName("attribute-mapper-username");
+        usernameAttrMapper.setIdentityProviderMapper(UserAttributeMapper.PROVIDER_ID);
+        usernameAttrMapper.setConfig(ImmutableMap.<String,String>builder()
+          .put(IdentityProviderMapperModel.SYNC_MODE, syncMode.toString())
+          .put(UserAttributeMapper.CLAIM, "preferred_username")
+          .put(UserAttributeMapper.USER_ATTRIBUTE, "username")
+          .build());
+
+        return Lists.newArrayList(attrMapper1, emailAttrMapper, nestedEmailAttrMapper, dottedEmailAttrMapper, usernameAttrMapper);
     }
 
 }


### PR DESCRIPTION
In the constructor there are exact two things can cause the error message showing in the ticket, one field is realmId (ruled out), and another is username. This is a regression issue since from 25.x, we rewrote UserUpdateEvent and added Object.requiredNonNull(username). In the constructor, A null username was tolerated before, so the new guard turns a previous harmless state into a NPE during cache invalidation, which breaks every login of the affected user. User created before the upgrade keep their null username so the failure appears immediately.


This fix is to tolerate a null username in UserUpdatedEvent.  The username is only used to build a cache-invalidation key, where null is harmless (same as the already-nullable email). and also stop the oidc attribute mapper from blanking the username, so an empty claim can no longer wipe an existing username 


Closes #50209

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
