### PR TITLE
Honor explicit username mapper over email-as-username during first-broker-login

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpCreateUserIfUniqueAuthenticator.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/broker/IdpCreateUserIfUniqueAuthenticator.java
@@ -165,7 +165,20 @@ public class IdpCreateUserIfUniqueAuthenticator extends AbstractIdpAuthenticator
 
     protected String getUsername(AuthenticationFlowContext context, SerializedBrokeredIdentityContext serializedCtx, BrokeredIdentityContext brokerContext) {
         RealmModel realm = context.getRealm();
-        return realm.isRegistrationEmailAsUsername() ? brokerContext.getEmail() : brokerContext.getModelUsername();
+        // An explicitly mapped username (e.g. set by a UsernameTemplateMapper) must take
+        // precedence over the realm's "email as username" setting. IdentityBrokerService
+        // already resolves modelUsername with this precedence (falling back to the email
+        // when no mapper provided a username), so honour that resolved value here instead
+        // of unconditionally overriding it with the email.
+        String modelUsername = brokerContext.getModelUsername();
+        if (modelUsername != null) {
+            return modelUsername;
+        }
+        // No resolved model username (e.g. when this authenticator is reached without
+        // IdentityBrokerService having resolved one): mirror the realm's default
+        // behaviour, falling back to the identity provider username rather than the
+        // always-null modelUsername when "email as username" is disabled.
+        return realm.isRegistrationEmailAsUsername() ? brokerContext.getEmail() : brokerContext.getUsername();
     }
 
 

--- a/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/UsernameTemplateMapperTest.java
+++ b/testsuite/integration-arquillian/tests/base/src/test/java/org/keycloak/testsuite/broker/UsernameTemplateMapperTest.java
@@ -6,6 +6,7 @@ import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
 import org.keycloak.broker.oidc.mappers.UsernameTemplateMapper;
 import org.keycloak.representations.idm.IdentityProviderMapperRepresentation;
 import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import com.google.common.collect.ImmutableMap;
@@ -16,6 +17,7 @@ import org.junit.Test;
 import static org.keycloak.testsuite.broker.BrokerTestTools.getConsumerRoot;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class UsernameTemplateMapperTest extends AbstractBaseBrokerTest {
 
@@ -88,5 +90,38 @@ public class UsernameTemplateMapperTest extends AbstractBaseBrokerTest {
 
         String username = user.getUsername();
         assertEquals(bc.getIDPAlias() + "_" + idpUserId, username, "Should render alias:sub as Username");
+    }
+
+    /**
+     * Regression test for https://github.com/keycloak/keycloak/issues/49300
+     *
+     * An explicit UsernameTemplateMapper must take precedence over the realm's
+     * "Email as username" setting during first-broker-login. Before the fix,
+     * IdpCreateUserIfUniqueAuthenticator#getUsername unconditionally used the email
+     * when registrationEmailAsUsername was enabled, ignoring the mapped username.
+     */
+    @Test
+    public void usernameTemplateMapperShouldTakePrecedenceOverEmailAsUsername() {
+        RealmResource consumerRealm = adminClient.realm(bc.consumerRealmName());
+        RealmRepresentation consumerRealmRep = consumerRealm.toRepresentation();
+        Boolean originalRegistrationEmailAsUsername = consumerRealmRep.isRegistrationEmailAsUsername();
+        consumerRealmRep.setRegistrationEmailAsUsername(true);
+        consumerRealm.update(consumerRealmRep);
+
+        try {
+            logInAsUserInIDP();
+            logoutFromRealm(getConsumerRoot(), bc.consumerRealmName());
+
+            UserRepresentation user = consumerRealm.users().search(bc.getUserEmail(), 0, 1).get(0);
+
+            String username = user.getUsername();
+            assertEquals(bc.getIDPAlias() + "_" + idpUserId, username,
+                    "Mapped username should win over email-as-username realm setting");
+            assertNotEquals(bc.getUserEmail(), username,
+                    "Username must not fall back to the email when a mapper provides one");
+        } finally {
+            consumerRealmRep.setRegistrationEmailAsUsername(originalRegistrationEmailAsUsername);
+            consumerRealm.update(consumerRealmRep);
+        }
     }
 }


### PR DESCRIPTION
Closes #49300

## Summary

When a realm has **Email as username** (`registrationEmailAsUsername`) enabled,
an explicitly configured identity-provider `UsernameTemplateMapper` was silently
ignored during first-broker-login: the brokered user's username was set to the
email instead of the mapped value.

The root cause is an inconsistency between two code paths:

- `IdentityBrokerService` already resolves the username with the correct
  precedence — it keeps the mapper-provided `modelUsername` when present and only
  falls back to the email (when email-as-username is enabled) if no mapper set a
  username.
- `IdpCreateUserIfUniqueAuthenticator#getUsername` then re-derived the username
  with `realm.isRegistrationEmailAsUsername() ? brokerContext.getEmail() :
  brokerContext.getModelUsername()`, unconditionally preferring the email and
  clobbering the already-resolved value.

This change makes the authenticator honor the resolved `modelUsername` and fall
back to the existing email-as-username behavior only when it is `null`. The fix
is also inherited by `IdpDetectExistingBrokerUserAuthenticator`. Realms without a
username mapper are unaffected: `modelUsername` already equals the email in that
case, so the behavior is unchanged.

## Testing

Added `usernameTemplateMapperShouldTakePrecedenceOverEmailAsUsername` to
`UsernameTemplateMapperTest`, which enables `registrationEmailAsUsername` on the
consumer realm, performs first-broker-login, and asserts the created user's
username equals the mapper template result (`${ALIAS}_${CLAIM.sub}`) rather than
the email.

## Note on tooling

This contribution was prepared with the assistance of an AI coding agent. I have
reviewed and understand every change, and I am able to explain and revise it in
response to review feedback.
