### PR TITLE
Restrict java keystore files to a realm folder (#703)

### DIFF
--- a/docs/documentation/server_admin/topics/realms/keys.adoc
+++ b/docs/documentation/server_admin/topics/realms/keys.adoc
@@ -128,7 +128,16 @@ For the associated certificate chain to be loaded it must be imported to the Jav
 . Click *Add provider* and select *java-keystore*.
 . Enter a number in the *Priority* field. This number determines if the new key pair becomes the active key pair.
 . Enter the desired *Algorithm*. Note that the algorithm should match the key type (for example `RS256` requires a RSA private key, `ES256` a EC private key or `AES` an AES secret key).
-. Enter a value for *Keystore*. Path to the keystore file.
+. Enter a value for *Keystore*. Path to the keystore file. The keystore should be located inside a folder named like the realm name inside the main keystores directory (by default `data` directory under {project_name}'s installation folder). For a realm called `test` the keystore file should located inside `${kc.home.dir}/data/test`. This way the keystore file is isolated between realms. If the path is relative, the file will be located from that folder.
++
+[NOTE]
+====
+The keystores directory can be customized using the startup option `$$spi-keys--java-keystore--keystores-path$$`. For example:
+```
+kc.[sh|bat] start --spi-keys--java-keystore--keystores-path /path/to/keystores
+```
+====
++
 . Enter the *Keystore Password*. The option can refer a value from an external <<_vault-administration,vault>>.
 . Enter a value for *Keystore Type* (`JKS`, `PKCS12` or `BCFKS`).
 . Enter a value for the *Key Alias* to load from the keystore.

--- a/docs/documentation/upgrading/topics/changes/changes-26_6_4.adoc
+++ b/docs/documentation/upgrading/topics/changes/changes-26_6_4.adoc
@@ -19,6 +19,22 @@ Before upgrading, you should check if any of your users, service accounts, or gr
 information after the upgrade. The `manage-realm` admin role is a high-privileged role and should only be granted to
 highly-trusted accounts.
 
+=== Files for the Java Keystore provider should be placed inside a fixed realm directory
+
+The Java Keystore provider allows the realm administrator to load keys from an encrypted Java keystore file instead of the {project_name}'s database. Since this release, the path of the file is restricted to be inside a folder whose name should be the realm name and, in turn, this realm folder should be inside a fixed main directory for keystores (by default the `data` directory, `${kc.home.dir}/data`). For example, for a realm called `test`, all keystore files should be located under `${kc.home.dir}/data/test`. This way, {project_name} avoids leaking information from the File System and the keys are isolated between realms.
+
+The main keystores directory, where the different realm folders are located, can be customized using a provider startup option:
+
+```
+kc.[sh|bat] start --spi-keys--java-keystore--keystores-path /path/to/keystores
+```
+
+When a keystore is created or updated, the `keystore` configuration option is checked to be a file under the commented realm folder. If the keystore is outside its boundaries, the operation fails. This new behavior means that existing keystores continue working but cannot be updated or modified until the file is copied to an allowed path. Imports from a previous configuration, with store files outside the realm folder, will fail in the same way.
+
+If you are using a Java Keystore file to provide keys for a realm, please copy the keystore inside the appropriate realm folder and update the `java-keystore` provider configuration accordingly.
+
+For more information, see link:{adminguide_link}#realm_keys[Configuring realm keys] chapter in the {adminguide_name}.
+
 // ------------------------ Notable changes ------------------------ //
 == Notable changes
 
@@ -32,15 +48,4 @@ Registration Access Tokens (RAT) can no longer be used to retrieve, update, or d
 If you attempt to use a RAT to manage a disabled client, the request will be rejected with an HTTP 401 Unauthorized response. To manage a disabled client, you must use admin credentials instead of the client's RAT.
 
 Note that a RAT can still be used to disable a client, but once the client is disabled, the RAT can no longer be used to enable it again or perform other operations.
-
-// ------------------------ Deprecated features ------------------------ //
-== Deprecated features
-
-The following sections provide details on deprecated features.
-
-
-// ------------------------ Removed features ------------------------ //
-== Removed features
-
-The following features have been removed from this release.
 

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProvider.java
@@ -20,6 +20,9 @@ package org.keycloak.keys;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.security.KeyPair;
@@ -71,7 +74,7 @@ public class JavaKeystoreKeyProvider implements KeyProvider {
 
     private final String algorithm;
 
-    public JavaKeystoreKeyProvider(RealmModel realm, ComponentModel model, VaultTranscriber vault) {
+    public JavaKeystoreKeyProvider(Path keystoresPath, RealmModel realm, ComponentModel model, VaultTranscriber vault) {
         this.model = model;
         this.vault = vault;
         this.status = KeyStatus.from(model.get(Attributes.ACTIVE_KEY, true), model.get(Attributes.ENABLED_KEY, true));
@@ -81,16 +84,23 @@ public class JavaKeystoreKeyProvider implements KeyProvider {
 
         KeyWrapper tmpKey = KeyNoteUtils.retrieveKeyFromNotes(model, KeyWrapper.class.getName());
         if (tmpKey == null) {
-            tmpKey = loadKey(realm, model);
+            tmpKey = loadKey(keystoresPath, realm, model);
             KeyNoteUtils.attachKeyNotes(model, KeyWrapper.class.getName(), tmpKey);
         }
         this.key = tmpKey;
     }
 
-    protected KeyWrapper loadKey(RealmModel realm, ComponentModel model) {
-        String keystorePath = model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_KEY);
-        try (FileInputStream is = new FileInputStream(keystorePath)) {
-            KeyStore keyStore = loadKeyStore(is, keystorePath);
+    protected KeyWrapper loadKey(Path keystoresPath, RealmModel realm, ComponentModel model) {
+        Path keystorePath = Paths.get(model.get(JavaKeystoreKeyProviderFactory.KEYSTORE_KEY));
+        if (!keystorePath.isAbsolute()) {
+            // resolve the path from the keystores directory if file exists, if not use previous file for backwards compatibility
+            Path path = keystoresPath.resolve(realm.getName()).resolve(keystorePath);
+            if (Files.exists(path)) {
+                keystorePath = path;
+            }
+        }
+        try (FileInputStream is = new FileInputStream(keystorePath.toFile())) {
+            KeyStore keyStore = loadKeyStore(is, keystorePath.toString());
             String keyAlias = model.get(JavaKeystoreKeyProviderFactory.KEY_ALIAS_KEY);
 
             return switch (algorithm) {

--- a/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
+++ b/services/src/main/java/org/keycloak/keys/JavaKeystoreKeyProviderFactory.java
@@ -17,6 +17,8 @@
 
 package org.keycloak.keys;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertPath;
 import java.security.cert.CertPathValidator;
@@ -58,30 +60,40 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
 
     public static final String ID = "java-keystore";
 
-    public static String KEYSTORE_KEY = "keystore";
-    public static ProviderConfigProperty KEYSTORE_PROPERTY = new ProviderConfigProperty(KEYSTORE_KEY, "Keystore", "Path to keys file", STRING_TYPE, null);
+    public static final String KEYSTORES_PATH_INIT_KEY = "keystores-path";
 
-    public static String KEYSTORE_PASSWORD_KEY = "keystorePassword";
-    public static ProviderConfigProperty KEYSTORE_PASSWORD_PROPERTY = new ProviderConfigProperty(KEYSTORE_PASSWORD_KEY, "Keystore Password", "Password for the keys", STRING_TYPE, null, true);
+    public static final String KEYSTORE_KEY = "keystore";
+    public static final ProviderConfigProperty KEYSTORE_PROPERTY = new ProviderConfigProperty(KEYSTORE_KEY, "Keystore",
+            """
+            Path to the keystore file. The keystore should be located inside a folder named like the realm name inside
+            the main keystores directory (by default `data` directory under {project_name}'s installation folder). For a
+            realm called `test` the keystore file should located inside `${kc.home.dir}/data/test`. This way the keystore
+            file is isolated between different realms. If the path is relative, the file will be located from that folder.
+            """,
+            STRING_TYPE, null);
 
-    public static String KEYSTORE_TYPE_KEY = "keystoreType";
+    public static final String KEYSTORE_PASSWORD_KEY = "keystorePassword";
+    public static final ProviderConfigProperty KEYSTORE_PASSWORD_PROPERTY = new ProviderConfigProperty(KEYSTORE_PASSWORD_KEY, "Keystore Password", "Password for the keys", STRING_TYPE, null, true);
+
+    public static final String KEYSTORE_TYPE_KEY = "keystoreType";
 
     // Initialization of this property is postponed to "init()" due the CryptoProvider must be set
     private ProviderConfigProperty keystoreTypeProperty;
 
-    public static String KEY_ALIAS_KEY = "keyAlias";
-    public static ProviderConfigProperty KEY_ALIAS_PROPERTY = new ProviderConfigProperty(KEY_ALIAS_KEY, "Key Alias", "Alias for the private key", STRING_TYPE, null);
+    public static final String KEY_ALIAS_KEY = "keyAlias";
+    public static final ProviderConfigProperty KEY_ALIAS_PROPERTY = new ProviderConfigProperty(KEY_ALIAS_KEY, "Key Alias", "Alias for the private key", STRING_TYPE, null);
 
-    public static String KEY_PASSWORD_KEY = "keyPassword";
-    public static ProviderConfigProperty KEY_PASSWORD_PROPERTY = new ProviderConfigProperty(KEY_PASSWORD_KEY, "Key Password", "Password for the private key", STRING_TYPE, null, true);
+    public static final String KEY_PASSWORD_KEY = "keyPassword";
+    public static final ProviderConfigProperty KEY_PASSWORD_PROPERTY = new ProviderConfigProperty(KEY_PASSWORD_KEY, "Key Password", "Password for the private key", STRING_TYPE, null, true);
 
     private static final String HELP_TEXT = "Loads keys from a Java keys file";
 
     private List<ProviderConfigProperty> configProperties;
-
+    private Path keystoresPath;
 
     @Override
     public void init(Config.Scope config) {
+        this.keystoresPath = Paths.get(config.get(KEYSTORES_PATH_INIT_KEY, System.getProperty("kc.home.dir") + "/data")).normalize();
         String[] supportedKeystoreTypes = CryptoIntegration.getProvider().getSupportedKeyStoreTypes()
                 .map(KeystoreUtil.KeystoreFormat::toString)
                 .toArray(String[]::new);
@@ -105,7 +117,7 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
 
     @Override
     public KeyProvider create(KeycloakSession session, ComponentModel model) {
-        return new JavaKeystoreKeyProvider(session.getContext().getRealm(), model, session.vault());
+        return new JavaKeystoreKeyProvider(keystoresPath, session.getContext().getRealm(), model, session.vault());
     }
 
     @Override
@@ -127,8 +139,17 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
                 .checkSingle(KEY_ALIAS_PROPERTY, true)
                 .checkSingle(KEY_PASSWORD_PROPERTY, true);
 
+        Path keystorePath = Paths.get(model.get(KEYSTORE_KEY)).normalize();
+        if (!keystorePath.isAbsolute()) {
+            keystorePath = this.keystoresPath.resolve(realm.getName()).resolve(keystorePath);
+        }
+        if (!keystorePath.startsWith(keystoresPath.resolve(realm.getName()))) {
+            throw new ComponentValidationException(String.format(
+                    "Keystore file '%s' is not under the realm directory '%s'", keystorePath, keystoresPath.resolve(realm.getName())));
+        }
+
         try {
-            KeyWrapper key = new JavaKeystoreKeyProvider(realm, model, session.vault()).loadKey(realm, model);
+            KeyWrapper key = new JavaKeystoreKeyProvider(keystoresPath, realm, model, session.vault()).loadKey(keystoresPath, realm, model);
             validateCertificateChain(key.getCertificateChain());
         } catch(GeneralSecurityException e) {
             logger.error("Failed to load keys.", e);
@@ -197,4 +218,21 @@ public class JavaKeystoreKeyProviderFactory implements KeyProviderFactory {
         return ID;
     }
 
+    @Override
+    public List<ProviderConfigProperty> getConfigMetadata() {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(KEYSTORES_PATH_INIT_KEY)
+                .type("string")
+                .helpText(
+                        """
+                        The parent directory where the keystore files should be placed. The default value is the keycloak
+                        data folder "${kc.home.dir}/data". In order to isolate keystores between realms, the final keystore
+                        files should be placed in a folder with the realm name inside this directory. For example:
+                        "${kc.home.dir}/data/{realm-name}/keystore.jks".
+                        """
+                )
+                .add()
+                .build();
+    }
 }

--- a/test-framework/core/src/main/java/org/keycloak/testframework/crypto/CryptoKeyStore.java
+++ b/test-framework/core/src/main/java/org/keycloak/testframework/crypto/CryptoKeyStore.java
@@ -106,9 +106,9 @@ public class CryptoKeyStore {
         if (file.exists()) {
             throw new RuntimeException("Keystore file already exists: " + file.getAbsolutePath());
         }
-        FileOutputStream fos = new FileOutputStream(file);
-        keyStore.store(fos, keystorePassword.trim().toCharArray());
-        fos.close();
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            keyStore.store(fos, keystorePassword.trim().toCharArray());
+        }
         return file;
     }
 

--- a/tests/base/src/test/java/org/keycloak/tests/keys/JavaKeystoreKeyProviderTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/keys/JavaKeystoreKeyProviderTest.java
@@ -18,10 +18,13 @@
 package org.keycloak.tests.keys;
 
 import java.io.File;
+import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -52,9 +55,12 @@ import org.keycloak.representations.idm.KeysMetadataRepresentation.KeyMetadataRe
 import org.keycloak.testframework.annotations.InjectCryptoHelper;
 import org.keycloak.testframework.annotations.InjectRealm;
 import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
 import org.keycloak.testframework.crypto.CryptoHelper;
 import org.keycloak.testframework.crypto.KeystoreInfo;
 import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
 import org.keycloak.testframework.remote.timeoffset.InjectTimeOffSet;
 import org.keycloak.testframework.remote.timeoffset.TimeOffSet;
 import org.keycloak.testframework.server.KeycloakServerConfig;
@@ -63,12 +69,13 @@ import org.keycloak.testframework.util.ApiUtil;
 import org.keycloak.tests.utils.KeyUtils;
 import org.keycloak.testsuite.util.saml.SamlConstants;
 
+import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.jboss.logging.Logger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -89,14 +96,31 @@ public class JavaKeystoreKeyProviderTest {
     @InjectCryptoHelper
     CryptoHelper cryptoHelper;
 
-    @TempDir
     public static File folder;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
 
     protected Logger log = Logger.getLogger(this.getClass());
 
     private String keyAlgorithm;
 
     private KeystoreInfo generatedKeystore;
+
+    @TestSetup
+    public void configureTestRealm() throws IOException {
+        String kcHome = runOnServer.fetchString(session -> System.getProperty("kc.home.dir"));
+        Path path = Paths.get(kcHome).normalize().resolve("data").resolve(realm.getName());
+        if (!Files.exists(path)) {
+            Files.createDirectory(path);
+        }
+        folder = path.toFile();
+    }
+
+    @AfterAll
+    public static void afterAll() throws IOException {
+        FileUtils.deleteDirectory(folder);
+    }
 
     @Test
     public void createJksRSA() throws Exception {
@@ -248,10 +272,20 @@ public class JavaKeystoreKeyProviderTest {
     public void invalidKeystore() throws Exception {
         generateKeystore(cryptoHelper.keystore().getPreferredKeystoreType(), AlgorithmType.RSA, Algorithm.RS256);
         ComponentRepresentation rep = createRep("valid", System.currentTimeMillis(), keyAlgorithm);
-        rep.getConfig().putSingle("keystore", "/nosuchfile");
+        rep.getConfig().putSingle("keystore", "nosuchfile");
 
         Response response = realm.admin().components().add(rep);
         assertError(response, "Failed to load keys. File not found on server.");
+    }
+
+    @Test
+    public void invalidKeystoreOutsideKeystoreDirectories() throws Exception {
+        generateKeystore(cryptoHelper.keystore().getPreferredKeystoreType(), AlgorithmType.RSA, Algorithm.RS256);
+        ComponentRepresentation rep = createRep("valid", System.currentTimeMillis(), keyAlgorithm);
+        rep.getConfig().putSingle("keystore", "/invalid");
+
+        Response response = realm.admin().components().add(rep);
+        assertError(response, "is not under the realm directory");
     }
 
     @Test


### PR DESCRIPTION
Closes CVE-2026-9083
Closes #50345

Port to main from the branch. Only one conflict in the notes. I added just the breaking change for this change and removed the empty sections as it was done in the branch.
