### PR TITLE
Create mapper for Token Exchange Delegation to create the may_act claim

### DIFF
--- a/core/src/main/java/org/keycloak/representations/IDToken.java
+++ b/core/src/main/java/org/keycloak/representations/IDToken.java
@@ -62,6 +62,9 @@ public class IDToken extends JsonWebToken {
     // http://openid.net/specs/openid-financial-api-part-2.html#authorization-server
     public static final String S_HASH = "s_hash";
 
+    // RFC 8693 - OAuth 2.0 Token Exchange
+    public static final String MAY_ACT = "may_act";
+
     // NOTE!!!  WE used to use @JsonUnwrapped on a UserClaimSet object.  This screws up otherClaims and the won't work
     // anymore.  So don't have any @JsonUnwrapped!
     @JsonProperty(NONCE)

--- a/docs/guides/securing-apps/token-exchange.adoc
+++ b/docs/guides/securing-apps/token-exchange.adoc
@@ -291,8 +291,8 @@ for the requester client (if the client session was not yet created).
 
 * {project_name} Token exchange does not yet have support for the `resource` parameter.
 
-* The token exchange specification mentions the concepts of https://datatracker.ietf.org/doc/html/rfc8693#name-delegation-vs-impersonation[impersonation and delegation]. {project_name} has support for the
-impersonation use case, but not yet for the delegation use case.
+* The token exchange specification mentions the concepts of https://datatracker.ietf.org/doc/html/rfc8693#name-delegation-vs-impersonation[impersonation and delegation]. {project_name} has support for
+impersonation and experimental support for delegation through the <<_token-exchange-delegation,Token Exchange Delegation>> feature.
 
 ==== Revocation
 
@@ -328,12 +328,80 @@ s|Public clients  | Not available. Downscoping implemented by V1 can be replaced
 s|Consents        | Allowed for clients with `Consent required` as long as the user is already granted consent | Not allowed for clients with *Consent required*
 s|Authorization  | Verification that the requester client must be in the audience of the `subject_token`. Integration with client policies. No Fine-grained admin permissions | Based on fine-grained admin permissions version 1
 s|Revocation chain | Not available for access tokens. Available for refresh tokens   | Not available for access nor refresh tokens
-s|Delegation per RFC 8693|Not supported yet|Not supported
+s|Delegation per RFC 8693|Experimental support via <<_token-exchange-delegation,Token Exchange Delegation>>|Not supported
 s|Resource parameter per RFC 8693|Not supported yet|Not supported
 s|Internal to external Token Exchange | Identity brokering APIs can be used instead. See link:{developerguide_link}#_identity-brokering-apis[Identity Brokering APIs] for more information. | Implemented as a preview
 s|External to internal Token Exchange | Use-case implemented by Standard Token Exchange V2 and JWT Authorization Grant. See <@links.securingapps id="oauth-identity-authorization-chaining-across-domains" /> for more information. | Implemented as a preview
 s|Subject impersonation (including direct naked impersonation)   | Not implemented yet | Implemented as a preview
 |===
+
+[[_token-exchange-delegation]]
+== Token exchange delegation
+
+<#include "/templates/experimental-feature.adoc">
+
+Token exchange delegation allows a subject to pre-authorize an actor to act on their behalf, as described in the https://datatracker.ietf.org/doc/html/rfc8693#name-delegation-vs-impersonation[delegation semantics of the token exchange specification].
+
+This feature requires the `parameterized-scopes` feature to be enabled. To enable both features, start {project_name} with:
+
+[source,bash]
+----
+bin/kc.[sh|bat] start --features=token-exchange-delegation,parameterized-scopes
+----
+
+=== Admin delegation
+
+Admin delegation allows a user (subject) to delegate their token to an administrator. The client requests the `delegation` scope with the administrator's identifier as a parameter using the https://datatracker.ietf.org/doc/html/rfc9396[parameterized scopes] syntax.
+
+When the feature is enabled, a `delegation` client scope is automatically created in new realms. Clients that want to use delegation must add the `delegation` scope to their optional client scopes in the Admin Console.
+
+==== How it works
+
+. The client requests the `delegation` scope with the administrator's (actor) identifier as a parameter, for example `scope=openid delegation:admin`.
+. {project_name} validates that the specified administrator (actor) exists and has the `impersonation` role from the `realm-management` client.
+. The user (subject) is presented with a consent screen to approve the delegation.
+. If the user consents and validation passes, the issued token includes the `may_act` claim with the actor's user ID as the `sub`:
++
+[source,json]
+----
+{
+  "sub": "subject@example.com",
+  "may_act": {
+    "sub": "f1234567-89ab-cdef-0123-456789abcdef"
+  },
+  "scope": "openid delegation:admin",
+  ...
+}
+----
+
+The `may_act` claim declares that the specified administrator (actor) is authorized to act on behalf of the user (subject). The `sub` inside `may_act` contains the actor's user ID, consistent with {project_name}'s standard `sub` claim semantics. An external Security Token Service (STS) receiving this token can verify the delegation authorization directly from the claim without querying back to {project_name}.
+
+If the administrator (actor) does not have impersonation permission, the delegation scope is silently dropped and the `may_act` claim is not included in the token. The consent for delegation is always required and is not stored permanently - the user must approve delegation each login session.
+
+==== Adding additional claims to `may_act`
+
+By default, only the actor's `sub` (user ID) is included in the `may_act` claim. Additional claims can be added by configuring extra "Parameterized Scope User Property" mappers on the `delegation` client scope in the Admin Console.
+
+For example, to include the actor's username:
+
+. Navigate to *Client scopes* -> *delegation* -> *Mappers* -> *Add mapper* -> *By type* -> *Parameterized Scope User Property*.
+. Set *User Property* to `username`.
+. Set *Token Claim Name* to `may_act.preferred_username`.
+. Enable the token types where the claim should be included (e.g. access token, ID token).
+
+The resulting token will then include:
+
+[source,json]
+----
+{
+  "may_act": {
+    "sub": "f1234567-89ab-cdef-0123-456789abcdef",
+    "preferred_username": "admin"
+  }
+}
+----
+
+Other useful claims to add include `may_act.email` (user property `email`) or `may_act.iss` (for cross-realm delegation scenarios).
 
 [[_legacy-token-exchange]]
 == Legacy token exchange

--- a/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/OIDCLoginProtocolFactory.java
@@ -46,6 +46,7 @@ import org.keycloak.protocol.oidc.mappers.AddressMapper;
 import org.keycloak.protocol.oidc.mappers.AllowedWebOriginsProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.AudienceResolveProtocolMapper;
 import org.keycloak.protocol.oidc.mappers.FullNameMapper;
+import org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper;
 import org.keycloak.protocol.oidc.mappers.SubMapper;
 import org.keycloak.protocol.oidc.mappers.UserAttributeMapper;
 import org.keycloak.protocol.oidc.mappers.UserClientRoleMappingMapper;
@@ -71,6 +72,8 @@ import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_R
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_ADDITIONAL_REQ_TOKEN_PARAMS_FAIL_FAST;
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_REQ_PARAMS_DEFAULT_MAX_SIZE;
 import static org.keycloak.protocol.oidc.OIDCProviderConfig.DEFAULT_REQ_TOKEN_PARAMS_DEFAULT_MAX_SIZE;
+import static org.keycloak.representations.IDToken.MAY_ACT;
+import static org.keycloak.representations.JsonWebToken.SUBJECT;
 
 /**
  * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
@@ -108,6 +111,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
     public static final String AUDIENCE_RESOLVE = "audience resolve";
     public static final String ALLOWED_WEB_ORIGINS = "allowed web origins";
     public static final String ACR = "acr loa level";
+    public static final String DELEGATION_MAY_ACT_SUB = "may_act sub";
     public static final String ORGANIZATION = "organization";
     // microprofile-jwt claims
     public static final String UPN = "upn";
@@ -271,6 +275,12 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             builtins.put(ACR, model);
         }
 
+        if (Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION)) {
+            model = ParameterizedScopeUserPropertyMapper.create(
+                    DELEGATION_MAY_ACT_SUB, "id", MAY_ACT + "." + SUBJECT, "String", true, true, true);
+            builtins.put(DELEGATION_MAY_ACT_SUB, model);
+        }
+
         model = UserSessionNoteMapper.createClaimMapper(IDToken.AUTH_TIME, AuthenticationManager.AUTH_TIME,
                 IDToken.AUTH_TIME, "long",
                 true, true, false, true);
@@ -372,7 +382,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
 
         if (Profile.isFeatureEnabled(Profile.Feature.TOKEN_EXCHANGE_DELEGATION)) {
             ClientScopeModel delegationScope = newRealm.addClientScope(DELEGATION_SCOPE);
-            delegationScope.setDescription("Delegation scope to add the 'may_act' claim to the access token using parameters");
+            delegationScope.setDescription("OpenID Connect scope for token exchange delegation");
             delegationScope.setIsParameterizedScope(true);
             delegationScope.setDisplayOnConsentScreen(true);
             delegationScope.setAttribute(ClientScopeModel.IS_ALWAYS_CONSENT, Boolean.TRUE.toString());
@@ -380,6 +390,7 @@ public class OIDCLoginProtocolFactory extends AbstractLoginProtocolFactory {
             delegationScope.setIncludeInTokenScope(true);
             delegationScope.setProtocol(getId());
             delegationScope.setConsentScreenText("${delegationScopeConsentText}");
+            delegationScope.addProtocolMapper(builtins.get(DELEGATION_MAY_ACT_SUB));
         }
     }
 

--- a/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/TokenManager.java
@@ -737,7 +737,7 @@ public class TokenManager {
         return true;
     }
 
-    private static boolean isRepeatableScope(KeycloakSession session, ClientScopeModel clientScope) {
+    public static boolean isRepeatableScope(KeycloakSession session, ClientScopeModel clientScope) {
         String attr = clientScope.getAttribute(ClientScopeModel.IS_REPEATABLE_SCOPE);
         if (attr != null) {
             return Boolean.parseBoolean(attr);

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ParameterizedScopeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ParameterizedScopeMapper.java
@@ -1,0 +1,114 @@
+package org.keycloak.protocol.oidc.mappers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.keycloak.Config;
+import org.keycloak.common.Profile;
+import org.keycloak.models.ClientSessionContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.provider.EnvironmentDependentProviderFactory;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.rar.AuthorizationDetails;
+import org.keycloak.rar.AuthorizationRequestContext;
+import org.keycloak.representations.IDToken;
+import org.keycloak.utils.StringUtil;
+
+public class ParameterizedScopeMapper extends AbstractOIDCProtocolMapper
+        implements OIDCAccessTokenMapper, OIDCIDTokenMapper, TokenIntrospectionTokenMapper, EnvironmentDependentProviderFactory {
+
+    public static final String PROVIDER_ID = "oidc-parameterized-scope-mapper";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    static {
+        OIDCAttributeMapperHelper.addAttributeConfig(configProperties, ParameterizedScopeMapper.class);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Parameterized Scope Parameter";
+    }
+
+    @Override
+    public String getDisplayCategory() {
+        return TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Maps the parameter value from a parameterized scope directly to a token claim.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession,
+                            KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
+        List<String> parameterValues = resolveParameterValues(mappingModel, clientSessionCtx);
+        if (!parameterValues.isEmpty()) {
+            setClaim(token, mappingModel, userSession, keycloakSession, parameterValues);
+        }
+    }
+
+    /**
+     * Maps resolved parameter values to a token claim. The mapper's {@code multivalued} config
+     * controls whether multiple values are mapped as a JSON array or only the first value is used.
+     */
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession,
+                            KeycloakSession keycloakSession, List<String> parameterValues) {
+        OIDCAttributeMapperHelper.mapClaim(token, mappingModel, parameterValues);
+    }
+
+    protected List<String> resolveParameterValues(ProtocolMapperModel mappingModel, ClientSessionContext clientSessionCtx) {
+        AuthorizationRequestContext ctx = clientSessionCtx.getAuthorizationRequestContext();
+        if (ctx == null) {
+            return List.of();
+        }
+
+        List<String> values = new ArrayList<>();
+        for (AuthorizationDetails detail : ctx.getAuthorizationDetailEntries()) {
+            if (detail.getClientScope() != null
+                    && detail.isParameterizedScope()
+                    && detail.getClientScope().getProtocolMapperById(mappingModel.getId()) != null) {
+                String paramValue = detail.getParameterizedScopeParam();
+                if (StringUtil.isNotBlank(paramValue)) {
+                    values.add(paramValue);
+                }
+            }
+        }
+        return values;
+    }
+
+    @Override
+    public boolean isSupported(Config.Scope config) {
+        return Profile.isFeatureEnabled(Profile.Feature.PARAMETERIZED_SCOPES);
+    }
+
+    public static ProtocolMapperModel create(String name, String tokenClaimName, String claimType,
+                                              boolean accessToken, boolean idToken, boolean introspectionEndpoint) {
+        return create(name, tokenClaimName, claimType, accessToken, idToken, introspectionEndpoint, false);
+    }
+
+    public static ProtocolMapperModel create(String name, String tokenClaimName, String claimType,
+                                              boolean accessToken, boolean idToken, boolean introspectionEndpoint,
+                                              boolean multivalued) {
+        ProtocolMapperModel mapper = OIDCAttributeMapperHelper.createClaimMapper(
+                name, null, tokenClaimName, claimType,
+                accessToken, idToken, false, introspectionEndpoint,
+                PROVIDER_ID);
+        mapper.getConfig().put(ProtocolMapperUtils.MULTIVALUED, Boolean.toString(multivalued));
+        return mapper;
+    }
+}

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ParameterizedScopeMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ParameterizedScopeMapper.java
@@ -2,14 +2,17 @@ package org.keycloak.protocol.oidc.mappers;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.keycloak.Config;
 import org.keycloak.common.Profile;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ClientSessionContext;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.models.UserSessionModel;
 import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.provider.EnvironmentDependentProviderFactory;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.rar.AuthorizationDetails;
@@ -56,9 +59,16 @@ public class ParameterizedScopeMapper extends AbstractOIDCProtocolMapper
     @Override
     protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession,
                             KeycloakSession keycloakSession, ClientSessionContext clientSessionCtx) {
-        List<String> parameterValues = resolveParameterValues(mappingModel, clientSessionCtx);
+        ClientScopeModel clientScope = resolveClientScope(mappingModel, clientSessionCtx).orElse(null);
+        if (clientScope == null) {
+            return;
+        }
+
+        List<String> parameterValues = resolveParameterValues(clientScope, clientSessionCtx);
+        ProtocolMapperModel model = new ProtocolMapperModel(mappingModel);
+        model.getConfig().put(ProtocolMapperUtils.MULTIVALUED, Boolean.toString(TokenManager.isRepeatableScope(keycloakSession, clientScope)));
         if (!parameterValues.isEmpty()) {
-            setClaim(token, mappingModel, userSession, keycloakSession, parameterValues);
+            setClaim(token, model, userSession, keycloakSession, parameterValues);
         }
     }
 
@@ -71,7 +81,20 @@ public class ParameterizedScopeMapper extends AbstractOIDCProtocolMapper
         OIDCAttributeMapperHelper.mapClaim(token, mappingModel, parameterValues);
     }
 
-    protected List<String> resolveParameterValues(ProtocolMapperModel mappingModel, ClientSessionContext clientSessionCtx) {
+    protected Optional<ClientScopeModel> resolveClientScope(ProtocolMapperModel mappingModel, ClientSessionContext clientSessionCtx) {
+        AuthorizationRequestContext ctx = clientSessionCtx.getAuthorizationRequestContext();
+        if (ctx == null) {
+            return Optional.empty();
+        }
+
+        return ctx.getAuthorizationDetailEntries().stream()
+                .filter(d -> d.getClientScope() != null && d.isParameterizedScope()
+                        && d.getClientScope().getProtocolMapperById(mappingModel.getId()) != null)
+                .map(AuthorizationDetails::getClientScope)
+                .findAny();
+    }
+
+    protected List<String> resolveParameterValues(ClientScopeModel clientScope, ClientSessionContext clientSessionCtx) {
         AuthorizationRequestContext ctx = clientSessionCtx.getAuthorizationRequestContext();
         if (ctx == null) {
             return List.of();
@@ -80,8 +103,7 @@ public class ParameterizedScopeMapper extends AbstractOIDCProtocolMapper
         List<String> values = new ArrayList<>();
         for (AuthorizationDetails detail : ctx.getAuthorizationDetailEntries()) {
             if (detail.getClientScope() != null
-                    && detail.isParameterizedScope()
-                    && detail.getClientScope().getProtocolMapperById(mappingModel.getId()) != null) {
+                    && detail.getClientScope().getId().equals(clientScope.getId())) {
                 String paramValue = detail.getParameterizedScopeParam();
                 if (StringUtil.isNotBlank(paramValue)) {
                     values.add(paramValue);
@@ -98,17 +120,10 @@ public class ParameterizedScopeMapper extends AbstractOIDCProtocolMapper
 
     public static ProtocolMapperModel create(String name, String tokenClaimName, String claimType,
                                               boolean accessToken, boolean idToken, boolean introspectionEndpoint) {
-        return create(name, tokenClaimName, claimType, accessToken, idToken, introspectionEndpoint, false);
-    }
-
-    public static ProtocolMapperModel create(String name, String tokenClaimName, String claimType,
-                                              boolean accessToken, boolean idToken, boolean introspectionEndpoint,
-                                              boolean multivalued) {
         ProtocolMapperModel mapper = OIDCAttributeMapperHelper.createClaimMapper(
                 name, null, tokenClaimName, claimType,
                 accessToken, idToken, false, introspectionEndpoint,
                 PROVIDER_ID);
-        mapper.getConfig().put(ProtocolMapperUtils.MULTIVALUED, Boolean.toString(multivalued));
         return mapper;
     }
 }

--- a/services/src/main/java/org/keycloak/protocol/oidc/mappers/ParameterizedScopeUserPropertyMapper.java
+++ b/services/src/main/java/org/keycloak/protocol/oidc/mappers/ParameterizedScopeUserPropertyMapper.java
@@ -1,0 +1,104 @@
+package org.keycloak.protocol.oidc.mappers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.keycloak.common.util.CollectionUtil;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.protocol.ProtocolMapperUtils;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.IDToken;
+import org.keycloak.utils.StringUtil;
+
+public class ParameterizedScopeUserPropertyMapper extends ParameterizedScopeMapper {
+
+    public static final String PROVIDER_ID = "oidc-parameterized-scope-user-property-mapper";
+
+    private static final List<ProviderConfigProperty> configProperties = new ArrayList<>();
+
+    static {
+        ProviderConfigProperty property = new ProviderConfigProperty();
+        property.setName(ProtocolMapperUtils.USER_ATTRIBUTE);
+        property.setLabel(ProtocolMapperUtils.USER_MODEL_ATTRIBUTE_LABEL);
+        property.setHelpText("User profile attribute or built-in property (e.g. id, email, firstName) to map to the token claim.");
+        property.setType(ProviderConfigProperty.USER_PROFILE_ATTRIBUTE_LIST_TYPE);
+        configProperties.add(property);
+
+        OIDCAttributeMapperHelper.addAttributeConfig(configProperties, ParameterizedScopeUserPropertyMapper.class);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public String getDisplayType() {
+        return "Parameterized Scope User Property";
+    }
+
+    @Override
+    public String getHelpText() {
+        return "Resolves a user from a parameterized scope parameter (username) and maps a user attribute or property to a token claim.";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return configProperties;
+    }
+
+    @Override
+    protected void setClaim(IDToken token, ProtocolMapperModel mappingModel, UserSessionModel userSession,
+                            KeycloakSession keycloakSession, List<String> parameterValues) {
+        String attributeName = mappingModel.getConfig().get(ProtocolMapperUtils.USER_ATTRIBUTE);
+        if (StringUtil.isBlank(attributeName)) {
+            return;
+        }
+
+        List<Object> resolvedValues = new ArrayList<>();
+        for (String parameterValue : parameterValues) {
+            UserModel user = keycloakSession.users().getUserByUsername(userSession.getRealm(), parameterValue);
+            if (user == null) {
+                continue;
+            }
+
+            Collection<String> attributeValue = KeycloakModelUtils.resolveAttribute(user, attributeName, false);
+            if (CollectionUtil.isNotEmpty(attributeValue)) {
+                resolvedValues.addAll(attributeValue);
+                continue;
+            }
+
+            String propertyValue = ProtocolMapperUtils.getUserModelValue(user, attributeName);
+            if (propertyValue != null) {
+                resolvedValues.add(propertyValue);
+            }
+        }
+
+        if (!resolvedValues.isEmpty()) {
+            OIDCAttributeMapperHelper.mapClaim(token, mappingModel, resolvedValues);
+        }
+    }
+
+    public static ProtocolMapperModel create(String name, String userAttribute,
+                                              String tokenClaimName, String claimType,
+                                              boolean accessToken, boolean idToken, boolean introspectionEndpoint) {
+        return create(name, userAttribute, tokenClaimName, claimType, accessToken, idToken, introspectionEndpoint, false);
+    }
+
+    public static ProtocolMapperModel create(String name, String userAttribute,
+                                              String tokenClaimName, String claimType,
+                                              boolean accessToken, boolean idToken, boolean introspectionEndpoint,
+                                              boolean multivalued) {
+        ProtocolMapperModel mapper = OIDCAttributeMapperHelper.createClaimMapper(
+                name, userAttribute, tokenClaimName, claimType,
+                accessToken, idToken, false, introspectionEndpoint,
+                PROVIDER_ID);
+        mapper.getConfig().put(ProtocolMapperUtils.MULTIVALUED, Boolean.toString(multivalued));
+        return mapper;
+    }
+}

--- a/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/services/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -59,6 +59,8 @@ org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCIssuedAtTimeClaimMapper
 org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCGeneratedIdMapper
 org.keycloak.protocol.oidc.mappers.SessionStateMapper
 org.keycloak.protocol.oidc.mappers.SubMapper
+org.keycloak.protocol.oidc.mappers.ParameterizedScopeMapper
+org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationMembershipMapper
 org.keycloak.organization.protocol.mappers.saml.OrganizationGroupMembershipMapper
 org.keycloak.protocol.saml.mappers.AuthnContextClassRefMapper

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopeMapperTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopeMapperTest.java
@@ -1,0 +1,403 @@
+package org.keycloak.tests.oauth;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.keycloak.common.Profile;
+import org.keycloak.models.ClientScopeModel;
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.utils.ModelToRepresentation;
+import org.keycloak.protocol.oidc.OIDCConfigAttributes;
+import org.keycloak.protocol.oidc.OIDCLoginProtocol;
+import org.keycloak.protocol.oidc.mappers.ParameterizedScopeMapper;
+import org.keycloak.protocol.oidc.mappers.ParameterizedScopeUserPropertyMapper;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.idm.ClientScopeRepresentation;
+import org.keycloak.testframework.annotations.InjectClient;
+import org.keycloak.testframework.annotations.InjectEvents;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.InjectUser;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.annotations.TestSetup;
+import org.keycloak.testframework.events.Events;
+import org.keycloak.testframework.oauth.OAuthClient;
+import org.keycloak.testframework.oauth.annotations.InjectOAuthClient;
+import org.keycloak.testframework.realm.ClientBuilder;
+import org.keycloak.testframework.realm.ClientConfig;
+import org.keycloak.testframework.realm.ClientScopeBuilder;
+import org.keycloak.testframework.realm.ManagedClient;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.realm.ManagedUser;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.UserBuilder;
+import org.keycloak.testframework.realm.UserConfig;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+import org.keycloak.testframework.ui.annotations.InjectPage;
+import org.keycloak.testframework.ui.page.OAuthGrantPage;
+import org.keycloak.testframework.util.ApiUtil;
+import org.keycloak.tests.suites.DatabaseTest;
+import org.keycloak.testsuite.util.AccountHelper;
+import org.keycloak.testsuite.util.oauth.AccessTokenResponse;
+import org.keycloak.testsuite.util.oauth.IntrospectionResponse;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.keycloak.tests.oauth.ParameterizedScopeBuilder.create;
+
+@DatabaseTest
+@KeycloakIntegrationTest(config = ParameterizedScopeMapperTest.ServerConfig.class)
+public class ParameterizedScopeMapperTest {
+
+    private static final String SCOPE_NAME = "test-param-scope";
+    private static final String SECOND_SCOPE_NAME = "other-param-scope";
+    private static final String CLIENT_ID = "test-mapper-client";
+    private static final String DEFAULT_USERNAME = "test-user@localhost";
+    private static final String DEFAULT_PASSWORD = "password";
+    private static final String TARGET_USERNAME = "target-user";
+    private static final String RAW_PARAM_CLAIM = "param_value";
+    private static final String USER_ID_CLAIM = "resolved_user_id";
+    private static final String USER_EMAIL_CLAIM = "resolved_user_email";
+    private static final String SECOND_RAW_PARAM_CLAIM = "other_param_value";
+
+    @InjectRealm(config = TestRealmConfig.class)
+    ManagedRealm realm;
+
+    @InjectClient(config = TestClientConfig.class)
+    ManagedClient client;
+
+    @InjectOAuthClient
+    OAuthClient oauth;
+
+    @InjectUser(config = TargetUserConfig.class, ref = "target")
+    ManagedUser targetUser;
+
+    @InjectUser(config = SecondTargetUserConfig.class, ref = "secondTarget")
+    ManagedUser secondTargetUser;
+
+    @InjectEvents
+    Events events;
+
+    @InjectPage
+    OAuthGrantPage grantPage;
+
+    @TestSetup
+    public void setup() {
+        String mainScopeId = createParameterizedScope(SCOPE_NAME);
+        addMapper(mainScopeId, ParameterizedScopeMapper.create(
+                "raw-param-mapper", RAW_PARAM_CLAIM, "String", true, false, true));
+        addMapper(mainScopeId, ParameterizedScopeUserPropertyMapper.create(
+                "user-id-mapper", "id", USER_ID_CLAIM, "String", true, false, true));
+        addMapper(mainScopeId, ParameterizedScopeUserPropertyMapper.create(
+                "user-email-mapper", "email", USER_EMAIL_CLAIM, "String", true, false, true));
+        client.admin().addOptionalClientScope(mainScopeId);
+
+        String secondScopeId = createParameterizedScope(SECOND_SCOPE_NAME);
+        addMapper(secondScopeId, ParameterizedScopeMapper.create(
+                "other-raw-param-mapper", SECOND_RAW_PARAM_CLAIM, "String", true, false, true));
+        client.admin().addOptionalClientScope(secondScopeId);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        try {
+            AccountHelper.logout(realm.admin(), DEFAULT_USERNAME);
+        } catch (Exception ignored) {
+        }
+        try {
+            List<Map<String, Object>> userConsents = AccountHelper.getUserConsents(realm.admin(), DEFAULT_USERNAME);
+            if (userConsents.stream().anyMatch(m -> CLIENT_ID.equals(m.get("clientId")))) {
+                AccountHelper.revokeConsents(realm.admin(), DEFAULT_USERNAME, CLIENT_ID);
+            }
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Test
+    public void parameterizedScopeMapperRawValue() {
+        AccessToken token = loginWithScopeParam(TARGET_USERNAME);
+        assertRawParamClaim(token, TARGET_USERNAME);
+    }
+
+    @Test
+    public void parameterizedScopeUserPropertyMapperId() {
+        AccessToken token = loginWithScopeParam(TARGET_USERNAME);
+        assertUserIdClaim(token, targetUser.getId());
+    }
+
+    @Test
+    public void parameterizedScopeUserPropertyMapperEmail() {
+        AccessToken token = loginWithScopeParam(TARGET_USERNAME);
+        assertUserEmailClaim(token, "target@localhost");
+    }
+
+    @Test
+    public void parameterizedScopeMapperNotPresent() {
+        AccessTokenResponse res = loginAndGetResponse("openid");
+        AccessToken token = oauth.verifyToken(res.getAccessToken());
+        assertNoMappedClaims(token);
+    }
+
+    @Test
+    public void parameterizedScopeMapperNonExistentUser() {
+        AccessToken token = loginWithScopeParam("nonexistent");
+        assertRawParamClaim(token, "nonexistent");
+        assertNoUserClaims(token);
+    }
+
+    @Test
+    public void claimsPersistOnRefresh() {
+        AccessTokenResponse res = loginAndGetResponse(SCOPE_NAME + ":" + TARGET_USERNAME);
+
+        AccessToken token = oauth.verifyToken(res.getAccessToken());
+        assertAllClaims(token, TARGET_USERNAME, targetUser.getId(), "target@localhost");
+
+        res = oauth.scope(null).doRefreshTokenRequest(res.getRefreshToken());
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+
+        AccessToken refreshedToken = oauth.verifyToken(res.getAccessToken());
+        assertAllClaims(refreshedToken, TARGET_USERNAME, targetUser.getId(), "target@localhost");
+    }
+
+    @Test
+    public void introspectionContainsClaims() throws IOException {
+        AccessTokenResponse res = loginAndGetResponse(SCOPE_NAME + ":" + TARGET_USERNAME);
+
+        IntrospectionResponse introspection = oauth.doIntrospectionAccessTokenRequest(res.getAccessToken());
+        Assertions.assertTrue(introspection.isSuccess(),
+                "Introspection failed with status " + introspection.getStatusCode()
+                        + ": " + introspection.getError() + " - " + introspection.getErrorDescription());
+
+        JsonNode json = introspection.asJsonNode();
+        Assertions.assertTrue(json.get("active").asBoolean());
+        Assertions.assertEquals(TARGET_USERNAME, json.get(RAW_PARAM_CLAIM).asText());
+        Assertions.assertEquals(targetUser.getId(), json.get(USER_ID_CLAIM).asText());
+        Assertions.assertEquals("target@localhost", json.get(USER_EMAIL_CLAIM).asText());
+    }
+
+    @Test
+    public void nonParameterizedScopeMappersIgnored() {
+        String nonParamScopeId = createNonParameterizedScopeWithMappers();
+        client.admin().addOptionalClientScope(nonParamScopeId);
+        realm.cleanup().add(r -> {
+            r.clients().get(client.getId()).removeOptionalClientScope(nonParamScopeId);
+            r.clientScopes().get(nonParamScopeId).remove();
+        });
+
+        AccessTokenResponse res = loginAndGetResponse("non-param-scope");
+        AccessToken token = oauth.verifyToken(res.getAccessToken());
+        assertNoMappedClaims(token);
+    }
+
+    @Test
+    public void multipleParameterizedScopesMapIndependently() {
+        AccessTokenResponse res = loginAndGetResponse(SCOPE_NAME + ":value-one " + SECOND_SCOPE_NAME + ":value-two");
+        AccessToken token = oauth.verifyToken(res.getAccessToken());
+
+        Assertions.assertEquals("value-one", token.getOtherClaims().get(RAW_PARAM_CLAIM),
+                "First scope's mapper should map its own parameter value");
+        Assertions.assertEquals("value-two", token.getOtherClaims().get(SECOND_RAW_PARAM_CLAIM),
+                "Second scope's mapper should map its own parameter value");
+    }
+
+    @Test
+    public void repeatableScopeMapsMultipleValues() {
+        String repScopeId = addOptionalScopeWithCleanup("rep-scope", true,
+                ParameterizedScopeMapper.create("rep-raw-mapper", "rep_values", "String", true, false, true, true));
+
+        AccessToken token = loginWithScopeParam("rep-scope", TARGET_USERNAME, "second-target");
+        assertListClaim(token, "rep_values", TARGET_USERNAME, "second-target");
+    }
+
+    @Test
+    public void repeatableScopeUserPropertyMapsMultipleUsers() {
+        String repScopeId = addOptionalScopeWithCleanup("rep-user-scope", true,
+                ParameterizedScopeUserPropertyMapper.create("rep-user-id-mapper", "id", "rep_user_ids", "String", true, false, true, true));
+
+        AccessToken token = loginWithScopeParam("rep-user-scope", TARGET_USERNAME, secondTargetUser.getUsername());
+        assertListClaim(token, "rep_user_ids", targetUser.getId(), secondTargetUser.getId());
+    }
+
+    // --- Helpers ---
+
+    private AccessToken loginWithScopeParam(String paramValue) {
+        AccessTokenResponse res = loginAndGetResponse(SCOPE_NAME + ":" + paramValue);
+        return oauth.verifyToken(res.getAccessToken());
+    }
+
+    private AccessToken loginWithScopeParam(String scopeName, String... paramValues) {
+        String scope = Arrays.stream(paramValues)
+                .map(v -> scopeName + ":" + v)
+                .collect(Collectors.joining(" "));
+        AccessTokenResponse res = loginAndGetResponse(scope);
+        return oauth.verifyToken(res.getAccessToken());
+    }
+
+    private String addOptionalScopeWithCleanup(String name, boolean repeatable, ProtocolMapperModel... mappers) {
+        String id = createParameterizedScope(name, repeatable);
+        for (ProtocolMapperModel mapper : mappers) {
+            addMapper(id, mapper);
+        }
+        client.admin().addOptionalClientScope(id);
+        realm.cleanup().add(r -> {
+            r.clients().get(client.getId()).removeOptionalClientScope(id);
+            r.clientScopes().get(id).remove();
+        });
+        return id;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertListClaim(AccessToken token, String claimName, String... expectedValues) {
+        Object claim = token.getOtherClaims().get(claimName);
+        Assertions.assertInstanceOf(List.class, claim, claimName + " should be mapped as a list");
+        List<String> values = (List<String>) claim;
+        Assertions.assertEquals(expectedValues.length, values.size());
+        for (String expected : expectedValues) {
+            Assertions.assertTrue(values.contains(expected), claimName + " should contain " + expected);
+        }
+    }
+
+    private AccessTokenResponse loginAndGetResponse(String scope) {
+        oauth.client(CLIENT_ID, "password");
+        oauth.scope(scope);
+        oauth.openLoginForm();
+        oauth.fillLoginForm(DEFAULT_USERNAME, DEFAULT_PASSWORD);
+        grantPage.assertCurrent();
+        grantPage.accept();
+        events.poll();
+
+        String code = oauth.parseLoginResponse().getCode();
+        AccessTokenResponse res = oauth.doAccessTokenRequest(code);
+        Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
+        return res;
+    }
+
+    private String createParameterizedScope(String name) {
+        return createParameterizedScope(name, false);
+    }
+
+    private String createParameterizedScope(String name, boolean repeatable) {
+        ClientScopeRepresentation scope = create(name)
+                .parameterizedScopeType("string")
+                .isRepeatableScope(repeatable)
+                .displayOnConsentScreen(true)
+                .alwaysConsent(false)
+                .build();
+        return ApiUtil.getCreatedId(realm.admin().clientScopes().create(scope));
+    }
+
+    private String createNonParameterizedScopeWithMappers() {
+        ClientScopeRepresentation scope = ClientScopeBuilder.create()
+                .name("non-param-scope")
+                .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                .attribute(ClientScopeModel.IS_PARAMETERIZED_SCOPE, Boolean.FALSE.toString())
+                .attribute(ClientScopeModel.DISPLAY_ON_CONSENT_SCREEN, Boolean.TRUE.toString())
+                .build();
+        String id = ApiUtil.getCreatedId(realm.admin().clientScopes().create(scope));
+        addMapper(id, ParameterizedScopeMapper.create(
+                "non-param-raw-mapper", RAW_PARAM_CLAIM, "String", true, false, true));
+        addMapper(id, ParameterizedScopeUserPropertyMapper.create(
+                "non-param-user-id-mapper", "id", USER_ID_CLAIM, "String", true, false, true));
+        return id;
+    }
+
+    private void addMapper(String clientScopeId, ProtocolMapperModel mapper) {
+        realm.admin().clientScopes().get(clientScopeId).getProtocolMappers()
+                .createMapper(ModelToRepresentation.toRepresentation(mapper));
+    }
+
+    private static void assertRawParamClaim(AccessToken token, String expectedValue) {
+        Assertions.assertEquals(expectedValue, token.getOtherClaims().get(RAW_PARAM_CLAIM),
+                "Raw param claim should contain the scope parameter value");
+    }
+
+    private static void assertUserIdClaim(AccessToken token, String expectedId) {
+        Assertions.assertEquals(expectedId, token.getOtherClaims().get(USER_ID_CLAIM),
+                "User id claim should contain the resolved user's ID");
+    }
+
+    private static void assertUserEmailClaim(AccessToken token, String expectedEmail) {
+        Assertions.assertEquals(expectedEmail, token.getOtherClaims().get(USER_EMAIL_CLAIM),
+                "User email claim should contain the resolved user's email");
+    }
+
+    private static void assertAllClaims(AccessToken token, String rawParam, String userId, String email) {
+        assertRawParamClaim(token, rawParam);
+        assertUserIdClaim(token, userId);
+        assertUserEmailClaim(token, email);
+    }
+
+    private static void assertNoUserClaims(AccessToken token) {
+        Assertions.assertNull(token.getOtherClaims().get(USER_ID_CLAIM),
+                "User id claim should not be present");
+        Assertions.assertNull(token.getOtherClaims().get(USER_EMAIL_CLAIM),
+                "User email claim should not be present");
+    }
+
+    private static void assertNoMappedClaims(AccessToken token) {
+        Assertions.assertNull(token.getOtherClaims().get(RAW_PARAM_CLAIM),
+                "Raw param claim should not be present");
+        assertNoUserClaims(token);
+    }
+
+    // --- Config classes ---
+
+    static class ServerConfig implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder config) {
+            return config.features(Profile.Feature.PARAMETERIZED_SCOPES);
+        }
+    }
+
+    static class TestRealmConfig implements RealmConfig {
+        @Override
+        public RealmBuilder configure(RealmBuilder realm) {
+            return realm.users(UserBuilder.create(DEFAULT_USERNAME)
+                    .email(DEFAULT_USERNAME)
+                    .name("Test", "User")
+                    .emailVerified(true)
+                    .password(DEFAULT_PASSWORD)
+                    .enabled(true));
+        }
+    }
+
+    static class TestClientConfig implements ClientConfig {
+        @Override
+        public ClientBuilder configure(ClientBuilder client) {
+            return client.clientId(CLIENT_ID)
+                    .protocol(OIDCLoginProtocol.LOGIN_PROTOCOL)
+                    .publicClient(false)
+                    .consentRequired(Boolean.TRUE)
+                    .redirectUris("*")
+                    .secret("password")
+                    .attribute(OIDCConfigAttributes.ALLOW_TOKEN_INTROSPECTION_WITHOUT_AUDIENCE_CHECK, "true");
+        }
+    }
+
+    static class TargetUserConfig implements UserConfig {
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            return user.username(TARGET_USERNAME)
+                    .password(DEFAULT_PASSWORD)
+                    .email("target@localhost")
+                    .name("Target", "User");
+        }
+    }
+
+    static class SecondTargetUserConfig implements UserConfig {
+        @Override
+        public UserBuilder configure(UserBuilder user) {
+            return user.username("second-target-user")
+                    .password(DEFAULT_PASSWORD)
+                    .email("second-target@localhost")
+                    .name("Second", "Target");
+        }
+    }
+}

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopeMapperTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/ParameterizedScopeMapperTest.java
@@ -210,7 +210,7 @@ public class ParameterizedScopeMapperTest {
     @Test
     public void repeatableScopeMapsMultipleValues() {
         String repScopeId = addOptionalScopeWithCleanup("rep-scope", true,
-                ParameterizedScopeMapper.create("rep-raw-mapper", "rep_values", "String", true, false, true, true));
+                ParameterizedScopeMapper.create("rep-raw-mapper", "rep_values", "String", true, false, true));
 
         AccessToken token = loginWithScopeParam("rep-scope", TARGET_USERNAME, "second-target");
         assertListClaim(token, "rep_values", TARGET_USERNAME, "second-target");

--- a/tests/base/src/test/java/org/keycloak/tests/oauth/TokenExchangeDelegationTest.java
+++ b/tests/base/src/test/java/org/keycloak/tests/oauth/TokenExchangeDelegationTest.java
@@ -19,6 +19,7 @@ import org.keycloak.protocol.oidc.OIDCLoginProtocolFactory;
 import org.keycloak.protocol.oidc.grants.ciba.CibaGrantTypeFactory;
 import org.keycloak.protocol.oidc.grants.ciba.channel.AuthenticationChannelResponse;
 import org.keycloak.protocol.oidc.grants.ciba.endpoints.ClientNotificationEndpointRequest;
+import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.idm.EventRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.testframework.annotations.InjectEvents;
@@ -52,6 +53,9 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.keycloak.representations.IDToken.MAY_ACT;
+import static org.keycloak.representations.JsonWebToken.SUBJECT;
 
 /**
  *
@@ -104,6 +108,7 @@ public class TokenExchangeDelegationTest {
         AccessTokenResponse res = oauth.doAccessTokenRequest(code);
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
 
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
@@ -138,17 +143,20 @@ public class TokenExchangeDelegationTest {
         AccessTokenResponse res = oauth.doAccessTokenRequest(code);
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeContains(res.getScope(), scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
         // refresh the token
         res = oauth.scope(null).doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeContains(res.getScope(), scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
         // remove the impersonation and refresh the token
         administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
 
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
@@ -215,21 +223,35 @@ public class TokenExchangeDelegationTest {
                 .details(Details.USERNAME, USERNAME)
                 .details(Details.CONSENT, Details.CONSENT_VALUE_CONSENT_GRANTED);
        assertScopeContains(res.getScope(), scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
         // refresh the token
         res = oauth.scope(null).doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeContains(res.getScope(), scope);
+        assertMayActPresent(oauth.verifyToken(res.getAccessToken()), administrator.getId());
 
         // remove the impersonation and refresh the token
         administrator.admin().roles().clientLevel(clientUUID).remove(List.of(impersonation));
         res = oauth.doRefreshTokenRequest(res.getRefreshToken());
         Assertions.assertTrue(res.isSuccess(), res.getError() + " - " + res.getErrorDescription());
         assertScopeNotContains(res.getScope(), scope);
+        assertMayActNotPresent(oauth.verifyToken(res.getAccessToken()));
 
         // logout
         LogoutResponse logout = oauth.doLogout(res.getRefreshToken());
         Assertions.assertTrue(logout.isSuccess(), logout.getError() + " - " + logout.getErrorDescription());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertMayActPresent(AccessToken token, String expectedActorId) {
+        Map<String, Object> mayAct = (Map<String, Object>) token.getOtherClaims().get(MAY_ACT);
+        Assertions.assertNotNull(mayAct, "may_act claim should be present");
+        Assertions.assertEquals(expectedActorId, mayAct.get(SUBJECT), "may_act.sub should contain the actor user ID");
+    }
+
+    private static void assertMayActNotPresent(AccessToken token) {
+        Assertions.assertNull(token.getOtherClaims().get(MAY_ACT), "may_act claim should not be present");
     }
 
     private static void assertScopeContains(String scopeString, String expectedScope) {
@@ -283,4 +305,5 @@ public class TokenExchangeDelegationTest {
                     .email("administrator@localhost").firstName("Administrator").lastName("User");
         }
     }
+
 }


### PR DESCRIPTION
- Closes #49955
- Closes https://github.com/keycloak/keycloak/issues/50552
- Included documentation
- Based on the RFC, only the single `sub` for `may_act` is allowed (some other vendors also restrict to specific clients)
- As there might be one allowed actor (for now), we should deny specifying the scope multiple times. Perhaps we should provide a switch "Repeatable" or sth like that. EDIT: in the https://github.com/keycloak/keycloak/pull/50433
 
## Demo
### Delegation scope + sub mapper

https://github.com/user-attachments/assets/2f2c1908-dba9-4732-a3c4-89c1e1d93784

### Delegation scope + add mapper for including a username in the `may_act.preferred_username` claim

https://github.com/user-attachments/assets/0da2a6ee-42a0-4fbb-b4ef-7a848889d5cf

### Parameterized scope + simple integer mapper for token claims
 
https://github.com/user-attachments/assets/01781389-0abe-4c50-8134-4cca4819d29b


